### PR TITLE
Fail closed when SDK credential environment lacks review

### DIFF
--- a/.github/workflows/sdk-release-cut.yml
+++ b/.github/workflows/sdk-release-cut.yml
@@ -512,10 +512,34 @@ jobs:
             echo "remote_tag_state_sha256=$remote_tag_state_sha256"
           } >> "$GITHUB_OUTPUT"
 
+  credential-environment-preflight:
+    needs:
+      - revalidate-tags
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify credential environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 cmux-tui/bindings/verify_github_environment_policy.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --environment sdk-release-credentials \
+            --dispatcher "$GITHUB_ACTOR"
+
   cut-tags:
     needs:
       - validate-release
       - revalidate-tags
+      - credential-environment-preflight
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions: {}

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "verify_github_environment_policy.py"
+SPEC = importlib.util.spec_from_file_location(
+    "verify_github_environment_policy",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
+    environment_name = "sdk-release-credentials"
+    dispatcher = "lawrencecchen"
+
+    def environment(
+        self,
+        *,
+        reviewers: object = None,
+        prevent_self_review: object = True,
+        can_admins_bypass: object = False,
+        deployment_branch_policy: object = None,
+    ) -> dict[str, object]:
+        if reviewers is None:
+            reviewers = [
+                {
+                    "type": "User",
+                    "reviewer": {"login": "austinywang"},
+                }
+            ]
+        if deployment_branch_policy is None:
+            deployment_branch_policy = {
+                "protected_branches": True,
+                "custom_branch_policies": False,
+            }
+        return {
+            "name": self.environment_name,
+            "can_admins_bypass": can_admins_bypass,
+            "deployment_branch_policy": deployment_branch_policy,
+            "protection_rules": [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": prevent_self_review,
+                    "reviewers": reviewers,
+                },
+                {"type": "branch_policy"},
+            ],
+        }
+
+    def assert_rejected(self, payload: dict[str, object]) -> None:
+        with self.assertRaises(policy.EnvironmentPolicyError):
+            policy.validate_environment_policy(
+                payload,
+                self.environment_name,
+                self.dispatcher,
+            )
+
+    def test_accepts_a_protected_environment_with_another_reviewer(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+    def test_rejects_missing_required_reviewer_rule(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = [{"type": "branch_policy"}]
+        self.assert_rejected(payload)
+
+    def test_rejects_self_review_only(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "User",
+                        "reviewer": {"login": self.dispatcher},
+                    }
+                ]
+            )
+        )
+
+    def test_rejects_self_review_setting_disabled(self) -> None:
+        self.assert_rejected(self.environment(prevent_self_review=False))
+
+    def test_rejects_administrator_bypass(self) -> None:
+        self.assert_rejected(self.environment(can_admins_bypass=True))
+
+    def test_rejects_unprotected_or_custom_branch_policy(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                deployment_branch_policy={
+                    "protected_branches": False,
+                    "custom_branch_policies": True,
+                }
+            )
+        )
+
+    def test_accepts_a_team_reviewer_with_self_review_disabled(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "Team",
+                        "reviewer": {"slug": "sdk-release-reviewers"},
+                    }
+                ]
+            ),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -74,6 +74,11 @@ class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
         payload["protection_rules"] = [{"type": "branch_policy"}]
         self.assert_rejected(payload)
 
+    def test_rejects_malformed_protection_rules(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = None
+        self.assert_rejected(payload)
+
     def test_rejects_self_review_only(self) -> None:
         self.assert_rejected(
             self.environment(

--- a/cmux-tui/bindings/verify_github_environment_policy.py
+++ b/cmux-tui/bindings/verify_github_environment_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Verify the protection policy on a GitHub Actions environment."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import sys
+from typing import Any, Mapping, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+GITHUB_API_VERSION = "2022-11-28"
+GITHUB_API_URL = "https://api.github.com"
+USER_AGENT = "cmux-sdk-environment-policy/1 (https://github.com/manaflow-ai/cmux)"
+REPOSITORY_PATTERN = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$"
+)
+
+
+class EnvironmentPolicyError(RuntimeError):
+    """Raised when GitHub cannot prove the required environment policy."""
+
+
+def _repository_slug(repository: str) -> str:
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise EnvironmentPolicyError("GitHub repository must be OWNER/REPOSITORY")
+    return repository
+
+
+def _environment_url(
+    api_url: str,
+    repository: str,
+    environment: str,
+) -> str:
+    if not environment or environment.strip() != environment:
+        raise EnvironmentPolicyError("GitHub environment name must be non-empty")
+    return (
+        f"{api_url.rstrip('/')}/repos/{quote(_repository_slug(repository), safe='/')}"
+        f"/environments/{quote(environment, safe='')}"
+    )
+
+
+def _fetch_environment(
+    repository: str,
+    environment: str,
+    token: str,
+    *,
+    api_url: str = GITHUB_API_URL,
+) -> dict[str, Any]:
+    if not token:
+        raise EnvironmentPolicyError("GitHub API token is missing")
+    request = Request(
+        _environment_url(api_url, repository, environment),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = response.read()
+    except HTTPError as error:
+        raise EnvironmentPolicyError(
+            f"GitHub environment lookup failed with HTTP {error.code}"
+        ) from error
+    except (URLError, OSError, http.client.IncompleteRead) as error:
+        raise EnvironmentPolicyError("GitHub environment lookup failed") from error
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise EnvironmentPolicyError(
+            "GitHub environment lookup returned invalid JSON"
+        ) from error
+    if not isinstance(value, dict):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    return value
+
+
+def _reviewer_is_separate(
+    reviewer: Mapping[str, Any],
+    dispatcher: str,
+) -> bool:
+    reviewer_type = reviewer.get("type")
+    subject = reviewer.get("reviewer")
+    if not isinstance(subject, dict):
+        raise EnvironmentPolicyError("GitHub reviewer identity is malformed")
+    if reviewer_type == "User":
+        login = subject.get("login")
+        if not isinstance(login, str) or not login:
+            raise EnvironmentPolicyError("GitHub user reviewer identity is malformed")
+        return login.casefold() != dispatcher.casefold()
+    if reviewer_type == "Team":
+        slug = subject.get("slug")
+        if not isinstance(slug, str) or not slug:
+            raise EnvironmentPolicyError("GitHub team reviewer identity is malformed")
+        # A team is a separate approval principal. GitHub's prevent_self_review
+        # rule prevents the dispatcher from approving their own deployment even
+        # when they belong to that team.
+        return True
+    raise EnvironmentPolicyError("GitHub reviewer type is unsupported")
+
+
+def validate_environment_policy(
+    payload: Mapping[str, Any],
+    expected_environment: str,
+    dispatcher: str,
+) -> None:
+    """Require the protected, independently reviewed credential environment."""
+
+    if not isinstance(payload, Mapping):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    if not expected_environment or payload.get("name") != expected_environment:
+        raise EnvironmentPolicyError("GitHub environment name does not match")
+    if payload.get("can_admins_bypass") is not False:
+        raise EnvironmentPolicyError(
+            "GitHub environment administrator bypass must be disabled"
+        )
+
+    branch_policy = payload.get("deployment_branch_policy")
+    if not isinstance(branch_policy, Mapping) or (
+        branch_policy.get("protected_branches") is not True
+        or branch_policy.get("custom_branch_policies") is not False
+    ):
+        raise EnvironmentPolicyError(
+            "GitHub environment must allow protected branches only"
+        )
+
+    if not isinstance(dispatcher, str) or not dispatcher.strip():
+        raise EnvironmentPolicyError("GitHub dispatch actor is missing")
+    protection_rules = payload.get("protection_rules")
+    if not isinstance(protection_rules, list):
+        raise EnvironmentPolicyError(
+            "GitHub environment protection rules are malformed"
+        )
+    reviewer_rules = [
+        rule
+        for rule in protection_rules
+        if isinstance(rule, Mapping) and rule.get("type") == "required_reviewers"
+    ]
+    if not reviewer_rules:
+        raise EnvironmentPolicyError(
+            "GitHub environment must require an independent reviewer"
+        )
+    for rule in reviewer_rules:
+        if rule.get("prevent_self_review") is not True:
+            raise EnvironmentPolicyError(
+                "GitHub environment must prevent self-review"
+            )
+        reviewers = rule.get("reviewers")
+        if not isinstance(reviewers, list) or not reviewers:
+            raise EnvironmentPolicyError(
+                "GitHub environment required-reviewer list is empty"
+            )
+        if not any(
+            _reviewer_is_separate(reviewer, dispatcher)
+            for reviewer in reviewers
+            if isinstance(reviewer, Mapping)
+        ):
+            raise EnvironmentPolicyError(
+                "GitHub environment has no reviewer other than the dispatcher"
+            )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+    )
+    parser.add_argument("--environment", required=True)
+    parser.add_argument(
+        "--dispatcher",
+        default=os.environ.get("GITHUB_ACTOR", ""),
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("GITHUB_API_URL", GITHUB_API_URL),
+    )
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="environment variable containing the GitHub API token",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        payload = _fetch_environment(
+            args.repository,
+            args.environment,
+            os.environ.get(args.token_env, ""),
+            api_url=args.api_url,
+        )
+        validate_environment_policy(payload, args.environment, args.dispatcher)
+    except EnvironmentPolicyError as error:
+        print(f"GitHub environment policy verification failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"verified GitHub environment policy for {args.repository}/"
+        f"{args.environment}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sdk_release_credential_environment_policy.py
+++ b/tests/test_sdk_release_credential_environment_policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "sdk-release-cut.yml"
+
+
+def workflow_job(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_sdk_release_credential_environment_policy_is_fail_closed() -> None:
+    release = WORKFLOW.read_text()
+    policy = workflow_job(release, "credential-environment-preflight")
+    cut_tags = workflow_job(release, "cut-tags")
+
+    assert "actions: read" in policy
+    assert "contents: read" in policy
+    assert "GITHUB_TOKEN: ${{ github.token }}" in policy
+    assert "verify_github_environment_policy.py" in policy
+    assert "--environment sdk-release-credentials" in policy
+    assert "--dispatcher \"$GITHUB_ACTOR\"" in policy
+    assert "credential-environment-preflight" in cut_tags
+    assert release.index("revalidate-tags:") < release.index(
+        "credential-environment-preflight:"
+    ) < release.index("cut-tags:")


### PR DESCRIPTION
## Summary

- Add a credential-free preflight that reads the `sdk-release-credentials` GitHub environment policy before the tag-cut job can start.
- Fail closed unless protected branches are required, administrator bypass is disabled, and a required reviewer other than the dispatcher must approve with self-review prevention enabled.
- Add behavior tests for valid and unsafe environment responses plus a workflow wiring contract.

## Live audit evidence

The current `manaflow-ai/cmux` environment response is:

- `can_admins_bypass: false`
- `deployment_branch_policy.protected_branches: true`
- `deployment_branch_policy.custom_branch_policies: false`
- `protection_rules: [{"type":"branch_policy"}]`

The required-reviewer rule is absent. The new preflight fails with `GitHub environment must require an independent reviewer`, so the release remains blocked until an administrator configures the environment. No environment setting was changed.

## Regression sequence

- `533973e7bd` adds the failing behavior tests.
- `8bb1cd7e0d` adds the validator and workflow gate.

## Testing

- `python3 -m unittest discover -s cmux-tui/bindings/tests -p 'test_*.py' -v` (135 passed)
- `python3 -m pytest -q tests/test_sdk_release_credential_environment_policy.py tests/test_tui_publish_workflow_security.py` (48 passed)
- `python3 -m compileall -q cmux-tui/bindings/verify_github_environment_policy.py`
- `git diff --check`
- `actionlint .github/workflows/sdk-release-cut.yml` (existing SC2035 warnings only)

## Issues

- Related: https://github.com/manaflow-ai/cmux/pull/10245

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789539657&installation_model_id=21920&pr_number=10250&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10250&signature=e1ff4f20f514e7d2b31fb79e940f09743e14f1e157b83208d4b8d2f40b191b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on SDK tag cuts when the `sdk-release-credentials` environment lacks independent review. Previously, `cut-tags` ran regardless of environment protections; now a preflight job verifies policy and blocks the release until it meets strict rules.

- Adds a `credential-environment-preflight` job that runs before `cut-tags` and uses the new validator to read the environment via the GitHub API with `GITHUB_TOKEN`. It enforces: protected-branches-only (no custom policies), administrator bypass disabled, required reviewers present with self-review prevented, and at least one reviewer other than the dispatcher. Tests cover valid and unsafe responses and workflow wiring.

**Rollout**
- Configure the `sdk-release-credentials` environment to: require protected branches only, disable administrator bypass, require reviewers with prevent self-review enabled, and include at least one reviewer who is not the dispatcher. Releases will remain blocked until these settings are in place.

<sup>Written for commit 8bb1cd7e0d14d9c455826a9bb9b6cced54150152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

