### PR TITLE
Integration: release-wave fixes on TUI SDK candidate

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "npm package version, or the shared stable X.Y.Z version"
+        description: "canonical binary and npm version, or the shared stable X.Y.Z version"
         required: true
         type: string
       pypi_version:
-        description: "PyPI package version; defaults to version"
+        description: "PyPI metadata version; defaults to version and does not change the binary stamp"
         required: false
         default: ""
         type: string
@@ -626,6 +626,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1
@@ -678,6 +680,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -622,8 +622,14 @@ jobs:
             --version "$NPM_VERSION" \
             --install-npm-package "$install_target"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
           CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
           CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
           export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
@@ -642,6 +648,10 @@ jobs:
           if probe.get("distribution_version") != expected:
               raise SystemExit(
                   f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(
+                  f"binary version {probe.get('version')!r} != {expected!r}"
               )
           if probe.get("npm_bootstrap_version") != expected:
               raise SystemExit(
@@ -664,8 +674,36 @@ jobs:
             --pypi-wheels dist/pypi-wheels \
             --version "$PYPI_VERSION"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
+          CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
+          CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
+          export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
+          python3 - <<'PY'
+          import json
+          import os
+
+          probe = json.loads(os.environ["CMUX_TUI_PROBE"])
+          expected = os.environ["NPM_VERSION"]
+          expected_identity = os.environ["CMUX_TUI_EXPECTED_BUILD_IDENTITY"]
+          if probe.get("build_identity") != expected_identity:
+              raise SystemExit(
+                  f"binary build identity {probe.get('build_identity')!r} "
+                  f"!= {expected_identity!r}"
+              )
+          if probe.get("distribution_version") != expected:
+              raise SystemExit(
+                  f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(f"binary version {probe.get('version')!r} != {expected!r}")
+          PY
           python3 -m venv /tmp/cmux-tui-wheel-smoke
           /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="$PYPI_VERSION"
           /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt

--- a/.github/workflows/sdk-release-cut.yml
+++ b/.github/workflows/sdk-release-cut.yml
@@ -512,10 +512,34 @@ jobs:
             echo "remote_tag_state_sha256=$remote_tag_state_sha256"
           } >> "$GITHUB_OUTPUT"
 
+  credential-environment-preflight:
+    needs:
+      - revalidate-tags
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify credential environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 cmux-tui/bindings/verify_github_environment_policy.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --environment sdk-release-credentials \
+            --dispatcher "$GITHUB_ACTOR"
+
   cut-tags:
     needs:
       - validate-release
       - revalidate-tags
+      - credential-environment-preflight
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions: {}

--- a/cmux-tui/bindings/RELEASING.md
+++ b/cmux-tui/bindings/RELEASING.md
@@ -78,9 +78,12 @@ authorization is valid for the same workflow run attempt and 15 minutes.
   A credential-free job tests and packs `0.0.0-bootstrap.0`, then uploads the
   exact archive. A fresh job downloads and digest-checks that archive before
   its final step receives the temporary token. That step disables npm
-  lifecycle scripts, publishes with provenance under the `bootstrap` tag, and
-  cannot claim `latest`. A separate credential-free job reconciles the exact
-  archive and provenance after an ambiguous publish result. Configure repository
+  lifecycle scripts, and publishes with provenance under the `bootstrap` tag.
+  npm also assigns `latest` to `0.0.0-bootstrap.0` for this sole reservation
+  release. The stable preflight accepts that exact `cmux-sdk` state and
+  requires `latest` to move to the requested stable version after publish. A
+  separate credential-free job reconciles the exact archive and provenance
+  after an ambiguous publish result. Configure repository
   `manaflow-ai/cmux`, workflow `sdk-release-cut.yml`, and the `npm` environment
   as the trusted publisher. In the package's **Settings > Publishing access**,
   select **Require two-factor authentication and disallow tokens**. This still

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -51,6 +51,8 @@ PYPI_VERSION = re.compile(
 )
 PYPI_BOOTSTRAP_VERSION = "0.0.0a0"
 CRATES_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
+NPM_BOOTSTRAP_PACKAGE = "cmux-sdk"
+NPM_BOOTSTRAP_VERSION = "0.0.0-bootstrap.0"
 PUBLISH_POLL_SECONDS = 0.25
 PUBLISH_STOP_SECONDS = 5
 PUBLISH_TIMEOUT_EXIT = 124
@@ -410,20 +412,30 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
         )
         latest = dist_tags.get("latest")
         if latest is not None:
-            if not isinstance(latest, str):
+            if (
+                package == NPM_BOOTSTRAP_PACKAGE
+                and latest == NPM_BOOTSTRAP_VERSION
+            ):
+                # The one-time SDK bootstrap intentionally reserves the npm
+                # name by putting its prerelease on `latest`. The stable
+                # release path below still requires `latest == version` once
+                # the immutable stable archive exists.
+                pass
+            elif not isinstance(latest, str):
                 raise RegistryError(
                     f"npm dist-tag latest is malformed for {package}: {latest!r}"
                 )
-            latest_version = _stable_version(latest)
-            if latest_version is None:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
-                )
-            if latest_version >= candidate:
-                raise ReleaseStateMismatch(
-                    f"npm dist-tag latest points to {latest!r}, which is not older "
-                    f"than requested {version!r}"
-                )
+            else:
+                latest_version = _stable_version(latest)
+                if latest_version is None:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest is not a stable X.Y.Z version: {latest!r}"
+                    )
+                if latest_version >= candidate:
+                    raise ReleaseStateMismatch(
+                        f"npm dist-tag latest points to {latest!r}, which is not older "
+                        f"than requested {version!r}"
+                    )
         return MISSING
     if not isinstance(release, dict):
         raise RegistryError(f"npm metadata is malformed for {package}@{version}")

--- a/cmux-tui/bindings/reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/reconcile_registry_artifact.py
@@ -416,6 +416,14 @@ def _npm_status(package: str, version: str, artifact: Path) -> str:
                 package == NPM_BOOTSTRAP_PACKAGE
                 and latest == NPM_BOOTSTRAP_VERSION
             ):
+                bootstrap_release = versions.get(NPM_BOOTSTRAP_VERSION)
+                if (
+                    not isinstance(bootstrap_release, dict)
+                    or dist_tags.get("bootstrap") != NPM_BOOTSTRAP_VERSION
+                ):
+                    raise RegistryError(
+                        "npm bootstrap metadata is incomplete for cmux-sdk"
+                    )
                 # The one-time SDK bootstrap intentionally reserves the npm
                 # name by putting its prerelease on `latest`. The stable
                 # release path below still requires `latest == version` once

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -482,6 +482,29 @@ class RegistryArtifactTests(unittest.TestCase):
         ), self.assertRaises(reconcile.ReleaseStateMismatch):
             reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
 
+    def test_npm_bootstrap_latest_exception_requires_bootstrap_metadata(self) -> None:
+        metadata = {
+            "dist-tags": {"latest": "0.0.0-bootstrap.0"},
+            "versions": {},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaisesRegex(reconcile.RegistryError, "bootstrap metadata"):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
+    def test_npm_bootstrap_latest_exception_is_sdk_only(self) -> None:
+        metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "other-package", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
+++ b/cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
@@ -445,6 +445,43 @@ class RegistryArtifactTests(unittest.TestCase):
                 reconcile.MISSING,
             )
 
+    def test_npm_allows_bootstrap_latest_until_stable_publish(self) -> None:
+        bootstrap_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {"0.0.0-bootstrap.0": {"dist": {}}},
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(bootstrap_metadata)
+        ):
+            self.assertEqual(
+                reconcile.registry_status(
+                    "npm", "cmux-sdk", "1.0.0", self.artifact
+                ),
+                reconcile.MISSING,
+            )
+
+        stable_metadata = {
+            "dist-tags": {
+                "latest": "0.0.0-bootstrap.0",
+                "bootstrap": "0.0.0-bootstrap.0",
+            },
+            "versions": {
+                "0.0.0-bootstrap.0": {"dist": {}},
+                "1.0.0": {
+                    "dist": {
+                        "integrity": reconcile._integrity(self.artifact, "sha512")
+                    }
+                },
+            },
+        }
+        with mock.patch.object(
+            reconcile, "urlopen", return_value=self.response(stable_metadata)
+        ), self.assertRaises(reconcile.ReleaseStateMismatch):
+            reconcile.registry_status("npm", "cmux-sdk", "1.0.0", self.artifact)
+
     def test_pypi_matches_the_exact_filename_and_sha256(self) -> None:
         metadata = {
             "urls": [

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "verify_github_environment_policy.py"
+SPEC = importlib.util.spec_from_file_location(
+    "verify_github_environment_policy",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
+    environment_name = "sdk-release-credentials"
+    dispatcher = "lawrencecchen"
+
+    def environment(
+        self,
+        *,
+        reviewers: object = None,
+        prevent_self_review: object = True,
+        can_admins_bypass: object = False,
+        deployment_branch_policy: object = None,
+    ) -> dict[str, object]:
+        if reviewers is None:
+            reviewers = [
+                {
+                    "type": "User",
+                    "reviewer": {"login": "austinywang"},
+                }
+            ]
+        if deployment_branch_policy is None:
+            deployment_branch_policy = {
+                "protected_branches": True,
+                "custom_branch_policies": False,
+            }
+        return {
+            "name": self.environment_name,
+            "can_admins_bypass": can_admins_bypass,
+            "deployment_branch_policy": deployment_branch_policy,
+            "protection_rules": [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": prevent_self_review,
+                    "reviewers": reviewers,
+                },
+                {"type": "branch_policy"},
+            ],
+        }
+
+    def assert_rejected(self, payload: dict[str, object]) -> None:
+        with self.assertRaises(policy.EnvironmentPolicyError):
+            policy.validate_environment_policy(
+                payload,
+                self.environment_name,
+                self.dispatcher,
+            )
+
+    def test_accepts_a_protected_environment_with_another_reviewer(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+    def test_rejects_missing_required_reviewer_rule(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = [{"type": "branch_policy"}]
+        self.assert_rejected(payload)
+
+    def test_rejects_self_review_only(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "User",
+                        "reviewer": {"login": self.dispatcher},
+                    }
+                ]
+            )
+        )
+
+    def test_rejects_self_review_setting_disabled(self) -> None:
+        self.assert_rejected(self.environment(prevent_self_review=False))
+
+    def test_rejects_administrator_bypass(self) -> None:
+        self.assert_rejected(self.environment(can_admins_bypass=True))
+
+    def test_rejects_unprotected_or_custom_branch_policy(self) -> None:
+        self.assert_rejected(
+            self.environment(
+                deployment_branch_policy={
+                    "protected_branches": False,
+                    "custom_branch_policies": True,
+                }
+            )
+        )
+
+    def test_accepts_a_team_reviewer_with_self_review_disabled(self) -> None:
+        policy.validate_environment_policy(
+            self.environment(
+                reviewers=[
+                    {
+                        "type": "Team",
+                        "reviewer": {"slug": "sdk-release-reviewers"},
+                    }
+                ]
+            ),
+            self.environment_name,
+            self.dispatcher,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
+++ b/cmux-tui/bindings/tests/test_verify_github_environment_policy.py
@@ -74,6 +74,11 @@ class VerifyGithubEnvironmentPolicyTests(unittest.TestCase):
         payload["protection_rules"] = [{"type": "branch_policy"}]
         self.assert_rejected(payload)
 
+    def test_rejects_malformed_protection_rules(self) -> None:
+        payload = self.environment()
+        payload["protection_rules"] = None
+        self.assert_rejected(payload)
+
     def test_rejects_self_review_only(self) -> None:
         self.assert_rejected(
             self.environment(

--- a/cmux-tui/bindings/verify_github_environment_policy.py
+++ b/cmux-tui/bindings/verify_github_environment_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Verify the protection policy on a GitHub Actions environment."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import sys
+from typing import Any, Mapping, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+GITHUB_API_VERSION = "2022-11-28"
+GITHUB_API_URL = "https://api.github.com"
+USER_AGENT = "cmux-sdk-environment-policy/1 (https://github.com/manaflow-ai/cmux)"
+REPOSITORY_PATTERN = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$"
+)
+
+
+class EnvironmentPolicyError(RuntimeError):
+    """Raised when GitHub cannot prove the required environment policy."""
+
+
+def _repository_slug(repository: str) -> str:
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise EnvironmentPolicyError("GitHub repository must be OWNER/REPOSITORY")
+    return repository
+
+
+def _environment_url(
+    api_url: str,
+    repository: str,
+    environment: str,
+) -> str:
+    if not environment or environment.strip() != environment:
+        raise EnvironmentPolicyError("GitHub environment name must be non-empty")
+    return (
+        f"{api_url.rstrip('/')}/repos/{quote(_repository_slug(repository), safe='/')}"
+        f"/environments/{quote(environment, safe='')}"
+    )
+
+
+def _fetch_environment(
+    repository: str,
+    environment: str,
+    token: str,
+    *,
+    api_url: str = GITHUB_API_URL,
+) -> dict[str, Any]:
+    if not token:
+        raise EnvironmentPolicyError("GitHub API token is missing")
+    request = Request(
+        _environment_url(api_url, repository, environment),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = response.read()
+    except HTTPError as error:
+        raise EnvironmentPolicyError(
+            f"GitHub environment lookup failed with HTTP {error.code}"
+        ) from error
+    except (URLError, OSError, http.client.IncompleteRead) as error:
+        raise EnvironmentPolicyError("GitHub environment lookup failed") from error
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise EnvironmentPolicyError(
+            "GitHub environment lookup returned invalid JSON"
+        ) from error
+    if not isinstance(value, dict):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    return value
+
+
+def _reviewer_is_separate(
+    reviewer: Mapping[str, Any],
+    dispatcher: str,
+) -> bool:
+    reviewer_type = reviewer.get("type")
+    subject = reviewer.get("reviewer")
+    if not isinstance(subject, dict):
+        raise EnvironmentPolicyError("GitHub reviewer identity is malformed")
+    if reviewer_type == "User":
+        login = subject.get("login")
+        if not isinstance(login, str) or not login:
+            raise EnvironmentPolicyError("GitHub user reviewer identity is malformed")
+        return login.casefold() != dispatcher.casefold()
+    if reviewer_type == "Team":
+        slug = subject.get("slug")
+        if not isinstance(slug, str) or not slug:
+            raise EnvironmentPolicyError("GitHub team reviewer identity is malformed")
+        # A team is a separate approval principal. GitHub's prevent_self_review
+        # rule prevents the dispatcher from approving their own deployment even
+        # when they belong to that team.
+        return True
+    raise EnvironmentPolicyError("GitHub reviewer type is unsupported")
+
+
+def validate_environment_policy(
+    payload: Mapping[str, Any],
+    expected_environment: str,
+    dispatcher: str,
+) -> None:
+    """Require the protected, independently reviewed credential environment."""
+
+    if not isinstance(payload, Mapping):
+        raise EnvironmentPolicyError("GitHub environment response is malformed")
+    if not expected_environment or payload.get("name") != expected_environment:
+        raise EnvironmentPolicyError("GitHub environment name does not match")
+    if payload.get("can_admins_bypass") is not False:
+        raise EnvironmentPolicyError(
+            "GitHub environment administrator bypass must be disabled"
+        )
+
+    branch_policy = payload.get("deployment_branch_policy")
+    if not isinstance(branch_policy, Mapping) or (
+        branch_policy.get("protected_branches") is not True
+        or branch_policy.get("custom_branch_policies") is not False
+    ):
+        raise EnvironmentPolicyError(
+            "GitHub environment must allow protected branches only"
+        )
+
+    if not isinstance(dispatcher, str) or not dispatcher.strip():
+        raise EnvironmentPolicyError("GitHub dispatch actor is missing")
+    protection_rules = payload.get("protection_rules")
+    if not isinstance(protection_rules, list):
+        raise EnvironmentPolicyError(
+            "GitHub environment protection rules are malformed"
+        )
+    reviewer_rules = [
+        rule
+        for rule in protection_rules
+        if isinstance(rule, Mapping) and rule.get("type") == "required_reviewers"
+    ]
+    if not reviewer_rules:
+        raise EnvironmentPolicyError(
+            "GitHub environment must require an independent reviewer"
+        )
+    for rule in reviewer_rules:
+        if rule.get("prevent_self_review") is not True:
+            raise EnvironmentPolicyError(
+                "GitHub environment must prevent self-review"
+            )
+        reviewers = rule.get("reviewers")
+        if not isinstance(reviewers, list) or not reviewers:
+            raise EnvironmentPolicyError(
+                "GitHub environment required-reviewer list is empty"
+            )
+        if not any(
+            _reviewer_is_separate(reviewer, dispatcher)
+            for reviewer in reviewers
+            if isinstance(reviewer, Mapping)
+        ):
+            raise EnvironmentPolicyError(
+                "GitHub environment has no reviewer other than the dispatcher"
+            )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+    )
+    parser.add_argument("--environment", required=True)
+    parser.add_argument(
+        "--dispatcher",
+        default=os.environ.get("GITHUB_ACTOR", ""),
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("GITHUB_API_URL", GITHUB_API_URL),
+    )
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="environment variable containing the GitHub API token",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        payload = _fetch_environment(
+            args.repository,
+            args.environment,
+            os.environ.get(args.token_env, ""),
+            api_url=args.api_url,
+        )
+        validate_environment_policy(payload, args.environment, args.dispatcher)
+    except EnvironmentPolicyError as error:
+        print(f"GitHub environment policy verification failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"verified GitHub environment policy for {args.repository}/"
+        f"{args.environment}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
+++ b/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
@@ -10,12 +10,7 @@ use tokio::process::{Child, Command};
 
 const SSH_BOOTSTRAP_OUTPUT_LIMIT: usize = 4_096;
 
-/// The version of the npm/PyPI distribution that contains this binary. Release
-/// workflows stamp it independently from the Rust crate's internal version.
-pub const DISTRIBUTION_VERSION: &str = match option_env!("CMUX_TUI_DISTRIBUTION_VERSION") {
-    Some(version) => version,
-    None => env!("CARGO_PKG_VERSION"),
-};
+pub use cmux_tui_core::DISTRIBUTION_VERSION;
 pub const NPM_BOOTSTRAP_VERSION: Option<&str> = option_env!("CMUX_TUI_NPM_BOOTSTRAP_VERSION");
 pub const BUILD_IDENTITY: &str = env!("CMUX_TUI_BUILD_IDENTITY");
 

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod terminal_host_protocol;
 pub mod terminal_host_runtime;
 #[cfg(unix)]
 pub mod unix_process_scope;
+mod version;
 
 pub use agent_hooks::{
     AGENT_HOOK_MANIFEST_VERSION, AGENT_HOOK_PRODUCER_ID, agent_hook_journal_ingress,
@@ -78,6 +79,7 @@ pub use surface::{
     SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
     TerminalPointerSnapshot,
 };
+pub use version::DISTRIBUTION_VERSION;
 pub use workspace_registry::{
     FrontendProjection, JournalAppendCommit, JournalAuthority, JournalCheckpoint, JournalClass,
     JournalContentRef, JournalEventSchema, JournalHookDeliveryPolicy, JournalHookExec,

--- a/cmux-tui/crates/cmux-tui-core/src/version.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/version.rs
@@ -1,0 +1,46 @@
+//! Version identity shared by every cmux-tui binary entrypoint.
+
+/// Resolve the version stamped into a distributed binary.
+///
+/// Release workflows provide `CMUX_TUI_DISTRIBUTION_VERSION`. Local builds do
+/// not set it, so they retain the Cargo package version as their fallback.
+const fn resolve_distribution_version<'a>(
+    stamped_version: Option<&'a str>,
+    cargo_version: &'a str,
+) -> &'a str {
+    match stamped_version {
+        Some(version) => version,
+        None => cargo_version,
+    }
+}
+
+/// Canonical version shown by `cmux-tui --version` and `remote-probe`.
+///
+/// Stable releases use the shared `X.Y.Z` package version. Nightly builds use
+/// the npm-form prerelease stamp; the PyPI `.dev...` suffix remains packaging
+/// metadata because one binary is shared by both registries.
+pub const DISTRIBUTION_VERSION: &str = resolve_distribution_version(
+    option_env!("CMUX_TUI_DISTRIBUTION_VERSION"),
+    env!("CARGO_PKG_VERSION"),
+);
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_distribution_version;
+
+    #[test]
+    fn stable_release_stamp_overrides_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(Some("0.11.0"), "0.1.0"), "0.11.0");
+    }
+
+    #[test]
+    fn nightly_binary_stamp_preserves_the_npm_prerelease_form() {
+        let nightly = "0.11.1-nightly.20260817.42";
+        assert_eq!(resolve_distribution_version(Some(nightly), "0.1.0"), nightly);
+    }
+
+    #[test]
+    fn local_builds_fall_back_to_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(None, "0.1.0"), "0.1.0");
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -86,7 +86,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Context;
 use cmux_tui_core::resource::TerminalPublicId;
-use cmux_tui_core::{Mux, ProviderWorkspaceAuthority, SurfaceOptions};
+use cmux_tui_core::{DISTRIBUTION_VERSION, Mux, ProviderWorkspaceAuthority, SurfaceOptions};
 #[cfg(unix)]
 use cmux_tui_machine_protocol::BearerToken;
 use machine::{
@@ -770,17 +770,18 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
 fn version_string() -> String {
     // Packaged builds stamp both source identities so artifact validation can
     // reject a cmux binary built against a different Ghostty checkout before
-    // it enters an app bundle. Local builds report the crate version alone.
+    // it enters an app bundle. The version follows the canonical distribution
+    // stamp and falls back to the Cargo version for local builds.
     let commit = option_env!("CMUX_TUI_BUILD_COMMIT")
         .or(option_env!("CMUX_MUX_BUILD_COMMIT"))
         .filter(|commit| !commit.is_empty());
     let ghostty = option_env!("CMUX_TUI_GHOSTTY_COMMIT").filter(|commit| !commit.is_empty());
     match (commit, ghostty) {
         (Some(commit), Some(ghostty)) => {
-            format!("{} ({commit}; ghostty {ghostty})", env!("CARGO_PKG_VERSION"))
+            format!("{DISTRIBUTION_VERSION} ({commit}; ghostty {ghostty})")
         }
-        (Some(commit), None) => format!("{} ({commit})", env!("CARGO_PKG_VERSION")),
-        (None, _) => env!("CARGO_PKG_VERSION").to_string(),
+        (Some(commit), None) => format!("{DISTRIBUTION_VERSION} ({commit})"),
+        (None, _) => DISTRIBUTION_VERSION.to_string(),
     }
 }
 
@@ -2627,6 +2628,16 @@ mod tests {
 
     fn args(values: &[&str]) -> Args {
         parse_args_result(values.iter().map(|value| value.to_string())).unwrap()
+    }
+
+    #[test]
+    fn version_output_uses_the_canonical_distribution_stamp() {
+        let output = version_string();
+        assert!(
+            output == DISTRIBUTION_VERSION
+                || output.starts_with(&format!("{DISTRIBUTION_VERSION} (")),
+            "version output {output:?} does not use distribution version {DISTRIBUTION_VERSION:?}"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -31,11 +31,12 @@ use cmux_remote::provider::{
     RelayCredentialSource, SshProvider, SshProviderConfig, SupportedClientAuthModes,
     sanitized_route,
 };
-use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, DISTRIBUTION_VERSION, NPM_BOOTSTRAP_VERSION};
+use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, NPM_BOOTSTRAP_VERSION};
 use cmux_remote_protocol::{
     LanePolicy, REMOTE_PROTOCOL_VERSION, RoutePolicy, SessionId, WorkspaceRequest,
     WorkspaceResponse,
 };
+use cmux_tui_core::DISTRIBUTION_VERSION;
 use serde_json::Value;
 use url::Url;
 use zeroize::Zeroizing;
@@ -1687,28 +1688,31 @@ fn print_admin_response(action: &str, response: AdminResponse, json: bool) -> an
 }
 
 fn run_probe(args: &[String]) -> anyhow::Result<()> {
-    let value = serde_json::json!({
-        "app": "cmux-tui",
-        "version": env!("CARGO_PKG_VERSION"),
-        "distribution_version": DISTRIBUTION_VERSION,
-        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
-        "build_identity": BUILD_IDENTITY,
-        "remote_protocol": REMOTE_PROTOCOL_VERSION,
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-    });
+    let value = probe_value();
     if args.iter().any(|argument| argument == "--json") {
         println!("{}", serde_json::to_string(&value)?);
     } else {
         println!(
-            "cmux-tui {} remote-protocol={} {}-{}",
-            env!("CARGO_PKG_VERSION"),
+            "cmux-tui {DISTRIBUTION_VERSION} remote-protocol={} {}-{}",
             REMOTE_PROTOCOL_VERSION,
             std::env::consts::OS,
             std::env::consts::ARCH
         );
     }
     Ok(())
+}
+
+fn probe_value() -> Value {
+    serde_json::json!({
+        "app": "cmux-tui",
+        "version": DISTRIBUTION_VERSION,
+        "distribution_version": DISTRIBUTION_VERSION,
+        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
+        "build_identity": BUILD_IDENTITY,
+        "remote_protocol": REMOTE_PROTOCOL_VERSION,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+    })
 }
 
 struct PendingInstall {
@@ -2474,6 +2478,13 @@ fn expand_home(path: String) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_probe_uses_one_canonical_distribution_version() {
+        let value = probe_value();
+        assert_eq!(value["version"].as_str(), Some(DISTRIBUTION_VERSION));
+        assert_eq!(value["distribution_version"].as_str(), Some(DISTRIBUTION_VERSION));
+    }
 
     fn seed_legacy_authorization_state(state_dir: &Path) {
         let auth_state_dir = state_dir.join("auth");

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -8,9 +8,19 @@ TUI distribution versions are independent of the SDK version. SDKs publish as
 `cmux-sdk` on npm and PyPI, so the `cmux` name remains exclusive to this TUI
 release path.
 
-The TUI does not store its version in a checked-in manifest. The packaging
-scripts receive `--version`, so cutting a stable TUI release is just creating a
-`cmux-tui-vX.Y.Z` tag on `main`.
+The TUI does not store its version in a checked-in manifest. The reusable build
+workflow receives one canonical `version` input and exports it as
+`CMUX_TUI_DISTRIBUTION_VERSION`. `cmux-tui --version` and the `version` and
+`distribution_version` fields from `remote-probe --json` all use that stamp;
+the Cargo crate version remains an internal fallback for local builds.
+
+Stable builds pass the same `X.Y.Z` value to the binary, npm metadata, and PyPI
+metadata. Nightly builds keep the existing registry-specific forms: the npm
+form is the canonical binary stamp, while the PyPI `.dev...` value is wheel
+metadata only because both registries ship the same binaries.
+
+The packaging scripts receive their registry-specific `--version` values, so
+cutting a stable TUI release is just creating a `cmux-tui-vX.Y.Z` tag on `main`.
 
 ## Packages
 

--- a/tests/test_sdk_release_credential_environment_policy.py
+++ b/tests/test_sdk_release_credential_environment_policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "sdk-release-cut.yml"
+
+
+def workflow_job(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_sdk_release_credential_environment_policy_is_fail_closed() -> None:
+    release = WORKFLOW.read_text()
+    policy = workflow_job(release, "credential-environment-preflight")
+    cut_tags = workflow_job(release, "cut-tags")
+
+    assert "actions: read" in policy
+    assert "contents: read" in policy
+    assert "GITHUB_TOKEN: ${{ github.token }}" in policy
+    assert "verify_github_environment_policy.py" in policy
+    assert "--environment sdk-release-credentials" in policy
+    assert "--dispatcher \"$GITHUB_ACTOR\"" in policy
+    assert "credential-environment-preflight" in cut_tags
+    assert release.index("revalidate-tags:") < release.index(
+        "credential-environment-preflight:"
+    ) < release.index("cut-tags:")

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -137,6 +137,9 @@ def test_npm_bootstrap_preserves_the_first_stable_version() -> None:
     assert sdk_ci.count('".github/workflows/sdk-bootstrap-npm.yml"') == 2
     assert "sdk-bootstrap-npm.yml" in releasing
     assert "0.0.0-bootstrap.0" in releasing
+    assert "also assigns `latest` to `0.0.0-bootstrap.0`" in releasing
+    assert "stable preflight accepts that exact `cmux-sdk` state" in releasing
+    assert "cannot claim `latest`" not in releasing
     assert "first `cmux-sdk` release interactively" not in releasing
 
 


### PR DESCRIPTION
## Integrated candidate

This dependent draft layers the release-wave fixes from PRs [10251](https://github.com/manaflow-ai/cmux/pull/10251), [10245](https://github.com/manaflow-ai/cmux/pull/10245), and [10250](https://github.com/manaflow-ai/cmux/pull/10250) onto [PR10258](https://github.com/manaflow-ai/cmux/pull/10258), whose base is [PR10253](https://github.com/manaflow-ai/cmux/pull/10253) at `162c188fe24455a95a108879a355f52f358496d6`.

The candidate head is `e53e51608ef3a77fdb4b2c18aa44ad7a94edbfb4`.

## Preserved history

- PR10251 red `ab0e3dfbd2`, green `25a51c39ee`
- PR10245 red/green sequence `a7fdb695be`, `dee6e61a0e`, `3408174779`, `5f4c6d355a`, `b989285d19`, `d864bd677c`
- PR10250 red `5d874ab344`, green `e53e51608e`

No original PR branch was modified. No merge or release action is requested.

## Local evidence

Python release and policy tests, TUI spec/schema/resource checks, codegen drift checks, Python compilation, `git diff --check`, and actionlint passed. Actionlint reported only existing shellcheck style warnings outside this candidate's changed lines.

Hosted SDK, spec, and TUI version checks are dispatched for this exact head.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789545781&installation_model_id=21920&pr_number=10262&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10262&signature=9586521b0a533cfc492b1fc22bcafba42e7c5233313928ac79ca94f1e00b7148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns TUI binaries to a single distribution version and gates SDK tag cutting on verified credential environment protection. Also permits the one-time npm bootstrap `latest` reservation for `cmux-sdk` during preflight while preserving strict stable publish checks.

- TUI binary version identity: `cmux-tui --version` and `remote-probe --json` now use the canonical distribution stamp (`CMUX_TUI_DISTRIBUTION_VERSION`), not the Cargo crate version. The build workflow verifies the binary `--version` and `remote-probe` fields match the canonical stamp and the current build identity.
- SDK release protection: Adds a preflight job that blocks `cut-tags` unless the `sdk-release-credentials` environment requires independent reviewers, prevents self‑review, disallows admin bypass, and limits deployments to protected branches. Includes a verifier script and tests that fail closed.
- npm bootstrap handling: `reconcile_registry_artifact` allows `cmux-sdk` to keep `latest` on `0.0.0-bootstrap.0` until the immutable stable archive exists, but requires complete bootstrap metadata and resumes strict `latest` semantics for stable publishes. Docs and tests cover this behavior.

**Rollout**
- Configure the `sdk-release-credentials` environment to meet the verifier’s requirements (independent reviewers, self‑review disabled, no admin bypass, protected branches only). No other migration is required.

<sup>Written for commit e53e51608ef3a77fdb4b2c18aa44ad7a94edbfb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

