### PR TITLE
Fix cmux-tui terminal color environment

### DIFF
--- a/cmux-tui/README.md
+++ b/cmux-tui/README.md
@@ -87,7 +87,7 @@ ssh -T dev@buildbox cmux relay --session agents
 
 The Unix-only `machine-agent` shares an existing local session through one outbound SSH registration with cmux.cloud. It prints a one-time pairing code and opens no listener. The final command is a low-level raw JSON-lines diagnostic; the machine rail and `cmux ssh` use the managed remote lifecycle instead.
 
-Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-256color`; `CMUX_TUI_TERM` can override the terminal runtime default, with `CMUX_MUX_TERM` retained as a legacy fallback.
+Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-ghostty` when that terminfo entry is available, otherwise `xterm-256color`; `CMUX_TUI_TERM` can override the terminal runtime default, with `CMUX_MUX_TERM` retained as a legacy fallback. The TUI removes `NO_COLOR` for its own and child-terminal rendering and sets `COLORTERM=truecolor`.
 
 ## Browser ownership
 

--- a/cmux-tui/README.md
+++ b/cmux-tui/README.md
@@ -87,7 +87,7 @@ ssh -T dev@buildbox cmux relay --session agents
 
 The Unix-only `machine-agent` shares an existing local session through one outbound SSH registration with cmux.cloud. It prints a one-time pairing code and opens no listener. The final command is a low-level raw JSON-lines diagnostic; the machine rail and `cmux ssh` use the managed remote lifecycle instead.
 
-Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-ghostty` when that terminfo entry is available, otherwise `xterm-256color`; `CMUX_TUI_TERM` can override the terminal runtime default, with `CMUX_MUX_TERM` retained as a legacy fallback. The TUI removes `NO_COLOR` for its own and child-terminal rendering and sets `COLORTERM=truecolor`.
+Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-ghostty` when that terminfo entry is available, otherwise `xterm-256color`; `CMUX_TUI_TERM` can override the terminal runtime default, with `CMUX_MUX_TERM` retained as a legacy fallback. The TUI forces color for its own output. The cmux-pty runtime removes `NO_COLOR` only from child PTYs and sets `COLORTERM=truecolor` for them.
 
 ## Browser ownership
 

--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -248,6 +248,18 @@ mod tests {
     }
 
     #[test]
+    fn env_remove_prevents_a_color_suppression_variable_from_reaching_the_child() {
+        let pair = open(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }).unwrap();
+        let mut command = PtyCommand::new("/bin/sh");
+        command.env("NO_COLOR", "1");
+        command.env_remove("NO_COLOR");
+        command.args(["-c", "test -z \"${NO_COLOR+x}\""]);
+
+        let mut spawned = pair.spawn(command).unwrap();
+        assert!(spawned.child.wait().unwrap().success());
+    }
+
+    #[test]
     fn successful_exec_does_not_inherit_unmarked_parent_descriptors() {
         let source = File::open("/dev/null").unwrap();
         let descriptor = unsafe { libc::fcntl(source.as_raw_fd(), libc::F_DUPFD, 200) };

--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -4,7 +4,7 @@
 //! descriptor-pinned working directories. Non-Unix platforms use
 //! portable-pty's native backend.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 #[cfg(unix)]
 use std::fs::File;
@@ -96,6 +96,7 @@ pub struct PtyCommand {
     #[cfg(unix)]
     cwd_descriptor: Option<Arc<File>>,
     environment: BTreeMap<String, String>,
+    removed_environment: BTreeSet<String>,
     clean_environment: bool,
 }
 
@@ -108,6 +109,7 @@ impl PtyCommand {
             #[cfg(unix)]
             cwd_descriptor: None,
             environment: BTreeMap::new(),
+            removed_environment: BTreeSet::new(),
             clean_environment: false,
         }
     }
@@ -135,12 +137,30 @@ impl PtyCommand {
     }
 
     pub fn env(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.environment.insert(key.into(), value.into());
+        let key = key.into();
+        self.removed_environment.remove(&key);
+        self.environment.insert(key, value.into());
+    }
+
+    /// Remove an inherited variable from the child process environment.
+    pub fn env_remove(&mut self, key: impl Into<String>) {
+        let key = key.into();
+        self.environment.remove(&key);
+        self.removed_environment.insert(key);
+    }
+
+    /// Set the environment identity used by a terminal child.
+    pub fn env_terminal_identity(&mut self, term: impl Into<String>) {
+        self.env("TERM", term);
+        self.env("COLORTERM", "truecolor");
+        self.env("TERM_PROGRAM", "ghostty");
+        self.env_remove("NO_COLOR");
     }
 
     pub fn env_clear(&mut self) {
         self.clean_environment = true;
         self.environment.clear();
+        self.removed_environment.clear();
     }
 }
 
@@ -203,6 +223,9 @@ mod platform {
         }
         for (key, value) in command.environment {
             builder.env(key, value);
+        }
+        for key in command.removed_environment {
+            builder.env_remove(key);
         }
         slave.0.spawn_command(builder)
     }

--- a/cmux-tui/crates/cmux-pty/src/macos.rs
+++ b/cmux-tui/crates/cmux-pty/src/macos.rs
@@ -181,6 +181,9 @@ pub(crate) fn spawn(
         process.env_clear();
     }
     process.envs(&command.environment);
+    for key in &command.removed_environment {
+        process.env_remove(key);
+    }
     process.env("SHELL", shell);
     let cwd_descriptor = command.cwd_descriptor;
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -11,13 +11,15 @@ use std::io::{Read, Write};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::path::PathBuf;
+#[cfg(unix)]
+use std::process::Command;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{
     Receiver, RecvError, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel,
 };
-use std::sync::{Arc, Condvar, Mutex, TryLockError, Weak};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, TryLockError, Weak};
 use std::time::{Duration, Instant};
 
 use cmux_pty::{ChildKiller, MasterPty, PtyCommand, PtySize};
@@ -69,6 +71,30 @@ mod color_environment_tests {
     }
 }
 
+fn resolve_terminal_name(explicit: Option<&str>, ghostty_terminfo_available: bool) -> String {
+    if let Some(term) = explicit.filter(|term| !term.is_empty()) {
+        return term.to_string();
+    }
+    if ghostty_terminfo_available { "xterm-ghostty".into() } else { "xterm-256color".into() }
+}
+
+fn ghostty_terminfo_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        #[cfg(unix)]
+        {
+            Command::new("infocmp")
+                .arg("xterm-ghostty")
+                .status()
+                .is_ok_and(|status| status.success())
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    })
+}
+
 /// Result of encoding terminal mouse input against a previously observed
 /// pointer snapshot without blocking on terminal parsing.
 #[derive(Debug)]
@@ -117,8 +143,8 @@ pub struct SurfaceOptions {
     /// Command argv; defaults to the platform shell.
     pub command: Option<Vec<String>>,
     pub cwd: Option<String>,
-    /// TERM value for children. xterm-256color is the compatible default;
-    /// set xterm-ghostty when the ghostty terminfo is installed.
+    /// TERM value for children. Uses xterm-ghostty when its terminfo is
+    /// available, with xterm-256color as the portable fallback.
     pub term: String,
     pub cols: u16,
     pub rows: u16,
@@ -155,9 +181,13 @@ impl Default for SurfaceOptions {
         SurfaceOptions {
             command: None,
             cwd: None,
-            term: std::env::var("CMUX_TUI_TERM")
-                .or_else(|_| std::env::var("CMUX_MUX_TERM"))
-                .unwrap_or_else(|_| "xterm-256color".into()),
+            term: resolve_terminal_name(
+                std::env::var("CMUX_TUI_TERM")
+                    .or_else(|_| std::env::var("CMUX_MUX_TERM"))
+                    .ok()
+                    .as_deref(),
+                ghostty_terminfo_available(),
+            ),
             cols: 80,
             rows: 24,
             scrollback: 10_000,
@@ -2267,10 +2297,10 @@ impl Surface {
             .unwrap_or_else(|| vec![platform::default_shell()]);
         let mut cmd = PtyCommand::new(&argv[0]);
         cmd.args(argv[1..].iter().cloned());
-        cmd.env("TERM", &opts.term);
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
         }
+        cmd.env_terminal_identity(&opts.term);
         let cwd = opts
             .cwd
             .clone()

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -12,7 +12,7 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::path::PathBuf;
 #[cfg(unix)]
-use std::process::Command;
+use std::process::{Command, Stdio};
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
@@ -85,6 +85,9 @@ fn ghostty_terminfo_available() -> bool {
         {
             Command::new("infocmp")
                 .arg("xterm-ghostty")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .is_ok_and(|status| status.success())
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -49,6 +49,26 @@ use crate::terminal_host_protocol::{
 };
 use cmux_tui_cdp::BrowserMode;
 
+#[cfg(test)]
+mod color_environment_tests {
+    use super::resolve_terminal_name;
+
+    #[test]
+    fn prefers_ghostty_term_when_terminfo_is_available() {
+        assert_eq!(resolve_terminal_name(None, true), "xterm-ghostty");
+    }
+
+    #[test]
+    fn keeps_compatible_fallback_without_terminfo() {
+        assert_eq!(resolve_terminal_name(None, false), "xterm-256color");
+    }
+
+    #[test]
+    fn explicit_term_always_wins() {
+        assert_eq!(resolve_terminal_name(Some("screen-256color"), true), "screen-256color");
+    }
+}
+
 /// Result of encoding terminal mouse input against a previously observed
 /// pointer snapshot without blocking on terminal parsing.
 #[derive(Debug)]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -4835,10 +4835,10 @@ mod unix {
         let pty = cmux_pty::open(initial_pty_size)?;
         let mut command = PtyCommand::new(&launch.command[0]);
         command.args(launch.command[1..].iter().cloned());
-        command.env("TERM", &launch.term);
         for (key, value) in &launch.extra_env {
             command.env(key, value);
         }
+        command.env_terminal_identity(&launch.term);
         if let Some(cwd) = launch.cwd.as_deref() {
             command.cwd(cwd);
         }

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -412,7 +412,7 @@ START OPTIONS
                     Refresh the relay ticket from an argv-based command.
   --iroh            Publish an Iroh route for NAT traversal and mobile use.
   --advertise <url> Add a non-secret route hint to enrollment invitations.
-  --term <value>     TERM for child shells (default: xterm-256color).
+  --term <value>     TERM for child shells (default: xterm-ghostty when available, otherwise xterm-256color).
   -h, --help         Show this help.
   -V, --version      Print the cmux version.
 ";
@@ -1439,6 +1439,9 @@ fn main() {
         discard_provider_secret_environment();
         std::process::exit(cli::run(&raw_args, &usage()));
     }
+    // cmux-tui is a color terminal application. Crossterm otherwise treats an
+    // inherited NO_COLOR variable as a request to disable its own rendering.
+    crossterm::style::force_color_output(true);
     let args = parse_args(raw_args);
     #[cfg(unix)]
     let provider_token = CapturedProviderToken::capture();

--- a/cmux-tui/docs/getting-started.md
+++ b/cmux-tui/docs/getting-started.md
@@ -23,7 +23,7 @@ The default session is `main`. Quitting a local TUI shuts down that in-process s
 
 Press `Ctrl-b` to reveal the active prefix commands in the bottom bar. Press `Ctrl-b ?` for the full scrollable shortcut list. Right-click a pane for pane actions, or anywhere in the sidebar for sidebar actions; hold Shift while right-clicking when an inner terminal app owns mouse input.
 
-Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-256color`; the terminal runtime also honors `CMUX_TUI_TERM` when no CLI value is supplied, with `CMUX_MUX_TERM` retained as a legacy fallback.
+Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-ghostty` when that terminfo entry is available, otherwise `xterm-256color`; the terminal runtime also honors `CMUX_TUI_TERM` when no CLI value is supplied, with `CMUX_MUX_TERM` retained as a legacy fallback.
 
 ## Headless server and attach
 


### PR DESCRIPTION
## Summary
- Preserve color output when the parent sets NO_COLOR.
- Select xterm-ghostty only when terminfo is available, with a portable xterm-256color fallback.
- Set truecolor and Ghostty terminal metadata for child PTYs on every backend.

## Testing
- Hosted focused cmux-tui verification is running for env_remove_prevents_a_color_suppression_variable.
- Local git diff check and rustfmt check passed.

## Scope
- The implementation does not use the cmux app bundle or a cmux-specific resource path.
- Kitty graphics is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789465977&installation_model_id=21920&pr_number=10228&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10228&signature=0f1534c40033d4538272e2c03291b1177bc2f6461df6a2fb85d42c9c80562f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves color output in `cmux-tui` and child PTYs and improves terminal identity defaults. Previously, inheriting NO_COLOR disabled the TUI and child colors and TERM defaulted to xterm-256color; now the TUI always renders color, children ignore NO_COLOR and advertise truecolor, and TERM defaults to xterm-ghostty when available.

- Default TERM: prefer `xterm-ghostty` when its terminfo is present (silent `infocmp` probe on Unix), otherwise `xterm-256color`. `--term`, `CMUX_TUI_TERM`, and legacy `CMUX_MUX_TERM` still take precedence.
- Child env and API: add `PtyCommand::env_remove` and `env_terminal_identity` in `cmux-pty` to set `TERM`, `COLORTERM=truecolor`, `TERM_PROGRAM=ghostty`, and remove `NO_COLOR` across backends (including macOS). Side effect: `NO_COLOR` is always removed from child PTYs even if provided via extra env.
- TUI rendering: force color with `crossterm::style::force_color_output(true)` so parent `NO_COLOR` no longer suppresses UI colors.
- Docs and CLI help updated; tests added for terminal selection and env removal.

<sup>Written for commit 8f07d195f9801b3ccfb6c604c822b6aa5325be0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal compatibility by preferring `xterm-ghostty` when available, with `xterm-256color` as a fallback.
  * Child terminal sessions now receive consistent truecolor settings and exclude `NO_COLOR`.
  * Explicit terminal and environment overrides continue to be honored.
  * Environment variables can now be explicitly removed from child terminal sessions.

* **Documentation**
  * Updated command-line help and getting-started documentation to describe terminal defaults, color behavior, and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->