### PR TITLE
fix(tui): compile journal restore projection receipts

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -346,9 +346,7 @@ impl RestoreReducer {
     fn apply_required_record(&mut self, record: &SessionJournalRecord) -> anyhow::Result<bool> {
         if matches!(
             record.kind.as_str(),
-            "journal.checkpoint.created"
-                | "journal.segment.sealed"
-                | "journal.restore.applied"
+            "journal.checkpoint.created" | "journal.segment.sealed" | "journal.restore.applied"
         ) {
             return Ok(true);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use ghostty_vt::KittyGraphicsLimits;
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use zeroize::Zeroize;
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -26954,10 +26954,14 @@ mod tests {
 
     fn journal_restore_test_mux(label: &str) -> (std::path::PathBuf, Arc<Mux>) {
         let root = journal_restore_test_root(label);
-        let mux = Mux::open_persistent(
-            format!("journal-restore-{label}"),
+        let session = format!("journal-restore-{label}");
+        let registry = WorkspaceRegistry::open(&root, &session).unwrap();
+        let mux = Mux::from_workspace_registry(
+            session,
             SurfaceOptions::default(),
-            &root,
+            registry,
+            ProviderWorkspaceState::default(),
+            true,
         )
         .unwrap();
         (root, mux)

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -27068,7 +27068,6 @@ mod tests {
         let (root, mux) = journal_restore_test_mux("receipt-projection-status");
         let (surface, _terminal_id) = journal_restore_surface_and_terminal(&mux);
         let (_checkpoint, plan) = journal_restore_plan_after_agent(&mux, surface);
-        let expected_head = plan.head_sequence.to_string();
 
         let (result, _commit) = mux
             .restore_journal_projections_with_receipt(
@@ -27079,7 +27078,8 @@ mod tests {
             .unwrap();
 
         let projection = &result["projection"];
-        assert_eq!(projection["head_sequence"].as_str(), Some(expected_head.as_str()));
+        let committed_sequence = result["sequence"].as_str().expect("restore sequence");
+        assert_eq!(projection["head_sequence"].as_str(), Some(committed_sequence));
         assert!(projection["pending"].is_boolean());
         assert!(
             projection["cursor_sequence"].is_string() || projection["cursor_sequence"].is_null()

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5639,8 +5639,7 @@ impl Mux {
             .journal_checkpoints()?
             .into_iter()
             .find(|summary| {
-                summary.checkpoint_id
-                    == plan.preview["checkpoint_id"].as_str().unwrap_or_default()
+                summary.checkpoint_id == plan.preview["checkpoint_id"].as_str().unwrap_or_default()
             })
             .context("selected journal checkpoint has no summary")?;
         Ok(json!({
@@ -26970,9 +26969,7 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
-    fn journal_restore_surface_and_terminal(
-        mux: &Arc<Mux>,
-    ) -> (SurfaceId, TerminalPublicId) {
+    fn journal_restore_surface_and_terminal(mux: &Arc<Mux>) -> (SurfaceId, TerminalPublicId) {
         let surface = mux.new_workspace(None, None).unwrap();
         let terminal_id = surface.terminal_public_id().cloned().unwrap();
         (surface.id, terminal_id)
@@ -26992,9 +26989,7 @@ mod tests {
             Some("restore-session".into()),
         )
         .unwrap();
-        let plan = mux
-            .prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id)
-            .unwrap();
+        let plan = mux.prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id).unwrap();
         (checkpoint, plan)
     }
 
@@ -27018,8 +27013,7 @@ mod tests {
 
     fn append_journal_restore_required_record(mux: &Arc<Mux>, key: &str) {
         let manifest = journal_restore_required_manifest();
-        mux.put_journal_producer(&manifest, "journal-restore-test", "restore-producer")
-            .unwrap();
+        mux.put_journal_producer(&manifest, "journal-restore-test", "restore-producer").unwrap();
         let event = manifest.events[0].clone();
         let ingress = crate::JournalIngress {
             producer_id: manifest.producer_id.clone(),
@@ -27130,12 +27124,9 @@ mod tests {
     fn journal_restore_rejects_concurrent_head_change_without_mutation() {
         let (root, mux) = journal_restore_test_mux("head-fence");
         let (surface, _terminal_id) = journal_restore_surface_and_terminal(&mux);
-        let checkpoint = mux
-            .create_journal_checkpoint("journal-restore-test", "checkpoint-head-fence")
-            .unwrap();
-        let plan = mux
-            .prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id)
-            .unwrap();
+        let checkpoint =
+            mux.create_journal_checkpoint("journal-restore-test", "checkpoint-head-fence").unwrap();
+        let plan = mux.prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id).unwrap();
         mux.report_agent(
             surface,
             AgentState::Working,
@@ -27165,9 +27156,7 @@ mod tests {
             .create_journal_checkpoint("journal-restore-test", "checkpoint-incompatible")
             .unwrap();
         append_journal_restore_required_record(&mux, "restore-incompatible");
-        let plan = mux
-            .prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id)
-            .unwrap();
+        let plan = mux.prepare_journal_restore(&checkpoint.checkpoint.checkpoint_id).unwrap();
         assert_eq!(plan.preview["fully_reducible"], false);
         assert_eq!(plan.preview["unsupported_required_record_count"], "1");
 
@@ -27188,15 +27177,10 @@ mod tests {
     #[test]
     fn journal_inspect_keeps_immutable_history_diagnostics_actionable() {
         let (root, mux) = journal_restore_test_mux("immutable");
-        let checkpoint = mux
-            .create_journal_checkpoint("journal-restore-test", "checkpoint-immutable")
-            .unwrap();
-        let database = mux
-            .workspace_registry
-            .lock()
-            .unwrap()
-            .session_journal_database_path()
-            .unwrap();
+        let checkpoint =
+            mux.create_journal_checkpoint("journal-restore-test", "checkpoint-immutable").unwrap();
+        let database =
+            mux.workspace_registry.lock().unwrap().session_journal_database_path().unwrap();
         let connection = rusqlite::Connection::open(database).unwrap();
         let error = connection
             .execute(
@@ -27208,13 +27192,8 @@ mod tests {
         assert!(error.contains("journal checkpoints are immutable"), "{error}");
         drop(connection);
 
-        let inspected = mux
-            .journal_inspect(Some(&checkpoint.checkpoint.checkpoint_id))
-            .unwrap();
-        assert_eq!(
-            inspected["checkpoint"]["checkpoint_id"],
-            checkpoint.checkpoint.checkpoint_id
-        );
+        let inspected = mux.journal_inspect(Some(&checkpoint.checkpoint.checkpoint_id)).unwrap();
+        assert_eq!(inspected["checkpoint"]["checkpoint_id"], checkpoint.checkpoint.checkpoint_id);
         assert_eq!(inspected["preview"]["checkpoint_id"], checkpoint.checkpoint.checkpoint_id);
         finish_journal_restore_test(root, mux);
     }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -27064,6 +27064,30 @@ mod tests {
     }
 
     #[test]
+    fn journal_restore_receipt_includes_transactional_projection_status() {
+        let (root, mux) = journal_restore_test_mux("receipt-projection-status");
+        let (surface, _terminal_id) = journal_restore_surface_and_terminal(&mux);
+        let (_checkpoint, plan) = journal_restore_plan_after_agent(&mux, surface);
+        let expected_head = plan.head_sequence.to_string();
+
+        let (result, _commit) = mux
+            .restore_journal_projections_with_receipt(
+                plan,
+                "journal-restore-test",
+                "restore-projection-status",
+            )
+            .unwrap();
+
+        let projection = &result["projection"];
+        assert_eq!(projection["head_sequence"].as_str(), Some(expected_head.as_str()));
+        assert!(projection["pending"].is_boolean());
+        assert!(
+            projection["cursor_sequence"].is_string() || projection["cursor_sequence"].is_null()
+        );
+        finish_journal_restore_test(root, mux);
+    }
+
+    #[test]
     fn journal_restore_replay_is_idempotent_after_head_advances() {
         let (root, mux) = journal_restore_test_mux("idempotent");
         let (surface, terminal_id) = journal_restore_surface_and_terminal(&mux);

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/agent_projection_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/agent_projection_store.rs
@@ -1015,10 +1015,7 @@ pub(super) fn replace_agent_projections_from_reduced_state(
             [terminal_id.as_str()],
             |row| row.get::<_, bool>(0),
         )?;
-        anyhow::ensure!(
-            exists,
-            "reduced journal state references unknown terminal {terminal_id}"
-        );
+        anyhow::ensure!(exists, "reduced journal state references unknown terminal {terminal_id}");
     }
 
     transaction.execute("DELETE FROM resource_agent_projection_rebuild_changes", [])?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2207,8 +2207,7 @@ impl WorkspaceRegistry {
                 previous_resource_revision: None,
             },
         )?;
-        let projection =
-            WorkspaceRegistry::agent_projection_restore_status_for_transaction(&tx)?;
+        let projection = WorkspaceRegistry::agent_projection_restore_status_for_transaction(&tx)?;
         let result = json!({
             "restored":true,
             "checkpoint_id":checkpoint_id,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2213,7 +2213,9 @@ impl WorkspaceRegistry {
             },
         )?;
         let projection =
-            super::agent_projection_store::agent_projection_restore_status_for_transaction(&tx)?;
+            super::agent_projection_store::WorkspaceRegistry::agent_projection_restore_status_for_transaction(
+                &tx,
+            )?;
         let result = json!({
             "restored":true,
             "checkpoint_id":checkpoint_id,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2170,12 +2170,11 @@ impl WorkspaceRegistry {
             journal_head(&tx)? == expected_head,
             "journal head changed while preparing restore; preview the journal again and retry"
         );
-        let projections =
-            agent_projection_store::replace_agent_projections_from_reduced_state(
-                &tx,
-                state,
-                expected_head,
-            )?;
+        let projections = agent_projection_store::replace_agent_projections_from_reduced_state(
+            &tx,
+            state,
+            expected_head,
+        )?;
         let now = unix_epoch_ms()?;
         let session_id = transaction_session_id(&tx)?;
         let subjects = vec![JournalSubject { kind: "session".into(), id: session_id }];

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2208,9 +2208,7 @@ impl WorkspaceRegistry {
             },
         )?;
         let projection =
-            agent_projection_store::WorkspaceRegistry::agent_projection_restore_status_for_transaction(
-                &tx,
-            )?;
+            WorkspaceRegistry::agent_projection_restore_status_for_transaction(&tx)?;
         let result = json!({
             "restored":true,
             "checkpoint_id":checkpoint_id,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2136,11 +2136,7 @@ impl WorkspaceRegistry {
         idempotency_key: &str,
         checkpoint_id: Option<&str>,
         state_sha256: Option<&str>,
-    ) -> anyhow::Result<(
-        JournalRestoreCommit,
-        Vec<RegistryAgentProjection>,
-        Value,
-    )> {
+    ) -> anyhow::Result<(JournalRestoreCommit, Vec<RegistryAgentProjection>, Value)> {
         validate_identifier("journal restore origin", origin)?;
         validate_identifier("journal restore idempotency key", idempotency_key)?;
         let fingerprint = journal_restore_request_fingerprint(checkpoint_id, state_sha256)?;
@@ -2175,7 +2171,7 @@ impl WorkspaceRegistry {
             "journal head changed while preparing restore; preview the journal again and retry"
         );
         let projections =
-            super::agent_projection_store::replace_agent_projections_from_reduced_state(
+            agent_projection_store::replace_agent_projections_from_reduced_state(
                 &tx,
                 state,
                 expected_head,
@@ -2213,7 +2209,7 @@ impl WorkspaceRegistry {
             },
         )?;
         let projection =
-            super::agent_projection_store::WorkspaceRegistry::agent_projection_restore_status_for_transaction(
+            agent_projection_store::WorkspaceRegistry::agent_projection_restore_status_for_transaction(
                 &tx,
             )?;
         let result = json!({

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1864,13 +1864,15 @@ fn run_server(
     let restore_journal = !args.no_restore;
     let mux =
         match (state_root.as_deref(), provider_workspace_authority, provider_management_pending) {
-            (Some(root), Some(authority), false) => Mux::open_persistent_provider_managed_with_restore(
-                args.session.clone(),
-                surface_options,
-                root,
-                authority,
-                restore_journal,
-            ),
+            (Some(root), Some(authority), false) => {
+                Mux::open_persistent_provider_managed_with_restore(
+                    args.session.clone(),
+                    surface_options,
+                    root,
+                    authority,
+                    restore_journal,
+                )
+            }
             (Some(root), None, true) => Mux::open_persistent_provider_managed_pending_with_restore(
                 args.session.clone(),
                 surface_options,

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1294,7 +1294,10 @@ fn json_socket_request(path: &std::path::Path, request: serde_json::Value) -> se
 }
 
 #[cfg(unix)]
-fn journal_cli_fixture(args: &[&str], result: serde_json::Value) -> (Output, Option<serde_json::Value>) {
+fn journal_cli_fixture(
+    args: &[&str],
+    result: serde_json::Value,
+) -> (Output, Option<serde_json::Value>) {
     let dir = unique_temp_dir("journal-cli-contract");
     fs::create_dir_all(&dir).unwrap();
     let socket = dir.join("journal.sock");
@@ -1391,14 +1394,7 @@ fn journal_cli_routes_list_and_inspect_and_preserves_decimal_strings() {
     assert_eq!(list_json["projection"]["cursor_sequence"].as_str(), Some(HUGE));
 
     let (inspect, request) = journal_cli_fixture(
-        &[
-            "session",
-            SESSION,
-            "journal",
-            "inspect",
-            "--checkpoint",
-            "latest",
-        ],
+        &["session", SESSION, "journal", "inspect", "--checkpoint", "latest"],
         serde_json::json!({
             "head_sequence": HUGE,
             "checkpoint": {"source_sequence": HUGE},
@@ -3866,7 +3862,9 @@ fn help_uses_public_cmux_scopes_and_keeps_startup_options_discoverable() {
     assert!(startup.contains("--ws <addr>"));
     assert!(startup.contains("--ws-token <token>"));
     assert!(startup.contains("--ws-insecure-bind"));
-    assert!(startup.contains("--no-restore       Skip startup journal projection replay for this run."));
+    assert!(
+        startup.contains("--no-restore       Skip startup journal projection replay for this run.")
+    );
     assert!(!startup.contains("cmux-tui"));
 }
 
@@ -3881,7 +3879,9 @@ fn journal_help_lists_read_and_mutating_administration_paths() {
     let help = String::from_utf8(output.stdout).unwrap();
     assert!(help.contains("cmux session <selector> journal list"), "{help}");
     assert!(
-        help.contains("cmux session <selector> journal inspect [--checkpoint latest|<checkpoint-id>]"),
+        help.contains(
+            "cmux session <selector> journal inspect [--checkpoint latest|<checkpoint-id>]"
+        ),
         "{help}"
     );
     assert!(
@@ -3923,9 +3923,7 @@ fn no_restore_is_a_start_only_option_and_provider_modes_reject_it() {
             .unwrap();
         assert_eq!(output.status.code(), Some(2), "{provider_args:?}");
         assert!(
-            String::from_utf8(output.stderr)
-                .unwrap()
-                .contains("--no-restore"),
+            String::from_utf8(output.stderr).unwrap().contains("--no-restore"),
             "{provider_args:?}"
         );
     }


### PR DESCRIPTION
## Summary
- Cover the restore receipt projection status after the restore journal append.
- Fix the core build errors in journal list/inspect and transactional restore status.

## Testing
- Hosted cmux-tui verification will run after the green fix commit.
- No local cargo, rustc, zig, or Xcode commands.

Stacked on [PR #10136](https://github.com/manaflow-ai/cmux/pull/10136).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789536572&installation_model_id=21920&pr_number=10236&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10236&signature=3380dc01e73665dd499eea04c946cfca7047be892407b83ccb2b1ca45c6ce860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles and always includes transactional projection status in TUI journal restore receipts. Previously, receipts could fail to compile and omit projection fields; now they include `projection.head_sequence` (equal to the committed `sequence`), `pending` (bool), and `cursor_sequence` (string|null).

- Builds the receipt with `serde_json::json` and reads projection status via `WorkspaceRegistry::agent_projection_restore_status_for_transaction(&tx)` in the same transaction as the append.
- Adds a Mux test that validates the `projection` fields and the `head_sequence == sequence`; test harness uses a deterministic restore runtime via `Mux::from_workspace_registry`.
- Matches hosted journal formatting; formatting-only updates elsewhere; no CLI behavior or protocol changes.

<sup>Written for commit e720a02c9faf02de70ec3712a915523d3977ccf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

