### PR TITLE
Fix TUI installer tests for static route bodies

### DIFF
--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -23,7 +23,14 @@ on:
       - ".github/workflows/sdk-release-cut.yml"
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_installers.py"
+      - "tests/test_tui_installer_workflow.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "web/app/tui/install.ps1/route.ts"
+      - "web/app/tui/install.sh/route.ts"
+      - "web/public/tui/install-static.ps1"
+      - "web/public/tui/install-static.sh"
+      - "web/tests/install-analytics.test.tsx"
   pull_request:
     paths:
       - "cmux-tui/**"
@@ -44,7 +51,14 @@ on:
       - ".github/workflows/sdk-release-cut.yml"
       - ".github/workflows/tui-publish-npm.yml"
       - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_installers.py"
+      - "tests/test_tui_installer_workflow.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "web/app/tui/install.ps1/route.ts"
+      - "web/app/tui/install.sh/route.ts"
+      - "web/public/tui/install-static.ps1"
+      - "web/public/tui/install-static.sh"
+      - "web/tests/install-analytics.test.tsx"
   workflow_dispatch:
 
 concurrency:
@@ -73,10 +87,27 @@ jobs:
         run: |
           python3 -m pip install \
             --disable-pip-version-check \
-            "PyYAML==6.0.3"
+            "PyYAML==6.0.3" \
+            "pytest==8.4.1"
 
       - name: Test protocol inventory
         run: python3 cmux-tui/scripts/test_check_spec_inventory.py
+
+      - name: Test TUI installer bodies and workflow contract
+        run: python3 -m pytest -q tests/test_tui_installers.py tests/test_tui_installer_workflow.py
+
+      - name: Set up Bun for TUI installer redirect test
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install web dependencies for TUI installer redirect test
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Test TUI installer redirects
+        working-directory: web
+        run: bun test --isolate tests/install-analytics.test.tsx
 
       - name: Check protocol and TUI action inventory
         run: python3 cmux-tui/scripts/check-spec-inventory.py

--- a/tests/test_tui_installer_workflow.py
+++ b/tests/test_tui_installer_workflow.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/cmux-tui-sdks.yml"
+REQUIRED_PATHS = {
+    "tests/test_tui_installers.py",
+    "web/app/tui/install.sh/route.ts",
+    "web/app/tui/install.ps1/route.ts",
+    "web/public/tui/install-static.sh",
+    "web/public/tui/install-static.ps1",
+    "web/tests/install-analytics.test.tsx",
+}
+
+
+def _workflow() -> dict[str, object]:
+    document = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(document, dict)
+    return document
+
+
+def _paths(document: dict[str, object], event: str) -> set[str]:
+    triggers = document["on"]
+    assert isinstance(triggers, dict)
+    event_config = triggers[event]
+    assert isinstance(event_config, dict)
+    paths = event_config["paths"]
+    assert isinstance(paths, list)
+    return {str(path) for path in paths}
+
+
+def _run_steps(document: dict[str, object]) -> list[dict[str, object]]:
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+    contract = jobs["contract"]
+    assert isinstance(contract, dict)
+    steps = contract["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def test_tui_installer_checks_run_in_the_hosted_contract_job() -> None:
+    document = _workflow()
+    steps = _run_steps(document)
+    run_commands = [str(step.get("run", "")) for step in steps]
+
+    assert any("pytest -q tests/test_tui_installers.py" in command for command in run_commands)
+    assert any(
+        "bun test --isolate tests/install-analytics.test.tsx" in command
+        and step.get("working-directory") == "web"
+        for step, command in zip(steps, run_commands)
+    )
+    assert any(
+        step.get("uses", "").startswith("oven-sh/setup-bun@")
+        for step in steps
+    )
+    assert any(
+        "bun install --frozen-lockfile" in command
+        and step.get("working-directory") == "web"
+        for step, command in zip(steps, run_commands)
+    )
+
+    for event in ("push", "pull_request"):
+        assert REQUIRED_PATHS <= _paths(document, event)

--- a/tests/test_tui_installers.py
+++ b/tests/test_tui_installers.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-UNIX_INSTALLER = ROOT / "web/public/tui/install.sh"
-WINDOWS_INSTALLER = ROOT / "web/public/tui/install.ps1"
+UNIX_INSTALLER = ROOT / "web/public/tui/install-static.sh"
+WINDOWS_INSTALLER = ROOT / "web/public/tui/install-static.ps1"
 
 
 def write_executable(path: Path, contents: str) -> None:

--- a/tests/test_tui_installers.py
+++ b/tests/test_tui_installers.py
@@ -92,5 +92,10 @@ def test_install_scripts_are_public_and_checksum_verified() -> None:
     assert "release manifest" not in windows
 
 
+def test_static_installer_bodies_are_available_to_route_handlers() -> None:
+    assert UNIX_INSTALLER.is_file()
+    assert WINDOWS_INSTALLER.is_file()
+
+
 def test_unix_installer_has_valid_shell_syntax() -> None:
     subprocess.run(["/bin/sh", "-n", str(UNIX_INSTALLER)], check=True)


### PR DESCRIPTION
## Summary

The TUI installer tests still opened `web/public/tui/install.sh` and `install.ps1`, but those files were renamed to `install-static.sh` and `install-static.ps1`. The route handlers at `/tui/install.sh` and `/tui/install.ps1` still redirect to those static bodies.

This PR points the behavior tests at the current static files and adds an existence check for the route-backed bodies. It does not change either redirect or installer script.

## Regression proof

- `a6d286f69b`: failing test-only commit. The installer suite remains red because the test paths point at removed files.
- `574f4e071f`: updates the test paths to the static route bodies.

## Checks

- `pytest -q tests/test_tui_installers.py` (4 passed)
- `bun test --isolate web/tests/install-analytics.test.tsx` (4 passed, including both TUI redirects)
- `python3 tests/test_tui_publish_workflow_security.py -v` (47 passed)
- `python3 -m py_compile tests/test_tui_installers.py`
- `git diff --check`

No R2 mutation, publish, or merge was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542593&installation_model_id=21920&pr_number=10256&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10256&signature=5c66f71c6990b0b5b6c1d59af79cac3e21851753de8a629b9dff0182bdde6062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI installer tests to use the static script bodies and adds a file-existence check plus a workflow contract test so CI enforces them. Previously tests opened `web/public/tui/install.sh` and `web/public/tui/install.ps1` and the hosted contract job did not run installer checks; now they target `web/public/tui/install-static.sh` and `web/public/tui/install-static.ps1`, and the workflow runs `pytest` and `bun test --isolate` in `web/` when relevant paths change. Runtime behavior is unchanged: `/tui/install.sh` and `/tui/install.ps1` still redirect to these static bodies.

<sup>Written for commit b60199938bc2800c798b1e676956890e5e3b34c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

