### PR TITLE
Fix browser chrome appearance authority across focus transitions

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -264,9 +264,10 @@ struct BrowserPanelView: View {
     let paneOwnershipOverride: Bool?
     private let resolvedColorScheme: ColorScheme
     private let resolvedThemeBackgroundColor: NSColor
-    /// Inherited SwiftUI appearance is observed only to refresh WebKit's
-    /// system theme. It is never used to resolve browser toolbar colors.
-    @Environment(\.colorScheme) private var inheritedColorScheme
+    /// Appearance captured from the host before the parent injects the
+    /// surface-resolved scheme. It is observed only to refresh WebKit's system
+    /// theme and is never used to resolve browser toolbar colors.
+    private let inheritedColorScheme: ColorScheme
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
     @Environment(\.paneDropZone) private var paneDropZone
     /// Held detector instance used to summarize installed browsers rather than
@@ -361,6 +362,7 @@ struct BrowserPanelView: View {
         portalPriority: Int,
         paneOwnershipOverride: Bool? = nil,
         resolvedColorScheme: ColorScheme,
+        inheritedColorScheme: ColorScheme,
         resolvedThemeBackgroundColor: NSColor,
         onRequestPanelFocus: @escaping () -> Void
     ) {
@@ -372,6 +374,7 @@ struct BrowserPanelView: View {
         self.portalPriority = portalPriority
         self.paneOwnershipOverride = paneOwnershipOverride
         self.resolvedColorScheme = resolvedColorScheme
+        self.inheritedColorScheme = inheritedColorScheme
         self.resolvedThemeBackgroundColor = resolvedThemeBackgroundColor
         self.onRequestPanelFocus = onRequestPanelFocus
         self._browserChromeStyle = State(initialValue: BrowserChromeStyle.resolve(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -187,14 +187,14 @@ func resolvedBrowserChromeBackgroundColor(
 }
 
 func resolvedBrowserChromeColorScheme(
-    for colorScheme: ColorScheme,
-    themeBackgroundColor: NSColor,
-    windowBackgroundColor: NSColor
+    for surfaceColorScheme: ColorScheme,
+    ambientColorScheme: ColorScheme? = nil
 ) -> ColorScheme {
-    let perceivedBackgroundColor = themeBackgroundColor.alphaComponent < 0.999
-        ? cmuxCompositedNSColor(themeBackgroundColor, over: windowBackgroundColor)
-        : themeBackgroundColor
-    return cmuxReadableColorScheme(for: perceivedBackgroundColor)
+    // Browser chrome is composed inside the already-resolved cmux surface.
+    // The inherited scheme can change when SwiftUI/AppKit hosting or focus
+    // changes, but it must not replace the surface authority.
+    _ = ambientColorScheme
+    return surfaceColorScheme
 }
 
 func resolvedBrowserOmnibarPillBackgroundColor(
@@ -217,7 +217,6 @@ func resolvedBrowserOmnibarPillBackgroundColor(
 
 private struct BrowserChromeStyle {
     let backgroundColor: NSColor
-    let colorScheme: ColorScheme
     let omnibarPillBackgroundColor: NSColor
 
     static func resolve(
@@ -230,18 +229,13 @@ private struct BrowserChromeStyle {
             themeBackgroundColor: themeBackgroundColor,
             drawsBackground: drawsBackground
         )
-        // The browser is hosted inside the window/Dock chrome. Its semantic
-        // colors must follow the resolved cmux scheme injected by the parent,
-        // even when a translucent theme would otherwise be composited against
-        // AppKit's ambient window appearance.
-        let chromeColorScheme = colorScheme
+        let chromeColorScheme = resolvedBrowserChromeColorScheme(for: colorScheme)
         let omnibarPillBackgroundColor = resolvedBrowserOmnibarPillBackgroundColor(
             for: chromeColorScheme,
             themeBackgroundColor: themeBackgroundColor
         )
         return BrowserChromeStyle(
             backgroundColor: backgroundColor,
-            colorScheme: chromeColorScheme,
             omnibarPillBackgroundColor: omnibarPillBackgroundColor
         )
     }
@@ -268,8 +262,11 @@ struct BrowserPanelView: View {
     /// panels in `DockSplitStore`). When set, it overrides the workspace lookup
     /// in `isCurrentPaneOwner`; `nil` preserves the main-area behavior.
     let paneOwnershipOverride: Bool?
+    private let resolvedColorScheme: ColorScheme
     private let resolvedThemeBackgroundColor: NSColor
-    @Environment(\.colorScheme) private var colorScheme
+    /// Inherited SwiftUI appearance is observed only to refresh WebKit's
+    /// system theme. It is never used to resolve browser toolbar colors.
+    @Environment(\.colorScheme) private var inheritedColorScheme
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
     @Environment(\.paneDropZone) private var paneDropZone
     /// Held detector instance used to summarize installed browsers rather than
@@ -374,6 +371,7 @@ struct BrowserPanelView: View {
         self.isVisibleInUI = isVisibleInUI
         self.portalPriority = portalPriority
         self.paneOwnershipOverride = paneOwnershipOverride
+        self.resolvedColorScheme = resolvedColorScheme
         self.resolvedThemeBackgroundColor = resolvedThemeBackgroundColor
         self.onRequestPanelFocus = onRequestPanelFocus
         self._browserChromeStyle = State(initialValue: BrowserChromeStyle.resolve(
@@ -459,10 +457,6 @@ struct BrowserPanelView: View {
         browserChromeStyle.backgroundColor
     }
 
-    private var browserChromeColorScheme: ColorScheme {
-        browserChromeStyle.colorScheme
-    }
-
     private var browserContentAccessibilityIdentifier: String {
         "BrowserPanelContent.\(panel.id.uuidString)"
     }
@@ -508,7 +502,7 @@ struct BrowserPanelView: View {
         return BrowserPortalOmnibarSuggestionsConfiguration(
             panelId: panel.id,
             popupFrame: frame,
-            colorScheme: browserChromeColorScheme,
+            colorScheme: resolvedColorScheme,
             engineName: searchConfiguration.displayName,
             items: omnibarState.suggestions,
             selectedIndex: omnibarState.selectedSuggestionIndex,
@@ -831,7 +825,11 @@ struct BrowserPanelView: View {
         panel.setBrowserThemeMode(normalizedMode)
     }
 
-    private func handleSystemColorSchemeChange() {
+    private func handleInheritedColorSchemeChange() {
+        panel.refreshAppearanceDrivenColors()
+    }
+
+    private func handleResolvedColorSchemeChange() {
         refreshBrowserChromeStyle()
         panel.refreshAppearanceDrivenColors()
     }
@@ -1003,7 +1001,7 @@ struct BrowserPanelView: View {
             .frame(width: omnibarPillFrame.width)
             .offset(x: omnibarPillFrame.minX, y: omnibarPillFrame.maxY + 3)
             .zIndex(1000)
-            .environment(\.colorScheme, browserChromeColorScheme)
+            .environment(\.colorScheme, resolvedColorScheme)
         }
     }
 
@@ -1084,8 +1082,11 @@ struct BrowserPanelView: View {
         .onChange(of: browserThemeModeRaw) { _ in
             handleBrowserThemeModeRawChange()
         }
-        .onChange(of: colorScheme) { _ in
-            handleSystemColorSchemeChange()
+        .onChange(of: inheritedColorScheme) { _ in
+            handleInheritedColorSchemeChange()
+        }
+        .onChange(of: resolvedColorScheme) { _ in
+            handleResolvedColorSchemeChange()
         }
         .onChange(of: resolvedThemeBackgroundIdentity) { _, _ in
             refreshBrowserChromeStyle()
@@ -1130,6 +1131,10 @@ struct BrowserPanelView: View {
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
             refreshBrowserChromeStyle()
         }
+        // Keep every SwiftUI browser control on the resolved cmux surface
+        // scheme, even when this view is rehosted under an ambient AppKit
+        // appearance during a focus transition.
+        .environment(\.colorScheme, resolvedColorScheme)
     }
 
     private var addressBar: some View {
@@ -1196,7 +1201,7 @@ struct BrowserPanelView: View {
         }
         // Keep the omnibar stack above WKWebView so the suggestions popup is visible.
         .zIndex(1)
-        .environment(\.colorScheme, browserChromeColorScheme)
+        .environment(\.colorScheme, resolvedColorScheme)
     }
 
     private var addressBarButtonBar: some View {
@@ -1412,7 +1417,7 @@ struct BrowserPanelView: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .popover(isPresented: $isBrowserProfileMenuPresented, arrowEdge: .bottom) {
-            browserProfilePopover.browserChromePopoverAppearance(browserChromeColorScheme)
+            browserProfilePopover.browserChromePopoverAppearance(resolvedColorScheme)
         }
         .safeHelp(
             String(
@@ -1486,7 +1491,7 @@ struct BrowserPanelView: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .popover(isPresented: $isBrowserThemeMenuPresented, arrowEdge: .bottom) {
-            browserThemeModePopover.browserChromePopoverAppearance(browserChromeColorScheme)
+            browserThemeModePopover.browserChromePopoverAppearance(resolvedColorScheme)
         }
         .safeHelp(
             String(
@@ -1516,7 +1521,7 @@ struct BrowserPanelView: View {
         }
         .buttonStyle(OmnibarAddressButtonStyle())
         .popover(isPresented: $isBrowserImportHintPopoverPresented, arrowEdge: .bottom) {
-            browserImportHintPopover.browserChromePopoverAppearance(browserChromeColorScheme)
+            browserImportHintPopover.browserChromePopoverAppearance(resolvedColorScheme)
         }
         .safeHelp(String(localized: "browser.import.hint.toolbar.help", defaultValue: "Import browser data"))
         .accessibilityIdentifier("BrowserImportHintToolbarChip")
@@ -1855,7 +1860,10 @@ struct BrowserPanelView: View {
 
     private func refreshBrowserChromeStyle() {
         browserChromeStyle = BrowserChromeStyle.resolve(
-            for: colorScheme,
+            for: resolvedBrowserChromeColorScheme(
+                for: resolvedColorScheme,
+                ambientColorScheme: inheritedColorScheme
+            ),
             themeBackgroundColor: resolvedThemeBackgroundColor,
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         )

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -25,6 +25,10 @@ struct PanelContentView: View {
     let customSidebarUnread: SidebarUnreadModel = TerminalNotificationStore.shared.sidebarUnread
     let hasUnreadNotification: Bool
     let terminalAgentContext: String
+    /// Appearance inherited from the host before this view injects the
+    /// surface-resolved scheme for its rendered panel subtree. Browser WebKit
+    /// system theming may observe this value; browser chrome must not.
+    @Environment(\.colorScheme) private var inheritedColorScheme
     /// Explicit browser pane-ownership signal for hosts whose panels live outside
     /// the main `Workspace` tree (the Dock). `nil` keeps the main-area behavior.
     var paneOwnershipOverride: Bool? = nil
@@ -77,6 +81,7 @@ struct PanelContentView: View {
                     portalPriority: portalPriority,
                     paneOwnershipOverride: paneOwnershipOverride,
                     resolvedColorScheme: windowAppearance.resolvedColorScheme,
+                    inheritedColorScheme: inheritedColorScheme,
                     resolvedThemeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
                     onRequestPanelFocus: onRequestPanelFocus
                 )

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -1,4 +1,7 @@
 import CoreGraphics
+import AppKit
+import CmuxFoundation
+import SwiftUI
 import Testing
 
 #if canImport(cmux_DEV)
@@ -80,5 +83,53 @@ import Testing
         let metrics = BrowserChromeMetrics(tabBarFontSize: value)
         #expect(metrics.scale == 1)
         #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize)
+    }
+
+    @Test
+    func browserToolbarAndDockTextUseSurfaceAuthorityAcrossAppearanceAndFocus() {
+        let cases: [(surface: ColorScheme, app: ColorScheme, focused: Bool)] = [
+            (.light, .light, false),
+            (.light, .light, true),
+            (.light, .dark, false),
+            (.light, .dark, true),
+            (.dark, .light, false),
+            (.dark, .light, true),
+            (.dark, .dark, false),
+            (.dark, .dark, true),
+        ]
+
+        for testCase in cases {
+            let themeBackground = testCase.surface == .light
+                ? NSColor.white.withAlphaComponent(0.2)
+                : NSColor.black.withAlphaComponent(0.2)
+            let appBackground = testCase.app == .dark ? NSColor.black : NSColor.white
+            let browserScheme = resolvedBrowserChromeColorScheme(
+                for: testCase.surface,
+                themeBackgroundColor: themeBackground,
+                windowBackgroundColor: appBackground
+            )
+
+            #expect(
+                browserScheme == testCase.surface,
+                "Browser toolbar authority changed for surface=\(testCase.surface) app=\(testCase.app) focused=\(testCase.focused)"
+            )
+
+            let dockText = SidebarAppearanceColorResolver().activeForegroundColor(
+                opacity: 1,
+                for: testCase.surface
+            )
+            let expectedTextIsWhite = testCase.surface == .dark
+            let resolvedDockText = dockText.usingColorSpace(.sRGB) ?? dockText
+            var red: CGFloat = 0
+            var green: CGFloat = 0
+            var blue: CGFloat = 0
+            var alpha: CGFloat = 0
+            resolvedDockText.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+            #expect((red > 0.99) == expectedTextIsWhite)
+            #expect((green > 0.99) == expectedTextIsWhite)
+            #expect((blue > 0.99) == expectedTextIsWhite)
+            #expect(alpha == 1)
+        }
     }
 }

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -137,4 +137,23 @@ import Testing
             #expect(alpha == 1)
         }
     }
+
+    @Test
+    func inheritedAppearanceOnlyChangeKeepsBrowserChromeStableForWebKitRefresh() {
+        let surfaceScheme: ColorScheme = .light
+        let beforeRefresh = resolvedBrowserChromeColorScheme(
+            for: surfaceScheme,
+            ambientColorScheme: .dark
+        )
+        let afterRefresh = resolvedBrowserChromeColorScheme(
+            for: surfaceScheme,
+            ambientColorScheme: .light
+        )
+
+        // `BrowserPanelView` refreshes WebKit when this inherited value
+        // changes, while the toolbar authority must remain unchanged.
+        #expect(beforeRefresh == surfaceScheme)
+        #expect(afterRefresh == surfaceScheme)
+        #expect(afterRefresh == beforeRefresh)
+    }
 }

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -1,6 +1,5 @@
 import CoreGraphics
 import AppKit
-import CmuxFoundation
 import SwiftUI
 import Testing
 
@@ -87,31 +86,37 @@ import Testing
 
     @Test
     func browserToolbarAndDockTextUseSurfaceAuthorityAcrossAppearanceAndFocus() {
-        let cases: [(surface: ColorScheme, app: ColorScheme, focused: Bool)] = [
-            (.light, .light, false),
-            (.light, .light, true),
-            (.light, .dark, false),
-            (.light, .dark, true),
-            (.dark, .light, false),
-            (.dark, .light, true),
-            (.dark, .dark, false),
-            (.dark, .dark, true),
+        let cases: [(surface: ColorScheme, app: ColorScheme)] = [
+            (.light, .light),
+            (.light, .dark),
+            (.dark, .light),
+            (.dark, .dark),
         ]
 
         for testCase in cases {
-            let themeBackground = testCase.surface == .light
-                ? NSColor.white.withAlphaComponent(0.2)
-                : NSColor.black.withAlphaComponent(0.2)
-            let appBackground = testCase.app == .dark ? NSColor.black : NSColor.white
-            let browserScheme = resolvedBrowserChromeColorScheme(
+            let unfocusedScheme = resolvedBrowserChromeColorScheme(
                 for: testCase.surface,
-                themeBackgroundColor: themeBackground,
-                windowBackgroundColor: appBackground
+                ambientColorScheme: testCase.app
+            )
+            // A focus/hosting transition can expose the opposite inherited
+            // scheme even though the browser surface did not change.
+            let focusedAmbient = testCase.app == .dark ? ColorScheme.light : .dark
+            let focusedScheme = resolvedBrowserChromeColorScheme(
+                for: testCase.surface,
+                ambientColorScheme: focusedAmbient
             )
 
             #expect(
-                browserScheme == testCase.surface,
-                "Browser toolbar authority changed for surface=\(testCase.surface) app=\(testCase.app) focused=\(testCase.focused)"
+                unfocusedScheme == testCase.surface,
+                "Browser toolbar authority changed while unfocused for surface=\(testCase.surface) app=\(testCase.app)"
+            )
+            #expect(
+                focusedScheme == testCase.surface,
+                "Browser toolbar authority changed while focused for surface=\(testCase.surface) app=\(testCase.app)"
+            )
+            #expect(
+                focusedScheme == unfocusedScheme,
+                "Browser toolbar scheme flipped across focus for surface=\(testCase.surface) app=\(testCase.app)"
             )
 
             let dockText = SidebarAppearanceColorResolver().activeForegroundColor(

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -455,16 +455,13 @@ final class BrowserPanelChromeBackgroundColorTests: XCTestCase {
         XCTAssertEqual(themeBackground.alphaComponent, 1.0, accuracy: 0.001)
     }
 
-    func testBrowserChromeColorSchemeAccountsForTranslucentBackground() {
-        let darkTranslucentBackground = NSColor(srgbRed: 0.02, green: 0.03, blue: 0.04, alpha: 0.05)
-
+    func testBrowserChromeColorSchemeUsesExplicitSurfaceAuthority() {
         XCTAssertEqual(
             resolvedBrowserChromeColorScheme(
                 for: .dark,
-                themeBackgroundColor: darkTranslucentBackground,
-                windowBackgroundColor: .white
+                ambientColorScheme: .light
             ),
-            .light
+            .dark
         )
     }
 


### PR DESCRIPTION
## Summary

Browser toolbar chrome now treats the explicit `WindowAppearanceSnapshot.resolvedColorScheme` passed for the surface as its single appearance authority. Refreshes and SwiftUI/AppKit hosting transitions can no longer replace it with an inherited ambient scheme; the inherited scheme is retained only for WebKit system-theme refreshes. The browser subtree, suggestions portal, and browser popovers all receive the explicit surface scheme.

Behavior coverage exercises light/dark surface themes against light/dark inherited app appearance, including a simulated focus/hosting transition where the inherited scheme flips. Dock active-item text is checked against the same surface authority.

## Prior art and scope

PR #10149 (now merged) fixes the Dock/sidebar side of this family: it makes the terminal-derived `WindowAppearanceSnapshot.resolvedColorScheme` authoritative for Dock and sidebar roots, Bonsplit chrome/backgrounds, and AppKit sidebar controls, including Dock item foreground resolution. This branch is based on that merge and does not duplicate or alter those Dock fixes.

This PR adds the browser-side lifecycle fix that #10149 does not cover. `BrowserPanelView` previously seeded the explicit scheme but later refreshed `BrowserChromeStyle` from `@Environment(\.colorScheme)`, which can be the window/app appearance while a focused or rehosted browser view is being rebuilt. The refresh seam and all browser chrome presentation boundaries now use the immutable surface authority instead.

## Testing

- `swiftc -frontend -parse Sources/Panels/BrowserPanelView.swift`
- `swiftc -frontend -parse cmuxTests/BrowserChromeMetricsTests.swift`
- `swiftc -frontend -parse cmuxTests/BrowserPanelTests.swift`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `./tests/test_ci_swift_warning_budget.sh`

The intermittent focus race is covered at the deterministic appearance-authority seam rather than with screenshots. No app build, `xcodebuild test`, or XCUITest was run locally per the repository workflow.

Closes #10210

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789438594&installation_model_id=21920&pr_number=10224&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10224&signature=2d2577cbe0b20c1fcabc362e6d1c06876127d1811d69223b035d9173221e1dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the browser toolbar, suggestions portal, and browser popovers on the explicit surface `resolvedColorScheme` across focus and hosting transitions. Previously these views could inherit `@Environment(\.colorScheme)` and flip light/dark; now the surface scheme is the single authority, and the inherited scheme is used only to refresh WebKit’s system theme.

- Injects `.environment(\.colorScheme, resolvedColorScheme)` at browser chrome boundaries and replaces toolbar coloring reads of `@Environment(\.colorScheme)`.
- Splits handlers: `inheritedColorScheme` change refreshes WebKit only; `resolvedColorScheme` change refreshes chrome style and appearance-driven colors.
- Adds `inheritedColorScheme` to `BrowserPanelView` initializer; panel hosts pass the ambient scheme so WebKit can refresh without affecting chrome.
- Simplifies `resolvedBrowserChromeColorScheme` to return the surface scheme; keeps optional `ambientColorScheme` for tests.
- Removes `BrowserChromeStyle.colorScheme`; derives omnibar and popup colors from the surface scheme; ensures suggestions and popovers use `resolvedColorScheme`.
- Adds tests verifying toolbar stability across focus transitions and that Dock active-item text and browser chrome follow the surface scheme.

<sup>Written for commit f0da2a52628e476f1df4475972f7bb6d91a6c020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser controls, omnibox suggestions, and popovers now consistently follow the selected surface light or dark appearance.
  * Browser colors remain stable when the surrounding window or application appearance changes.
  * Improved color handling for dock text and toolbar elements across light and dark combinations.
  * Web content appearance now refreshes appropriately when the surrounding environment changes.

* **Tests**
  * Added coverage for browser appearance behavior across surface and ambient color schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->