### PR TITLE
fix: align cmux-tui binary version with distribution metadata

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "npm package version, or the shared stable X.Y.Z version"
+        description: "canonical binary and npm version, or the shared stable X.Y.Z version"
         required: true
         type: string
       pypi_version:
-        description: "PyPI package version; defaults to version"
+        description: "PyPI metadata version; defaults to version and does not change the binary stamp"
         required: false
         default: ""
         type: string
@@ -640,6 +640,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1
@@ -704,6 +706,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -636,8 +636,14 @@ jobs:
                   raise SystemExit(f"{hook} is not executable")
           PY
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
           CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
           CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
           export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
@@ -656,6 +662,10 @@ jobs:
           if probe.get("distribution_version") != expected:
               raise SystemExit(
                   f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(
+                  f"binary version {probe.get('version')!r} != {expected!r}"
               )
           if probe.get("npm_bootstrap_version") != expected:
               raise SystemExit(
@@ -690,8 +700,36 @@ jobs:
                       raise SystemExit(f"{path}: bundled cmux-tui-hook is not executable")
           PY
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
+          CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
+          CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
+          export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
+          python3 - <<'PY'
+          import json
+          import os
+
+          probe = json.loads(os.environ["CMUX_TUI_PROBE"])
+          expected = os.environ["NPM_VERSION"]
+          expected_identity = os.environ["CMUX_TUI_EXPECTED_BUILD_IDENTITY"]
+          if probe.get("build_identity") != expected_identity:
+              raise SystemExit(
+                  f"binary build identity {probe.get('build_identity')!r} "
+                  f"!= {expected_identity!r}"
+              )
+          if probe.get("distribution_version") != expected:
+              raise SystemExit(
+                  f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(f"binary version {probe.get('version')!r} != {expected!r}")
+          PY
           python3 -m venv /tmp/cmux-tui-wheel-smoke
           /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="$PYPI_VERSION"
           /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt

--- a/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
+++ b/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
@@ -10,12 +10,7 @@ use tokio::process::{Child, Command};
 
 const SSH_BOOTSTRAP_OUTPUT_LIMIT: usize = 4_096;
 
-/// The version of the npm/PyPI distribution that contains this binary. Release
-/// workflows stamp it independently from the Rust crate's internal version.
-pub const DISTRIBUTION_VERSION: &str = match option_env!("CMUX_TUI_DISTRIBUTION_VERSION") {
-    Some(version) => version,
-    None => env!("CARGO_PKG_VERSION"),
-};
+pub use cmux_tui_core::DISTRIBUTION_VERSION;
 pub const NPM_BOOTSTRAP_VERSION: Option<&str> = option_env!("CMUX_TUI_NPM_BOOTSTRAP_VERSION");
 pub const BUILD_IDENTITY: &str = env!("CMUX_TUI_BUILD_IDENTITY");
 

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod terminal_host_protocol;
 pub mod terminal_host_runtime;
 #[cfg(unix)]
 pub mod unix_process_scope;
+mod version;
 
 pub use agent_hooks::{
     AGENT_HOOK_MANIFEST_VERSION, AGENT_HOOK_PRODUCER_ID, agent_hook_journal_ingress,
@@ -78,6 +79,7 @@ pub use surface::{
     SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
     TerminalPointerSnapshot,
 };
+pub use version::DISTRIBUTION_VERSION;
 pub use workspace_registry::{
     FrontendProjection, JournalAppendCommit, JournalAuthority, JournalCheckpoint, JournalClass,
     JournalContentRef, JournalEventSchema, JournalHookDeliveryPolicy, JournalHookExec,

--- a/cmux-tui/crates/cmux-tui-core/src/version.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/version.rs
@@ -1,0 +1,46 @@
+//! Version identity shared by every cmux-tui binary entrypoint.
+
+/// Resolve the version stamped into a distributed binary.
+///
+/// Release workflows provide `CMUX_TUI_DISTRIBUTION_VERSION`. Local builds do
+/// not set it, so they retain the Cargo package version as their fallback.
+const fn resolve_distribution_version<'a>(
+    stamped_version: Option<&'a str>,
+    cargo_version: &'a str,
+) -> &'a str {
+    match stamped_version {
+        Some(version) => version,
+        None => cargo_version,
+    }
+}
+
+/// Canonical version shown by `cmux-tui --version` and `remote-probe`.
+///
+/// Stable releases use the shared `X.Y.Z` package version. Nightly builds use
+/// the npm-form prerelease stamp; the PyPI `.dev...` suffix remains packaging
+/// metadata because one binary is shared by both registries.
+pub const DISTRIBUTION_VERSION: &str = resolve_distribution_version(
+    option_env!("CMUX_TUI_DISTRIBUTION_VERSION"),
+    env!("CARGO_PKG_VERSION"),
+);
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_distribution_version;
+
+    #[test]
+    fn stable_release_stamp_overrides_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(Some("0.11.0"), "0.1.0"), "0.11.0");
+    }
+
+    #[test]
+    fn nightly_binary_stamp_preserves_the_npm_prerelease_form() {
+        let nightly = "0.11.1-nightly.20260817.42";
+        assert_eq!(resolve_distribution_version(Some(nightly), "0.1.0"), nightly);
+    }
+
+    #[test]
+    fn local_builds_fall_back_to_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(None, "0.1.0"), "0.1.0");
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -86,7 +86,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Context;
 use cmux_tui_core::resource::TerminalPublicId;
-use cmux_tui_core::{Mux, ProviderWorkspaceAuthority, SurfaceOptions};
+use cmux_tui_core::{DISTRIBUTION_VERSION, Mux, ProviderWorkspaceAuthority, SurfaceOptions};
 #[cfg(unix)]
 use cmux_tui_machine_protocol::BearerToken;
 use machine::{
@@ -768,17 +768,18 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
 fn version_string() -> String {
     // Packaged builds stamp both source identities so artifact validation can
     // reject a cmux binary built against a different Ghostty checkout before
-    // it enters an app bundle. Local builds report the crate version alone.
+    // it enters an app bundle. The version follows the canonical distribution
+    // stamp and falls back to the Cargo version for local builds.
     let commit = option_env!("CMUX_TUI_BUILD_COMMIT")
         .or(option_env!("CMUX_MUX_BUILD_COMMIT"))
         .filter(|commit| !commit.is_empty());
     let ghostty = option_env!("CMUX_TUI_GHOSTTY_COMMIT").filter(|commit| !commit.is_empty());
     match (commit, ghostty) {
         (Some(commit), Some(ghostty)) => {
-            format!("{} ({commit}; ghostty {ghostty})", env!("CARGO_PKG_VERSION"))
+            format!("{DISTRIBUTION_VERSION} ({commit}; ghostty {ghostty})")
         }
-        (Some(commit), None) => format!("{} ({commit})", env!("CARGO_PKG_VERSION")),
-        (None, _) => env!("CARGO_PKG_VERSION").to_string(),
+        (Some(commit), None) => format!("{DISTRIBUTION_VERSION} ({commit})"),
+        (None, _) => DISTRIBUTION_VERSION.to_string(),
     }
 }
 
@@ -2595,6 +2596,16 @@ mod tests {
 
     fn args(values: &[&str]) -> Args {
         parse_args_result(values.iter().map(|value| value.to_string())).unwrap()
+    }
+
+    #[test]
+    fn version_output_uses_the_canonical_distribution_stamp() {
+        let output = version_string();
+        assert!(
+            output == DISTRIBUTION_VERSION
+                || output.starts_with(&format!("{DISTRIBUTION_VERSION} (")),
+            "version output {output:?} does not use distribution version {DISTRIBUTION_VERSION:?}"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -31,11 +31,12 @@ use cmux_remote::provider::{
     RelayCredentialSource, SshProvider, SshProviderConfig, SupportedClientAuthModes,
     sanitized_route,
 };
-use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, DISTRIBUTION_VERSION, NPM_BOOTSTRAP_VERSION};
+use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, NPM_BOOTSTRAP_VERSION};
 use cmux_remote_protocol::{
     LanePolicy, REMOTE_PROTOCOL_VERSION, RoutePolicy, SessionId, WorkspaceRequest,
     WorkspaceResponse,
 };
+use cmux_tui_core::DISTRIBUTION_VERSION;
 use serde_json::Value;
 use url::Url;
 use zeroize::Zeroizing;
@@ -1687,28 +1688,31 @@ fn print_admin_response(action: &str, response: AdminResponse, json: bool) -> an
 }
 
 fn run_probe(args: &[String]) -> anyhow::Result<()> {
-    let value = serde_json::json!({
-        "app": "cmux-tui",
-        "version": env!("CARGO_PKG_VERSION"),
-        "distribution_version": DISTRIBUTION_VERSION,
-        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
-        "build_identity": BUILD_IDENTITY,
-        "remote_protocol": REMOTE_PROTOCOL_VERSION,
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-    });
+    let value = probe_value();
     if args.iter().any(|argument| argument == "--json") {
         println!("{}", serde_json::to_string(&value)?);
     } else {
         println!(
-            "cmux-tui {} remote-protocol={} {}-{}",
-            env!("CARGO_PKG_VERSION"),
+            "cmux-tui {DISTRIBUTION_VERSION} remote-protocol={} {}-{}",
             REMOTE_PROTOCOL_VERSION,
             std::env::consts::OS,
             std::env::consts::ARCH
         );
     }
     Ok(())
+}
+
+fn probe_value() -> Value {
+    serde_json::json!({
+        "app": "cmux-tui",
+        "version": DISTRIBUTION_VERSION,
+        "distribution_version": DISTRIBUTION_VERSION,
+        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
+        "build_identity": BUILD_IDENTITY,
+        "remote_protocol": REMOTE_PROTOCOL_VERSION,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+    })
 }
 
 struct PendingInstall {
@@ -2469,6 +2473,13 @@ fn expand_home(path: String) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_probe_uses_one_canonical_distribution_version() {
+        let value = probe_value();
+        assert_eq!(value["version"].as_str(), Some(DISTRIBUTION_VERSION));
+        assert_eq!(value["distribution_version"].as_str(), Some(DISTRIBUTION_VERSION));
+    }
 
     fn seed_legacy_authorization_state(state_dir: &Path) {
         let auth_state_dir = state_dir.join("auth");

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -8,9 +8,19 @@ TUI distribution versions are independent of the SDK version. SDKs publish as
 `cmux-sdk` on npm and PyPI, so the `cmux` name remains exclusive to this TUI
 release path.
 
-The TUI does not store its version in a checked-in manifest. The packaging
-scripts receive `--version`, so cutting a stable TUI release is just creating a
-`cmux-tui-vX.Y.Z` tag on `main`.
+The TUI does not store its version in a checked-in manifest. The reusable build
+workflow receives one canonical `version` input and exports it as
+`CMUX_TUI_DISTRIBUTION_VERSION`. `cmux-tui --version` and the `version` and
+`distribution_version` fields from `remote-probe --json` all use that stamp;
+the Cargo crate version remains an internal fallback for local builds.
+
+Stable builds pass the same `X.Y.Z` value to the binary, npm metadata, and PyPI
+metadata. Nightly builds keep the existing registry-specific forms: the npm
+form is the canonical binary stamp, while the PyPI `.dev...` value is wheel
+metadata only because both registries ship the same binaries.
+
+The packaging scripts receive their registry-specific `--version` values, so
+cutting a stable TUI release is just creating a `cmux-tui-vX.Y.Z` tag on `main`.
 
 ## Packages
 


### PR DESCRIPTION
## Summary

- Centralize `CMUX_TUI_DISTRIBUTION_VERSION` in `cmux-tui-core` and keep Cargo package version semantics unchanged.
- Make `cmux-tui --version`, remote-probe text, and both remote-probe JSON version fields use the canonical distribution stamp.
- Add stable, nightly, and local fallback behavior tests, release smoke checks, and release documentation.

## Regression evidence

The published 0.10.0 TUI packages exposed inconsistent identities: all four npm binaries (`cmux-tui-darwin-arm64`, `cmux-tui-darwin-x64`, `cmux-tui-linux-arm64`, and `cmux-tui-linux-x64`) and all six `cmux` PyPI wheels (macOS arm64/x86_64, manylinux arm64/x86_64, musllinux arm64/x86_64) reported `cmux-tui 0.1.0`, while their npm/PyPI metadata was `0.10.0`.

The test-only commit [`995f72527f`](https://github.com/manaflow-ai/cmux/commit/995f72527f) made the package artifact checks enforce the expected identity. Its hosted run [31998467903](https://github.com/manaflow-ai/cmux/actions/runs/31998467903) failed at `package distributions`, proving the regression.

The fix is [`920ff20fd3`](https://github.com/manaflow-ai/cmux/commit/920ff20fd356381a04b137ade53ce4df98495ee9). Focused hosted verification passed in [31999445120](https://github.com/manaflow-ai/cmux/actions/runs/31999445120). Full hosted verification passed at [32000348701](https://github.com/manaflow-ai/cmux/actions/runs/32000348701) for this exact head.

## Version contract

- Stable release: `CMUX_TUI_DISTRIBUTION_VERSION=0.11.0`; binary output, npm metadata, and PyPI metadata all use `0.11.0`.
- Nightly release: the binary and npm package use the existing npm-form stamp; PyPI may retain a `.dev...` metadata suffix because the same binary is shared.
- Local builds: when the environment stamp is absent, binaries fall back to Cargo package version `0.1.0`.

## Hosted test scope

- Linux and macOS TUI test jobs, including core tests, parser tests, scripted PTY smoke, and detach/reattach smoke.
- Focused distribution-version tests, Valgrind startup and full checks, bindings E2E, and web frontend checks.
- All four Unix package builds plus Windows artifact build.
- npm and PyPI package smoke checks assert binary `--version`, remote-probe JSON version, build identity, and package metadata.
- Linux package entrypoint verification for x64 and arm64.

No local Rust, Cargo, Zig, or Xcode builds were used. This PR does not publish, tag, or merge anything.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789539858&installation_model_id=21920&pr_number=10251&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10251&signature=dfc49e0714f0de568c2c414eee4be292a86b0c50fef9f8a2b036727c5d6c5c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `cmux-tui` binary version with distribution metadata and centralizes stamping. Previously binaries reported the Cargo crate version; now `--version` and `remote-probe` use one canonical distribution stamp, with local builds falling back to the crate version.

- Centralizes `DISTRIBUTION_VERSION` in `cmux-tui-core`, resolved from `CMUX_TUI_DISTRIBUTION_VERSION` or `CARGO_PKG_VERSION` for local builds.
- Updates `cmux --version` and `remote-probe --json` to report the canonical distribution version; both `"version"` and `"distribution_version"` are identical.
- Tightens CI smoke checks: `--version` must start with `NPM_VERSION`; probe JSON fields (`version`, `distribution_version`, `npm_bootstrap_version`) and `build_identity` must match.
- Keeps release behavior consistent: stable uses `X.Y.Z` across binary, npm, and PyPI; nightly uses the npm-form prerelease stamp in the binary and npm, while PyPI’s `.dev…` remains metadata only.
- Rollout: release workflows must pass the canonical `version` input; optional `pypi_version` only affects PyPI metadata and does not change the binary stamp.

<sup>Written for commit 920ff20fd356381a04b137ade53ce4df98495ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->