### PR TITLE
Integration: TUI version and docs contracts on release stack

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "npm package version, or the shared stable X.Y.Z version"
+        description: "canonical binary and npm version, or the shared stable X.Y.Z version"
         required: true
         type: string
       pypi_version:
-        description: "PyPI package version; defaults to version"
+        description: "PyPI metadata version; defaults to version and does not change the binary stamp"
         required: false
         default: ""
         type: string
@@ -626,6 +626,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1
@@ -678,6 +680,8 @@ jobs:
             printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
             exit 1
           }
+          # NPM_VERSION is the canonical binary stamp. PyPI nightlies may use
+          # a different `.dev...` metadata version for the same binaries.
           if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
             echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
             exit 1

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -622,8 +622,14 @@ jobs:
             --version "$NPM_VERSION" \
             --install-npm-package "$install_target"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
           CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
           CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
           export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
@@ -642,6 +648,10 @@ jobs:
           if probe.get("distribution_version") != expected:
               raise SystemExit(
                   f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(
+                  f"binary version {probe.get('version')!r} != {expected!r}"
               )
           if probe.get("npm_bootstrap_version") != expected:
               raise SystemExit(
@@ -664,8 +674,36 @@ jobs:
             --pypi-wheels dist/pypi-wheels \
             --version "$PYPI_VERSION"
           chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
-          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
+          CMUX_TUI_VERSION_OUTPUT="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version 2>&1)" || {
+            printf '%s\n' "$CMUX_TUI_VERSION_OUTPUT" >&2
+            exit 1
+          }
+          if [[ "$CMUX_TUI_VERSION_OUTPUT" != "cmux $NPM_VERSION"* ]]; then
+            echo "binary --version output $CMUX_TUI_VERSION_OUTPUT does not start with cmux $NPM_VERSION" >&2
+            exit 1
+          fi
+          CMUX_TUI_PROBE="$(dist/binaries/cmux-tui-x86_64-unknown-linux-musl remote-probe --json)"
+          CMUX_TUI_EXPECTED_BUILD_IDENTITY="$(git rev-parse HEAD)"
+          export CMUX_TUI_PROBE CMUX_TUI_EXPECTED_BUILD_IDENTITY
+          python3 - <<'PY'
+          import json
+          import os
+
+          probe = json.loads(os.environ["CMUX_TUI_PROBE"])
+          expected = os.environ["NPM_VERSION"]
+          expected_identity = os.environ["CMUX_TUI_EXPECTED_BUILD_IDENTITY"]
+          if probe.get("build_identity") != expected_identity:
+              raise SystemExit(
+                  f"binary build identity {probe.get('build_identity')!r} "
+                  f"!= {expected_identity!r}"
+              )
+          if probe.get("distribution_version") != expected:
+              raise SystemExit(
+                  f"binary distribution version {probe.get('distribution_version')!r} != {expected!r}"
+              )
+          if probe.get("version") != expected:
+              raise SystemExit(f"binary version {probe.get('version')!r} != {expected!r}")
+          PY
           python3 -m venv /tmp/cmux-tui-wheel-smoke
           /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="$PYPI_VERSION"
           /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt

--- a/.github/workflows/cmux-tui-spec.yml
+++ b/.github/workflows/cmux-tui-spec.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Test inventory checker
         run: python3 cmux-tui/scripts/test_check_spec_inventory.py
 
+      - name: Test frontend documentation protocol
+        run: python3 cmux-tui/scripts/test_frontend_docs.py
+
       - name: Check protocol and TUI action inventory
         run: python3 cmux-tui/scripts/check-spec-inventory.py
 

--- a/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
+++ b/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
@@ -10,12 +10,7 @@ use tokio::process::{Child, Command};
 
 const SSH_BOOTSTRAP_OUTPUT_LIMIT: usize = 4_096;
 
-/// The version of the npm/PyPI distribution that contains this binary. Release
-/// workflows stamp it independently from the Rust crate's internal version.
-pub const DISTRIBUTION_VERSION: &str = match option_env!("CMUX_TUI_DISTRIBUTION_VERSION") {
-    Some(version) => version,
-    None => env!("CARGO_PKG_VERSION"),
-};
+pub use cmux_tui_core::DISTRIBUTION_VERSION;
 pub const NPM_BOOTSTRAP_VERSION: Option<&str> = option_env!("CMUX_TUI_NPM_BOOTSTRAP_VERSION");
 pub const BUILD_IDENTITY: &str = env!("CMUX_TUI_BUILD_IDENTITY");
 

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod terminal_host_protocol;
 pub mod terminal_host_runtime;
 #[cfg(unix)]
 pub mod unix_process_scope;
+mod version;
 
 pub use agent_hooks::{
     AGENT_HOOK_MANIFEST_VERSION, AGENT_HOOK_PRODUCER_ID, agent_hook_journal_ingress,
@@ -78,6 +79,7 @@ pub use surface::{
     SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
     TerminalPointerSnapshot,
 };
+pub use version::DISTRIBUTION_VERSION;
 pub use workspace_registry::{
     FrontendProjection, JournalAppendCommit, JournalAuthority, JournalCheckpoint, JournalClass,
     JournalContentRef, JournalEventSchema, JournalHookDeliveryPolicy, JournalHookExec,

--- a/cmux-tui/crates/cmux-tui-core/src/version.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/version.rs
@@ -1,0 +1,46 @@
+//! Version identity shared by every cmux-tui binary entrypoint.
+
+/// Resolve the version stamped into a distributed binary.
+///
+/// Release workflows provide `CMUX_TUI_DISTRIBUTION_VERSION`. Local builds do
+/// not set it, so they retain the Cargo package version as their fallback.
+const fn resolve_distribution_version<'a>(
+    stamped_version: Option<&'a str>,
+    cargo_version: &'a str,
+) -> &'a str {
+    match stamped_version {
+        Some(version) => version,
+        None => cargo_version,
+    }
+}
+
+/// Canonical version shown by `cmux-tui --version` and `remote-probe`.
+///
+/// Stable releases use the shared `X.Y.Z` package version. Nightly builds use
+/// the npm-form prerelease stamp; the PyPI `.dev...` suffix remains packaging
+/// metadata because one binary is shared by both registries.
+pub const DISTRIBUTION_VERSION: &str = resolve_distribution_version(
+    option_env!("CMUX_TUI_DISTRIBUTION_VERSION"),
+    env!("CARGO_PKG_VERSION"),
+);
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_distribution_version;
+
+    #[test]
+    fn stable_release_stamp_overrides_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(Some("0.11.0"), "0.1.0"), "0.11.0");
+    }
+
+    #[test]
+    fn nightly_binary_stamp_preserves_the_npm_prerelease_form() {
+        let nightly = "0.11.1-nightly.20260817.42";
+        assert_eq!(resolve_distribution_version(Some(nightly), "0.1.0"), nightly);
+    }
+
+    #[test]
+    fn local_builds_fall_back_to_the_cargo_crate_version() {
+        assert_eq!(resolve_distribution_version(None, "0.1.0"), "0.1.0");
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -86,7 +86,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Context;
 use cmux_tui_core::resource::TerminalPublicId;
-use cmux_tui_core::{Mux, ProviderWorkspaceAuthority, SurfaceOptions};
+use cmux_tui_core::{DISTRIBUTION_VERSION, Mux, ProviderWorkspaceAuthority, SurfaceOptions};
 #[cfg(unix)]
 use cmux_tui_machine_protocol::BearerToken;
 use machine::{
@@ -770,17 +770,18 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
 fn version_string() -> String {
     // Packaged builds stamp both source identities so artifact validation can
     // reject a cmux binary built against a different Ghostty checkout before
-    // it enters an app bundle. Local builds report the crate version alone.
+    // it enters an app bundle. The version follows the canonical distribution
+    // stamp and falls back to the Cargo version for local builds.
     let commit = option_env!("CMUX_TUI_BUILD_COMMIT")
         .or(option_env!("CMUX_MUX_BUILD_COMMIT"))
         .filter(|commit| !commit.is_empty());
     let ghostty = option_env!("CMUX_TUI_GHOSTTY_COMMIT").filter(|commit| !commit.is_empty());
     match (commit, ghostty) {
         (Some(commit), Some(ghostty)) => {
-            format!("{} ({commit}; ghostty {ghostty})", env!("CARGO_PKG_VERSION"))
+            format!("{DISTRIBUTION_VERSION} ({commit}; ghostty {ghostty})")
         }
-        (Some(commit), None) => format!("{} ({commit})", env!("CARGO_PKG_VERSION")),
-        (None, _) => env!("CARGO_PKG_VERSION").to_string(),
+        (Some(commit), None) => format!("{DISTRIBUTION_VERSION} ({commit})"),
+        (None, _) => DISTRIBUTION_VERSION.to_string(),
     }
 }
 
@@ -2627,6 +2628,16 @@ mod tests {
 
     fn args(values: &[&str]) -> Args {
         parse_args_result(values.iter().map(|value| value.to_string())).unwrap()
+    }
+
+    #[test]
+    fn version_output_uses_the_canonical_distribution_stamp() {
+        let output = version_string();
+        assert!(
+            output == DISTRIBUTION_VERSION
+                || output.starts_with(&format!("{DISTRIBUTION_VERSION} (")),
+            "version output {output:?} does not use distribution version {DISTRIBUTION_VERSION:?}"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -31,11 +31,12 @@ use cmux_remote::provider::{
     RelayCredentialSource, SshProvider, SshProviderConfig, SupportedClientAuthModes,
     sanitized_route,
 };
-use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, DISTRIBUTION_VERSION, NPM_BOOTSTRAP_VERSION};
+use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, NPM_BOOTSTRAP_VERSION};
 use cmux_remote_protocol::{
     LanePolicy, REMOTE_PROTOCOL_VERSION, RoutePolicy, SessionId, WorkspaceRequest,
     WorkspaceResponse,
 };
+use cmux_tui_core::DISTRIBUTION_VERSION;
 use serde_json::Value;
 use url::Url;
 use zeroize::Zeroizing;
@@ -1687,28 +1688,31 @@ fn print_admin_response(action: &str, response: AdminResponse, json: bool) -> an
 }
 
 fn run_probe(args: &[String]) -> anyhow::Result<()> {
-    let value = serde_json::json!({
-        "app": "cmux-tui",
-        "version": env!("CARGO_PKG_VERSION"),
-        "distribution_version": DISTRIBUTION_VERSION,
-        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
-        "build_identity": BUILD_IDENTITY,
-        "remote_protocol": REMOTE_PROTOCOL_VERSION,
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-    });
+    let value = probe_value();
     if args.iter().any(|argument| argument == "--json") {
         println!("{}", serde_json::to_string(&value)?);
     } else {
         println!(
-            "cmux-tui {} remote-protocol={} {}-{}",
-            env!("CARGO_PKG_VERSION"),
+            "cmux-tui {DISTRIBUTION_VERSION} remote-protocol={} {}-{}",
             REMOTE_PROTOCOL_VERSION,
             std::env::consts::OS,
             std::env::consts::ARCH
         );
     }
     Ok(())
+}
+
+fn probe_value() -> Value {
+    serde_json::json!({
+        "app": "cmux-tui",
+        "version": DISTRIBUTION_VERSION,
+        "distribution_version": DISTRIBUTION_VERSION,
+        "npm_bootstrap_version": NPM_BOOTSTRAP_VERSION,
+        "build_identity": BUILD_IDENTITY,
+        "remote_protocol": REMOTE_PROTOCOL_VERSION,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+    })
 }
 
 struct PendingInstall {
@@ -2474,6 +2478,13 @@ fn expand_home(path: String) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_probe_uses_one_canonical_distribution_version() {
+        let value = probe_value();
+        assert_eq!(value["version"].as_str(), Some(DISTRIBUTION_VERSION));
+        assert_eq!(value["distribution_version"].as_str(), Some(DISTRIBUTION_VERSION));
+    }
 
     fn seed_legacy_authorization_state(state_dir: &Path) {
         let auth_state_dir = state_dir.join("auth");

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -8,9 +8,19 @@ TUI distribution versions are independent of the SDK version. SDKs publish as
 `cmux-sdk` on npm and PyPI, so the `cmux` name remains exclusive to this TUI
 release path.
 
-The TUI does not store its version in a checked-in manifest. The packaging
-scripts receive `--version`, so cutting a stable TUI release is just creating a
-`cmux-tui-vX.Y.Z` tag on `main`.
+The TUI does not store its version in a checked-in manifest. The reusable build
+workflow receives one canonical `version` input and exports it as
+`CMUX_TUI_DISTRIBUTION_VERSION`. `cmux-tui --version` and the `version` and
+`distribution_version` fields from `remote-probe --json` all use that stamp;
+the Cargo crate version remains an internal fallback for local builds.
+
+Stable builds pass the same `X.Y.Z` value to the binary, npm metadata, and PyPI
+metadata. Nightly builds keep the existing registry-specific forms: the npm
+form is the canonical binary stamp, while the PyPI `.dev...` value is wheel
+metadata only because both registries ship the same binaries.
+
+The packaging scripts receive their registry-specific `--version` values, so
+cutting a stable TUI release is just creating a `cmux-tui-vX.Y.Z` tag on `main`.
 
 ## Packages
 

--- a/cmux-tui/frontends/README.ja.md
+++ b/cmux-tui/frontends/README.ja.md
@@ -3,7 +3,7 @@
 [English](README.md)
 
 リポジトリ内のリファレンス実装は[ウェブフロントエンド](web)です。
-プロトコルv7のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリポイントを
 使用した実装例です。
 
 macOSネイティブフロントエンドは、非公開の

--- a/cmux-tui/frontends/README.md
+++ b/cmux-tui/frontends/README.md
@@ -3,7 +3,7 @@
 [日本語](README.ja.md)
 
 The in-tree reference frontend is the [web frontend](web). It demonstrates the
-protocol-v7 WebSocket API and the browser entry point of the TypeScript SDK.
+protocol-v12 WebSocket API and the browser entry point of the TypeScript SDK.
 
 The native macOS frontend is maintained separately in the private
 [`manaflow-ai/cmux-lite`](https://github.com/manaflow-ai/cmux-lite) repository.

--- a/cmux-tui/frontends/web/README.ja.md
+++ b/cmux-tui/frontends/web/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-プロトコルv10のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
+プロトコルv12のWebSocket APIとTypeScript SDKのブラウザ向けエントリだけで、
 自然なcmuxクライアントを構築できることを示す小規模なサードパーティー形式の
 フロントエンドです。信頼できるワークスペースツリーの表示、アクティブなPTY
 サーフェスへのxterm.jsの接続、キーボード入力の転送、ターミナルセル単位の

--- a/cmux-tui/scripts/test_frontend_docs.py
+++ b/cmux-tui/scripts/test_frontend_docs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep frontend README protocol claims aligned with the supported wire API."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+TUI = Path(__file__).resolve().parents[1]
+README_PATHS = (
+    TUI / "frontends" / "README.md",
+    TUI / "frontends" / "README.ja.md",
+    TUI / "frontends" / "web" / "README.md",
+    TUI / "frontends" / "web" / "README.ja.md",
+)
+
+
+def supported_protocol() -> int:
+    source = (TUI / "frontends" / "web" / "src" / "lib" / "protocol.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"SUPPORTED_PROTOCOL\s*=\s*(\d+)", source)
+    if match is None:
+        raise AssertionError("web frontend has no supported protocol constant")
+    return int(match.group(1))
+
+
+def documented_protocol() -> int:
+    source = (TUI / "docs" / "protocol.md").read_text(encoding="utf-8")
+    match = re.search(r"^# Raw control protocol v(\d+)\s*$", source, re.MULTILINE)
+    if match is None:
+        raise AssertionError("raw protocol guide has no version heading")
+    return int(match.group(1))
+
+
+class FrontendReadmeProtocolTests(unittest.TestCase):
+    def test_readmes_match_the_supported_websocket_protocol(self) -> None:
+        expected = supported_protocol()
+        self.assertEqual(expected, documented_protocol())
+
+        for path in README_PATHS:
+            text = path.read_text(encoding="utf-8")
+            websocket_lines = [
+                line for line in text.splitlines() if "websocket" in line.lower()
+            ]
+            self.assertTrue(websocket_lines, path)
+            versions = {
+                int(version)
+                for line in websocket_lines
+                for version in re.findall(
+                    r"(?:protocol|プロトコル)[-\s]?v?(\d+)",
+                    line,
+                    re.IGNORECASE,
+                )
+            }
+            self.assertEqual(versions, {expected}, path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Final integrated candidate

This dependent draft layers the version identity red/green pair from [PR 10251](https://github.com/manaflow-ai/cmux/pull/10251) and the frontend protocol documentation red/green pair from [PR 10260](https://github.com/manaflow-ai/cmux/pull/10260) onto [PR 10261](https://github.com/manaflow-ai/cmux/pull/10261), which already carries the PR 10258 TUI SDK validation stack and SDK release policy fixes from PRs 10245 and 10250.

Base head: `74a9aef90a0196f2cd8bece7f1ae79647d79ecb9`.
Candidate head: `9dd3c77aab`.

## Preserved red/green history

- Version identity: `56a8991d10` (red), `3cd80a1479` (green).
- Frontend docs contract: `f2d9663b25` (red), `9dd3c77aab` (green).

Original PR branches and PR10261 remain unchanged. No merge or release action is requested.

## Local evidence

Frontend docs behavior test, TUI spec/schema/resource checks, generated SDK drift check, Python compilation, and `git diff --check` pass. Hosted SDK and spec checks are dispatched for this exact head.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789545930&installation_model_id=21920&pr_number=10264&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10264&signature=d106a0a89841e381a49cbe7c3c158be8f785ec882b1b4b164cb4266f918988ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `cmux-tui` binary version identity under one canonical distribution stamp and enforces frontend protocol docs against the supported wire API. Previously `cmux-tui --version` and `remote-probe` mixed the Cargo crate version with a distribution stamp; now both report the same canonical distribution version, and README claims align to protocol v12.

- Centralizes `DISTRIBUTION_VERSION` in `cmux-tui-core` and uses it in `--version` output and `remote-probe` JSON (`version` and `distribution_version` are identical).
- Updates `.github` workflows to stamp `CMUX_TUI_DISTRIBUTION_VERSION` from a single `version` input and to validate:
  - `--version` output starts with `cmux <version>` (npm prerelease is the canonical nightly stamp).
  - `remote-probe --json` `build_identity`, `version`, and `distribution_version` match the expected head and stamp.
- Adds `cmux-tui/scripts/test_frontend_docs.py` and runs it in the spec workflow to keep README protocol references in sync with the supported WebSocket protocol and the raw protocol guide; updates READMEs to v12.
- Release notes: pass the canonical `version` to the reusable build workflow; PyPI nightlies may use `.dev...` as metadata only—the binaries stay stamped with the npm value.

<sup>Written for commit 9dd3c77aab373fa4728dd07a4e9b62bfc051fc1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

