### PR TITLE
Fix startup benchmark tool path construction

### DIFF
--- a/.github/workflows/cmux-tui-startup-benchmark.yml
+++ b/.github/workflows/cmux-tui-startup-benchmark.yml
@@ -492,6 +492,12 @@ jobs:
           printf 'trusted=%s\nbaseline=%s\ncandidate=%s\n' \
             "$actual_trusted" "$actual_baseline" "$actual_candidate"
 
+      - name: Test startup benchmark path helpers
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$PYTHON_CMD" "$TRUSTED_SOURCE/cmux-tui/scripts/tests/test_record_startup_tools.py"
+
       - name: Initialize exact Ghostty revisions
         shell: bash
         run: |
@@ -1192,43 +1198,7 @@ jobs:
               "${harness_args[@]}"
           )
 
-          "$PYTHON_CMD" - <<'PY'
-          import hashlib
-          import os
-          import pathlib
-
-          target = os.environ["RUST_TARGET"]
-          suffix = os.environ["BINARY_SUFFIX"]
-
-          def binary(root):
-              release = pathlib.Path(os.environ[root])
-              if target:
-                  release /= target
-              return release / "release" / f"cmux-tui{suffix}"
-
-          def digest(path):
-              sha256 = hashlib.sha256()
-              with path.open("rb") as source:
-                  for chunk in iter(lambda: source.read(1024 * 1024), b""):
-                      sha256.update(chunk)
-              return sha256.hexdigest()
-
-          baseline_sha256 = digest(binary("BASELINE_TARGET_ROOT"))
-          trusted_release = pathlib.Path(os.environ["TRUSTED_TARGET_ROOT"])
-          if target:
-              trusted_release /= target
-          trusted_release /= "release" / "examples"
-          supervisor = trusted_release / f"startup_benchmark_supervisor{suffix}"
-          preflight = trusted_release / f"startup_benchmark_preflight{suffix}"
-          harness = trusted_release / f"startup_benchmark{suffix}"
-          for path in (supervisor, preflight, harness):
-              if not path.is_file():
-                  raise SystemExit(f"trusted benchmark tool is missing: {path}")
-          supervisor_sha256 = digest(supervisor)
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              print(f"binary_sha256={baseline_sha256}", file=output)
-              print(f"supervisor_sha256={supervisor_sha256}", file=output)
-          PY
+          "$PYTHON_CMD" "$TRUSTED_SOURCE/cmux-tui/scripts/record_startup_tools.py"
 
       - name: Prove startup sandbox behavior
         id: sandbox-preflight

--- a/cmux-tui/scripts/record_startup_tools.py
+++ b/cmux-tui/scripts/record_startup_tools.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Record the trusted startup benchmark tool paths and digests."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def release_root(target_root: Path, target: str) -> Path:
+    """Return the Cargo release directory for a target root."""
+
+    release = target_root
+    if target:
+        release /= target
+    return release / "release"
+
+
+def tool_paths(trusted_target_root: Path, target: str, suffix: str) -> dict[str, Path]:
+    """Return the trusted benchmark executables for one platform."""
+
+    trusted_release = trusted_target_root
+    if target:
+        trusted_release /= target
+    # Keep this expression in the first red commit to reproduce the hosted bug.
+    trusted_release /= "release" / "examples"
+    return {
+        "supervisor": trusted_release / f"startup_benchmark_supervisor{suffix}",
+        "preflight": trusted_release / f"startup_benchmark_preflight{suffix}",
+        "harness": trusted_release / f"startup_benchmark{suffix}",
+    }
+
+
+def digest(path: Path) -> str:
+    """Return the SHA-256 digest of a regular file."""
+
+    sha256 = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def record_from_environment() -> None:
+    """Validate benchmark tools and append their digests to GITHUB_OUTPUT."""
+
+    target = os.environ["RUST_TARGET"]
+    suffix = os.environ["BINARY_SUFFIX"]
+    baseline_binary = release_root(
+        Path(os.environ["BASELINE_TARGET_ROOT"]), target
+    ) / f"cmux-tui{suffix}"
+    baseline_sha256 = digest(baseline_binary)
+
+    tools = tool_paths(Path(os.environ["TRUSTED_TARGET_ROOT"]), target, suffix)
+    for path in tools.values():
+        if not path.is_file():
+            raise SystemExit(f"trusted benchmark tool is missing: {path}")
+
+    supervisor_sha256 = digest(tools["supervisor"])
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+        print(f"binary_sha256={baseline_sha256}", file=output)
+        print(f"supervisor_sha256={supervisor_sha256}", file=output)
+
+
+if __name__ == "__main__":
+    record_from_environment()

--- a/cmux-tui/scripts/record_startup_tools.py
+++ b/cmux-tui/scripts/record_startup_tools.py
@@ -23,8 +23,8 @@ def tool_paths(trusted_target_root: Path, target: str, suffix: str) -> dict[str,
     trusted_release = trusted_target_root
     if target:
         trusted_release /= target
-    # Keep this expression in the first red commit to reproduce the hosted bug.
-    trusted_release /= "release" / "examples"
+    trusted_release /= "release"
+    trusted_release /= "examples"
     return {
         "supervisor": trusted_release / f"startup_benchmark_supervisor{suffix}",
         "preflight": trusted_release / f"startup_benchmark_preflight{suffix}",

--- a/cmux-tui/scripts/tests/test_record_startup_tools.py
+++ b/cmux-tui/scripts/tests/test_record_startup_tools.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Regression tests for startup benchmark tool path construction."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "record_startup_tools.py"
+SPEC = importlib.util.spec_from_file_location("record_startup_tools", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+TOOLS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TOOLS)
+
+
+class StartupToolPathTests(unittest.TestCase):
+    def test_targeted_tools_live_under_release_examples(self) -> None:
+        paths = TOOLS.tool_paths(Path("/tmp/target"), "x86_64-pc-windows-gnu", ".exe")
+
+        self.assertEqual(
+            paths,
+            {
+                "supervisor": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark_supervisor.exe"
+                ),
+                "preflight": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark_preflight.exe"
+                ),
+                "harness": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark.exe"
+                ),
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- move trusted startup benchmark tool path and digest recording into a tested Python helper
- fix the hosted Windows/Linux/macOS failure caused by dividing two strings instead of joining `Path` values
- run the helper regression test in the benchmark job before the build

## Evidence

Red commit `3bb0241000` fails `cmux-tui/scripts/tests/test_record_startup_tools.py` with the hosted `TypeError: unsupported operand type(s) for /: 'str' and 'str'`.

Green commit `187dffe3e1` passes the same test and uses separate `Path` joins for `release/examples`.

No local Rust, Cargo, Zig, Xcode, or build command was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789536651&installation_model_id=21920&pr_number=10237&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10237&signature=3cd85dbea88f24386e9b5a9cfb76a1512fc276aa2f5a75170f3f4e0fb3d570eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures in the startup benchmark by moving path construction and digest recording into a tested Python helper. Old behavior used inline workflow Python that divided strings when building paths (TypeError on hosted runners); new behavior uses `pathlib.Path`, validates tool presence under release/examples, and writes digests to `GITHUB_OUTPUT`. Side effect: adds a small pre-build test step.

- Replaces the heredoc Python step in `.github/workflows/cmux-tui-startup-benchmark.yml` with `cmux-tui/scripts/record_startup_tools.py`.
- Adds `cmux-tui/scripts/tests/test_record_startup_tools.py` and runs it before the build.
- Helper emits `binary_sha256` and `supervisor_sha256`; supports targets and platform suffixes.
- No change to benchmark semantics; CI is now reliable across Windows, Linux, and macOS.

<sup>Written for commit 187dffe3e181fd6a85f99dc3fec2244c4fbe6fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

