### PR TITLE
Add Periphery unused code workflow

### DIFF
--- a/.github/workflows/periphery-comment.yml
+++ b/.github/workflows/periphery-comment.yml
@@ -1,0 +1,15 @@
+name: Unused code comment
+
+on:
+  workflow_run:
+    workflows: [Unused code]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    permissions:
+      actions: read
+      pull-requests: write
+    uses: periphery-pro/actions/.github/workflows/comment.yml@v1

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -1,0 +1,20 @@
+name: Unused code
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  periphery:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: periphery-pro/actions/.github/workflows/scan.yml@v1
+    with:
+      checkout_submodules: true
+      setup: |
+        ./scripts/download-prebuilt-ghosttykit.sh
+        ./scripts/install-zig-ci.sh
+        ./scripts/install-rust-ci.sh

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,3 @@
+project: cmux.xcodeproj
+schemes:
+  - cmux


### PR DESCRIPTION
## Summary

Any interest in detecting unused code in PRs?

This change integrates the [Periphery reusable workflow](https://github.com/periphery-pro/actions). On pushes to the `main` branch, it scans for unused code and records a baseline. On PRs, it pulls the baseline for the merge-base commit and then reports any code that’s newly identified as unused.

The results are reported as inline comments in the diff for newly introduced unused code, and also a PR comment which also includes any results that aren’t present in the diff (i.e the change removes the final references to some existing code).

The scan uses the `cmux` scheme for the build, and therefore any code that’s compiled by the scheme is scanned. I see there’s also the `cmux-ios` and `cmux-unit` schemes, perhaps either of those is more appropriate to use?

There aren’t any results posted in this PR, because main doesn’t have a baseline yet, and the `run_without_baseline` option is disabled (there are too many results), so it’ll take some time before folks base their PRs on `main` and start affecting the code graph.

Here’s a preview of the PR report. This is produced with `run_without_baseline` temporarily enabled, so in reality the actual reports will typically contain far fewer results.

<img width="831" height="708" alt="Screenshot 2026-08-18 at 15 11 34" src="https://github.com/user-attachments/assets/8e181db5-b114-40bf-bccf-79ae6bf5c80d" />

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789464266&installation_model_id=21920&pr_number=10227&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10227&signature=edb9f47325ed47c010f746d1e7a3fabce48732a79db3471f433256058e444d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Periphery unused‑code CI gate for cmux and posts scan results as a pull‑request comment, making dead code visible and enforceable in CI. Previously there was no unused‑code check.

- Adds `.github/workflows/periphery.yml` using `periphery-pro/actions/.github/workflows/scan.yml@v1`; triggers on pull requests and pushes to `main`; permissions `actions: read`, `contents: read`, `id-token: write`; runs with `checkout_submodules: true` and setup scripts: `./scripts/download-prebuilt-ghosttykit.sh`, `./scripts/install-zig-ci.sh`, `./scripts/install-rust-ci.sh`.
- Adds `.github/workflows/periphery-comment.yml` to post the unused‑code report via `periphery-pro/actions/.github/workflows/comment.yml@v1`; triggers on `workflow_run` of “Unused code” when completed; job permissions `actions: read`, `pull-requests: write`.
- Adds `.periphery.yml` targeting `cmux.xcodeproj` and the `cmux` scheme.
- Migration: PRs must fix or suppress unused symbols to pass the “Unused code” check.

<sup>Written for commit 64dee97371d9a870124d4565a9d2cbab79efc7d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated unused-code scanning for pull requests and updates to the main branch.
  * Added pull request reporting for unused-code findings.
  * Configured scanning for the cmux Xcode project and build scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->