### PR TITLE
docs(tui): add release-scope protocol metadata

### DIFF
--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -1,8 +1,8 @@
 name: cmux-tui nightly
 
 on:
-  # CI pause: the macOS Nightly and rolling iOS beta remain automatic; this
-  # separate TUI package build remains available on demand.
+  # TUI package nightlies are manual-dispatch only. Dispatch on main when an
+  # on-demand prerelease package is required.
   workflow_dispatch:
 
 permissions: {}

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -83,10 +83,11 @@ Nightly publishing uses the same environments. Add trusted publishers for:
 
 ## Nightly channel
 
-`.github/workflows/cmux-tui-nightly.yml` runs on a daily schedule and by manual
-dispatch. It always checks out `main`, derives the next stable version from the
-latest reachable `cmux-tui-vX.Y.Z` tag by bumping patch, and falls back to
-`0.9.0` when no stable TUI tag exists.
+`.github/workflows/cmux-tui-nightly.yml` is manual-dispatch only. Dispatch it
+from `main` for an on-demand package nightly. It checks out the dispatched
+`main` commit, derives the next stable version from the latest reachable
+`cmux-tui-vX.Y.Z` tag by bumping patch, and falls back to `0.9.0` when no stable
+TUI tag exists.
 
 Nightly versions use registry-specific prerelease forms:
 
@@ -100,10 +101,9 @@ npm nightlies are published with `npm publish --provenance --tag nightly`, so
 stable `latest` dist-tag. PyPI nightlies are dev releases, so normal
 `uvx cmux` resolution ignores them; `uvx --prerelease allow cmux` opts in.
 
-The nightly workflow intentionally always builds and publishes a fresh run
-instead of trying to skip when `main` has not changed. The build is cheap, and a
-GitHub API lookup for the last successful nightly is more fragile than the
-extra build.
+Each manual dispatch builds and publishes a fresh run, even when `main` has not
+changed. The build is cheap, and a GitHub API lookup for the last successful
+nightly is more fragile than the extra build.
 
 ## Cutting a Stable Release
 

--- a/cmux-tui/scripts/test_check_spec_inventory.py
+++ b/cmux-tui/scripts/test_check_spec_inventory.py
@@ -619,6 +619,41 @@ class InventoryContractTests(unittest.TestCase):
     def inventory(self) -> dict:
         return json.loads((CHECKER.SPEC / "inventory.json").read_text())
 
+    def test_private_protocol_domain_ids_match_inventory_version(self) -> None:
+        inventory = self.inventory()
+        private_domains = {
+            domain["id"]
+            for domain in inventory["protocol_domains"]
+            if domain["spec"] in {"commands.md", "events.md"}
+        }
+        expected = {
+            f"mux-control-v{inventory['mux_protocol']}",
+            f"mux-events-v{inventory['mux_protocol']}",
+        }
+        self.assertEqual(private_domains, expected)
+
+    def test_merged_terminal_shortcuts_head_is_not_pending(self) -> None:
+        inventory = self.inventory()
+        pending_urls = {head["url"] for head in inventory["pending_heads"]}
+        self.assertNotIn(
+            "https://github.com/manaflow-ai/cmux/pull/8698",
+            pending_urls,
+        )
+
+    def test_programmability_prose_uses_current_protocol_and_no_pending_8698(self) -> None:
+        inventory = self.inventory()
+        prose = (CHECKER.SPEC / "programmability.md").read_text()
+        self.assertIn(
+            f"The implemented v{inventory['mux_protocol']} inventory",
+            prose,
+        )
+        pending_8698_lines = [
+            line
+            for line in prose.splitlines()
+            if "8698" in line and "pending" in line
+        ]
+        self.assertEqual(pending_8698_lines, [])
+
     def test_command_profile_drift_is_rejected(self) -> None:
         inventory = copy.deepcopy(self.inventory())
         inventory["commands"]["local-admin"].remove("shutdown-daemon")

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -538,8 +538,8 @@
     }
   },
   "protocol_domains": [
-    {"id": "mux-control-v10", "status": "implemented", "spec": "commands.md"},
-    {"id": "mux-events-v10", "status": "implemented", "spec": "events.md"},
+    {"id": "mux-control-v12", "status": "implemented", "spec": "commands.md"},
+    {"id": "mux-events-v12", "status": "implemented", "spec": "events.md"},
     {"id": "terminal-host-v1", "status": "partial", "spec": "terminal-host.md"},
     {"id": "machine-provider-v0-v1", "status": "implemented", "spec": "machine-provider.md"},
     {"id": "cmux.machine-agent-v1", "status": "implemented", "spec": "machine-agent.md"},
@@ -549,12 +549,5 @@
     {"id": "frontend-actions-vNext", "status": "proposed", "spec": "programmability.md"},
     {"id": "configuration-vNext", "status": "proposed", "spec": "programmability.md"}
   ],
-  "pending_heads": [
-    {
-      "name": "terminal-shortcuts",
-      "url": "https://github.com/manaflow-ai/cmux/pull/8698",
-      "status": "pending",
-      "note": "Adds clear-history and structured key work. It is not part of the main protocol inventory."
-    }
-  ]
+  "pending_heads": []
 }

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v12 inventory is complete as a description of current wire behavior. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |
@@ -62,7 +62,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
-| Terminal history | Paged retained rows have unstable indexes | History revision, cursor pagination, eviction boundary, and explicit clear-history operation |
+| Terminal history | Paged retained rows have unstable indexes | History revision, cursor pagination, and eviction boundary |
 | Browser basics | Create, input, navigate, back, forward, reload, activate, state, and frames are implemented | Typed methods in every frontend SDK |
 | Browser lifecycle | Browser success is asynchronous and CDP failures arrive later | Correlated operation ids, target/crash/dialog/download events, viewport revision, and optional raw CDP profile |
 | Client identity | `list-clients` exposes transient connection ids | `hello` or `whoami` with client instance, authenticated principal, rights, credential expiry, and protocol selection |
@@ -111,8 +111,8 @@ Each implemented command needs success, invalid request, target-not-found, and n
 
 Feature-family `wire_status` records whether a current transport exists. `programmability` records portable typed SDK and conformance completeness. This distinction prevents a live raw command, such as browser control, from being reported as complete while language clients remain uneven.
 
-The initial inventory gate prevents undocumented runtime drift. It does not claim that the current 11 shared fixtures cover all 83 commands. Fixture coverage becomes a required per-command field when deterministic schema-driven generation replaces the current prompt-based binding script.
+The initial inventory gate prevents undocumented runtime drift. It does not claim that the current shared fixtures cover every command. Fixture coverage becomes a required per-command field when deterministic schema-driven generation replaces the current prompt-based binding script.
 
-## Pending protocol heads
+## Protocol inventory status
 
-The inventory is based on `main`. [PR 8698](https://github.com/manaflow-ai/cmux/pull/8698) adds clear-history and structured shortcut work and remains `pending` in `inventory.json`. Per-surface client sizing landed with protocol 10 and is part of the implemented inventory.
+The inventory is based on `main` and tracks private protocol v12. [PR 8698](https://github.com/manaflow-ai/cmux/pull/8698) added clear-history and structured shortcut work; both are included in the implemented inventory. Per-surface client sizing landed with protocol 10 and remains part of the implemented inventory.

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1517,6 +1517,19 @@ def test_nightly_build_is_pinned_to_its_provenance_commit() -> None:
     assert '--version "${{ needs.version.outputs.pypi_version }}"' not in text
 
 
+def test_nightly_channel_is_manual_only_and_documented_as_such() -> None:
+    text = workflow("cmux-tui-nightly.yml")
+    docs = (ROOT / "cmux-tui" / "dist" / "RELEASING-TUI.md").read_text()
+    nightly_docs = docs.split("## Nightly channel", 1)[1].split("## ", 1)[0]
+    triggers = workflow_triggers(text)
+
+    assert set(triggers) == {"workflow_dispatch"}
+    assert "schedule" not in triggers
+    assert "manual-dispatch only" in text
+    assert "manual-dispatch only" in nightly_docs
+    assert "daily schedule" not in nightly_docs.lower()
+
+
 def test_sdk_publish_conformance_runs_live_against_exact_built_binary() -> None:
     for name, language in (
         ("sdk-publish-crates.yml", "rust"),


### PR DESCRIPTION
## Summary
- layer PR #10242 protocol-v12 inventory/prose metadata onto cumulative TUI candidate #10253
- layer PR #10241 manual-nightly documentation and workflow contract onto the same candidate
- preserve both red/green commit pairs in order

## Stack
Base: `51e86225ca0ed8611922b416cb0a8ca9b0fc9f3a`

1. `3fd5b47512` red PR #10242 inventory contract
2. `48ca9a51b8` green PR #10242 metadata/prose
3. `52bc53eca2` red PR #10241 nightly contract
4. `12961f7a40` green PR #10241 docs/workflow

All four commits replayed cleanly with no conflict. Existing cumulative frontend docs from #10246 remain in the base.

## Verification
- local inventory and SDK schema checks
- resource boundary and generated SDK checks
- 68 workflow-security contract tests
- frontend docs contract
- PyYAML parse and `actionlint` for spec, SDK, and nightly workflows
- exact hosted checks will run against this head

No merge, tag, package publication, build, or settings mutation was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789547319&installation_model_id=21920&pr_number=10265&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10265&signature=d2aa180075d1e46994ea9e48cf74161b9d91bbb5741f0298a0453fb6f6218f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds release-scope protocol metadata to `cmux-tui` docs/spec and makes the nightly channel manual-only. Old: nightly ran on a daily schedule and manual dispatch, inventory tracked v10 with a pending terminal-shortcuts head; New: manual-dispatch only and inventory tracks private protocol v12 with no pending heads.

- Updates `cmux-tui/spec/inventory.json` to v12 for `mux-control` and `mux-events`; clears `pending_heads`.
- Aligns `cmux-tui/spec/programmability.md` to v12, removes the “explicit clear-history operation” requirement, and records that PR 8698’s shortcut and clear-history work is included.
- Documents manual-only nightlies in `cmux-tui/dist/RELEASING-TUI.md`; clarifies that each dispatch builds and publishes a fresh run.
- Ensures `.github/workflows/cmux-tui-nightly.yml` uses `workflow_dispatch` only; no `schedule`.
- Adds tests that enforce protocol-domain/version alignment, remove the pending 8698 reference, and require manual-only nightly behavior across workflow and docs.

- Required action: Trigger `cmux-tui nightly` manually from `main` when a prerelease package is needed.

<sup>Written for commit 12961f7a40f0924a57de61a1f47c00215ddc2f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

