### PR TITLE
Run web typecheck on web pull requests

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,51 @@
+name: Web CI
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - "package.json"
+      - "bun.lock"
+      - "biome.json"
+      - "tests/test_web_ci_workflow.py"
+      - ".github/workflows/web-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-typecheck:
+    name: web-typecheck
+    # Web pull requests run untrusted code. Keep this check on a public
+    # GitHub-hosted runner with no private network or provider credentials.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate web CI workflow contract
+        run: python3 tests/test_web_ci_workflow.py
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Validate managed relay catalog
+        working-directory: web
+        run: bun tools/generate-managed-iroh-relay-catalog.ts --check
+
+      - name: Typecheck
+        working-directory: web
+        run: bun run typecheck

--- a/docs/web-ci.md
+++ b/docs/web-ci.md
@@ -1,0 +1,24 @@
+# Web pull request checks
+
+`Web CI` runs for pull requests that change the web app, its root JavaScript
+dependencies, or this workflow. It validates the managed relay catalog and
+runs `bun run typecheck` in `web/` with Bun 1.3.14 on a GitHub-hosted Ubuntu
+runner.
+
+The check is limited to catalog and static type validation. A green result does
+not prove Bun unit tests, Playwright browser behavior, API or database smoke
+tests, or a Vercel deployment.
+
+The equivalent local evidence is:
+
+```sh
+cd web
+bun install --frozen-lockfile
+bun tools/generate-managed-iroh-relay-catalog.ts --check
+bun run typecheck
+```
+
+A successful Vercel preview proves that the Next.js production build completed
+for that deployment. Vercel's build-time TypeScript phase is not the same as
+`tsgo --noEmit`, and a preview does not prove Bun tests, Playwright tests, or
+live API behavior.

--- a/tests/test_web_ci_workflow.py
+++ b/tests/test_web_ci_workflow.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Contract tests for the web-only pull request workflow."""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "web-ci.yml"
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.is_file(), f"missing web workflow: {WORKFLOW}"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _top_level_section(text: str, name: str) -> str:
+    lines = text.splitlines()
+    marker = f"{name}:"
+    try:
+        start = lines.index(marker)
+    except ValueError as error:
+        raise AssertionError(f"missing top-level {name} section") from error
+
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith((" ", "\t")):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _pull_request_paths(text: str) -> list[str]:
+    trigger = _top_level_section(text, "on")
+    lines = trigger.splitlines()
+    try:
+        start = next(index for index, line in enumerate(lines) if line == "  pull_request:")
+    except StopIteration as error:
+        raise AssertionError("web workflow must declare a pull_request trigger") from error
+
+    paths: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("  ") and not line.startswith("    ") and line.strip():
+            break
+        match = re.fullmatch(r'\s+-\s+"([^"]+)"', line)
+        if match:
+            paths.append(match.group(1))
+    return paths
+
+
+def _job_block(text: str, job_name: str) -> str:
+    lines = text.splitlines()
+    marker = f"  {job_name}:"
+    try:
+        start = lines.index(marker)
+    except ValueError as error:
+        raise AssertionError(f"missing {job_name} job") from error
+
+    body = [lines[start]]
+    for line in lines[start + 1 :]:
+        if line and line.startswith("  ") and not line.startswith("    "):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def test_web_pull_request_path_runs_web_typecheck() -> None:
+    text = _workflow_text()
+    paths = _pull_request_paths(text)
+
+    assert any(fnmatch.fnmatch("web/app/page.tsx", pattern) for pattern in paths), paths
+    assert not any(fnmatch.fnmatch("Sources/AppDelegate.swift", pattern) for pattern in paths), paths
+
+    job = _job_block(text, "web-typecheck")
+    assert "runs-on: ubuntu-24.04" in job
+    assert "bun run typecheck" in job
+    assert "bun install --frozen-lockfile" in job
+    assert "working-directory: web" in job
+    assert "if:" not in job
+
+
+def test_web_workflow_is_pr_only_and_read_only() -> None:
+    text = _workflow_text()
+    trigger = _top_level_section(text, "on")
+
+    assert "pull_request:" in trigger
+    assert "push:" not in trigger
+    assert "workflow_dispatch:" not in trigger
+    assert "permissions:\n  contents: read" in text
+    assert "persist-credentials: false" in text
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: web CI workflow contract")


### PR DESCRIPTION
## Summary

- Add a path-filtered `Web CI` pull request workflow for web changes and web dependency changes.
- Run the managed relay catalog check and `bun run typecheck` with Bun 1.3.14 on `ubuntu-24.04`.
- Keep the workflow read-only, without provider credentials, browser tests, API calls, or manual dispatch.
- Add a contract test and document the exact evidence limits.

## Validation

- Red commit `c8a148b4d3`: `python3 tests/test_web_ci_workflow.py` failed because the workflow was absent.
- Green commit `fa922340b9`: `python3 tests/test_web_ci_workflow.py` passed.
- `python3 tests/test_ci_change_areas.py` passed.
- `actionlint .github/workflows/web-ci.yml` passed.
- Local Bun 1.3.14 install, relay catalog check, and `bun run typecheck` passed.

No hosted workflow was dispatched from this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789538119&installation_model_id=21920&pr_number=10247&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10247&signature=189ccbc16bbe8a10fde0c76c0f4b5071f5890a3353c3e2998d8a838fa338e664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a path-filtered `Web CI` workflow that typechecks the web app and validates the managed relay catalog on relevant pull requests. Previously, web PRs had no automatic typecheck; now `Web CI` runs `bun run typecheck` with Bun 1.3.14 on `ubuntu-24.04` without provider credentials.

- Triggers on changes to `web/**`, `package.json`, `bun.lock`, `biome.json`, and the workflow/test files.
- Runs `bun install --frozen-lockfile`, `bun tools/generate-managed-iroh-relay-catalog.ts --check`, and `bun run typecheck` in `web/`.
- PR-only and read-only: `permissions: contents: read`, `persist-credentials: false`; no unit, Playwright, API, or deployment checks.
- Includes a contract test (`tests/test_web_ci_workflow.py`) and docs (`docs/web-ci.md`) defining evidence limits.
- Uses concurrency to cancel in-progress duplicates per PR.

<sup>Written for commit fa922340b996fd69f4ba4c3af82db5ea9e697222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Web CI checks for pull requests, including dependency validation, relay catalog verification, and web type checking.
* **Documentation**
  * Added guidance explaining Web CI coverage, local validation commands, and how checks differ from preview deployments.
* **Tests**
  * Added automated safeguards to verify workflow triggers, permissions, runtime configuration, and required validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->