### PR TITLE
Speed up Blacksmith reload builds with warm caches

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -115,6 +115,9 @@ jobs:
           # resolve/build instead of consuming stale absolute paths.
           workspace_digest="$(printf '%s' "$GITHUB_WORKSPACE" | shasum -a 256 | awk '{ print substr($1, 1, 12) }')"
           workspace_key="workspace-${workspace_digest}"
+          runner_os="$(printf '%s' "$(uname -s)" | tr -c 'A-Za-z0-9._-' '-')"
+          runner_arch="$(printf '%s' "$(uname -m)" | tr -c 'A-Za-z0-9._-' '-')"
+          runner_key="${runner_os}-${runner_arch}"
 
           resolved_file="cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
           source_sha="$(git rev-parse HEAD)"
@@ -122,7 +125,9 @@ jobs:
           # source prefix lets a cold retry publish a newer repaired entry.
           cache_run_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           spm_prefix="reload-build-macos-spm-v2-${xcode_key}-${workspace_key}-"
-          derived_prefix="reload-build-macos-deriveddata-v3-${xcode_key}-${workspace_key}-"
+          # DerivedData contains ONLY_ACTIVE_ARCH products and object files;
+          # never restore those across OS/architecture changes.
+          derived_prefix="reload-build-macos-deriveddata-v3-${xcode_key}-${runner_key}-${workspace_key}-"
           if [ -f "$resolved_file" ]; then
             resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
             spm_cache_enabled=true
@@ -142,6 +147,7 @@ jobs:
             echo "xcode_key=$xcode_key"
             echo "branch_key=$branch_key"
             echo "workspace_key=$workspace_key"
+            echo "runner_key=$runner_key"
             echo "source_sha=$source_sha"
             echo "spm_cache_enabled=$spm_cache_enabled"
             echo "spm_prefix=$spm_prefix"
@@ -194,6 +200,10 @@ jobs:
       - name: Build fallback GhosttyKit
         if: ${{ steps.ghosttykit_prebuilt.outputs.available != 'true' }}
         id: ghosttykit_fallback
+        env:
+          # The bounded download step already proved the prebuilt path failed;
+          # do not let ensure-ghosttykit retry that URL with its long defaults.
+          CMUX_GHOSTTYKIT_NO_PREBUILT: "1"
         run: |
           set -euo pipefail
           start=$(date +%s)
@@ -709,6 +719,7 @@ jobs:
           CACHE_XCODE_KEY: ${{ steps.cache_meta.outputs.xcode_key }}
           CACHE_BRANCH_KEY: ${{ steps.cache_meta.outputs.branch_key }}
           CACHE_WORKSPACE_KEY: ${{ steps.cache_meta.outputs.workspace_key }}
+          CACHE_RUNNER_KEY: ${{ steps.cache_meta.outputs.runner_key }}
           SPM_CACHE_PRIMARY_KEY: ${{ steps.cache_meta.outputs.spm_key }}
           SPM_CACHE_STATUS: ${{ steps.spm_sanitize.outputs.status || 'not_applicable' }}
           SPM_CACHE_EXACT_HIT: ${{ steps.spm_sanitize.outputs.status == 'exact_hit' }}
@@ -767,6 +778,7 @@ jobs:
               "cache_xcode_key": os.environ.get("CACHE_XCODE_KEY", ""),
               "cache_branch_key": os.environ.get("CACHE_BRANCH_KEY", ""),
               "cache_workspace_key": os.environ.get("CACHE_WORKSPACE_KEY", ""),
+              "cache_runner_key": os.environ.get("CACHE_RUNNER_KEY", ""),
               "spm_cache_primary_key": os.environ.get("SPM_CACHE_PRIMARY_KEY", ""),
               "spm_cache_status": spm_status,
               "spm_cache_hit": spm_status in {"exact_hit", "fallback_hit"},

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -114,7 +114,7 @@ jobs:
           resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
           source_sha="$(git rev-parse HEAD)"
           spm_prefix="reload-build-macos-spm-v1-${xcode_key}-"
-          derived_prefix="reload-build-macos-deriveddata-v1-${xcode_key}-"
+          derived_prefix="reload-build-macos-deriveddata-v2-${xcode_key}-"
 
           {
             echo "xcode_key=$xcode_key"
@@ -234,10 +234,12 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          # Cache compiler state only. Product bundles, archives, indexes, logs,
-          # and SourcePackages are deliberately excluded to bound archive growth.
+          # Keep the build database, compiler outputs, and Debug products that
+          # Xcode needs for a true incremental build. Archives, indexes, logs,
+          # SourcePackages, and every non-Debug product remain excluded.
           path: |
             .ci-reload-derived-data/Build/Intermediates.noindex
+            .ci-reload-derived-data/Build/Products/Debug
             .ci-reload-derived-data/ModuleCache.noindex
             .ci-reload-derived-data/SDKStatCaches.noindex
           key: ${{ steps.cache_meta.outputs.derived_data_key }}
@@ -279,6 +281,46 @@ jobs:
             echo "exact_hit=$cache_hit"
             echo "matched_key=$matched_key"
           } >> "$GITHUB_OUTPUT"
+
+      # actions/checkout gives every tracked source a fresh mtime, newer than
+      # restored compiler outputs. Xcode then recompiles an exact cache hit as
+      # if it were cold. Derive a stable, pre-2020 mtime from each Git blob id:
+      # unchanged files stay unchanged across runs, while changed blobs receive
+      # a different file signature and are still invalidated correctly.
+      - name: Normalize tracked source mtimes for Xcode
+        if: ${{ inputs.platform == 'macos' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import subprocess
+
+          # 2001-01-01 plus at most fifteen years keeps source mtimes safely
+          # behind newly generated outputs while preserving nanosecond entropy.
+          base_seconds = 978_307_200
+          span_seconds = 15 * 365 * 24 * 60 * 60
+          records = subprocess.check_output(
+              ["git", "ls-files", "--recurse-submodules", "--stage", "-z"]
+          ).split(b"\0")
+          normalized = 0
+          for record in records:
+              if not record:
+                  continue
+              metadata, raw_path = record.split(b"\t", 1)
+              mode, object_id, stage = metadata.split()
+              if mode == b"160000" or stage != b"0":
+                  continue
+              path = os.fsdecode(raw_path)
+              if not os.path.lexists(path):
+                  continue
+              digest = object_id.decode("ascii")
+              seconds = base_seconds + int(digest[:12], 16) % span_seconds
+              nanoseconds = int(digest[12:20], 16) % 1_000_000_000
+              mtime_ns = seconds * 1_000_000_000 + nanoseconds
+              os.utime(path, ns=(mtime_ns, mtime_ns), follow_symlinks=False)
+              normalized += 1
+          print(f"normalized {normalized} Git-tracked source mtimes")
+          PY
 
       - name: Mark deps-ready
         id: t1
@@ -522,9 +564,10 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          # Match the bounded restore set; never upload app products or archives.
+          # Match the bounded restore set; only Debug products are included.
           path: |
             .ci-reload-derived-data/Build/Intermediates.noindex
+            .ci-reload-derived-data/Build/Products/Debug
             .ci-reload-derived-data/ModuleCache.noindex
             .ci-reload-derived-data/SDKStatCaches.noindex
           key: ${{ steps.cache_meta.outputs.derived_data_key }}
@@ -675,6 +718,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reload-${{ inputs.tag }}-${{ inputs.platform }}

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -111,18 +111,39 @@ jobs:
           fi
 
           resolved_file="cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
-          resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
           source_sha="$(git rev-parse HEAD)"
-          spm_prefix="reload-build-macos-spm-v1-${xcode_key}-"
-          derived_prefix="reload-build-macos-deriveddata-v2-${xcode_key}-"
+          # Cache entries are immutable. A run-scoped save key plus a stable
+          # source prefix lets a cold retry publish a newer repaired entry.
+          cache_run_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          spm_prefix="reload-build-macos-spm-v2-${xcode_key}-"
+          derived_prefix="reload-build-macos-deriveddata-v3-${xcode_key}-"
+          if [ -f "$resolved_file" ]; then
+            resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
+            spm_cache_enabled=true
+            spm_key_base="${spm_prefix}${resolved_hash}"
+            spm_key="${spm_key_base}-run-${cache_run_key}"
+            spm_source_prefix="${spm_key_base}-run-"
+          else
+            echo "::warning::$resolved_file absent in source ref; disabling the SPM cache"
+            spm_cache_enabled=false
+            spm_key_base=""
+            spm_key=""
+            spm_source_prefix=""
+          fi
+          derived_data_key_base="${derived_prefix}${branch_key}-${source_sha}"
 
           {
             echo "xcode_key=$xcode_key"
             echo "branch_key=$branch_key"
             echo "source_sha=$source_sha"
+            echo "spm_cache_enabled=$spm_cache_enabled"
             echo "spm_prefix=$spm_prefix"
-            echo "spm_key=${spm_prefix}${resolved_hash}"
-            echo "derived_data_key=${derived_prefix}${branch_key}-${source_sha}"
+            echo "spm_key_base=$spm_key_base"
+            echo "spm_key=$spm_key"
+            echo "spm_source_prefix=$spm_source_prefix"
+            echo "derived_data_key_base=$derived_data_key_base"
+            echo "derived_data_key=${derived_data_key_base}-run-${cache_run_key}"
+            echo "derived_data_source_prefix=${derived_data_key_base}-run-"
             echo "derived_data_branch_prefix=${derived_prefix}${branch_key}-"
             echo "derived_data_main_prefix=${derived_prefix}main-"
           } >> "$GITHUB_OUTPUT"
@@ -170,24 +191,26 @@ jobs:
         run: test -d GhosttyKit.xcframework
 
       - name: Start SPM cache restore timer
-        if: ${{ inputs.platform == 'macos' }}
+        if: ${{ inputs.platform == 'macos' && steps.cache_meta.outputs.spm_cache_enabled == 'true' }}
         id: spm_restore_start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Restore SPM SourcePackages cache
-        if: ${{ inputs.platform == 'macos' }}
+        if: ${{ inputs.platform == 'macos' && steps.cache_meta.outputs.spm_cache_enabled == 'true' }}
         id: restore_spm
         continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
           key: ${{ steps.cache_meta.outputs.spm_key }}
-          restore-keys: ${{ steps.cache_meta.outputs.spm_prefix }}
+          restore-keys: ${{ steps.cache_meta.outputs.spm_source_prefix }}
 
       - name: Finish SPM cache restore
         if: ${{ always() && inputs.platform == 'macos' }}
         id: spm_restore
         env:
+          CACHE_ENABLED: ${{ steps.cache_meta.outputs.spm_cache_enabled }}
+          CACHE_SOURCE_PREFIX: ${{ steps.cache_meta.outputs.spm_source_prefix }}
           START_EPOCH: ${{ steps.spm_restore_start.outputs.epoch }}
           CACHE_OUTCOME: ${{ steps.restore_spm.outcome }}
           CACHE_HIT: ${{ steps.restore_spm.outputs.cache-hit }}
@@ -201,11 +224,16 @@ jobs:
           fi
           cache_hit=${CACHE_HIT:-false}
           matched_key=${CACHE_MATCHED_KEY:-}
-          if [ "${CACHE_OUTCOME:-failure}" != "success" ]; then
+          exact_hit=false
+          if [ "${CACHE_ENABLED:-false}" != "true" ]; then
+            status=disabled_missing_resolved
+            rm -rf "$GITHUB_WORKSPACE/.ci-source-packages"
+          elif [ "${CACHE_OUTCOME:-failure}" != "success" ]; then
             status=restore_error
             rm -rf "$GITHUB_WORKSPACE/.ci-source-packages"
-          elif [ "$cache_hit" = "true" ]; then
+          elif [ "$cache_hit" = "true" ] || { [ -n "${CACHE_SOURCE_PREFIX:-}" ] && [[ "$matched_key" == "$CACHE_SOURCE_PREFIX"* ]]; }; then
             status=exact_hit
+            exact_hit=true
           elif [ -n "$matched_key" ]; then
             status=fallback_hit
           else
@@ -215,13 +243,38 @@ jobs:
           {
             echo "seconds=$(( now - start ))"
             echo "status=$status"
-            echo "exact_hit=$cache_hit"
+            echo "exact_hit=$exact_hit"
             echo "matched_key=$matched_key"
           } >> "$GITHUB_OUTPUT"
 
       - name: Sanitize restored SPM cache
         if: ${{ inputs.platform == 'macos' }}
-        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+        id: spm_sanitize
+        env:
+          CACHE_ENABLED: ${{ steps.cache_meta.outputs.spm_cache_enabled }}
+          CACHE_STATUS: ${{ steps.spm_restore.outputs.status }}
+        run: |
+          set -euo pipefail
+          status=${CACHE_STATUS:-restore_error}
+          discarded=false
+          sanitizer=scripts/ci/sanitize-xcode-source-packages-cache.py
+          if [ "${CACHE_ENABLED:-false}" != "true" ]; then
+            status=disabled_missing_resolved
+          elif [ ! -f "$sanitizer" ]; then
+            echo "::warning::$sanitizer absent in source ref; discarding the restored SPM cache"
+            status=sanitize_error
+            discarded=true
+          elif ! python3 "$sanitizer" .ci-source-packages; then
+            echo "::warning::SPM cache sanitize failed; discarding it and building cold"
+            status=sanitize_error
+            discarded=true
+          fi
+          if [ "$discarded" = "true" ]; then
+            rm -rf "$GITHUB_WORKSPACE/.ci-source-packages"
+            mkdir -p "$GITHUB_WORKSPACE/.ci-source-packages"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "discarded=$discarded" >> "$GITHUB_OUTPUT"
 
       - name: Start DerivedData cache restore timer
         if: ${{ inputs.platform == 'macos' }}
@@ -244,6 +297,7 @@ jobs:
             .ci-reload-derived-data/SDKStatCaches.noindex
           key: ${{ steps.cache_meta.outputs.derived_data_key }}
           restore-keys: |
+            ${{ steps.cache_meta.outputs.derived_data_source_prefix }}
             ${{ steps.cache_meta.outputs.derived_data_branch_prefix }}
             ${{ steps.cache_meta.outputs.derived_data_main_prefix }}
 
@@ -251,6 +305,7 @@ jobs:
         if: ${{ always() && inputs.platform == 'macos' }}
         id: derived_data_restore
         env:
+          CACHE_SOURCE_PREFIX: ${{ steps.cache_meta.outputs.derived_data_source_prefix }}
           START_EPOCH: ${{ steps.derived_data_restore_start.outputs.epoch }}
           CACHE_OUTCOME: ${{ steps.restore_derived_data.outcome }}
           CACHE_HIT: ${{ steps.restore_derived_data.outputs.cache-hit }}
@@ -264,11 +319,13 @@ jobs:
           fi
           cache_hit=${CACHE_HIT:-false}
           matched_key=${CACHE_MATCHED_KEY:-}
+          exact_hit=false
           if [ "${CACHE_OUTCOME:-failure}" != "success" ]; then
             status=restore_error
             rm -rf "$GITHUB_WORKSPACE/.ci-reload-derived-data"
-          elif [ "$cache_hit" = "true" ]; then
+          elif [ "$cache_hit" = "true" ] || { [ -n "${CACHE_SOURCE_PREFIX:-}" ] && [[ "$matched_key" == "$CACHE_SOURCE_PREFIX"* ]]; }; then
             status=exact_hit
+            exact_hit=true
           elif [ -n "$matched_key" ]; then
             status=fallback_hit
           else
@@ -278,7 +335,7 @@ jobs:
           {
             echo "seconds=$(( now - start ))"
             echo "status=$status"
-            echo "exact_hit=$cache_hit"
+            echo "exact_hit=$exact_hit"
             echo "matched_key=$matched_key"
           } >> "$GITHUB_OUTPUT"
 
@@ -334,7 +391,7 @@ jobs:
           BUILD_TAG: ${{ inputs.tag }}
           CMUX_GHOSTTYKIT_PREPROVISIONED: "1"
           CMUX_SOURCE_PACKAGES_DIR: ${{ github.workspace }}/.ci-source-packages
-          SPM_CACHE_STATUS: ${{ steps.spm_restore.outputs.status }}
+          SPM_CACHE_STATUS: ${{ steps.spm_sanitize.outputs.status }}
           DERIVED_DATA_CACHE_STATUS: ${{ steps.derived_data_restore.outputs.status }}
         run: |
           set -euo pipefail
@@ -510,12 +567,12 @@ jobs:
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Start SPM cache save timer
-        if: ${{ success() && inputs.platform == 'macos' && steps.restore_spm.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.platform == 'macos' && steps.cache_meta.outputs.spm_cache_enabled == 'true' && (steps.spm_restore.outputs.exact_hit != 'true' || steps.spm_sanitize.outputs.discarded == 'true' || steps.build_macos.outputs.cache_retry == 'true') }}
         id: spm_save_start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Save SPM SourcePackages cache
-        if: ${{ success() && inputs.platform == 'macos' && steps.restore_spm.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.platform == 'macos' && steps.cache_meta.outputs.spm_cache_enabled == 'true' && (steps.spm_restore.outputs.exact_hit != 'true' || steps.spm_sanitize.outputs.discarded == 'true' || steps.build_macos.outputs.cache_retry == 'true') }}
         id: save_spm
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -527,9 +584,10 @@ jobs:
         if: ${{ always() && inputs.platform == 'macos' }}
         id: spm_save
         env:
+          CACHE_ENABLED: ${{ steps.cache_meta.outputs.spm_cache_enabled }}
           START_EPOCH: ${{ steps.spm_save_start.outputs.epoch }}
           SAVE_OUTCOME: ${{ steps.save_spm.outcome }}
-          RESTORE_EXACT_HIT: ${{ steps.restore_spm.outputs.cache-hit }}
+          RESTORE_EXACT_HIT: ${{ steps.spm_restore.outputs.exact_hit }}
         run: |
           set -euo pipefail
           now=$(date +%s)
@@ -543,7 +601,9 @@ jobs:
             success) status=saved ;;
             failure) status=save_error ;;
             *)
-              if [ "${RESTORE_EXACT_HIT:-false}" = "true" ]; then
+              if [ "${CACHE_ENABLED:-false}" != "true" ]; then
+                status=skipped_disabled
+              elif [ "${RESTORE_EXACT_HIT:-false}" = "true" ]; then
                 status=skipped_exact_hit
               else
                 status=skipped
@@ -554,12 +614,12 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
 
       - name: Start DerivedData cache save timer
-        if: ${{ success() && inputs.platform == 'macos' && steps.restore_derived_data.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.platform == 'macos' && (steps.derived_data_restore.outputs.exact_hit != 'true' || steps.build_macos.outputs.cache_retry == 'true') }}
         id: derived_data_save_start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Save DerivedData cache
-        if: ${{ success() && inputs.platform == 'macos' && steps.restore_derived_data.outputs.cache-hit != 'true' }}
+        if: ${{ success() && inputs.platform == 'macos' && (steps.derived_data_restore.outputs.exact_hit != 'true' || steps.build_macos.outputs.cache_retry == 'true') }}
         id: save_derived_data
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -578,7 +638,7 @@ jobs:
         env:
           START_EPOCH: ${{ steps.derived_data_save_start.outputs.epoch }}
           SAVE_OUTCOME: ${{ steps.save_derived_data.outcome }}
-          RESTORE_EXACT_HIT: ${{ steps.restore_derived_data.outputs.cache-hit }}
+          RESTORE_EXACT_HIT: ${{ steps.derived_data_restore.outputs.exact_hit }}
         run: |
           set -euo pipefail
           now=$(date +%s)
@@ -619,8 +679,8 @@ jobs:
           CACHE_XCODE_KEY: ${{ steps.cache_meta.outputs.xcode_key }}
           CACHE_BRANCH_KEY: ${{ steps.cache_meta.outputs.branch_key }}
           SPM_CACHE_PRIMARY_KEY: ${{ steps.cache_meta.outputs.spm_key }}
-          SPM_CACHE_STATUS: ${{ steps.spm_restore.outputs.status || 'not_applicable' }}
-          SPM_CACHE_EXACT_HIT: ${{ steps.spm_restore.outputs.exact_hit || 'false' }}
+          SPM_CACHE_STATUS: ${{ steps.spm_sanitize.outputs.status || 'not_applicable' }}
+          SPM_CACHE_EXACT_HIT: ${{ steps.spm_sanitize.outputs.status == 'exact_hit' }}
           SPM_CACHE_MATCHED_KEY: ${{ steps.spm_restore.outputs.matched_key }}
           SPM_CACHE_RESTORE_OUTCOME: ${{ steps.restore_spm.outcome || 'not_applicable' }}
           SPM_CACHE_RESTORE_SECONDS: ${{ steps.spm_restore.outputs.seconds || '0' }}

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -163,7 +163,14 @@ jobs:
         run: |
           set -euo pipefail
           start=$(date +%s)
-          if ./scripts/download-prebuilt-ghosttykit.sh; then
+          # Keep a transient release outage from consuming the whole 60-minute
+          # job before the Zig-backed fallback gets a chance to run. The script
+          # still owns checksum/archive validation and preserves its normal
+          # defaults for local and fleet callers.
+          if GHOSTTYKIT_DOWNLOAD_RETRIES=2 \
+            GHOSTTYKIT_DOWNLOAD_RETRY_DELAY=5 \
+            GHOSTTYKIT_DOWNLOAD_MAX_TIME=60 \
+            ./scripts/download-prebuilt-ghosttykit.sh; then
             available=true
           else
             available=false
@@ -691,7 +698,7 @@ jobs:
           TIMING_TAG: ${{ inputs.tag }}
           TIMING_PLATFORM: ${{ inputs.platform }}
           TIMING_RUNNER: ${{ inputs.runner }}
-          TIMING_REF: ${{ inputs.ref }}
+          TIMING_REF: ${{ inputs.ref || github.ref }}
           TIMING_T0: ${{ steps.t0.outputs.epoch || '0' }}
           TIMING_T1: ${{ steps.t1.outputs.epoch || '0' }}
           TIMING_T2: ${{ steps.t2.outputs.epoch || '0' }}
@@ -742,6 +749,7 @@ jobs:
           t1 = integer("TIMING_T1")
           t2 = integer("TIMING_T2")
           now = integer("TIMING_NOW")
+          timing_clock_valid = t0 > 0
           spm_status = os.environ["SPM_CACHE_STATUS"]
           derived_status = os.environ["DERIVED_DATA_CACHE_STATUS"]
           payload = {
@@ -749,9 +757,9 @@ jobs:
               "platform": os.environ["TIMING_PLATFORM"],
               "runner": os.environ["TIMING_RUNNER"],
               "ref": os.environ["TIMING_REF"],
-              "deps_seconds": t1 - t0 if t1 > t0 else 0,
-              "build_seconds": t2 - t1 if t2 > t1 else 0,
-              "post_checkout_total_seconds": now - t0 if now > t0 else 0,
+              "deps_seconds": t1 - t0 if timing_clock_valid and t1 > t0 else 0,
+              "build_seconds": t2 - t1 if timing_clock_valid and t1 > t0 and t2 > t1 else 0,
+              "post_checkout_total_seconds": now - t0 if timing_clock_valid and now > t0 else 0,
               "ghosttykit_prebuilt": boolean("GHOSTTYKIT_PREBUILT"),
               "ghosttykit_download_seconds": integer("GHOSTTYKIT_DOWNLOAD_SECONDS"),
               "zig_install_seconds": integer("ZIG_INSTALL_SECONDS"),
@@ -785,9 +793,21 @@ jobs:
           t0=${TIMING_T0:-0}
           t1=${TIMING_T1:-0}
           t2=${TIMING_T2:-0}
-          deps_seconds=$(( t1 > t0 ? t1 - t0 : 0 ))
-          build_seconds=$(( t2 > t1 ? t2 - t1 : 0 ))
-          total_seconds=$(( now > t0 ? now - t0 : 0 ))
+          if (( t0 > 0 && t1 > t0 )); then
+            deps_seconds=$(( t1 - t0 ))
+          else
+            deps_seconds=0
+          fi
+          if (( t0 > 0 && t1 > t0 && t2 > t1 )); then
+            build_seconds=$(( t2 - t1 ))
+          else
+            build_seconds=0
+          fi
+          if (( t0 > 0 && now > t0 )); then
+            total_seconds=$(( now - t0 ))
+          else
+            total_seconds=0
+          fi
           {
             echo "### reload-build timings"
             echo ""

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -116,8 +116,10 @@ jobs:
           workspace_digest="$(printf '%s' "$GITHUB_WORKSPACE" | shasum -a 256 | awk '{ print substr($1, 1, 12) }')"
           workspace_key="workspace-${workspace_digest}"
           runner_os="$(printf '%s' "$(uname -s)" | tr -c 'A-Za-z0-9._-' '-')"
+          runner_os_version="$(sw_vers -productVersion 2>/dev/null || uname -r)"
+          runner_os_version="$(printf '%s' "$runner_os_version" | tr -c 'A-Za-z0-9._-' '-')"
           runner_arch="$(printf '%s' "$(uname -m)" | tr -c 'A-Za-z0-9._-' '-')"
-          runner_key="${runner_os}-${runner_arch}"
+          runner_key="${runner_os}-${runner_os_version}-${runner_arch}"
 
           resolved_file="cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
           source_sha="$(git rev-parse HEAD)"

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -109,14 +109,20 @@ jobs:
           else
             branch_key="${branch_slug:0:48}-${branch_digest}"
           fi
+          # Xcode's SourcePackages workspace state and DerivedData build
+          # database contain absolute checkout paths. Keep exact-state caches
+          # tied to the path contract; a different runner workspace must cold
+          # resolve/build instead of consuming stale absolute paths.
+          workspace_digest="$(printf '%s' "$GITHUB_WORKSPACE" | shasum -a 256 | awk '{ print substr($1, 1, 12) }')"
+          workspace_key="workspace-${workspace_digest}"
 
           resolved_file="cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
           source_sha="$(git rev-parse HEAD)"
           # Cache entries are immutable. A run-scoped save key plus a stable
           # source prefix lets a cold retry publish a newer repaired entry.
           cache_run_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          spm_prefix="reload-build-macos-spm-v2-${xcode_key}-"
-          derived_prefix="reload-build-macos-deriveddata-v3-${xcode_key}-"
+          spm_prefix="reload-build-macos-spm-v2-${xcode_key}-${workspace_key}-"
+          derived_prefix="reload-build-macos-deriveddata-v3-${xcode_key}-${workspace_key}-"
           if [ -f "$resolved_file" ]; then
             resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
             spm_cache_enabled=true
@@ -135,6 +141,7 @@ jobs:
           {
             echo "xcode_key=$xcode_key"
             echo "branch_key=$branch_key"
+            echo "workspace_key=$workspace_key"
             echo "source_sha=$source_sha"
             echo "spm_cache_enabled=$spm_cache_enabled"
             echo "spm_prefix=$spm_prefix"
@@ -694,6 +701,7 @@ jobs:
           GHOSTTYKIT_FALLBACK_SECONDS: ${{ steps.ghosttykit_fallback.outputs.seconds || '0' }}
           CACHE_XCODE_KEY: ${{ steps.cache_meta.outputs.xcode_key }}
           CACHE_BRANCH_KEY: ${{ steps.cache_meta.outputs.branch_key }}
+          CACHE_WORKSPACE_KEY: ${{ steps.cache_meta.outputs.workspace_key }}
           SPM_CACHE_PRIMARY_KEY: ${{ steps.cache_meta.outputs.spm_key }}
           SPM_CACHE_STATUS: ${{ steps.spm_sanitize.outputs.status || 'not_applicable' }}
           SPM_CACHE_EXACT_HIT: ${{ steps.spm_sanitize.outputs.status == 'exact_hit' }}
@@ -750,6 +758,7 @@ jobs:
               "ghosttykit_fallback_seconds": integer("GHOSTTYKIT_FALLBACK_SECONDS"),
               "cache_xcode_key": os.environ.get("CACHE_XCODE_KEY", ""),
               "cache_branch_key": os.environ.get("CACHE_BRANCH_KEY", ""),
+              "cache_workspace_key": os.environ.get("CACHE_WORKSPACE_KEY", ""),
               "spm_cache_primary_key": os.environ.get("SPM_CACHE_PRIMARY_KEY", ""),
               "spm_cache_status": spm_status,
               "spm_cache_hit": spm_status in {"exact_hit", "fallback_hit"},

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -63,6 +63,9 @@ jobs:
     env:
       # The ghostty CLI helper zig build is skipped; GhosttyKit comes prebuilt.
       CMUX_SKIP_ZIG_BUILD: "1"
+      # A degraded cache must lose to a cold build instead of stalling this
+      # latency-sensitive lane for actions/cache's ten-minute default.
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
       SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"
     steps:
       - name: Checkout source ref
@@ -80,12 +83,202 @@ jobs:
           set -euo pipefail
           ./scripts/select-ci-xcode.sh
 
-      - name: Install zig
-        run: ./scripts/install-zig-ci.sh
-
-      - name: Provision GhosttyKit (macOS)
+      - name: Prepare macOS cache metadata
         if: ${{ inputs.platform == 'macos' }}
-        run: ./scripts/download-prebuilt-ghosttykit.sh || ./scripts/ensure-ghosttykit.sh
+        id: cache_meta
+        env:
+          SOURCE_REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          xcode_version="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
+          xcode_build="$(xcodebuild -version | awk 'NR == 2 { print $3 }')"
+          xcode_key="$(printf 'xcode-%s-%s' "$xcode_version" "$xcode_build" | tr -c 'A-Za-z0-9._-' '-')"
+
+          branch_name="${SOURCE_REF#refs/heads/}"
+          branch_name="${branch_name#refs/tags/}"
+          if [ -z "$branch_name" ]; then
+            branch_name="$(git branch --show-current)"
+          fi
+          if [ -z "$branch_name" ]; then
+            branch_name="detached"
+          fi
+          branch_slug="$(printf '%s' "$branch_name" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+          branch_digest="$(printf '%s' "$branch_name" | shasum -a 256 | awk '{ print substr($1, 1, 12) }')"
+          if [ "$branch_name" = "main" ]; then
+            branch_key="main"
+          else
+            branch_key="${branch_slug:0:48}-${branch_digest}"
+          fi
+
+          resolved_file="cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          resolved_hash="$(shasum -a 256 "$resolved_file" | awk '{ print $1 }')"
+          source_sha="$(git rev-parse HEAD)"
+          spm_prefix="reload-build-macos-spm-v1-${xcode_key}-"
+          derived_prefix="reload-build-macos-deriveddata-v1-${xcode_key}-"
+
+          {
+            echo "xcode_key=$xcode_key"
+            echo "branch_key=$branch_key"
+            echo "source_sha=$source_sha"
+            echo "spm_prefix=$spm_prefix"
+            echo "spm_key=${spm_prefix}${resolved_hash}"
+            echo "derived_data_key=${derived_prefix}${branch_key}-${source_sha}"
+            echo "derived_data_branch_prefix=${derived_prefix}${branch_key}-"
+            echo "derived_data_main_prefix=${derived_prefix}main-"
+          } >> "$GITHUB_OUTPUT"
+
+      # The verified prebuilt is the happy path for both platforms. Zig is
+      # installed only after this attempt fails, immediately before the local
+      # ensure-ghosttykit.sh fallback that needs it.
+      - name: Download prebuilt GhosttyKit
+        id: ghosttykit_prebuilt
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          if ./scripts/download-prebuilt-ghosttykit.sh; then
+            available=true
+          else
+            available=false
+            echo "::warning::Prebuilt GhosttyKit download failed; enabling the Zig-backed fallback"
+          fi
+          end=$(date +%s)
+          echo "available=$available" >> "$GITHUB_OUTPUT"
+          echo "seconds=$(( end - start ))" >> "$GITHUB_OUTPUT"
+
+      - name: Install zig for GhosttyKit fallback
+        if: ${{ steps.ghosttykit_prebuilt.outputs.available != 'true' }}
+        id: zig_fallback
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          ./scripts/install-zig-ci.sh
+          end=$(date +%s)
+          seconds="$(awk -v start="$start" -v end="$end" 'BEGIN { print end - start }')"
+          echo "seconds=$seconds" >> "$GITHUB_OUTPUT"
+
+      - name: Build fallback GhosttyKit
+        if: ${{ steps.ghosttykit_prebuilt.outputs.available != 'true' }}
+        id: ghosttykit_fallback
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          ./scripts/ensure-ghosttykit.sh
+          end=$(date +%s)
+          echo "seconds=$(( end - start ))" >> "$GITHUB_OUTPUT"
+
+      - name: Verify provisioned GhosttyKit
+        run: test -d GhosttyKit.xcframework
+
+      - name: Start SPM cache restore timer
+        if: ${{ inputs.platform == 'macos' }}
+        id: spm_restore_start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore SPM SourcePackages cache
+        if: ${{ inputs.platform == 'macos' }}
+        id: restore_spm
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .ci-source-packages
+          key: ${{ steps.cache_meta.outputs.spm_key }}
+          restore-keys: ${{ steps.cache_meta.outputs.spm_prefix }}
+
+      - name: Finish SPM cache restore
+        if: ${{ always() && inputs.platform == 'macos' }}
+        id: spm_restore
+        env:
+          START_EPOCH: ${{ steps.spm_restore_start.outputs.epoch }}
+          CACHE_OUTCOME: ${{ steps.restore_spm.outcome }}
+          CACHE_HIT: ${{ steps.restore_spm.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.restore_spm.outputs.cache-matched-key }}
+        run: |
+          set -euo pipefail
+          now=$(date +%s)
+          start=${START_EPOCH:-0}
+          if ! [[ "$start" =~ ^[0-9]+$ ]] || [ "$start" -eq 0 ]; then
+            start=$now
+          fi
+          cache_hit=${CACHE_HIT:-false}
+          matched_key=${CACHE_MATCHED_KEY:-}
+          if [ "${CACHE_OUTCOME:-failure}" != "success" ]; then
+            status=restore_error
+            rm -rf "$GITHUB_WORKSPACE/.ci-source-packages"
+          elif [ "$cache_hit" = "true" ]; then
+            status=exact_hit
+          elif [ -n "$matched_key" ]; then
+            status=fallback_hit
+          else
+            status=miss
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/.ci-source-packages"
+          {
+            echo "seconds=$(( now - start ))"
+            echo "status=$status"
+            echo "exact_hit=$cache_hit"
+            echo "matched_key=$matched_key"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sanitize restored SPM cache
+        if: ${{ inputs.platform == 'macos' }}
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
+      - name: Start DerivedData cache restore timer
+        if: ${{ inputs.platform == 'macos' }}
+        id: derived_data_restore_start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore DerivedData cache
+        if: ${{ inputs.platform == 'macos' }}
+        id: restore_derived_data
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Cache compiler state only. Product bundles, archives, indexes, logs,
+          # and SourcePackages are deliberately excluded to bound archive growth.
+          path: |
+            .ci-reload-derived-data/Build/Intermediates.noindex
+            .ci-reload-derived-data/ModuleCache.noindex
+            .ci-reload-derived-data/SDKStatCaches.noindex
+          key: ${{ steps.cache_meta.outputs.derived_data_key }}
+          restore-keys: |
+            ${{ steps.cache_meta.outputs.derived_data_branch_prefix }}
+            ${{ steps.cache_meta.outputs.derived_data_main_prefix }}
+
+      - name: Finish DerivedData cache restore
+        if: ${{ always() && inputs.platform == 'macos' }}
+        id: derived_data_restore
+        env:
+          START_EPOCH: ${{ steps.derived_data_restore_start.outputs.epoch }}
+          CACHE_OUTCOME: ${{ steps.restore_derived_data.outcome }}
+          CACHE_HIT: ${{ steps.restore_derived_data.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.restore_derived_data.outputs.cache-matched-key }}
+        run: |
+          set -euo pipefail
+          now=$(date +%s)
+          start=${START_EPOCH:-0}
+          if ! [[ "$start" =~ ^[0-9]+$ ]] || [ "$start" -eq 0 ]; then
+            start=$now
+          fi
+          cache_hit=${CACHE_HIT:-false}
+          matched_key=${CACHE_MATCHED_KEY:-}
+          if [ "${CACHE_OUTCOME:-failure}" != "success" ]; then
+            status=restore_error
+            rm -rf "$GITHUB_WORKSPACE/.ci-reload-derived-data"
+          elif [ "$cache_hit" = "true" ]; then
+            status=exact_hit
+          elif [ -n "$matched_key" ]; then
+            status=fallback_hit
+          else
+            status=miss
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/.ci-reload-derived-data"
+          {
+            echo "seconds=$(( now - start ))"
+            echo "status=$status"
+            echo "exact_hit=$cache_hit"
+            echo "matched_key=$matched_key"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Mark deps-ready
         id: t1
@@ -95,12 +288,54 @@ jobs:
       - name: Build tagged macOS app
         if: ${{ inputs.platform == 'macos' }}
         id: build_macos
+        env:
+          BUILD_TAG: ${{ inputs.tag }}
+          CMUX_GHOSTTYKIT_PREPROVISIONED: "1"
+          CMUX_SOURCE_PACKAGES_DIR: ${{ github.workspace }}/.ci-source-packages
+          SPM_CACHE_STATUS: ${{ steps.spm_restore.outputs.status }}
+          DERIVED_DATA_CACHE_STATUS: ${{ steps.derived_data_restore.outputs.status }}
         run: |
           set -euo pipefail
           # Per-run log path: /tmp/reload.log collides across tenants on the
           # multi-tenant self-hosted fleet Macs (tee: Permission denied).
           log="$RUNNER_TEMP/reload.log"
-          ./scripts/reload.sh --tag "${{ inputs.tag }}" --swift-frontend-workaround 2>&1 | tee "$log"
+          derived_data="$GITHUB_WORKSPACE/.ci-reload-derived-data"
+          echo "cache_retry=false" >> "$GITHUB_OUTPUT"
+
+          run_reload() {
+            ./scripts/reload.sh \
+              --tag "$BUILD_TAG" \
+              --derived-data "$derived_data" \
+              --swift-frontend-workaround
+          }
+
+          set +e
+          run_reload 2>&1 | tee "$log"
+          build_status=${PIPESTATUS[0]}
+          set -e
+
+          # A successfully restored but stale/corrupt cache must cost at most
+          # one failed attempt: clear both cache roots and retry once from cold.
+          if [ "$build_status" -ne 0 ] && {
+            [ "$SPM_CACHE_STATUS" = "exact_hit" ] ||
+            [ "$SPM_CACHE_STATUS" = "fallback_hit" ] ||
+            [ "$DERIVED_DATA_CACHE_STATUS" = "exact_hit" ] ||
+            [ "$DERIVED_DATA_CACHE_STATUS" = "fallback_hit" ];
+          }; then
+            echo "::warning::Cached macOS build failed; clearing SPM and DerivedData caches and retrying cold"
+            rm -rf "$CMUX_SOURCE_PACKAGES_DIR" "$derived_data"
+            mkdir -p "$CMUX_SOURCE_PACKAGES_DIR" "$derived_data"
+            : > "$log"
+            set +e
+            run_reload 2>&1 | tee "$log"
+            build_status=${PIPESTATUS[0]}
+            set -e
+            echo "cache_retry=true" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$build_status" -ne 0 ]; then
+            exit "$build_status"
+          fi
+
           app_path="$(awk '/^App path:/{getline; sub(/^  /,""); print; exit}' "$log")"
           [ -n "$app_path" ] && [ -d "$app_path" ] || { echo "could not locate built app" >&2; exit 1; }
           echo "app_path=$app_path" >> "$GITHUB_OUTPUT"
@@ -147,6 +382,7 @@ jobs:
 
           # Match ios/scripts/reload.sh --swift-frontend-workaround. Optimized
           # Debug builds need this Xcode 26 codegen path disabled on every lane.
+          # shellcheck disable=SC2016 # Xcode expands $(inherited), not this shell.
           swift_workaround_args=(
             SWIFT_ENABLE_BATCH_MODE=NO
             DEBUG_INFORMATION_FORMAT=
@@ -162,7 +398,7 @@ jobs:
             ios_ready || { echo "iOS platform still not registered; archive would fail" >&2; exit 1; }
           fi
 
-          ./scripts/ensure-ghosttykit.sh
+          test -d GhosttyKit.xcframework
           out="$GITHUB_WORKSPACE/build"
           mkdir -p "$out"
           archive="$out/cmux-ios-$slug.xcarchive"
@@ -227,33 +463,215 @@ jobs:
           ditto "$sim_app" "$pkg/simulator/cmux.app"
           ditto -c -k "$pkg" "$GITHUB_WORKSPACE/artifact/archive.zip"
 
+      - name: Mark build-ready
+        id: t2
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Start SPM cache save timer
+        if: ${{ success() && inputs.platform == 'macos' && steps.restore_spm.outputs.cache-hit != 'true' }}
+        id: spm_save_start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Save SPM SourcePackages cache
+        if: ${{ success() && inputs.platform == 'macos' && steps.restore_spm.outputs.cache-hit != 'true' }}
+        id: save_spm
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .ci-source-packages
+          key: ${{ steps.cache_meta.outputs.spm_key }}
+
+      - name: Finish SPM cache save
+        if: ${{ always() && inputs.platform == 'macos' }}
+        id: spm_save
+        env:
+          START_EPOCH: ${{ steps.spm_save_start.outputs.epoch }}
+          SAVE_OUTCOME: ${{ steps.save_spm.outcome }}
+          RESTORE_EXACT_HIT: ${{ steps.restore_spm.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          now=$(date +%s)
+          start=${START_EPOCH:-0}
+          if [[ "$start" =~ ^[0-9]+$ ]] && [ "$start" -gt 0 ]; then
+            seconds=$(( now - start ))
+          else
+            seconds=0
+          fi
+          case "${SAVE_OUTCOME:-skipped}" in
+            success) status=saved ;;
+            failure) status=save_error ;;
+            *)
+              if [ "${RESTORE_EXACT_HIT:-false}" = "true" ]; then
+                status=skipped_exact_hit
+              else
+                status=skipped
+              fi
+              ;;
+          esac
+          echo "seconds=$seconds" >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Start DerivedData cache save timer
+        if: ${{ success() && inputs.platform == 'macos' && steps.restore_derived_data.outputs.cache-hit != 'true' }}
+        id: derived_data_save_start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Save DerivedData cache
+        if: ${{ success() && inputs.platform == 'macos' && steps.restore_derived_data.outputs.cache-hit != 'true' }}
+        id: save_derived_data
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Match the bounded restore set; never upload app products or archives.
+          path: |
+            .ci-reload-derived-data/Build/Intermediates.noindex
+            .ci-reload-derived-data/ModuleCache.noindex
+            .ci-reload-derived-data/SDKStatCaches.noindex
+          key: ${{ steps.cache_meta.outputs.derived_data_key }}
+
+      - name: Finish DerivedData cache save
+        if: ${{ always() && inputs.platform == 'macos' }}
+        id: derived_data_save
+        env:
+          START_EPOCH: ${{ steps.derived_data_save_start.outputs.epoch }}
+          SAVE_OUTCOME: ${{ steps.save_derived_data.outcome }}
+          RESTORE_EXACT_HIT: ${{ steps.restore_derived_data.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          now=$(date +%s)
+          start=${START_EPOCH:-0}
+          if [[ "$start" =~ ^[0-9]+$ ]] && [ "$start" -gt 0 ]; then
+            seconds=$(( now - start ))
+          else
+            seconds=0
+          fi
+          case "${SAVE_OUTCOME:-skipped}" in
+            success) status=saved ;;
+            failure) status=save_error ;;
+            *)
+              if [ "${RESTORE_EXACT_HIT:-false}" = "true" ]; then
+                status=skipped_exact_hit
+              else
+                status=skipped
+              fi
+              ;;
+          esac
+          echo "seconds=$seconds" >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
       - name: Write timings.json
         if: ${{ always() }}
+        env:
+          TIMING_TAG: ${{ inputs.tag }}
+          TIMING_PLATFORM: ${{ inputs.platform }}
+          TIMING_RUNNER: ${{ inputs.runner }}
+          TIMING_REF: ${{ inputs.ref }}
+          TIMING_T0: ${{ steps.t0.outputs.epoch || '0' }}
+          TIMING_T1: ${{ steps.t1.outputs.epoch || '0' }}
+          TIMING_T2: ${{ steps.t2.outputs.epoch || '0' }}
+          GHOSTTYKIT_PREBUILT: ${{ steps.ghosttykit_prebuilt.outputs.available || 'false' }}
+          GHOSTTYKIT_DOWNLOAD_SECONDS: ${{ steps.ghosttykit_prebuilt.outputs.seconds || '0' }}
+          ZIG_INSTALL_SECONDS: ${{ steps.zig_fallback.outputs.seconds || '0' }}
+          GHOSTTYKIT_FALLBACK_SECONDS: ${{ steps.ghosttykit_fallback.outputs.seconds || '0' }}
+          CACHE_XCODE_KEY: ${{ steps.cache_meta.outputs.xcode_key }}
+          CACHE_BRANCH_KEY: ${{ steps.cache_meta.outputs.branch_key }}
+          SPM_CACHE_PRIMARY_KEY: ${{ steps.cache_meta.outputs.spm_key }}
+          SPM_CACHE_STATUS: ${{ steps.spm_restore.outputs.status || 'not_applicable' }}
+          SPM_CACHE_EXACT_HIT: ${{ steps.spm_restore.outputs.exact_hit || 'false' }}
+          SPM_CACHE_MATCHED_KEY: ${{ steps.spm_restore.outputs.matched_key }}
+          SPM_CACHE_RESTORE_OUTCOME: ${{ steps.restore_spm.outcome || 'not_applicable' }}
+          SPM_CACHE_RESTORE_SECONDS: ${{ steps.spm_restore.outputs.seconds || '0' }}
+          SPM_CACHE_SAVE_STATUS: ${{ steps.spm_save.outputs.status || 'not_applicable' }}
+          SPM_CACHE_SAVE_SECONDS: ${{ steps.spm_save.outputs.seconds || '0' }}
+          DERIVED_DATA_CACHE_PRIMARY_KEY: ${{ steps.cache_meta.outputs.derived_data_key }}
+          DERIVED_DATA_CACHE_STATUS: ${{ steps.derived_data_restore.outputs.status || 'not_applicable' }}
+          DERIVED_DATA_CACHE_EXACT_HIT: ${{ steps.derived_data_restore.outputs.exact_hit || 'false' }}
+          DERIVED_DATA_CACHE_MATCHED_KEY: ${{ steps.derived_data_restore.outputs.matched_key }}
+          DERIVED_DATA_CACHE_RESTORE_OUTCOME: ${{ steps.restore_derived_data.outcome || 'not_applicable' }}
+          DERIVED_DATA_CACHE_RESTORE_SECONDS: ${{ steps.derived_data_restore.outputs.seconds || '0' }}
+          DERIVED_DATA_CACHE_SAVE_STATUS: ${{ steps.derived_data_save.outputs.status || 'not_applicable' }}
+          DERIVED_DATA_CACHE_SAVE_SECONDS: ${{ steps.derived_data_save.outputs.seconds || '0' }}
+          CACHE_COLD_RETRY: ${{ steps.build_macos.outputs.cache_retry || 'false' }}
         run: |
           set -euo pipefail
           mkdir -p artifact
           now=$(date +%s)
-          t0=${{ steps.t0.outputs.epoch }}
-          t1=${{ steps.t1.outputs.epoch || 0 }}
-          cat > artifact/timings.json <<JSON
-          {
-            "tag": "${{ inputs.tag }}",
-            "platform": "${{ inputs.platform }}",
-            "runner": "${{ inputs.runner }}",
-            "ref": "${{ inputs.ref }}",
-            "deps_seconds": $(( t1 > t0 ? t1 - t0 : 0 )),
-            "build_seconds": $(( t1 > 0 ? now - t1 : 0 )),
-            "post_checkout_total_seconds": $(( now - t0 ))
+          export TIMING_NOW=$now
+          python3 - <<'PY' > artifact/timings.json
+          import json
+          import os
+          import sys
+
+          def integer(name: str) -> int:
+              try:
+                  return int(os.environ.get(name, "0"))
+              except ValueError:
+                  return 0
+
+          def boolean(name: str) -> bool:
+              return os.environ.get(name, "false").lower() == "true"
+
+          t0 = integer("TIMING_T0")
+          t1 = integer("TIMING_T1")
+          t2 = integer("TIMING_T2")
+          now = integer("TIMING_NOW")
+          spm_status = os.environ["SPM_CACHE_STATUS"]
+          derived_status = os.environ["DERIVED_DATA_CACHE_STATUS"]
+          payload = {
+              "tag": os.environ["TIMING_TAG"],
+              "platform": os.environ["TIMING_PLATFORM"],
+              "runner": os.environ["TIMING_RUNNER"],
+              "ref": os.environ["TIMING_REF"],
+              "deps_seconds": t1 - t0 if t1 > t0 else 0,
+              "build_seconds": t2 - t1 if t2 > t1 else 0,
+              "post_checkout_total_seconds": now - t0 if now > t0 else 0,
+              "ghosttykit_prebuilt": boolean("GHOSTTYKIT_PREBUILT"),
+              "ghosttykit_download_seconds": integer("GHOSTTYKIT_DOWNLOAD_SECONDS"),
+              "zig_install_seconds": integer("ZIG_INSTALL_SECONDS"),
+              "ghosttykit_fallback_seconds": integer("GHOSTTYKIT_FALLBACK_SECONDS"),
+              "cache_xcode_key": os.environ.get("CACHE_XCODE_KEY", ""),
+              "cache_branch_key": os.environ.get("CACHE_BRANCH_KEY", ""),
+              "spm_cache_primary_key": os.environ.get("SPM_CACHE_PRIMARY_KEY", ""),
+              "spm_cache_status": spm_status,
+              "spm_cache_hit": spm_status in {"exact_hit", "fallback_hit"},
+              "spm_cache_exact_hit": boolean("SPM_CACHE_EXACT_HIT"),
+              "spm_cache_matched_key": os.environ.get("SPM_CACHE_MATCHED_KEY", ""),
+              "spm_cache_restore_outcome": os.environ["SPM_CACHE_RESTORE_OUTCOME"],
+              "spm_cache_restore_seconds": integer("SPM_CACHE_RESTORE_SECONDS"),
+              "spm_cache_save_status": os.environ["SPM_CACHE_SAVE_STATUS"],
+              "spm_cache_save_seconds": integer("SPM_CACHE_SAVE_SECONDS"),
+              "derived_data_cache_primary_key": os.environ.get("DERIVED_DATA_CACHE_PRIMARY_KEY", ""),
+              "derived_data_cache_status": derived_status,
+              "derived_data_cache_hit": derived_status in {"exact_hit", "fallback_hit"},
+              "derived_data_cache_exact_hit": boolean("DERIVED_DATA_CACHE_EXACT_HIT"),
+              "derived_data_cache_matched_key": os.environ.get("DERIVED_DATA_CACHE_MATCHED_KEY", ""),
+              "derived_data_cache_restore_outcome": os.environ["DERIVED_DATA_CACHE_RESTORE_OUTCOME"],
+              "derived_data_cache_restore_seconds": integer("DERIVED_DATA_CACHE_RESTORE_SECONDS"),
+              "derived_data_cache_save_status": os.environ["DERIVED_DATA_CACHE_SAVE_STATUS"],
+              "derived_data_cache_save_seconds": integer("DERIVED_DATA_CACHE_SAVE_SECONDS"),
+              "cache_cold_retry": boolean("CACHE_COLD_RETRY"),
           }
-          JSON
+          json.dump(payload, fp=sys.stdout, indent=2, sort_keys=True)
+          print()
+          PY
+          t0=${TIMING_T0:-0}
+          t1=${TIMING_T1:-0}
+          t2=${TIMING_T2:-0}
+          deps_seconds=$(( t1 > t0 ? t1 - t0 : 0 ))
+          build_seconds=$(( t2 > t1 ? t2 - t1 : 0 ))
+          total_seconds=$(( now > t0 ? now - t0 : 0 ))
           {
             echo "### reload-build timings"
             echo ""
-            echo "- runner: \`${{ inputs.runner }}\`"
-            echo "- platform: \`${{ inputs.platform }}\`"
-            echo "- deps: $(( t1 > t0 ? t1 - t0 : 0 ))s"
-            echo "- build: $(( t1 > 0 ? now - t1 : 0 ))s"
-            echo "- post-checkout total: $(( now - t0 ))s"
+            echo "- runner: \`$TIMING_RUNNER\`"
+            echo "- platform: \`$TIMING_PLATFORM\`"
+            echo "- deps: ${deps_seconds}s"
+            echo "- build: ${build_seconds}s"
+            echo "- SPM cache: ${SPM_CACHE_STATUS} (restore ${SPM_CACHE_RESTORE_SECONDS}s, save ${SPM_CACHE_SAVE_SECONDS}s / ${SPM_CACHE_SAVE_STATUS})"
+            echo "- DerivedData cache: ${DERIVED_DATA_CACHE_STATUS} (restore ${DERIVED_DATA_CACHE_RESTORE_SECONDS}s, save ${DERIVED_DATA_CACHE_SAVE_SECONDS}s / ${DERIVED_DATA_CACHE_SAVE_STATUS})"
+            echo "- cache-triggered cold retry: ${CACHE_COLD_RETRY}"
+            echo "- GhosttyKit prebuilt: ${GHOSTTYKIT_PREBUILT} (download ${GHOSTTYKIT_DOWNLOAD_SECONDS}s, Zig fallback ${ZIG_INSTALL_SECONDS}s)"
+            echo "- post-checkout total: ${total_seconds}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -608,6 +608,20 @@ jobs:
         id: t2
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Trim tag-specific products before DerivedData cache save
+        if: ${{ success() && inputs.platform == 'macos' }}
+        run: |
+          set -euo pipefail
+          products="$GITHUB_WORKSPACE/.ci-reload-derived-data/Build/Products/Debug"
+          [ -d "$products" ] || exit 0
+          # reload.sh stages the requested tagged app beside the stable base
+          # product. Keep only the base product in the cache; otherwise every
+          # tag accumulates another app bundle under the branch/SHA key.
+          for product in "$products"/cmux\ DEV\ *.app "$products"/.cmux\ DEV\ *.reload-*.app; do
+            [ -d "$product" ] || continue
+            [ "$(basename "$product")" = "cmux DEV.app" ] || rm -rf -- "$product"
+          done
+
       - name: Start SPM cache save timer
         if: ${{ success() && inputs.platform == 'macos' && steps.cache_meta.outputs.spm_cache_enabled == 'true' && (steps.spm_restore.outputs.exact_hit != 'true' || steps.spm_sanitize.outputs.discarded == 'true' || steps.build_macos.outputs.cache_retry == 'true') }}
         id: spm_save_start

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -260,6 +260,12 @@ jobs:
           sanitizer=scripts/ci/sanitize-xcode-source-packages-cache.py
           if [ "${CACHE_ENABLED:-false}" != "true" ]; then
             status=disabled_missing_resolved
+          elif [ "$status" = "exact_hit" ]; then
+            # The exact key is tied to Package.resolved, Xcode, source SHA, and
+            # the fixed Blacksmith checkout path. Preserve its workspace state
+            # so Xcode can reuse the resolved package graph; a bad state still
+            # trips the guarded cold retry below.
+            echo "preserving exact-hit SourcePackages workspace state"
           elif [ ! -f "$sanitizer" ]; then
             echo "::warning::$sanitizer absent in source ref; discarding the restored SPM cache"
             status=sanitize_error
@@ -402,6 +408,14 @@ jobs:
           echo "cache_retry=false" >> "$GITHUB_OUTPUT"
 
           run_reload() {
+            if [ "$SPM_CACHE_STATUS" = "exact_hit" ]; then
+              # The exact Package.resolved/state pair is safe to reuse. If it
+              # is stale or corrupt, the caller clears both caches and changes
+              # this marker before retrying from a normal cold resolve.
+              export CMUX_DISABLE_AUTOMATIC_PACKAGE_RESOLUTION=1
+            else
+              export CMUX_DISABLE_AUTOMATIC_PACKAGE_RESOLUTION=0
+            fi
             ./scripts/reload.sh \
               --tag "$BUILD_TAG" \
               --derived-data "$derived_data" \
@@ -424,6 +438,8 @@ jobs:
             echo "::warning::Cached macOS build failed; clearing SPM and DerivedData caches and retrying cold"
             rm -rf "$CMUX_SOURCE_PACKAGES_DIR" "$derived_data"
             mkdir -p "$CMUX_SOURCE_PACKAGES_DIR" "$derived_data"
+            SPM_CACHE_STATUS=miss
+            DERIVED_DATA_CACHE_STATUS=miss
             : > "$log"
             set +e
             run_reload 2>&1 | tee "$log"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ios/Config/AppStoreConnect.local.plist
 # Swift Package Manager
 .swiftpm/
 .ci-source-packages/
+.ci-reload-derived-data/
 
 # GhosttyKit binary (built from ghostty submodule via scripts/setup.sh)
 GhosttyKit.xcframework

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -701,7 +701,7 @@ select_cmux_shim_target() {
     # PATH may contain a literal ~/ prefix; expand that spelling deliberately.
     # shellcheck disable=SC2088
     if [[ "$path_entry" == "~/"* ]]; then
-      path_entry="$HOME/${path_entry#~/}"
+      path_entry="$HOME/${path_entry:2}"
     fi
     if [[ "$path_entry" == "$app_cli_dir" ]]; then
       break

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -40,7 +40,6 @@ NO_GLOBAL_CLI_LINKS="${CMUX_RELOAD_NO_GLOBAL_CLI_LINKS:-0}"
 _cmux_account_home="$(perl -e 'print((getpwuid($<))[7])' 2>/dev/null || true)"
 LAST_SOCKET_PATH_DIR="${_cmux_account_home:-$HOME}/.local/state/cmux"
 LEGACY_SOCKET_PATH_DIR="${_cmux_account_home:-$HOME}/Library/Application Support/cmux"
-AUTO_SKIP_ZIG_BUILD_REASON=""
 SWIFT_FRONTEND_WORKAROUND=0
 XCODEBUILD_STARTED=0
 XCODEBUILD_OUTPUT_VALID=0
@@ -546,13 +545,7 @@ wait_for_tag_socket_lock_release() {
 }
 
 should_skip_ghostty_cli_helper_zig_build() {
-  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
-    AUTO_SKIP_ZIG_BUILD_REASON="CMUX_SKIP_ZIG_BUILD=1"
-    return 0
-  fi
-
-  AUTO_SKIP_ZIG_BUILD_REASON=""
-  return 1
+  [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]
 }
 
 write_dev_cli_shim() {
@@ -705,6 +698,8 @@ select_cmux_shim_target() {
   IFS=':' read -r -a path_entries <<< "${PATH:-}"
   for path_entry in "${path_entries[@]}"; do
     [[ -z "$path_entry" ]] && continue
+    # PATH may contain a literal ~/ prefix; expand that spelling deliberately.
+    # shellcheck disable=SC2088
     if [[ "$path_entry" == "~/"* ]]; then
       path_entry="$HOME/${path_entry#~/}"
     fi
@@ -1038,7 +1033,7 @@ print_tag_cleanup_reminder() {
     if [[ "$path" == /tmp/cmux-* ]]; then
       tag="${path#/tmp/cmux-}"
     elif [[ "$path" == "$HOME/Library/Developer/Xcode/DerivedData/cmux-"* ]]; then
-      tag="${path#$HOME/Library/Developer/Xcode/DerivedData/cmux-}"
+      tag="${path#"$HOME"/Library/Developer/Xcode/DerivedData/cmux-}"
     else
       continue
     fi
@@ -1310,7 +1305,17 @@ trap reload_finalize EXIT
 # Tell the user we're starting (visible even though body output is redirected).
 echo "==> reload starting (tag: ${TAG}, log: ${RELOAD_LOG})" >&3
 
-"$PWD/scripts/ensure-ghosttykit.sh"
+# CI can verify/download the xcframework before deciding whether Zig is needed.
+# Fail closed if that caller assertion is inconsistent with the checkout.
+if [[ "${CMUX_GHOSTTYKIT_PREPROVISIONED:-0}" == "1" ]]; then
+  if [[ ! -d "$PWD/GhosttyKit.xcframework" ]]; then
+    echo "error: CMUX_GHOSTTYKIT_PREPROVISIONED=1 but GhosttyKit.xcframework is missing" >&2
+    exit 1
+  fi
+  echo "==> Reusing caller-provisioned GhosttyKit.xcframework"
+else
+  "$PWD/scripts/ensure-ghosttykit.sh"
+fi
 
 if should_skip_ghostty_cli_helper_zig_build; then
   export CMUX_SKIP_ZIG_BUILD=1
@@ -1358,6 +1363,7 @@ if [[ "$SWIFT_FRONTEND_WORKAROUND" -eq 1 || "${CMUX_SWIFT_FRONTEND_WORKAROUND:-}
   XCODEBUILD_ARGS+=(SWIFT_ENABLE_BATCH_MODE=NO)
   XCODEBUILD_ARGS+=(DEBUG_INFORMATION_FORMAT=)
   XCODEBUILD_ARGS+=(GCC_GENERATE_DEBUGGING_SYMBOLS=NO)
+  # shellcheck disable=SC2016 # Xcode expands $(inherited), not this shell.
   XCODEBUILD_ARGS+=('OTHER_SWIFT_FLAGS=$(inherited) -Xllvm -aarch64-enable-global-isel-at-O=-1')
 else
   SWIFT_FRONTEND_WORKAROUND_EFFECTIVE=0
@@ -1649,7 +1655,12 @@ CLI_PATH="$(dirname "$APP_PATH")/cmux"
 # Build cmuxd and ensure helper binaries are present (needed for both launch and no-launch).
 CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
 if [[ -d "$PWD/cmuxd" ]]; then
-  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
+    echo "Skipping legacy cmuxd zig build (CMUX_SKIP_ZIG_BUILD=1)"
+    CMUXD_SRC=""
+  else
+    (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+  fi
 fi
 if [[ -d "$PWD/ghostty" ]]; then
   BIN_DIR="$APP_PATH/Contents/Resources/bin"
@@ -1860,6 +1871,8 @@ if [[ "$LAUNCH" -eq 1 ]]; then
 
   # Safety: ensure only one instance is running.
   sleep 0.2
+  # macOS ships Bash 3.2 without mapfile/readarray; pgrep emits one PID per line.
+  # shellcheck disable=SC2207
   PIDS=($(pgrep -f "${APP_PATH}/Contents/MacOS/" || true))
   if [[ -n "${TAG_SLUG:-}" && "${#PIDS[@]}" -eq 0 ]]; then
     echo "error: tagged app exited immediately after launch" >&2

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1655,12 +1655,7 @@ CLI_PATH="$(dirname "$APP_PATH")/cmux"
 # Build cmuxd and ensure helper binaries are present (needed for both launch and no-launch).
 CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
 if [[ -d "$PWD/cmuxd" ]]; then
-  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
-    echo "Skipping legacy cmuxd zig build (CMUX_SKIP_ZIG_BUILD=1)"
-    CMUXD_SRC=""
-  else
-    (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
-  fi
+  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
 fi
 if [[ -d "$PWD/ghostty" ]]; then
   BIN_DIR="$APP_PATH/Contents/Resources/bin"


### PR DESCRIPTION
## Summary

- put the verified prebuilt GhosttyKit download before Zig for both macOS and iOS, installing Zig only when the download fails and `ensure-ghosttykit.sh` must build locally
- give the macOS lane fixed SourcePackages and DerivedData paths, SHA-pinned `actions/cache` restore/save steps, deterministic Git-source mtimes, and bounded Debug build outputs for real incremental reuse
- make cache failures non-fatal with a one-time cold retry, and add cache hit/miss plus restore/save timing/status fields to `timings.json` and the step summary

## Measurements

Issue baseline ([run 31860158731](https://github.com/manaflow-ai/cmux/actions/runs/31860158731), `blacksmith-6vcpu-macos-26`): 673s remote wall, including 483s build and 134s unconditional Zig install.

Final path-scoped dispatch measurements (the artifact values are `timings.json`'s post-checkout clock; Actions setup/checkout and caller download are reported separately):

| path | build | post-checkout | SPM | DerivedData | GhosttyKit | Zig |
| --- | ---: | ---: | --- | --- | --- | ---: |
| cold ([31921008301](https://github.com/manaflow-ai/cmux/actions/runs/31921008301)) | 543s | 593s | miss, restore 1s, save 6s | miss, restore 0s, save 11s | prebuilt, 3s | 0s |
| exact warm ([31921480063](https://github.com/manaflow-ai/cmux/actions/runs/31921480063)) | 151s | 192s | exact, restore 6s, save skipped | exact, restore 8s, save skipped | prebuilt, 2s | 0s |

The exact warm path is 192s post-checkout (about 3.2 minutes, under the five-minute target); the observed job wall was 218s before caller download. The true cold path removed the 134s Zig install and completed in a 620s Actions job before caller download, with only 17s of cache-save overhead. Its compile was 60s slower than the issue's 483s sample on this Blacksmith allocation, but the lane still avoids the unconditional Zig cost and the cache changes add no mandatory cold-build work beyond lookup/save. A branch-fallback proof ([31920771687](https://github.com/manaflow-ai/cmux/actions/runs/31920771687)) restored exact SPM plus fallback DerivedData and completed in 158s post-checkout.


## Live `reload-cloud.sh` validation

The authorized tagged launch through the real wrapper ([run 32074405901](https://github.com/manaflow-ai/cmux/actions/runs/32074405901)) completed successfully in **669s caller wall-clock**: dispatch 6s, remote queue+build 592s, artifact download 38s, local install/sign 5s. Its artifact recorded a 513s build, 29s deps, 0s Zig, and **SPM/DerivedData cache misses**.

The controlled exact same-ref dispatch remains 192s post-checkout (151s build), so the workflow cache implementation works when its cache scope is reachable. The live wrapper creates a unique `reload-build/...` branch and dispatches with that branch as `--ref`; the empty matched keys show that successive ephemeral refs do not see the branch-scoped caches. Sharing those caches requires a follow-up in the `cmuxterm-hq` dispatcher (dispatch the workflow from a stable ref while passing the ephemeral source through `inputs.ref`, or use a cross-ref cache backend). That control-repo change is outside this clone-only PR. The local comparison artifact is [issue-10204-build-timing-report.html](/Users/austinwang/manaflow/term/cmux9/artifacts/issue-10204-build-timing-report.html:1).

## Cache and failure behavior

- SPM key: selected Xcode version/build + root `Package.resolved` hash + a `GITHUB_WORKSPACE` digest; run-scoped saves and same-source restore prefixes repair immutable poisoned entries.
- DerivedData key: selected Xcode version/build + macOS product version + runner architecture + workspace digest + branch + source SHA, with same-branch then latest `main` restore prefixes (all under the same workspace contract).
- Fixed CI paths are `.ci-source-packages` and `.ci-reload-derived-data`; local/fleet `reload.sh` defaults are unchanged. Exact SPM hits preserve the validated workspace state and disable automatic package resolution; misses/fallbacks sanitize and resolve normally. The branch dispatches produced the tagged app at the existing `App path:` location and uploaded it successfully.
- The DerivedData archive contains only compiler intermediates, module/SDK caches, and the stable base Debug product; a pre-save trim removes every tag-specific app/staging bundle so repeated tags cannot grow the archive. Archives, indexes, logs, SourcePackages, and non-Debug products are excluded.
- A cache restore transport/error is `continue-on-error`, cleared, and treated as a miss. If a successfully restored cache makes the build fail, both cache roots are cleared and the build retries once cold. A cache can cost time, but cannot turn an otherwise-good cold build into a failed lane.
- If the prebuilt GhosttyKit download fails, the workflow uses a bounded CI retry budget, then sets `CMUX_GHOSTTYKIT_NO_PREBUILT=1` before `ensure-ghosttykit.sh` so the fallback goes straight to Zig instead of retrying the URL. The resulting framework is verified before either platform builds. `CMUX_SKIP_ZIG_BUILD` remains scoped to the Ghostty helper; legacy `cmuxd` behavior is unchanged for source refs that contain it. The iOS lane skips macOS caches but retains this same prebuilt/fallback flow and its existing archive/simulator build behavior.

## Cache action and runner choice

Blacksmith's [dependency caching docs](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions) mark `useblacksmith/cache` archived and recommend upstream `actions/cache`; Blacksmith transparently routes that action to its colocated cache. This PR therefore uses SHA-pinned `actions/cache` v5 restore/save actions.

Blacksmith's [runner overview](https://docs.blacksmith.sh/blacksmith-runners/overview) lists `blacksmith-12vcpu-macos-26` at $0.16/min versus the current 6-vCPU tier at $0.08/min; an exploratory prior-head run ([31920458164](https://github.com/manaflow-ai/cmux/actions/runs/31920458164)) measured 286s post-checkout on that tier. A larger tier exists, but this PR deliberately leaves the default runner unchanged.

## Validation

- `actionlint` v1.7.12 with ShellCheck v0.11.0 integration
- standalone `shellcheck -x scripts/reload.sh`, `bash -n`, Ruby YAML parsing, and Python compilation of the workflow's mtime block
- 11/11 reload-shim tests
- focused mobile workflow-origin test
- Xcode SourcePackages cache sanitizer test
- GhosttyKit checksum verification and current-pin tests
- Zig install guard and self-hosted workflow runner guard
- branch `workflow_dispatch` with both `--ref issue-10204-reload-build-perf` and `ref=issue-10204-reload-build-perf`
- live `reload-cloud.sh --tag issue-10204-reload-build-perf --launch` (run 32074405901), including tagged socket verification
- review hardening: effective-ref timing output, zero-safe timing guards, bounded GhosttyKit retry/fallback, OS-version/architecture cache namespace, literal `~/` shim expansion, tag-product cache trimming, and preserved legacy `cmuxd` behavior

There is no meaningful standalone behavioral test for this Xcode cache interaction; source-pattern assertions would be fake coverage. The branch dispatch exercises the real `reload.sh`, fixed DerivedData path, tagged product extraction, cache transport, and timing artifact on Blacksmith. No Swift or warning-budget files changed. Localization audit: not applicable; these are CI/developer diagnostics with no app or web user-facing strings.

Closes #10204

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789358653&installation_model_id=21920&pr_number=10211&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10211&signature=1bbea339ee53c6a68d677375b434b7176a5c9154e996d58baa80b2d9c86dd277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up Blacksmith reload builds by preferring a verified prebuilt GhosttyKit and reusing warm macOS caches with tighter budgets and safe fallbacks. Previously we always installed Zig and rebuilt; now we fetch and verify the xcframework first, reuse bounded SPM/DerivedData state, and fall back to a single cold rebuild if a cache is bad.

- macOS caches: fixed roots `/.ci-source-packages` and `/.ci-reload-derived-data` with SHA‑pinned `actions/cache` v5 and `SEGMENT_DOWNLOAD_TIMEOUT_MINS=2`. Keys scope SPM to Xcode version/build, the root `Package.resolved` hash, and the workspace path; DerivedData keys include runner OS/version/arch, branch, and source SHA. Restore tries source→branch→main. Cache only intermediates and Debug products, normalize Git‑tracked mtimes, prune tag‑specific Debug app bundles before save, disable SPM cache when `Package.resolved` is absent, sanitize non‑exact SPM hits, and set `CMUX_DISABLE_AUTOMATIC_PACKAGE_RESOLUTION=1` on exact hits.
- GhosttyKit flow: download and verify the prebuilt first on macOS and iOS with bounded retries and a 60‑second budget; on failure, install Zig and build locally with `CMUX_GHOSTTYKIT_NO_PREBUILT=1`. `scripts/reload.sh` enforces `CMUX_GHOSTTYKIT_PREPROVISIONED=1` (fails closed if missing), honors `CMUX_SKIP_ZIG_BUILD=1` to skip the legacy `cmuxd` Zig build in CI while preserving default developer behavior, and fixes `~/` expansion in PATH for the CLI shim.
- Failure handling and telemetry: cache restores are continue‑on‑error; if a cache‑hit build fails, clear both caches and retry once cold. `timings.json` and the step summary report restore/save status and durations, cache exact/fallback hits and keys, GhosttyKit/Zig timings, and whether a cold retry occurred. Artifacts always upload. No developer migration.

Closes #10204

<sup>Written for commit 04576b88f5386f8d2242409dfbbeb57aee3130bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Improved macOS and iOS build reliability with bounded caching, recovery handling, and automatic retry support.
  * Builds can reuse validated prebuilt components when available, with local fallback provisioning.
  * Added clearer build summaries covering cache usage, component setup, retries, and timing.
* **Developer Experience**
  * Improved shell compatibility and diagnostics for local build workflows.
  * Added support for caller-provided build components and configurable optional build steps.
  * Improved handling and cleanup of generated build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


