### PR TITLE
browser snapshot: use <label> text as accessible name for form controls

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7711,6 +7711,10 @@ class TerminalController {
                   const text = labelledBy.split(/\\s+/).map((id) => document.getElementById(id)).filter(Boolean).map((n) => __normalize(n.textContent || '')).join(' ').trim();
                   if (text) return text;
                 }
+                if (el.labels && el.labels.length) {
+                  const text = Array.from(el.labels).map((n) => __normalize(n.textContent || '')).join(' ').trim();
+                  if (text) return text;
+                }
                 if (el.tagName && String(el.tagName).toLowerCase() === 'input') {
                   const placeholder = __normalize(el.getAttribute('placeholder') || '');
                   if (placeholder) return placeholder;


### PR DESCRIPTION
## Problem

`cmux browser snapshot` names elements via `__nameFor` in the snapshot script (`Sources/TerminalController.swift`), which checks `aria-label`, `aria-labelledby`, `placeholder`/`value` for inputs, `title`, then inner text. It never looks at associated `<label>` elements.

Plain HTML forms that label fields with `<label for="id">` or a wrapping `<label>` therefore come out nameless, so an agent reading the snapshot cannot tell the fields apart and has to fall back to CSS selectors.

Repro (cmux 0.64.22) on https://the-internet.herokuapp.com/login:

```
$ cmux browser snapshot -i
- document "The Internet"
  - textbox [ref=e18]
  - textbox [ref=e19]
  - button "Login" [ref=e20]
  - link "Elemental Selenium" [ref=e21]
```

The page has `<label for="username">Username</label>` and `<label for="password">Password</label>`.

## Fix

Consult `el.labels` after the ARIA attributes and before `placeholder`, following accessible-name precedence. `HTMLElement.labels` covers both `for=` and wrapping labels and exists on input, textarea, select, button, meter, output and progress.

Verified in the cmux WKWebView on the page above:

```
$ cmux browser eval 'Array.from(document.querySelectorAll("input,button")).map(e => e.tagName + ":" + (e.labels?.length ? Array.from(e.labels).map(l => l.textContent.trim()).join(" ") : "<none>")).join(" | ")'
INPUT:Username | INPUT:Password | BUTTON:<none>
```

Expected snapshot after the change:

```
- textbox "Username" [ref=e18]
- textbox "Password" [ref=e19]
- button "Login" [ref=e20]
```

Note: `findRoleFinderBody` in `BrowserControlService+Scripts.swift` has a separate `__nameFor` with the same gap; left untouched here to keep the change scoped, happy to follow up if wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789496684&installation_model_id=21920&pr_number=10231&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10231&signature=0cdefd926f459f1f999b2f257926f5ed0a5982d5bc4bfc2589dfcd6eb8e60677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `<label>` text to accessible names in `cmux browser snapshot` so standard form controls are named. Previously, the snapshot ignored associated labels and many inputs appeared nameless; now it consults `el.labels` after ARIA attributes and before `placeholder`/`value`, improving field disambiguation.

- **Review notes**
  - Scope: only the snapshot script’s `__nameFor`; the role-finder’s version is unchanged.
  - Precedence: `aria-label`/`aria-labelledby` > label text (`el.labels`) > `placeholder`/`value` (inputs) > `title` > inner text.
  - Expect snapshot output changes on plain HTML forms; update any snapshots/tests that assert control names.

<sup>Written for commit e278025351a4161fae902f40374d5419ba5b669d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved browser snapshot element naming by using associated label text when accessible names are unavailable.
  * Preserved fallback naming behavior for elements without associated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->