### PR TITLE
Prevent duplicate Codex restore writers

### DIFF
--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -186,6 +186,27 @@ extension CMUXCLI {
             )
         }
 
+        // Codex serializes writers for a thread. A stale hook PID can make
+        // cmux believe the session is idle even while a resumed Codex process
+        // still owns the transcript. Refuse the duplicate launch before
+        // replacing this CLI process, so the user gets a recoverable message
+        // instead of Codex's low-level -32600 protocol error.
+        if record.kind == "codex",
+           let checkpointID = record.checkpointID,
+           let activePID = sessionsListAgentProcessIDs(
+               executableBasename: "codex",
+               containingSessionID: checkpointID
+           ).first {
+            throw loggedRestoreError(
+                stage: "session.active-writer",
+                detail: "pid=\(activePID) session=\(checkpointID)",
+                message: String(
+                    localized: "cli.restore.error.activeWriter",
+                    defaultValue: "restore: this Codex session is already running. Close that Codex process before restoring it again."
+                ) + " (pid \(activePID))."
+            )
+        }
+
         for preflight in invocation.preflightInvocations {
             try runRestorePreflight(
                 preflight,

--- a/CLI/CMUXCLI+SessionsListProcessArguments.swift
+++ b/CLI/CMUXCLI+SessionsListProcessArguments.swift
@@ -18,6 +18,48 @@ extension CMUXCLI {
         )
     }
 
+    /// Returns live PIDs whose executable and argv identify an agent session.
+    /// This catches a resumed process after its hook record has gone stale or
+    /// missed the replacement PID. The caller must still validate the agent
+    /// and session token in the returned process arguments.
+    func sessionsListAgentProcessIDs(
+        executableBasename: String,
+        containingSessionID sessionID: String
+    ) -> [Int] {
+        guard !sessionID.isEmpty else { return [] }
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL]
+        var size: size_t = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0,
+              size >= MemoryLayout<kinfo_proc>.stride else {
+            return []
+        }
+        let count = size / MemoryLayout<kinfo_proc>.stride
+        var processes = [kinfo_proc](repeating: kinfo_proc(), count: count)
+        guard sysctl(
+            &mib,
+            u_int(mib.count),
+            &processes,
+            &size,
+            nil,
+            0
+        ) == 0 else {
+            return []
+        }
+        let normalizedExecutable = executableBasename.lowercased()
+        return processes.prefix(size / MemoryLayout<kinfo_proc>.stride).compactMap { process -> Int? in
+            let pid = Int(process.kp_proc.p_pid)
+            guard pid > 0,
+                  let identity = sessionsListProcessIdentity(for: pid),
+                  identity.arguments.contains(sessionID) else {
+                return nil
+            }
+            let executable = identity.executablePath.map { ($0 as NSString).lastPathComponent }
+                ?? identity.arguments.first.map { ($0 as NSString).lastPathComponent }
+            guard executable?.lowercased() == normalizedExecutable else { return nil }
+            return pid
+        }
+    }
+
     func sessionsListProcessStartTimeMatchesRecord(
         _ processStartTime: TimeInterval,
         record: ClaudeHookSessionRecord

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -50926,6 +50926,13 @@
         "ja": { "stringUnit": { "state": "translated", "value": "restore: 保存されたプロセスを開始できませんでした。表示されている復元コマンドを再実行してください。" } }
       }
     },
+    "cli.restore.error.activeWriter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "restore: this Codex session is already running. Close that Codex process before restoring it again." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "restore: この Codex セッションはすでに実行中です。もう一度復元する前に、その Codex プロセスを終了してください。" } }
+      }
+    },
     "cli.restore.error.incompleteData": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Fixes manual Codex restore when the hook record has a stale PID but the thread is still owned by a live Codex process.

Before launching a structured restore, cmux scans live process identities for the exact Codex session ID. It returns a localized actionable error instead of spawning a second writer and surfacing Codex protocol error -32600.

Validation: cmux-cli target compiled past the changed files in the tagged cloud build. The full app build reached unrelated existing errors in Sources/TerminalController+MobileSurfaces.swift.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789534637&installation_model_id=21920&pr_number=10235&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10235&signature=b1ddbe33d1e3eadcc1762afc85f28c9e6470e929fe96cc2ba27f7c59478eba13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents launching a second Codex restore writer when a resumed Codex process still owns the session. Previously, manual restore could start a duplicate writer and then fail with Codex protocol error -32600; now we detect the live owner and return a localized, actionable error.

**Key changes**
- Add a restore preflight for `kind == "codex"` sessions: scan live processes for basename "codex" whose argv contains the exact session/checkpoint ID; if found, abort with `loggedRestoreError(stage: "session.active-writer")` including the PID and `cli.restore.error.activeWriter`.
- Introduce `sessionsListAgentProcessIDs` (sysctl-based) to enumerate processes and match by executable basename (case-insensitive) and session ID in arguments; returns an empty list on sysctl failure.
- Add localized strings for the new error in English and Japanese.
- No change to non-Codex restores; no migration or configuration changes required.

<sup>Written for commit ab31dbad2d01a96f66e65e6f02cc5beda53fcb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restore now prevents duplicate Codex sessions when the target session is already running.
  * Displays a clear error with the active process ID when restoration is blocked.
  * Added English and Japanese messages explaining that the running session must be closed before restoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->