### PR TITLE
docs(tui): align frontend protocol references on stack

### DIFF
--- a/.github/workflows/cmux-tui-spec.yml
+++ b/.github/workflows/cmux-tui-spec.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Test inventory checker
         run: python3 cmux-tui/scripts/test_check_spec_inventory.py
 
+      - name: Test frontend documentation protocol
+        run: python3 cmux-tui/scripts/test_frontend_docs.py
+
       - name: Check protocol and TUI action inventory
         run: python3 cmux-tui/scripts/check-spec-inventory.py
 

--- a/cmux-tui/frontends/README.ja.md
+++ b/cmux-tui/frontends/README.ja.md
@@ -3,7 +3,7 @@
 [English](README.md)
 
 リポジトリ内のリファレンス実装は[ウェブフロントエンド](web)です。
-プロトコルv7のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
 使用した実装例です。
 
 macOSネイティブフロントエンドは、非公開の

--- a/cmux-tui/frontends/README.md
+++ b/cmux-tui/frontends/README.md
@@ -3,7 +3,7 @@
 [日本語](README.ja.md)
 
 The in-tree reference frontend is the [web frontend](web). It demonstrates the
-protocol-v7 WebSocket API and the browser entry point of the TypeScript SDK.
+protocol-v12 WebSocket API and the browser entry point of the TypeScript SDK.
 
 The native macOS frontend is maintained separately in the private
 [`manaflow-ai/cmux-lite`](https://github.com/manaflow-ai/cmux-lite) repository.

--- a/cmux-tui/frontends/web/README.ja.md
+++ b/cmux-tui/frontends/web/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-プロトコルv10のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
 自然なcmuxクライアントを構築できることを示す小規模なサードパーティー形式の
 フロントエンドです。信頼できるワークスペースツリーの表示、アクティブなPTY
 サーフェスへのxterm.jsの接続、キーボード入力の転送、ターミナルセル単位の

--- a/cmux-tui/scripts/test_frontend_docs.py
+++ b/cmux-tui/scripts/test_frontend_docs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep frontend README protocol claims aligned with the supported wire API."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+TUI = Path(__file__).resolve().parents[1]
+README_PATHS = (
+    TUI / "frontends" / "README.md",
+    TUI / "frontends" / "README.ja.md",
+    TUI / "frontends" / "web" / "README.md",
+    TUI / "frontends" / "web" / "README.ja.md",
+)
+
+
+def supported_protocol() -> int:
+    source = (TUI / "frontends" / "web" / "src" / "lib" / "protocol.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"SUPPORTED_PROTOCOL\s*=\s*(\d+)", source)
+    if match is None:
+        raise AssertionError("web frontend has no supported protocol constant")
+    return int(match.group(1))
+
+
+def documented_protocol() -> int:
+    source = (TUI / "docs" / "protocol.md").read_text(encoding="utf-8")
+    match = re.search(r"^# Raw control protocol v(\d+)\s*$", source, re.MULTILINE)
+    if match is None:
+        raise AssertionError("raw protocol guide has no version heading")
+    return int(match.group(1))
+
+
+class FrontendReadmeProtocolTests(unittest.TestCase):
+    def test_readmes_match_the_supported_websocket_protocol(self) -> None:
+        expected = supported_protocol()
+        self.assertEqual(expected, documented_protocol())
+
+        for path in README_PATHS:
+            text = path.read_text(encoding="utf-8")
+            websocket_lines = [
+                line for line in text.splitlines() if "websocket" in line.lower()
+            ]
+            self.assertTrue(websocket_lines, path)
+            versions = {
+                int(version)
+                for line in websocket_lines
+                for version in re.findall(
+                    r"(?:protocol|プロトコル)[-\s]?v?(\d+)",
+                    line,
+                    re.IGNORECASE,
+                )
+            }
+            self.assertEqual(versions, {expected}, path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replay PR #10246 frontend protocol docs and contract test on integrated TUI stack head `162c188fe244`
- preserve the red/green commit order
- keep the spec workflow contract check wired

## Base and history
- base: `162c188fe24455a95a108879a355f52f358496d6`
- red commit: `1d9552e6e6`
- green commit: `cb8d6eb982`
- source PR: #10246

## Verification
- frontend docs contract
- Python compile check
- inventory, SDK schema, resource-boundary, and codegen checks
- PyYAML workflow contract and `actionlint`

No merge, tag, package publication, or build was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789545470&installation_model_id=21920&pr_number=10260&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10260&signature=a3bf12919dff2246b631783e52c438ab12824ec398957740ff0a878f9eb4596c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns TUI frontend README protocol references to v12 and adds a CI test that prevents version drift. Previously READMEs cited v7/v10 with no check; now they cite v12 and the spec workflow fails if docs diverge from the supported wire API.

- Adds `cmux-tui/scripts/test_frontend_docs.py` to assert that `SUPPORTED_PROTOCOL` in the web frontend, `cmux-tui/docs/protocol.md`, and all frontend READMEs reference the same protocol version.
- Runs the new test in `.github/workflows/cmux-tui-spec.yml`.
- No runtime or SDK changes; documentation and CI only.

**Rollout**
- When bumping the wire protocol, update `SUPPORTED_PROTOCOL`, `cmux-tui/docs/protocol.md`, and README protocol lines; CI will fail if they are inconsistent.

<sup>Written for commit cb8d6eb98233040f4c3b53d88421e4f8d366cae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

