### PR TITLE
Fix nightly macOS Release compile on main

### DIFF
--- a/Sources/DockSplitStore+PanelDestruction.swift
+++ b/Sources/DockSplitStore+PanelDestruction.swift
@@ -21,7 +21,10 @@ extension DockSplitStore {
             forTabId: workspaceId,
             surfaceId: panelId
         )
-        TerminalController.shared.cleanupSurfaceState(surfaceIds: [panelId])
+        TerminalController.shared.cleanupSurfaceState(
+            surfaceIds: [panelId],
+            workspaceID: workspaceId
+        )
         removeDetachedSurfaceTransfer(forPanelID: panelId)
         terminalStartupRestoreCoordinator.discardPendingRestoreForPanelTeardown(
             panelID: panelId

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -293,7 +293,8 @@ extension DockSplitStore {
         // A rebuilt shell must not inherit socket-report dedupe state from a
         // closed surface whose persisted ID it is reusing.
         TerminalController.shared.cleanupSurfaceState(
-            surfaceIds: [reusableSurfaceId]
+            surfaceIds: [reusableSurfaceId],
+            workspaceID: workspaceId
         )
         let terminal = TerminalPanel(
             id: reusableSurfaceId,

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -28,6 +28,10 @@ extension TerminalController {
             return .extensionBrowser
         case .workspaceTodo:
             return .todo
+        case .notifications:
+            // Notifications use the open-vocabulary fallback until the phone
+            // provides a native renderer for this panel kind.
+            return MobileSurfaceKind(rawValue: "notifications")
         case .cloudVMLoading:
             return .cloudVMLoading
         case .simulator:
@@ -154,6 +158,8 @@ extension TerminalController {
                 message: "Surface not found",
                 data: ["surface_id": id.uuidString]
             )
+        case let .dockUnavailable(message):
+            return .err(code: "unavailable", message: message, data: nil)
         case let .focused(windowID, focusedWorkspaceID, focusedSurfaceID):
             return .ok([
                 "workspace_id": focusedWorkspaceID.uuidString,
@@ -276,6 +282,12 @@ extension TerminalController {
                     defaultValue: "Artifact transfer is temporarily unavailable.",
                     path: nil
                 )
+            case .permissionDenied:
+                return mobileArtifactReadFailure(.permissionDenied, path: v2RawString(params, "path"))
+            case .notRegularFile:
+                return mobileArtifactReadFailure(.notRegularFile, path: v2RawString(params, "path"))
+            case .readFailed:
+                return mobileArtifactReadFailure(.readFailed, path: v2RawString(params, "path"))
             }
         } catch ArtifactByteReader.Error.fileNotFound {
             return mobilePanelArtifactFileError(

--- a/Sources/TerminalController+RemoteTmuxControlRefs.swift
+++ b/Sources/TerminalController+RemoteTmuxControlRefs.swift
@@ -22,7 +22,10 @@ extension TerminalController {
                     surfaceId: surfaceID
                 )
             }
-            controller?.cleanupSurfaceState(surfaceIds: [surfaceID])
+            controller?.cleanupSurfaceState(
+                surfaceIds: [surfaceID],
+                workspaceID: workspaceID
+            )
         }
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -140,6 +140,10 @@ class TerminalController {
     @MainActor private(set) var caffeineController: CaffeineController?
     @MainActor var agentChatTranscriptService: AgentChatTranscriptService?
     nonisolated let terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore
+    /// Main-actor grants for the file currently displayed by each mobile panel.
+    /// The live panel inventory and artifact reads share this owner so a closed
+    /// or replaced panel cannot retain an old file authorization.
+    let panelArtifactAuthorizationStore: PanelArtifactAuthorizationStore
     // Sendable value type; injected at construction so socket auth never reaches a global.
     nonisolated let passwordStore: SocketControlPasswordStore
     private nonisolated let socketPasswordFileWatcher: FileWatcher?
@@ -356,9 +360,21 @@ class TerminalController {
     )
     private var browserDownloadObserver: NSObjectProtocol?
 
-    func cleanupSurfaceState(surfaceIds: [UUID], paneIds: [UUID] = []) {
+    func cleanupSurfaceState(
+        surfaceIds: [UUID],
+        paneIds: [UUID] = [],
+        workspaceID: UUID? = nil
+    ) {
         let uniqueSurfaceIds = Set(surfaceIds)
         socketFastPathState.removeShellActivity(panelIds: uniqueSurfaceIds)
+        if let workspaceID {
+            for surfaceId in uniqueSurfaceIds {
+                panelArtifactAuthorizationStore.invalidate(
+                    workspaceID: workspaceID.uuidString,
+                    surfaceID: surfaceId.uuidString
+                )
+            }
+        }
         for surfaceId in uniqueSurfaceIds {
             v2BrowserFrameSelectorBySurface.removeValue(forKey: surfaceId)
             v2BrowserDialogQueueBySurface.removeValue(forKey: surfaceId)
@@ -391,6 +407,7 @@ class TerminalController {
             shellPath: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         ),
         terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore = .init(),
+        panelArtifactAuthorizationStore: PanelArtifactAuthorizationStore? = nil,
         remoteProxyBroker: any RemoteProxyBrokering = RemoteProxyBroker(
             tunnelProvider: RemoteDaemonProxyTunnelProvider(strings: .appLocalized, ptyBridgeStrings: AppRemotePTYBridgeStrings())
         ),
@@ -406,6 +423,7 @@ class TerminalController {
         self.mobileTaskFilesystemJobQuota = mobileTaskFilesystemJobQuota
         self.mobileTaskModelDiscovery = mobileTaskModelDiscovery
         self.terminalArtifactAuthorizationStore = terminalArtifactAuthorizationStore
+        self.panelArtifactAuthorizationStore = panelArtifactAuthorizationStore ?? PanelArtifactAuthorizationStore()
         self.transport = transport
         let socketMarkerFileManager = FileManager.default
         let socketMarkerBundleIdentifier = Bundle.main.bundleIdentifier


### PR DESCRIPTION
## Summary

Fixes the universal Release macOS compile failure reported by nightly run [31982229698](https://github.com/manaflow-ai/cmux/actions/runs/31982229698).

- Reconcile `TerminalController+MobileSurfaces` with the API shapes already present on `main`.
- Restore the main-actor `PanelArtifactAuthorizationStore` owner and invalidate panel grants during workspace-aware surface cleanup.
- Forward workspace identity from panel destruction, session restore, and remote-tmux cleanup so the grant lifecycle is complete.
- Leave the existing nightly workflow unchanged; no new GitHub Actions workflow is added.

## Root cause

PR #10072 (`04ff18eea6`, “Remove iOS todo row sparkles and preserve native mobile surfaces”) is the first failing commit after the last green commit `5734a451c`; it is a direct child of that commit. The PR added `TerminalController+MobileSurfaces.swift` and a `cleanupSurfaceState(workspaceID:)` call, but omitted the matching `TerminalController` store/signature changes. It also wrote switches against an older shape even though `main` already had `PanelType.notifications` (from `8fa42e5e23`), `ControlSurfaceFocusResolution.dockUnavailable` (from `11538d4bb7`), and the Iroh artifact failure cases (from `b71e48880b`). The current-main nightly run [32072634751](https://github.com/manaflow-ai/cmux/actions/runs/32072634751) reproduces those exact macOS errors on `21c48914dd`; the later iOS-only follow-up #10287 did not touch them. This patch reconciles the stale new file with the existing APIs and preserves the intended panel-grant lifecycle.

## Why PR CI looked green

`.github/workflows/ci.yml` is dispatch-only, so #10072 had no automatic macOS app-target compile check. The existing scheduled nightly universal Release lane was the first automatic compiler check and exposed the stale API assumptions. This PR does not add or modify workflow YAML.

## Testing

- Existing remote macOS Release compile run [31996563485](https://github.com/manaflow-ai/cmux/actions/runs/31996563485) passed on the source tree; it compiled both `arm64` and `x86_64` with Xcode 26.5. The only later history cleanup removed the PR-only workflow file.
- Existing `nightly.yml` was dispatched against this branch as run [32073919120](https://github.com/manaflow-ai/cmux/actions/runs/32073919120); its universal Release app build is the direct verification path.
- `git diff --check`, workspace package checks, and Swift warning-budget validation pass.
- No app launch, local XCUITest, or bare local `xcodebuild`.
- The requested `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` are absent from this historical checkout/main; no budget TSV was created or modified.

## Checklist

- [x] References nightly failure run 31982229698.
- [x] Identifies and fixes the first failing commit's stale API assumptions rather than adding a CI workaround.
- [x] Leaves GitHub workflow YAML unchanged.
- [x] PR author is `austinywang`.
