### PR TITLE
docs(tui): describe manual nightly channel

### DIFF
--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -1,8 +1,8 @@
 name: cmux-tui nightly
 
 on:
-  # CI pause: the macOS Nightly and rolling iOS beta remain automatic; this
-  # separate TUI package build remains available on demand.
+  # TUI package nightlies are manual-dispatch only. Dispatch on main when an
+  # on-demand prerelease package is required.
   workflow_dispatch:
 
 permissions: {}

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -61,10 +61,11 @@ Nightly publishing uses the same environments. Add trusted publishers for:
 
 ## Nightly channel
 
-`.github/workflows/cmux-tui-nightly.yml` runs on a daily schedule and by manual
-dispatch. It always checks out `main`, derives the next stable version from the
-latest reachable `cmux-tui-vX.Y.Z` tag by bumping patch, and falls back to
-`0.9.0` when no stable TUI tag exists.
+`.github/workflows/cmux-tui-nightly.yml` is manual-dispatch only. Dispatch it
+from `main` for an on-demand package nightly. It checks out the dispatched
+`main` commit, derives the next stable version from the latest reachable
+`cmux-tui-vX.Y.Z` tag by bumping patch, and falls back to `0.9.0` when no stable
+TUI tag exists.
 
 Nightly versions use registry-specific prerelease forms:
 
@@ -78,10 +79,9 @@ npm nightlies are published with `npm publish --provenance --tag nightly`, so
 stable `latest` dist-tag. PyPI nightlies are dev releases, so normal
 `uvx cmux` resolution ignores them; `uvx --prerelease allow cmux` opts in.
 
-The nightly workflow intentionally always builds and publishes a fresh run
-instead of trying to skip when `main` has not changed. The build is cheap, and a
-GitHub API lookup for the last successful nightly is more fragile than the
-extra build.
+Each manual dispatch builds and publishes a fresh run, even when `main` has not
+changed. The build is cheap, and a GitHub API lookup for the last successful
+nightly is more fragile than the extra build.
 
 ## Cutting a Stable Release
 

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1371,6 +1371,19 @@ def test_nightly_build_is_pinned_to_its_provenance_commit() -> None:
     assert "checkout_ref: ${{ needs.version.outputs.head_sha }}" in text
 
 
+def test_nightly_channel_is_manual_only_and_documented_as_such() -> None:
+    text = workflow("cmux-tui-nightly.yml")
+    docs = (ROOT / "cmux-tui" / "dist" / "RELEASING-TUI.md").read_text()
+    nightly_docs = docs.split("## Nightly channel", 1)[1].split("## ", 1)[0]
+    triggers = workflow_triggers(text)
+
+    assert set(triggers) == {"workflow_dispatch"}
+    assert "schedule" not in triggers
+    assert "manual-dispatch only" in text
+    assert "manual-dispatch only" in nightly_docs
+    assert "daily schedule" not in nightly_docs.lower()
+
+
 def test_sdk_publish_conformance_runs_live_against_exact_built_binary() -> None:
     for name, language in (
         ("sdk-publish-crates.yml", "rust"),


### PR DESCRIPTION
## Summary
- describe `cmux-tui-nightly.yml` as manual-dispatch only
- keep the package publication behavior documented for each manual dispatch
- add a contract test for the workflow trigger and nightly docs wording

## Verification
- commit `e33fa20894` adds the failing contract test (red)
- commit `3afd7ce263` updates the comment and docs (green)
- `python3 -m unittest tests/test_tui_publish_workflow_security.py`
- `python3 -m py_compile tests/test_tui_publish_workflow_security.py`
- PyYAML BaseLoader trigger check
- `actionlint .github/workflows/cmux-tui-nightly.yml`

No schedule, workflow dispatch, package publish, or build was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789536867&installation_model_id=21920&pr_number=10241&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10241&signature=f41de903138137e69a3b474c30f3a3abc5c7f13c7b0a8c0d50f285d509d759e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that the `cmux-tui` nightly channel is manual-dispatch only and enforces it with a contract test. Previously docs claimed a daily schedule; now docs and workflow comments state manual-only, so nightlies publish only when explicitly dispatched from `main`.

- `.github/workflows/cmux-tui-nightly.yml` has only `workflow_dispatch` and documents “manual-dispatch only.”
- `cmux-tui/dist/RELEASING-TUI.md` updates “Nightly channel” to manual-only, retaining per-dispatch publish behavior (builds and publishes a fresh run each time).
- `tests/test_tui_publish_workflow_security.py` asserts the trigger set is `{"workflow_dispatch"}` and that the docs reflect manual-only.

<sup>Written for commit 3afd7ce263b31b7f7e68bccd81e26d3254202344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that TUI package nightlies run only through manual dispatch.
  * Documented that on-demand prereleases may be dispatched from the main branch.

* **Tests**
  * Added coverage to verify the nightly workflow remains manual-only and does not describe a daily schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->