### PR TITLE
Fix double-open: deliver each terminal open event to exactly one handler

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3385,7 +3385,12 @@ class GhosttyApp {
                 workingDirectory: surfaceView.currentDirectoryActionDispatcher.directorySnapshot()
             )
             return performOnMain {
-                TerminalLinkOpenCoordinator().open(request)
+                // Mark the dispatch before routing: this action fires
+                // synchronously inside `ghostty_surface_mouse_button`, and the
+                // release path must see it even when routing returns false
+                // (Ghostty then opens the URL with its own fallback).
+                surfaceView.noteGhosttyOpenURLActionDispatched()
+                return TerminalLinkOpenCoordinator().open(request)
             }
         default:
             return false
@@ -3788,6 +3793,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var lastDrawableSize: CGSize = .zero
     private var isFindEscapeSuppressionArmed = false
     private var hasPendingLeftMouseRelease = false
+    /// Monotonic count of Ghostty `open_url` actions dispatched for this
+    /// surface. Ghostty fires that action synchronously inside
+    /// `ghostty_surface_mouse_button` when a release lands on a link, so the
+    /// release path snapshots this counter around the call: an advance means
+    /// Ghostty already routed the clicked link through
+    /// `TerminalLinkOpenCoordinator`, and the cmd-click word-path fallback
+    /// must not deliver the same click to a second handler (#10222).
+    private var ghosttyOpenURLDispatchCount: UInt64 = 0
     let imageTransferPreparation: TerminalImageTransferPreparationService?
 #if DEBUG
     private var lastSizeSkipSignature: String?
@@ -6474,6 +6487,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return true
     }
 
+    /// Records that Ghostty dispatched an `open_url` action for this surface.
+    /// Called by the runtime action handler so the in-flight mouse release can
+    /// tell that Ghostty owns the clicked link, whatever the routing outcome.
+    func noteGhosttyOpenURLActionDispatched() {
+        ghosttyOpenURLDispatchCount += 1
+    }
+
     @discardableResult
     func completePendingLeftMouseRelease(with event: NSEvent) -> Bool {
         if routeInputDuringClipboardRead(event) { return true }
@@ -6481,13 +6501,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         hasPendingLeftMouseRelease = false
         guard let surface else { return false }
         let point = convert(event.locationInWindow, from: nil)
+        let openURLCountBeforeRelease = ghosttyOpenURLDispatchCount
         let consumed = sendGhosttyMouseButton(
             surface,
             state: GHOSTTY_MOUSE_RELEASE,
             button: GHOSTTY_MOUSE_LEFT,
             mods: mouseModsFromEvent(event)
         )
-        _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
+        _ = handleCommandClickRelease(
+            at: point,
+            modifierFlags: event.modifierFlags,
+            ghosttyConsumed: consumed,
+            ghosttyDispatchedOpenURL: ghosttyOpenURLDispatchCount != openURLCountBeforeRelease
+        )
         return true
     }
 
@@ -6839,9 +6865,24 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func handleCommandClickRelease(
         at point: NSPoint,
         modifierFlags: NSEvent.ModifierFlags,
-        ghosttyConsumed: Bool
+        ghosttyConsumed: Bool,
+        ghosttyDispatchedOpenURL: Bool
     ) -> WordPathResolution? {
         guard let surface else { return nil }
+        // Ghostty dispatched its open-url action for this release, so the
+        // clicked link is already being routed through
+        // TerminalLinkOpenCoordinator. Resolving and opening the word under
+        // the pointer as well would deliver the same click to two handlers —
+        // e.g. an image opening in both Preview and the preferred editor
+        // (#10222). `ghosttyConsumed` alone cannot gate this: Ghostty also
+        // consumes releases for mouse reporting and prompt clicks, where the
+        // snapshot fallback must keep working.
+        guard !ghosttyDispatchedOpenURL else {
+#if DEBUG
+            cmuxDebugLog("link.wordFallback skipped reason=ghostty_open_url_dispatched")
+#endif
+            return nil
+        }
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: modifierFlags)
         let cmdHeld = modifierFlags.contains(.command)
         let resolvedPoint = preferredPointerPoint(from: point)
@@ -7095,21 +7136,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             button: GHOSTTY_MOUSE_LEFT,
             mods: mods
         )
+        let openURLCountBeforeRelease = ghosttyOpenURLDispatchCount
         let releaseConsumed = sendGhosttyMouseButton(
             surface,
             state: GHOSTTY_MOUSE_RELEASE,
             button: GHOSTTY_MOUSE_LEFT,
             mods: mods
         )
+        let dispatchedOpenURL = ghosttyOpenURLDispatchCount != openURLCountBeforeRelease
         let resolution = handleCommandClickRelease(
             at: clampedPoint,
             modifierFlags: flags,
-            ghosttyConsumed: releaseConsumed
+            ghosttyConsumed: releaseConsumed,
+            ghosttyDispatchedOpenURL: dispatchedOpenURL
         )
 
         var payload: [String: Any] = [
             "pressHandled": pressHandled ? "1" : "0",
             "releaseConsumed": releaseConsumed ? "1" : "0",
+            "dispatchedOpenURL": dispatchedOpenURL ? "1" : "0",
         ]
         if let resolution {
             payload["openedPath"] = resolution.path

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7154,7 +7154,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var payload: [String: Any] = [
             "pressHandled": pressHandled ? "1" : "0",
             "releaseConsumed": releaseConsumed ? "1" : "0",
-            "dispatchedOpenURL": dispatchedOpenURL ? "1" : "0",
         ]
         if let resolution {
             payload["openedPath"] = resolution.path

--- a/Sources/TerminalLinkOpenCoordinator.swift
+++ b/Sources/TerminalLinkOpenCoordinator.swift
@@ -1,21 +1,29 @@
 import AppKit
 import CmuxTerminalCore
 import CmuxTestSupport
+import CmuxWorkspaces
 import Foundation
 
 /// Owns terminal-link policy and routes the resulting action through whichever
 /// panel container currently owns the source terminal.
+///
+/// Local files that leave cmux go through the shared ``FileOpening`` seam
+/// (`PreferredEditorService`), the single decision point for "open this file
+/// for the user": the preferred editor when configured, the system default
+/// otherwise. Non-file URLs go through `externalOpen` (the system browser).
 @MainActor
 struct TerminalLinkOpenCoordinator {
     private let defaults: UserDefaults
     private let containerResolver: @MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)?
     private let externalOpen: @MainActor @Sendable (URL) -> Bool
+    private let fileOpen: any FileOpening
     private let deferOperation: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
 
     init(
         defaults: UserDefaults = .standard,
         containerResolver: (@MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)?)? = nil,
         externalOpen: @escaping @MainActor @Sendable (URL) -> Bool = { NSWorkspace.shared.open($0) },
+        fileOpen: (any FileOpening)? = nil,
         deferOperation: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { operation in
             Task { @MainActor in operation() }
         }
@@ -23,6 +31,7 @@ struct TerminalLinkOpenCoordinator {
         self.defaults = defaults
         self.containerResolver = containerResolver ?? Self.resolveContainer
         self.externalOpen = externalOpen
+        self.fileOpen = fileOpen ?? PreferredEditorService(defaults: defaults)
         self.deferOperation = deferOperation
     }
 
@@ -129,7 +138,7 @@ struct TerminalLinkOpenCoordinator {
         guard container.deferTerminalFileLinkOpen(
             sourcePanelId: sourcePanelId,
             filePath: fileURL.path,
-            fallback: { [externalOpen] in _ = externalOpen(fileURL) }
+            fallback: { [self] in _ = openExternally(fileURL, reason: "cmux file route fallback") }
         ) else {
             return openExternally(fileURL, reason: unavailableReason)
         }
@@ -154,9 +163,7 @@ struct TerminalLinkOpenCoordinator {
                 sourcePanelId
             )
             let externalFallback: @MainActor @Sendable () -> Void = { [self] in
-                if !self.externalOpen(fileURL) {
-                    NSSound.beep()
-                }
+                _ = self.openExternally(fileURL, reason: "html route fallback")
             }
 
             guard let currentContainer,
@@ -255,6 +262,11 @@ struct TerminalLinkOpenCoordinator {
     }
 
     private func openExternally(_ url: URL, reason: String) -> Bool {
+        if url.isFileURL {
+            log("link.openURL opening file via preferred-editor seam reason=\(reason) url=\(url)")
+            fileOpen.open(url)
+            return true
+        }
         log("link.openURL opening externally reason=\(reason) url=\(url)")
         return externalOpen(url)
     }

--- a/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
+++ b/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import Testing
 import struct CmuxSettings.AppCatalogSection
+import protocol CmuxWorkspaces.FileOpening
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -237,6 +238,88 @@ struct TerminalLinkOpenCoordinatorTests {
         )
     }
 
+    @Test("Local file external opens are handed to the injected file-opening seam")
+    @MainActor
+    func localFileExternalOpenRoutesThroughFileOpeningSeam() throws {
+        let defaults = makeDefaults()
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        defaults.set(
+            false,
+            forKey: AppCatalogSection().openSupportedFilesInCmux.userDefaultsKey
+        )
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-file-open-seam-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileURL = directory.appendingPathComponent("photo.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: fileURL)
+
+        var externallyOpened: [URL] = []
+        let fileOpener = RecordingFileOpener()
+        let coordinator = TerminalLinkOpenCoordinator(
+            defaults: defaults,
+            containerResolver: { _, _ in nil },
+            externalOpen: { openedURL in
+                externallyOpened.append(openedURL)
+                return true
+            },
+            fileOpen: fileOpener,
+            deferOperation: { operation in operation() }
+        )
+
+        let handled = coordinator.open(
+            TerminalLinkOpenRequest(
+                rawValue: fileURL.path,
+                sourceWorkspaceId: nil,
+                sourcePanelId: UUID(),
+                workingDirectory: nil
+            )
+        )
+
+        #expect(handled)
+        #expect(fileOpener.opened == [URL(fileURLWithPath: fileURL.path)])
+        #expect(externallyOpened.isEmpty)
+    }
+
+    @Test("Web URLs still open through the raw system opener with a preferred editor configured")
+    @MainActor
+    func webURLExternalOpenIgnoresPreferredEditor() throws {
+        let defaults = makeDefaults()
+        defaults.set(
+            "/usr/bin/true",
+            forKey: AppCatalogSection().preferredEditor.userDefaultsKey
+        )
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+
+        let url = try #require(URL(string: "https://example.com/reference"))
+        var externallyOpened: [URL] = []
+        let fileOpener = RecordingFileOpener()
+        let coordinator = TerminalLinkOpenCoordinator(
+            defaults: defaults,
+            containerResolver: { _, _ in nil },
+            externalOpen: { openedURL in
+                externallyOpened.append(openedURL)
+                return true
+            },
+            fileOpen: fileOpener,
+            deferOperation: { operation in operation() }
+        )
+
+        let handled = coordinator.open(
+            TerminalLinkOpenRequest(
+                rawValue: url.absoluteString,
+                sourceWorkspaceId: nil,
+                sourcePanelId: UUID(),
+                workingDirectory: nil
+            )
+        )
+
+        #expect(handled)
+        #expect(externallyOpened == [url])
+        #expect(fileOpener.opened.isEmpty)
+    }
+
     private func makeHTMLFixture(pathExtension: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-html-click-\(UUID().uuidString)", isDirectory: true)
@@ -248,5 +331,15 @@ struct TerminalLinkOpenCoordinatorTests {
             encoding: .utf8
         )
         return fileURL
+    }
+}
+
+/// Records URLs handed to the coordinator's file-opening seam.
+@MainActor
+private final class RecordingFileOpener: FileOpening {
+    private(set) var opened: [URL] = []
+
+    func open(_ url: URL) {
+        opened.append(url)
     }
 }

--- a/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
+++ b/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
@@ -185,6 +185,58 @@ struct TerminalLinkOpenCoordinatorTests {
         #expect(externallyOpened.isEmpty)
     }
 
+    @Test("Local file external opens honor the preferred editor, not the raw system opener")
+    @MainActor
+    func localFileExternalOpenHonorsPreferredEditor() throws {
+        let defaults = makeDefaults()
+        // The reporter's configuration from issue #10222: a preferred editor is
+        // set, terminal links in the cmux browser are off, and supported-file
+        // routing is off, so the file must go to exactly one external handler —
+        // the preferred editor.
+        defaults.set(
+            "/usr/bin/true",
+            forKey: AppCatalogSection().preferredEditor.userDefaultsKey
+        )
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        defaults.set(
+            false,
+            forKey: AppCatalogSection().openSupportedFilesInCmux.userDefaultsKey
+        )
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-preferred-editor-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileURL = directory.appendingPathComponent("photo.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: fileURL)
+
+        var externallyOpened: [URL] = []
+        let coordinator = TerminalLinkOpenCoordinator(
+            defaults: defaults,
+            containerResolver: { _, _ in nil },
+            externalOpen: { openedURL in
+                externallyOpened.append(openedURL)
+                return true
+            },
+            deferOperation: { operation in operation() }
+        )
+
+        let handled = coordinator.open(
+            TerminalLinkOpenRequest(
+                rawValue: fileURL.path,
+                sourceWorkspaceId: nil,
+                sourcePanelId: UUID(),
+                workingDirectory: nil
+            )
+        )
+
+        #expect(handled)
+        #expect(
+            externallyOpened.isEmpty,
+            "A local file open must be routed through the preferred-editor seam when app.preferredEditor is configured, never handed to the raw system opener (issue #10222)."
+        )
+    }
+
     private func makeHTMLFixture(pathExtension: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-html-click-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -250,6 +250,13 @@ final class TerminalCmdClickUITests: XCTestCase {
             waitForOpenCountToStay(0, timeout: 1.5),
             "Cmd-click dispatched a second open for the same click: the word-path fallback ran even though Ghostty already routed the link. opened=\(loadCapturedOpenPaths()) result=\(result)"
         )
+        // The open-url route itself must also stay at exactly one dispatch
+        // through the settle window — never a duplicate primary open either.
+        XCTAssertEqual(
+            loadCapturedOpenPaths(path: openURLCapturePath),
+            [expectedURL],
+            "Expected exactly one open-url dispatch for the click after settling. result=\(result)"
+        )
     }
 
     func testCmdClickRawLsStylePathPrefersSnapshotWhenQuicklookDisagrees() throws {

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -219,6 +219,39 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
+    func testCmdClickOsc8FileHyperlinkOpensExactlyOneHandler() throws {
+        let fileName = "Cmd Click Fixture.txt"
+        let app = launchApp(
+            displayMode: .raw,
+            lineFormat: .osc8,
+            fileName: fileName,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let setup = try waitForReadySetup()
+        let expectedURL = URL(fileURLWithPath: setup.expectedPath).absoluteString
+
+        let result = try runCommand(action: "cmd_click_token")
+
+        let openedURLs = waitForCapturedOpenPaths(timeout: 5.0, path: openURLCapturePath)
+        XCTAssertEqual(
+            openedURLs,
+            [expectedURL],
+            "Expected Ghostty's open-url action to route the OSC 8 file link exactly once. result=\(result)"
+        )
+
+        // Issue #10222: when Ghostty consumes the click and dispatches its
+        // open-url action, the cmd-click word-path fallback must not ALSO open
+        // the same file through the preferred-editor/system path — that is the
+        // double-open (e.g. Preview and the preferred editor at once).
+        XCTAssertTrue(
+            waitForOpenCountToStay(0, timeout: 1.5),
+            "Cmd-click dispatched a second open for the same click: the word-path fallback ran even though Ghostty already routed the link. opened=\(loadCapturedOpenPaths()) result=\(result)"
+        )
+    }
+
     func testCmdClickRawLsStylePathPrefersSnapshotWhenQuicklookDisagrees() throws {
         let app = launchApp(
             displayMode: .raw,


### PR DESCRIPTION
Closes #10222

## Root cause

One cmd-click could be handled by **two independent open paths**:

1. When the click lands on a link Ghostty recognizes (URL regex match or an OSC 8 hyperlink, e.g. `file://` links printed by `ls --hyperlink` or agent tools), Ghostty consumes the mouse release and dispatches its `open_url` action **synchronously inside `ghostty_surface_mouse_button`**. cmux routes that through `TerminalLinkOpenCoordinator`, which opens the target (cmux panel, or externally).
2. Back in `GhosttyNSView.handleCommandClickRelease`, cmux's own cmd-click word-path fallback resolves the token under the pointer. Its guard `!ghosttyConsumed || resolution.source == .snapshot` deliberately lets pointer-snapshot resolutions through even when Ghostty consumed the release — because `ghosttyConsumed` alone can't distinguish "Ghostty opened a link" from "Ghostty consumed the click for mouse reporting / prompt clicks" (TUIs like Claude Code), where the fallback must keep working.

When Ghostty had actually dispatched `open_url`, **both** paths fired. Each path decides independently among {cmux panel, preferred editor, system default}, so with `app.preferredEditor` configured the two decisions diverge and the double becomes visible: an image opens in both Preview (coordinator → `NSWorkspace`) and the preferred editor (fallback → `PreferredEditorService`), or in Preview and a cmux panel at once. Without a preferred editor both opens usually landed in the same app (macOS coalesces) or were deduped by `openOrFocus…Split`, which is why removing the setting "fixed" it.

A second inconsistency compounded it: the coordinator opened local files externally with raw `NSWorkspace.shared.open`, ignoring `app.preferredEditor` entirely — so even a single open was routed differently depending on which path won.

## Fix

Single decision point per click, and a single seam for "open this local file for the user":

1. **`GhosttyNSView` now tracks Ghostty `open_url` dispatches** (`ghosttyOpenURLDispatchCount`, incremented by the `GHOSTTY_ACTION_OPEN_URL` handler). Because the action fires synchronously inside the mouse-release call, `completePendingLeftMouseRelease` (and the debug click harness) snapshots the counter around the release: if it advanced, Ghostty owns this click's open and `handleCommandClickRelease` returns before resolving anything. The `.snapshot` exception is preserved for consumed-but-not-link releases (mouse reporting, prompt clicks), so cmd-click on paths inside TUIs keeps working.
2. **`TerminalLinkOpenCoordinator` routes local-file external opens through the shared `FileOpening` seam** (`PreferredEditorService`) instead of raw `NSWorkspace`: preferred editor when configured, system default otherwise (with the service's existing failure fallback). Non-file URLs still open through the system opener. This makes the Ghostty-link path consistent with the cmd-click fallback, the Files shortcuts, and the settings openers, which already used the seam.

## Tests

Two-commit regression structure (commit 1 red, commit 2 green):

- **`TerminalLinkOpenCoordinatorTests.localFileExternalOpenHonorsPreferredEditor`** (commit 1, fails pre-fix): with `app.preferredEditor` configured and the reporter's settings (terminal links in cmux browser off, supported-file routing off), a local file must not reach the raw system opener.
- **`TerminalCmdClickUITests.testCmdClickOsc8FileHyperlinkOpensExactlyOneHandler`** (commit 1, fails pre-fix): cmd-clicking an OSC 8 file hyperlink must produce exactly one open — the Ghostty `open_url` route — and zero word-fallback opens. Pre-fix both capture files record an open for the same click.
- Commit 2 adds seam-level tests: injected `FileOpening` fake receives local files; web URLs still go to the system opener.

## Localization audit

No user-facing strings were added or changed (code comments and debug log lines only), so no `Localizable.xcstrings` / web message catalog changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI validation (main is broken — #10225 — so proof runs are pinned to revert branches)

`ci.yml` is paused (dispatch-only) and the current main tip (77adc69121) does not compile the macOS target because of 04ff18eea6 (#10225). The red/green proof therefore ran via `test-e2e.yml` on branches that are exactly this PR's commits plus a revert of that broken commit:

- **Red** (`issue-10222-validate-red` = commit 1, tests only): unit run [31921640704](https://github.com/manaflow-ai/cmux/actions/runs/31921640704) — **failed on exactly the new assertion**: `Expectation failed: (externallyOpened → [file:///…/photo.png]).isEmpty → false` (the local file reached the raw system opener pre-fix); the other 4 suite tests passed.
- **Green** (`issue-10222-validate-green` = full PR): unit runs [31921649000](https://github.com/manaflow-ai/cmux/actions/runs/31921649000) and [31923752707](https://github.com/manaflow-ai/cmux/actions/runs/31923752707) (re-run at the final head incl. review tweaks) — all 7 suite tests pass.

**UI test caveat (honest limitation):** `testCmdClickOsc8FileHyperlinkOpensExactlyOneHandler` could not be exercised on CI — on both macOS-15 e2e runners the app currently fails to activate and the whole `TerminalCmdClickUITests` suite silently reports *passed* without running (filed as #10226, with a probe run proving an unconditional `XCTFail` still "passes"). The UI test is therefore an invariant guard that runs truthfully wherever the app can foreground (local dev, fixed runners), not a CI-proven red→green pair. The CI-proven regression pair for this PR is the coordinator unit test above.

Once main builds again, the same `test-e2e.yml` unit filter can be re-dispatched at this branch directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
