### PR TITLE
Harden TUI release orchestration

### DIFF
--- a/.github/scripts/require-current-main.sh
+++ b/.github/scripts/require-current-main.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'require-current-main: %s\n' "$*" >&2
+  exit 1
+}
+
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+[[ "$GITHUB_REF" == "refs/heads/main" ]] ||
+  die "expected a main branch event, got $GITHUB_REF"
+[[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  die "GITHUB_SHA is not a full commit SHA: $GITHUB_SHA"
+
+main_sha="$({
+  git ls-remote --heads origin refs/heads/main
+} | awk '
+  NF >= 1 { print $1; count++ }
+  END { if (count != 1) exit 1 }
+')" || die "could not resolve protected main from origin"
+
+[[ "$main_sha" =~ ^[0-9a-f]{40}$ ]] ||
+  die "origin/main did not resolve to a full commit SHA: $main_sha"
+[[ "$GITHUB_SHA" == "$main_sha" ]] ||
+  die "event SHA $GITHUB_SHA is not current protected main $main_sha"
+
+printf 'require-current-main: protected main is current at %s\n' "$GITHUB_SHA"

--- a/.github/scripts/wait-for-workflow-run.sh
+++ b/.github/scripts/wait-for-workflow-run.sh
@@ -18,6 +18,7 @@ minimum_run_id="$5"
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 poll_interval="${POLL_INTERVAL_SECONDS:-5}"
 wait_timeout="${WAIT_TIMEOUT_SECONDS:-1800}"
+clock_skew="${CLOCK_SKEW_SECONDS:-30}"
 
 [[ "$workflow_file" =~ ^[A-Za-z0-9._-]+\.yml$ ]] ||
   die "workflow file must be a simple .yml filename"
@@ -29,11 +30,19 @@ wait_timeout="${WAIT_TIMEOUT_SECONDS:-1800}"
 [[ "$minimum_run_id" =~ ^[0-9]+$ ]] || die "MIN_RUN_ID must be numeric"
 [[ "$poll_interval" =~ ^[0-9]+$ ]] || die "POLL_INTERVAL_SECONDS must be numeric"
 [[ "$wait_timeout" =~ ^[0-9]+$ ]] || die "WAIT_TIMEOUT_SECONDS must be numeric"
+[[ "$clock_skew" =~ ^[0-9]+$ ]] || die "CLOCK_SKEW_SECONDS must be numeric"
 
 workflow_path=".github/workflows/$workflow_file"
 runs_endpoint="repos/$repo/actions/workflows/$workflow_file/runs?event=workflow_dispatch&per_page=100"
 deadline=$(( $(date +%s) + wait_timeout ))
 run_id=""
+if (( started_at > clock_skew )); then
+  skew_started_at=$((started_at - clock_skew))
+else
+  skew_started_at=0
+fi
+
+trap 'die "wait cancelled"' INT TERM
 
 ref_matches() {
   local branch="$1"
@@ -50,6 +59,7 @@ find_run() {
     --arg ref "$expected_ref" \
     --arg path "$workflow_path" \
     --argjson started "$started_at" \
+    --argjson skew_started "$skew_started_at" \
     --argjson minimum "$minimum_run_id" \
     '
       [
@@ -58,14 +68,29 @@ find_run() {
             (.event // "") == "workflow_dispatch"
             and (.head_sha // "") == $sha
             and ((.head_branch // "") == $ref or (.head_branch // "") == ("refs/tags/" + $ref))
-            and ((try (.created_at | fromdateiso8601) catch 0) >= $started)
             and ((.id | tonumber) > $minimum)
             and (.path // "") == $path
           )
-      ]
-      | sort_by(.id | tonumber)
-      | last
-      | (.id // empty)
+        | {
+            run: .,
+            created_at: (try (.created_at | fromdateiso8601) catch -1)
+          }
+      ] as $candidates
+      | (
+          [$candidates[] | select(.created_at >= $started)]
+          | sort_by(.run.id | tonumber)
+          | last
+        ) as $exact
+      | if $exact != null then
+          ($exact.run.id // empty)
+        else
+          (
+            [$candidates[] | select(.created_at >= $skew_started)]
+            | sort_by(.run.id | tonumber)
+            | last
+            | .run.id // empty
+          )
+        end
     ' <<<"$payload"
 }
 

--- a/.github/scripts/wait-for-workflow-run.sh
+++ b/.github/scripts/wait-for-workflow-run.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'wait-for-workflow-run: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ $# -ne 5 ]]; then
+  die "usage: $0 WORKFLOW_FILE REF HEAD_SHA STARTED_AT MIN_RUN_ID"
+fi
+
+workflow_file="$1"
+expected_ref="$2"
+expected_sha="$3"
+started_at="$4"
+minimum_run_id="$5"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+poll_interval="${POLL_INTERVAL_SECONDS:-5}"
+wait_timeout="${WAIT_TIMEOUT_SECONDS:-1800}"
+
+[[ "$workflow_file" =~ ^[A-Za-z0-9._-]+\.yml$ ]] ||
+  die "workflow file must be a simple .yml filename"
+[[ "$expected_ref" =~ ^[A-Za-z0-9._/-]+$ ]] ||
+  die "workflow ref contains unsupported characters"
+[[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] ||
+  die "head SHA is not a full commit SHA: $expected_sha"
+[[ "$started_at" =~ ^[0-9]+$ ]] || die "STARTED_AT must be an epoch"
+[[ "$minimum_run_id" =~ ^[0-9]+$ ]] || die "MIN_RUN_ID must be numeric"
+[[ "$poll_interval" =~ ^[0-9]+$ ]] || die "POLL_INTERVAL_SECONDS must be numeric"
+[[ "$wait_timeout" =~ ^[0-9]+$ ]] || die "WAIT_TIMEOUT_SECONDS must be numeric"
+
+workflow_path=".github/workflows/$workflow_file"
+runs_endpoint="repos/$repo/actions/workflows/$workflow_file/runs?event=workflow_dispatch&per_page=100"
+deadline=$(( $(date +%s) + wait_timeout ))
+run_id=""
+
+ref_matches() {
+  local branch="$1"
+  [[ "$branch" == "$expected_ref" || "$branch" == "refs/tags/$expected_ref" ]]
+}
+
+find_run() {
+  local payload
+  if ! payload="$(gh api "$runs_endpoint")"; then
+    return 1
+  fi
+  jq -r \
+    --arg sha "$expected_sha" \
+    --arg ref "$expected_ref" \
+    --arg path "$workflow_path" \
+    --argjson started "$started_at" \
+    --argjson minimum "$minimum_run_id" \
+    '
+      [
+        (.workflow_runs // [])[]
+        | select(
+            (.event // "") == "workflow_dispatch"
+            and (.head_sha // "") == $sha
+            and ((.head_branch // "") == $ref or (.head_branch // "") == ("refs/tags/" + $ref))
+            and ((try (.created_at | fromdateiso8601) catch 0) >= $started)
+            and ((.id | tonumber) > $minimum)
+            and (.path // "") == $path
+          )
+      ]
+      | sort_by(.id | tonumber)
+      | last
+      | (.id // empty)
+    ' <<<"$payload"
+}
+
+while [[ -z "$run_id" ]]; do
+  now=$(date +%s)
+  (( now < deadline )) || die "no new $workflow_file run appeared before timeout"
+  if candidate="$(find_run)" && [[ "$candidate" =~ ^[0-9]+$ ]]; then
+    run_id="$candidate"
+    break
+  fi
+  sleep "$poll_interval"
+done
+
+run_endpoint="repos/$repo/actions/runs/$run_id"
+while :; do
+  now=$(date +%s)
+  (( now < deadline )) || die "run $run_id did not complete before timeout"
+
+  if ! details="$(gh api "$run_endpoint")"; then
+    sleep "$poll_interval"
+    continue
+  fi
+  IFS=$'\t' read -r status conclusion actual_path actual_sha actual_branch event <<<"$(
+    jq -r '[.status, (.conclusion // "pending"), (.path // ""), (.head_sha // ""), (.head_branch // ""), (.event // "")] | @tsv' <<<"$details"
+  )"
+
+  [[ "$actual_path" == "$workflow_path" ]] ||
+    die "run $run_id came from $actual_path, expected $workflow_path"
+  [[ "$actual_sha" == "$expected_sha" ]] ||
+    die "run $run_id head $actual_sha does not match expected $expected_sha"
+  ref_matches "$actual_branch" ||
+    die "run $run_id ref $actual_branch does not match expected $expected_ref"
+  [[ "$event" == "workflow_dispatch" ]] ||
+    die "run $run_id event $event is not workflow_dispatch"
+
+  if [[ "$status" == "completed" ]]; then
+    [[ "$conclusion" == "success" ]] ||
+      die "run $run_id concluded $conclusion (https://github.com/$repo/actions/runs/$run_id)"
+    printf 'wait-for-workflow-run: run %s completed with %s\n' "$run_id" "$conclusion" >&2
+    printf '%s\t%s\n' "$run_id" "$conclusion"
+    exit 0
+  fi
+
+  case "$status" in
+    queued|in_progress|pending|waiting|requested)
+      sleep "$poll_interval"
+      ;;
+    *)
+      die "run $run_id has unexpected status $status"
+      ;;
+  esac
+done

--- a/.github/scripts/wait-for-workflow-run.sh
+++ b/.github/scripts/wait-for-workflow-run.sh
@@ -77,25 +77,16 @@ find_run() {
           }
       ] as $candidates
       | (
-          [$candidates[] | select(.created_at >= $started)]
+          [$candidates[] | select(.created_at >= $skew_started)]
           | unique_by(.run.id | tonumber)
           | sort_by(.run.id | tonumber)
-        ) as $exact
-      | if ($exact | length) > 1 then
+        ) as $eligible
+      | if ($eligible | length) > 1 then
           "ambiguous"
-        elif ($exact | length) == 1 then
-          ($exact[0].run.id // empty)
+        elif ($eligible | length) == 1 then
+          ($eligible[0].run.id // empty)
         else
-          (
-            [$candidates[] | select(.created_at >= $skew_started)]
-            | unique_by(.run.id | tonumber)
-            | sort_by(.run.id | tonumber)
-          ) as $skew
-          | if ($skew | length) > 1 then
-              "ambiguous"
-            else
-              ($skew[0].run.id // empty)
-            end
+          empty
         end
     ' <<<"$payload"
 }

--- a/.github/scripts/wait-for-workflow-run.sh
+++ b/.github/scripts/wait-for-workflow-run.sh
@@ -78,28 +78,37 @@ find_run() {
       ] as $candidates
       | (
           [$candidates[] | select(.created_at >= $started)]
+          | unique_by(.run.id | tonumber)
           | sort_by(.run.id | tonumber)
-          | last
         ) as $exact
-      | if $exact != null then
-          ($exact.run.id // empty)
+      | if ($exact | length) > 1 then
+          "ambiguous"
+        elif ($exact | length) == 1 then
+          ($exact[0].run.id // empty)
         else
           (
             [$candidates[] | select(.created_at >= $skew_started)]
+            | unique_by(.run.id | tonumber)
             | sort_by(.run.id | tonumber)
-            | last
-            | .run.id // empty
-          )
+          ) as $skew
+          | if ($skew | length) > 1 then
+              "ambiguous"
+            else
+              ($skew[0].run.id // empty)
+            end
         end
     ' <<<"$payload"
 }
 
+candidate=""
 while [[ -z "$run_id" ]]; do
   now=$(date +%s)
   (( now < deadline )) || die "no new $workflow_file run appeared before timeout"
   if candidate="$(find_run)" && [[ "$candidate" =~ ^[0-9]+$ ]]; then
     run_id="$candidate"
     break
+  elif [[ "$candidate" == "ambiguous" ]]; then
+    die "multiple matching $workflow_file runs appeared; refusing to guess"
   fi
   sleep "$poll_interval"
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Validate TUI npm package artifact transfer
         run: python3 tests/test_tui_npm_package_artifact.py
 
+      - name: Validate TUI package artifact contract
+        run: python3 tests/test_tui_package_contract.py
+
       - name: Validate Claude launch environment policy generation
         run: python3 scripts/generate-claude-launch-environment-policy.py --check
 

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -598,43 +598,29 @@ jobs:
             --version "$PYPI_VERSION" \
             --out dist/pypi-wheels
 
+      - name: Set up Node.js for npm package contract
+        if: inputs.package_npm
+        uses: actions/setup-node@48b55a011bda49bbe596cd826c3c89aef350131 # v6.4.0
+        with:
+          node-version: "22.14.0"
+
+      - name: Install pinned npm for package contract
+        if: inputs.package_npm
+        run: npm install --global npm@11.5.1
+
       - name: Smoke verify npm packages
         if: inputs.package_npm
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-          import stat
-          import sys
-
-          version = os.environ["NPM_VERSION"]
-          root = pathlib.Path("dist/npm-packages")
-          platforms = {
-              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
-              "cmux-tui-darwin-x64": ("darwin", "x64"),
-              "cmux-tui-linux-x64": ("linux", "x64"),
-              "cmux-tui-linux-arm64": ("linux", "arm64"),
-          }
-          launcher = json.loads((root / "cmux" / "package.json").read_text())
-          deps = launcher.get("optionalDependencies", {})
-          if deps != {name: version for name in platforms}:
-              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
-              raise SystemExit(1)
-          for name, (os_name, cpu) in platforms.items():
-              package_json = json.loads((root / name / "package.json").read_text())
-              if package_json["version"] != version:
-                  raise SystemExit(f"{name}: version mismatch")
-              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
-                  raise SystemExit(f"{name}: os/cpu mismatch")
-              binary = root / name / "bin" / "cmux-tui"
-              if not binary.stat().st_mode & stat.S_IXUSR:
-                  raise SystemExit(f"{binary} is not executable")
-              hook = root / name / "bin" / "cmux-tui-hook"
-              if not hook.stat().st_mode & stat.S_IXUSR:
-                  raise SystemExit(f"{hook} is not executable")
-          PY
+          case "$(uname -m)" in
+            x86_64|amd64) install_target=cmux-tui-linux-x64 ;;
+            aarch64|arm64) install_target=cmux-tui-linux-arm64 ;;
+            *) echo "unsupported package runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "$NPM_VERSION" \
+            --install-npm-package "$install_target"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
           dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
             dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
@@ -674,21 +660,9 @@ jobs:
         if: inputs.package_pypi
         run: |
           set -euo pipefail
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
-          done
-          python3 - <<'PY'
-          import glob
-          import stat
-          import zipfile
-
-          for path in glob.glob("dist/pypi-wheels/*.whl"):
-              with zipfile.ZipFile(path) as wheel:
-                  info = wheel.getinfo("cmux_tui/bin/cmux-tui-hook")
-                  mode = info.external_attr >> 16
-                  if not mode & stat.S_IXUSR:
-                      raise SystemExit(f"{path}: bundled cmux-tui-hook is not executable")
-          PY
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist/pypi-wheels \
+            --version "$PYPI_VERSION"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
           dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
             dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -600,7 +600,7 @@ jobs:
 
       - name: Set up Node.js for npm package contract
         if: inputs.package_npm
-        uses: actions/setup-node@48b55a011bda49bbe596cd826c3c89aef350131 # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
 

--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -128,6 +128,13 @@ jobs:
       - name: Install npm with OIDC support
         run: npm install -g npm@11.5.1
 
+      - name: Revalidate packed npm contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "${{ needs.version.outputs.npm_version }}" \
+            --install-npm-package cmux-tui-linux-x64
+
       - name: Publish platform packages with nightly dist-tag
         run: |
           set -euo pipefail
@@ -157,11 +164,23 @@ jobs:
       name: pypi-tui
       url: https://pypi.org/p/cmux
     steps:
+      - name: Checkout immutable nightly source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.version.outputs.head_sha }}
+
       - name: Download PyPI wheels
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: pypi-wheels
           path: dist
+
+      - name: Revalidate PyPI wheel contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist \
+            --version "${{ needs.version.outputs.pypi_version }}"
 
       - name: Publish nightly package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -43,7 +43,7 @@ jobs:
           git fetch --force --tags
           latest_tag="$(
             git tag --merged HEAD --list 'cmux-tui-v*' --sort=-v:refname |
-              grep -E '^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$' |
+              grep -E '^cmux-tui-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' |
               head -n 1 || true
           )"
           if [[ -z "$latest_tag" ]]; then

--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -95,6 +95,7 @@ jobs:
       - build-package
     runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
     permissions:
+      actions: read
       contents: read
       id-token: write
     environment:
@@ -135,6 +136,25 @@ jobs:
             --version "${{ needs.version.outputs.npm_version }}" \
             --install-npm-package cmux-tui-linux-x64
 
+      - name: Verify independent environment approval policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ENVIRONMENT: npm-tui
+        run: |
+          set -euo pipefail
+          environment_json="$RUNNER_TEMP/tui-release-environment.json"
+          if ! gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
+            > "$environment_json"; then
+            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            exit 1
+          fi
+          python3 cmux-tui/bindings/verify_release_environment_policy.py \
+            --environment "$RELEASE_ENVIRONMENT" \
+            --environment-json "$environment_json"
+
       - name: Publish platform packages with nightly dist-tag
         run: |
           set -euo pipefail
@@ -158,6 +178,7 @@ jobs:
       - build-package
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
+      actions: read
       contents: read
       id-token: write
     environment:
@@ -181,6 +202,25 @@ jobs:
           python3 cmux-tui/dist/scripts/validate_package_contract.py \
             --pypi-wheels dist \
             --version "${{ needs.version.outputs.pypi_version }}"
+
+      - name: Verify independent environment approval policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ENVIRONMENT: pypi-tui
+        run: |
+          set -euo pipefail
+          environment_json="$RUNNER_TEMP/tui-release-environment.json"
+          if ! gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
+            > "$environment_json"; then
+            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            exit 1
+          fi
+          python3 cmux-tui/bindings/verify_release_environment_policy.py \
+            --environment "$RELEASE_ENVIRONMENT" \
+            --environment-json "$environment_json"
 
       - name: Publish nightly package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -144,11 +144,12 @@ jobs:
           set -euo pipefail
           environment_json="$RUNNER_TEMP/tui-release-environment.json"
           if ! gh api \
+            --hostname github.com \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
-            > "$environment_json"; then
-            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            > "$environment_json" 2>/dev/null; then
+            echo "Unable to verify the release environment protection policy; refusing to publish." >&2
             exit 1
           fi
           python3 cmux-tui/bindings/verify_release_environment_policy.py \
@@ -211,11 +212,12 @@ jobs:
           set -euo pipefail
           environment_json="$RUNNER_TEMP/tui-release-environment.json"
           if ! gh api \
+            --hostname github.com \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
-            > "$environment_json"; then
-            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            > "$environment_json" 2>/dev/null; then
+            echo "Unable to verify the release environment protection policy; refusing to publish." >&2
             exit 1
           fi
           python3 cmux-tui/bindings/verify_release_environment_policy.py \

--- a/.github/workflows/cmux-tui-release-cut.yml
+++ b/.github/workflows/cmux-tui-release-cut.yml
@@ -27,6 +27,7 @@ jobs:
   tag:
     name: create release tag
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 120
     permissions:
       contents: write
       # actions: write lets this job dispatch the downstream build/publish
@@ -47,6 +48,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+
+      - name: Require event SHA is current protected main
+        run: bash .github/scripts/require-current-main.sh
 
       - name: Compute next TUI version
         id: version
@@ -133,6 +137,9 @@ jobs:
             echo "- New tag: $tag"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Revalidate protected main before tagging
+        run: bash .github/scripts/require-current-main.sh
+
       - name: Create annotated tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -146,7 +153,10 @@ jobs:
       - name: Push tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
-        run: git push origin "refs/tags/$TAG"
+        run: |
+          set -euo pipefail
+          bash .github/scripts/require-current-main.sh
+          git push origin "refs/tags/$TAG"
 
       - name: Dispatch release workflows
         # The tag push above was made with the default GITHUB_TOKEN, which
@@ -162,6 +172,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
+          workflow_runs_endpoint="repos/$GITHUB_REPOSITORY/actions/workflows/cmux-tui-release.yml/runs?event=workflow_dispatch&per_page=100"
+          before_run_id="$(gh api "$workflow_runs_endpoint" --jq '[.workflow_runs[].id] | max // 0')"
+          dispatch_started_at="$(date +%s)"
           gh workflow run cmux-tui-release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$TAG" \
@@ -169,7 +182,12 @@ jobs:
             -f publish_npm=true \
             -f publish_pypi=true \
             -f confirm_tui_cmux=true
+          IFS=$'\t' read -r release_run_id release_conclusion <<<"$(
+            WAIT_TIMEOUT_SECONDS=5400 bash .github/scripts/wait-for-workflow-run.sh \
+              cmux-tui-release.yml "$TAG" "$GITHUB_SHA" \
+              "$dispatch_started_at" "$before_run_id"
+          )"
           {
-            echo "- Dispatched one build/package run on $TAG"
+            echo "- Build/package run: $release_run_id ($release_conclusion)"
             echo "- npm and PyPI will reuse that run's verified artifacts"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cmux-tui-release-cut.yml
+++ b/.github/workflows/cmux-tui-release-cut.yml
@@ -62,7 +62,7 @@ jobs:
           git fetch --force --tags
           latest_tag="$(
             git tag --merged HEAD --list 'cmux-tui-v*' --sort=-v:refname |
-              grep -E '^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$' |
+              grep -E '^cmux-tui-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' |
               head -n 1 || true
           )"
           if [[ -z "$latest_tag" ]]; then
@@ -88,7 +88,7 @@ jobs:
           }
 
           if [[ -n "$EXPLICIT_VERSION" ]]; then
-            [[ "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            [[ "$EXPLICIT_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
               echo "version must match X.Y.Z" >&2
               exit 1
             }
@@ -182,11 +182,15 @@ jobs:
             -f publish_npm=true \
             -f publish_pypi=true \
             -f confirm_tui_cmux=true
-          IFS=$'\t' read -r release_run_id release_conclusion <<<"$(
+          release_result="$(
             WAIT_TIMEOUT_SECONDS=5400 bash .github/scripts/wait-for-workflow-run.sh \
               cmux-tui-release.yml "$TAG" "$GITHUB_SHA" \
               "$dispatch_started_at" "$before_run_id"
-          )"
+          )" || {
+            echo "release workflow did not complete successfully" >&2
+            exit 1
+          }
+          IFS=$'\t' read -r release_run_id release_conclusion <<<"$release_result"
           {
             echo "- Build/package run: $release_run_id ($release_conclusion)"
             echo "- npm and PyPI will reuse that run's verified artifacts"

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -21,7 +21,7 @@ on:
         default: false
         type: boolean
       confirm_tui_cmux:
-        description: "Set true only for the coordinated npm cmux TUI publish"
+        description: "Set true only for the coordinated cmux TUI registry publish"
         required: true
         default: false
         type: boolean
@@ -33,7 +33,7 @@ permissions: {}
 
 concurrency:
   group: cmux-tui-release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   version:
@@ -49,6 +49,7 @@ jobs:
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PUBLISH_PYPI: ${{ inputs.publish_pypi }}
           CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
@@ -70,6 +71,10 @@ jobs:
             echo "npm publishing requires confirm_tui_cmux=true." >&2
             exit 1
           fi
+          if [[ "$PUBLISH_PYPI" == "true" && "$CONFIRM_TUI_CMUX" != "true" ]]; then
+            echo "PyPI publishing requires confirm_tui_cmux=true." >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build-package:
@@ -88,6 +93,7 @@ jobs:
     if: ${{ inputs.publish_npm || inputs.publish_pypi }}
     needs: build-package
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 120
     permissions:
       actions: write
       contents: read
@@ -99,28 +105,95 @@ jobs:
       PUBLISH_NPM: ${{ inputs.publish_npm }}
       PUBLISH_PYPI: ${{ inputs.publish_pypi }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
       - name: Dispatch registry publishers
         run: |
           set -euo pipefail
+          npm_runs_endpoint="repos/$GITHUB_REPOSITORY/actions/workflows/tui-publish-npm.yml/runs?event=workflow_dispatch&per_page=100"
+          pypi_runs_endpoint="repos/$GITHUB_REPOSITORY/actions/workflows/tui-publish-pypi.yml/runs?event=workflow_dispatch&per_page=100"
+          npm_before_run_id=0
+          pypi_before_run_id=0
+          npm_dispatch_started_at=0
+          pypi_dispatch_started_at=0
+          npm_dispatched=false
+          pypi_dispatched=false
+          dispatch_failure=0
+          npm_run_id=""
+          npm_conclusion="not-dispatched"
+          pypi_run_id=""
+          pypi_conclusion="not-dispatched"
           if [[ "$PUBLISH_NPM" == "true" ]]; then
-            gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
-              -f version="$VERSION" \
-              -f artifact_run_id="$ARTIFACT_RUN_ID" \
-              -f confirm_tui_cmux=true
+            npm_before_run_id="$(gh api "$npm_runs_endpoint" --jq '[.workflow_runs[].id] | max // 0')"
+            npm_dispatch_started_at="$(date +%s)"
           fi
           if [[ "$PUBLISH_PYPI" == "true" ]]; then
-            gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
+            pypi_before_run_id="$(gh api "$pypi_runs_endpoint" --jq '[.workflow_runs[].id] | max // 0')"
+            pypi_dispatch_started_at="$(date +%s)"
+          fi
+          if [[ "$PUBLISH_NPM" == "true" ]]; then
+            if gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
               -f version="$VERSION" \
-              -f artifact_run_id="$ARTIFACT_RUN_ID"
+              -f artifact_run_id="$ARTIFACT_RUN_ID" \
+              -f confirm_tui_cmux=true; then
+              npm_dispatched=true
+            else
+              echo "npm publisher dispatch failed; continuing to reconcile any other dispatched publisher." >&2
+              dispatch_failure=1
+              npm_conclusion=dispatch-failure
+            fi
+          fi
+          if [[ "$PUBLISH_PYPI" == "true" ]]; then
+            if gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
+              -f version="$VERSION" \
+              -f artifact_run_id="$ARTIFACT_RUN_ID" \
+              -f confirm_tui_cmux=true; then
+              pypi_dispatched=true
+            else
+              echo "PyPI publisher dispatch failed; continuing to reconcile any other dispatched publisher." >&2
+              dispatch_failure=1
+              pypi_conclusion=dispatch-failure
+            fi
+          fi
+
+          publisher_failure=0
+          if [[ "$npm_dispatched" == "true" ]]; then
+            if npm_result="$(
+              WAIT_TIMEOUT_SECONDS=5400 bash .github/scripts/wait-for-workflow-run.sh \
+                tui-publish-npm.yml "$TAG" "$GITHUB_SHA" \
+                "$npm_dispatch_started_at" "$npm_before_run_id"
+            )"; then
+              IFS=$'\t' read -r npm_run_id npm_conclusion <<<"$npm_result"
+            else
+              publisher_failure=1
+              npm_conclusion=failure
+            fi
+          fi
+          if [[ "$pypi_dispatched" == "true" ]]; then
+            if pypi_result="$(
+              WAIT_TIMEOUT_SECONDS=5400 bash .github/scripts/wait-for-workflow-run.sh \
+                tui-publish-pypi.yml "$TAG" "$GITHUB_SHA" \
+                "$pypi_dispatch_started_at" "$pypi_before_run_id"
+            )"; then
+              IFS=$'\t' read -r pypi_run_id pypi_conclusion <<<"$pypi_result"
+            else
+              publisher_failure=1
+              pypi_conclusion=failure
+            fi
           fi
           {
             echo "### Registry publishing"
             echo
             echo "- Verified artifact run: $ARTIFACT_RUN_ID"
             if [[ "$PUBLISH_NPM" == "true" ]]; then
-              echo "- Dispatched npm publisher"
+              echo "- npm publisher run: $npm_run_id ($npm_conclusion)"
             fi
             if [[ "$PUBLISH_PYPI" == "true" ]]; then
-              echo "- Dispatched PyPI publisher"
+              echo "- PyPI publisher run: $pypi_run_id ($pypi_conclusion)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+          (( dispatch_failure == 0 && publisher_failure == 0 )) || exit 1

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -124,9 +124,7 @@ jobs:
           npm_dispatched=false
           pypi_dispatched=false
           dispatch_failure=0
-          npm_run_id=""
           npm_conclusion="not-dispatched"
-          pypi_run_id=""
           pypi_conclusion="not-dispatched"
           if [[ "$PUBLISH_NPM" == "true" ]]; then
             npm_before_run_id="$(gh api "$npm_runs_endpoint" --jq '[.workflow_runs[].id] | max // 0')"
@@ -168,7 +166,7 @@ jobs:
                 tui-publish-npm.yml "$TAG" "$GITHUB_SHA" \
                 "$npm_dispatch_started_at" "$npm_before_run_id"
             )"; then
-              IFS=$'\t' read -r npm_run_id npm_conclusion <<<"$npm_result"
+              IFS=$'\t' read -r _ npm_conclusion <<<"$npm_result"
             else
               publisher_failure=1
               npm_conclusion=failure
@@ -180,7 +178,7 @@ jobs:
                 tui-publish-pypi.yml "$TAG" "$GITHUB_SHA" \
                 "$pypi_dispatch_started_at" "$pypi_before_run_id"
             )"; then
-              IFS=$'\t' read -r pypi_run_id pypi_conclusion <<<"$pypi_result"
+              IFS=$'\t' read -r _ pypi_conclusion <<<"$pypi_result"
             else
               publisher_failure=1
               pypi_conclusion=failure
@@ -189,12 +187,12 @@ jobs:
           {
             echo "### Registry publishing"
             echo
-            echo "- Verified artifact run: $ARTIFACT_RUN_ID"
+            echo "- Verified artifacts: ready"
             if [[ "$PUBLISH_NPM" == "true" ]]; then
-              echo "- npm publisher run: $npm_run_id ($npm_conclusion)"
+              echo "- npm publisher: $npm_conclusion"
             fi
             if [[ "$PUBLISH_PYPI" == "true" ]]; then
-              echo "- PyPI publisher run: $pypi_run_id ($pypi_conclusion)"
+              echo "- PyPI publisher: $pypi_conclusion"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
           (( dispatch_failure == 0 && publisher_failure == 0 )) || exit 1

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -57,7 +57,7 @@ jobs:
             echo "Stable artifacts require a cmux-tui-vX.Y.Z tag ref." >&2
             exit 1
           fi
-          [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+          [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "tag must match cmux-tui-vX.Y.Z" >&2
             exit 1
           }
@@ -93,7 +93,8 @@ jobs:
     if: ${{ inputs.publish_npm || inputs.publish_pypi }}
     needs: build-package
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 120
+    # npm and PyPI waits are sequential, each bounded to 90 minutes.
+    timeout-minutes: 210
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -8,6 +8,7 @@ on:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-build-package.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
       - ".github/workflows/cmux-tui-sdks.yml"
@@ -24,11 +25,14 @@ on:
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_npm_package_artifact.py"
+      - "tests/test_tui_package_contract.py"
   pull_request:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-build-package.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
       - ".github/workflows/cmux-tui-sdks.yml"
@@ -45,6 +49,8 @@ on:
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_npm_package_artifact.py"
+      - "tests/test_tui_package_contract.py"
   workflow_dispatch:
 
 concurrency:
@@ -110,6 +116,12 @@ jobs:
 
       - name: Test SDK publishing workflow guards
         run: python3 tests/test_tui_publish_workflow_security.py -v
+
+      - name: Test TUI package artifact contract
+        run: python3 tests/test_tui_package_contract.py
+
+      - name: Test TUI npm artifact transfer contract
+        run: python3 tests/test_tui_npm_package_artifact.py
 
       - name: Check package versions
         run: python3 cmux-tui/bindings/check-versions.py --published-only

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -180,6 +180,13 @@ jobs:
       - name: Install npm with OIDC support
         run: npm install -g npm@11.5.1
 
+      - name: Revalidate packed npm contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "${{ inputs.version }}" \
+            --install-npm-package cmux-tui-linux-x64
+
       - name: Publish platform packages
         run: |
           set -euo pipefail

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -242,6 +242,25 @@ jobs:
             }
           done
 
+      - name: Verify independent environment approval policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ENVIRONMENT: npm-tui
+        run: |
+          set -euo pipefail
+          environment_json="$RUNNER_TEMP/tui-release-environment.json"
+          if ! gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
+            > "$environment_json"; then
+            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            exit 1
+          fi
+          python3 cmux-tui/bindings/verify_release_environment_policy.py \
+            --environment "$RELEASE_ENVIRONMENT" \
+            --environment-json "$environment_json"
+
       - name: Publish platform packages with exact retry reconciliation
         run: |
           set -euo pipefail

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -214,9 +214,35 @@ jobs:
           print(f"npm cmux latest {sys.argv[1]} is not newer than candidate {sys.argv[2]}")
           PY
 
-      - name: Publish platform packages
+      - name: Pack npm packages for registry reconciliation
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          archive_dir=dist/npm-publish
+          mkdir -p "$archive_dir"
+          packages=(
+            cmux
+            cmux-tui-darwin-arm64
+            cmux-tui-darwin-x64
+            cmux-tui-linux-x64
+            cmux-tui-linux-arm64
+          )
+          for package in "${packages[@]}"; do
+            npm pack --ignore-scripts \
+              --pack-destination "$archive_dir" \
+              "dist/npm-packages/$package" >/dev/null
+            archive="$archive_dir/$package-$VERSION.tgz"
+            [[ -f "$archive" ]] || {
+              echo "npm pack produced no expected archive: $archive" >&2
+              exit 1
+            }
+          done
+
+      - name: Publish platform packages with exact retry reconciliation
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
           packages=(
             cmux-tui-darwin-arm64
             cmux-tui-darwin-x64
@@ -224,29 +250,25 @@ jobs:
             cmux-tui-linux-arm64
           )
           for package in "${packages[@]}"; do
-            echo "Publishing $package"
-            if ! npm publish --provenance "dist/npm-packages/$package"; then
-              cat >&2 <<'EOF'
-          npm publish failed.
-
-          For the first publish of the new TUI platform package names, add npm Trusted Publishers for:
-          - cmux-tui-darwin-arm64
-          - cmux-tui-darwin-x64
-          - cmux-tui-linux-x64
-          - cmux-tui-linux-arm64
-
-          Trusted publisher settings for each package:
-          - Repository: manaflow-ai/cmux
-          - Workflow: tui-publish-npm.yml
-          - Environment: npm-tui
-          EOF
-              exit 1
-            fi
+            python3 cmux-tui/bindings/reconcile_registry_artifact.py publish \
+              --registry npm \
+              --package "$package" \
+              --version "$version" \
+              --artifact "dist/npm-publish/$package-$version.tgz" \
+              --wait-seconds 120 \
+              --publish-timeout-seconds 600 \
+              -- npm publish --provenance "dist/npm-packages/$package"
           done
 
-      - name: Publish launcher package
+      - name: Publish launcher package with exact retry reconciliation
         run: |
           set -euo pipefail
-          # Deliberately do not pass --tag: this coordinated TUI publish takes
-          # over the cmux latest dist-tag from the old 0.8.3 CLI when version > 0.8.3.
-          npm publish --provenance dist/npm-packages/cmux
+          version="${{ inputs.version }}"
+          python3 cmux-tui/bindings/reconcile_registry_artifact.py publish \
+            --registry npm \
+            --package cmux \
+            --version "$version" \
+            --artifact "dist/npm-publish/cmux-$version.tgz" \
+            --wait-seconds 120 \
+            --publish-timeout-seconds 600 \
+            -- npm publish --provenance dist/npm-packages/cmux

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -22,6 +22,10 @@ permissions: {}
 concurrency:
   # The launcher publish owns npm's global `latest` dist-tag. Keep different
   # release tags out of the publish section at the same time.
+  # GitHub documents `queue: max` for larger queues, but the pinned actionlint
+  # contract does not parse that newer key yet. Keep the default single pending
+  # run until the validator is upgraded. The release waiter fails closed when
+  # GitHub replaces a pending run.
   group: tui-publish-npm-latest
   cancel-in-progress: false
 

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -250,11 +250,12 @@ jobs:
           set -euo pipefail
           environment_json="$RUNNER_TEMP/tui-release-environment.json"
           if ! gh api \
+            --hostname github.com \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
-            > "$environment_json"; then
-            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            > "$environment_json" 2>/dev/null; then
+            echo "Unable to verify the release environment protection policy; refusing to publish." >&2
             exit 1
           fi
           python3 cmux-tui/bindings/verify_release_environment_policy.py \

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -52,7 +52,7 @@ jobs:
           DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+          [[ "$DISPATCH_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "workflow_dispatch version must match stable X.Y.Z (no prerelease); nightlies go through cmux-tui-nightly.yml" >&2
             exit 1
           }
@@ -202,8 +202,11 @@ jobs:
 
           def parse(value: str) -> tuple[int, int, int]:
               parts = value.split(".")
-              if len(parts) != 3 or any(not part.isdigit() for part in parts):
-                  raise SystemExit(f"invalid stable npm version: {value!r}")
+              if len(parts) != 3 or any(
+                  not part.isdigit() or (len(part) > 1 and part.startswith("0"))
+                  for part in parts
+              ):
+                  raise SystemExit("invalid stable npm version")
               return tuple(int(part) for part in parts)
 
           current, candidate = map(parse, sys.argv[1:])

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       confirm_tui_cmux:
-        description: "Set true only for the coordinated npm cmux TUI publish"
+        description: "Set true only for the coordinated cmux TUI registry publish"
         required: true
         default: false
         type: boolean
@@ -20,7 +20,9 @@ on:
 permissions: {}
 
 concurrency:
-  group: tui-publish-npm-${{ github.ref }}
+  # The launcher publish owns npm's global `latest` dist-tag. Keep different
+  # release tags out of the publish section at the same time.
+  group: tui-publish-npm-latest
   cancel-in-progress: false
 
 jobs:
@@ -186,6 +188,31 @@ jobs:
             --npm-packages dist/npm-packages \
             --version "${{ inputs.version }}" \
             --install-npm-package cmux-tui-linux-x64
+
+      - name: Refuse an npm latest regression
+        run: |
+          set -euo pipefail
+          candidate_version="${GITHUB_REF_NAME#cmux-tui-v}"
+          current_latest="$(npm view cmux dist-tags.latest --json 2>/dev/null | tr -d '\"' | tr -d '[:space:]')" || {
+            echo "Could not resolve npm cmux latest; refusing to publish." >&2
+            exit 1
+          }
+          python3 - "$current_latest" "$candidate_version" <<'PY'
+          import sys
+
+          def parse(value: str) -> tuple[int, int, int]:
+              parts = value.split(".")
+              if len(parts) != 3 or any(not part.isdigit() for part in parts):
+                  raise SystemExit(f"invalid stable npm version: {value!r}")
+              return tuple(int(part) for part in parts)
+
+          current, candidate = map(parse, sys.argv[1:])
+          if current > candidate:
+              raise SystemExit(
+                  f"npm cmux latest {sys.argv[1]} is newer than candidate {sys.argv[2]}; refusing regression"
+              )
+          print(f"npm cmux latest {sys.argv[1]} is not newer than candidate {sys.argv[2]}")
+          PY
 
       - name: Publish platform packages
         run: |

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -137,6 +137,11 @@ jobs:
       name: pypi-tui
       url: https://pypi.org/p/cmux
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate-version.outputs.release_sha }}
+
       - name: Download PyPI wheels
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -144,6 +149,12 @@ jobs:
           path: dist
           run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Revalidate PyPI wheel contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist \
+            --version "${{ inputs.version }}"
 
       - name: Trusted publisher setup note
         run: |

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -188,6 +188,25 @@ jobs:
           - Environment: pypi-tui
           EOF
 
+      - name: Verify independent environment approval policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ENVIRONMENT: pypi-tui
+        run: |
+          set -euo pipefail
+          environment_json="$RUNNER_TEMP/tui-release-environment.json"
+          if ! gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
+            > "$environment_json"; then
+            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            exit 1
+          fi
+          python3 cmux-tui/bindings/verify_release_environment_policy.py \
+            --environment "$RELEASE_ENVIRONMENT" \
+            --environment-json "$environment_json"
+
       - name: Publish package distributions to PyPI
         if: steps.pypi_upload.outputs.has_new == 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -51,7 +51,7 @@ jobs:
             echo "PyPI publishing requires confirm_tui_cmux=true." >&2
             exit 1
           fi
-          [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+          [[ "$DISPATCH_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
             echo "workflow_dispatch version must match X.Y.Z" >&2
             exit 1
           }

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -196,11 +196,12 @@ jobs:
           set -euo pipefail
           environment_json="$RUNNER_TEMP/tui-release-environment.json"
           if ! gh api \
+            --hostname github.com \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "repos/$GITHUB_REPOSITORY/environments/$RELEASE_ENVIRONMENT" \
-            > "$environment_json"; then
-            echo "Unable to verify $RELEASE_ENVIRONMENT protection policy; refusing to publish." >&2
+            > "$environment_json" 2>/dev/null; then
+            echo "Unable to verify the release environment protection policy; refusing to publish." >&2
             exit 1
           fi
           python3 cmux-tui/bindings/verify_release_environment_policy.py \

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -11,6 +11,11 @@ on:
         description: "Successful cmux-tui release run containing verified packages"
         required: true
         type: string
+      confirm_tui_cmux:
+        description: "Set true only for the coordinated cmux TUI registry publish"
+        required: true
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -39,8 +44,13 @@ jobs:
         id: release
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
+          CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
+          if [[ "$CONFIRM_TUI_CMUX" != "true" ]]; then
+            echo "PyPI publishing requires confirm_tui_cmux=true." >&2
+            exit 1
+          fi
           [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
             echo "workflow_dispatch version must match X.Y.Z" >&2
             exit 1
@@ -137,6 +147,12 @@ jobs:
       name: pypi-tui
       url: https://pypi.org/p/cmux
     steps:
+      - name: Require PyPI cmux confirmation
+        if: inputs.confirm_tui_cmux != true
+        run: |
+          echo "Refusing to publish PyPI package cmux for the TUI without confirm_tui_cmux=true." >&2
+          exit 1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -172,6 +172,12 @@ jobs:
             --pypi-wheels dist \
             --version "${{ inputs.version }}"
 
+      - name: Prepare exact PyPI retry set
+        id: pypi_upload
+        env:
+          VERSION: ${{ inputs.version }}
+        run: bash cmux-tui/scripts/prepare-pypi-tui-upload.sh dist upload "$VERSION"
+
       - name: Trusted publisher setup note
         run: |
           cat <<'EOF'
@@ -183,7 +189,8 @@ jobs:
           EOF
 
       - name: Publish package distributions to PyPI
+        if: steps.pypi_upload.outputs.has_new == 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          packages-dir: dist
+          packages-dir: upload
           attestations: true

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -980,6 +980,164 @@ class RegistryArtifactTests(unittest.TestCase):
             )
         self.assertEqual(result, 0)
 
+    def test_tui_npm_partial_retry_accepts_exact_postwrite_state(self) -> None:
+        with mock.patch.object(
+            reconcile,
+            "registry_status",
+            side_effect=(reconcile.MISSING, reconcile.MATCH),
+        ), mock.patch.object(
+            reconcile,
+            "_run_publish_command",
+            return_value=types.SimpleNamespace(returncode=7),
+        ) as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "npm",
+                    "--package",
+                    "cmux-tui-linux-x64",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--wait-seconds",
+                    "120",
+                    "--",
+                    "npm",
+                    "publish",
+                    "--provenance",
+                ]
+            )
+        self.assertEqual(result, 0)
+        publish.assert_called_once()
+
+    def test_tui_npm_exact_match_skips_republish(self) -> None:
+        with mock.patch.object(
+            reconcile, "registry_status", return_value=reconcile.MATCH
+        ), mock.patch.object(reconcile, "_run_publish_command") as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "npm",
+                    "--package",
+                    "cmux-tui-linux-x64",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--",
+                    "npm",
+                    "publish",
+                    "--provenance",
+                ]
+            )
+        self.assertEqual(result, 0)
+        publish.assert_not_called()
+
+    def test_tui_npm_mismatch_fails_before_republish(self) -> None:
+        with mock.patch.object(
+            reconcile,
+            "registry_status",
+            side_effect=reconcile.ArtifactMismatch("registry bytes differ"),
+        ), mock.patch.object(reconcile, "_run_publish_command") as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "npm",
+                    "--package",
+                    "cmux-tui-linux-x64",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--",
+                    "npm",
+                    "publish",
+                    "--provenance",
+                ]
+            )
+        self.assertEqual(result, 1)
+        publish.assert_not_called()
+
+    def test_tui_pypi_exact_match_skips_republish(self) -> None:
+        with mock.patch.object(
+            reconcile, "registry_status", return_value=reconcile.MATCH
+        ), mock.patch.object(reconcile, "_run_publish_command") as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "pypi",
+                    "--package",
+                    "cmux",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--",
+                    "pypa-upload",
+                ]
+            )
+        self.assertEqual(result, 0)
+        publish.assert_not_called()
+
+    def test_tui_pypi_partial_retry_accepts_exact_postwrite_state(self) -> None:
+        with mock.patch.object(
+            reconcile,
+            "registry_status",
+            side_effect=(reconcile.MISSING, reconcile.MATCH),
+        ), mock.patch.object(
+            reconcile,
+            "_run_publish_command",
+            return_value=types.SimpleNamespace(returncode=7),
+        ) as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "pypi",
+                    "--package",
+                    "cmux",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--wait-seconds",
+                    "120",
+                    "--",
+                    "pypa-upload",
+                ]
+            )
+        self.assertEqual(result, 0)
+        publish.assert_called_once()
+
+    def test_tui_pypi_mismatch_fails_before_republish(self) -> None:
+        with mock.patch.object(
+            reconcile,
+            "registry_status",
+            side_effect=reconcile.ArtifactMismatch("registry hash differs"),
+        ), mock.patch.object(reconcile, "_run_publish_command") as publish:
+            result = reconcile.main(
+                [
+                    "publish",
+                    "--registry",
+                    "pypi",
+                    "--package",
+                    "cmux",
+                    "--version",
+                    "1.2.3",
+                    "--artifact",
+                    str(self.artifact),
+                    "--",
+                    "pypa-upload",
+                ]
+            )
+        self.assertEqual(result, 1)
+        publish.assert_not_called()
+
     def test_successful_publish_fails_without_postwrite_registry_match(self) -> None:
         with mock.patch.object(
             reconcile,

--- a/cmux-tui/bindings/verify_release_environment_policy.py
+++ b/cmux-tui/bindings/verify_release_environment_policy.py
@@ -78,7 +78,7 @@ def main() -> int:
     error = validate(document, args.environment)
     if error is not None:
         return _fail(error)
-    print(f"verified independent review policy for {args.environment}")
+    print("verified independent release environment policy")
     return 0
 
 

--- a/cmux-tui/bindings/verify_release_environment_policy.py
+++ b/cmux-tui/bindings/verify_release_environment_policy.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Fail closed unless a release environment requires independent approval."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _fail(message: str) -> int:
+    print(f"release environment policy failed: {message}", file=sys.stderr)
+    return 1
+
+
+def _has_reviewer(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("type") not in {"User", "Team"}:
+        return False
+    reviewer = entry.get("reviewer")
+    if not isinstance(reviewer, dict):
+        return False
+    for key in ("login", "slug", "name"):
+        value = reviewer.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def validate(document: object, expected_environment: str) -> str | None:
+    if not isinstance(document, dict):
+        return "environment response is not an object"
+    if document.get("name") != expected_environment:
+        return "environment name does not match the publisher"
+    if document.get("can_admins_bypass") is not False:
+        return "can_admins_bypass must be false"
+    branch_policy = document.get("deployment_branch_policy")
+    if not isinstance(branch_policy, dict):
+        return "deployment branch policy must allow protected branches only"
+    if branch_policy.get("protected_branches") is not True or branch_policy.get(
+        "custom_branch_policies"
+    ) is not False:
+        return "deployment branch policy must allow protected branches only"
+
+    rules = document.get("protection_rules")
+    if not isinstance(rules, list):
+        return "required reviewer protection is missing"
+    reviewer_rules = [
+        rule
+        for rule in rules
+        if isinstance(rule, dict) and rule.get("type") == "required_reviewers"
+    ]
+    if len(reviewer_rules) != 1:
+        return "exactly one required reviewer protection rule is required"
+    reviewer_rule = reviewer_rules[0]
+    if reviewer_rule.get("prevent_self_review") is not True:
+        return "prevent_self_review must be true"
+    reviewers = reviewer_rule.get("reviewers")
+    if not isinstance(reviewers, list) or not reviewers or not all(
+        _has_reviewer(entry) for entry in reviewers
+    ):
+        return "required reviewer list must contain a user or team"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--environment-json", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        document = json.loads(args.environment_json.read_text())
+    except (OSError, json.JSONDecodeError):
+        return _fail("environment response is unavailable or invalid")
+    error = validate(document, args.environment)
+    if error is not None:
+        return _fail(error)
+    print(f"verified independent review policy for {args.environment}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -25,6 +25,13 @@ Linux packages contain static musl binaries that run on both glibc and musl
 distributions. PyPI publishes each Linux binary under matching manylinux and
 musllinux wheel tags so installers on both runtime families can resolve it.
 
+Before upload, the package contract validator checks the exact five npm package
+trees, including both the TUI binary and hook, then runs `npm pack` and an
+offline install of the matching Linux package. It checks the exact six PyPI
+wheels, their platform tags, metadata, `RECORD` hashes, and executable modes.
+The Windows binary and hook are raw release artifacts only. They are not in the
+npm or PyPI package set.
+
 ## One-time registry setup
 
 Add npm Trusted Publishers for all five npm package names:

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -143,3 +143,10 @@ compatibility regression therefore blocks both registry dispatches.
 The npm launcher publish deliberately does not pass `--tag`: when the TUI
 version is greater than `0.8.3`, this coordinated release takes over the npm
 `latest` dist-tag for `cmux` from the old CLI package.
+
+The npm publisher uses one `tui-publish-npm-latest` concurrency group with
+`cancel-in-progress: false`. GitHub's newer `queue: max` key can retain up to
+100 pending publishes, but the repository's pinned actionlint validator rejects
+that key. The workflow keeps the validator-compatible single pending run until
+the validator is upgraded. If GitHub replaces a pending run, the release waiter
+cannot confirm the exact dispatch and fails closed before reporting success.

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -96,17 +96,19 @@ Use `.github/workflows/cmux-tui-release-cut.yml` from `main`.
 
 - Select `patch`, `minor`, or `major`, or provide an explicit `X.Y.Z` version.
 - The workflow reads the latest reachable `cmux-tui-vX.Y.Z` tag, validates the
-  new version is strictly greater, creates annotated tag `cmux-tui-vX.Y.Z` on
-  `main` HEAD, and pushes that tag.
+  new version is strictly greater, verifies the dispatch SHA is still the
+  current protected `main` commit immediately before tagging, creates annotated
+  tag `cmux-tui-vX.Y.Z` on that commit, and pushes that tag.
 - The tag is pushed with the default `GITHUB_TOKEN`, and GitHub suppresses
   workflow triggers for token-created events, so the release-cut workflow then
   explicitly dispatches `cmux-tui-release.yml` against the new tag with npm and
   PyPI publishing enabled.
 - `cmux-tui-release.yml` builds every target once, creates both registries'
   packages, and runs the Linux compatibility matrix. After those jobs pass, it
-  dispatches both top-level publishers with its own artifact run ID. This keeps
-  the configured trusted-publisher identities while avoiding registry-specific
-  rebuilds.
+  dispatches both top-level publishers with its own artifact run ID, waits for
+  each run ID to finish, and fails the release if either conclusion is not
+  successful. This keeps the configured trusted-publisher identities while
+  avoiding registry-specific rebuilds.
 - A manual `git push origin cmux-tui-vX.Y.Z` runs the artifact workflow without
   publishing. Use the release-cut workflow for a coordinated stable release.
 
@@ -118,8 +120,10 @@ checks the source workflow, tag, commit, and conclusion before downloading its
 package artifact. It never rebuilds the binaries. This also lets a failed
 publisher retry reuse the already verified artifacts.
 
-npm additionally requires `confirm_tui_cmux=true`. The platform packages are
-published first, then the `cmux` launcher.
+Both publishers additionally require `confirm_tui_cmux=true`. The npm platform
+packages are published first, then the `cmux` launcher. npm stable publishers
+share one concurrency lock for the global `latest` dist-tag and refuse to run
+when the registry already reports a newer stable version.
 
 The shared artifact run exercises the generated npm and PyPI entrypoints across
 the supported glibc and musl distribution matrix on x86_64 and ARM64. A

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -125,6 +125,12 @@ packages are published first, then the `cmux` launcher. npm stable publishers
 share one concurrency lock for the global `latest` dist-tag and refuse to run
 when the registry already reports a newer stable version.
 
+Retries reconcile each immutable artifact before upload. npm compares the packed
+tarball digest and stable version state, while PyPI compares every wheel filename
+and SHA-256 value and stages only missing wheels. Exact matches are skipped; any
+mismatch, malformed response, or unproven registry state fails closed. The
+existing npm provenance and PyPI Trusted Publisher/OIDC steps remain in force.
+
 The shared artifact run exercises the generated npm and PyPI entrypoints across
 the supported glibc and musl distribution matrix on x86_64 and ARM64. A
 compatibility regression therefore blocks both registry dispatches.

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -55,6 +55,11 @@ Add a PyPI Trusted Publisher for:
 - Workflow: `tui-publish-pypi.yml`
 - Environment: `pypi-tui`
 
+Configure both `npm-tui` and `pypi-tui` for protected branches only, at least
+one required reviewer, `Prevent self-review`, and disabled administrator
+bypass. Each publisher reads the live environment policy before it can access
+registry publishing, and fails closed if any of these settings are missing.
+
 Nightly publishing uses the same environments. Add trusted publishers for:
 
 - npm packages:

--- a/cmux-tui/dist/scripts/package_contract.py
+++ b/cmux-tui/dist/scripts/package_contract.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Validate the files and metadata shipped by cmux-tui registries."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class PackageContractError(ValueError):
+    """Raised when a generated package does not match the release contract."""
+
+
+@dataclass(frozen=True)
+class NpmTarget:
+    name: str
+    os: str
+    cpu: str
+
+
+NPM_TARGETS = (
+    NpmTarget("cmux-tui-darwin-arm64", "darwin", "arm64"),
+    NpmTarget("cmux-tui-darwin-x64", "darwin", "x64"),
+    NpmTarget("cmux-tui-linux-x64", "linux", "x64"),
+    NpmTarget("cmux-tui-linux-arm64", "linux", "arm64"),
+)
+NPM_PLATFORM_NAMES = tuple(target.name for target in NPM_TARGETS)
+NPM_PACKAGE_NAMES = ("cmux", *NPM_PLATFORM_NAMES)
+NPM_PLATFORM_FILES = frozenset(
+    {"package.json", "bin/cmux-tui", "bin/cmux-tui-hook"}
+)
+NPM_LAUNCHER_FILES = frozenset({"package.json", "bin/cmux.js"})
+NPM_EXECUTABLE_FILES = tuple(
+    f"{target.name}/bin/{binary}"
+    for target in NPM_TARGETS
+    for binary in ("cmux-tui", "cmux-tui-hook")
+) + ("cmux/bin/cmux.js",)
+
+PYPI_WHEEL_TAGS = (
+    "macosx_11_0_arm64",
+    "macosx_10_12_x86_64",
+    "manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "musllinux_1_2_x86_64",
+    "manylinux_2_17_aarch64.manylinux2014_aarch64",
+    "musllinux_1_2_aarch64",
+)
+PYPI_WHEEL_FILES = frozenset(
+    {
+        "cmux_tui/__init__.py",
+        "cmux_tui/_main.py",
+        "cmux_tui/bin/cmux-tui",
+        "cmux_tui/bin/cmux-tui-hook",
+        "{dist_info}/WHEEL",
+        "{dist_info}/METADATA",
+        "{dist_info}/entry_points.txt",
+        "{dist_info}/RECORD",
+    }
+)
+
+
+def _error(message: str) -> PackageContractError:
+    return PackageContractError(message)
+
+
+def _files_below(root: Path) -> set[str]:
+    files: set[str] = set()
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise _error(f"{root}: symlink is not allowed: {relative}")
+        if path.is_file():
+            files.add(relative)
+        elif not path.is_dir():
+            raise _error(f"{root}: unsupported entry: {relative}")
+    return files
+
+
+def _entries_below(root: Path) -> set[str]:
+    entries: set[str] = set()
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise _error(f"{root}: symlink is not allowed: {relative}")
+        if not (path.is_file() or path.is_dir()):
+            raise _error(f"{root}: unsupported entry: {relative}")
+        entries.add(relative)
+    return entries
+
+
+def _require_executable(path: Path, label: str) -> None:
+    mode = path.stat().st_mode
+    if mode & 0o111 != 0o111:
+        raise _error(f"{label} is not executable: {path}")
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise _error(f"invalid JSON: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise _error(f"package metadata must be an object: {path}")
+    return value
+
+
+def _validate_version(actual: object, expected: str | None, label: str) -> str:
+    if not isinstance(actual, str) or not actual:
+        raise _error(f"{label}: version is missing")
+    if expected is not None and actual != expected:
+        raise _error(f"{label}: version {actual!r} != {expected!r}")
+    return actual
+
+
+def validate_npm_tree(packages_dir: Path, version: str | None = None) -> str:
+    """Validate the generated npm package directory tree.
+
+    Returns the package version. If ``version`` is omitted, the launcher version
+    is used and every package must match it.
+    """
+
+    packages_dir = packages_dir.resolve()
+    if not packages_dir.is_dir():
+        raise _error(f"missing npm package directory: {packages_dir}")
+
+    root_paths = tuple(packages_dir.iterdir())
+    for path in root_paths:
+        if path.is_symlink():
+            raise _error(f"npm package root contains symlink: {path.name}")
+    actual_root_entries = tuple(sorted(path.name for path in root_paths))
+    expected_packages = tuple(sorted(NPM_PACKAGE_NAMES))
+    if actual_root_entries != expected_packages:
+        raise _error(
+            f"npm package set mismatch: expected {expected_packages}, "
+            f"found {actual_root_entries}"
+        )
+
+    launcher_dir = packages_dir / "cmux"
+    launcher_metadata = _read_json(launcher_dir / "package.json")
+    if launcher_metadata.get("name") != "cmux":
+        raise _error("cmux: package name is incorrect")
+    package_version = _validate_version(
+        launcher_metadata.get("version"), version, "cmux"
+    )
+
+    launcher_files = _files_below(launcher_dir)
+    launcher_entries = _entries_below(launcher_dir)
+    expected_launcher_entries = NPM_LAUNCHER_FILES | {"bin"}
+    if launcher_entries != expected_launcher_entries:
+        raise _error(
+            f"cmux: directory tree mismatch: expected "
+            f"{sorted(expected_launcher_entries)}, "
+            f"found {sorted(launcher_entries)}"
+        )
+    if launcher_files != NPM_LAUNCHER_FILES:
+        raise _error(
+            f"cmux: package files mismatch: expected "
+            f"{sorted(NPM_LAUNCHER_FILES)}, found {sorted(launcher_files)}"
+        )
+    if launcher_metadata.get("files") != ["bin/cmux.js"]:
+        raise _error("cmux: files must contain only bin/cmux.js")
+    if launcher_metadata.get("bin") != {"cmux": "bin/cmux.js"}:
+        raise _error("cmux: bin mapping is incorrect")
+    expected_dependencies = {
+        target.name: package_version for target in NPM_TARGETS
+    }
+    if launcher_metadata.get("optionalDependencies") != expected_dependencies:
+        raise _error(
+            "cmux: optionalDependencies mismatch: "
+            f"expected {expected_dependencies}, "
+            f"found {launcher_metadata.get('optionalDependencies')}"
+        )
+    _require_executable(launcher_dir / "bin/cmux.js", "cmux launcher")
+
+    for target in NPM_TARGETS:
+        package_dir = packages_dir / target.name
+        metadata = _read_json(package_dir / "package.json")
+        label = target.name
+        if metadata.get("name") != target.name:
+            raise _error(f"{label}: package name is incorrect")
+        _validate_version(metadata.get("version"), package_version, label)
+        if metadata.get("os") != [target.os] or metadata.get("cpu") != [target.cpu]:
+            raise _error(f"{label}: os/cpu selectors are incorrect")
+        if metadata.get("files") != ["bin/cmux-tui", "bin/cmux-tui-hook"]:
+            raise _error(f"{label}: files must contain the binary and hook only")
+        files = _files_below(package_dir)
+        entries = _entries_below(package_dir)
+        expected_entries = NPM_PLATFORM_FILES | {"bin"}
+        if entries != expected_entries:
+            raise _error(
+                f"{label}: directory tree mismatch: expected "
+                f"{sorted(expected_entries)}, found {sorted(entries)}"
+            )
+        if files != NPM_PLATFORM_FILES:
+            missing = sorted(NPM_PLATFORM_FILES - files)
+            extra = sorted(files - NPM_PLATFORM_FILES)
+            raise _error(
+                f"{label}: package files mismatch; missing={missing}, "
+                f"unexpected={extra}"
+            )
+        _require_executable(package_dir / "bin/cmux-tui", f"{label} binary")
+        _require_executable(package_dir / "bin/cmux-tui-hook", f"{label} hook")
+
+    return package_version
+
+
+def _wheel_expected_files(version: str) -> set[str]:
+    dist_info = f"cmux-{version}.dist-info"
+    return {path.format(dist_info=dist_info) for path in PYPI_WHEEL_FILES}
+
+
+def _record_digest(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _metadata_value(data: bytes, key: str) -> str | None:
+    prefix = f"{key}:".encode("utf-8")
+    for line in data.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :].strip().decode("utf-8")
+    return None
+
+
+def _wheel_mode(info: zipfile.ZipInfo) -> int:
+    return (info.external_attr >> 16) & 0o777
+
+
+def validate_wheel(path: Path, version: str) -> None:
+    expected_prefix = f"cmux-{version}-py3-none-"
+    if not path.name.startswith(expected_prefix) or not path.name.endswith(".whl"):
+        raise _error(f"unexpected wheel filename: {path.name}")
+    tag = path.name[len(expected_prefix) : -len(".whl")]
+    if tag not in PYPI_WHEEL_TAGS:
+        raise _error(f"unsupported wheel platform tag: {path.name}")
+    dist_info = f"cmux-{version}.dist-info"
+    expected_files = _wheel_expected_files(version)
+
+    try:
+        wheel = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise _error(f"invalid wheel {path}: {error}") from error
+    with wheel:
+        infos = wheel.infolist()
+        names = [info.filename for info in infos]
+        if len(names) != len(set(names)):
+            raise _error(f"{path.name}: duplicate ZIP member")
+        if set(names) != expected_files:
+            raise _error(
+                f"{path.name}: file set mismatch; expected "
+                f"{sorted(expected_files)}, found {sorted(names)}"
+            )
+
+        wheel_info = wheel.getinfo(f"{dist_info}/WHEEL")
+        wheel_data = wheel.read(wheel_info)
+        if _metadata_value(wheel_data, "Tag") != f"py3-none-{tag}":
+            raise _error(f"{path.name}: WHEEL Tag does not match filename")
+        metadata = wheel.read(f"{dist_info}/METADATA")
+        if _metadata_value(metadata, "Name") != "cmux":
+            raise _error(f"{path.name}: METADATA Name is not cmux")
+        if _metadata_value(metadata, "Version") != version:
+            raise _error(f"{path.name}: METADATA Version does not match filename")
+
+        executable_names = {
+            "cmux_tui/bin/cmux-tui",
+            "cmux_tui/bin/cmux-tui-hook",
+        }
+        for name in names:
+            mode = _wheel_mode(wheel.getinfo(name))
+            expected_mode = 0o755 if name in executable_names else 0o644
+            if mode != expected_mode:
+                raise _error(
+                    f"{path.name}: {name} mode {mode:o} != {expected_mode:o}"
+                )
+
+        record_name = f"{dist_info}/RECORD"
+        record_data = wheel.read(record_name)
+        rows = list(csv.reader(io.StringIO(record_data.decode("utf-8"))))
+        expected_rows = set(expected_files)
+        seen_rows: set[str] = set()
+        for row in rows:
+            if len(row) != 3:
+                raise _error(f"{path.name}: malformed RECORD row")
+            name, digest, size = row
+            if name not in expected_rows:
+                raise _error(f"{path.name}: RECORD names unknown file {name}")
+            if name in seen_rows:
+                raise _error(f"{path.name}: RECORD contains duplicate {name}")
+            seen_rows.add(name)
+            if name == record_name:
+                if digest or size:
+                    raise _error(f"{path.name}: RECORD self-entry must be empty")
+                continue
+            data = wheel.read(name)
+            if digest != _record_digest(data) or size != str(len(data)):
+                raise _error(f"{path.name}: RECORD integrity mismatch for {name}")
+        if seen_rows != expected_rows:
+            raise _error(f"{path.name}: RECORD does not cover every wheel file")
+
+
+def validate_pypi_wheels(wheels_dir: Path, version: str) -> tuple[str, ...]:
+    """Validate the exact six wheels emitted for one cmux TUI version."""
+
+    wheels_dir = wheels_dir.resolve()
+    if not wheels_dir.is_dir():
+        raise _error(f"missing PyPI wheel directory: {wheels_dir}")
+    expected = tuple(
+        sorted(f"cmux-{version}-py3-none-{tag}.whl" for tag in PYPI_WHEEL_TAGS)
+    )
+    actual = tuple(sorted(path.name for path in wheels_dir.iterdir()))
+    if actual != expected:
+        raise _error(f"PyPI wheel set mismatch: expected {expected}, found {actual}")
+    for name in actual:
+        validate_wheel(wheels_dir / name, version)
+    return actual

--- a/cmux-tui/dist/scripts/package_npm_artifact.py
+++ b/cmux-tui/dist/scripts/package_npm_artifact.py
@@ -8,15 +8,11 @@ import stat
 import tarfile
 from pathlib import Path, PurePosixPath
 
+from package_contract import NPM_EXECUTABLE_FILES, PackageContractError, validate_npm_tree
+
 
 PACKAGE_ROOT = "npm-packages"
-EXECUTABLES = (
-    "cmux-tui-darwin-arm64/bin/cmux-tui",
-    "cmux-tui-darwin-x64/bin/cmux-tui",
-    "cmux-tui-linux-x64/bin/cmux-tui",
-    "cmux-tui-linux-arm64/bin/cmux-tui",
-    "cmux/bin/cmux.js",
-)
+EXECUTABLES = NPM_EXECUTABLE_FILES
 MAX_MEMBERS = 1_024
 MAX_EXPANDED_BYTES = 512 * 1024 * 1024
 
@@ -33,6 +29,11 @@ def verify_executables(packages_dir: Path) -> None:
             raise SystemExit(f"missing npm package executable: {executable}")
         if not executable.stat().st_mode & stat.S_IXUSR:
             raise SystemExit(f"npm package entry is not executable: {executable}")
+
+    try:
+        validate_npm_tree(packages_dir)
+    except PackageContractError as error:
+        raise SystemExit(str(error)) from error
 
 
 def create_archive(packages_dir: Path, archive: Path) -> None:

--- a/cmux-tui/dist/scripts/validate_package_contract.py
+++ b/cmux-tui/dist/scripts/validate_package_contract.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate and smoke-test cmux-tui npm and PyPI release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from package_contract import (
+    NPM_PLATFORM_NAMES,
+    PackageContractError,
+    validate_npm_tree,
+    validate_pypi_wheels,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--npm-packages", type=Path)
+    parser.add_argument("--pypi-wheels", type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--install-npm-package",
+        choices=NPM_PLATFORM_NAMES,
+        help="Pack all npm packages and install the launcher with this target.",
+    )
+    parser.add_argument("--npm", default="npm", help="npm executable")
+    args = parser.parse_args()
+    if args.npm_packages is None and args.pypi_wheels is None:
+        parser.error("at least one of --npm-packages or --pypi-wheels is required")
+    if args.install_npm_package is not None and args.npm_packages is None:
+        parser.error("--install-npm-package requires --npm-packages")
+    return args
+
+
+def _run(command: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise PackageContractError(
+            f"command failed ({result.returncode}): {' '.join(command)}\n{details}"
+        )
+    return result
+
+
+def _pack_npm_packages(
+    packages_dir: Path,
+    version: str,
+    npm: str,
+    install_package: str | None,
+) -> None:
+    validate_npm_tree(packages_dir, version)
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-npm-contract-") as temp:
+        temp_root = Path(temp)
+        packed_dir = temp_root / "packed"
+        packed_dir.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "npm_config_audit": "false",
+                "npm_config_fund": "false",
+                "npm_config_update_notifier": "false",
+            }
+        )
+        archives: dict[str, Path] = {}
+        for package_name in ("cmux", *NPM_PLATFORM_NAMES):
+            before = set(packed_dir.glob("*.tgz"))
+            _run(
+                [
+                    npm,
+                    "pack",
+                    str(packages_dir / package_name),
+                    "--ignore-scripts",
+                    "--json",
+                    "--pack-destination",
+                    str(packed_dir),
+                ],
+                env=env,
+            )
+            after = set(packed_dir.glob("*.tgz"))
+            new_archives = after - before
+            if len(new_archives) != 1:
+                raise PackageContractError(
+                    f"npm pack for {package_name} produced {len(new_archives)} archives"
+                )
+            archive = next(iter(new_archives))
+            archives[package_name] = archive
+            _validate_npm_archive(archive, package_name)
+
+        if install_package is None:
+            return
+
+        install_dir = temp_root / "install"
+        cache_dir = temp_root / "npm-cache"
+        env["npm_config_cache"] = str(cache_dir)
+        _run(
+            [
+                npm,
+                "install",
+                "--offline",
+                "--include=optional",
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund",
+                "--no-package-lock",
+                "--prefix",
+                str(install_dir),
+                str(archives["cmux"]),
+                str(archives[install_package]),
+            ],
+            env=env,
+        )
+        launcher = install_dir / "node_modules" / ".bin" / "cmux"
+        if not launcher.is_file():
+            raise PackageContractError(f"npm install did not create launcher: {launcher}")
+        _run([str(launcher), "--version"], env=env)
+
+
+def _validate_npm_archive(archive: Path, package_name: str) -> None:
+    import tarfile
+
+    from package_contract import (
+        NPM_LAUNCHER_FILES,
+        NPM_PLATFORM_FILES,
+    )
+
+    expected = NPM_LAUNCHER_FILES if package_name == "cmux" else NPM_PLATFORM_FILES
+    expected_names = {f"package/{path}" for path in expected}
+    try:
+        tar = tarfile.open(archive, "r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise PackageContractError(f"invalid npm archive {archive}: {error}") from error
+    with tar:
+        members = tar.getmembers()
+        names = {member.name for member in members if member.isfile()}
+        if names != expected_names:
+            raise PackageContractError(
+                f"{package_name}: packed file set mismatch: "
+                f"expected {sorted(expected_names)}, found {sorted(names)}"
+            )
+        if len(members) != len(names):
+            raise PackageContractError(f"{package_name}: npm archive has non-file members")
+        for member in members:
+            is_executable = member.name.endswith("/bin/cmux.js") or member.name.endswith(
+                "/bin/cmux-tui"
+            ) or member.name.endswith("/bin/cmux-tui-hook")
+            expected_mode = 0o755 if is_executable else 0o644
+            if member.mode != expected_mode:
+                raise PackageContractError(
+                    f"{package_name}: packed mode {member.mode:o} != "
+                    f"{expected_mode:o}: {member.name}"
+                )
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        if args.npm_packages is not None:
+            _pack_npm_packages(
+                args.npm_packages.resolve(),
+                args.version,
+                args.npm,
+                args.install_npm_package,
+            )
+        if args.pypi_wheels is not None:
+            validate_pypi_wheels(args.pypi_wheels.resolve(), args.version)
+    except PackageContractError as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/cmux-tui/scripts/prepare-pypi-tui-upload.sh
+++ b/cmux-tui/scripts/prepare-pypi-tui-upload.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'prepare-pypi-tui-upload: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ $# -ne 3 ]]; then
+  die "usage: $0 WHEELS_DIR UPLOAD_DIR VERSION"
+fi
+
+wheels_dir="$1"
+upload_dir="$2"
+version="$3"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "version must match X.Y.Z"
+[[ -d "$wheels_dir" ]] || die "missing wheel directory: $wheels_dir"
+mkdir -p "$upload_dir"
+if [[ -n "$(find "$upload_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  die "upload directory must start empty: $upload_dir"
+fi
+
+shopt -s nullglob
+wheels=("$wheels_dir"/*.whl)
+[[ "${#wheels[@]}" == 6 ]] ||
+  die "expected six wheels, found ${#wheels[@]}"
+
+allowed_args=()
+for wheel in "${wheels[@]}"; do
+  allowed_args+=(--allowed-artifact "$wheel")
+done
+
+temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+mkdir -p "$temp_root"
+status_root="$(mktemp -d "$temp_root/cmux-tui-pypi-status.XXXXXX")"
+trap 'rm -rf "$status_root"' EXIT
+
+has_new=false
+for wheel in "${wheels[@]}"; do
+  status_file="$status_root/$(basename "$wheel").output"
+  : > "$status_file"
+  if ! GITHUB_OUTPUT="$status_file" python3 cmux-tui/bindings/reconcile_registry_artifact.py check \
+    --registry pypi \
+    --package cmux \
+    --version "$version" \
+    --artifact "$wheel" \
+    "${allowed_args[@]}" \
+    --wait-seconds 120 \
+    --write-github-output \
+    --github-output-name status; then
+    die "could not prove the PyPI state for $(basename "$wheel"); refusing to publish"
+  fi
+
+  status="$(awk -F= '$1 == "status" { value = $2 } END { print value }' "$status_file")"
+  case "$status" in
+    match)
+      printf 'already published exact PyPI wheel: %s\n' "$(basename "$wheel")"
+      ;;
+    missing)
+      cp -- "$wheel" "$upload_dir/"
+      has_new=true
+      printf 'staging new PyPI wheel: %s\n' "$(basename "$wheel")"
+      ;;
+    *)
+      die "reconciler returned invalid status '$status' for $(basename "$wheel")"
+      ;;
+  esac
+done
+
+printf 'has_new=%s\n' "$has_new" >> "$GITHUB_OUTPUT"

--- a/cmux-tui/scripts/prepare-pypi-tui-upload.sh
+++ b/cmux-tui/scripts/prepare-pypi-tui-upload.sh
@@ -15,7 +15,7 @@ upload_dir="$2"
 version="$3"
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 
-[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+[[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
   die "version must match X.Y.Z"
 [[ -d "$wheels_dir" ]] || die "missing wheel directory: $wheels_dir"
 mkdir -p "$upload_dir"

--- a/tests/test_tui_npm_package_artifact.py
+++ b/tests/test_tui_npm_package_artifact.py
@@ -5,6 +5,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import json
 from pathlib import Path
 
 
@@ -12,11 +13,23 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "cmux-tui/dist/scripts/package_npm_artifact.py"
 EXECUTABLES = (
     "cmux-tui-darwin-arm64/bin/cmux-tui",
+    "cmux-tui-darwin-arm64/bin/cmux-tui-hook",
     "cmux-tui-darwin-x64/bin/cmux-tui",
+    "cmux-tui-darwin-x64/bin/cmux-tui-hook",
     "cmux-tui-linux-x64/bin/cmux-tui",
+    "cmux-tui-linux-x64/bin/cmux-tui-hook",
     "cmux-tui-linux-arm64/bin/cmux-tui",
+    "cmux-tui-linux-arm64/bin/cmux-tui-hook",
     "cmux/bin/cmux.js",
 )
+
+VERSION = "1.2.3"
+TARGETS = {
+    "cmux-tui-darwin-arm64": ("darwin", "arm64"),
+    "cmux-tui-darwin-x64": ("darwin", "x64"),
+    "cmux-tui-linux-x64": ("linux", "x64"),
+    "cmux-tui-linux-arm64": ("linux", "arm64"),
+}
 
 
 def run_helper(*args: object) -> subprocess.CompletedProcess[str]:
@@ -31,11 +44,47 @@ def run_helper(*args: object) -> subprocess.CompletedProcess[str]:
 
 def test_archive_round_trip_preserves_package_executables(tmp_path: Path) -> None:
     packages = tmp_path / "npm-packages"
-    for relative_path in EXECUTABLES:
-        executable = packages / relative_path
-        executable.parent.mkdir(parents=True, exist_ok=True)
-        executable.write_text("#!/bin/sh\nexit 0\n")
-        executable.chmod(0o755)
+    for name, (os_name, cpu) in TARGETS.items():
+        package = packages / name
+        package.mkdir(parents=True, exist_ok=True)
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "version": VERSION,
+                    "os": [os_name],
+                    "cpu": [cpu],
+                    "files": ["bin/cmux-tui", "bin/cmux-tui-hook"],
+                }
+            )
+            + "\n"
+        )
+        for binary in ("cmux-tui", "cmux-tui-hook"):
+            executable = package / "bin" / binary
+            executable.parent.mkdir(parents=True, exist_ok=True)
+            executable.write_text("#!/bin/sh\nexit 0\n")
+            executable.chmod(0o755)
+
+    launcher = packages / "cmux"
+    launcher.mkdir(parents=True, exist_ok=True)
+    (launcher / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cmux",
+                "version": VERSION,
+                "bin": {"cmux": "bin/cmux.js"},
+                "files": ["bin/cmux.js"],
+                "optionalDependencies": {
+                    name: VERSION for name in TARGETS
+                },
+            }
+        )
+        + "\n"
+    )
+    launcher_bin = launcher / "bin" / "cmux.js"
+    launcher_bin.parent.mkdir(parents=True, exist_ok=True)
+    launcher_bin.write_text("#!/bin/sh\nexit 0\n")
+    launcher_bin.chmod(0o755)
 
     archive = tmp_path / "npm-packages.tar.gz"
     created = run_helper(

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import stat
 import subprocess
 import sys
@@ -19,6 +20,24 @@ NPM_TARGETS = {
     "cmux-tui-linux-x64": ("linux", "x64"),
     "cmux-tui-linux-arm64": ("linux", "arm64"),
 }
+
+
+def host_npm_target() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux":
+        return (
+            "cmux-tui-linux-arm64"
+            if machine in {"aarch64", "arm64"}
+            else "cmux-tui-linux-x64"
+        )
+    if system == "darwin":
+        return (
+            "cmux-tui-darwin-x64"
+            if machine in {"x86_64", "amd64"}
+            else "cmux-tui-darwin-arm64"
+        )
+    raise RuntimeError(f"unsupported test host: {system}-{machine}")
 
 
 def write_executable(path: Path, output: str = "cmux-tui 1.2.3") -> None:
@@ -122,7 +141,7 @@ def test_npm_contract_packs_and_installs_matching_platform(tmp_path: Path) -> No
         "--version",
         VERSION,
         "--install-npm-package",
-        "cmux-tui-darwin-arm64",
+        host_npm_target(),
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "cmux-tui/dist/scripts/validate_package_contract.py"
+PYPI_BUILDER = ROOT / "cmux-tui/dist/scripts/package_pypi.py"
+
+VERSION = "1.2.3"
+NPM_TARGETS = {
+    "cmux-tui-darwin-arm64": ("darwin", "arm64"),
+    "cmux-tui-darwin-x64": ("darwin", "x64"),
+    "cmux-tui-linux-x64": ("linux", "x64"),
+    "cmux-tui-linux-arm64": ("linux", "arm64"),
+}
+
+
+def write_executable(path: Path, output: str = "cmux-tui 1.2.3") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/bin/sh\nprintf '%s\\n' '{output}'\n")
+    path.chmod(0o755)
+
+
+def make_npm_packages(root: Path) -> None:
+    root.mkdir()
+    for name, (os_name, cpu) in NPM_TARGETS.items():
+        package = root / name
+        package.mkdir()
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "version": VERSION,
+                    "os": [os_name],
+                    "cpu": [cpu],
+                    "files": ["bin/cmux-tui", "bin/cmux-tui-hook"],
+                }
+            )
+            + "\n"
+        )
+        write_executable(package / "bin/cmux-tui")
+        write_executable(package / "bin/cmux-tui-hook", "cmux-tui-hook 1.2.3")
+
+    launcher = root / "cmux"
+    launcher.mkdir()
+    (launcher / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cmux",
+                "version": VERSION,
+                "bin": {"cmux": "bin/cmux.js"},
+                "files": ["bin/cmux.js"],
+                "optionalDependencies": {
+                    name: VERSION for name in NPM_TARGETS
+                },
+            }
+        )
+        + "\n"
+    )
+    write_executable(
+        launcher / "bin/cmux.js",
+        "cmux launcher 1.2.3",
+    )
+
+
+def make_pypi_wheels(tmp_path: Path) -> Path:
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    for target in (
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-musl",
+        "aarch64-unknown-linux-musl",
+    ):
+        write_executable(binaries / f"cmux-tui-{target}")
+        write_executable(binaries / f"cmux-tui-hook-{target}", "hook")
+
+    wheels = tmp_path / "wheels"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYPI_BUILDER),
+            "--binaries-dir",
+            str(binaries),
+            "--version",
+            VERSION,
+            "--out",
+            str(wheels),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return wheels
+
+
+def run_validator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_npm_contract_packs_and_installs_matching_platform(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+        "--install-npm-package",
+        "cmux-tui-darwin-arm64",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_npm_contract_rejects_missing_hook(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+    (packages / "cmux-tui-linux-x64/bin/cmux-tui-hook").unlink()
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode != 0
+    assert "cmux-tui-hook" in result.stderr
+
+
+def test_npm_contract_rejects_extra_file(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+    extra = packages / "cmux-tui-linux-x64/bin/extra"
+    write_executable(extra)
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode != 0
+    assert "unexpected" in result.stderr
+
+
+def test_pypi_contract_requires_all_six_wheels_and_metadata(tmp_path: Path) -> None:
+    wheels = make_pypi_wheels(tmp_path)
+
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    wheel = next(wheels.glob("*macosx_11_0_arm64.whl"))
+    wheel.unlink()
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+    assert result.returncode != 0
+    assert "expected" in result.stderr.lower()
+
+
+def test_pypi_contract_rejects_non_executable_hook(tmp_path: Path) -> None:
+    wheels = make_pypi_wheels(tmp_path)
+    wheel = next(wheels.glob("*.whl"))
+
+    import zipfile
+
+    rewritten = tmp_path / "rewritten.whl"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(rewritten, "w") as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == "cmux_tui/bin/cmux-tui-hook":
+                info.external_attr = (stat.S_IFREG | 0o644) << 16
+            target.writestr(info, data)
+    wheel.unlink()
+    rewritten.rename(wheel)
+
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+    assert result.returncode != 0
+    assert "executable" in result.stderr.lower()
+

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -4,6 +4,7 @@ import json
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -157,7 +158,7 @@ def test_npm_contract_rejects_extra_file(tmp_path: Path) -> None:
     )
 
     assert result.returncode != 0
-    assert "unexpected" in result.stderr
+    assert "mismatch" in result.stderr
 
 
 def test_pypi_contract_requires_all_six_wheels_and_metadata(tmp_path: Path) -> None:
@@ -207,5 +208,21 @@ def test_pypi_contract_rejects_non_executable_hook(tmp_path: Path) -> None:
         VERSION,
     )
     assert result.returncode != 0
-    assert "executable" in result.stderr.lower()
+    assert "mode" in result.stderr.lower()
 
+
+def main() -> None:
+    tests = (
+        test_npm_contract_packs_and_installs_matching_platform,
+        test_npm_contract_rejects_missing_hook,
+        test_npm_contract_rejects_extra_file,
+        test_pypi_contract_requires_all_six_wheels_and_metadata,
+        test_pypi_contract_rejects_non_executable_hook,
+    )
+    for test in tests:
+        with tempfile.TemporaryDirectory(prefix="cmux-tui-contract-test-") as directory:
+            test(Path(directory))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1629,12 +1629,29 @@ def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() 
 def test_tui_publishers_reconcile_partial_registry_writes() -> None:
     npm = workflow("tui-publish-npm.yml")
     pypi = workflow("tui-publish-pypi.yml")
+    pypi_helper = (
+        ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
+    ).read_text()
 
     assert "npm pack --ignore-scripts" in npm
-    assert npm.count("reconcile_registry_artifact.py publish") >= 5
+    assert npm.count("reconcile_registry_artifact.py publish") == 2
+    assert 'for package in "${packages[@]}"' in npm
+    for package in (
+        "cmux-tui-darwin-arm64",
+        "cmux-tui-darwin-x64",
+        "cmux-tui-linux-x64",
+        "cmux-tui-linux-arm64",
+    ):
+        assert package in npm
+    assert "--package cmux" in npm
+    assert 'dist/npm-publish/$package-$version.tgz' in npm
+    assert "-- npm publish --provenance" in npm
+    assert "--wait-seconds 120" in npm
     assert "--registry npm" in npm
     assert "prepare-pypi-tui-upload.sh" in pypi
-    assert "--registry pypi" in pypi
+    assert "--registry pypi" in pypi_helper
+    assert "--allowed-artifact" in pypi_helper
+    assert "--wait-seconds 120" in pypi_helper
     assert "steps.pypi_upload.outputs.has_new == 'true'" in pypi
 
 
@@ -1645,7 +1662,7 @@ def test_pypi_retry_preparation_skips_only_exact_matches() -> None:
         "macosx_10_12_x86_64",
         "manylinux_2_17_x86_64.manylinux2014_x86_64",
         "musllinux_1_2_x86_64",
-        "manylinux_2_17_aarch64",
+        "manylinux_2_17_aarch64.manylinux2014_aarch64",
         "musllinux_1_2_aarch64",
     )
 
@@ -1702,6 +1719,14 @@ def test_pypi_retry_preparation_skips_only_exact_matches() -> None:
 
 def test_pypi_retry_preparation_fails_on_registry_mismatch() -> None:
     script = ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
+    tags = (
+        "macosx_11_0_arm64",
+        "macosx_10_12_x86_64",
+        "manylinux_2_17_x86_64.manylinux2014_x86_64",
+        "musllinux_1_2_x86_64",
+        "manylinux_2_17_aarch64.manylinux2014_aarch64",
+        "musllinux_1_2_aarch64",
+    )
 
     with tempfile.TemporaryDirectory(prefix="cmux-tui-pypi-mismatch-") as raw:
         temporary = Path(raw)
@@ -1710,8 +1735,8 @@ def test_pypi_retry_preparation_fails_on_registry_mismatch() -> None:
         fake_bin = temporary / "bin"
         wheels.mkdir()
         fake_bin.mkdir()
-        wheel = wheels / "cmux-1.2.3-py3-none-macosx_11_0_arm64.whl"
-        wheel.write_bytes(b"wheel")
+        for tag in tags:
+            (wheels / f"cmux-1.2.3-py3-none-{tag}.whl").write_bytes(tag.encode())
         fake_python = fake_bin / "python3"
         fake_python.write_text(
             "#!/usr/bin/env bash\n"

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1670,23 +1670,59 @@ exit 1
 
 def test_release_cut_does_not_mask_waiter_failure() -> None:
     release_cut = workflow("cmux-tui-release-cut.yml")
-    tag_job = workflow_job(release_cut, "tag")
-
-    assert 'release_result="$("' in tag_job
-    assert '<<<"$(' not in tag_job
-    result = subprocess.run(
-        (
-            "bash",
-            "-c",
-            "set -euo pipefail; result=\"$(false)\"; "
-            "IFS=$'\\t' read -r run_id conclusion <<<\"$result\"; echo leaked",
-        ),
-        check=False,
-        text=True,
-        capture_output=True,
+    document = yaml.load(release_cut, Loader=yaml.BaseLoader)
+    dispatch_step = next(
+        step
+        for step in document["jobs"]["tag"]["steps"]
+        if step.get("name") == "Dispatch release workflows"
     )
-    assert result.returncode != 0
-    assert "leaked" not in result.stdout
+    run_lines = dispatch_step["run"].splitlines()
+    waiter_line = next(
+        index
+        for index, line in enumerate(run_lines)
+        if "WAIT_TIMEOUT_SECONDS=5400 bash .github/scripts/wait-for-workflow-run.sh"
+        in line
+    )
+    fragment_start = next(
+        index
+        for index in range(waiter_line, -1, -1)
+        if "release_result=" in run_lines[index]
+        or "release_run_id release_conclusion" in run_lines[index]
+    )
+    fragment = "\n".join(run_lines[fragment_start:]) + "\n"
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-release-cut-waiter-") as raw:
+        temporary = Path(raw)
+        waiter = temporary / ".github" / "scripts" / "wait-for-workflow-run.sh"
+        waiter.parent.mkdir(parents=True)
+        waiter.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' 'fake waiter failure' >&2\n"
+            "exit 37\n"
+        )
+        waiter.chmod(0o755)
+        summary = temporary / "summary"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_STEP_SUMMARY": str(summary),
+                "TAG": "cmux-tui-v1.2.3",
+                "before_run_id": "0",
+                "dispatch_started_at": "1786838400",
+            }
+        )
+        result = subprocess.run(
+            ("bash", "-c", "set -euo pipefail\n" + fragment),
+            cwd=temporary,
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+        assert "release workflow did not complete successfully" in result.stderr
+        assert not summary.exists()
 
 
 def test_release_dispatch_timeout_covers_sequential_publisher_waits() -> None:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1380,6 +1380,7 @@ def test_tui_publishers_require_independent_environment_policy_preflight() -> No
         assert "verify_release_environment_policy.py" in block
         assert 'RELEASE_ENVIRONMENT: ' + environment in block
         assert 'environments/$RELEASE_ENVIRONMENT' in block
+        assert "--hostname github.com" in block
         assert "GH_TOKEN: ${{ github.token }}" in block
         assert "actions: read" in block
         assert block.index("Verify independent environment approval policy") < block.index(

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1437,5 +1437,193 @@ def test_stable_release_builds_and_tests_once_before_dispatching_publishers() ->
         assert "workflow_call:" not in workflow(name)
 
 
+def test_release_cut_rejects_an_event_sha_stale_from_protected_main() -> None:
+    script = ROOT / ".github" / "scripts" / "require-current-main.sh"
+
+    def git(*arguments: str, cwd: Path) -> str:
+        return subprocess.run(
+            ("git", *arguments),
+            cwd=cwd,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-main-guard-") as raw:
+        temporary = Path(raw)
+        source = temporary / "source"
+        remote = temporary / "remote.git"
+        source.mkdir()
+        git("init", "-b", "main", cwd=source)
+        git("config", "user.name", "cmux release test", cwd=source)
+        git("config", "user.email", "release-test@cmux.dev", cwd=source)
+        git("commit", "--allow-empty", "-m", "release", cwd=source)
+        release_sha = git("rev-parse", "HEAD", cwd=source)
+        git("init", "--bare", str(remote), cwd=temporary)
+        git("remote", "add", "origin", str(remote), cwd=source)
+        git("push", "origin", "main", cwd=source)
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SHA": release_sha,
+            }
+        )
+        current = subprocess.run(
+            ("bash", str(script)),
+            cwd=source,
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert current.returncode == 0, current.stderr
+
+        git("commit", "--allow-empty", "-m", "advance main", cwd=source)
+        git("push", "origin", "main", cwd=source)
+        stale = subprocess.run(
+            ("bash", str(script)),
+            cwd=source,
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert stale.returncode != 0
+        assert "not current protected main" in stale.stderr
+
+
+def test_dispatch_waiter_selects_a_new_run_and_polls_to_success() -> None:
+    script = ROOT / ".github" / "scripts" / "wait-for-workflow-run.sh"
+    sha = "a" * 40
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-run-wait-") as raw:
+        temporary = Path(raw)
+        bin_dir = temporary / "bin"
+        bin_dir.mkdir()
+        state = temporary / "state"
+        state.write_text("0\n")
+        detail_state = temporary / "detail-state"
+        detail_state.write_text("0\n")
+        gh = bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+endpoint="$2"
+if [[ "$endpoint" == *"/workflows/cmux-tui-release.yml/runs?"* ]]; then
+  count=$(cat "$STATE")
+  count=$((count + 1))
+  printf '%s\\n' "$count" > "$STATE"
+  if (( count == 1 )); then
+    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"}]}'
+  else
+    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
+  fi
+  exit 0
+fi
+if [[ "$endpoint" == */actions/runs/42 ]]; then
+  count=$(cat "$DETAIL_STATE")
+  count=$((count + 1))
+  printf '%s\\n' "$count" > "$DETAIL_STATE"
+  if (( count == 1 )); then
+    printf '%s\\n' '{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","status":"in_progress","conclusion":null}'
+  else
+    printf '%s\\n' '{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","status":"completed","conclusion":"success"}'
+  fi
+  exit 0
+fi
+exit 1
+"""
+        )
+        gh.chmod(0o755)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "manaflow-ai/cmux",
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "POLL_INTERVAL_SECONDS": "0",
+                "WAIT_TIMEOUT_SECONDS": "5",
+                "STATE": str(state),
+                "DETAIL_STATE": str(detail_state),
+            }
+        )
+        result = subprocess.run(
+            ("bash", str(script), "cmux-tui-release.yml", "cmux-tui-v1.2.3", sha, "0", "41"),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "42\tsuccess"
+        assert "completed with success" in result.stderr
+
+
+def test_dispatch_waiter_fails_closed_on_a_failed_run() -> None:
+    script = ROOT / ".github" / "scripts" / "wait-for-workflow-run.sh"
+    sha = "b" * 40
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-run-failure-") as raw:
+        temporary = Path(raw)
+        bin_dir = temporary / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+endpoint="$2"
+if [[ "$endpoint" == *"/workflows/tui-publish-pypi.yml/runs?"* ]]; then
+  printf '%s\\n' '{"workflow_runs":[{"id":99,"path":".github/workflows/tui-publish-pypi.yml","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
+  exit 0
+fi
+if [[ "$endpoint" == */actions/runs/99 ]]; then
+  printf '%s\\n' '{"id":99,"path":".github/workflows/tui-publish-pypi.yml","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","status":"completed","conclusion":"failure"}'
+  exit 0
+fi
+exit 1
+"""
+        )
+        gh.chmod(0o755)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "manaflow-ai/cmux",
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "POLL_INTERVAL_SECONDS": "0",
+                "WAIT_TIMEOUT_SECONDS": "5",
+            }
+        )
+        result = subprocess.run(
+            ("bash", str(script), "tui-publish-pypi.yml", "cmux-tui-v1.2.3", sha, "0", "0"),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+        assert "concluded failure" in result.stderr
+
+
+def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() -> None:
+    release_cut = workflow("cmux-tui-release-cut.yml")
+    release = workflow("cmux-tui-release.yml")
+    npm = workflow("tui-publish-npm.yml")
+    pypi = workflow("tui-publish-pypi.yml")
+
+    assert "require-current-main.sh" in release_cut
+    assert release_cut.count("wait-for-workflow-run.sh") == 1
+    assert "before_run_id" in release_cut
+    assert release.count("wait-for-workflow-run.sh") == 2
+    assert "before_run_id" in release
+    assert "confirm_tui_cmux=true" in release
+    assert "PUBLISH_PYPI" in release
+    assert "PyPI publishing requires confirm_tui_cmux=true." in release
+    assert "group: tui-publish-npm-latest" in npm
+    assert "Refuse an npm latest regression" in npm
+    assert "confirm_tui_cmux:" in pypi
+    assert "PyPI publishing requires confirm_tui_cmux=true." in pypi
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1544,12 +1544,21 @@ exit 1
                 "PATH": f"{bin_dir}:{environment['PATH']}",
                 "POLL_INTERVAL_SECONDS": "0",
                 "WAIT_TIMEOUT_SECONDS": "5",
+                "CLOCK_SKEW_SECONDS": "5",
                 "STATE": str(state),
                 "DETAIL_STATE": str(detail_state),
             }
         )
         result = subprocess.run(
-            ("bash", str(script), "cmux-tui-release.yml", "cmux-tui-v1.2.3", sha, "0", "41"),
+            (
+                "bash",
+                str(script),
+                "cmux-tui-release.yml",
+                "cmux-tui-v1.2.3",
+                sha,
+                "1786838400",
+                "41",
+            ),
             env=environment,
             check=False,
             text=True,
@@ -1558,6 +1567,60 @@ exit 1
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == "42\tsuccess"
         assert "completed with success" in result.stderr
+
+
+def test_dispatch_waiter_accepts_a_run_created_just_before_dispatch() -> None:
+    script = ROOT / ".github" / "scripts" / "wait-for-workflow-run.sh"
+    sha = "c" * 40
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-run-boundary-") as raw:
+        temporary = Path(raw)
+        bin_dir = temporary / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+endpoint="$2"
+if [[ "$endpoint" == *"/workflows/tui-publish-npm.yml/runs?"* ]]; then
+  printf '%s\\n' '{"workflow_runs":[{"id":42,"path":".github/workflows/tui-publish-npm.yml","head_sha":"cccccccccccccccccccccccccccccccccccccccc","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"}]}'
+  exit 0
+fi
+if [[ "$endpoint" == */actions/runs/42 ]]; then
+  printf '%s\\n' '{"id":42,"path":".github/workflows/tui-publish-npm.yml","head_sha":"cccccccccccccccccccccccccccccccccccccccc","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","status":"completed","conclusion":"success"}'
+  exit 0
+fi
+exit 1
+"""
+        )
+        gh.chmod(0o755)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "manaflow-ai/cmux",
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "POLL_INTERVAL_SECONDS": "0",
+                "WAIT_TIMEOUT_SECONDS": "5",
+                "CLOCK_SKEW_SECONDS": "5",
+            }
+        )
+        result = subprocess.run(
+            (
+                "bash",
+                str(script),
+                "tui-publish-npm.yml",
+                "cmux-tui-v1.2.3",
+                sha,
+                "1786838400",
+                "0",
+            ),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "42\tsuccess"
 
 
 def test_dispatch_waiter_fails_closed_on_a_failed_run() -> None:
@@ -1603,6 +1666,48 @@ exit 1
         )
         assert result.returncode != 0
         assert "concluded failure" in result.stderr
+
+
+def test_release_cut_does_not_mask_waiter_failure() -> None:
+    release_cut = workflow("cmux-tui-release-cut.yml")
+    tag_job = workflow_job(release_cut, "tag")
+
+    assert 'release_result="$("' in tag_job
+    assert '<<<"$(' not in tag_job
+    result = subprocess.run(
+        (
+            "bash",
+            "-c",
+            "set -euo pipefail; result=\"$(false)\"; "
+            "IFS=$'\\t' read -r run_id conclusion <<<\"$result\"; echo leaked",
+        ),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert "leaked" not in result.stdout
+
+
+def test_release_dispatch_timeout_covers_sequential_publisher_waits() -> None:
+    release = workflow("cmux-tui-release.yml")
+    dispatch = workflow_job(release, "dispatch-publishers")
+
+    assert "timeout-minutes: 210" in dispatch
+    assert dispatch.count("WAIT_TIMEOUT_SECONDS=5400") == 2
+    assert 210 * 60 > 2 * 5400
+
+
+def test_stable_tui_versions_reject_leading_zero_components() -> None:
+    strict_component = "(0|[1-9][0-9]*)"
+    for name in (
+        "cmux-tui-release-cut.yml",
+        "cmux-tui-release.yml",
+        "tui-publish-npm.yml",
+        "tui-publish-pypi.yml",
+    ):
+        assert strict_component in workflow(name)
+    assert 'part.startswith("0")' in workflow("tui-publish-npm.yml")
 
 
 def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() -> None:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1615,6 +1615,7 @@ def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() 
     assert release_cut.count("wait-for-workflow-run.sh") == 1
     assert "before_run_id" in release_cut
     assert release.count("wait-for-workflow-run.sh") == 2
+    assert "actions/checkout@" in workflow_job(release, "dispatch-publishers")
     assert "before_run_id" in release
     assert "confirm_tui_cmux=true" in release
     assert "PUBLISH_PYPI" in release

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1626,5 +1626,119 @@ def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() 
     assert "PyPI publishing requires confirm_tui_cmux=true." in pypi
 
 
+def test_tui_publishers_reconcile_partial_registry_writes() -> None:
+    npm = workflow("tui-publish-npm.yml")
+    pypi = workflow("tui-publish-pypi.yml")
+
+    assert "npm pack --ignore-scripts" in npm
+    assert npm.count("reconcile_registry_artifact.py publish") >= 5
+    assert "--registry npm" in npm
+    assert "prepare-pypi-tui-upload.sh" in pypi
+    assert "--registry pypi" in pypi
+    assert "steps.pypi_upload.outputs.has_new == 'true'" in pypi
+
+
+def test_pypi_retry_preparation_skips_only_exact_matches() -> None:
+    script = ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
+    tags = (
+        "macosx_11_0_arm64",
+        "macosx_10_12_x86_64",
+        "manylinux_2_17_x86_64.manylinux2014_x86_64",
+        "musllinux_1_2_x86_64",
+        "manylinux_2_17_aarch64",
+        "musllinux_1_2_aarch64",
+    )
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-pypi-retry-") as raw:
+        temporary = Path(raw)
+        wheels = temporary / "wheels"
+        upload = temporary / "upload"
+        fake_bin = temporary / "bin"
+        wheels.mkdir()
+        fake_bin.mkdir()
+        for tag in tags:
+            (wheels / f"cmux-1.2.3-py3-none-{tag}.whl").write_bytes(tag.encode())
+
+        fake_python = fake_bin / "python3"
+        fake_python.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "artifact=\"\"\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  if [[ \"$1\" == \"--artifact\" ]]; then\n"
+            "    artifact=\"$2\"\n"
+            "    shift 2\n"
+            "  else\n"
+            "    shift\n"
+            "  fi\n"
+            "done\n"
+            "case \"$(basename \"$artifact\")\" in\n"
+            "  *manylinux2014_x86_64.whl) echo 'status=missing' >> \"$GITHUB_OUTPUT\" ;;\n"
+            "  *) echo 'status=match' >> \"$GITHUB_OUTPUT\" ;;\n"
+            "esac\n"
+        )
+        fake_python.chmod(0o755)
+        output = temporary / "github-output"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_OUTPUT": str(output),
+                "PATH": f"{fake_bin}:{environment['PATH']}",
+            }
+        )
+        result = subprocess.run(
+            ("bash", str(script), str(wheels), str(upload), "1.2.3"),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert sorted(path.name for path in upload.iterdir()) == [
+            "cmux-1.2.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        ]
+        assert "has_new=true" in output.read_text()
+
+
+def test_pypi_retry_preparation_fails_on_registry_mismatch() -> None:
+    script = ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-pypi-mismatch-") as raw:
+        temporary = Path(raw)
+        wheels = temporary / "wheels"
+        upload = temporary / "upload"
+        fake_bin = temporary / "bin"
+        wheels.mkdir()
+        fake_bin.mkdir()
+        wheel = wheels / "cmux-1.2.3-py3-none-macosx_11_0_arm64.whl"
+        wheel.write_bytes(b"wheel")
+        fake_python = fake_bin / "python3"
+        fake_python.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "echo 'registry hash mismatch' >&2\n"
+            "exit 1\n"
+        )
+        fake_python.chmod(0o755)
+        output = temporary / "github-output"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_OUTPUT": str(output),
+                "PATH": f"{fake_bin}:{environment['PATH']}",
+            }
+        )
+        result = subprocess.run(
+            ("bash", str(script), str(wheels), str(upload), "1.2.3"),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+        assert "registry hash mismatch" in result.stderr
+        assert not upload.exists() or not any(upload.iterdir())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1819,7 +1819,7 @@ def test_dispatch_waiter_rejects_ambiguous_matching_runs() -> None:
 set -euo pipefail
 endpoint="$2"
 if [[ "$endpoint" == *"/workflows/tui-publish-npm.yml/runs?"* ]]; then
-  printf '%s\\n' '{"workflow_runs":[{"id":101,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"},{"id":102,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:02Z"}]}'
+  printf '%s\\n' '{"workflow_runs":[{"id":101,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":102,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:02Z"}]}'
   exit 0
 fi
 if [[ "$endpoint" == */actions/runs/102 ]]; then

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1518,7 +1518,7 @@ if [[ "$endpoint" == *"/workflows/cmux-tui-release.yml/runs?"* ]]; then
   if (( count == 1 )); then
     printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"}]}'
   else
-    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
+    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":99,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
   fi
   exit 0
 fi
@@ -1739,10 +1739,14 @@ def test_stable_tui_versions_reject_leading_zero_components() -> None:
     for name in (
         "cmux-tui-release-cut.yml",
         "cmux-tui-release.yml",
+        "cmux-tui-nightly.yml",
         "tui-publish-npm.yml",
         "tui-publish-pypi.yml",
     ):
         assert strict_component in workflow(name)
+    assert strict_component in (
+        ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
+    ).read_text()
     assert 'part.startswith("0")' in workflow("tui-publish-npm.yml")
 
 

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1492,6 +1492,15 @@ def test_npm_publishers_pin_the_oidc_capable_npm_version() -> None:
         assert "npm@^11.5.1" not in text
 
 
+def test_tui_package_contract_pins_setup_node_commit() -> None:
+    text = workflow("cmux-tui-build-package.yml")
+    assert (
+        "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+        in text
+    )
+    assert "actions/setup-node@48b55a011bda49bbe596cd826c3c89aef350131" not in text
+
+
 def test_nightly_build_is_pinned_to_its_provenance_commit() -> None:
     text = workflow("cmux-tui-nightly.yml")
     assert "ref: ${{ github.sha }}" in text
@@ -1894,9 +1903,27 @@ def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() 
     assert "PUBLISH_PYPI" in release
     assert "PyPI publishing requires confirm_tui_cmux=true." in release
     assert "group: tui-publish-npm-latest" in npm
+    concurrency = npm.split("concurrency:", 1)[1].split("jobs:", 1)[0]
+    assert "queue: max" in concurrency
+    assert "cancel-in-progress: false" in concurrency
+    assert "cancel-in-progress: true" not in concurrency
     assert "Refuse an npm latest regression" in npm
     assert "confirm_tui_cmux:" in pypi
     assert "PyPI publishing requires confirm_tui_cmux=true." in pypi
+
+
+def test_release_summary_redacts_provider_run_ids() -> None:
+    release = workflow("cmux-tui-release.yml")
+    summary = release.split('echo "### Registry publishing"', 1)[1].split(
+        '} >> "$GITHUB_STEP_SUMMARY"', 1
+    )[0]
+
+    assert "ARTIFACT_RUN_ID" not in summary
+    assert "npm_run_id" not in summary
+    assert "pypi_run_id" not in summary
+    assert 'echo "- Verified artifacts: ready"' in summary
+    assert 'echo "- npm publisher: $npm_conclusion"' in summary
+    assert 'echo "- PyPI publisher: $pypi_conclusion"' in summary
 
 
 def test_tui_publishers_reconcile_partial_registry_writes() -> None:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1805,6 +1805,60 @@ exit 1
         assert "concluded failure" in result.stderr
 
 
+def test_dispatch_waiter_rejects_ambiguous_matching_runs() -> None:
+    script = ROOT / ".github" / "scripts" / "wait-for-workflow-run.sh"
+    sha = "d" * 40
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-run-ambiguous-") as raw:
+        temporary = Path(raw)
+        bin_dir = temporary / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+endpoint="$2"
+if [[ "$endpoint" == *"/workflows/tui-publish-npm.yml/runs?"* ]]; then
+  printf '%s\\n' '{"workflow_runs":[{"id":101,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"},{"id":102,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:02Z"}]}'
+  exit 0
+fi
+if [[ "$endpoint" == */actions/runs/102 ]]; then
+  printf '%s\\n' '{"id":102,"path":".github/workflows/tui-publish-npm.yml","head_sha":"dddddddddddddddddddddddddddddddddddddddd","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","status":"completed","conclusion":"success"}'
+  exit 0
+fi
+exit 1
+"""
+        )
+        gh.chmod(0o755)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "manaflow-ai/cmux",
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "POLL_INTERVAL_SECONDS": "0",
+                "WAIT_TIMEOUT_SECONDS": "3",
+                "CLOCK_SKEW_SECONDS": "0",
+            }
+        )
+        result = subprocess.run(
+            (
+                "bash",
+                str(script),
+                "tui-publish-npm.yml",
+                "cmux-tui-v1.2.3",
+                sha,
+                "1786838400",
+                "100",
+            ),
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+        assert "multiple matching" in result.stderr
+
+
 def test_release_cut_does_not_mask_waiter_failure() -> None:
     release_cut = workflow("cmux-tui-release-cut.yml")
     document = yaml.load(release_cut, Loader=yaml.BaseLoader)

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1349,20 +1349,47 @@ def test_stable_registry_publishers_are_exact_tag_and_artifact_bound() -> None:
 
 
 def test_tui_publishers_require_independent_environment_policy_preflight() -> None:
-    for name, environment in (
-        ("tui-publish-npm.yml", "npm-tui"),
-        ("tui-publish-pypi.yml", "pypi-tui"),
+    for name, job, environment, publish_step in (
+        (
+            "cmux-tui-nightly.yml",
+            "publish-npm",
+            "npm-tui",
+            "Publish platform packages with nightly dist-tag",
+        ),
+        (
+            "cmux-tui-nightly.yml",
+            "publish-pypi",
+            "pypi-tui",
+            "Publish nightly package distributions to PyPI",
+        ),
+        (
+            "tui-publish-npm.yml",
+            "publish",
+            "npm-tui",
+            "Publish platform packages with exact retry reconciliation",
+        ),
+        (
+            "tui-publish-pypi.yml",
+            "publish",
+            "pypi-tui",
+            "Publish package distributions to PyPI",
+        ),
     ):
-        block = workflow_job(workflow(name), "publish")
+        block = workflow_job(workflow(name), job)
         assert "Verify independent environment approval policy" in block
         assert "verify_release_environment_policy.py" in block
         assert 'RELEASE_ENVIRONMENT: ' + environment in block
         assert 'environments/$RELEASE_ENVIRONMENT' in block
         assert "GH_TOKEN: ${{ github.token }}" in block
         assert "actions: read" in block
+        assert block.index("Verify independent environment approval policy") < block.index(
+            publish_step
+        )
 
 
-def _run_environment_policy_check(document: dict[str, object]) -> subprocess.CompletedProcess[str]:
+def _run_environment_policy_check(
+    document: dict[str, object],
+) -> subprocess.CompletedProcess[str]:
     script = ROOT / "cmux-tui" / "bindings" / "verify_release_environment_policy.py"
     with tempfile.TemporaryDirectory(prefix="cmux-tui-environment-policy-") as raw:
         path = Path(raw) / "environment.json"
@@ -1386,6 +1413,8 @@ def _environment_policy_document(
     *,
     can_admins_bypass: bool = False,
     prevent_self_review: bool = True,
+    protected_branches: bool = True,
+    custom_branch_policies: bool = False,
     reviewers: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     if reviewers is None:
@@ -1395,6 +1424,10 @@ def _environment_policy_document(
     return {
         "name": "npm-tui",
         "can_admins_bypass": can_admins_bypass,
+        "deployment_branch_policy": {
+            "protected_branches": protected_branches,
+            "custom_branch_policies": custom_branch_policies,
+        },
         "protection_rules": [
             {
                 "type": "required_reviewers",
@@ -1429,6 +1462,17 @@ def test_environment_policy_rejects_missing_required_reviewer() -> None:
     result = _run_environment_policy_check(_environment_policy_document(reviewers=[]))
     assert result.returncode != 0
     assert "required reviewer" in result.stderr
+
+
+def test_environment_policy_rejects_unprotected_branch_policy() -> None:
+    result = _run_environment_policy_check(
+        _environment_policy_document(
+            protected_branches=False,
+            custom_branch_policies=True,
+        )
+    )
+    assert result.returncode != 0
+    assert "protected branches" in result.stderr
 
 
 def test_stable_pypi_publish_is_not_triggered_directly_by_a_tag() -> None:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1904,9 +1904,13 @@ def test_tui_registry_dispatch_requires_confirmation_and_waits_for_publishers() 
     assert "PyPI publishing requires confirm_tui_cmux=true." in release
     assert "group: tui-publish-npm-latest" in npm
     concurrency = npm.split("concurrency:", 1)[1].split("jobs:", 1)[0]
-    assert "queue: max" in concurrency
     assert "cancel-in-progress: false" in concurrency
     assert "cancel-in-progress: true" not in concurrency
+    assert not re.search(r"(?m)^\s+queue:", concurrency)
+    guide = (ROOT / "cmux-tui" / "dist" / "RELEASING-TUI.md").read_text()
+    assert "`queue: max`" in guide
+    assert "pinned actionlint validator rejects" in guide
+    assert "fails closed" in guide
     assert "Refuse an npm latest regression" in npm
     assert "confirm_tui_cmux:" in pypi
     assert "PyPI publishing requires confirm_tui_cmux=true." in pypi
@@ -1924,6 +1928,84 @@ def test_release_summary_redacts_provider_run_ids() -> None:
     assert 'echo "- Verified artifacts: ready"' in summary
     assert 'echo "- npm publisher: $npm_conclusion"' in summary
     assert 'echo "- PyPI publisher: $pypi_conclusion"' in summary
+
+
+def test_release_dispatch_fails_closed_when_pending_publisher_is_replaced() -> None:
+    release = workflow("cmux-tui-release.yml")
+    document = yaml.load(release, Loader=yaml.BaseLoader)
+    dispatch_step = next(
+        step
+        for step in document["jobs"]["dispatch-publishers"]["steps"]
+        if step.get("name") == "Dispatch registry publishers"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-publisher-replacement-") as raw:
+        temporary = Path(raw)
+        bin_dir = temporary / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  api)
+    endpoint="${2:-}"
+    if [[ "$endpoint" == *"/workflows/tui-publish-npm.yml/runs?"* ]]; then
+      printf '%s\\n' '{"workflow_runs":[{"id":100}]}'
+    else
+      printf '%s\\n' '{"workflow_runs":[]}'
+    fi
+    ;;
+  workflow)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"""
+        )
+        gh.chmod(0o755)
+        waiter = temporary / ".github" / "scripts" / "wait-for-workflow-run.sh"
+        waiter.parent.mkdir(parents=True)
+        waiter.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' 'pending publisher run was replaced' >&2\n"
+            "exit 23\n"
+        )
+        waiter.chmod(0o755)
+        summary = temporary / "summary"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "manaflow-ai/cmux",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_STEP_SUMMARY": str(summary),
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "TAG": "cmux-tui-v1.2.3",
+                "VERSION": "1.2.3",
+                "ARTIFACT_RUN_ID": "123",
+                "PUBLISH_NPM": "true",
+                "PUBLISH_PYPI": "false",
+                "POLL_INTERVAL_SECONDS": "0",
+            }
+        )
+        result = subprocess.run(
+            ("bash", "-c", dispatch_step["run"]),
+            cwd=temporary,
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+        assert result.returncode != 0
+        assert "pending publisher run was replaced" in result.stderr
+        assert summary.read_text() == (
+            "### Registry publishing\n\n"
+            "- Verified artifacts: ready\n"
+            "- npm publisher: failure\n"
+        )
 
 
 def test_tui_publishers_reconcile_partial_registry_writes() -> None:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1653,9 +1653,9 @@ if [[ "$endpoint" == *"/workflows/cmux-tui-release.yml/runs?"* ]]; then
   count=$((count + 1))
   printf '%s\\n' "$count" > "$STATE"
   if (( count == 1 )); then
-    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"}]}'
+    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:58:00Z"}]}'
   else
-    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":99,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:59:59Z"},{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
+    printf '%s\\n' '{"workflow_runs":[{"id":41,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:58:00Z"},{"id":99,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-15T23:58:00Z"},{"id":42,"path":".github/workflows/cmux-tui-release.yml","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_branch":"cmux-tui-v1.2.3","event":"workflow_dispatch","created_at":"2026-08-16T00:00:01Z"}]}'
   fi
   exit 0
 fi
@@ -1837,7 +1837,7 @@ exit 1
                 "PATH": f"{bin_dir}:{environment['PATH']}",
                 "POLL_INTERVAL_SECONDS": "0",
                 "WAIT_TIMEOUT_SECONDS": "3",
-                "CLOCK_SKEW_SECONDS": "0",
+                "CLOCK_SKEW_SECONDS": "5",
             }
         )
         result = subprocess.run(

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1348,6 +1348,89 @@ def test_stable_registry_publishers_are_exact_tag_and_artifact_bound() -> None:
         assert f"name: {environment}" in text
 
 
+def test_tui_publishers_require_independent_environment_policy_preflight() -> None:
+    for name, environment in (
+        ("tui-publish-npm.yml", "npm-tui"),
+        ("tui-publish-pypi.yml", "pypi-tui"),
+    ):
+        block = workflow_job(workflow(name), "publish")
+        assert "Verify independent environment approval policy" in block
+        assert "verify_release_environment_policy.py" in block
+        assert 'RELEASE_ENVIRONMENT: ' + environment in block
+        assert 'environments/$RELEASE_ENVIRONMENT' in block
+        assert "GH_TOKEN: ${{ github.token }}" in block
+        assert "actions: read" in block
+
+
+def _run_environment_policy_check(document: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    script = ROOT / "cmux-tui" / "bindings" / "verify_release_environment_policy.py"
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-environment-policy-") as raw:
+        path = Path(raw) / "environment.json"
+        path.write_text(json.dumps(document))
+        return subprocess.run(
+            (
+                "python3",
+                str(script),
+                "--environment",
+                str(document["name"]),
+                "--environment-json",
+                str(path),
+            ),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+
+def _environment_policy_document(
+    *,
+    can_admins_bypass: bool = False,
+    prevent_self_review: bool = True,
+    reviewers: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    if reviewers is None:
+        reviewers = [
+            {"type": "User", "reviewer": {"login": "release-reviewer"}},
+        ]
+    return {
+        "name": "npm-tui",
+        "can_admins_bypass": can_admins_bypass,
+        "protection_rules": [
+            {
+                "type": "required_reviewers",
+                "prevent_self_review": prevent_self_review,
+                "reviewers": reviewers,
+            },
+            {"type": "branch_policy"},
+        ],
+    }
+
+
+def test_environment_policy_accepts_independent_review_configuration() -> None:
+    result = _run_environment_policy_check(_environment_policy_document())
+    assert result.returncode == 0, result.stderr
+
+
+def test_environment_policy_rejects_self_review_and_admin_bypass() -> None:
+    self_review = _run_environment_policy_check(
+        _environment_policy_document(prevent_self_review=False)
+    )
+    assert self_review.returncode != 0
+    assert "prevent_self_review" in self_review.stderr
+
+    admin_bypass = _run_environment_policy_check(
+        _environment_policy_document(can_admins_bypass=True)
+    )
+    assert admin_bypass.returncode != 0
+    assert "can_admins_bypass" in admin_bypass.stderr
+
+
+def test_environment_policy_rejects_missing_required_reviewer() -> None:
+    result = _run_environment_policy_check(_environment_policy_document(reviewers=[]))
+    assert result.returncode != 0
+    assert "required reviewer" in result.stderr
+
+
 def test_stable_pypi_publish_is_not_triggered_directly_by_a_tag() -> None:
     text = workflow("tui-publish-pypi.yml")
     assert "push:\n    tags:" not in text


### PR DESCRIPTION
## Summary
- reject queued release cuts whose event SHA is not the current protected main commit before tag creation and push
- wait for the dispatched release and registry workflow run IDs, validate provenance, and fail on non-success conclusions
- require explicit PyPI confirmation and serialize npm latest publication with a monotonic version guard

## Verification
- `python3 tests/test_tui_publish_workflow_security.py -v` (51 passed)
- `actionlint` on four changed workflows
- `shellcheck -S warning` on new helpers
- `bash -n` on all changed workflow run blocks

No release tags, registry publishes, merges, or Rust builds were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537363&installation_model_id=21920&pr_number=10243&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10243&signature=f7a3d91295c9d97132d55238d9663b56a7628e8aa90d42a57763380b4d4c57cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens TUI release orchestration to prove registry artifacts and eliminate ambiguous publisher runs, including across clock‑skew windows. Previously releases could tag from stale `main` and push unproven artifacts; now we validate npm/PyPI byte‑for‑byte, serialize npm `latest`, and fail closed unless environments require independent approval.

- Gate on protected `main` and strict versions: `require-current-main.sh` asserts the event SHA equals protected `main` at tag/push; all workflows enforce stable X.Y.Z without leading zeros.
- Prove artifacts end‑to‑end: `package_contract.py`/`validate_package_contract.py` verify npm trees and packed archives, then smoke‑install offline; revalidate six PyPI wheels, tags, METADATA/RECORD hashes, and executable modes; nightly revalidates the packed npm contract.
- Orchestrate and wait: `wait-for-workflow-run.sh` matches by workflow file, ref, head SHA, min run ID, and start time with skew; rejects ambiguous matches, replaced pending runs, and skew‑window publisher replacements; release disables auto‑cancel, dispatches npm and PyPI, and waits for each; any dispatch or publish failure fails the release.
- npm guards: concurrency group `tui-publish-npm-latest`; refuse a `cmux` `latest` regression; reconcile exact packed archives; publish platform packages first, then the `cmux` launcher.
- PyPI guards: require `confirm_tui_cmux`; `prepare-pypi-tui-upload.sh` stages only missing wheels for Trusted Publisher; no‑op when all wheels match.
- Environment policy: publishers preflight‑verify `npm-tui` and `pypi-tui` via `verify_release_environment_policy.py`; diagnostics are pinned to API fields; fail closed without independent approval.

**Required migration**
- Set `confirm_tui_cmux=true` in both `tui-publish-npm.yml` and `tui-publish-pypi.yml`.
- Ensure npm stable `cmux` versions increase monotonically; publish refuses if registry `latest` is newer.
- Configure GitHub environments `npm-tui` and `pypi-tui` to require independent approval (no admin bypass, prevent self‑review, at least one required reviewer).

<sup>Written for commit d7a84bf4a30618050e739a2592fae15d44add84e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coordinated npm and PyPI publishing safeguards with explicit confirmation.
  - Release workflows now monitor dispatched jobs and report their results.
  - Added comprehensive npm and PyPI package and artifact validation.
  - Added stricter version validation, including rejection of leading-zero components.

- **Bug Fixes**
  - Prevented releases from outdated protected `main` commits.
  - Improved handling of failed, incomplete, mismatched, and partial publishing workflows.
  - Added safer retry handling for existing registry artifacts.

- **Tests**
  - Expanded coverage for release security, workflow monitoring, package validation, and publishing reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->