### PR TITLE
Fix tab actions in background workspaces

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7166,7 +7166,6 @@ struct CMUXCLI {
                 return try validateSurfaceHandleInWindow(
                     trimmed,
                     client: client,
-                    workspaceHandle: workspaceHandle,
                     windowHandle: windowHandle
                 )
             }
@@ -7197,21 +7196,8 @@ struct CMUXCLI {
     private func validateSurfaceHandleInWindow(
         _ surfaceHandle: String,
         client: SocketClient,
-        workspaceHandle: String?,
         windowHandle: String
     ) throws -> String {
-        if let workspaceHandle {
-            if let matched = try matchingSurfaceHandleInWorkspace(
-                surfaceHandle,
-                client: client,
-                workspaceHandle: workspaceHandle,
-                windowHandle: windowHandle
-            ) {
-                return matched
-            }
-            throw CLIError(message: "Surface not found in window")
-        }
-
         let listed = try client.sendV2(method: "workspace.list", params: ["window_id": windowHandle])
         let workspaces = listed["workspaces"] as? [[String: Any]] ?? []
         for workspace in workspaces {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7148,6 +7148,20 @@ struct CMUXCLI {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
         if isUUID(trimmed) || isHandleRef(trimmed) {
+            if let workspaceHandle {
+                if let matched = try matchingSurfaceHandleInWorkspace(
+                    trimmed,
+                    client: client,
+                    workspaceHandle: workspaceHandle,
+                    windowHandle: windowHandle
+                ) {
+                    return matched
+                }
+                throw CLIError(message: String(
+                    localized: "socket.surfaceSplitOff.error.surfaceNotFoundInWorkspace",
+                    defaultValue: "Surface not found in workspace"
+                ))
+            }
             if let windowHandle {
                 return try validateSurfaceHandleInWindow(
                     trimmed,
@@ -7220,14 +7234,15 @@ struct CMUXCLI {
         _ surfaceHandle: String,
         client: SocketClient,
         workspaceHandle: String,
-        windowHandle: String
+        windowHandle: String?
     ) throws -> String? {
+        var params: [String: Any] = ["workspace_id": workspaceHandle]
+        if let windowHandle {
+            params["window_id"] = windowHandle
+        }
         let listed = try client.sendV2(
             method: "surface.list",
-            params: [
-                "workspace_id": workspaceHandle,
-                "window_id": windowHandle,
-            ]
+            params: params
         )
         let surfaces = listed["surfaces"] as? [[String: Any]] ?? []
         for surface in surfaces where surfaceHandleMatches(surfaceHandle, item: surface) {

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -63,6 +63,8 @@ class FakeCmuxState:
                 "surface_ref": "surface:2",
             }
         if method == "surface.list":
+            if params.get("workspace_id") != WORKSPACE_ID:
+                return {"surfaces": []}
             return {
                 "surfaces": [
                     {

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -62,6 +62,16 @@ class FakeCmuxState:
                 "surface_id": NEW_SURFACE_ID,
                 "surface_ref": "surface:2",
             }
+        if method == "surface.list":
+            return {
+                "surfaces": [
+                    {
+                        "id": SURFACE_ID,
+                        "ref": "surface:1",
+                        "index": 1,
+                    },
+                ],
+            }
         if method == "surface.reorder":
             return {
                 "workspace_id": WORKSPACE_ID,
@@ -72,6 +82,8 @@ class FakeCmuxState:
                 "surface_ref": "surface:1",
             }
         if method == "tab.action":
+            if params.get("surface_id") != SURFACE_ID:
+                raise RuntimeError("Tab not found")
             return {
                 "action": params.get("action", ""),
                 "workspace_id": WORKSPACE_ID,
@@ -88,7 +100,15 @@ class FakeCmuxHandler(socketserver.StreamRequestHandler):
             line = self.rfile.readline()
             if not line:
                 return
-            request = json.loads(line.decode("utf-8"))
+            decoded = line.decode("utf-8").rstrip("\r\n")
+            if decoded.startswith("auth "):
+                self.wfile.write(b"OK\n")
+                self.wfile.flush()
+                continue
+            capability_prefix = "_cmux_capability_v1 "
+            if decoded.startswith(capability_prefix):
+                decoded = decoded[len(capability_prefix):].split(" ", 1)[-1]
+            request = json.loads(decoded)
             try:
                 result = self.server.state.handle(  # type: ignore[attr-defined]
                     request["method"],
@@ -295,6 +315,57 @@ def main() -> int:
                 state,
                 "tab.action",
                 {"action": "duplicate", "workspace_id": WORKSPACE_ID, "surface_id": SURFACE_ID, "focus": False},
+            )
+
+            run_cli(
+                cli,
+                socket_path,
+                [
+                    "tab-action",
+                    "--action",
+                    "rename",
+                    "--workspace",
+                    WORKSPACE_ID,
+                    "--tab",
+                    "tab:1",
+                    "--title",
+                    "remote agent",
+                ],
+            )
+            assert_last_call(
+                state,
+                "tab.action",
+                {
+                    "action": "rename",
+                    "workspace_id": WORKSPACE_ID,
+                    "surface_id": SURFACE_ID,
+                    "title": "remote agent",
+                    "focus": False,
+                },
+            )
+
+            run_cli(
+                cli,
+                socket_path,
+                [
+                    "tab-action",
+                    "--action",
+                    "new-terminal-right",
+                    "--workspace",
+                    WORKSPACE_ID,
+                    "--surface",
+                    "surface:1",
+                ],
+            )
+            assert_last_call(
+                state,
+                "tab.action",
+                {
+                    "action": "new_terminal_right",
+                    "workspace_id": WORKSPACE_ID,
+                    "surface_id": SURFACE_ID,
+                    "focus": False,
+                },
             )
 
             run_cli(cli, socket_path, ["split-off", "--workspace", WORKSPACE_ID, "--surface", SURFACE_ID, "down"])


### PR DESCRIPTION
## What changed

- resolve `surface:N` / `tab:N` through the explicitly supplied workspace before sending `tab.action`
- cover both background-workspace `rename` and `new-terminal-right`
- preserve the current workspace and focus

This fixes the shared ref-resolution failure that made native remote-attach tabs return `Tab not found` unless their workspace was focused. It deliberately does not add another layout schema or change `open` behavior.

## Validation

- regression proof: the new behavioral test fails against the installed pre-fix CLI with `fake_error: Tab not found`
- tagged macOS build: https://github.com/krandder/cmux/actions/runs/31859203389
- bundled-CLI contract test: `PASS: CLI layout commands default to focus=false and split-off uses v2`
- isolated dogfood: created background `workspace:2`, renamed `surface:2`, ran `new-terminal-right`, renamed `surface:3`, and sent commands to both while active focus remained `workspace:1/surface:1`
- static gates: diff check, Python compile, strict test determinism, test wiring, pbxproj normalization, package grouping, and Package.resolved policy
- localization audit: no new user-facing string; the existing error key has English and Japanese entries

Local standalone `swiftc -frontend -parse` is unavailable because this Mac only has CommandLineTools with duplicate SwiftBridging module maps; the tagged Xcode 26 build compiled the CLI successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab actions in background workspaces by resolving tab/surface refs within the `--workspace` provided. Previously refs were validated only in the active window, so `tab-action --workspace` often failed; now resolution happens in the target workspace with a clear “Surface not found in workspace” error.

- Parser resolves refs in the specified workspace first; it falls back to window-only checks otherwise. `validateSurfaceHandleInWindow` no longer accepts a workspace and reports only window-scope errors.
- `matchingSurfaceHandleInWorkspace` now takes an optional `windowHandle` and calls `surface.list` with `workspace_id` and optional `window_id`.
- Tests add `surface.list`, auth/capability handling, and enforce workspace-scoped resolution. They cover `tab-action` for `rename` and `new-terminal-right` and assert the correct `surface_id` (else “Tab not found”).

<sup>Written for commit eafc6217f92df664642bb874ce790bb449639f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface selection by validating handles within the active workspace.
  * Added a clearer localized not-found error when a requested surface cannot be found.
  * Improved window-aware surface listing for more accurate command targeting.

* **CLI Improvements**
  * Added reliable support for renaming tabs and opening a new terminal to the right.
  * Actions now use normalized parameters and remain unfocused by default unless explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->