### PR TITLE
Verify cmux-tui registry package contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Validate TUI npm package artifact transfer
         run: python3 tests/test_tui_npm_package_artifact.py
 
+      - name: Validate TUI package artifact contract
+        run: python3 tests/test_tui_package_contract.py
+
       - name: Validate Claude launch environment policy generation
         run: python3 scripts/generate-claude-launch-environment-policy.py --check
 

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -598,43 +598,29 @@ jobs:
             --version "$PYPI_VERSION" \
             --out dist/pypi-wheels
 
+      - name: Set up Node.js for npm package contract
+        if: inputs.package_npm
+        uses: actions/setup-node@48b55a011bda49bbe596cd826c3c89aef350131 # v6.4.0
+        with:
+          node-version: "22.14.0"
+
+      - name: Install pinned npm for package contract
+        if: inputs.package_npm
+        run: npm install --global npm@11.5.1
+
       - name: Smoke verify npm packages
         if: inputs.package_npm
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-          import stat
-          import sys
-
-          version = os.environ["NPM_VERSION"]
-          root = pathlib.Path("dist/npm-packages")
-          platforms = {
-              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
-              "cmux-tui-darwin-x64": ("darwin", "x64"),
-              "cmux-tui-linux-x64": ("linux", "x64"),
-              "cmux-tui-linux-arm64": ("linux", "arm64"),
-          }
-          launcher = json.loads((root / "cmux" / "package.json").read_text())
-          deps = launcher.get("optionalDependencies", {})
-          if deps != {name: version for name in platforms}:
-              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
-              raise SystemExit(1)
-          for name, (os_name, cpu) in platforms.items():
-              package_json = json.loads((root / name / "package.json").read_text())
-              if package_json["version"] != version:
-                  raise SystemExit(f"{name}: version mismatch")
-              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
-                  raise SystemExit(f"{name}: os/cpu mismatch")
-              binary = root / name / "bin" / "cmux-tui"
-              if not binary.stat().st_mode & stat.S_IXUSR:
-                  raise SystemExit(f"{binary} is not executable")
-              hook = root / name / "bin" / "cmux-tui-hook"
-              if not hook.stat().st_mode & stat.S_IXUSR:
-                  raise SystemExit(f"{hook} is not executable")
-          PY
+          case "$(uname -m)" in
+            x86_64|amd64) install_target=cmux-tui-linux-x64 ;;
+            aarch64|arm64) install_target=cmux-tui-linux-arm64 ;;
+            *) echo "unsupported package runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "$NPM_VERSION" \
+            --install-npm-package "$install_target"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
           dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
             dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
@@ -674,21 +660,9 @@ jobs:
         if: inputs.package_pypi
         run: |
           set -euo pipefail
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
-          done
-          python3 - <<'PY'
-          import glob
-          import stat
-          import zipfile
-
-          for path in glob.glob("dist/pypi-wheels/*.whl"):
-              with zipfile.ZipFile(path) as wheel:
-                  info = wheel.getinfo("cmux_tui/bin/cmux-tui-hook")
-                  mode = info.external_attr >> 16
-                  if not mode & stat.S_IXUSR:
-                      raise SystemExit(f"{path}: bundled cmux-tui-hook is not executable")
-          PY
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist/pypi-wheels \
+            --version "$PYPI_VERSION"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
           dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
             dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -600,7 +600,7 @@ jobs:
 
       - name: Set up Node.js for npm package contract
         if: inputs.package_npm
-        uses: actions/setup-node@48b55a011bda49bbe596cd826c3c89aef350131 # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
 

--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -128,6 +128,13 @@ jobs:
       - name: Install npm with OIDC support
         run: npm install -g npm@11.5.1
 
+      - name: Revalidate packed npm contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "${{ needs.version.outputs.npm_version }}" \
+            --install-npm-package cmux-tui-linux-x64
+
       - name: Publish platform packages with nightly dist-tag
         run: |
           set -euo pipefail
@@ -157,11 +164,23 @@ jobs:
       name: pypi-tui
       url: https://pypi.org/p/cmux
     steps:
+      - name: Checkout immutable nightly source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.version.outputs.head_sha }}
+
       - name: Download PyPI wheels
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: pypi-wheels
           path: dist
+
+      - name: Revalidate PyPI wheel contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist \
+            --version "${{ needs.version.outputs.pypi_version }}"
 
       - name: Publish nightly package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -8,6 +8,7 @@ on:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-build-package.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
       - ".github/workflows/cmux-tui-sdks.yml"
@@ -24,11 +25,14 @@ on:
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_npm_package_artifact.py"
+      - "tests/test_tui_package_contract.py"
   pull_request:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-build-package.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
       - ".github/workflows/cmux-tui-sdks.yml"
@@ -45,6 +49,8 @@ on:
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_npm_package_artifact.py"
+      - "tests/test_tui_package_contract.py"
   workflow_dispatch:
 
 concurrency:
@@ -110,6 +116,12 @@ jobs:
 
       - name: Test SDK publishing workflow guards
         run: python3 tests/test_tui_publish_workflow_security.py -v
+
+      - name: Test TUI package artifact contract
+        run: python3 tests/test_tui_package_contract.py
+
+      - name: Test TUI npm artifact transfer contract
+        run: python3 tests/test_tui_npm_package_artifact.py
 
       - name: Check package versions
         run: python3 cmux-tui/bindings/check-versions.py --published-only

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -180,6 +180,13 @@ jobs:
       - name: Install npm with OIDC support
         run: npm install -g npm@11.5.1
 
+      - name: Revalidate packed npm contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --npm-packages dist/npm-packages \
+            --version "${{ inputs.version }}" \
+            --install-npm-package cmux-tui-linux-x64
+
       - name: Publish platform packages
         run: |
           set -euo pipefail

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -137,6 +137,11 @@ jobs:
       name: pypi-tui
       url: https://pypi.org/p/cmux
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate-version.outputs.release_sha }}
+
       - name: Download PyPI wheels
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -144,6 +149,12 @@ jobs:
           path: dist
           run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Revalidate PyPI wheel contract
+        run: |
+          python3 cmux-tui/dist/scripts/validate_package_contract.py \
+            --pypi-wheels dist \
+            --version "${{ inputs.version }}"
 
       - name: Trusted publisher setup note
         run: |

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -25,6 +25,13 @@ Linux packages contain static musl binaries that run on both glibc and musl
 distributions. PyPI publishes each Linux binary under matching manylinux and
 musllinux wheel tags so installers on both runtime families can resolve it.
 
+Before upload, the package contract validator checks the exact five npm package
+trees, including both the TUI binary and hook, then runs `npm pack` and an
+offline install of the matching Linux package. It checks the exact six PyPI
+wheels, their platform tags, metadata, `RECORD` hashes, and executable modes.
+The Windows binary and hook are raw release artifacts only. They are not in the
+npm or PyPI package set.
+
 ## One-time registry setup
 
 Add npm Trusted Publishers for all five npm package names:

--- a/cmux-tui/dist/scripts/package_contract.py
+++ b/cmux-tui/dist/scripts/package_contract.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Validate the files and metadata shipped by cmux-tui registries."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class PackageContractError(ValueError):
+    """Raised when a generated package does not match the release contract."""
+
+
+@dataclass(frozen=True)
+class NpmTarget:
+    name: str
+    os: str
+    cpu: str
+
+
+NPM_TARGETS = (
+    NpmTarget("cmux-tui-darwin-arm64", "darwin", "arm64"),
+    NpmTarget("cmux-tui-darwin-x64", "darwin", "x64"),
+    NpmTarget("cmux-tui-linux-x64", "linux", "x64"),
+    NpmTarget("cmux-tui-linux-arm64", "linux", "arm64"),
+)
+NPM_PLATFORM_NAMES = tuple(target.name for target in NPM_TARGETS)
+NPM_PACKAGE_NAMES = ("cmux", *NPM_PLATFORM_NAMES)
+NPM_PLATFORM_FILES = frozenset(
+    {"package.json", "bin/cmux-tui", "bin/cmux-tui-hook"}
+)
+NPM_LAUNCHER_FILES = frozenset({"package.json", "bin/cmux.js"})
+NPM_EXECUTABLE_FILES = tuple(
+    f"{target.name}/bin/{binary}"
+    for target in NPM_TARGETS
+    for binary in ("cmux-tui", "cmux-tui-hook")
+) + ("cmux/bin/cmux.js",)
+
+PYPI_WHEEL_TAGS = (
+    "macosx_11_0_arm64",
+    "macosx_10_12_x86_64",
+    "manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "musllinux_1_2_x86_64",
+    "manylinux_2_17_aarch64.manylinux2014_aarch64",
+    "musllinux_1_2_aarch64",
+)
+PYPI_WHEEL_FILES = frozenset(
+    {
+        "cmux_tui/__init__.py",
+        "cmux_tui/_main.py",
+        "cmux_tui/bin/cmux-tui",
+        "cmux_tui/bin/cmux-tui-hook",
+        "{dist_info}/WHEEL",
+        "{dist_info}/METADATA",
+        "{dist_info}/entry_points.txt",
+        "{dist_info}/RECORD",
+    }
+)
+
+
+def _error(message: str) -> PackageContractError:
+    return PackageContractError(message)
+
+
+def _files_below(root: Path) -> set[str]:
+    files: set[str] = set()
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise _error(f"{root}: symlink is not allowed: {relative}")
+        if path.is_file():
+            files.add(relative)
+        elif not path.is_dir():
+            raise _error(f"{root}: unsupported entry: {relative}")
+    return files
+
+
+def _entries_below(root: Path) -> set[str]:
+    entries: set[str] = set()
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise _error(f"{root}: symlink is not allowed: {relative}")
+        if not (path.is_file() or path.is_dir()):
+            raise _error(f"{root}: unsupported entry: {relative}")
+        entries.add(relative)
+    return entries
+
+
+def _require_executable(path: Path, label: str) -> None:
+    mode = path.stat().st_mode
+    if mode & 0o111 != 0o111:
+        raise _error(f"{label} is not executable: {path}")
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise _error(f"invalid JSON: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise _error(f"package metadata must be an object: {path}")
+    return value
+
+
+def _validate_version(actual: object, expected: str | None, label: str) -> str:
+    if not isinstance(actual, str) or not actual:
+        raise _error(f"{label}: version is missing")
+    if expected is not None and actual != expected:
+        raise _error(f"{label}: version {actual!r} != {expected!r}")
+    return actual
+
+
+def validate_npm_tree(packages_dir: Path, version: str | None = None) -> str:
+    """Validate the generated npm package directory tree.
+
+    Returns the package version. If ``version`` is omitted, the launcher version
+    is used and every package must match it.
+    """
+
+    packages_dir = packages_dir.resolve()
+    if not packages_dir.is_dir():
+        raise _error(f"missing npm package directory: {packages_dir}")
+
+    root_paths = tuple(packages_dir.iterdir())
+    for path in root_paths:
+        if path.is_symlink():
+            raise _error(f"npm package root contains symlink: {path.name}")
+    actual_root_entries = tuple(sorted(path.name for path in root_paths))
+    expected_packages = tuple(sorted(NPM_PACKAGE_NAMES))
+    if actual_root_entries != expected_packages:
+        raise _error(
+            f"npm package set mismatch: expected {expected_packages}, "
+            f"found {actual_root_entries}"
+        )
+
+    launcher_dir = packages_dir / "cmux"
+    launcher_metadata = _read_json(launcher_dir / "package.json")
+    if launcher_metadata.get("name") != "cmux":
+        raise _error("cmux: package name is incorrect")
+    package_version = _validate_version(
+        launcher_metadata.get("version"), version, "cmux"
+    )
+
+    launcher_files = _files_below(launcher_dir)
+    launcher_entries = _entries_below(launcher_dir)
+    expected_launcher_entries = NPM_LAUNCHER_FILES | {"bin"}
+    if launcher_entries != expected_launcher_entries:
+        raise _error(
+            f"cmux: directory tree mismatch: expected "
+            f"{sorted(expected_launcher_entries)}, "
+            f"found {sorted(launcher_entries)}"
+        )
+    if launcher_files != NPM_LAUNCHER_FILES:
+        raise _error(
+            f"cmux: package files mismatch: expected "
+            f"{sorted(NPM_LAUNCHER_FILES)}, found {sorted(launcher_files)}"
+        )
+    if launcher_metadata.get("files") != ["bin/cmux.js"]:
+        raise _error("cmux: files must contain only bin/cmux.js")
+    if launcher_metadata.get("bin") != {"cmux": "bin/cmux.js"}:
+        raise _error("cmux: bin mapping is incorrect")
+    expected_dependencies = {
+        target.name: package_version for target in NPM_TARGETS
+    }
+    if launcher_metadata.get("optionalDependencies") != expected_dependencies:
+        raise _error(
+            "cmux: optionalDependencies mismatch: "
+            f"expected {expected_dependencies}, "
+            f"found {launcher_metadata.get('optionalDependencies')}"
+        )
+    _require_executable(launcher_dir / "bin/cmux.js", "cmux launcher")
+
+    for target in NPM_TARGETS:
+        package_dir = packages_dir / target.name
+        metadata = _read_json(package_dir / "package.json")
+        label = target.name
+        if metadata.get("name") != target.name:
+            raise _error(f"{label}: package name is incorrect")
+        _validate_version(metadata.get("version"), package_version, label)
+        if metadata.get("os") != [target.os] or metadata.get("cpu") != [target.cpu]:
+            raise _error(f"{label}: os/cpu selectors are incorrect")
+        if metadata.get("files") != ["bin/cmux-tui", "bin/cmux-tui-hook"]:
+            raise _error(f"{label}: files must contain the binary and hook only")
+        files = _files_below(package_dir)
+        entries = _entries_below(package_dir)
+        expected_entries = NPM_PLATFORM_FILES | {"bin"}
+        if entries != expected_entries:
+            raise _error(
+                f"{label}: directory tree mismatch: expected "
+                f"{sorted(expected_entries)}, found {sorted(entries)}"
+            )
+        if files != NPM_PLATFORM_FILES:
+            missing = sorted(NPM_PLATFORM_FILES - files)
+            extra = sorted(files - NPM_PLATFORM_FILES)
+            raise _error(
+                f"{label}: package files mismatch; missing={missing}, "
+                f"unexpected={extra}"
+            )
+        _require_executable(package_dir / "bin/cmux-tui", f"{label} binary")
+        _require_executable(package_dir / "bin/cmux-tui-hook", f"{label} hook")
+
+    return package_version
+
+
+def _wheel_expected_files(version: str) -> set[str]:
+    dist_info = f"cmux-{version}.dist-info"
+    return {path.format(dist_info=dist_info) for path in PYPI_WHEEL_FILES}
+
+
+def _record_digest(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _metadata_value(data: bytes, key: str) -> str | None:
+    prefix = f"{key}:".encode("utf-8")
+    for line in data.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :].strip().decode("utf-8")
+    return None
+
+
+def _wheel_mode(info: zipfile.ZipInfo) -> int:
+    return (info.external_attr >> 16) & 0o777
+
+
+def validate_wheel(path: Path, version: str) -> None:
+    expected_prefix = f"cmux-{version}-py3-none-"
+    if not path.name.startswith(expected_prefix) or not path.name.endswith(".whl"):
+        raise _error(f"unexpected wheel filename: {path.name}")
+    tag = path.name[len(expected_prefix) : -len(".whl")]
+    if tag not in PYPI_WHEEL_TAGS:
+        raise _error(f"unsupported wheel platform tag: {path.name}")
+    dist_info = f"cmux-{version}.dist-info"
+    expected_files = _wheel_expected_files(version)
+
+    try:
+        wheel = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise _error(f"invalid wheel {path}: {error}") from error
+    with wheel:
+        infos = wheel.infolist()
+        names = [info.filename for info in infos]
+        if len(names) != len(set(names)):
+            raise _error(f"{path.name}: duplicate ZIP member")
+        if set(names) != expected_files:
+            raise _error(
+                f"{path.name}: file set mismatch; expected "
+                f"{sorted(expected_files)}, found {sorted(names)}"
+            )
+
+        wheel_info = wheel.getinfo(f"{dist_info}/WHEEL")
+        wheel_data = wheel.read(wheel_info)
+        if _metadata_value(wheel_data, "Tag") != f"py3-none-{tag}":
+            raise _error(f"{path.name}: WHEEL Tag does not match filename")
+        metadata = wheel.read(f"{dist_info}/METADATA")
+        if _metadata_value(metadata, "Name") != "cmux":
+            raise _error(f"{path.name}: METADATA Name is not cmux")
+        if _metadata_value(metadata, "Version") != version:
+            raise _error(f"{path.name}: METADATA Version does not match filename")
+
+        executable_names = {
+            "cmux_tui/bin/cmux-tui",
+            "cmux_tui/bin/cmux-tui-hook",
+        }
+        for name in names:
+            mode = _wheel_mode(wheel.getinfo(name))
+            expected_mode = 0o755 if name in executable_names else 0o644
+            if mode != expected_mode:
+                raise _error(
+                    f"{path.name}: {name} mode {mode:o} != {expected_mode:o}"
+                )
+
+        record_name = f"{dist_info}/RECORD"
+        record_data = wheel.read(record_name)
+        rows = list(csv.reader(io.StringIO(record_data.decode("utf-8"))))
+        expected_rows = set(expected_files)
+        seen_rows: set[str] = set()
+        for row in rows:
+            if len(row) != 3:
+                raise _error(f"{path.name}: malformed RECORD row")
+            name, digest, size = row
+            if name not in expected_rows:
+                raise _error(f"{path.name}: RECORD names unknown file {name}")
+            if name in seen_rows:
+                raise _error(f"{path.name}: RECORD contains duplicate {name}")
+            seen_rows.add(name)
+            if name == record_name:
+                if digest or size:
+                    raise _error(f"{path.name}: RECORD self-entry must be empty")
+                continue
+            data = wheel.read(name)
+            if digest != _record_digest(data) or size != str(len(data)):
+                raise _error(f"{path.name}: RECORD integrity mismatch for {name}")
+        if seen_rows != expected_rows:
+            raise _error(f"{path.name}: RECORD does not cover every wheel file")
+
+
+def validate_pypi_wheels(wheels_dir: Path, version: str) -> tuple[str, ...]:
+    """Validate the exact six wheels emitted for one cmux TUI version."""
+
+    wheels_dir = wheels_dir.resolve()
+    if not wheels_dir.is_dir():
+        raise _error(f"missing PyPI wheel directory: {wheels_dir}")
+    expected = tuple(
+        sorted(f"cmux-{version}-py3-none-{tag}.whl" for tag in PYPI_WHEEL_TAGS)
+    )
+    actual = tuple(sorted(path.name for path in wheels_dir.iterdir()))
+    if actual != expected:
+        raise _error(f"PyPI wheel set mismatch: expected {expected}, found {actual}")
+    for name in actual:
+        validate_wheel(wheels_dir / name, version)
+    return actual

--- a/cmux-tui/dist/scripts/package_npm_artifact.py
+++ b/cmux-tui/dist/scripts/package_npm_artifact.py
@@ -8,15 +8,11 @@ import stat
 import tarfile
 from pathlib import Path, PurePosixPath
 
+from package_contract import NPM_EXECUTABLE_FILES, PackageContractError, validate_npm_tree
+
 
 PACKAGE_ROOT = "npm-packages"
-EXECUTABLES = (
-    "cmux-tui-darwin-arm64/bin/cmux-tui",
-    "cmux-tui-darwin-x64/bin/cmux-tui",
-    "cmux-tui-linux-x64/bin/cmux-tui",
-    "cmux-tui-linux-arm64/bin/cmux-tui",
-    "cmux/bin/cmux.js",
-)
+EXECUTABLES = NPM_EXECUTABLE_FILES
 MAX_MEMBERS = 1_024
 MAX_EXPANDED_BYTES = 512 * 1024 * 1024
 
@@ -33,6 +29,11 @@ def verify_executables(packages_dir: Path) -> None:
             raise SystemExit(f"missing npm package executable: {executable}")
         if not executable.stat().st_mode & stat.S_IXUSR:
             raise SystemExit(f"npm package entry is not executable: {executable}")
+
+    try:
+        validate_npm_tree(packages_dir)
+    except PackageContractError as error:
+        raise SystemExit(str(error)) from error
 
 
 def create_archive(packages_dir: Path, archive: Path) -> None:

--- a/cmux-tui/dist/scripts/validate_package_contract.py
+++ b/cmux-tui/dist/scripts/validate_package_contract.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate and smoke-test cmux-tui npm and PyPI release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from package_contract import (
+    NPM_PLATFORM_NAMES,
+    PackageContractError,
+    validate_npm_tree,
+    validate_pypi_wheels,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--npm-packages", type=Path)
+    parser.add_argument("--pypi-wheels", type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--install-npm-package",
+        choices=NPM_PLATFORM_NAMES,
+        help="Pack all npm packages and install the launcher with this target.",
+    )
+    parser.add_argument("--npm", default="npm", help="npm executable")
+    args = parser.parse_args()
+    if args.npm_packages is None and args.pypi_wheels is None:
+        parser.error("at least one of --npm-packages or --pypi-wheels is required")
+    if args.install_npm_package is not None and args.npm_packages is None:
+        parser.error("--install-npm-package requires --npm-packages")
+    return args
+
+
+def _run(command: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise PackageContractError(
+            f"command failed ({result.returncode}): {' '.join(command)}\n{details}"
+        )
+    return result
+
+
+def _pack_npm_packages(
+    packages_dir: Path,
+    version: str,
+    npm: str,
+    install_package: str | None,
+) -> None:
+    validate_npm_tree(packages_dir, version)
+    with tempfile.TemporaryDirectory(prefix="cmux-tui-npm-contract-") as temp:
+        temp_root = Path(temp)
+        packed_dir = temp_root / "packed"
+        packed_dir.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "npm_config_audit": "false",
+                "npm_config_fund": "false",
+                "npm_config_update_notifier": "false",
+            }
+        )
+        archives: dict[str, Path] = {}
+        for package_name in ("cmux", *NPM_PLATFORM_NAMES):
+            before = set(packed_dir.glob("*.tgz"))
+            _run(
+                [
+                    npm,
+                    "pack",
+                    str(packages_dir / package_name),
+                    "--ignore-scripts",
+                    "--json",
+                    "--pack-destination",
+                    str(packed_dir),
+                ],
+                env=env,
+            )
+            after = set(packed_dir.glob("*.tgz"))
+            new_archives = after - before
+            if len(new_archives) != 1:
+                raise PackageContractError(
+                    f"npm pack for {package_name} produced {len(new_archives)} archives"
+                )
+            archive = next(iter(new_archives))
+            archives[package_name] = archive
+            _validate_npm_archive(archive, package_name)
+
+        if install_package is None:
+            return
+
+        install_dir = temp_root / "install"
+        cache_dir = temp_root / "npm-cache"
+        env["npm_config_cache"] = str(cache_dir)
+        _run(
+            [
+                npm,
+                "install",
+                "--offline",
+                "--include=optional",
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund",
+                "--no-package-lock",
+                "--prefix",
+                str(install_dir),
+                str(archives["cmux"]),
+                str(archives[install_package]),
+            ],
+            env=env,
+        )
+        launcher = install_dir / "node_modules" / ".bin" / "cmux"
+        if not launcher.is_file():
+            raise PackageContractError(f"npm install did not create launcher: {launcher}")
+        _run([str(launcher), "--version"], env=env)
+
+
+def _validate_npm_archive(archive: Path, package_name: str) -> None:
+    import tarfile
+
+    from package_contract import (
+        NPM_LAUNCHER_FILES,
+        NPM_PLATFORM_FILES,
+    )
+
+    expected = NPM_LAUNCHER_FILES if package_name == "cmux" else NPM_PLATFORM_FILES
+    expected_names = {f"package/{path}" for path in expected}
+    try:
+        tar = tarfile.open(archive, "r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise PackageContractError(f"invalid npm archive {archive}: {error}") from error
+    with tar:
+        members = tar.getmembers()
+        names = {member.name for member in members if member.isfile()}
+        if names != expected_names:
+            raise PackageContractError(
+                f"{package_name}: packed file set mismatch: "
+                f"expected {sorted(expected_names)}, found {sorted(names)}"
+            )
+        if len(members) != len(names):
+            raise PackageContractError(f"{package_name}: npm archive has non-file members")
+        for member in members:
+            is_executable = member.name.endswith("/bin/cmux.js") or member.name.endswith(
+                "/bin/cmux-tui"
+            ) or member.name.endswith("/bin/cmux-tui-hook")
+            expected_mode = 0o755 if is_executable else 0o644
+            if member.mode != expected_mode:
+                raise PackageContractError(
+                    f"{package_name}: packed mode {member.mode:o} != "
+                    f"{expected_mode:o}: {member.name}"
+                )
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        if args.npm_packages is not None:
+            _pack_npm_packages(
+                args.npm_packages.resolve(),
+                args.version,
+                args.npm,
+                args.install_npm_package,
+            )
+        if args.pypi_wheels is not None:
+            validate_pypi_wheels(args.pypi_wheels.resolve(), args.version)
+    except PackageContractError as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tui_npm_package_artifact.py
+++ b/tests/test_tui_npm_package_artifact.py
@@ -5,6 +5,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import json
 from pathlib import Path
 
 
@@ -12,11 +13,23 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "cmux-tui/dist/scripts/package_npm_artifact.py"
 EXECUTABLES = (
     "cmux-tui-darwin-arm64/bin/cmux-tui",
+    "cmux-tui-darwin-arm64/bin/cmux-tui-hook",
     "cmux-tui-darwin-x64/bin/cmux-tui",
+    "cmux-tui-darwin-x64/bin/cmux-tui-hook",
     "cmux-tui-linux-x64/bin/cmux-tui",
+    "cmux-tui-linux-x64/bin/cmux-tui-hook",
     "cmux-tui-linux-arm64/bin/cmux-tui",
+    "cmux-tui-linux-arm64/bin/cmux-tui-hook",
     "cmux/bin/cmux.js",
 )
+
+VERSION = "1.2.3"
+TARGETS = {
+    "cmux-tui-darwin-arm64": ("darwin", "arm64"),
+    "cmux-tui-darwin-x64": ("darwin", "x64"),
+    "cmux-tui-linux-x64": ("linux", "x64"),
+    "cmux-tui-linux-arm64": ("linux", "arm64"),
+}
 
 
 def run_helper(*args: object) -> subprocess.CompletedProcess[str]:
@@ -31,11 +44,47 @@ def run_helper(*args: object) -> subprocess.CompletedProcess[str]:
 
 def test_archive_round_trip_preserves_package_executables(tmp_path: Path) -> None:
     packages = tmp_path / "npm-packages"
-    for relative_path in EXECUTABLES:
-        executable = packages / relative_path
-        executable.parent.mkdir(parents=True, exist_ok=True)
-        executable.write_text("#!/bin/sh\nexit 0\n")
-        executable.chmod(0o755)
+    for name, (os_name, cpu) in TARGETS.items():
+        package = packages / name
+        package.mkdir(parents=True, exist_ok=True)
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "version": VERSION,
+                    "os": [os_name],
+                    "cpu": [cpu],
+                    "files": ["bin/cmux-tui", "bin/cmux-tui-hook"],
+                }
+            )
+            + "\n"
+        )
+        for binary in ("cmux-tui", "cmux-tui-hook"):
+            executable = package / "bin" / binary
+            executable.parent.mkdir(parents=True, exist_ok=True)
+            executable.write_text("#!/bin/sh\nexit 0\n")
+            executable.chmod(0o755)
+
+    launcher = packages / "cmux"
+    launcher.mkdir(parents=True, exist_ok=True)
+    (launcher / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cmux",
+                "version": VERSION,
+                "bin": {"cmux": "bin/cmux.js"},
+                "files": ["bin/cmux.js"],
+                "optionalDependencies": {
+                    name: VERSION for name in TARGETS
+                },
+            }
+        )
+        + "\n"
+    )
+    launcher_bin = launcher / "bin" / "cmux.js"
+    launcher_bin.parent.mkdir(parents=True, exist_ok=True)
+    launcher_bin.write_text("#!/bin/sh\nexit 0\n")
+    launcher_bin.chmod(0o755)
 
     archive = tmp_path / "npm-packages.tar.gz"
     created = run_helper(

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,17 +27,17 @@ def host_npm_target() -> str:
     system = platform.system().lower()
     machine = platform.machine().lower()
     if system == "linux":
-        return (
-            "cmux-tui-linux-arm64"
-            if machine in {"aarch64", "arm64"}
-            else "cmux-tui-linux-x64"
-        )
+        if machine in {"aarch64", "arm64"}:
+            return "cmux-tui-linux-arm64"
+        if machine in {"x86_64", "amd64"}:
+            return "cmux-tui-linux-x64"
+        raise RuntimeError(f"unsupported test host: {system}-{machine}")
     if system == "darwin":
-        return (
-            "cmux-tui-darwin-x64"
-            if machine in {"x86_64", "amd64"}
-            else "cmux-tui-darwin-arm64"
-        )
+        if machine in {"x86_64", "amd64"}:
+            return "cmux-tui-darwin-x64"
+        if machine in {"aarch64", "arm64"}:
+            return "cmux-tui-darwin-arm64"
+        raise RuntimeError(f"unsupported test host: {system}-{machine}")
     raise RuntimeError(f"unsupported test host: {system}-{machine}")
 
 
@@ -147,6 +148,19 @@ def test_npm_contract_packs_and_installs_matching_platform(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
 
 
+def test_host_npm_target_rejects_unknown_architecture() -> None:
+    for system in ("Linux", "Darwin"):
+        with mock.patch.object(platform, "system", return_value=system), mock.patch.object(
+            platform, "machine", return_value="riscv64"
+        ):
+            try:
+                host_npm_target()
+            except RuntimeError as error:
+                assert str(error) == f"unsupported test host: {system.lower()}-riscv64"
+            else:
+                raise AssertionError("unknown host architecture must raise RuntimeError")
+
+
 def test_npm_contract_rejects_missing_hook(tmp_path: Path) -> None:
     packages = tmp_path / "npm-packages"
     make_npm_packages(packages)
@@ -233,6 +247,7 @@ def test_pypi_contract_rejects_non_executable_hook(tmp_path: Path) -> None:
 def main() -> None:
     tests = (
         test_npm_contract_packs_and_installs_matching_platform,
+        lambda _directory: test_host_npm_target_rejects_unknown_architecture(),
         test_npm_contract_rejects_missing_hook,
         test_npm_contract_rejects_extra_file,
         test_pypi_contract_requires_all_six_wheels_and_metadata,

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import stat
 import subprocess
 import sys
@@ -19,6 +20,24 @@ NPM_TARGETS = {
     "cmux-tui-linux-x64": ("linux", "x64"),
     "cmux-tui-linux-arm64": ("linux", "arm64"),
 }
+
+
+def host_npm_target() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux":
+        return (
+            "cmux-tui-linux-arm64"
+            if machine in {"aarch64", "arm64"}
+            else "cmux-tui-linux-x64"
+        )
+    if system == "darwin":
+        return (
+            "cmux-tui-darwin-x64"
+            if machine in {"x86_64", "amd64"}
+            else "cmux-tui-darwin-arm64"
+        )
+    raise RuntimeError(f"unsupported test host: {system}-{machine}")
 
 
 def write_executable(path: Path, output: str = "cmux-tui 1.2.3") -> None:
@@ -122,7 +141,7 @@ def test_npm_contract_packs_and_installs_matching_platform(tmp_path: Path) -> No
         "--version",
         VERSION,
         "--install-npm-package",
-        "cmux-tui-darwin-arm64",
+        host_npm_target(),
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "cmux-tui/dist/scripts/validate_package_contract.py"
+PYPI_BUILDER = ROOT / "cmux-tui/dist/scripts/package_pypi.py"
+
+VERSION = "1.2.3"
+NPM_TARGETS = {
+    "cmux-tui-darwin-arm64": ("darwin", "arm64"),
+    "cmux-tui-darwin-x64": ("darwin", "x64"),
+    "cmux-tui-linux-x64": ("linux", "x64"),
+    "cmux-tui-linux-arm64": ("linux", "arm64"),
+}
+
+
+def write_executable(path: Path, output: str = "cmux-tui 1.2.3") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/bin/sh\nprintf '%s\\n' '{output}'\n")
+    path.chmod(0o755)
+
+
+def make_npm_packages(root: Path) -> None:
+    root.mkdir()
+    for name, (os_name, cpu) in NPM_TARGETS.items():
+        package = root / name
+        package.mkdir()
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "version": VERSION,
+                    "os": [os_name],
+                    "cpu": [cpu],
+                    "files": ["bin/cmux-tui", "bin/cmux-tui-hook"],
+                }
+            )
+            + "\n"
+        )
+        write_executable(package / "bin/cmux-tui")
+        write_executable(package / "bin/cmux-tui-hook", "cmux-tui-hook 1.2.3")
+
+    launcher = root / "cmux"
+    launcher.mkdir()
+    (launcher / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cmux",
+                "version": VERSION,
+                "bin": {"cmux": "bin/cmux.js"},
+                "files": ["bin/cmux.js"],
+                "optionalDependencies": {
+                    name: VERSION for name in NPM_TARGETS
+                },
+            }
+        )
+        + "\n"
+    )
+    write_executable(
+        launcher / "bin/cmux.js",
+        "cmux launcher 1.2.3",
+    )
+
+
+def make_pypi_wheels(tmp_path: Path) -> Path:
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    for target in (
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-musl",
+        "aarch64-unknown-linux-musl",
+    ):
+        write_executable(binaries / f"cmux-tui-{target}")
+        write_executable(binaries / f"cmux-tui-hook-{target}", "hook")
+
+    wheels = tmp_path / "wheels"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYPI_BUILDER),
+            "--binaries-dir",
+            str(binaries),
+            "--version",
+            VERSION,
+            "--out",
+            str(wheels),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return wheels
+
+
+def run_validator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_npm_contract_packs_and_installs_matching_platform(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+        "--install-npm-package",
+        "cmux-tui-darwin-arm64",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_npm_contract_rejects_missing_hook(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+    (packages / "cmux-tui-linux-x64/bin/cmux-tui-hook").unlink()
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode != 0
+    assert "cmux-tui-hook" in result.stderr
+
+
+def test_npm_contract_rejects_extra_file(tmp_path: Path) -> None:
+    packages = tmp_path / "npm-packages"
+    make_npm_packages(packages)
+    extra = packages / "cmux-tui-linux-x64/bin/extra"
+    write_executable(extra)
+
+    result = run_validator(
+        "--npm-packages",
+        str(packages),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode != 0
+    assert "unexpected" in result.stderr
+
+
+def test_pypi_contract_requires_all_six_wheels_and_metadata(tmp_path: Path) -> None:
+    wheels = make_pypi_wheels(tmp_path)
+
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    wheel = next(wheels.glob("*macosx_11_0_arm64.whl"))
+    wheel.unlink()
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+    assert result.returncode != 0
+    assert "expected" in result.stderr.lower()
+
+
+def test_pypi_contract_rejects_non_executable_hook(tmp_path: Path) -> None:
+    wheels = make_pypi_wheels(tmp_path)
+    wheel = next(wheels.glob("*.whl"))
+
+    import zipfile
+
+    rewritten = tmp_path / "rewritten.whl"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(rewritten, "w") as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == "cmux_tui/bin/cmux-tui-hook":
+                info.external_attr = (stat.S_IFREG | 0o644) << 16
+            target.writestr(info, data)
+    wheel.unlink()
+    rewritten.rename(wheel)
+
+    result = run_validator(
+        "--pypi-wheels",
+        str(wheels),
+        "--version",
+        VERSION,
+    )
+    assert result.returncode != 0
+    assert "executable" in result.stderr.lower()
+

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -9,7 +9,6 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -155,11 +154,12 @@ def test_host_npm_target_rejects_unknown_architecture() -> None:
         with mock.patch.object(platform, "system", return_value=system), mock.patch.object(
             platform, "machine", return_value="riscv64"
         ):
-            with pytest.raises(
-                RuntimeError,
-                match=rf"^unsupported test host: {system.lower()}-riscv64$",
-            ):
+            try:
                 host_npm_target()
+            except RuntimeError as error:
+                assert str(error) == f"unsupported test host: {system.lower()}-riscv64"
+            else:
+                raise AssertionError("unknown host architecture must raise RuntimeError")
 
 
 def test_npm_contract_rejects_missing_hook(tmp_path: Path) -> None:

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -9,6 +9,8 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = ROOT / "cmux-tui/dist/scripts/validate_package_contract.py"
@@ -153,12 +155,11 @@ def test_host_npm_target_rejects_unknown_architecture() -> None:
         with mock.patch.object(platform, "system", return_value=system), mock.patch.object(
             platform, "machine", return_value="riscv64"
         ):
-            try:
+            with pytest.raises(
+                RuntimeError,
+                match=rf"^unsupported test host: {system.lower()}-riscv64$",
+            ):
                 host_npm_target()
-            except RuntimeError as error:
-                assert str(error) == f"unsupported test host: {system.lower()}-riscv64"
-            else:
-                raise AssertionError("unknown host architecture must raise RuntimeError")
 
 
 def test_npm_contract_rejects_missing_hook(tmp_path: Path) -> None:

--- a/tests/test_tui_package_contract.py
+++ b/tests/test_tui_package_contract.py
@@ -4,6 +4,7 @@ import json
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -157,7 +158,7 @@ def test_npm_contract_rejects_extra_file(tmp_path: Path) -> None:
     )
 
     assert result.returncode != 0
-    assert "unexpected" in result.stderr
+    assert "mismatch" in result.stderr
 
 
 def test_pypi_contract_requires_all_six_wheels_and_metadata(tmp_path: Path) -> None:
@@ -207,5 +208,21 @@ def test_pypi_contract_rejects_non_executable_hook(tmp_path: Path) -> None:
         VERSION,
     )
     assert result.returncode != 0
-    assert "executable" in result.stderr.lower()
+    assert "mode" in result.stderr.lower()
 
+
+def main() -> None:
+    tests = (
+        test_npm_contract_packs_and_installs_matching_platform,
+        test_npm_contract_rejects_missing_hook,
+        test_npm_contract_rejects_extra_file,
+        test_pypi_contract_requires_all_six_wheels_and_metadata,
+        test_pypi_contract_rejects_non_executable_hook,
+    )
+    for test in tests:
+        with tempfile.TemporaryDirectory(prefix="cmux-tui-contract-test-") as directory:
+            test(Path(directory))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- validate the exact five npm package trees, including both TUI binaries and hooks
- pack every npm package and perform an offline install smoke on the runner-matching Linux target
- validate the exact six PyPI wheels, platform tags, metadata, executable modes, and RECORD hashes
- revalidate downloaded artifacts in stable and nightly publishers before registry upload
- keep Windows binaries documented as raw release artifacts only

The PR has two commits. The first adds failing contract tests. The second adds the validator and workflow wiring.

## Checks

- `python3 tests/test_tui_package_contract.py`
- `python3 tests/test_tui_npm_package_artifact.py`
- `python3 -m pytest -q tests/test_tui_package_contract.py tests/test_tui_npm_package_artifact.py tests/test_tui_publish_workflow_security.py`
- YAML parse and Python compile checks

No Rust, Zig, Xcode, build, publish, tag, or merge operation was run.

Residual gaps remain: macOS wheel runtime is not exercised in this PR, and manylinux glibc floor still needs a matching runtime image.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537373&installation_model_id=21920&pr_number=10244&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10244&signature=23a682be9f8f206128fb659525ffa4f80c1493440dcfe1315dac69b6085c4eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a strict release contract for `cmux` TUI npm packages and PyPI wheels across CI, nightly, and publish workflows. Replaces ad‑hoc checks with exact tree and packed‑archive validation, an offline install smoke test, and strict wheel integrity verification; unsupported runner architectures now fail fast.

- New validators: `cmux-tui/dist/scripts/package_contract.py` (rules) and `cmux-tui/dist/scripts/validate_package_contract.py` (CLI). `package_npm_artifact.py` reuses the tree validator and checks all executables, including the hook.
- Workflows (`ci.yml`, `cmux-tui-build-package.yml`, `cmux-tui-nightly.yml`, `cmux-tui-sdks.yml`, `tui-publish-npm.yml`, `tui-publish-pypi.yml`) invoke the validator; Node.js `22.14.0` and npm `11.5.1` are pinned; nightly and PyPI publishers re‑checkout immutable source before revalidation.
- npm: validates exact file sets and modes for all five packages via `npm pack`, then offline installs `cmux` plus the runner‑matching Linux target and runs `cmux --version`.
- PyPI: validates the six wheels’ platform tags, METADATA/WHEEL/`RECORD`, and executable modes.
- Tests cover missing/extra files, bad modes, `RECORD` integrity, and unknown architectures; workflows run them as standalone Python scripts (no `pytest` dependency).
- Docs updated in `RELEASING-TUI.md`; Windows binaries remain raw release artifacts only.

<sup>Written for commit c0b8dd5107fb29ef56972ab23c8c6bb70726c57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved validation of platform-specific npm packages and PyPI wheels before release.
  * Added checks for package versions, required files, supported platforms, and executable permissions.
  * Added safeguards to ensure published artifacts match the validated release source.

* **Testing**
  * Expanded automated coverage for valid and invalid package artifacts, including missing files, unexpected contents, incomplete releases, and installation behavior.

* **Release Process**
  * Strengthened CI, nightly, and publishing workflows to revalidate artifacts before distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->