### PR TITLE
docs(tui): align protocol inventory metadata with v12

### DIFF
--- a/cmux-tui/scripts/test_check_spec_inventory.py
+++ b/cmux-tui/scripts/test_check_spec_inventory.py
@@ -619,6 +619,41 @@ class InventoryContractTests(unittest.TestCase):
     def inventory(self) -> dict:
         return json.loads((CHECKER.SPEC / "inventory.json").read_text())
 
+    def test_private_protocol_domain_ids_match_inventory_version(self) -> None:
+        inventory = self.inventory()
+        private_domains = {
+            domain["id"]
+            for domain in inventory["protocol_domains"]
+            if domain["spec"] in {"commands.md", "events.md"}
+        }
+        expected = {
+            f"mux-control-v{inventory['mux_protocol']}",
+            f"mux-events-v{inventory['mux_protocol']}",
+        }
+        self.assertEqual(private_domains, expected)
+
+    def test_merged_terminal_shortcuts_head_is_not_pending(self) -> None:
+        inventory = self.inventory()
+        pending_urls = {head["url"] for head in inventory["pending_heads"]}
+        self.assertNotIn(
+            "https://github.com/manaflow-ai/cmux/pull/8698",
+            pending_urls,
+        )
+
+    def test_programmability_prose_uses_current_protocol_and_no_pending_8698(self) -> None:
+        inventory = self.inventory()
+        prose = (CHECKER.SPEC / "programmability.md").read_text()
+        self.assertIn(
+            f"The implemented v{inventory['mux_protocol']} inventory",
+            prose,
+        )
+        pending_8698_lines = [
+            line
+            for line in prose.splitlines()
+            if "8698" in line and "pending" in line
+        ]
+        self.assertEqual(pending_8698_lines, [])
+
     def test_command_profile_drift_is_rejected(self) -> None:
         inventory = copy.deepcopy(self.inventory())
         inventory["commands"]["local-admin"].remove("shutdown-daemon")

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -538,8 +538,8 @@
     }
   },
   "protocol_domains": [
-    {"id": "mux-control-v10", "status": "implemented", "spec": "commands.md"},
-    {"id": "mux-events-v10", "status": "implemented", "spec": "events.md"},
+    {"id": "mux-control-v12", "status": "implemented", "spec": "commands.md"},
+    {"id": "mux-events-v12", "status": "implemented", "spec": "events.md"},
     {"id": "terminal-host-v1", "status": "partial", "spec": "terminal-host.md"},
     {"id": "machine-provider-v0-v1", "status": "implemented", "spec": "machine-provider.md"},
     {"id": "cmux.machine-agent-v1", "status": "implemented", "spec": "machine-agent.md"},
@@ -549,12 +549,5 @@
     {"id": "frontend-actions-vNext", "status": "proposed", "spec": "programmability.md"},
     {"id": "configuration-vNext", "status": "proposed", "spec": "programmability.md"}
   ],
-  "pending_heads": [
-    {
-      "name": "terminal-shortcuts",
-      "url": "https://github.com/manaflow-ai/cmux/pull/8698",
-      "status": "pending",
-      "note": "Adds clear-history and structured key work. It is not part of the main protocol inventory."
-    }
-  ]
+  "pending_heads": []
 }

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v12 inventory is complete as a description of current wire behavior. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |
@@ -62,7 +62,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
-| Terminal history | Paged retained rows have unstable indexes | History revision, cursor pagination, eviction boundary, and explicit clear-history operation |
+| Terminal history | Paged retained rows have unstable indexes | History revision, cursor pagination, and eviction boundary |
 | Browser basics | Create, input, navigate, back, forward, reload, activate, state, and frames are implemented | Typed methods in every frontend SDK |
 | Browser lifecycle | Browser success is asynchronous and CDP failures arrive later | Correlated operation ids, target/crash/dialog/download events, viewport revision, and optional raw CDP profile |
 | Client identity | `list-clients` exposes transient connection ids | `hello` or `whoami` with client instance, authenticated principal, rights, credential expiry, and protocol selection |
@@ -111,8 +111,8 @@ Each implemented command needs success, invalid request, target-not-found, and n
 
 Feature-family `wire_status` records whether a current transport exists. `programmability` records portable typed SDK and conformance completeness. This distinction prevents a live raw command, such as browser control, from being reported as complete while language clients remain uneven.
 
-The initial inventory gate prevents undocumented runtime drift. It does not claim that the current 11 shared fixtures cover all 83 commands. Fixture coverage becomes a required per-command field when deterministic schema-driven generation replaces the current prompt-based binding script.
+The initial inventory gate prevents undocumented runtime drift. It does not claim that the current shared fixtures cover every command. Fixture coverage becomes a required per-command field when deterministic schema-driven generation replaces the current prompt-based binding script.
 
-## Pending protocol heads
+## Protocol inventory status
 
-The inventory is based on `main`. [PR 8698](https://github.com/manaflow-ai/cmux/pull/8698) adds clear-history and structured shortcut work and remains `pending` in `inventory.json`. Per-surface client sizing landed with protocol 10 and is part of the implemented inventory.
+The inventory is based on `main` and tracks private protocol v12. [PR 8698](https://github.com/manaflow-ai/cmux/pull/8698) added clear-history and structured shortcut work; both are included in the implemented inventory. Per-surface client sizing landed with protocol 10 and remains part of the implemented inventory.


### PR DESCRIPTION
## Summary

- Align private protocol domain IDs with inventory protocol v12.
- Remove merged PR 8698 from pending heads and record its clear-history and shortcut work as implemented.
- Remove stale v10 and fixture-count claims from the programmability specification.
- Add inventory contract tests for protocol IDs, merged heads, and current prose.

The nightly release runbook is excluded because PR work on that file is already in progress on a separate branch.

## Verification

- Red commit: `7bac8981f6` adds the contract tests; all three new tests fail against the old metadata.
- Green commit: `2230e15f44` updates the metadata and prose; the three new tests pass.
- `python3 -m unittest cmux-tui.scripts.test_check_spec_inventory.DocumentationConsistencyTests cmux-tui.scripts.test_check_spec_inventory.SchemaValidationTests cmux-tui.scripts.test_check_spec_inventory.InventoryContractTests.test_private_protocol_domain_ids_match_inventory_version cmux-tui.scripts.test_check_spec_inventory.InventoryContractTests.test_merged_terminal_shortcuts_head_is_not_pending cmux-tui.scripts.test_check_spec_inventory.InventoryContractTests.test_programmability_prose_uses_current_protocol_and_no_pending_8698 -v`
- `git diff --check origin/main...HEAD`
- Inventory JSON schema and protocol-domain validation passed.

No build or publish was run. The full inventory checker was not run because its Rust source scan is not safe on this Mac; the focused Python contract checks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537158&installation_model_id=21920&pr_number=10242&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10242&signature=d8ccc29516d59e04aa8aff915341c3fe54ad4f85d821fa74e95acd55a6441836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns TUI protocol inventory metadata and docs with private protocol v12 to remove stale v10 references and lock the version with tests.

- Old: `protocol_domains` used v10 IDs; New: v12 IDs (`mux-control-v12`, `mux-events-v12`).
- Old: PR 8698 was `pending`; New: removed from `pending_heads` and treated as implemented (clear-history and structured shortcuts).
- Programmability prose now references v12, removes the clear-history requirement, and drops the fixture-count claim.
- Adds contract tests to enforce: private domain IDs match `mux_protocol`, PR 8698 is not pending, and prose cites the current protocol.

Migration:
- Update any tooling that matches `mux-control-v10`/`mux-events-v10` to v12.
- Remove assumptions that PR 8698 appears in `pending_heads`.

<sup>Written for commit 2230e15f44bcb0b915bc3764aaf74c21af79ebdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated programmability documentation to reflect the current protocol version and implementation status.
  * Clarified terminal history and shortcut support details.

* **Tests**
  * Added consistency checks to ensure protocol inventory, pending changes, and documentation remain synchronized.

* **Chores**
  * Updated protocol domain inventory records and removed the completed terminal shortcut item from pending work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->