### PR TITLE
fix(ios): drop the workspace preview line when it repeats the row title

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
@@ -20,12 +20,21 @@ extension MobileWorkspacePreview {
 
     var previewLine: String {
         // Prefer the Mac's last-activity preview (latest notification text). Fall
-        // back to the first terminal's name (or the workspace name) when the Mac
-        // has no activity to preview or is old enough not to emit one.
+        // back to the first terminal's name when the Mac has no activity to
+        // preview or is old enough not to emit one.
         if let previewText, !previewText.isEmpty {
             return previewText
         }
-        return terminals.first?.name ?? name
+        // The row renders `name` as its title with this line directly underneath,
+        // so a fallback that resolves to the title paints the same string twice.
+        // Workspaces opened at $HOME hit this constantly: the workspace and its
+        // first terminal are both "~", so the list fills with rows reading "~"
+        // over "~". The row reserves this line's space either way, so leaving it
+        // empty keeps every row the same height without echoing the title.
+        guard let terminalName = terminals.first?.name, terminalName != name else {
+            return ""
+        }
+        return terminalName
     }
 
     func statusColor(connectionStatus: MobileMacConnectionStatus) -> Color {
@@ -80,7 +89,11 @@ extension MobileWorkspacePreview {
         if let displayDescription {
             parts.append(displayDescription)
         }
-        parts.append(previewLine)
+        // A row whose preview would only repeat its title renders an empty line;
+        // VoiceOver skips it rather than hearing a blank element.
+        if !previewLine.isEmpty {
+            parts.append(previewLine)
+        }
         // A healthy connection contributes no status text anywhere, including VoiceOver.
         if connectionStatus != .connected {
             parts.append(connectionStatus.label)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWorkspacePreviewLineTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWorkspacePreviewLineTests.swift
@@ -1,0 +1,69 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShellUI
+
+/// The row shows `name` as its title and `previewLine` directly underneath, so a
+/// fallback that resolves to the title paints the same string twice. Workspaces
+/// opened at `$HOME` are the common case: the workspace and its first terminal
+/// are both named "~", so every such row renders "~" over "~" and the list stops
+/// telling rows apart.
+@MainActor
+@Suite struct MobileWorkspacePreviewLineTests {
+    @Test func previewLineIsEmptyWhenTheTerminalFallbackRepeatsTheTitle() {
+        let workspace = MobileWorkspacePreview(
+            id: "home-workspace",
+            name: "~",
+            terminals: [MobileTerminalPreview(id: "terminal-1", name: "~")]
+        )
+
+        #expect(workspace.previewLine.isEmpty)
+    }
+
+    @Test func previewLineIsEmptyWhenTheWorkspaceHasNoTerminals() {
+        let workspace = MobileWorkspacePreview(
+            id: "empty-workspace",
+            name: "~",
+            terminals: []
+        )
+
+        #expect(workspace.previewLine.isEmpty)
+    }
+
+    @Test func previewLineKeepsATerminalNameThatDiffersFromTheTitle() {
+        let workspace = MobileWorkspacePreview(
+            id: "dev-workspace",
+            name: "goldberg",
+            terminals: [MobileTerminalPreview(id: "terminal-1", name: "vite dev")]
+        )
+
+        #expect(workspace.previewLine == "vite dev")
+    }
+
+    @Test func previewLinePrefersRemoteActivityOverTheFallback() {
+        let workspace = MobileWorkspacePreview(
+            id: "active-workspace",
+            name: "~",
+            previewText: "Claude is waiting for your input",
+            terminals: [MobileTerminalPreview(id: "terminal-1", name: "~")]
+        )
+
+        #expect(workspace.previewLine == "Claude is waiting for your input")
+    }
+
+    @Test func accessibilitySummaryOmitsTheEmptyPreviewLine() {
+        let workspace = MobileWorkspacePreview(
+            id: "home-workspace",
+            name: "~",
+            terminals: [MobileTerminalPreview(id: "terminal-1", name: "~")]
+        )
+
+        let summary = workspace.accessibilitySummary(connectionStatus: .connected)
+
+        // An empty preview must drop out of the spoken summary entirely rather
+        // than leave VoiceOver an empty element between two separators.
+        #expect(!summary.contains(", ,"))
+        #expect(!summary.hasPrefix(", "))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- **What changed?** `MobileWorkspacePreview.previewLine` no longer falls back to a string the row already shows as its title. When the Mac reports no activity preview, the fallback was `terminals.first?.name ?? name`; both resolve to the row's own title, so the row painted the same string twice. The fallback now yields an empty line in that case, and `accessibilitySummary` skips the empty line so VoiceOver doesn't hear a blank element between separators.

- **Why?** Every workspace opened at `$HOME` renders `~` over `~`, because the workspace and its first terminal are both named `~`. On my iPad the workspace list is a column of identical `~` / `~` rows that differ only by their timestamp, and there is no way to tell them apart. The same duplication shows up whenever a workspace and its terminal share a name (`kit client` over `kit client`, `harness sync 3-2-1` over `harness sync 3-2-1`).

The row already reserves this line's space (`lineLimit(previewLineLimit, reservesSpace: true)`), so emptying it keeps every row the same height and nothing shifts in the list.

Two commits, per the regression-test policy in `CLAUDE.md`: the first adds the failing coverage, the second the fix.

## Testing

- Added `MobileWorkspacePreviewLineTests` to `CmuxMobileShellUITests`: the duplicate case, the no-terminal case, a distinct terminal name that must survive, remote activity taking priority over the fallback, and the accessibility summary dropping the empty line.
- Checked that search does not regress: `WorkspaceListView.matchesQuery` already tests `workspace.name` and each `terminals.name` in their own clauses, so no row becomes unfindable when `previewLine` goes empty.
- Grepped the repo for other consumers of `previewLine`: only the row, the search predicate, and `accessibilitySummary`. The UIKit table path keys its row metrics on `displayDescription`, not on this line.
- No user-facing strings added or changed, so no `Localizable.xcstrings` or web catalog update is needed.

**I could not build or run the test suite locally**, so I am relying on CI to validate. `CmuxMobileShellUI` depends on `CmuxMobileTerminal`, which links the `GhosttyKit.xcframework` binary target, and I do not have the disk headroom to build the ghostty submodule on this machine. The change is pure display logic in a value-model extension, and the new tests exercise it directly. If CI is red I will fix it promptly, and I am happy to rework or close this if you would rather handle it differently.

## Demo Video

No video: this is a list-row display change and I cannot produce a build. The current behavior is reproducible on the TestFlight iPad build by opening several workspaces created at `$HOME`; the workspace list shows them all as `~` over `~`. I have a screenshot of that state from the current beta and can attach it here if useful.

## Checklist

- [ ] I tested the change locally (see the note under Testing: no local build possible, CI validates)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed: no user-facing string, setting, or documented behavior)
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789433421&installation_model_id=21920&pr_number=10220&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10220&signature=7733f1e0b9f3a9a29aac8f1728d241728b0612ac2d5264652fef6856d36079a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops rendering duplicate preview text in iOS workspace list rows. Previously `previewLine` fell back to the first terminal name or the workspace name, duplicating the title (for example “~” over “~”); now it returns empty in those cases, and `accessibilitySummary` omits it to avoid a blank VoiceOver element.

- Prefers `previewText`; otherwise uses the first terminal name only if it differs from the workspace `name`; otherwise returns empty.
- Keeps row height unchanged because the row still reserves the line’s space.
- Adds tests in `CmuxMobileShellUITests` covering duplicate and no-terminal cases, distinct terminal names, remote activity precedence, and the accessibility summary.
- Search remains unaffected since `matchesQuery` already checks the workspace and terminal names separately.

<sup>Written for commit 30815c1a27941eb49ff4f5466d01238c894585ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workspace previews from displaying duplicate titles when the first terminal shares the workspace name.
  * Improved accessibility summaries by omitting empty preview content.
  * Preserved consistent preview row spacing when duplicate titles are hidden.

* **Tests**
  * Added coverage for empty workspaces, distinct terminal names, duplicate-title fallbacks, remote activity, and accessibility summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->