### PR TITLE
cmux-tui SDKs: reject unsafe session names before socket paths

### DIFF
--- a/cmux-tui/bindings/cpp/README.md
+++ b/cmux-tui/bindings/cpp/README.md
@@ -62,6 +62,16 @@ those routing selectors when callers supply only an opaque target ID.
 route. Direct opaque nested IDs remain globally addressable without repeating
 their structural ancestors.
 
+Derived socket paths validate the session before joining it. Names must be
+non-empty single path components without `.`, `..`, separators, NUL, control
+characters, or Unicode line separators. Spaces, Unicode, leading punctuation,
+colons, and long legacy names remain valid. `resolve_socket_path()` and
+`try_default_socket_path()` return `ErrorCode::invalid_argument` before path
+use. The source-compatible `default_socket_path()` wrapper maps invalid input
+to a deterministic per-input hash path under `cmux-tui-invalid-<uid>`; it never
+joins the invalid text and cannot select a normal session socket. Explicit
+socket paths and environment overrides remain authoritative.
+
 Every resource factory also accepts `Selector<Id>::by_id(id)`,
 `Selector<Id>::current()`, or `Selector<Id>::exact_name(name)`. Child factories
 retain the complete parent route without performing I/O:

--- a/cmux-tui/bindings/cpp/README.md
+++ b/cmux-tui/bindings/cpp/README.md
@@ -69,8 +69,10 @@ colons, and long legacy names remain valid. `resolve_socket_path()` and
 `try_default_socket_path()` return `ErrorCode::invalid_argument` before path
 use. The source-compatible `default_socket_path()` wrapper maps invalid input
 to a deterministic per-input hash path under `cmux-tui-invalid-<uid>`; it never
-joins the invalid text and cannot select a normal session socket. Explicit
-socket paths and environment overrides remain authoritative.
+joins the invalid text and cannot select a normal session socket. The FNV-1a
+leaf is a deterministic namespace guard, not a cryptographic identity. Use
+`try_default_socket_path()` for any path that will be opened. Explicit socket
+paths and environment overrides remain authoritative.
 
 Every resource factory also accepts `Selector<Id>::by_id(id)`,
 `Selector<Id>::current()`, or `Selector<Id>::exact_name(name)`. Child factories

--- a/cmux-tui/bindings/cpp/include/cmux/raw/client.hpp
+++ b/cmux-tui/bindings/cpp/include/cmux/raw/client.hpp
@@ -16,6 +16,7 @@ using ::cmux::TransportFactory;
 using ::cmux::TransportLimits;
 using ::cmux::UnixTransport;
 using ::cmux::default_socket_path;
+using ::cmux::try_default_socket_path;
 using ::cmux::make_error;
 using ::cmux::socket_path_from_environment;
 using ::cmux::unix_transport_factory;

--- a/cmux-tui/bindings/cpp/include/cmux/transport.hpp
+++ b/cmux-tui/bindings/cpp/include/cmux/transport.hpp
@@ -57,9 +57,9 @@ private:
     std::unique_ptr<Impl> impl_;
 };
 
-// Returns a validated default path. For source compatibility, invalid input
-// maps to a per-input isolated path; use try_default_socket_path when the
-// caller needs an invalid_argument result before any path use.
+// Returns a validated default path. This path-only compatibility helper maps
+// invalid input to a per-input isolated path; use try_default_socket_path when
+// a connector needs an invalid_argument result before any path use.
 [[nodiscard]] std::string default_socket_path(std::string_view session = "main");
 // Validates the session name before joining it into the derived path.
 [[nodiscard]] Result<std::string> try_default_socket_path(std::string_view session = "main");

--- a/cmux-tui/bindings/cpp/include/cmux/transport.hpp
+++ b/cmux-tui/bindings/cpp/include/cmux/transport.hpp
@@ -57,7 +57,12 @@ private:
     std::unique_ptr<Impl> impl_;
 };
 
+// Returns a validated default path. For source compatibility, invalid input
+// maps to a per-input isolated path; use try_default_socket_path when the
+// caller needs an invalid_argument result before any path use.
 [[nodiscard]] std::string default_socket_path(std::string_view session = "main");
+// Validates the session name before joining it into the derived path.
+[[nodiscard]] Result<std::string> try_default_socket_path(std::string_view session = "main");
 [[nodiscard]] std::string socket_path_from_environment();
 [[nodiscard]] Result<std::string> resolve_socket_path(
     std::string_view explicit_path,

--- a/cmux-tui/bindings/cpp/src/unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/src/unix_transport.cpp
@@ -4,8 +4,10 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <utility>
 
@@ -78,27 +80,131 @@ using Clock = std::chrono::steady_clock;
     return base;
 }
 
-[[nodiscard]] bool ascii_alphanumeric(char byte) noexcept {
-    return (byte >= 'A' && byte <= 'Z') ||
-           (byte >= 'a' && byte <= 'z') ||
-           (byte >= '0' && byte <= '9');
+[[nodiscard]] bool decode_utf8(
+    std::string_view text,
+    std::size_t& offset,
+    std::uint32_t& codepoint) noexcept {
+    const auto byte_at = [&](std::size_t index) {
+        return static_cast<unsigned char>(text[index]);
+    };
+    const auto continuation = [&](std::size_t index) {
+        return index < text.size() && (byte_at(index) & 0xC0U) == 0x80U;
+    };
+
+    const auto first = byte_at(offset++);
+    if (first <= 0x7FU) {
+        codepoint = first;
+        return true;
+    }
+    if (first >= 0xC2U && first <= 0xDFU) {
+        if (!continuation(offset)) {
+            return false;
+        }
+        codepoint = (static_cast<std::uint32_t>(first & 0x1FU) << 6U) |
+            (byte_at(offset) & 0x3FU);
+        ++offset;
+        return true;
+    }
+    if (first >= 0xE0U && first <= 0xEFU) {
+        if (!continuation(offset) || !continuation(offset + 1U)) {
+            return false;
+        }
+        const auto second = byte_at(offset);
+        if ((first == 0xE0U && second < 0xA0U) ||
+            (first == 0xEDU && second > 0x9FU)) {
+            return false;
+        }
+        codepoint = (static_cast<std::uint32_t>(first & 0x0FU) << 12U) |
+            (static_cast<std::uint32_t>(second & 0x3FU) << 6U) |
+            (byte_at(offset + 1U) & 0x3FU);
+        offset += 2U;
+        return true;
+    }
+    if (first >= 0xF0U && first <= 0xF4U) {
+        if (!continuation(offset) || !continuation(offset + 1U) ||
+            !continuation(offset + 2U)) {
+            return false;
+        }
+        const auto second = byte_at(offset);
+        if ((first == 0xF0U && second < 0x90U) ||
+            (first == 0xF4U && second > 0x8FU)) {
+            return false;
+        }
+        codepoint = (static_cast<std::uint32_t>(first & 0x07U) << 18U) |
+            (static_cast<std::uint32_t>(second & 0x3FU) << 12U) |
+            (static_cast<std::uint32_t>(byte_at(offset + 1U) & 0x3FU) << 6U) |
+            (byte_at(offset + 2U) & 0x3FU);
+        offset += 3U;
+        return true;
+    }
+    return false;
 }
 
-[[nodiscard]] Result<void> validate_session_name(
-    std::string_view session) {
-    const auto valid_tail = [](char byte) {
-        return ascii_alphanumeric(byte) ||
-               byte == '.' || byte == '_' || byte == '-';
-    };
-    if (session.empty() || session.size() > 64U ||
-        session == "." || session == ".." ||
-        !ascii_alphanumeric(session.front()) ||
-        !std::all_of(session.begin() + 1, session.end(), valid_tail)) {
+[[nodiscard]] Result<void> validate_session_name(std::string_view session) {
+    if (session.empty() || session == "." || session == "..") {
         return make_error(
             ErrorCode::invalid_argument,
-            "session must match [A-Za-z0-9][A-Za-z0-9._-]{0,63}");
+            "session name must be a non-empty UTF-8 path component without separators or control characters");
+    }
+
+    std::size_t offset = 0;
+    while (offset < session.size()) {
+        std::uint32_t codepoint = 0;
+        if (!decode_utf8(session, offset, codepoint) ||
+            codepoint == '/' || codepoint == '\\' || codepoint == '\0' ||
+            codepoint < 0x20U ||
+            (codepoint >= 0x7FU && codepoint <= 0x9FU) ||
+            codepoint == 0x2028U || codepoint == 0x2029U) {
+            return make_error(
+                ErrorCode::invalid_argument,
+                "session name must be a non-empty UTF-8 path component without separators or control characters");
+        }
     }
     return {};
+}
+
+[[nodiscard]] std::string runtime_base() {
+    const char* base = std::getenv("XDG_RUNTIME_DIR");
+    if (!base || *base == '\0') {
+        base = std::getenv("TMPDIR");
+    }
+    if (!base || *base == '\0') {
+        base = "/tmp";
+    }
+    return base;
+}
+
+[[nodiscard]] std::string fnv1a_hex(std::string_view value) {
+    std::uint64_t hash = 0xcbf29ce484222325ULL;
+    for (const auto byte : value) {
+        hash ^= static_cast<unsigned char>(byte);
+        hash *= 0x100000001b3ULL;
+    }
+    constexpr char digits[] = "0123456789abcdef";
+    std::string result(16, '0');
+    for (std::size_t index = 0; index < result.size(); ++index) {
+        const auto shift = static_cast<unsigned>(60U - (index * 4U));
+        result[index] = digits[(hash >> shift) & 0x0FU];
+    }
+    return result;
+}
+
+[[nodiscard]] std::string invalid_session_socket_path(std::string_view session) {
+    const auto directory = std::string("cmux-tui-invalid-") +
+        std::to_string(static_cast<unsigned long>(::getuid()));
+    const auto leaf = fnv1a_hex(session) + ".sock";
+    auto base = runtime_base();
+    if (base.empty()) {
+        base = "/tmp";
+    }
+    if (base.back() != '/') {
+        base.push_back('/');
+    }
+    auto preferred = base + directory + "/" + leaf;
+    if (!unix_socket_path_fits(preferred)) {
+        preferred = "/tmp/" + directory + "/" + leaf;
+    }
+    return preferred;
 }
 
 }  // namespace
@@ -322,19 +428,26 @@ void UnixTransport::close() noexcept {
     }
 }
 
-std::string default_socket_path(std::string_view session) {
-    const char* base = std::getenv("XDG_RUNTIME_DIR");
-    if (!base || *base == '\0') {
-        base = std::getenv("TMPDIR");
+Result<std::string> try_default_socket_path(std::string_view session) {
+    auto valid = validate_session_name(session);
+    if (!valid) {
+        return std::move(valid).error();
     }
-    if (!base || *base == '\0') {
-        base = "/tmp";
-    }
-    auto preferred = runtime_socket_path(base, session);
+    auto preferred = runtime_socket_path(runtime_base(), session);
     if (!unix_socket_path_fits(preferred)) {
         return runtime_socket_path("/tmp", session);
     }
     return preferred;
+}
+
+std::string default_socket_path(std::string_view session) {
+    auto path = try_default_socket_path(session);
+    if (path) {
+        return std::move(path).value();
+    }
+    // Preserve the historical non-fallible helper without ever joining the
+    // caller's invalid text. New code should use try_default_socket_path.
+    return invalid_session_socket_path(session);
 }
 
 std::string socket_path_from_environment() {
@@ -357,11 +470,7 @@ Result<std::string> resolve_socket_path(
     if (!environment_path.empty()) {
         return environment_path;
     }
-    auto valid = validate_session_name(session);
-    if (!valid) {
-        return std::move(valid).error();
-    }
-    return default_socket_path(session);
+    return try_default_socket_path(session);
 }
 
 TransportFactory unix_transport_factory(

--- a/cmux-tui/bindings/cpp/src/unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/src/unix_transport.cpp
@@ -189,11 +189,20 @@ using Clock = std::chrono::steady_clock;
     return result;
 }
 
+[[nodiscard]] std::string invalid_session_socket_path_in_runtime_dir(
+    std::string_view session,
+    std::string base);
+
 [[nodiscard]] std::string invalid_session_socket_path(std::string_view session) {
+    return invalid_session_socket_path_in_runtime_dir(session, runtime_base());
+}
+
+[[nodiscard]] std::string invalid_session_socket_path_in_runtime_dir(
+    std::string_view session,
+    std::string base) {
     const auto directory = std::string("cmux-tui-invalid-") +
         std::to_string(static_cast<unsigned long>(::getuid()));
     const auto leaf = fnv1a_hex(session) + ".sock";
-    auto base = runtime_base();
     if (base.empty()) {
         base = "/tmp";
     }

--- a/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
@@ -296,11 +296,15 @@ TEST("legacy default socket wrapper isolates invalid names") {
     environment.unset("TMPDIR");
 
     const auto escaped = cmux::default_socket_path("../escape");
+    const auto escaped_again = cmux::default_socket_path("../escape");
     const auto nested = cmux::default_socket_path("nested/escape");
+    CHECK_EQ(escaped, escaped_again);
     CHECK(escaped != nested);
     CHECK(escaped.find("../") == std::string::npos);
     CHECK(escaped.find("../escape.sock") == std::string::npos);
     CHECK(escaped.find("/cmux-tui-invalid-") != std::string::npos);
+    const auto normalized = std::filesystem::path(escaped).lexically_normal();
+    CHECK(normalized.string().starts_with("/tmp/cmux-cpp-session/"));
 }
 
 TEST("fallible default socket paths reject unsafe names before joining") {

--- a/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
@@ -286,6 +286,46 @@ TEST("derived socket paths reject invalid session names") {
     }
 }
 
+TEST("fallible default socket paths reject unsafe names before joining") {
+    std::lock_guard lock(environment_mutex);
+    ScopedEnvironment environment({"XDG_RUNTIME_DIR", "TMPDIR"});
+    environment.set("XDG_RUNTIME_DIR", "/tmp/cmux-cpp-session");
+    environment.unset("TMPDIR");
+
+    const std::vector<std::string> invalid_sessions{
+        "",
+        ".",
+        "..",
+        "../escape",
+        "nested/session",
+        "nested\\session",
+        std::string("bad\0name", 8),
+        "bad\nname",
+        "bad\xC2\x85name",
+        "bad\xE2\x80\xA8name",
+        "bad\xE2\x80\xA9name",
+    };
+    for (const auto& session : invalid_sessions) {
+        auto path = cmux::try_default_socket_path(session);
+        CHECK(!path);
+        CHECK_EQ(path.error().code, cmux::ErrorCode::invalid_argument);
+    }
+
+    for (const auto& session : {
+             std::string("legacy name"),
+             std::string("名前"),
+             std::string("_legacy"),
+             std::string("-legacy"),
+             std::string("legacy:colon"),
+         }) {
+        auto path = cmux::try_default_socket_path(session);
+        CHECK(path);
+        CHECK(path.value().ends_with("/" + session + ".sock"));
+    }
+    auto long_name = std::string("legacy-") + std::string(200, 'x');
+    CHECK(cmux::try_default_socket_path(long_name));
+}
+
 TEST("explicit socket paths bypass derived session validation") {
     std::lock_guard lock(environment_mutex);
     ScopedEnvironment environment(

--- a/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
@@ -1,6 +1,8 @@
 #include "test.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -303,6 +305,11 @@ TEST("legacy default socket wrapper isolates invalid names") {
     CHECK(escaped.find("../") == std::string::npos);
     CHECK(escaped.find("../escape.sock") == std::string::npos);
     CHECK(escaped.find("/cmux-tui-invalid-") != std::string::npos);
+    const auto leaf = std::filesystem::path(escaped).filename().string();
+    CHECK_EQ(leaf.size(), std::size_t{21});
+    CHECK(std::all_of(leaf.begin(), leaf.begin() + 16, [](char character) {
+        return std::isxdigit(static_cast<unsigned char>(character)) != 0;
+    }));
     const auto normalized = std::filesystem::path(escaped).lexically_normal();
     CHECK(normalized.string().starts_with("/tmp/cmux-cpp-session/"));
 }

--- a/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
+++ b/cmux-tui/bindings/cpp/tests/test_unix_transport.cpp
@@ -251,16 +251,14 @@ TEST("derived socket paths reject invalid session names") {
         "",
         ".",
         "..",
-        ".hidden",
-        "_leading",
-        "-leading",
         "../other",
         "a/b",
         "a\\b",
-        "contains space",
         "line\nbreak",
-        std::string(65, 'a'),
-        std::string("\xC3\xA9", 2),
+        std::string("bad\0name", 8),
+        "line\xC2\x85" "break",
+        "line\xE2\x80\xA8" "break",
+        "line\xE2\x80\xA9" "break",
     };
     for (const auto& session : invalid_sessions) {
         auto path = cmux::resolve_socket_path("", session);
@@ -271,7 +269,12 @@ TEST("derived socket paths reject invalid session names") {
     const std::vector<std::string> valid_sessions{
         "A",
         "a.b_C-9",
-        std::string(64, 'a'),
+        ".hidden",
+        "_leading",
+        "-leading",
+        "contains space",
+        "名前",
+        std::string(200, 'a'),
     };
     for (const auto& session : valid_sessions) {
         auto path = cmux::resolve_socket_path("", session);
@@ -284,6 +287,20 @@ TEST("derived socket paths reject invalid session names") {
                 : expected_socket("/tmp", session);
         CHECK_EQ(path.value(), expected);
     }
+}
+
+TEST("legacy default socket wrapper isolates invalid names") {
+    std::lock_guard lock(environment_mutex);
+    ScopedEnvironment environment({"XDG_RUNTIME_DIR", "TMPDIR"});
+    environment.set("XDG_RUNTIME_DIR", "/tmp/cmux-cpp-session");
+    environment.unset("TMPDIR");
+
+    const auto escaped = cmux::default_socket_path("../escape");
+    const auto nested = cmux::default_socket_path("nested/escape");
+    CHECK(escaped != nested);
+    CHECK(escaped.find("../") == std::string::npos);
+    CHECK(escaped.find("../escape.sock") == std::string::npos);
+    CHECK(escaped.find("/cmux-tui-invalid-") != std::string::npos);
 }
 
 TEST("fallible default socket paths reject unsafe names before joining") {
@@ -301,9 +318,9 @@ TEST("fallible default socket paths reject unsafe names before joining") {
         "nested\\session",
         std::string("bad\0name", 8),
         "bad\nname",
-        "bad\xC2\x85name",
-        "bad\xE2\x80\xA8name",
-        "bad\xE2\x80\xA9name",
+        "bad\xC2\x85" "name",
+        "bad\xE2\x80\xA8" "name",
+        "bad\xE2\x80\xA9" "name",
     };
     for (const auto& session : invalid_sessions) {
         auto path = cmux::try_default_socket_path(session);

--- a/cmux-tui/bindings/examples/rust-agent-dashboard/src/main.rs
+++ b/cmux-tui/bindings/examples/rust-agent-dashboard/src/main.rs
@@ -35,10 +35,11 @@ fn main() -> ExitCode {
 }
 
 fn run(arguments: Arguments) -> Result<(), String> {
-    let config = arguments.socket.map_or_else(
-        || Config::from_env_or_default_session(&arguments.session),
-        Config::from_socket_path,
-    );
+    let config = match arguments.socket {
+        Some(path) => Config::from_socket_path(path),
+        None => Config::try_from_env_or_default_session(&arguments.session)
+            .map_err(|error| error.to_string())?,
+    };
     let shutdown = Arc::new(AtomicBool::new(false));
 
     if arguments.options.watch_for.is_none() {

--- a/cmux-tui/bindings/python/README.md
+++ b/cmux-tui/bindings/python/README.md
@@ -147,3 +147,10 @@ from cmux.raw import CmuxClient, COMMANDS
 An explicit socket path wins. Otherwise the client checks `CMUX_TUI_SOCKET`,
 then `CMUX_MUX_SOCKET`, then resolves the named session under
 `XDG_RUNTIME_DIR`, `TMPDIR`, or `/tmp`.
+
+Session names are validated before this path is joined. The name must be a
+non-empty single path component. Separators, NUL, control characters, and
+Unicode line separators are rejected. Spaces, Unicode, leading punctuation,
+colons, and long legacy names remain valid. `default_socket_path` and both
+client constructors raise `ValueError` before opening a socket for an invalid
+name. Explicit socket paths and environment overrides remain authoritative.

--- a/cmux-tui/bindings/python/cmux/__init__.py
+++ b/cmux-tui/bindings/python/cmux/__init__.py
@@ -1,7 +1,7 @@
 """Dependency-free Python SDK for the cmux resource API."""
 
 from . import aio
-from .client_defaults import default_socket_path, env_socket_path
+from .client_defaults import default_socket_path, env_socket_path, validate_session_name
 from .errors import (
     CancelledError,
     CmuxConnectionError,
@@ -77,6 +77,7 @@ __all__ = list(
             "aio",
             "default_socket_path",
             "env_socket_path",
+            "validate_session_name",
             *_id_all,
             *_model_all,
             *_option_all,

--- a/cmux-tui/bindings/python/cmux/client_defaults.py
+++ b/cmux-tui/bindings/python/cmux/client_defaults.py
@@ -4,7 +4,29 @@ import os
 from typing import Optional
 
 
+def validate_session_name(session: str) -> None:
+    """Reject session text that cannot be one safe socket path component."""
+    invalid = (
+        not session
+        or session in {".", ".."}
+        or any(
+            character in {"/", "\\", "\x00"}
+            or ord(character) < 0x20
+            or 0x7F <= ord(character) <= 0x9F
+            or character in {"\u0085", "\u2028", "\u2029"}
+            for character in session
+        )
+    )
+    if invalid:
+        raise ValueError(
+            "session name must be a non-empty path component "
+            "without separators or control characters"
+        )
+
+
 def default_socket_path(session: str = "main") -> str:
+    """Return the default socket path after validating the session name."""
+    validate_session_name(session)
     runtime = os.environ.get("XDG_RUNTIME_DIR")
     if not runtime:
         runtime = os.environ.get("TMPDIR") or "/tmp"
@@ -15,4 +37,4 @@ def env_socket_path() -> Optional[str]:
     return os.environ.get("CMUX_TUI_SOCKET") or os.environ.get("CMUX_MUX_SOCKET")
 
 
-__all__ = ["default_socket_path", "env_socket_path"]
+__all__ = ["default_socket_path", "env_socket_path", "validate_session_name"]

--- a/cmux-tui/bindings/python/cmux/raw/__init__.py
+++ b/cmux-tui/bindings/python/cmux/raw/__init__.py
@@ -22,6 +22,7 @@ from .client import (
     MissingType,
     default_socket_path,
     env_socket_path,
+    validate_session_name,
 )
 from .convenience import (
     SurfaceContext,
@@ -51,6 +52,7 @@ __all__ = list(
             "active_live_pty",
             "default_socket_path",
             "env_socket_path",
+            "validate_session_name",
             "find_surface",
             "render_row_text",
             *_generated_all,

--- a/cmux-tui/bindings/python/cmux/raw/client.py
+++ b/cmux-tui/bindings/python/cmux/raw/client.py
@@ -24,7 +24,11 @@ from ..errors import (
     ProtocolError,
     TimeoutError,
 )
-from ..client_defaults import default_socket_path, env_socket_path
+from ..client_defaults import (
+    default_socket_path,
+    env_socket_path,
+    validate_session_name,
+)
 from ..transport import DEFAULT_MAX_LINE_BYTES, JsonLineConnection
 
 
@@ -495,6 +499,7 @@ __all__ = [
     "EventStream",
     "default_socket_path",
     "env_socket_path",
+    "validate_session_name",
     "AuthorityError",
     "CmuxError",
     "CommandError",

--- a/cmux-tui/bindings/python/tests/test_protocol.py
+++ b/cmux-tui/bindings/python/tests/test_protocol.py
@@ -140,6 +140,37 @@ class GeneratedProtocolTests(unittest.TestCase):
                 f"/temporary/cmux-tui-{os.getuid()}/sdk.sock",
             )
 
+    def test_session_socket_paths_reject_unsafe_names_before_joining(self) -> None:
+        for session in (
+            "",
+            ".",
+            "..",
+            "../escape",
+            "nested/session",
+            r"nested\session",
+            "bad\x00name",
+            "bad\nname",
+            "bad\u0085name",
+            "bad\u2028name",
+            "bad\u2029name",
+        ):
+            with self.assertRaises(ValueError, msg=repr(session)):
+                default_socket_path(session)
+
+        for session in (
+            "legacy name",
+            "名前",
+            "_legacy",
+            "-legacy",
+            "legacy:colon",
+        ):
+            self.assertTrue(default_socket_path(session).endswith(f"/{session}.sock"))
+        self.assertTrue(
+            default_socket_path(f"legacy-{'x' * 200}").endswith(
+                f"/{'legacy-' + 'x' * 200}.sock"
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cmux-tui/bindings/python/tests/test_protocol.py
+++ b/cmux-tui/bindings/python/tests/test_protocol.py
@@ -6,12 +6,14 @@ import unittest
 from unittest.mock import patch
 
 from cmux.raw import (
+    CmuxClient,
     MISSING,
     MUX_PROTOCOL,
     UnknownEvent,
     default_socket_path,
     env_socket_path,
 )
+from cmux.resources import Client as ResourceClient
 from cmux.raw._generated import models
 from cmux.raw._generated._schema import SCHEMA
 from cmux.raw._generated.client import GeneratedClientMixin
@@ -170,6 +172,15 @@ class GeneratedProtocolTests(unittest.TestCase):
                 f"/{'legacy-' + 'x' * 200}.sock"
             )
         )
+
+        with patch("cmux.raw.client.JsonLineConnection") as connection:
+            with self.assertRaises(ValueError):
+                CmuxClient(session="../escape")
+            connection.assert_not_called()
+        with patch("cmux.resources.ProtocolConnection") as connection:
+            with self.assertRaises(ValueError):
+                ResourceClient(session="../escape")
+            connection.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/cmux-tui/bindings/rust/README.md
+++ b/cmux-tui/bindings/rust/README.md
@@ -125,6 +125,9 @@ punctuation, colons, and long legacy names remain valid. Use
 The older non-fallible `default_socket_path` and configuration constructors
 remain source-compatible; invalid names map to distinct paths below a private
 invalid-session directory and never to a normal session socket.
+The compatibility path uses a stable hash of the invalid input, so repeated
+calls for the same input are deterministic and different invalid inputs do not
+share one fallback socket.
 
 Verify:
 

--- a/cmux-tui/bindings/rust/README.md
+++ b/cmux-tui/bindings/rust/README.md
@@ -115,6 +115,17 @@ let _request = cmux::raw::PingRequest::default();
 The optional `cmux-sidebar` companion provides Ratatui rendering and input
 forwarding without adding Ratatui to this base crate.
 
+Default socket helpers validate session names before joining them into a path.
+Names must be non-empty single path components without separators, NUL,
+control characters, or Unicode line separators. Spaces, Unicode, leading
+punctuation, colons, and long legacy names remain valid. Use
+`cmux::raw::try_default_socket_path` or
+`ClientConfig::try_from_env_or_default_session` (and the corresponding
+`Config` method) when invalid input must return `Error::InvalidArgument`.
+The older non-fallible `default_socket_path` and configuration constructors
+remain source-compatible; invalid names map to distinct paths below a private
+invalid-session directory and never to a normal session socket.
+
 Verify:
 
 ```bash

--- a/cmux-tui/bindings/rust/README.md
+++ b/cmux-tui/bindings/rust/README.md
@@ -123,11 +123,14 @@ punctuation, colons, and long legacy names remain valid. Use
 `ClientConfig::try_from_env_or_default_session` (and the corresponding
 `Config` method) when invalid input must return `Error::InvalidArgument`.
 The older non-fallible `default_socket_path` and configuration constructors
-remain source-compatible; invalid names map to distinct paths below a private
-invalid-session directory and never to a normal session socket.
-The compatibility path uses a stable hash of the invalid input, so repeated
-calls for the same input are deterministic and different invalid inputs do not
-share one fallback socket.
+remain source-compatible. The configuration constructors report invalid names
+by panicking, so use their `try_` forms for user input. The path-only helper
+maps invalid names to distinct paths below a private invalid-session directory
+and never to a normal session socket. Its FNV-1a leaf is a deterministic
+namespace guard, not a cryptographic identity. It is never used by the
+fallible constructors or internal connect paths. Repeated calls for the same
+input are deterministic, and different invalid inputs are kept in separate
+compatibility leaves.
 
 Verify:
 

--- a/cmux-tui/bindings/rust/src/client.rs
+++ b/cmux-tui/bindings/rust/src/client.rs
@@ -178,6 +178,20 @@ impl ClientConfig {
         Self::from_socket_path(socket_path)
     }
 
+    /// Builds a configuration from the environment or a named session.
+    ///
+    /// Unlike [`Self::from_env_or_default_session`], this API reports an
+    /// invalid session before constructing a socket path. The older
+    /// non-fallible API remains source-compatible and uses an isolated,
+    /// deterministic path for invalid names.
+    pub fn try_from_env_or_default_session(session: &str) -> Result<Self> {
+        let socket_path = match env_socket_path() {
+            Some(path) => path,
+            None => try_default_socket_path(session)?,
+        };
+        Ok(Self::from_socket_path(socket_path))
+    }
+
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
@@ -604,13 +618,74 @@ pub fn env_socket_path() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// Validates the session component used by the default Unix socket path.
+///
+/// Session names may contain legacy spaces, Unicode, punctuation, and long
+/// text. They must remain one non-empty path component and cannot contain
+/// separators, NUL, control characters, or Unicode line separators.
+pub fn validate_session_name(session: &str) -> Result<()> {
+    let invalid = session.is_empty()
+        || matches!(session, "." | "..")
+        || session.chars().any(|character| {
+            character == '/'
+                || character == '\\'
+                || character == '\0'
+                || character.is_control()
+                || matches!(character, '\u{0085}' | '\u{2028}' | '\u{2029}')
+        });
+    if invalid {
+        return Err(CmuxError::InvalidArgument(
+            "session name must be a non-empty path component without separators or control characters"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Resolves a session socket path and reports invalid session input.
+pub fn try_default_socket_path(session: &str) -> Result<PathBuf> {
+    validate_session_name(session)?;
+    Ok(default_socket_path_for_session(session))
+}
+
+/// Resolves a session socket path without changing the historical signature.
+///
+/// New callers should use [`try_default_socket_path`]. If an old caller passes
+/// an invalid name, this wrapper returns a per-input path below a private
+/// invalid-session directory. It never joins the supplied text and cannot
+/// select a normal session socket.
 pub fn default_socket_path(session: &str) -> PathBuf {
+    match try_default_socket_path(session) {
+        Ok(path) => path,
+        Err(_) => invalid_session_socket_path(session),
+    }
+}
+
+fn default_socket_path_for_session(session: &str) -> PathBuf {
     let base = std::env::var_os("XDG_RUNTIME_DIR")
         .filter(|value| !value.is_empty())
         .or_else(|| std::env::var_os("TMPDIR").filter(|value| !value.is_empty()))
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"));
     default_socket_path_in_runtime_dir(session, base.join(private_runtime_dir_name()))
+}
+
+fn invalid_session_socket_path(session: &str) -> PathBuf {
+    let base = std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os("TMPDIR").filter(|value| !value.is_empty()))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    let component = format!("{}.sock", fnv1a_hex(session.as_bytes()));
+    let preferred =
+        base.join(format!("cmux-tui-invalid-{}", current_uid_component())).join(component);
+    if unix_socket_path_fits(&preferred) {
+        preferred
+    } else {
+        PathBuf::from("/tmp")
+            .join(format!("cmux-tui-invalid-{}", current_uid_component()))
+            .join(format!("{}.sock", fnv1a_hex(session.as_bytes())))
+    }
 }
 
 fn default_socket_path_in_runtime_dir(session: &str, runtime_dir: PathBuf) -> PathBuf {
@@ -635,6 +710,15 @@ fn unix_socket_path_fits(path: &Path) -> bool {
 fn current_uid_component() -> String {
     // SAFETY: getuid has no preconditions and does not dereference pointers.
     unsafe { libc::getuid() }.to_string()
+}
+
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 #[cfg(test)]
@@ -719,6 +803,7 @@ mod tests {
             "nested\\session",
             "bad\0name",
             "bad\nname",
+            "bad\u{0085}name",
             "bad\u{2028}name",
             "bad\u{2029}name",
         ] {
@@ -734,6 +819,18 @@ mod tests {
             );
         }
         assert!(try_default_socket_path(&format!("legacy-{}", "x".repeat(200))).is_ok());
+
+        let escaped = default_socket_path("../escape");
+        let other_escaped = default_socket_path("nested/escape");
+        assert_ne!(escaped, other_escaped);
+        assert!(!escaped.to_string_lossy().contains("../"));
+        assert!(
+            escaped
+                .parent()
+                .and_then(Path::file_name)
+                .is_some_and(|name| name.to_string_lossy().starts_with("cmux-tui-invalid-"))
+        );
+        assert!(ClientConfig::try_from_env_or_default_session("../escape").is_err());
     }
 
     #[test]

--- a/cmux-tui/bindings/rust/src/client.rs
+++ b/cmux-tui/bindings/rust/src/client.rs
@@ -173,9 +173,14 @@ impl ClientConfig {
         }
     }
 
+    /// Builds a configuration from the environment or a named session.
+    ///
+    /// This source-compatible convenience API cannot return an error. It
+    /// panics for an invalid session name; callers handling user input should
+    /// use [`Self::try_from_env_or_default_session`] instead.
     pub fn from_env_or_default_session(session: &str) -> Self {
-        let socket_path = env_socket_path().unwrap_or_else(|| default_socket_path(session));
-        Self::from_socket_path(socket_path)
+        Self::try_from_env_or_default_session(session)
+            .unwrap_or_else(|error| panic!("invalid session name: {error}"))
     }
 
     /// Builds a configuration from the environment or a named session.
@@ -183,12 +188,9 @@ impl ClientConfig {
     /// Unlike [`Self::from_env_or_default_session`], this API reports an
     /// invalid session before constructing a socket path. The older
     /// non-fallible API remains source-compatible and uses an isolated,
-    /// deterministic path for invalid names.
+    /// deterministic path only through the path-only compatibility helper.
     pub fn try_from_env_or_default_session(session: &str) -> Result<Self> {
-        let socket_path = match env_socket_path() {
-            Some(path) => path,
-            None => try_default_socket_path(session)?,
-        };
+        let socket_path = socket_path_for_session(session, env_socket_path())?;
         Ok(Self::from_socket_path(socket_path))
     }
 
@@ -216,7 +218,8 @@ impl ClientConfig {
 
 impl Default for ClientConfig {
     fn default() -> Self {
-        Self::from_env_or_default_session("main")
+        Self::try_from_env_or_default_session("main")
+            .expect("the built-in main session name is valid")
     }
 }
 
@@ -618,6 +621,16 @@ pub fn env_socket_path() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+pub(crate) fn socket_path_for_session(
+    session: &str,
+    environment_path: Option<PathBuf>,
+) -> Result<PathBuf> {
+    match environment_path {
+        Some(path) => Ok(path),
+        None => try_default_socket_path(session),
+    }
+}
+
 /// Validates the session component used by the default Unix socket path.
 ///
 /// Session names may contain legacy spaces, Unicode, punctuation, and long
@@ -652,8 +665,9 @@ pub fn try_default_socket_path(session: &str) -> Result<PathBuf> {
 ///
 /// New callers should use [`try_default_socket_path`]. If an old caller passes
 /// an invalid name, this wrapper returns a per-input path below a private
-/// invalid-session directory. It never joins the supplied text and cannot
-/// select a normal session socket.
+/// invalid-session directory. It is path-only compatibility behavior, not a
+/// connection route. It never joins the supplied text and cannot select a
+/// normal session socket.
 pub fn default_socket_path(session: &str) -> PathBuf {
     match try_default_socket_path(session) {
         Ok(path) => path,

--- a/cmux-tui/bindings/rust/src/client.rs
+++ b/cmux-tui/bindings/rust/src/client.rs
@@ -676,9 +676,13 @@ fn invalid_session_socket_path(session: &str) -> PathBuf {
         .or_else(|| std::env::var_os("TMPDIR").filter(|value| !value.is_empty()))
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"));
+    invalid_session_socket_path_in_runtime_dir(session, base)
+}
+
+fn invalid_session_socket_path_in_runtime_dir(session: &str, runtime_dir: PathBuf) -> PathBuf {
     let component = format!("{}.sock", fnv1a_hex(session.as_bytes()));
     let preferred =
-        base.join(format!("cmux-tui-invalid-{}", current_uid_component())).join(component);
+        runtime_dir.join(format!("cmux-tui-invalid-{}", current_uid_component())).join(component);
     if unix_socket_path_fits(&preferred) {
         preferred
     } else {
@@ -821,7 +825,9 @@ mod tests {
         assert!(try_default_socket_path(&format!("legacy-{}", "x".repeat(200))).is_ok());
 
         let escaped = default_socket_path("../escape");
+        let escaped_again = default_socket_path("../escape");
         let other_escaped = default_socket_path("nested/escape");
+        assert_eq!(escaped, escaped_again);
         assert_ne!(escaped, other_escaped);
         assert!(!escaped.to_string_lossy().contains("../"));
         assert!(
@@ -829,6 +835,23 @@ mod tests {
                 .parent()
                 .and_then(Path::file_name)
                 .is_some_and(|name| name.to_string_lossy().starts_with("cmux-tui-invalid-"))
+        );
+        let runtime_dir = PathBuf::from("/tmp/cmux-sdk-runtime");
+        let isolated = invalid_session_socket_path_in_runtime_dir("../escape", runtime_dir.clone());
+        assert_eq!(
+            isolated,
+            invalid_session_socket_path_in_runtime_dir("../escape", runtime_dir.clone())
+        );
+        assert!(
+            isolated
+                .components()
+                .all(|component| !matches!(component, std::path::Component::ParentDir))
+        );
+        assert_eq!(isolated.parent().and_then(Path::parent), Some(runtime_dir.as_path()));
+        let legacy_runtime = runtime_dir.join(private_runtime_dir_name());
+        assert_eq!(
+            default_socket_path_in_runtime_dir("legacy name", legacy_runtime.clone()),
+            legacy_runtime.join("legacy name.sock")
         );
         assert!(ClientConfig::try_from_env_or_default_session("../escape").is_err());
     }

--- a/cmux-tui/bindings/rust/src/client.rs
+++ b/cmux-tui/bindings/rust/src/client.rs
@@ -854,6 +854,10 @@ mod tests {
             legacy_runtime.join("legacy name.sock")
         );
         assert!(ClientConfig::try_from_env_or_default_session("../escape").is_err());
+        let invalid_leaf = escaped.file_name().expect("invalid path has a leaf").to_string_lossy();
+        assert_eq!(invalid_leaf.len(), 21, "16 hex hash characters plus .sock");
+        assert!(invalid_leaf[..16].chars().all(|character| character.is_ascii_hexdigit()));
+        assert!(socket_path_for_session("../escape", None).is_err());
     }
 
     #[test]

--- a/cmux-tui/bindings/rust/src/client.rs
+++ b/cmux-tui/bindings/rust/src/client.rs
@@ -709,6 +709,34 @@ mod tests {
     }
 
     #[test]
+    fn session_socket_helpers_reject_unsafe_names_before_joining() {
+        for session in [
+            "",
+            ".",
+            "..",
+            "../escape",
+            "nested/session",
+            "nested\\session",
+            "bad\0name",
+            "bad\nname",
+            "bad\u{2028}name",
+            "bad\u{2029}name",
+        ] {
+            assert!(
+                try_default_socket_path(session).is_err(),
+                "accepted unsafe session {session:?}"
+            );
+        }
+        for session in ["legacy name", "名前", "_legacy", "-legacy", "legacy:colon"] {
+            assert!(
+                try_default_socket_path(session).is_ok(),
+                "rejected legacy-safe session {session:?}"
+            );
+        }
+        assert!(try_default_socket_path(&format!("legacy-{}", "x".repeat(200))).is_ok());
+    }
+
+    #[test]
     fn stream_buffers_events_that_precede_ack() {
         let (path, server) = spawn_stream_server("pre-ack", |mut stream| {
             let mut request = String::new();

--- a/cmux-tui/bindings/rust/src/raw/mod.rs
+++ b/cmux-tui/bindings/rust/src/raw/mod.rs
@@ -6,7 +6,8 @@
 
 pub use crate::client::{
     ClientConfig, CmuxClient as Client, CmuxError as Error, CmuxStream as Stream, Result,
-    ServerInfo, StreamCloser, default_socket_path, env_socket_path,
+    ServerInfo, StreamCloser, default_socket_path, env_socket_path, try_default_socket_path,
+    validate_session_name,
 };
 pub use crate::convenience::{AttachBuilder, SubscriptionBuilder};
 pub use crate::generated::*;

--- a/cmux-tui/bindings/rust/src/resource/client.rs
+++ b/cmux-tui/bindings/rust/src/resource/client.rs
@@ -132,6 +132,15 @@ impl Config {
         Self::from_socket_path(socket_path)
     }
 
+    /// Builds a resource configuration and reports invalid session input.
+    pub fn try_from_env_or_default_session(session: &str) -> Result<Self> {
+        let socket_path = match crate::client::env_socket_path() {
+            Some(path) => path,
+            None => crate::client::try_default_socket_path(session)?,
+        };
+        Ok(Self::from_socket_path(socket_path))
+    }
+
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self

--- a/cmux-tui/bindings/rust/src/resource/client.rs
+++ b/cmux-tui/bindings/rust/src/resource/client.rs
@@ -137,10 +137,8 @@ impl Config {
 
     /// Builds a resource configuration and reports invalid session input.
     pub fn try_from_env_or_default_session(session: &str) -> Result<Self> {
-        let socket_path = crate::client::socket_path_for_session(
-            session,
-            crate::client::env_socket_path(),
-        )?;
+        let socket_path =
+            crate::client::socket_path_for_session(session, crate::client::env_socket_path())?;
         Ok(Self::from_socket_path(socket_path))
     }
 

--- a/cmux-tui/bindings/rust/src/resource/client.rs
+++ b/cmux-tui/bindings/rust/src/resource/client.rs
@@ -126,18 +126,21 @@ impl Config {
         }
     }
 
+    /// Builds a configuration from the environment or a named session.
+    ///
+    /// This source-compatible convenience API panics for invalid session
+    /// input. Use [`Self::try_from_env_or_default_session`] for user input.
     pub fn from_env_or_default_session(session: &str) -> Self {
-        let socket_path = crate::client::env_socket_path()
-            .unwrap_or_else(|| crate::client::default_socket_path(session));
-        Self::from_socket_path(socket_path)
+        Self::try_from_env_or_default_session(session)
+            .unwrap_or_else(|error| panic!("invalid session name: {error}"))
     }
 
     /// Builds a resource configuration and reports invalid session input.
     pub fn try_from_env_or_default_session(session: &str) -> Result<Self> {
-        let socket_path = match crate::client::env_socket_path() {
-            Some(path) => path,
-            None => crate::client::try_default_socket_path(session)?,
-        };
+        let socket_path = crate::client::socket_path_for_session(
+            session,
+            crate::client::env_socket_path(),
+        )?;
         Ok(Self::from_socket_path(socket_path))
     }
 
@@ -192,7 +195,8 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::from_env_or_default_session("main")
+        Self::try_from_env_or_default_session("main")
+            .expect("the built-in main session name is valid")
     }
 }
 

--- a/cmux-tui/bindings/rust/tests/clean_consumer.rs
+++ b/cmux-tui/bindings/rust/tests/clean_consumer.rs
@@ -27,7 +27,7 @@ fn clean_consumer_imports_high_level_and_raw_namespaces_together() {
     assert_eq!(selector.exact_name(), Some("same name"));
     high_level_types((None, None, None, None, None, None, None, None, None));
     raw_types(cmux::raw::PingRequest::default(), None);
-    let _config = Config::from_env_or_default_session("consumer");
+    let _config = Config::try_from_env_or_default_session("consumer").unwrap();
 
     fn typed_recovery_reads(session: &Session, terminal: &Terminal) {
         let _: cmux::Result<CreationResolution> =

--- a/cmux-tui/bindings/rust/tests/public_api.rs
+++ b/cmux-tui/bindings/rust/tests/public_api.rs
@@ -132,8 +132,7 @@ fn root_and_raw_clients_are_distinct_and_both_importable() {
 fn session_socket_helpers_expose_fallible_public_paths() {
     assert!(cmux::raw::try_default_socket_path("../escape").is_err());
     assert!(cmux::raw::validate_session_name("legacy name").is_ok());
-    let _: fn(&str) -> cmux::Result<cmux::Config> =
-        cmux::Config::try_from_env_or_default_session;
+    let _: fn(&str) -> cmux::Result<cmux::Config> = cmux::Config::try_from_env_or_default_session;
     let _: fn(&str) -> cmux::raw::Result<cmux::raw::ClientConfig> =
         cmux::raw::ClientConfig::try_from_env_or_default_session;
 }

--- a/cmux-tui/bindings/rust/tests/public_api.rs
+++ b/cmux-tui/bindings/rust/tests/public_api.rs
@@ -132,7 +132,7 @@ fn root_and_raw_clients_are_distinct_and_both_importable() {
 fn session_socket_helpers_expose_fallible_public_paths() {
     assert!(cmux::raw::try_default_socket_path("../escape").is_err());
     assert!(cmux::raw::validate_session_name("legacy name").is_ok());
-    let _: fn(&str) -> cmux::Result<cmux::Config> = cmux::Config::try_from_env_or_default_session;
+    let _: fn(&str) -> cmux::Result<Config> = Config::try_from_env_or_default_session;
     let _: fn(&str) -> cmux::raw::Result<cmux::raw::ClientConfig> =
         cmux::raw::ClientConfig::try_from_env_or_default_session;
 }

--- a/cmux-tui/bindings/rust/tests/public_api.rs
+++ b/cmux-tui/bindings/rust/tests/public_api.rs
@@ -129,6 +129,16 @@ fn root_and_raw_clients_are_distinct_and_both_importable() {
 }
 
 #[test]
+fn session_socket_helpers_expose_fallible_public_paths() {
+    assert!(cmux::raw::try_default_socket_path("../escape").is_err());
+    assert!(cmux::raw::validate_session_name("legacy name").is_ok());
+    let _: fn(&str) -> cmux::Result<cmux::Config> =
+        cmux::Config::try_from_env_or_default_session;
+    let _: fn(&str) -> cmux::raw::Result<cmux::raw::ClientConfig> =
+        cmux::raw::ClientConfig::try_from_env_or_default_session;
+}
+
+#[test]
 fn optional_metadata_updates_distinguish_unchanged_clear_and_empty() {
     assert_ne!(Update::<String>::Unchanged, Update::Clear);
     assert_ne!(Update::<String>::Clear, Update::Set(String::new()));

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -31,7 +31,13 @@ $TMPDIR
 
 It appends `cmux-tui-<uid>/<session>.sock`. When that path exceeds the platform Unix-socket limit, the server uses its short `/tmp` fallback. The TUI exports the resolved path to child surfaces as `CMUX_TUI_SOCKET` and legacy `CMUX_MUX_SOCKET`. SDKs must prefer an explicit socket or `CMUX_TUI_SOCKET`, then implement the same resolution algorithm.
 
-Protocol v9 does not validate session text before joining it into the path. Callers must currently restrict session names to `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` and reject `.`, `..`, separators, and control characters. vNext makes that validation mandatory in the server.
+The server validates session text before joining it into the path. A name must
+be a non-empty single path component. `.`, `..`, `/`, `\\`, NUL, control
+characters, and Unicode line separators are rejected. Existing names with
+spaces, Unicode, leading punctuation, colons, or long text remain valid. SDKs
+must expose a fallible validation path before opening a derived socket. Legacy
+non-fallible helpers must never join invalid text into the normal socket root;
+they may return a distinct per-input error path for source compatibility.
 
 The `cmux-tui` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path. The socket contains no canonical state. Workspace identity/order, mutation results/tombstones, and frontend projections are stored in SQLite under the platform state directory (macOS: `~/Library/Application Support/cmux-tui/sessions`), or under `--state <root>`. An explicit socket does not change the state root. `--ephemeral` selects an in-memory registry and is mutually exclusive with `--state`.
 

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -37,7 +37,9 @@ characters, and Unicode line separators are rejected. Existing names with
 spaces, Unicode, leading punctuation, colons, or long text remain valid. SDKs
 must expose a fallible validation path before opening a derived socket. Legacy
 non-fallible helpers must never join invalid text into the normal socket root;
-they may return a distinct per-input error path for source compatibility.
+they may return a distinct, hash-derived per-input error path for source
+compatibility. That path is outside the normal `cmux-tui-<uid>` session
+directory and is never a server-derived session socket.
 
 The `cmux-tui` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path. The socket contains no canonical state. Workspace identity/order, mutation results/tombstones, and frontend projections are stored in SQLite under the platform state directory (macOS: `~/Library/Application Support/cmux-tui/sessions`), or under `--state <root>`. An explicit socket does not change the state root. `--ephemeral` selects an in-memory registry and is mutually exclusive with `--state`.
 

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -39,7 +39,9 @@ must expose a fallible validation path before opening a derived socket. Legacy
 non-fallible helpers must never join invalid text into the normal socket root;
 they may return a distinct, hash-derived per-input error path for source
 compatibility. That path is outside the normal `cmux-tui-<uid>` session
-directory and is never a server-derived session socket.
+directory and is never a server-derived session socket. A compatibility hash
+is only a deterministic namespace guard, not a cryptographic identity. SDK
+connectors must use the fallible path and must not open a compatibility path.
 
 The `cmux-tui` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path. The socket contains no canonical state. Workspace identity/order, mutation results/tombstones, and frontend projections are stored in SQLite under the platform state directory (macOS: `~/Library/Application Support/cmux-tui/sessions`), or under `--state <root>`. An explicit socket does not change the state root. `--ephemeral` selects an in-memory registry and is mutually exclusive with `--state`.
 


### PR DESCRIPTION
## Summary

- Validate Rust, Python, and C++ session names before derived socket path use.
- Preserve spaces, Unicode, leading punctuation, colons, and long legacy-safe names.
- Add fallible Rust and C++ helpers. Python raises `ValueError` before opening a socket.
- Keep old Rust/C++ non-fallible helpers source-compatible with distinct per-input invalid-session paths that never join raw input.
- Document explicit socket and environment override behavior.

## Regression proof

- Commit 1 adds behavior tests for traversal, separators, controls, Unicode separators, legacy-safe names, and client construction. It fails because the fallible helper and validation are absent.
- Commit 2 adds the shared relaxed validation behavior and safe compatibility wrappers.

## Verification

- Python SDK: 98 tests passed.
- C++ SDK: CMake unit and installed package consumer tests passed, 2/2.
- Rust formatting check passed.
- SDK generator, resource boundary, schema, spec inventory, Python compile, and diff checks passed.
- Rust/Cargo/Zig/Xcode were not run locally. Hosted SDK checks are required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789539168&installation_model_id=21920&pr_number=10249&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10249&signature=b56d55e414da6aec60495b65d58c6c3fcc291e96538e7bbdebdaca4885c8e797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `cmux-tui` session names before deriving Unix socket paths across C++, Python, and Rust to prevent traversal and control‑character issues. Previously SDKs joined raw session text; now invalid names are rejected before any path use, and legacy non‑fallible helpers route invalid input to isolated per‑input compatibility paths outside normal session sockets.

- C++: Added `try_default_socket_path()` and validate in `resolve_socket_path()`. Non‑fallible `default_socket_path()` maps invalid names to `cmux-tui-invalid-<uid>/<fnv1a>.sock`. Explicit paths and environment overrides still win.
- Python: Exported `validate_session_name()`. `default_socket_path()` and both clients raise `ValueError` for invalid names before any socket open.
- Rust: Exported `validate_session_name()` and `try_default_socket_path()`. Added `raw::ClientConfig::try_from_env_or_default_session()` and `resource::Config::try_from_env_or_default_session()`. Non‑fallible constructors remain source‑compatible but panic on invalid names; fallible constructors/connectors never open compatibility paths. `cmux::raw` re‑exports the new helpers.
- Spec: Requires SDK‑side validation and forbids joining invalid text. Compatibility paths are non‑authoritative and must not be used by connectors.

• Required actions:
  - For untrusted names, use fallible helpers and handle errors: C++ `try_default_socket_path()`, Rust `try_default_socket_path()` or `try_from_env_or_default_session()`. In Python, catch `ValueError`.
  - Do not open compatibility paths; sanitize or replace invalid names, or provide an explicit socket path or environment override.

<sup>Written for commit de1c42443e689ad26520beff0ab8a965625a3498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-name validation across C++, Python, and Rust bindings.
  * Added fallible socket-path helpers that report invalid session names.
  * Added public validation utilities and environment-based configuration helpers.
  * Preserved compatibility for legacy helpers by routing unsafe names to isolated paths.

* **Documentation**
  * Documented accepted and rejected session-name formats and socket-path behavior.

* **Bug Fixes**
  * Prevented invalid session names from selecting or constructing normal socket paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->