### PR TITLE
Integration: stack SDK release gates on TUI SDK validation

### DIFF
--- a/.github/workflows/sdk-release-cut.yml
+++ b/.github/workflows/sdk-release-cut.yml
@@ -512,10 +512,34 @@ jobs:
             echo "remote_tag_state_sha256=$remote_tag_state_sha256"
           } >> "$GITHUB_OUTPUT"
 
+  credential-environment-preflight:
+    needs:
+      - revalidate-tags
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify credential environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 cmux-tui/bindings/verify_github_environment_policy.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --environment sdk-release-credentials \
+            --dispatcher "$GITHUB_ACTOR"
+
   cut-tags:
     needs:
       - validate-release
       - revalidate-tags
+      - credential-environment-preflight
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions: {}

--- a/cmux-tui/bindings/RELEASING.md
+++ b/cmux-tui/bindings/RELEASING.md
@@ -78,9 +78,12 @@ authorization is valid for the same workflow run attempt and 15 minutes.
   A credential-free job tests and packs `0.0.0-bootstrap.0`, then uploads the
   exact archive. A fresh job downloads and digest-checks that archive before
   its final step receives the temporary token. That step disables npm
-  lifecycle scripts, publishes with provenance under the `bootstrap` tag, and
-  cannot claim `latest`. A separate credential-free job reconciles the exact
-  archive and provenance after an ambiguous publish result. Configure repository
+  lifecycle scripts, and publishes with provenance under the `bootstrap` tag.
+  npm also assigns `latest` to `0.0.0-bootstrap.0` for this sole reservation
+  release. The stable preflight accepts that exact `cmux-sdk` state and
+  requires `latest` to move to the requested stable version after publish. A
+  separate credential-free job reconciles the exact archive and provenance
+  after an ambiguous publish result. Configure repository
   `manaflow-ai/cmux`, workflow `sdk-release-cut.yml`, and the `npm` environment
   as the trusted publisher. In the package's **Settings > Publishing access**,
   select **Require two-factor authentication and disallow tokens**. This still

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -51,6 +51,8 @@ PYPI_VERSION = re.compile(
 )
 PYPI_BOOTSTRAP_VERSION = "0.0.0a0"
 CRATES_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
+NPM_BOOTSTRAP_PACKAGE = "cmux-sdk"
+NPM_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
 PUBLISH_POLL_SECONDS = 0.25
 PUBLISH_STOP_SECONDS = 5
 PUBLISH_TIMEOUT_EXIT = 124
@@ -410,20 +412,30 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
         )
         latest = dist_tags.get("latest")
         if latest is not None:
-            if not isinstance(latest, str):
+            if (
+                package == NPM_BOOTSTRAP_PACKAGE
+                and latest == NPM_BOOTSTRAP_VERSION
+            ):
+                # The one-time SDK bootstrap intentionally reserves the npm
+                # name by putting its prerelease on `latest`. The stable
+                # release path below still requires `latest == version` once
+                # the immutable stable archive exists.
+                pass
+            elif not isinstance(latest, str):
                 raise RegistryError(
                     f"npm dist-tag latest is malformed for {package}: {latest!r}"
                 )
-            latest_version = _stable_version(latest)
-            if latest_version is None:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
-                )
-            if latest_version >= candidate:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest points to {latest!r}, which is not older "
-                    f"than requested {version!r}"
-                )
+            else:
+                latest_version = _stable_version(latest)
+                if latest_version is None:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
+                    )
+                if latest_version >= candidate:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest points to {latest!r}, which is not older "
+                        f"than requested {version!r}"
+                    )
         return MISSING
     if not isinstance(release, dict):
         raise RegistryError(f"npm metadata is malformed for {package}@{version}")

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -416,6 +416,14 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
                 package == NPM_BOOTSTRAP_PACKAGE
                 and latest == NPM_BOOTSTRAP_VERSION
             ):
+                bootstrap_release = versions.get(NPM_BOOTSTRAP_VERSION)
+                if (
+                    not isinstance(bootstrap_release, dict)
+                    or dist_tags.get("bootstrap") != NPM_BOOTSTRAP_VERSION
+                ):
+                    raise RegistryError(
+                        "npm bootstrap metadata is incomplete for cmux-sdk"
+                    )
                 # The one-time SDK bootstrap intentionally reserves the npm
                 # name by putting its prerelease on `latest`. The stable
                 # release path below still requires `latest == version` once

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -482,6 +482,29 @@ class RegistryArtifactTests(unittest.TestCase):
         ), self.assertRaises(reconcile.ReleaseStateMismatch):
             reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
 
+    def test_npm_bootstrap_latest_exception_requires_bootstrap_metadata(self) -> None:
+        metadata = {
+            "dist-tags": {"latest": "0.0.0-bootstrap.0"},
+            "versions": {},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaisesRegex(reconcile.RegistryError, "bootstrap metadata"):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
+    def test_npm_bootstrap_latest_exception_is_sdk_only(self) -> None:
+        metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "other-package", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -445,6 +445,43 @@ class RegistryArtifactTests(unittest.TestCase):
                 reconcile.MISSING,
             )
 
+    def test_npm_allows_bootstrap_latest_until_stable_publish(self) -> None:
+        bootstrap_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(bootstrap_metadata)
+        ):
+            self.assertEqual(
+                reconcile.registry_status(
+                    "npm", "cmux-sdk", "1.0.0", self.artifact
+                ),
+                reconcile.MISSING,
+            )
+
+        stable_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {
+                "0.0.0-bootstrap.0": {"dist": {}},
+                "1.0.0": {
+                    "dist": {
+                        "integrity": reconcile._integrity(self.artifact, "sha512")
+                    }
+                },
+            },
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(stable_metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "verify_github_environment_policy.py"
+SPEC = importlib.util.spec_from_file_location(
+    "verify_github_environment_policy",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
+    environment_name = "sdk-release-credentials"
+    dispatcher = "lawrencecchen"
+
+    def environment(
+        self,
+        *,
+        reviewers: object = None,
+        prevent_self_review: object = True,
+        can_admins_bypass: object = False,
+        deployment_branch_policy: object = None,
+    ) -> dict[str, object]:
+        if reviewers is None:
+            reviewers = [
+                {
+                    "type": "User",
+                    "reviewer": {"login": "austinywang"},
+                }
+            ]
+        if deployment_branch_policy is None:
+            deployment_branch_policy = {
+                "protected_branches": True,
+                "custom_branch_policies": False,
+            }
+        return {
+            "name": self.environment_name,
+            "can_admins_bypass": can_admins_bypass,
+            "deployment_branch_policy": deployment_branch_policy,
+            "protection_rules": [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": prevent_self_review,
+                    "reviewers": reviewers,
+                },
+                {"type": "branch_policy"},
+            ],
+        }
+
+    def assert_rejected(self, payload: dict[str, object]) -> None:
+        with self.assertRaises(policy.EnvironmentPolicyError):
+            policy.validate_environment_policy(
+                payload,
+                self.environment_name,
+                self.dispatcher,
+            )
+
+    def test_accepts_a_protected_environment_with_another_reviewer(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+    def test_rejects_missing_required_reviewer_rule(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = [{"type": "branch_policy"}]
+        self.assert_rejected(payload)
+
+    def test_rejects_self_review_only(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "User",
+                        "reviewer": {"login": self.dispatcher},
+                    }
+                ]
+            )
+        )
+
+    def test_rejects_self_review_setting_disabled(self) -> None:
+        self.assert_rejected(self.environment(prevent_self_review=False))
+
+    def test_rejects_administrator_bypass(self) -> None:
+        self.assert_rejected(self.environment(can_admins_bypass=True))
+
+    def test_rejects_unprotected_or_custom_branch_policy(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                deployment_branch_policy={
+                    "protected_branches": False,
+                    "custom_branch_policies": True,
+                }
+            )
+        )
+
+    def test_accepts_a_team_reviewer_with_self_review_disabled(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "Team",
+                        "reviewer": {"slug": "sdk-release-reviewers"},
+                    }
+                ]
+            ),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -74,6 +74,11 @@ class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
         payload["protection_rules"] = [{"type": "branch_policy"}]
         self.assert_rejected(payload)
 
+    def test_rejects_malformed_protection_rules(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = None
+        self.assert_rejected(payload)
+
     def test_rejects_self_review_only(self) -> None:
         self.assert_rejected(
             self.environment(

--- a/cmux-tui/bindings/verify_github_environment_policy.py
+++ b/cmux-tui/bindings/verify_github_environment_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Verify the protection policy on a GitHub Actions environment."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import sys
+from typing import Any, Mapping, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+GITHUB_API_VERSION = "2022-11-28"
+GITHUB_API_URL = "https://api.github.com"
+USER_AGENT = "cmux-sdk-environment-policy/1 (https://github.com/manaflow-ai/cmux)"
+REPOSITORY_PATTERN = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$"
+)
+
+
+class EnvironmentPolicyError(RuntimeError):
+    """Raised when GitHub cannot prove the required environment policy."""
+
+
+def _repository_slug(repository: str) -> str:
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise EnvironmentPolicyError("GitHub repository must be OWNER/REPOSITORY")
+    return repository
+
+
+def _environment_url(
+    api_url: str,
+    repository: str,
+    environment: str,
+) -> str:
+    if not environment or environment.strip() != environment:
+        raise EnvironmentPolicyError("GitHub environment name must be non-empty")
+    return (
+        f"{api_url.rstrip('/')}/repos/{quote(_repository_slug(repository), safe='/')}"
+        f"/environments/{quote(environment, safe='')}"
+    )
+
+
+def _fetch_environment(
+    repository: str,
+    environment: str,
+    token: str,
+    *,
+    api_url: str = GITHUB_API_URL,
+) -> dict[str, Any]:
+    if not token:
+        raise EnvironmentPolicyError("GitHub API token is missing")
+    request = Request(
+        _environment_url(api_url, repository, environment),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = response.read()
+    except HTTPError as error:
+        raise EnvironmentPolicyError(
+            f"GitHub environment lookup failed with HTTP {error.code}"
+        ) from error
+    except (URLError, OSError, http.client.IncompleteRead) as error:
+        raise EnvironmentPolicyError("GitHub environment lookup failed") from error
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise EnvironmentPolicyError(
+            "GitHub environment lookup returned invalid JSON"
+        ) from error
+    if not isinstance(value, dict):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    return value
+
+
+def _reviewer_is_separate(
+    reviewer: Mapping[str, Any],
+    dispatcher: str,
+) -> bool:
+    reviewer_type = reviewer.get("type")
+    subject = reviewer.get("reviewer")
+    if not isinstance(subject, dict):
+        raise EnvironmentPolicyError("GitHub reviewer identity is malformed")
+    if reviewer_type == "User":
+        login = subject.get("login")
+        if not isinstance(login, str) or not login:
+            raise EnvironmentPolicyError("GitHub user reviewer identity is malformed")
+        return login.casefold() != dispatcher.casefold()
+    if reviewer_type == "Team":
+        slug = subject.get("slug")
+        if not isinstance(slug, str) or not slug:
+            raise EnvironmentPolicyError("GitHub team reviewer identity is malformed")
+        # A team is a separate approval principal. GitHub's prevent_self_review
+        # rule prevents the dispatcher from approving their own deployment even
+        # when they belong to that team.
+        return True
+    raise EnvironmentPolicyError("GitHub reviewer type is unsupported")
+
+
+def validate_environment_policy(
+    payload: Mapping[str, Any],
+    expected_environment: str,
+    dispatcher: str,
+) -> None:
+    """Require the protected, independently reviewed credential environment."""
+
+    if not isinstance(payload, Mapping):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    if not expected_environment or payload.get("name") != expected_environment:
+        raise EnvironmentPolicyError("GitHub environment name does not match")
+    if payload.get("can_admins_bypass") is not False:
+        raise EnvironmentPolicyError(
+            "GitHub environment administrator bypass must be disabled"
+        )
+
+    branch_policy = payload.get("deployment_branch_policy")
+    if not isinstance(branch_policy, Mapping) or (
+        branch_policy.get("protected_branches") is not True
+        or branch_policy.get("custom_branch_policies") is not False
+    ):
+        raise EnvironmentPolicyError(
+            "GitHub environment must allow protected branches only"
+        )
+
+    if not isinstance(dispatcher, str) or not dispatcher.strip():
+        raise EnvironmentPolicyError("GitHub dispatch actor is missing")
+    protection_rules = payload.get("protection_rules")
+    if not isinstance(protection_rules, list):
+        raise EnvironmentPolicyError(
+            "GitHub environment protection rules are malformed"
+        )
+    reviewer_rules = [
+        rule
+        for rule in protection_rules
+        if isinstance(rule, Mapping) and rule.get("type") == "required_reviewers"
+    ]
+    if not reviewer_rules:
+        raise EnvironmentPolicyError(
+            "GitHub environment must require an independent reviewer"
+        )
+    for rule in reviewer_rules:
+        if rule.get("prevent_self_review") is not True:
+            raise EnvironmentPolicyError(
+                "GitHub environment must prevent self-review"
+            )
+        reviewers = rule.get("reviewers")
+        if not isinstance(reviewers, list) or not reviewers:
+            raise EnvironmentPolicyError(
+                "GitHub environment required-reviewer list is empty"
+            )
+        if not any(
+            _reviewer_is_separate(reviewer, dispatcher)
+            for reviewer in reviewers
+            if isinstance(reviewer, Mapping)
+        ):
+            raise EnvironmentPolicyError(
+                "GitHub environment has no reviewer other than the dispatcher"
+            )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+    )
+    parser.add_argument("--environment", required=True)
+    parser.add_argument(
+        "--dispatcher",
+        default=os.environ.get("GITHUB_ACTOR", ""),
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("GITHUB_API_URL", GITHUB_API_URL),
+    )
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="environment variable containing the GitHub API token",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        payload = _fetch_environment(
+            args.repository,
+            args.environment,
+            os.environ.get(args.token_env, ""),
+            api_url=args.api_url,
+        )
+        validate_environment_policy(payload, args.environment, args.dispatcher)
+    except EnvironmentPolicyError as error:
+        print(f"GitHub environment policy verification failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"verified GitHub environment policy for {args.repository}/"
+        f"{args.environment}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sdk_release_credential_environment_policy.py
+++ b/tests/test_sdk_release_credential_environment_policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "sdk-release-cut.yml"
+
+
+def workflow_job(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_sdk_release_credential_environment_policy_is_fail_closed() -> None:
+    release = WORKFLOW.read_text()
+    policy = workflow_job(release, "credential-environment-preflight")
+    cut_tags = workflow_job(release, "cut-tags")
+
+    assert "actions: read" in policy
+    assert "contents: read" in policy
+    assert "GITHUB_TOKEN: ${{ github.token }}" in policy
+    assert "verify_github_environment_policy.py" in policy
+    assert "--environment sdk-release-credentials" in policy
+    assert "--dispatcher \"$GITHUB_ACTOR\"" in policy
+    assert "credential-environment-preflight" in cut_tags
+    assert release.index("revalidate-tags:") < release.index(
+        "credential-environment-preflight:"
+    ) < release.index("cut-tags:")

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -137,6 +137,9 @@ def test_npm_bootstrap_preserves_the_first_stable_version() -> None:
     assert sdk_ci.count('".github/workflows/sdk-bootstrap-npm.yml"') == 2
     assert "sdk-bootstrap-npm.yml" in releasing
     assert "0.0.0-bootstrap.0" in releasing
+    assert "also assigns `latest` to `0.0.0-bootstrap.0`" in releasing
+    assert "stable preflight accepts that exact `cmux-sdk` state" in releasing
+    assert "cannot claim `latest`" not in releasing
     assert "first `cmux-sdk` release interactively" not in releasing
 
 


### PR DESCRIPTION
## Summary

Stack the SDK release fixes from [#10245](https://github.com/manaflow-ai/cmux/pull/10245) and [#10250](https://github.com/manaflow-ai/cmux/pull/10250) on the integrated TUI SDK head `8c1cc1075fc71ef18b9c35c7332667ddcf2d0e1d` from [#10258](https://github.com/manaflow-ai/cmux/pull/10258).

This branch preserves the source red/green history. It does not modify the source PR branches, GitHub environments, release tags, or package registries.

## Commit order

- `738bbd1e83` test: cover SDK npm bootstrap latest tag
- `66c9790611` fix: allow SDK bootstrap npm latest during preflight
- `234c590c82` test: reject incomplete SDK npm bootstrap metadata
- `2c2744b2f1` fix: validate SDK npm bootstrap metadata
- `8f88cd8265` test: document npm bootstrap latest reservation
- `76f279917c` docs: describe SDK npm bootstrap latest tag
- `84145a0c11` test: cover SDK credential environment policy
- `74a9aef90a` fix: gate SDK tags on credential environment policy

## Verification

- 58 registry reconciliation unit tests passed.
- 8 credential environment policy unit tests passed.
- 67 SDK/TUI workflow security tests passed.
- `compileall`, `git diff --check`, generated binding checks, version checks, spec inventory, and release-version checks passed.
- Exact `verify_release_registry_state.sh 1.0.0` passed against current registries with target artifacts absent.
- Live credential policy verification is expected to fail until `sdk-release-credentials` has an independent required reviewer. No environment setting was changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789545658&installation_model_id=21920&pr_number=10261&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10261&signature=058539bc9b45209ba292d746ba881fcef8c3c54781f5160e4ee165c520bd7592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates SDK tag cutting on a protected credential environment and allows the one-time `cmux-sdk` npm bootstrap to hold `latest` until the first stable publish. This blocks unreviewed credential use and preserves the bootstrap reservation without weakening stable release validation.

- Adds `credential-environment-preflight` to `sdk-release-cut.yml`. `cut-tags` now depends on a check that `sdk-release-credentials` has required reviewers, prevents self-review, disables admin bypass, and limits deployments to protected branches only.
- Updates npm reconciliation to accept `latest == 0.0.0-bootstrap.0` for `cmux-sdk` when bootstrap metadata is complete; once the stable archive exists, `latest` must move to the requested stable version or the release fails.
- Documents the npm bootstrap `latest` reservation and adds unit tests for environment policy and npm reconciliation.

**Required action**
- Add an independent reviewer to the `sdk-release-credentials` environment to unblock SDK releases.

<sup>Written for commit 74a9aef90a0196f2cd8bece7f1ae79647d79ecb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

