### PR TITLE
docs(tui): align frontend protocol references

### DIFF
--- a/.github/workflows/cmux-tui-spec.yml
+++ b/.github/workflows/cmux-tui-spec.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Test inventory checker
         run: python3 cmux-tui/scripts/test_check_spec_inventory.py
 
+      - name: Test frontend documentation protocol
+        run: python3 cmux-tui/scripts/test_frontend_docs.py
+
       - name: Check protocol and TUI action inventory
         run: python3 cmux-tui/scripts/check-spec-inventory.py
 

--- a/cmux-tui/frontends/README.ja.md
+++ b/cmux-tui/frontends/README.ja.md
@@ -3,7 +3,7 @@
 [English](README.md)
 
 リポジトリ内のリファレンス実装は[ウェブフロントエンド](web)です。
-プロトコルv7のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
 使用した実装例です。
 
 macOSネイティブフロントエンドは、非公開の

--- a/cmux-tui/frontends/README.md
+++ b/cmux-tui/frontends/README.md
@@ -3,7 +3,7 @@
 [日本語](README.ja.md)
 
 The in-tree reference frontend is the [web frontend](web). It demonstrates the
-protocol-v7 WebSocket API and the browser entry point of the TypeScript SDK.
+protocol-v12 WebSocket API and the browser entry point of the TypeScript SDK.
 
 The native macOS frontend is maintained separately in the private
 [`manaflow-ai/cmux-lite`](https://github.com/manaflow-ai/cmux-lite) repository.

--- a/cmux-tui/frontends/web/README.ja.md
+++ b/cmux-tui/frontends/web/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-プロトコルv10のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
 自然なcmuxクライアントを構築できることを示す小規模なサードパーティー形式の
 フロントエンドです。信頼できるワークスペースツリーの表示、アクティブなPTY
 サーフェスへのxterm.jsの接続、キーボード入力の転送、ターミナルセル単位の

--- a/cmux-tui/scripts/test_frontend_docs.py
+++ b/cmux-tui/scripts/test_frontend_docs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep frontend README protocol claims aligned with the supported wire API."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+TUI = Path(__file__).resolve().parents[1]
+README_PATHS = (
+    TUI / "frontends" / "README.md",
+    TUI / "frontends" / "README.ja.md",
+    TUI / "frontends" / "web" / "README.md",
+    TUI / "frontends" / "web" / "README.ja.md",
+)
+
+
+def supported_protocol() -> int:
+    source = (TUI / "frontends" / "web" / "src" / "lib" / "protocol.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"SUPPORTED_PROTOCOL\s*=\s*(\d+)", source)
+    if match is None:
+        raise AssertionError("web frontend has no supported protocol constant")
+    return int(match.group(1))
+
+
+def documented_protocol() -> int:
+    source = (TUI / "docs" / "protocol.md").read_text(encoding="utf-8")
+    match = re.search(r"^# Raw control protocol v(\d+)\s*$", source, re.MULTILINE)
+    if match is None:
+        raise AssertionError("raw protocol guide has no version heading")
+    return int(match.group(1))
+
+
+class FrontendReadmeProtocolTests(unittest.TestCase):
+    def test_readmes_match_the_supported_websocket_protocol(self) -> None:
+        expected = supported_protocol()
+        self.assertEqual(expected, documented_protocol())
+
+        for path in README_PATHS:
+            text = path.read_text(encoding="utf-8")
+            websocket_lines = [
+                line for line in text.splitlines() if "websocket" in line.lower()
+            ]
+            self.assertTrue(websocket_lines, path)
+            versions = {
+                int(version)
+                for line in websocket_lines
+                for version in re.findall(
+                    r"(?:protocol|プロトコル)[-\s]?v?(\d+)",
+                    line,
+                    re.IGNORECASE,
+                )
+            }
+            self.assertEqual(versions, {expected}, path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update English and Japanese frontend README protocol claims to v12
- add a contract test that derives the version from the web client and raw protocol guide
- run the contract in the TUI spec workflow

## Verification
- commit `a0ec52cfd2` adds the failing contract test (red)
- commit `a4a0767325` updates docs and workflow wiring (green)
- `python3 cmux-tui/scripts/test_frontend_docs.py -v`
- `python3 -m py_compile cmux-tui/scripts/test_frontend_docs.py`
- PyYAML workflow contract and `actionlint`
- TUI inventory, SDK schema, resource boundary, and codegen checks

No build, package publication, workflow dispatch, or merge was performed. This PR is independent of #10241 and #10242.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537827&installation_model_id=21920&pr_number=10246&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10246&signature=23da1565a96b120fa715e6f7c35d0c44eae1688395862d95ae629db39df091de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns frontend README protocol references to v12 and adds a contract test so docs can't drift from the supported WebSocket protocol. READMEs previously could claim an outdated protocol version with nothing enforcing it; now the spec workflow fails when they mismatch.

- Updates `frontends/README.md`, `frontends/README.ja.md`, and `frontends/web/README.ja.md` to reference protocol v12.
- Adds `cmux-tui/scripts/test_frontend_docs.py` to assert that the web client's `SUPPORTED_PROTOCOL`, the protocol guide heading, and README claims all match.
- Runs the new test in `cmux-tui-spec.yml` so version drift fails the workflow.
- On protocol bumps, update `frontends/web/src/lib/protocol.ts` and `docs/protocol.md` first, then fix README references to the new version.

<sup>Written for commit e13626d717a45b1c0401bbc6ca0629f09d915498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

