### PR TITLE
Fix startup benchmark tool path construction

### DIFF
--- a/.github/workflows/cmux-tui-startup-benchmark.yml
+++ b/.github/workflows/cmux-tui-startup-benchmark.yml
@@ -492,6 +492,12 @@ jobs:
           printf 'trusted=%s\nbaseline=%s\ncandidate=%s\n' \
             "$actual_trusted" "$actual_baseline" "$actual_candidate"
 
+      - name: Test startup benchmark path helpers
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$PYTHON_CMD" "$TRUSTED_SOURCE/cmux-tui/scripts/tests/test_record_startup_tools.py"
+
       - name: Initialize exact Ghostty revisions
         shell: bash
         run: |
@@ -1192,43 +1198,7 @@ jobs:
               "${harness_args[@]}"
           )
 
-          "$PYTHON_CMD" - <<'PY'
-          import hashlib
-          import os
-          import pathlib
-
-          target = os.environ["RUST_TARGET"]
-          suffix = os.environ["BINARY_SUFFIX"]
-
-          def binary(root):
-              release = pathlib.Path(os.environ[root])
-              if target:
-                  release /= target
-              return release / "release" / f"cmux-tui{suffix}"
-
-          def digest(path):
-              sha256 = hashlib.sha256()
-              with path.open("rb") as source:
-                  for chunk in iter(lambda: source.read(1024 * 1024), b""):
-                      sha256.update(chunk)
-              return sha256.hexdigest()
-
-          baseline_sha256 = digest(binary("BASELINE_TARGET_ROOT"))
-          trusted_release = pathlib.Path(os.environ["TRUSTED_TARGET_ROOT"])
-          if target:
-              trusted_release /= target
-          trusted_release /= "release" / "examples"
-          supervisor = trusted_release / f"startup_benchmark_supervisor{suffix}"
-          preflight = trusted_release / f"startup_benchmark_preflight{suffix}"
-          harness = trusted_release / f"startup_benchmark{suffix}"
-          for path in (supervisor, preflight, harness):
-              if not path.is_file():
-                  raise SystemExit(f"trusted benchmark tool is missing: {path}")
-          supervisor_sha256 = digest(supervisor)
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              print(f"binary_sha256={baseline_sha256}", file=output)
-              print(f"supervisor_sha256={supervisor_sha256}", file=output)
-          PY
+          "$PYTHON_CMD" "$TRUSTED_SOURCE/cmux-tui/scripts/record_startup_tools.py"
 
       - name: Prove startup sandbox behavior
         id: sandbox-preflight

--- a/cmux-tui/scripts/record_startup_tools.py
+++ b/cmux-tui/scripts/record_startup_tools.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Record the trusted startup benchmark tool paths and digests."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def release_root(target_root: Path, target: str) -> Path:
+    """Return the Cargo release directory for a target root."""
+
+    release = target_root
+    if target:
+        release /= target
+    return release / "release"
+
+
+def tool_paths(trusted_target_root: Path, target: str, suffix: str) -> dict[str, Path]:
+    """Return the trusted benchmark executables for one platform."""
+
+    trusted_release = trusted_target_root
+    if target:
+        trusted_release /= target
+    # Keep this expression in the first red commit to reproduce the hosted bug.
+    trusted_release /= "release" / "examples"
+    return {
+        "supervisor": trusted_release / f"startup_benchmark_supervisor{suffix}",
+        "preflight": trusted_release / f"startup_benchmark_preflight{suffix}",
+        "harness": trusted_release / f"startup_benchmark{suffix}",
+    }
+
+
+def digest(path: Path) -> str:
+    """Return the SHA-256 digest of a regular file."""
+
+    sha256 = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def record_from_environment() -> None:
+    """Validate benchmark tools and append their digests to GITHUB_OUTPUT."""
+
+    target = os.environ["RUST_TARGET"]
+    suffix = os.environ["BINARY_SUFFIX"]
+    baseline_binary = release_root(
+        Path(os.environ["BASELINE_TARGET_ROOT"]), target
+    ) / f"cmux-tui{suffix}"
+    baseline_sha256 = digest(baseline_binary)
+
+    tools = tool_paths(Path(os.environ["TRUSTED_TARGET_ROOT"]), target, suffix)
+    for path in tools.values():
+        if not path.is_file():
+            raise SystemExit(f"trusted benchmark tool is missing: {path}")
+
+    supervisor_sha256 = digest(tools["supervisor"])
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+        print(f"binary_sha256={baseline_sha256}", file=output)
+        print(f"supervisor_sha256={supervisor_sha256}", file=output)
+
+
+if __name__ == "__main__":
+    record_from_environment()

--- a/cmux-tui/scripts/record_startup_tools.py
+++ b/cmux-tui/scripts/record_startup_tools.py
@@ -23,8 +23,8 @@ def tool_paths(trusted_target_root: Path, target: str, suffix: str) -> dict[str,
     trusted_release = trusted_target_root
     if target:
         trusted_release /= target
-    # Keep this expression in the first red commit to reproduce the hosted bug.
-    trusted_release /= "release" / "examples"
+    trusted_release /= "release"
+    trusted_release /= "examples"
     return {
         "supervisor": trusted_release / f"startup_benchmark_supervisor{suffix}",
         "preflight": trusted_release / f"startup_benchmark_preflight{suffix}",

--- a/cmux-tui/scripts/tests/test_record_startup_tools.py
+++ b/cmux-tui/scripts/tests/test_record_startup_tools.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Regression tests for startup benchmark tool path construction."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "record_startup_tools.py"
+SPEC = importlib.util.spec_from_file_location("record_startup_tools", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+TOOLS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TOOLS)
+
+
+class StartupToolPathTests(unittest.TestCase):
+    def test_targeted_tools_live_under_release_examples(self) -> None:
+        paths = TOOLS.tool_paths(Path("/tmp/target"), "x86_64-pc-windows-gnu", ".exe")
+
+        self.assertEqual(
+            paths,
+            {
+                "supervisor": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark_supervisor.exe"
+                ),
+                "preflight": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark_preflight.exe"
+                ),
+                "harness": Path(
+                    "/tmp/target/x86_64-pc-windows-gnu/release/examples/startup_benchmark.exe"
+                ),
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Depends on https://github.com/manaflow-ai/cmux/pull/10238.

This branch replays the red test and green Path-based fix from PR10237 onto the current PR10238 head. The workflow expression `trusted_release /= "release" / "examples"` evaluates string division before pathlib division and raises TypeError. The helper now constructs release/example paths as Path operands and has a focused behavior test.

Checks: focused path test, cmux-tui SDK/spec checks, startup contract/claim checks. Rust/Cargo/Zig/Xcode builds were not run locally.