### PR TITLE
Allow SDK stable preflight after bootstrap npm publish

### DIFF
--- a/cmux-tui/bindings/RELEASING.md
+++ b/cmux-tui/bindings/RELEASING.md
@@ -78,9 +78,12 @@ authorization is valid for the same workflow run attempt and 15 minutes.
   A credential-free job tests and packs `0.0.0-bootstrap.0`, then uploads the
   exact archive. A fresh job downloads and digest-checks that archive before
   its final step receives the temporary token. That step disables npm
-  lifecycle scripts, publishes with provenance under the `bootstrap` tag, and
-  cannot claim `latest`. A separate credential-free job reconciles the exact
-  archive and provenance after an ambiguous publish result. Configure repository
+  lifecycle scripts, and publishes with provenance under the `bootstrap` tag.
+  npm also assigns `latest` to `0.0.0-bootstrap.0` for this sole reservation
+  release. The stable preflight accepts that exact `cmux-sdk` state and
+  requires `latest` to move to the requested stable version after publish. A
+  separate credential-free job reconciles the exact archive and provenance
+  after an ambiguous publish result. Configure repository
   `manaflow-ai/cmux`, workflow `sdk-release-cut.yml`, and the `npm` environment
   as the trusted publisher. In the package's **Settings > Publishing access**,
   select **Require two-factor authentication and disallow tokens**. This still

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -51,6 +51,8 @@ PYPI_VERSION = re.compile(
 )
 PYPI_BOOTSTRAP_VERSION = "0.0.0a0"
 CRATES_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
+NPM_BOOTSTRAP_PACKAGE = "cmux-sdk"
+NPM_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
 PUBLISH_POLL_SECONDS = 0.25
 PUBLISH_STOP_SECONDS = 5
 PUBLISH_TIMEOUT_EXIT = 124
@@ -410,20 +412,30 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
         )
         latest = dist_tags.get("latest")
         if latest is not None:
-            if not isinstance(latest, str):
+            if (
+                package == NPM_BOOTSTRAP_PACKAGE
+                and latest == NPM_BOOTSTRAP_VERSION
+            ):
+                # The one-time SDK bootstrap intentionally reserves the npm
+                # name by putting its prerelease on `latest`. The stable
+                # release path below still requires `latest == version` once
+                # the immutable stable archive exists.
+                pass
+            elif not isinstance(latest, str):
                 raise RegistryError(
                     f"npm dist-tag latest is malformed for {package}: {latest!r}"
                 )
-            latest_version = _stable_version(latest)
-            if latest_version is None:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
-                )
-            if latest_version >= candidate:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest points to {latest!r}, which is not older "
-                    f"than requested {version!r}"
-                )
+            else:
+                latest_version = _stable_version(latest)
+                if latest_version is None:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
+                    )
+                if latest_version >= candidate:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest points to {latest!r}, which is not older "
+                        f"than requested {version!r}"
+                    )
         return MISSING
     if not isinstance(release, dict):
         raise RegistryError(f"npm metadata is malformed for {package}@{version}")

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -416,6 +416,14 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
                 package == NPM_BOOTSTRAP_PACKAGE
                 and latest == NPM_BOOTSTRAP_VERSION
             ):
+                bootstrap_release = versions.get(NPM_BOOTSTRAP_VERSION)
+                if (
+                    not isinstance(bootstrap_release, dict)
+                    or dist_tags.get("bootstrap") != NPM_BOOTSTRAP_VERSION
+                ):
+                    raise RegistryError(
+                        "npm bootstrap metadata is incomplete for cmux-sdk"
+                    )
                 # The one-time SDK bootstrap intentionally reserves the npm
                 # name by putting its prerelease on `latest`. The stable
                 # release path below still requires `latest == version` once

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -482,6 +482,29 @@ class RegistryArtifactTests(unittest.TestCase):
         ), self.assertRaises(reconcile.ReleaseStateMismatch):
             reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
 
+    def test_npm_bootstrap_latest_exception_requires_bootstrap_metadata(self) -> None:
+        metadata = {
+            "dist-tags": {"latest": "0.0.0-bootstrap.0"},
+            "versions": {},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaisesRegex(reconcile.RegistryError, "bootstrap metadata"):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
+    def test_npm_bootstrap_latest_exception_is_sdk_only(self) -> None:
+        metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "other-package", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -445,6 +445,43 @@ class RegistryArtifactTests(unittest.TestCase):
                 reconcile.MISSING,
             )
 
+    def test_npm_allows_bootstrap_latest_until_stable_publish(self) -> None:
+        bootstrap_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(bootstrap_metadata)
+        ):
+            self.assertEqual(
+                reconcile.registry_status(
+                    "npm", "cmux-sdk", "1.0.0", self.artifact
+                ),
+                reconcile.MISSING,
+            )
+
+        stable_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {
+                "0.0.0-bootstrap.0": {"dist": {}},
+                "1.0.0": {
+                    "dist": {
+                        "integrity": reconcile._integrity(self.artifact, "sha512")
+                    }
+                },
+            },
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(stable_metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -137,6 +137,9 @@ def test_npm_bootstrap_preserves_the_first_stable_version() -> None:
     assert sdk_ci.count('".github/workflows/sdk-bootstrap-npm.yml"') == 2
     assert "sdk-bootstrap-npm.yml" in releasing
     assert "0.0.0-bootstrap.0" in releasing
+    assert "also assigns `latest` to `0.0.0-bootstrap.0`" in releasing
+    assert "stable preflight accepts that exact `cmux-sdk` state" in releasing
+    assert "cannot claim `latest`" not in releasing
     assert "first `cmux-sdk` release interactively" not in releasing
 
 


### PR DESCRIPTION
## Summary

The one-time `cmux-sdk@0.0.0-bootstrap.0` publish owns npm `latest` until the first stable SDK release. The stable release preflight rejected that known state before it could publish `1.0.0`.

This uses the exact SDK bootstrap package/version as the only allowed prerelease `latest` state when `1.0.0` is absent. It also requires the matching `versions` entry and `bootstrap` dist-tag, so incomplete metadata fails closed. Once the stable version exists, reconciliation still requires `dist-tags.latest == 1.0.0`, so a stale bootstrap tag fails closed.

The release guide now records npm's first-package reservation behavior and the stable preflight transition. The bootstrap artifacts remain immutable. This change does not republish, delete, retag, or bypass byte/provenance checks.

## Regression sequence

- `91b8e9568c` adds the initial failing state test.
- `985af47105` allows the known bootstrap state and keeps the post-publish latest check strict.
- `c31d1034ee` adds failing tests for incomplete metadata and non-SDK packages.
- `cb7a22d743` requires the bootstrap version entry and `bootstrap` tag.
- `edb72ec180` adds the failing release-guide contract for npm's latest reservation.
- `4c43a26592` corrects the guide.

## Verification

- `python3 -m unittest cmux-tui/bindings/tests/test_reconcile_registry_artifact.py -k npm -v` (11 passed)
- `python3 -m unittest cmux-tui/bindings/tests/test_reconcile_registry_artifact.py -v` (52 passed)
- `python3 -m pytest -q tests/test_tui_publish_workflow_security.py` (47 passed)
- `git diff --check`
- `python3 -m compileall -q cmux-tui/bindings/reconcile_registry_artifact.py cmux-tui/bindings/tests/test_reconcile_registry_artifact.py`
