### PR TITLE
Verify Windows TUI artifact before rolling latest

### DIFF
--- a/.github/workflows/cmux-tui-artifacts.yml
+++ b/.github/workflows/cmux-tui-artifacts.yml
@@ -102,6 +102,16 @@ jobs:
           build_manifest assets/cmux-tui cmux-tui- cmux-tui-checksums.txt
           build_manifest assets/cmux-relay cmux-relay- cmux-relay-checksums.txt
 
+      - name: Verify cmux-tui manifest before upload
+        env:
+          EXPECTED_WINDOWS_ARTIFACT: cmux-tui-x86_64-pc-windows-gnu.exe
+        run: |
+          set -euo pipefail
+          python3 cmux-tui/scripts/verify_published_manifest.py \
+            --manifest-file assets/cmux-tui/manifest.json \
+            --expected-commit "$GITHUB_SHA" \
+            --require-artifact "$EXPECTED_WINDOWS_ARTIFACT"
+
       - name: Upload to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
@@ -125,10 +135,6 @@ jobs:
           }
           publish_prefix assets/cmux-tui "cmux-tui/$GITHUB_SHA" "public, max-age=31536000, immutable"
           publish_prefix assets/cmux-relay "cmux-relay/$GITHUB_SHA" "public, max-age=31536000, immutable"
-          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            publish_prefix assets/cmux-tui "cmux-tui/latest" "no-cache, no-store, must-revalidate"
-            publish_prefix assets/cmux-relay "cmux-relay/latest" "no-cache, no-store, must-revalidate"
-          fi
           echo "Published: https://files.cmux.com/cmux-tui/$GITHUB_SHA/manifest.json"
           echo "Published: https://files.cmux.com/cmux-relay/$GITHUB_SHA/manifest.json"
 
@@ -176,6 +182,68 @@ jobs:
             done
           }
           publish_legacy_prefix "mux/$GITHUB_SHA" "public, max-age=31536000, immutable"
+
+      - name: Verify immutable cmux-tui manifest before latest publish
+        env:
+          EXPECTED_WINDOWS_ARTIFACT: cmux-tui-x86_64-pc-windows-gnu.exe
+        run: |
+          set -euo pipefail
+          python3 cmux-tui/scripts/verify_published_manifest.py \
+            --manifest-url "https://files.cmux.com/cmux-tui/$GITHUB_SHA/manifest.json" \
+            --expected-commit "$GITHUB_SHA" \
+            --require-artifact "$EXPECTED_WINDOWS_ARTIFACT"
+
+      - name: Publish rolling latest artifacts
+        if: github.ref == 'refs/heads/main'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          publish_prefix() {
+            local directory="$1"
+            local prefix="$2"
+            local cache="$3"
+            for file in "$directory"/*; do
+              python3 scripts/ci/upload-r2-object.py \
+                --file "$file" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --bucket cmux-binaries \
+                --key "$prefix/$(basename "$file")" \
+                --cache-control "$cache"
+            done
+          }
+          publish_prefix assets/cmux-tui "cmux-tui/latest" "no-cache, no-store, must-revalidate"
+          publish_prefix assets/cmux-relay "cmux-relay/latest" "no-cache, no-store, must-revalidate"
+
+          publish_legacy_prefix() {
+            local prefix="$1"
+            local cache="$2"
+            for file in assets-legacy/*; do
+              python3 scripts/ci/upload-r2-object.py \
+                --file "$file" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --bucket cmux-binaries \
+                --key "$prefix/$(basename "$file")" \
+                --cache-control "$cache"
+            done
+          }
+          publish_legacy_prefix "mux/latest" "no-cache, no-store, must-revalidate"
+
+      - name: Verify published cmux-tui manifests
+        env:
+          EXPECTED_WINDOWS_ARTIFACT: cmux-tui-x86_64-pc-windows-gnu.exe
+        run: |
+          set -euo pipefail
+          python3 cmux-tui/scripts/verify_published_manifest.py \
+            --manifest-url "https://files.cmux.com/cmux-tui/$GITHUB_SHA/manifest.json" \
+            --expected-commit "$GITHUB_SHA" \
+            --require-artifact "$EXPECTED_WINDOWS_ARTIFACT"
           if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            publish_legacy_prefix "mux/latest" "no-cache, no-store, must-revalidate"
+            python3 cmux-tui/scripts/verify_published_manifest.py \
+              --manifest-url "https://files.cmux.com/cmux-tui/latest/manifest.json?verify=$GITHUB_SHA" \
+              --expected-commit "$GITHUB_SHA" \
+              --require-artifact "$EXPECTED_WINDOWS_ARTIFACT"
           fi

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -24,7 +24,9 @@ on:
       - ".github/workflows/sdk-release-cut.yml"
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_installers.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "web/public/tui/install-static.ps1"
   pull_request:
     paths:
       - "cmux-tui/**"
@@ -46,7 +48,9 @@ on:
       - ".github/workflows/sdk-release-cut.yml"
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_installers.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "web/public/tui/install-static.ps1"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-artifacts.yml"
       - ".github/workflows/cmux-tui-nightly.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
@@ -28,6 +29,7 @@ on:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-artifacts.yml"
       - ".github/workflows/cmux-tui-nightly.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
@@ -77,6 +79,9 @@ jobs:
 
       - name: Test protocol inventory
         run: python3 cmux-tui/scripts/test_check_spec_inventory.py
+
+      - name: Test published artifact manifest verifier
+        run: python3 -m unittest discover -s cmux-tui/scripts -p 'test_verify_published_manifest.py' -v
 
       - name: Check protocol and TUI action inventory
         run: python3 cmux-tui/scripts/check-spec-inventory.py

--- a/cmux-tui/scripts/test_verify_published_manifest.py
+++ b/cmux-tui/scripts/test_verify_published_manifest.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("verify_published_manifest.py")
+SPEC = importlib.util.spec_from_file_location("verify_published_manifest", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+class FakeResponse:
+    def __init__(self, body: dict[str, object]) -> None:
+        self.body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+class VerifyPublishedManifestTests(TestCase):
+    COMMIT = "a" * 40
+    WINDOWS = "cmux-tui-x86_64-pc-windows-gnu.exe"
+    CURRENT_UNIX_ONLY_MANIFEST = {
+        "commit": "2dc5237c59e06b8f1007533cd4d14b13e702e553",
+        "builtAt": "2026-07-15T06:35:13.005735+00:00",
+        "binaries": {
+            "cmux-tui-aarch64-apple-darwin":
+                "21311bd5af176f5196937240b4f38c4810f01ed2e219731e8ba122256512b58d",
+            "cmux-tui-aarch64-unknown-linux-gnu":
+                "cc50a9cf5040f3d3a7d02d5d9faae6a479967adf3c3f5abb4c4c34796dee3046",
+            "cmux-tui-x86_64-apple-darwin":
+                "66ac1ee6d31fbb8de1004668de6517f59c075899a359c3946fce92f9273d3741",
+            "cmux-tui-x86_64-unknown-linux-gnu":
+                "8455dcebdb91d47a3988d64679f1d1ac0919ab558286e3a016ec88c24dce463a",
+        },
+    }
+
+    def manifest(self, *, windows: bool = True) -> dict[str, object]:
+        binaries: dict[str, str] = {}
+        if windows:
+            binaries[self.WINDOWS] = "b" * 64
+        return {"commit": self.COMMIT, "binaries": binaries}
+
+    def verify(self, manifest: dict[str, object], *extra: str) -> None:
+        with patch.object(VERIFY, "urlopen", return_value=FakeResponse(manifest)):
+            VERIFY.verify_manifest(
+                "https://files.example/cmux-tui/latest/manifest.json",
+                expected_commit=self.COMMIT,
+                required_artifacts=(self.WINDOWS,),
+                extra_args=extra,
+            )
+
+    def test_accepts_required_windows_artifact_and_digest(self) -> None:
+        self.verify(self.manifest())
+
+    def test_rejects_manifest_without_windows_artifact(self) -> None:
+        with self.assertRaisesRegex(VERIFY.ManifestError, "missing required artifact"):
+            self.verify(self.manifest(windows=False))
+
+    def test_rejects_current_unix_only_latest_manifest(self) -> None:
+        manifest = self.CURRENT_UNIX_ONLY_MANIFEST
+        with patch.object(VERIFY, "urlopen", return_value=FakeResponse(manifest)):
+            with self.assertRaisesRegex(
+                VERIFY.ManifestError,
+                "missing required artifact",
+            ):
+                VERIFY.verify_manifest(
+                    "https://files.example/cmux-tui/latest/manifest.json",
+                    expected_commit=manifest["commit"],
+                    required_artifacts=(self.WINDOWS,),
+                )
+
+    def test_rejects_manifest_with_invalid_digest(self) -> None:
+        manifest = self.manifest()
+        manifest["binaries"] = {self.WINDOWS: "not-a-sha256"}
+        with self.assertRaisesRegex(VERIFY.ManifestError, "invalid SHA-256"):
+            self.verify(manifest)
+
+    def test_rejects_manifest_for_a_different_commit(self) -> None:
+        manifest = self.manifest()
+        manifest["commit"] = "c" * 40
+        with self.assertRaisesRegex(VERIFY.ManifestError, "commit mismatch"):
+            self.verify(manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmux-tui/scripts/test_verify_published_manifest.py
+++ b/cmux-tui/scripts/test_verify_published_manifest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import re
 import tempfile
 from unittest import TestCase, main
 from unittest.mock import patch
@@ -13,6 +14,7 @@ import yaml
 SCRIPT = Path(__file__).with_name("verify_published_manifest.py")
 ROOT = SCRIPT.parents[2]
 ARTIFACT_WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui-artifacts.yml"
+WINDOWS_INSTALLER = ROOT / "web" / "public" / "tui" / "install-static.ps1"
 SPEC = importlib.util.spec_from_file_location("verify_published_manifest", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 VERIFY = importlib.util.module_from_spec(SPEC)
@@ -91,6 +93,11 @@ class VerifyPublishedManifestTests(TestCase):
         self.assertIs(build["include_windows"], True)
         self.assertIs(build["package_npm"], False)
         self.assertIs(build["package_pypi"], False)
+
+        installer = WINDOWS_INSTALLER.read_text(encoding="utf-8")
+        advertised = re.search(r'^\$Artifact = "([^"]+)"$', installer, re.MULTILINE)
+        self.assertIsNotNone(advertised)
+        self.assertEqual(advertised.group(1), self.WINDOWS)
 
         steps = document["jobs"]["publish"]["steps"]
         names = [step.get("name", "") for step in steps]

--- a/cmux-tui/scripts/test_verify_published_manifest.py
+++ b/cmux-tui/scripts/test_verify_published_manifest.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import tempfile
 from unittest import TestCase, main
 from unittest.mock import patch
 
+import yaml
+
 
 SCRIPT = Path(__file__).with_name("verify_published_manifest.py")
+ROOT = SCRIPT.parents[2]
+ARTIFACT_WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui-artifacts.yml"
 SPEC = importlib.util.spec_from_file_location("verify_published_manifest", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 VERIFY = importlib.util.module_from_spec(SPEC)
@@ -52,13 +57,12 @@ class VerifyPublishedManifestTests(TestCase):
             binaries[self.WINDOWS] = "b" * 64
         return {"commit": self.COMMIT, "binaries": binaries}
 
-    def verify(self, manifest: dict[str, object], *extra: str) -> None:
+    def verify(self, manifest: dict[str, object]) -> None:
         with patch.object(VERIFY, "urlopen", return_value=FakeResponse(manifest)):
             VERIFY.verify_manifest(
                 "https://files.example/cmux-tui/latest/manifest.json",
                 expected_commit=self.COMMIT,
                 required_artifacts=(self.WINDOWS,),
-                extra_args=extra,
             )
 
     def test_accepts_required_windows_artifact_and_digest(self) -> None:
@@ -81,11 +85,62 @@ class VerifyPublishedManifestTests(TestCase):
                     required_artifacts=(self.WINDOWS,),
                 )
 
+    def test_artifact_workflow_verifies_windows_before_rolling_latest(self) -> None:
+        document = yaml.safe_load(ARTIFACT_WORKFLOW.read_text(encoding="utf-8"))
+        build = document["jobs"]["build"]["with"]
+        self.assertIs(build["include_windows"], True)
+        self.assertIs(build["package_npm"], False)
+        self.assertIs(build["package_pypi"], False)
+
+        steps = document["jobs"]["publish"]["steps"]
+        names = [step.get("name", "") for step in steps]
+        before_upload = names.index("Verify cmux-tui manifest before upload")
+        upload = names.index("Upload to R2")
+        before_latest = names.index("Verify immutable cmux-tui manifest before latest publish")
+        rolling = names.index("Publish rolling latest artifacts")
+        after_publish = names.index("Verify published cmux-tui manifests")
+        self.assertLess(before_upload, upload)
+        self.assertLess(upload, before_latest)
+        self.assertLess(before_latest, rolling)
+        self.assertLess(rolling, after_publish)
+
+        upload_run = steps[upload]["run"]
+        self.assertNotIn("cmux-tui/latest", upload_run)
+        before_upload_run = steps[before_upload]["run"]
+        self.assertEqual(
+            steps[before_upload]["env"]["EXPECTED_WINDOWS_ARTIFACT"],
+            self.WINDOWS,
+        )
+        self.assertIn("$EXPECTED_WINDOWS_ARTIFACT", before_upload_run)
+        before_latest_run = steps[before_latest]["run"]
+        self.assertEqual(
+            steps[before_latest]["env"]["EXPECTED_WINDOWS_ARTIFACT"],
+            self.WINDOWS,
+        )
+        self.assertIn("$EXPECTED_WINDOWS_ARTIFACT", before_latest_run)
+        after_publish_run = steps[after_publish]["run"]
+        self.assertEqual(
+            steps[after_publish]["env"]["EXPECTED_WINDOWS_ARTIFACT"],
+            self.WINDOWS,
+        )
+        self.assertIn(f"cmux-tui/$GITHUB_SHA/manifest.json", after_publish_run)
+        self.assertIn("cmux-tui/latest/manifest.json?verify=$GITHUB_SHA", after_publish_run)
+
     def test_rejects_manifest_with_invalid_digest(self) -> None:
         manifest = self.manifest()
         manifest["binaries"] = {self.WINDOWS: "not-a-sha256"}
         with self.assertRaisesRegex(VERIFY.ManifestError, "invalid SHA-256"):
             self.verify(manifest)
+
+    def test_validates_local_manifest_before_upload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"
+            path.write_text(json.dumps(self.manifest()), encoding="utf-8")
+            VERIFY.verify_manifest_file(
+                path,
+                expected_commit=self.COMMIT,
+                required_artifacts=(self.WINDOWS,),
+            )
 
     def test_rejects_manifest_for_a_different_commit(self) -> None:
         manifest = self.manifest()

--- a/cmux-tui/scripts/verify_published_manifest.py
+++ b/cmux-tui/scripts/verify_published_manifest.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Verify a published cmux-tui raw-artifact manifest.
+
+The raw-artifact lane is separate from npm and PyPI publication.  This check
+is used after R2 uploads to prove that the immutable manifest (and, on main,
+the rolling ``latest`` manifest) points at the exact build and contains every
+artifact required by the public installers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+class ManifestError(ValueError):
+    """The manifest does not satisfy the raw-artifact contract."""
+
+
+def _decode_manifest(payload: bytes, source: str) -> dict[str, Any]:
+    try:
+        document = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ManifestError(f"{source} is not valid JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise ManifestError(f"{source} must contain a JSON object")
+    return document
+
+
+def _validate_manifest(
+    document: dict[str, Any],
+    *,
+    source: str,
+    expected_commit: str,
+    required_artifacts: Iterable[str],
+) -> None:
+    commit = document.get("commit")
+    if commit != expected_commit:
+        raise ManifestError(
+            f"{source} commit mismatch: expected {expected_commit}, got {commit!r}"
+        )
+
+    binaries = document.get("binaries")
+    if not isinstance(binaries, dict):
+        raise ManifestError(f"{source} must contain a binaries object")
+
+    for artifact, digest in binaries.items():
+        if not isinstance(artifact, str) or not isinstance(digest, str):
+            raise ManifestError(f"{source} contains a malformed binary digest")
+        if not SHA256_RE.fullmatch(digest):
+            raise ManifestError(f"{source} has invalid SHA-256 for artifact {artifact}")
+
+    for artifact in required_artifacts:
+        digest = binaries.get(artifact)
+        if digest is None:
+            raise ManifestError(f"{source} missing required artifact {artifact}")
+
+
+def _read_url(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Cache-Control": "no-cache",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            return response.read()
+    except (OSError, urllib.error.URLError) as error:
+        raise ManifestError(f"could not fetch {url}: {error}") from error
+
+
+# Keep this name patchable in the unit tests and consistent with the other
+# small network-verification helpers in cmux-tui.
+urlopen = urllib.request.urlopen
+
+
+def verify_manifest(
+    url: str,
+    *,
+    expected_commit: str,
+    required_artifacts: Iterable[str],
+) -> None:
+    """Fetch and validate one published manifest from a public URL."""
+
+    document = _decode_manifest(_read_url(url), url)
+    _validate_manifest(
+        document,
+        source=url,
+        expected_commit=expected_commit,
+        required_artifacts=required_artifacts,
+    )
+
+
+def verify_manifest_file(
+    path: Path,
+    *,
+    expected_commit: str,
+    required_artifacts: Iterable[str],
+) -> None:
+    """Validate the manifest generated before any R2 upload occurs."""
+
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise ManifestError(f"could not read {path}: {error}") from error
+    document = _decode_manifest(payload, str(path))
+    _validate_manifest(
+        document,
+        source=str(path),
+        expected_commit=expected_commit,
+        required_artifacts=required_artifacts,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify a cmux-tui raw-artifact manifest after publication."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--manifest-url", help="Public manifest URL to fetch")
+    source.add_argument(
+        "--manifest-file",
+        type=Path,
+        help="Manifest generated locally before upload",
+    )
+    parser.add_argument(
+        "--expected-commit",
+        required=True,
+        help="Exact commit SHA recorded in the manifest",
+    )
+    parser.add_argument(
+        "--require-artifact",
+        action="append",
+        dest="required_artifacts",
+        default=[],
+        help="Artifact name that must have a valid SHA-256 digest (repeatable)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.manifest_url:
+            verify_manifest(
+                args.manifest_url,
+                expected_commit=args.expected_commit,
+                required_artifacts=args.required_artifacts,
+            )
+            source = args.manifest_url
+        else:
+            assert args.manifest_file is not None
+            verify_manifest_file(
+                args.manifest_file,
+                expected_commit=args.expected_commit,
+                required_artifacts=args.required_artifacts,
+            )
+            source = str(args.manifest_file)
+    except ManifestError as error:
+        print(f"manifest verification failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Verified cmux-tui manifest: {source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmux-tui/scripts/verify_published_manifest.py
+++ b/cmux-tui/scripts/verify_published_manifest.py
@@ -71,6 +71,7 @@ def _read_url(url: str) -> bytes:
         headers={
             "Accept": "application/json",
             "Cache-Control": "no-cache",
+            "User-Agent": "cmux-tui-manifest-verifier/1 (https://github.com/manaflow-ai/cmux)",
         },
     )
     try:


### PR DESCRIPTION
## Summary

The public PowerShell installer requires `cmux-tui-x86_64-pc-windows-gnu.exe`, but the live `cmux-tui/latest` manifest was Unix-only. This PR adds a fail-closed raw-artifact manifest verifier and runs it before and after R2 publication.

The workflow now:

- validates the local manifest before any upload;
- uploads the immutable commit prefix;
- verifies the immutable manifest has the exact `GITHUB_SHA` and Windows artifact;
- rolls `latest` only after that check passes;
- verifies immutable and `latest` manifests against the same `GITHUB_SHA` after publication.

The verifier is limited to raw `cmux-tui` artifacts. npm and PyPI package publication stays in its existing workflows.

## Regression proof

- `93e20f9d55` adds the failing manifest contract test.
- `989ffdb2b7` adds the verifier, workflow ordering, and CI wiring.

## Checks

- `python3 -m unittest discover -s cmux-tui/scripts -p 'test_verify_published_manifest.py' -v`
- `python3 tests/test_tui_installers.py`
- `python3 tests/test_tui_publish_workflow_security.py -v`
- `actionlint .github/workflows/cmux-tui-artifacts.yml .github/workflows/cmux-tui-sdks.yml`
- `python3 -m py_compile cmux-tui/scripts/verify_published_manifest.py cmux-tui/scripts/test_verify_published_manifest.py`
- `git diff --check`

No R2 upload, package publish, or live manifest mutation was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789540058&installation_model_id=21920&pr_number=10252&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10252&signature=28b4a8b035ab37f1eeb25e72f0a4d4fe6fc46dd404db1d7610b6f47b59b75b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the `cmux-tui` “latest” roll behind a fail-closed manifest verifier so we only roll from builds that include the Windows artifact and match the exact commit. Previously, “latest” could roll from a Unix-only build; now we verify before upload, before rolling, and after publish to prevent broken Windows installs.

- Adds `cmux-tui/scripts/verify_published_manifest.py` to validate JSON, exact commit SHA, SHA-256 digests, and require `cmux-tui-x86_64-pc-windows-gnu.exe`; identifies verification requests with `User-Agent: cmux-tui-manifest-verifier/1` and `Cache-Control: no-cache`.
- Updates `.github/workflows/cmux-tui-artifacts.yml` to verify the local manifest before any upload; upload only immutable `$GITHUB_SHA` prefixes; verify the immutable manifest via public URL; publish `latest` on `main` only after that check; re-verify immutable and `latest` after publish using `?verify=$GITHUB_SHA`.
- Adds `cmux-tui/scripts/test_verify_published_manifest.py`; runs in `cmux-tui-sdks` and binds the PowerShell installer to the artifact contract; triggers on changes to the artifacts workflow, `tests/test_tui_installers.py`, and `web/public/tui/install-static.ps1`.
- Scope: only raw `cmux-tui` artifacts are verified; npm and PyPI publication are unchanged.

**Migration**
- If the Windows binary name changes, update `EXPECTED_WINDOWS_ARTIFACT`, the `$Artifact` in `web/public/tui/install-static.ps1`, and the tests.

<sup>Written for commit 000c30e730a6e6b1cbb34f752cdd2bf320e74f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

