### PR TITLE
Honor ui.newWorkspace.action for sidebar empty-area double-click

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7621,34 +7621,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func performNewWorkspaceAction(
         tabManager preferredTabManager: TabManager? = nil,
         event: NSEvent? = nil,
+        placementOverride: WorkspacePlacement? = nil,
         debugSource: String = "newWorkspace"
     ) -> Bool {
         performNewWorkspaceCreationAction(
             initialSurface: .terminal,
             preferredTabManager: preferredTabManager,
             event: event,
+            placementOverride: placementOverride,
             debugSource: debugSource
         )
     }
 
-    /// Empty-area double-click in the sidebar, shared by the SwiftUI sidebar and
-    /// the AppKit workspace table so both create a workspace the same way.
+    /// Empty-area double-click in the sidebar. Routes through the shared
+    /// new-workspace action path so a configured `ui.newWorkspace.action`
+    /// applies here exactly as it does for the `+` button and File → New
+    /// Workspace; without one, the plain workspace still lands after the last
+    /// row, which is what clicking below every row asks for.
     @discardableResult
     func performSidebarEmptyAreaNewWorkspaceAction(tabManager: TabManager) -> Bool {
         // A remote-tmux mirror creates a new tmux session rather than a local
-        // workspace. Gate on the SELECTED workspace, not `tabs.contains`: a
-        // dedicated remote window can be polluted with a dragged-in local
-        // workspace (move targets don't exclude dedicated windows), and
-        // `contains` would then misroute a local empty-area double-click into
-        // spawning an unwanted tmux session.
-        if tabManager.selectedTab?.isRemoteTmuxMirror == true {
-            return performNewWorkspaceAction(
-                tabManager: tabManager,
-                debugSource: "sidebar.emptyArea.remoteTmux"
-            )
-        }
-        tabManager.addWorkspace(placementOverride: .end)
-        return true
+        // workspace, and that session's placement is the remote server's to
+        // decide, so the end-of-list override does not apply there. Gate on the
+        // SELECTED workspace, not `tabs.contains`: a dedicated remote window can
+        // be polluted with a dragged-in local workspace (move targets don't
+        // exclude dedicated windows), and `contains` would then misroute a local
+        // empty-area double-click into spawning an unwanted tmux session.
+        let isRemoteTmuxMirror = tabManager.selectedTab?.isRemoteTmuxMirror == true
+        return performNewWorkspaceAction(
+            tabManager: tabManager,
+            placementOverride: isRemoteTmuxMirror ? nil : .end,
+            debugSource: isRemoteTmuxMirror ? "sidebar.emptyArea.remoteTmux" : "sidebar.emptyArea"
+        )
     }
 
     /// Creates a new workspace whose initial surface is a browser pane in its
@@ -7811,6 +7815,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         initialSurface: NewWorkspaceInitialSurface,
         preferredTabManager: TabManager?,
         event: NSEvent?,
+        placementOverride: WorkspacePlacement? = nil,
         debugSource: String,
         title: String? = nil,
         initialBrowserURL: URL? = nil,
@@ -7928,6 +7933,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 initialBrowserURL: initialBrowserURL,
                 initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
                 initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+                placementOverride: placementOverride,
                 applyCreationTitleAsCustomTitle: applyCreationTitleAsCustomTitle
             )
             createdWorkspaceHandler?(workspace)
@@ -7943,6 +7949,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             initialBrowserURL: initialBrowserURL,
             initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
             initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+            placementOverride: placementOverride,
             applyCreationTitleAsCustomTitle: applyCreationTitleAsCustomTitle,
             event: event,
             debugSource: debugSource
@@ -8727,6 +8734,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         initialBrowserURL: URL? = nil,
         initialBrowserOmnibarVisible: Bool = true,
         initialBrowserTransparentBackground: Bool = false,
+        placementOverride: WorkspacePlacement? = nil,
         applyCreationTitleAsCustomTitle: Bool = true,
         shouldBringToFront: Bool = false,
         event: NSEvent? = nil,
@@ -8783,6 +8791,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
                 initialBrowserTransparentBackground: initialBrowserTransparentBackground,
                 select: true,
+                placementOverride: placementOverride,
                 applyCreationTitleAsCustomTitle: applyCreationTitleAsCustomTitle
             )
         } else if workingDirectory != nil || initialTerminalInput != nil {
@@ -8791,6 +8800,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 workingDirectory: workingDirectory,
                 initialTerminalInput: initialTerminalInput,
                 select: true,
+                placementOverride: placementOverride,
                 autoWelcomeIfNeeded: initialTerminalInput == nil,
                 applyCreationTitleAsCustomTitle: applyCreationTitleAsCustomTitle
             )
@@ -8798,10 +8808,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             workspace = context.tabManager.addWorkspace(
                 title: title,
                 select: true,
+                placementOverride: placementOverride,
                 applyCreationTitleAsCustomTitle: applyCreationTitleAsCustomTitle
             )
         } else {
-            workspace = context.tabManager.addTab(select: true)
+            workspace = context.tabManager.addWorkspace(
+                select: true,
+                placementOverride: placementOverride
+            )
         }
         #if DEBUG
         logWorkspaceCreationRouting(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7631,6 +7631,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// Empty-area double-click in the sidebar, shared by the SwiftUI sidebar and
+    /// the AppKit workspace table so both create a workspace the same way.
+    @discardableResult
+    func performSidebarEmptyAreaNewWorkspaceAction(tabManager: TabManager) -> Bool {
+        // A remote-tmux mirror creates a new tmux session rather than a local
+        // workspace. Gate on the SELECTED workspace, not `tabs.contains`: a
+        // dedicated remote window can be polluted with a dragged-in local
+        // workspace (move targets don't exclude dedicated windows), and
+        // `contains` would then misroute a local empty-area double-click into
+        // spawning an unwanted tmux session.
+        if tabManager.selectedTab?.isRemoteTmuxMirror == true {
+            return performNewWorkspaceAction(
+                tabManager: tabManager,
+                debugSource: "sidebar.emptyArea.remoteTmux"
+            )
+        }
+        tabManager.addWorkspace(placementOverride: .end)
+        return true
+    }
+
     /// Creates a new workspace whose initial surface is a browser pane in its
     /// default new-tab state with the address bar focused. Shares the window
     /// routing, placement, and naming semantics of `performNewWorkspaceAction`.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7890,7 +7890,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let context = livePreferredContext
             ?? preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource)
 
-        let workspaceGroupTarget = context.flatMap { workspaceGroupNewWorkspaceTarget(in: $0) }
+        // An explicit placement override is the caller's own decision about
+        // where the workspace lands, so it outranks the selection-derived group
+        // target: `createWorkspaceInGroup` takes a group placement instead and
+        // would drop the override, filing a sidebar empty-area double-click
+        // into the selected workspace's group rather than after the last row.
+        let workspaceGroupTarget = placementOverride == nil
+            ? context.flatMap { workspaceGroupNewWorkspaceTarget(in: $0) }
+            : nil
         // The configured new-workspace action is the user's override for the
         // plain New Workspace behavior; the browser variant keeps its own
         // fixed semantics and skips it.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11973,11 +11973,8 @@ struct VerticalTabsSidebar: View, Equatable {
                 tabManager.closeWorkspaceWithConfirmation(workspace)
             },
             createWorkspaceAtEnd: {
-                if tabManager.selectedTab?.isRemoteTmuxMirror == true {
-                    _ = AppDelegate.shared?.performNewWorkspaceAction(
-                        tabManager: tabManager,
-                        debugSource: "sidebar.emptyArea.remoteTmux"
-                    )
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: tabManager)
                 } else {
                     tabManager.addWorkspace(placementOverride: .end)
                 }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -374,6 +374,14 @@ final class CmuxFeatureFlags {
 
     private var localOverridesByKey: [String: Bool] = [:]
     private var remoteValuesByKey: [String: Bool] = [:]
+    /// A remote value outranks a local override, so a UI-test launch pins flags
+    /// to their local values: otherwise a cached or freshly fetched rollout value
+    /// swaps the surface under a test that deliberately selected the other one.
+    private let pinsFlagsToLocalValues: Bool
+
+    nonisolated static var pinsFlagsToLocalValuesForCurrentLaunch: Bool {
+        ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1"
+    }
     private var resolutionsByKey: [String: CmuxFeatureFlagResolution] = [:]
 
     init(
@@ -381,10 +389,12 @@ final class CmuxFeatureFlags {
         telemetryEnabled: Bool = TelemetrySettings.enabledForCurrentLaunch,
         remoteFlagValueProvider: @escaping (String) -> Any? = { PostHogSDK.shared.getFeatureFlag($0) },
         remoteFlagLoader: (@Sendable () async -> [String: Bool]?)? = nil,
-        publishesOffMainSnapshot: Bool = false
+        publishesOffMainSnapshot: Bool = false,
+        pinsFlagsToLocalValues: Bool = CmuxFeatureFlags.pinsFlagsToLocalValuesForCurrentLaunch
     ) {
         self.defaults = defaults
         self.publishesOffMainSnapshot = publishesOffMainSnapshot
+        self.pinsFlagsToLocalValues = pinsFlagsToLocalValues
         self.remoteFlagValueProvider = remoteFlagValueProvider
         if let remoteFlagLoader {
             self.remoteFlagLoader = remoteFlagLoader
@@ -405,14 +415,16 @@ final class CmuxFeatureFlags {
                 values[definition.key] = value
             }
         }
-        remoteValuesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
-            if let value = Self.storedBoolValue(
-                forKey: Self.remoteCacheKey(for: definition.key),
-                defaults: defaults
-            ) {
-                values[definition.key] = value
+        remoteValuesByKey = pinsFlagsToLocalValues
+            ? [:]
+            : Self.allFlags.reduce(into: [:]) { values, definition in
+                if let value = Self.storedBoolValue(
+                    forKey: Self.remoteCacheKey(for: definition.key),
+                    defaults: defaults
+                ) {
+                    values[definition.key] = value
+                }
             }
-        }
         recomputeEffectiveValues()
     }
 
@@ -429,6 +441,7 @@ final class CmuxFeatureFlags {
     }
 
     private func refreshRemoteFlags() {
+        guard !pinsFlagsToLocalValues else { return }
         guard refreshTask == nil else { return }
         let loader = remoteFlagLoader
         refreshTask = Task { @MainActor [weak self] in

--- a/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
+++ b/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
@@ -590,18 +590,12 @@ struct SidebarEmptyArea: View {
     private var dropTarget: some View {
         let base = hitTarget
             .onTapGesture(count: 2) {
-                // When the active workspace is a remote-tmux mirror, route through
-                // performNewWorkspaceAction so a new workspace becomes a new tmux
-                // session instead of a local (orphan) workspace. Gate on the
-                // SELECTED tab, not `tabs.contains`: a dedicated remote window can
-                // be polluted with a dragged-in local workspace (move targets don't
-                // exclude dedicated windows), and `contains` would then misroute a
-                // local empty-area double-tap into spawning an unwanted tmux session.
-                if tabManager.selectedTab?.isRemoteTmuxMirror == true {
-                    _ = AppDelegate.shared?.performNewWorkspaceAction(
-                        tabManager: tabManager,
-                        debugSource: "sidebar.emptyArea.remoteTmux"
-                    )
+                // Both sidebar implementations (this one and the AppKit table)
+                // share one entry point so a configured `ui.newWorkspace.action`,
+                // and the remote-tmux mirror routing, behave identically here and
+                // for the `+` button.
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: tabManager)
                 } else {
                     tabManager.addWorkspace(placementOverride: .end)
                 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1958,6 +1958,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7AB34310000000000000001 /* SidebarBonsplitWorkspaceRowDropModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */; };
 		EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000004 /* SidebarDirectoryText.swift */; };
 		B804A0270000000000000027 /* SidebarDividerTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0270000000000000027 /* SidebarDividerTrackingView.swift */; };
+		B804C0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift */; };
 		B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */; };
 		A8624F0C0000000000000001 /* SidebarFocusBoundaryReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */; };
 		8175A0010000000000000001 /* SidebarGitProcessCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8175A0010000000000000002 /* SidebarGitProcessCompositionTests.swift */; };
@@ -4731,6 +4732,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitWorkspaceRowDropModifier.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000004 /* SidebarDirectoryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDirectoryText.swift; sourceTree = "<group>"; };
 		B804B0270000000000000027 /* SidebarDividerTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDividerTrackingView.swift; sourceTree = "<group>"; };
+		B804D0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarEmptyAreaNewWorkspaceActionTests.swift; sourceTree = "<group>"; };
 		B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFocusBoundaryLifecycleTests.swift; sourceTree = "<group>"; };
 		A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarFocusBoundaryReference.swift; sourceTree = "<group>"; };
 		8175A0010000000000000002 /* SidebarGitProcessCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarGitProcessCompositionTests.swift; sourceTree = "<group>"; };
@@ -8329,6 +8331,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
+				B804D0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift */,
 				B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */,
 				C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */,
 				B804D0030000000000000003 /* SidebarAppKitRowCellTests.swift */,
@@ -11477,6 +11480,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */,
 				C3467AB10000000000000001 /* ShortcutWhenClauseTests.swift in Sources */,
 				B804C0030000000000000003 /* SidebarAppKitRowCellTests.swift in Sources */,
+				B804C0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift in Sources */,
 				B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */,
 				8175A0010000000000000001 /* SidebarGitProcessCompositionTests.swift in Sources */,
 				B8624C010000000000000001 /* SidebarHiddenPresentationTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1958,6 +1958,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7AB34310000000000000001 /* SidebarBonsplitWorkspaceRowDropModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */; };
 		EA1F00000000000000000003 /* SidebarDirectoryText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000004 /* SidebarDirectoryText.swift */; };
 		B804A0270000000000000027 /* SidebarDividerTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0270000000000000027 /* SidebarDividerTrackingView.swift */; };
+		A1B2C3D410248001A1B2C3D4E5F60718 /* SidebarEmptyAreaDoubleClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D410248002A1B2C3D4E5F60718 /* SidebarEmptyAreaDoubleClickUITests.swift */; };
 		B804C0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift */; };
 		B8624C060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */; };
 		A8624F0C0000000000000001 /* SidebarFocusBoundaryReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */; };
@@ -4732,6 +4733,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitWorkspaceRowDropModifier.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000004 /* SidebarDirectoryText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDirectoryText.swift; sourceTree = "<group>"; };
 		B804B0270000000000000027 /* SidebarDividerTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDividerTrackingView.swift; sourceTree = "<group>"; };
+		A1B2C3D410248002A1B2C3D4E5F60718 /* SidebarEmptyAreaDoubleClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarEmptyAreaDoubleClickUITests.swift; sourceTree = "<group>"; };
 		B804D0010000000000009043 /* SidebarEmptyAreaNewWorkspaceActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarEmptyAreaNewWorkspaceActionTests.swift; sourceTree = "<group>"; };
 		B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFocusBoundaryLifecycleTests.swift; sourceTree = "<group>"; };
 		A8624F0C0000000000000002 /* SidebarFocusBoundaryReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarFocusBoundaryReference.swift; sourceTree = "<group>"; };
@@ -5762,6 +5764,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */,
 				B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
 				F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */,
+				A1B2C3D410248002A1B2C3D4E5F60718 /* SidebarEmptyAreaDoubleClickUITests.swift */,
 				C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
 				B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */,
 				E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
@@ -10944,6 +10947,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D10000000000000000A00014 /* SettingsTerminalBehaviorUITests.swift in Sources */,
 				D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */,
 				D10000000000000000A0001E /* SettingsWorkspaceColorsBehaviorUITests.swift in Sources */,
+				A1B2C3D410248001A1B2C3D4E5F60718 /* SidebarEmptyAreaDoubleClickUITests.swift in Sources */,
 				B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */,
 				B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */,
 				B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */,

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -7,6 +7,48 @@ import Testing
 @Suite(.serialized)
 struct PostHogAnalyticsPropertiesTests {
     @MainActor
+    @Test("a UI-test launch resolves flags from the local override, not a cached rollout value")
+    func featureFlagsPinnedToLocalValuesIgnoreRemoteValues() async throws {
+        let suiteName = "cmux.feature.flags.pinned.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let flagKey = CmuxFeatureFlags.appKitSidebarListFlag.key
+        defaults.set(true, forKey: "cmux.flags.remote.\(flagKey)")
+        defaults.set(false, forKey: "cmux.flags.override.\(flagKey)")
+        let probe = FeatureFlagRemoteLoaderProbe()
+
+        let flags = CmuxFeatureFlags(
+            defaults: defaults,
+            remoteFlagValueProvider: { _ in nil },
+            remoteFlagLoader: { await probe.load() },
+            pinsFlagsToLocalValues: true
+        )
+        flags.start()
+
+        #expect(flags.isAppKitSidebarListEnabled == false)
+        #expect(await probe.callCount == 0)
+    }
+
+    @MainActor
+    @Test("a normal launch lets a cached rollout value outrank a local override")
+    func featureFlagsNotPinnedPreferRemoteValues() throws {
+        let suiteName = "cmux.feature.flags.unpinned.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let flagKey = CmuxFeatureFlags.appKitSidebarListFlag.key
+        defaults.set(true, forKey: "cmux.flags.remote.\(flagKey)")
+        defaults.set(false, forKey: "cmux.flags.override.\(flagKey)")
+
+        let flags = CmuxFeatureFlags(
+            defaults: defaults,
+            remoteFlagValueProvider: { _ in nil },
+            pinsFlagsToLocalValues: false
+        )
+
+        #expect(flags.isAppKitSidebarListEnabled == true)
+    }
+
+    @MainActor
     @Test("feature flag control plane starts its injected remote loader")
     func featureFlagControlPlaneStartsInjectedRemoteLoader() async throws {
         let suiteName = "cmux.feature.flags.loader.\(UUID().uuidString)"

--- a/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
+++ b/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
@@ -1,5 +1,6 @@
 import AppKit
-import XCTest
+import Foundation
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -11,23 +12,14 @@ import XCTest
 /// way the `+` button and File → New Workspace do: through the shared
 /// new-workspace action path, so a configured `ui.newWorkspace.action` default
 /// layout applies. Without a configured default it still appends a plain
-/// workspace after the last row.
+/// workspace after the last row, outside any workspace group.
 /// https://github.com/manaflow-ai/cmux/issues/10043
 @MainActor
-final class SidebarEmptyAreaNewWorkspaceActionTests: XCTestCase {
-    private var configRoot: URL?
-
-    override func tearDown() {
-        if let configRoot {
-            try? FileManager.default.removeItem(at: configRoot)
-        }
-        configRoot = nil
-        super.tearDown()
-    }
-
-    func testEmptyAreaDoubleClickAppliesConfiguredNewWorkspaceLayout() throws {
-        let appDelegate = try XCTUnwrap(AppDelegate.shared)
-        let store = try makeConfigStore(globalJSON: """
+@Suite("Sidebar empty-area new workspace action", .serialized)
+struct SidebarEmptyAreaNewWorkspaceActionTests {
+    @Test func emptyAreaDoubleClickAppliesConfiguredNewWorkspaceLayout() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let fixture = try ConfigFixture(globalJSON: """
         {
           "actions": {
             "empty-area-layout": {
@@ -39,102 +31,147 @@ final class SidebarEmptyAreaNewWorkspaceActionTests: XCTestCase {
           "ui": { "newWorkspace": { "action": "empty-area-layout" } }
         }
         """)
+        defer { fixture.cleanUp() }
 
         let windowId = appDelegate.createMainWindow()
         defer { closeWindow(withId: windowId) }
-        let manager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: windowId))
-        let context = try XCTUnwrap(
+        let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+        let context = try #require(
             appDelegate.mainWindowContexts.values.first { $0.windowId == windowId }
         )
-        context.cmuxConfigStore = store
+        context.cmuxConfigStore = fixture.store
 
         let initialCount = manager.tabs.count
         appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
-        spinRunLoop()
+        waitUntil { manager.tabs.contains { $0.customTitle == "EmptyAreaLayout" } }
 
-        XCTAssertEqual(manager.tabs.count, initialCount + 1, "Expected exactly one new workspace")
-        XCTAssertTrue(
+        #expect(manager.tabs.count == initialCount + 1, "Expected exactly one new workspace")
+        #expect(
             manager.tabs.contains { $0.customTitle == "EmptyAreaLayout" },
-            "Empty-area double-click must honor ui.newWorkspace.action, got titles "
-                + "\(manager.tabs.map { $0.customTitle ?? "<none>" })"
+            Comment(
+                rawValue: "Empty-area double-click must honor ui.newWorkspace.action, got titles "
+                    + "\(manager.tabs.map { $0.customTitle ?? "<none>" })"
+            )
         )
     }
 
-    func testEmptyAreaDoubleClickWithoutConfiguredActionAppendsPlainWorkspace() throws {
-        let appDelegate = try XCTUnwrap(AppDelegate.shared)
-        let store = try makeConfigStore(globalJSON: "{}")
+    @Test func emptyAreaDoubleClickWithoutConfiguredActionAppendsPlainWorkspace() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let fixture = try ConfigFixture(globalJSON: "{}")
+        defer { fixture.cleanUp() }
 
         let windowId = appDelegate.createMainWindow()
         defer { closeWindow(withId: windowId) }
-        let manager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: windowId))
-        let context = try XCTUnwrap(
+        let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+        let context = try #require(
             appDelegate.mainWindowContexts.values.first { $0.windowId == windowId }
         )
-        context.cmuxConfigStore = store
+        context.cmuxConfigStore = fixture.store
 
         // Select the first workspace so "after the selected one" and "at the end"
         // are distinguishable positions.
-        let first = try XCTUnwrap(manager.tabs.first)
+        let first = try #require(manager.tabs.first)
         manager.addWorkspace(placementOverride: .end)
         manager.selectWorkspace(first)
         let countBeforeDoubleClick = manager.tabs.count
 
         appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
-        spinRunLoop()
+        waitUntil { manager.tabs.count == countBeforeDoubleClick + 1 }
 
-        XCTAssertEqual(manager.tabs.count, countBeforeDoubleClick + 1)
-        XCTAssertNotEqual(
-            manager.tabs.last?.id,
-            first.id,
+        #expect(manager.tabs.count == countBeforeDoubleClick + 1)
+        #expect(
+            manager.tabs.last?.id != first.id,
             "A plain empty-area workspace still lands after the last row"
         )
-        XCTAssertEqual(
-            manager.tabs.last?.id,
-            manager.selectedTabId,
+        #expect(
+            manager.tabs.last?.id == manager.selectedTabId,
             "The appended workspace is the selected one"
         )
     }
 
+    /// The empty area is the region below every row, so the gesture points
+    /// outside all groups: an end-of-list workspace must not be filed into the
+    /// selected workspace's group the way the `+` button's does.
+    @Test func emptyAreaDoubleClickWithGroupedSelectionAppendsOutsideTheGroup() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let fixture = try ConfigFixture(globalJSON: "{}")
+        defer { fixture.cleanUp() }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+        let context = try #require(
+            appDelegate.mainWindowContexts.values.first { $0.windowId == windowId }
+        )
+        context.cmuxConfigStore = fixture.store
+
+        let initialWorkspace = try #require(manager.tabs.first)
+        let groupId = try #require(
+            manager.createWorkspaceGroup(name: "Empty Area Group", childWorkspaceIds: [initialWorkspace.id])
+        )
+        let selected = try #require(manager.selectedWorkspace)
+        #expect(selected.groupId == groupId, "Group creation should leave the anchor selected")
+        let countBeforeDoubleClick = manager.tabs.count
+
+        appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
+        waitUntil { manager.tabs.count == countBeforeDoubleClick + 1 }
+
+        #expect(manager.tabs.count == countBeforeDoubleClick + 1)
+        let created = try #require(manager.tabs.last)
+        #expect(
+            created.groupId == nil,
+            "Empty-area double-click lands outside the selected workspace's group"
+        )
+        #expect(created.id == manager.selectedTabId, "The appended workspace is the selected one")
+    }
+
     // MARK: - Helpers
 
-    private func makeConfigStore(globalJSON: String) throws -> CmuxConfigStore {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "cmux-sidebar-empty-area-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        configRoot = root
-        let globalConfigURL = root.appendingPathComponent("cmux.json")
-        try globalJSON.write(to: globalConfigURL, atomically: true, encoding: .utf8)
-        let store = CmuxConfigStore(
-            globalConfigPath: globalConfigURL.path,
-            localConfigPath: nil,
-            startFileWatchers: false
-        )
-        store.loadAll()
-        return store
-    }
+    @MainActor
+    private struct ConfigFixture {
+        let store: CmuxConfigStore
+        private let root: URL
 
-    private func spinRunLoop() {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
-    }
+        init(globalJSON: String) throws {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "cmux-sidebar-empty-area-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let globalConfigURL = root.appendingPathComponent("cmux.json")
+            try globalJSON.write(to: globalConfigURL, atomically: true, encoding: .utf8)
+            let store = CmuxConfigStore(
+                globalConfigPath: globalConfigURL.path,
+                localConfigPath: nil,
+                startFileWatchers: false
+            )
+            store.loadAll()
+            self.root = root
+            self.store = store
+        }
 
-    private func window(withId windowId: UUID) -> NSWindow? {
-        let identifier = "cmux.main.\(windowId.uuidString)"
-        // The SwiftUI-hosted main window registers in `NSApp.windows` on a later
-        // run-loop turn, so poll briefly instead of racing a cold start.
-        let deadline = Date().addingTimeInterval(3.0)
-        repeat {
-            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
-                return window
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
-        } while Date() < deadline
-        return nil
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: root)
+        }
     }
 
     private func closeWindow(withId windowId: UUID) {
-        window(withId: windowId)?.close()
-        spinRunLoop()
+        guard let window = AppDelegate.shared?.windowForMainWindowId(windowId) else { return }
+        window.animationBehavior = .none
+        window.orderOut(nil)
+        window.close()
+        waitUntil {
+            AppDelegate.shared?.windowForMainWindowId(windowId) == nil || !window.isVisible
+        }
+    }
+
+    /// Polls the run loop until `condition` holds, so assertions wait on the
+    /// state they care about instead of a fixed delay that a slow runner can
+    /// outlast.
+    private func waitUntil(timeout: TimeInterval = 3.0, _ condition: () -> Bool) {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
     }
 }

--- a/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
+++ b/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
@@ -155,13 +155,22 @@ struct SidebarEmptyAreaNewWorkspaceActionTests {
         }
     }
 
+    /// Retiring the window's `MainWindowContext` is the authoritative end of
+    /// the close, so wait for that rather than for the window merely going
+    /// invisible: a half-closed window would otherwise leak its workspaces into
+    /// the next test.
     private func closeWindow(withId windowId: UUID) {
-        guard let window = AppDelegate.shared?.windowForMainWindowId(windowId) else { return }
+        guard let appDelegate = AppDelegate.shared,
+              let window = appDelegate.windowForMainWindowId(windowId) else { return }
+        let previousConfirmationHandler = appDelegate.debugCloseMainWindowConfirmationHandler
+        appDelegate.debugCloseMainWindowConfirmationHandler = { _ in true }
+        defer { appDelegate.debugCloseMainWindowConfirmationHandler = previousConfirmationHandler }
         window.animationBehavior = .none
         window.orderOut(nil)
         window.close()
         waitUntil {
-            AppDelegate.shared?.windowForMainWindowId(windowId) == nil || !window.isVisible
+            !appDelegate.mainWindowContexts.values.contains { $0.windowId == windowId }
+                && (appDelegate.windowForMainWindowId(windowId) == nil || !window.isVisible)
         }
     }
 

--- a/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
+++ b/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
@@ -41,16 +41,16 @@ struct SidebarEmptyAreaNewWorkspaceActionTests {
         )
         context.cmuxConfigStore = fixture.store
 
-        let initialCount = manager.tabs.count
+        let knownIds = Set(manager.tabs.map(\.id))
         appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
-        waitUntil { manager.tabs.contains { $0.customTitle == "EmptyAreaLayout" } }
+        let created = try createdWorkspace(in: manager, knownIds: knownIds)
+        waitUntil { created.customTitle != nil }
 
-        #expect(manager.tabs.count == initialCount + 1, "Expected exactly one new workspace")
         #expect(
-            manager.tabs.contains { $0.customTitle == "EmptyAreaLayout" },
+            created.customTitle == "EmptyAreaLayout",
             Comment(
-                rawValue: "Empty-area double-click must honor ui.newWorkspace.action, got titles "
-                    + "\(manager.tabs.map { $0.customTitle ?? "<none>" })"
+                rawValue: "Empty-area double-click must honor ui.newWorkspace.action, got title "
+                    + "\(created.customTitle ?? "<none>")"
             )
         )
     }
@@ -73,20 +73,16 @@ struct SidebarEmptyAreaNewWorkspaceActionTests {
         let first = try #require(manager.tabs.first)
         manager.addWorkspace(placementOverride: .end)
         manager.selectWorkspace(first)
-        let countBeforeDoubleClick = manager.tabs.count
+        let knownIds = Set(manager.tabs.map(\.id))
 
         appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
-        waitUntil { manager.tabs.count == countBeforeDoubleClick + 1 }
+        let created = try createdWorkspace(in: manager, knownIds: knownIds)
 
-        #expect(manager.tabs.count == countBeforeDoubleClick + 1)
         #expect(
-            manager.tabs.last?.id != first.id,
+            manager.tabs.last?.id == created.id,
             "A plain empty-area workspace still lands after the last row"
         )
-        #expect(
-            manager.tabs.last?.id == manager.selectedTabId,
-            "The appended workspace is the selected one"
-        )
+        #expect(created.id == manager.selectedTabId, "The appended workspace is the selected one")
     }
 
     /// The empty area is the region below every row, so the gesture points
@@ -111,17 +107,16 @@ struct SidebarEmptyAreaNewWorkspaceActionTests {
         )
         let selected = try #require(manager.selectedWorkspace)
         #expect(selected.groupId == groupId, "Group creation should leave the anchor selected")
-        let countBeforeDoubleClick = manager.tabs.count
+        let knownIds = Set(manager.tabs.map(\.id))
 
         appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
-        waitUntil { manager.tabs.count == countBeforeDoubleClick + 1 }
+        let created = try createdWorkspace(in: manager, knownIds: knownIds)
 
-        #expect(manager.tabs.count == countBeforeDoubleClick + 1)
-        let created = try #require(manager.tabs.last)
         #expect(
             created.groupId == nil,
             "Empty-area double-click lands outside the selected workspace's group"
         )
+        #expect(manager.tabs.last?.id == created.id, "The new workspace lands after the last row")
         #expect(created.id == manager.selectedTabId, "The appended workspace is the selected one")
     }
 
@@ -168,19 +163,48 @@ struct SidebarEmptyAreaNewWorkspaceActionTests {
         window.animationBehavior = .none
         window.orderOut(nil)
         window.close()
-        waitUntil {
+        let retired = waitUntil {
             !appDelegate.mainWindowContexts.values.contains { $0.windowId == windowId }
                 && (appDelegate.windowForMainWindowId(windowId) == nil || !window.isVisible)
         }
+        #expect(retired, "Timed out waiting for the test main window to retire")
+    }
+
+    /// The one workspace the gesture created, identified by id against the
+    /// pre-gesture snapshot: position and title alone could match a
+    /// pre-existing workspace and hide a creation that never happened.
+    private func createdWorkspace(
+        in manager: TabManager,
+        knownIds: Set<UUID>,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> Workspace {
+        var newWorkspaces: [Workspace] = []
+        let appeared = waitUntil {
+            newWorkspaces = manager.tabs.filter { !knownIds.contains($0.id) }
+            return newWorkspaces.count == 1
+        }
+        #expect(
+            appeared,
+            Comment(
+                rawValue: "Timed out waiting for exactly one new workspace, got "
+                    + "\(newWorkspaces.count)"
+            ),
+            sourceLocation: sourceLocation
+        )
+        return try #require(newWorkspaces.first, sourceLocation: sourceLocation)
     }
 
     /// Polls the run loop until `condition` holds, so assertions wait on the
     /// state they care about instead of a fixed delay that a slow runner can
-    /// outlast.
-    private func waitUntil(timeout: TimeInterval = 3.0, _ condition: () -> Bool) {
+    /// outlast. Returns false when the deadline passes first, letting callers
+    /// fail on the timeout itself rather than on whatever stale state remains.
+    @discardableResult
+    private func waitUntil(timeout: TimeInterval = 3.0, _ condition: () -> Bool) -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout)
-        while !condition(), Date() < deadline {
+        while !condition() {
+            guard Date() < deadline else { return false }
             RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         }
+        return true
     }
 }

--- a/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
+++ b/cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Double-clicking the sidebar's empty area must create a workspace the same
+/// way the `+` button and File → New Workspace do: through the shared
+/// new-workspace action path, so a configured `ui.newWorkspace.action` default
+/// layout applies. Without a configured default it still appends a plain
+/// workspace after the last row.
+/// https://github.com/manaflow-ai/cmux/issues/10043
+@MainActor
+final class SidebarEmptyAreaNewWorkspaceActionTests: XCTestCase {
+    private var configRoot: URL?
+
+    override func tearDown() {
+        if let configRoot {
+            try? FileManager.default.removeItem(at: configRoot)
+        }
+        configRoot = nil
+        super.tearDown()
+    }
+
+    func testEmptyAreaDoubleClickAppliesConfiguredNewWorkspaceLayout() throws {
+        let appDelegate = try XCTUnwrap(AppDelegate.shared)
+        let store = try makeConfigStore(globalJSON: """
+        {
+          "actions": {
+            "empty-area-layout": {
+              "type": "workspace",
+              "title": "Empty Area Layout",
+              "workspace": { "name": "EmptyAreaLayout" }
+            }
+          },
+          "ui": { "newWorkspace": { "action": "empty-area-layout" } }
+        }
+        """)
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        let manager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: windowId))
+        let context = try XCTUnwrap(
+            appDelegate.mainWindowContexts.values.first { $0.windowId == windowId }
+        )
+        context.cmuxConfigStore = store
+
+        let initialCount = manager.tabs.count
+        appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
+        spinRunLoop()
+
+        XCTAssertEqual(manager.tabs.count, initialCount + 1, "Expected exactly one new workspace")
+        XCTAssertTrue(
+            manager.tabs.contains { $0.customTitle == "EmptyAreaLayout" },
+            "Empty-area double-click must honor ui.newWorkspace.action, got titles "
+                + "\(manager.tabs.map { $0.customTitle ?? "<none>" })"
+        )
+    }
+
+    func testEmptyAreaDoubleClickWithoutConfiguredActionAppendsPlainWorkspace() throws {
+        let appDelegate = try XCTUnwrap(AppDelegate.shared)
+        let store = try makeConfigStore(globalJSON: "{}")
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        let manager = try XCTUnwrap(appDelegate.tabManagerFor(windowId: windowId))
+        let context = try XCTUnwrap(
+            appDelegate.mainWindowContexts.values.first { $0.windowId == windowId }
+        )
+        context.cmuxConfigStore = store
+
+        // Select the first workspace so "after the selected one" and "at the end"
+        // are distinguishable positions.
+        let first = try XCTUnwrap(manager.tabs.first)
+        manager.addWorkspace(placementOverride: .end)
+        manager.selectWorkspace(first)
+        let countBeforeDoubleClick = manager.tabs.count
+
+        appDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager: manager)
+        spinRunLoop()
+
+        XCTAssertEqual(manager.tabs.count, countBeforeDoubleClick + 1)
+        XCTAssertNotEqual(
+            manager.tabs.last?.id,
+            first.id,
+            "A plain empty-area workspace still lands after the last row"
+        )
+        XCTAssertEqual(
+            manager.tabs.last?.id,
+            manager.selectedTabId,
+            "The appended workspace is the selected one"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeConfigStore(globalJSON: String) throws -> CmuxConfigStore {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-sidebar-empty-area-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        configRoot = root
+        let globalConfigURL = root.appendingPathComponent("cmux.json")
+        try globalJSON.write(to: globalConfigURL, atomically: true, encoding: .utf8)
+        let store = CmuxConfigStore(
+            globalConfigPath: globalConfigURL.path,
+            localConfigPath: nil,
+            startFileWatchers: false
+        )
+        store.loadAll()
+        return store
+    }
+
+    private func spinRunLoop() {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+    private func window(withId windowId: UUID) -> NSWindow? {
+        let identifier = "cmux.main.\(windowId.uuidString)"
+        // The SwiftUI-hosted main window registers in `NSApp.windows` on a later
+        // run-loop turn, so poll briefly instead of racing a cold start.
+        let deadline = Date().addingTimeInterval(3.0)
+        repeat {
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                return window
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        } while Date() < deadline
+        return nil
+    }
+
+    private func closeWindow(withId windowId: UUID) {
+        window(withId: windowId)?.close()
+        spinRunLoop()
+    }
+}

--- a/cmuxUITests/SidebarEmptyAreaDoubleClickUITests.swift
+++ b/cmuxUITests/SidebarEmptyAreaDoubleClickUITests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import XCTest
+
+/// Double-clicking the sidebar's empty area must create a workspace through the
+/// shared new-workspace action, and the workspace must land after the last row.
+/// Two sidebar implementations own that gesture — the AppKit list behind
+/// `sidebar-appkit-list-experiment` and the SwiftUI `LazyVStack` it replaced —
+/// so each one gets driven for real here.
+///
+/// The unit suite (`SidebarEmptyAreaNewWorkspaceActionTests`) covers what the
+/// shared action does — configured `ui.newWorkspace.action` layouts and
+/// workspace-group placement — since a UI test cannot point the app at a
+/// throwaway `~/.config/cmux/cmux.json`. These tests cover the half the unit
+/// suite cannot reach: each gesture handler still routing into that action.
+/// Unwiring either call site turns both of them red.
+/// https://github.com/manaflow-ai/cmux/issues/10043
+final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
+    private let appDefaultsDomain = "com.cmuxterm.app.debug"
+    private let appKitSidebarListOverrideKey =
+        "cmux.flags.override.sidebar-appkit-list-experiment"
+    private let workspaceRowLabelMarker = ", workspace "
+    /// Keeps the empty-area click clear of the sidebar footer's account row.
+    private let sidebarFooterClearance: CGFloat = 80
+    private static let workspacePositionPattern = try! NSRegularExpression(
+        pattern: ", workspace ([0-9]+) of ([0-9]+)$"
+    )
+    private var previousAppKitSidebarListOverride: Any?
+    private var didSetAppKitSidebarListOverride = false
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    override func tearDown() {
+        restoreAppKitSidebarListOverride()
+        super.tearDown()
+    }
+
+    func testAppKitSidebarEmptyAreaDoubleClickAppendsWorkspaceAtEnd() throws {
+        try runEmptyAreaDoubleClick(appKitSidebarList: true)
+    }
+
+    func testSwiftUISidebarEmptyAreaDoubleClickAppendsWorkspaceAtEnd() throws {
+        try runEmptyAreaDoubleClick(appKitSidebarList: false)
+    }
+
+    // MARK: - Scenario
+
+    /// Parks the selection on the first workspace with the app's placement
+    /// preference set to `afterCurrent`, so a workspace appearing last can only
+    /// come from the empty area's own `.end` override, never from the default.
+    private func runEmptyAreaDoubleClick(appKitSidebarList: Bool) throws {
+        overrideAppKitSidebarList(appKitSidebarList)
+
+        let app = XCUIApplication.cmuxTestApplication()
+        defer { app.terminate() }
+        app.launchArguments += [
+            "-newWorkspacePlacement", "afterCurrent",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+            "-NSAppSleepDisabled", "YES",
+        ]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_TAG"] = "ui-empty-area-\(UUID().uuidString.prefix(8))"
+        launchAndEnsureRunning(app)
+        app.activate()
+
+        XCTAssertTrue(pollUntil(timeout: 20.0) { app.windows.count >= 1 }, "Expected a main window")
+        XCTAssertTrue(
+            pollUntil(timeout: 20.0) { self.workspaceRows(in: app).count == 1 },
+            "Expected the launch workspace row; rows=\(workspaceRowLabels(in: app))"
+        )
+
+        // Two more workspaces so "after the selected row" and "after the last
+        // row" are different positions. Clicking the titlebar's New Workspace
+        // control keeps setup independent of which view owns key focus.
+        let newWorkspaceControl = app.descendants(matching: .any)["titlebarControl.newTab"].firstMatch
+        XCTAssertTrue(
+            newWorkspaceControl.waitForExistence(timeout: 15.0),
+            "Expected the titlebar's New Workspace control"
+        )
+        for expectedCount in 2...3 {
+            newWorkspaceControl.click()
+            XCTAssertTrue(
+                pollUntil(timeout: 15.0) { self.workspaceRows(in: app).count == expectedCount },
+                "Expected \(expectedCount) workspace rows; rows=\(workspaceRowLabels(in: app))"
+            )
+        }
+
+        // Rename the last pre-existing workspace so one row is identifiable by
+        // title: with the selection parked on the first row, `afterCurrent`
+        // placement would push this row to the bottom, while the empty area's
+        // own `.end` placement must leave it where it is.
+        let markerTitle = "zeta-marker"
+        try renameLastWorkspace(in: app, to: markerTitle)
+
+        let rowsBefore = workspaceRows(in: app)
+        XCTAssertEqual(rowsBefore.count, 3, "Expected 3 workspace rows before the gesture")
+        XCTAssertEqual(
+            rowsBefore.last?.position,
+            3,
+            "Expected the renamed workspace to be the last row; rows=\(rowsBefore.map(\.label))"
+        )
+
+        let firstRow = try XCTUnwrap(rowsBefore.first, "Expected a first workspace row")
+        firstRow.element.click()
+
+        try doubleClickSidebarEmptyArea(in: app)
+
+        XCTAssertTrue(
+            pollUntil(timeout: 15.0) { self.workspaceRows(in: app).count == rowsBefore.count + 1 },
+            "Expected the empty-area double-click to create one workspace; "
+                + "rows=\(workspaceRowLabels(in: app))"
+        )
+
+        let rowsAfter = workspaceRows(in: app)
+        let markerRow = try XCTUnwrap(
+            rowsAfter.first { $0.label.hasPrefix(markerTitle) },
+            "Expected the renamed workspace to still be listed; rows=\(rowsAfter.map(\.label))"
+        )
+        XCTAssertEqual(
+            markerRow.position,
+            rowsBefore.count,
+            "The empty area sits below every row, so its workspace lands after the previously "
+                + "last row instead of after the selected one; rows=\(rowsAfter.map(\.label))"
+        )
+        XCTAssertFalse(
+            rowsAfter.last?.label.hasPrefix(markerTitle) == true,
+            "Expected the created workspace to be the last row; rows=\(rowsAfter.map(\.label))"
+        )
+    }
+
+    /// Inline-renames the bottom workspace row through its own double-click
+    /// rename gesture. Retries the edit: a dropped keystroke leaves a partial
+    /// title behind rather than failing the run outright.
+    private func renameLastWorkspace(in app: XCUIApplication, to title: String) throws {
+        for attempt in 1...3 {
+            let lastRow = try XCTUnwrap(
+                workspaceRows(in: app).last,
+                "Expected a workspace row to rename"
+            )
+            lastRow.element.doubleClick()
+            let field = app.textFields.firstMatch
+            guard field.waitForExistence(timeout: 10.0) else { continue }
+            field.typeKey("a", modifierFlags: [.command])
+            field.typeText(title)
+            field.typeKey(.return, modifierFlags: [])
+            let renamed = pollUntil(timeout: 5.0) {
+                self.workspaceRows(in: app).last?.label.hasPrefix(title) == true
+            }
+            if renamed {
+                return
+            }
+            XCTAssertLessThan(
+                attempt,
+                3,
+                "Expected the renamed title to appear in the sidebar; "
+                    + "rows=\(workspaceRowLabels(in: app))"
+            )
+        }
+    }
+
+    // MARK: - Gesture
+
+    /// Double-clicks the strip between the last workspace row and the sidebar
+    /// footer, which is the empty area both implementations listen on.
+    private func doubleClickSidebarEmptyArea(in app: XCUIApplication) throws {
+        let lastRow = try XCTUnwrap(
+            workspaceRows(in: app).last,
+            "Expected a workspace row to anchor the empty area below"
+        )
+        let rowFrame = lastRow.element.frame
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10.0), "Expected a main window")
+        let emptyAreaY = rowFrame.maxY + rowFrame.height
+        XCTAssertLessThan(
+            emptyAreaY,
+            window.frame.maxY - sidebarFooterClearance,
+            "Expected an empty strip below the last workspace row and above the sidebar footer"
+        )
+
+        lastRow.element
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .withOffset(CGVector(dx: 0, dy: emptyAreaY - rowFrame.midY))
+            .doubleClick()
+    }
+
+    // MARK: - Sidebar rows
+
+    /// A sidebar row, read from the accessibility label both sidebar
+    /// implementations build from `accessibility.workspacePosition`:
+    /// `"<title>, workspace <position> of <count>"`.
+    private struct WorkspaceRow {
+        let element: XCUIElement
+        let label: String
+        let position: Int
+        let count: Int
+
+        /// The selected sidebar row: AppKit reports it as the focused table
+        /// cell, SwiftUI as a selected element.
+        var isFocused: Bool { element.isSelected || element.value as? Bool == true }
+    }
+
+    private func workspaceRows(in app: XCUIApplication) -> [WorkspaceRow] {
+        // Query by element type first: a predicate over every descendant makes
+        // XCTest walk this app's whole accessibility tree per poll, which is
+        // both slow and deep enough to take the automation helper down.
+        let matching = NSPredicate(format: "label CONTAINS %@", workspaceRowLabelMarker)
+        let candidates = app.cells.matching(matching).allElementsBoundByIndex
+            + app.groups.matching(matching).allElementsBoundByIndex
+        return candidates
+            .compactMap { element -> WorkspaceRow? in
+                let label = element.label
+                guard element.frame.height > 0,
+                      let match = Self.workspacePositionPattern.firstMatch(
+                          in: label,
+                          range: NSRange(label.startIndex..., in: label)
+                      ),
+                      let positionRange = Range(match.range(at: 1), in: label),
+                      let countRange = Range(match.range(at: 2), in: label),
+                      let position = Int(label[positionRange]),
+                      let count = Int(label[countRange])
+                else {
+                    return nil
+                }
+                return WorkspaceRow(element: element, label: label, position: position, count: count)
+            }
+            .sorted { $0.position < $1.position }
+    }
+
+    private func workspaceRowLabels(in app: XCUIApplication) -> [String] {
+        workspaceRows(in: app).map(\.label)
+    }
+
+    // MARK: - Feature flag
+
+    private func overrideAppKitSidebarList(_ enabled: Bool) {
+        guard let defaults = UserDefaults(suiteName: appDefaultsDomain) else {
+            XCTFail("Expected the app's defaults domain to be writable")
+            return
+        }
+        previousAppKitSidebarListOverride = defaults.object(forKey: appKitSidebarListOverrideKey)
+        didSetAppKitSidebarListOverride = true
+        defaults.set(enabled, forKey: appKitSidebarListOverrideKey)
+    }
+
+    private func restoreAppKitSidebarListOverride() {
+        guard didSetAppKitSidebarListOverride,
+              let defaults = UserDefaults(suiteName: appDefaultsDomain) else {
+            return
+        }
+        if let previousAppKitSidebarListOverride {
+            defaults.set(previousAppKitSidebarListOverride, forKey: appKitSidebarListOverrideKey)
+        } else {
+            defaults.removeObject(forKey: appKitSidebarListOverrideKey)
+        }
+        previousAppKitSidebarListOverride = nil
+        didSetAppKitSidebarListOverride = false
+    }
+
+    // MARK: - Waiting
+
+    private func launchAndEnsureRunning(_ app: XCUIApplication) {
+        app.launch()
+        XCTAssertTrue(
+            pollUntil(timeout: 20.0) {
+                app.state == .runningForeground || app.state == .runningBackground
+            },
+            "App failed to launch. state=\(app.state.rawValue)"
+        )
+    }
+
+    private func pollUntil(
+        timeout: TimeInterval,
+        interval: TimeInterval = 0.05,
+        _ condition: () -> Bool
+    ) -> Bool {
+        let start = ProcessInfo.processInfo.systemUptime
+        while true {
+            if condition() {
+                return true
+            }
+            if ProcessInfo.processInfo.systemUptime - start >= timeout {
+                return false
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(interval))
+        }
+    }
+}

--- a/cmuxUITests/SidebarEmptyAreaDoubleClickUITests.swift
+++ b/cmuxUITests/SidebarEmptyAreaDoubleClickUITests.swift
@@ -21,10 +21,10 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
     private let workspaceRowLabelMarker = ", workspace "
     /// Keeps the empty-area click clear of the sidebar footer's account row.
     private let sidebarFooterClearance: CGFloat = 80
-    private static let workspacePositionPattern = try! NSRegularExpression(
-        pattern: ", workspace ([0-9]+) of ([0-9]+)$"
-    )
+    private let appKitSidebarListRemoteKey =
+        "cmux.flags.remote.sidebar-appkit-list-experiment"
     private var previousAppKitSidebarListOverride: Any?
+    private var previousAppKitSidebarListRemoteValue: Any?
     private var didSetAppKitSidebarListOverride = false
 
     override func setUp() {
@@ -135,7 +135,7 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
     /// rename gesture. Retries the edit: a dropped keystroke leaves a partial
     /// title behind rather than failing the run outright.
     private func renameLastWorkspace(in app: XCUIApplication, to title: String) throws {
-        for attempt in 1...3 {
+        for _ in 1...3 {
             let lastRow = try XCTUnwrap(
                 workspaceRows(in: app).last,
                 "Expected a workspace row to rename"
@@ -152,13 +152,11 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
             if renamed {
                 return
             }
-            XCTAssertLessThan(
-                attempt,
-                3,
-                "Expected the renamed title to appear in the sidebar; "
-                    + "rows=\(workspaceRowLabels(in: app))"
-            )
         }
+        XCTFail(
+            "Expected the renamed title to appear in the sidebar after 3 attempts; "
+                + "rows=\(workspaceRowLabels(in: app))"
+        )
     }
 
     // MARK: - Gesture
@@ -208,25 +206,39 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
         // both slow and deep enough to take the automation helper down.
         let matching = NSPredicate(format: "label CONTAINS %@", workspaceRowLabelMarker)
         let candidates = app.cells.matching(matching).allElementsBoundByIndex
-            + app.groups.matching(matching).allElementsBoundByIndex
         return candidates
             .compactMap { element -> WorkspaceRow? in
                 let label = element.label
                 guard element.frame.height > 0,
-                      let match = Self.workspacePositionPattern.firstMatch(
-                          in: label,
-                          range: NSRange(label.startIndex..., in: label)
-                      ),
-                      let positionRange = Range(match.range(at: 1), in: label),
-                      let countRange = Range(match.range(at: 2), in: label),
-                      let position = Int(label[positionRange]),
-                      let count = Int(label[countRange])
+                      let position = Self.workspacePosition(in: label)
                 else {
                     return nil
                 }
-                return WorkspaceRow(element: element, label: label, position: position, count: count)
+                return WorkspaceRow(
+                    element: element,
+                    label: label,
+                    position: position.position,
+                    count: position.count
+                )
             }
             .sorted { $0.position < $1.position }
+    }
+
+    /// Splits the `", workspace <position> of <count>"` suffix the label ends
+    /// with, or nil when the element is not a workspace row.
+    private static func workspacePosition(in label: String) -> (position: Int, count: Int)? {
+        guard let suffixStart = label.range(of: ", workspace ", options: .backwards) else {
+            return nil
+        }
+        let parts = label[suffixStart.upperBound...].split(separator: " ")
+        guard parts.count == 3,
+              parts[1] == "of",
+              let position = Int(parts[0]),
+              let count = Int(parts[2])
+        else {
+            return nil
+        }
+        return (position, count)
     }
 
     private func workspaceRowLabels(in app: XCUIApplication) -> [String] {
@@ -235,13 +247,19 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
 
     // MARK: - Feature flag
 
+    /// `CmuxFeatureFlagResolution` gives a cached remote value precedence over a
+    /// local override, so a machine that already cached the rollout value would
+    /// ignore the override and run the same sidebar in both tests. Park the
+    /// cached remote value for the duration of the test and restore it after.
     private func overrideAppKitSidebarList(_ enabled: Bool) {
         guard let defaults = UserDefaults(suiteName: appDefaultsDomain) else {
             XCTFail("Expected the app's defaults domain to be writable")
             return
         }
         previousAppKitSidebarListOverride = defaults.object(forKey: appKitSidebarListOverrideKey)
+        previousAppKitSidebarListRemoteValue = defaults.object(forKey: appKitSidebarListRemoteKey)
         didSetAppKitSidebarListOverride = true
+        defaults.removeObject(forKey: appKitSidebarListRemoteKey)
         defaults.set(enabled, forKey: appKitSidebarListOverrideKey)
     }
 
@@ -250,12 +268,18 @@ final class SidebarEmptyAreaDoubleClickUITests: XCTestCase {
               let defaults = UserDefaults(suiteName: appDefaultsDomain) else {
             return
         }
-        if let previousAppKitSidebarListOverride {
-            defaults.set(previousAppKitSidebarListOverride, forKey: appKitSidebarListOverrideKey)
-        } else {
-            defaults.removeObject(forKey: appKitSidebarListOverrideKey)
+        for (key, value) in [
+            (appKitSidebarListOverrideKey, previousAppKitSidebarListOverride),
+            (appKitSidebarListRemoteKey, previousAppKitSidebarListRemoteValue),
+        ] {
+            if let value {
+                defaults.set(value, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
         }
         previousAppKitSidebarListOverride = nil
+        previousAppKitSidebarListRemoteValue = nil
         didSetAppKitSidebarListOverride = false
     }
 


### PR DESCRIPTION
Fixes #10043.

## What

Double-clicking the sidebar's empty area created a plain blank workspace directly, ignoring a configured `ui.newWorkspace.action`, while the `+` button and File → New Workspace both ran the configured default layout. Both sidebar implementations now go through one AppDelegate entry point that resolves the configured action.

## Why it diverged

The empty-area handler called `tabManager.addWorkspace(placementOverride: .end)` inline and only reached `performNewWorkspaceAction` for remote-tmux mirrors — so the configured-action lookup (`executeConfiguredNewWorkspaceActionIfAvailable`) was never on this path. The same inline logic was duplicated in `SidebarEmptyArea` (SwiftUI) and in the `createWorkspaceAtEnd` closure feeding the AppKit table, so any fix had to land in both.

## Change

- `AppDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager:)` — single entry point for the gesture, called from `SidebarEmptyArea` and from `workspaceTableActions.createWorkspaceAtEnd`. Both keep their existing `tabManager.addWorkspace(placementOverride: .end)` line as the `AppDelegate.shared == nil` fallback.
- `performNewWorkspaceAction` takes a `placementOverride`, threaded through `performNewWorkspaceCreationAction` into `addWorkspaceInPreferredMainWindow` and the preferred-tab-manager branch. Empty-area double-click passes `.end`, so with no configured action the plain workspace still lands after the last row — the behavior clicking below every row asks for.
- A non-nil `placementOverride` now outranks the selection-derived workspace-group target: `performNewWorkspaceCreationAction` resolves `workspaceGroupNewWorkspaceTarget` only when there is no override, so `createWorkspaceInGroup` (which takes a group placement instead) can no longer drop it. The empty area is the region below every row, so the gesture points outside all groups; the `+` button, File → New Workspace and every other caller pass no override and keep group targeting unchanged.
- The remote-tmux mirror branch keeps routing through the shared action path with no placement override (the tmux server decides placement), and the `selectedTab`-not-`tabs.contains` reasoning moved into the new method's comment.

## Tests

`cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests.swift` (Swift Testing, wired into `project.pbxproj`):

- `emptyAreaDoubleClickAppliesConfiguredNewWorkspaceLayout` — real main window, a `CmuxConfigStore` loaded from a temp `cmux.json` with a `type: "workspace"` layout set as `ui.newWorkspace.action`; asserts the created workspace carries the layout's name.
- `emptyAreaDoubleClickWithoutConfiguredActionAppendsPlainWorkspace` — no configured action, selection parked on the first workspace; asserts the new workspace is appended last and selected.
- `emptyAreaDoubleClickWithGroupedSelectionAppendsOutsideTheGroup` — selection inside a workspace group, no configured action; asserts the created workspace is appended top-level (`groupId == nil`) and selected.

No fixed-duration waits: assertions sit behind a deadline-bounded poll of the state each one depends on, and teardown polls until the window's `MainWindowContext` is unregistered — the authoritative end of the close.

`cmuxUITests/SidebarEmptyAreaDoubleClickUITests.swift` covers the other half — each sidebar's own gesture handler still routing into that action, which a unit test calling the action directly cannot see:

- `testAppKitSidebarEmptyAreaDoubleClickAppendsWorkspaceAtEnd` / `testSwiftUISidebarEmptyAreaDoubleClickAppendsWorkspaceAtEnd` — the same scenario with `cmux.flags.override.sidebar-appkit-list-experiment` flipped, so both implementations get driven (override restored in `tearDown`).
- Placement preference set to `afterCurrent`, three workspaces created through the titlebar control, the bottom one renamed to a marker, selection parked on the first row; the gesture then double-clicks the strip below the last row. Only the gesture's own `.end` placement leaves the marker at position 3 with a new row below it.
- Unwiring either call site turns both red (`("4") is not equal to ("3")`); with the branch as it stands both pass (21.4s / 19.6s locally).

The configured-layout half stays in the unit suite: the config store reads `~/.config/cmux/cmux.json` with no path override, so a UI test cannot point the app at a throwaway config.

Selecting the sidebar implementation needed one production change: `CmuxFeatureFlagResolution` prefers a remote value over a local override, so a machine with a cached rollout value would have run the AppKit list in both tests. A UI-test launch now pins flags to local values — no cache seeding, no control-plane refresh — through an injectable `pinsFlagsToLocalValues` (default `CMUX_UI_TEST_MODE == "1"`), with both precedence rules covered in `PostHogAnalyticsPropertiesTests`.

Two commit pairs per the regression-test policy, each test-then-fix:

- `3b19c8b4f` adds the entry point with today's behavior plus the routing test (red: `got titles ["<none>", "<none>"]`), `1b8f0708e` fixes the routing.
- `920c6518b` adds the grouped-selection test (red: `created.groupId → 1818CCA6-… == nil` failed), `bf197c016` makes the placement override outrank the group target.

`b7d3b4728` then hardens that teardown (context-unregistered predicate plus a forced close confirmation).

Verified locally on macOS 26.5.1 / Xcode 26.4.1: `scripts/test-unit.sh test -only-testing:cmuxTests/SidebarEmptyAreaNewWorkspaceActionTests` runs 3 tests, 0 failures on `b7d3b4728`, and fails only the grouped-selection test on `920c6518b`.

No user-facing strings added, so no localization changes.

## Base

Branched off `5734a451c` rather than the `main` tip, which did not compile at the time (`Sources/Workspace+PanelLifecycle.swift:453` called `TerminalController.cleanupSurfaceState(surfaceIds:workspaceID:)` while the only declaration was `cleanupSurfaceState(surfaceIds:paneIds:)`). `main` has since moved past that (`7f9af0f90`) and this branch still merges cleanly, so it is left unrebased; say the word and I will rebase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789538706&installation_model_id=21920&pr_number=10248&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10248&signature=166554bdf94437214120fca1423245543f9d25de252b5e86fd6397dd4e99e113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-clicking the sidebar’s empty area now runs the configured `ui.newWorkspace.action`, matching the `+` button and File → New Workspace. Previously it always created a plain workspace at the end; without a configured action it still appends a plain workspace after the last row and never into a group.

- Both sidebars route to `AppDelegate.performSidebarEmptyAreaNewWorkspaceAction(tabManager:)`; fallback stays `tabManager.addWorkspace(placementOverride: .end)` if no `AppDelegate`.
- `performNewWorkspaceAction` and its creation path accept a `placementOverride`; a non-nil override outranks group targeting so the empty-area gesture lands outside groups. `+`/menu pass nil and keep group behavior.
- Remote-tmux mirrors skip the override and let tmux decide placement.
- Tests: unit tests verify honoring a configured action, plain append-and-select without a config, and append outside groups; UI tests drive the gesture in both sidebar implementations.
- UI-test launches pin feature flags to local overrides (`CMUX_UI_TEST_MODE=1`), ignoring cached/fetched remote values and skipping control-plane refresh; unit tests cover both precedence rules.

<sup>Written for commit e43746f588faa768e213d3ac2052de71c14c1b40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-clicking an empty sidebar area now creates a new workspace.
  * New workspaces follow the configured layout or can be added to the end of the sidebar.
  * Workspace placement is consistent across browser, terminal, titled, and standard workspaces.

* **Bug Fixes**
  * Preserved expected placement behavior for remote terminal workspaces.

* **Tests**
  * Added coverage for empty-area workspace creation, selection, titles, group membership, and placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



