### PR TITLE
Verify every TUI PyPI wheel after upload

### DIFF
--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -233,3 +233,29 @@ jobs:
         with:
           packages-dir: dist
           attestations: true
+
+      - name: Verify every nightly PyPI wheel after upload
+        env:
+          VERSION: ${{ needs.version.outputs.pypi_version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          [[ "${#wheels[@]}" == 6 ]] || {
+            echo "expected six immutable nightly PyPI wheels, found ${#wheels[@]}" >&2
+            exit 1
+          }
+          allowed_args=()
+          for wheel in "${wheels[@]}"; do
+            allowed_args+=(--allowed-artifact "$wheel")
+          done
+          for wheel in "${wheels[@]}"; do
+            python3 cmux-tui/bindings/reconcile_registry_artifact.py check \
+              --registry pypi \
+              --package cmux \
+              --version "$VERSION" \
+              --artifact "$wheel" \
+              "${allowed_args[@]}" \
+              --wait-seconds 120 \
+              --require-match
+          done

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -214,3 +214,29 @@ jobs:
         with:
           packages-dir: upload
           attestations: true
+
+      - name: Verify every PyPI wheel after upload
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          [[ "${#wheels[@]}" == 6 ]] || {
+            echo "expected six immutable PyPI wheels, found ${#wheels[@]}" >&2
+            exit 1
+          }
+          allowed_args=()
+          for wheel in "${wheels[@]}"; do
+            allowed_args+=(--allowed-artifact "$wheel")
+          done
+          for wheel in "${wheels[@]}"; do
+            python3 cmux-tui/bindings/reconcile_registry_artifact.py check \
+              --registry pypi \
+              --package cmux \
+              --version "$VERSION" \
+              --artifact "$wheel" \
+              "${allowed_args[@]}" \
+              --wait-seconds 120 \
+              --require-match
+          done

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -2113,6 +2113,30 @@ def test_tui_publishers_reconcile_partial_registry_writes() -> None:
     assert "steps.pypi_upload.outputs.has_new == 'true'" in pypi
 
 
+def test_tui_pypi_publisher_verifies_every_wheel_after_upload() -> None:
+    pypi = workflow("tui-publish-pypi.yml")
+    document = yaml.load(pypi, Loader=yaml.BaseLoader)
+    assert isinstance(document, dict)
+    publish = document["jobs"]["publish"]
+    steps = publish["steps"]
+    names = [step.get("name", "") for step in steps]
+    upload_index = names.index("Publish package distributions to PyPI")
+    verify_index = names.index("Verify every PyPI wheel after upload")
+    assert upload_index < verify_index
+
+    verify_step = steps[verify_index]
+    run = verify_step["run"]
+    assert 'wheels=(dist/*.whl)' in run
+    assert '[[ "${#wheels[@]}" == 6 ]]' in run
+    assert 'for wheel in "${wheels[@]}"' in run
+    assert "reconcile_registry_artifact.py check" in run
+    assert "--registry pypi" in run
+    assert "--package cmux" in run
+    assert '--artifact "$wheel"' in run
+    assert "--allowed-artifact" in run
+    assert "--require-match" in run
+
+
 def test_pypi_retry_preparation_skips_only_exact_matches() -> None:
     script = ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
     tags = (

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -2137,6 +2137,37 @@ def test_tui_pypi_publisher_verifies_every_wheel_after_upload() -> None:
     assert "--require-match" in run
 
 
+def test_tui_nightly_pypi_publisher_verifies_every_wheel_after_upload() -> None:
+    nightly = workflow("cmux-tui-nightly.yml")
+    document = yaml.load(nightly, Loader=yaml.BaseLoader)
+    assert isinstance(document, dict)
+    assert set(workflow_triggers(nightly)) == {"workflow_dispatch"}
+
+    publish = document["jobs"]["publish-pypi"]
+    assert publish["environment"]["name"] == "pypi-tui"
+    assert publish["permissions"]["id-token"] == "write"
+    steps = publish["steps"]
+    names = [step.get("name", "") for step in steps]
+    policy_index = names.index("Verify independent environment approval policy")
+    upload_index = names.index("Publish nightly package distributions to PyPI")
+    verify_index = names.index("Verify every nightly PyPI wheel after upload")
+    assert policy_index < upload_index < verify_index
+
+    verify_step = steps[verify_index]
+    assert verify_step["env"]["VERSION"] == "${{ needs.version.outputs.pypi_version }}"
+    run = verify_step["run"]
+    assert 'wheels=(dist/*.whl)' in run
+    assert '[[ "${#wheels[@]}" == 6 ]]' in run
+    assert 'for wheel in "${wheels[@]}"' in run
+    assert "reconcile_registry_artifact.py check" in run
+    assert "--registry pypi" in run
+    assert "--package cmux" in run
+    assert '--version "$VERSION"' in run
+    assert '--artifact "$wheel"' in run
+    assert "--allowed-artifact" in run
+    assert "--require-match" in run
+
+
 def test_pypi_retry_preparation_skips_only_exact_matches() -> None:
     script = ROOT / "cmux-tui" / "scripts" / "prepare-pypi-tui-upload.sh"
     tags = (


### PR DESCRIPTION
## Summary

The stable TUI PyPI publisher preflights each of the six immutable wheels, but after `gh-action-pypi-publish` it did not verify that every wheel was visible with the exact build bytes. A successful upload could therefore leave a partial or mismatched registry state unreported.

The publisher now performs a bounded post-upload reconciliation for all six local wheels. It uses PyPI JSON `digests.sha256` through the existing registry reconciler, passes the complete six-wheel allowed set, waits up to 120 seconds for propagation, and requires `MATCH`. Any missing, unexpected, yanked, or mismatched file fails the job. The step never republishes.

The npm path is unchanged. It already uses exact post-write reconciliation for all five packages.

This PR is dependent on the cumulative P2/docs head in [#10266](https://github.com/manaflow-ai/cmux/pull/10266). Source patch IDs are `b193150277` and `7c8e413073`; cherry-picked heads here are `748ba71b24` and `8caef33f84`.

## Regression sequence

- `748ba71b24` adds the failing workflow contract.
- `8caef33f84` adds the post-upload six-wheel check.

## Verification

- `actionlint .github/workflows/tui-publish-pypi.yml .github/workflows/tui-publish-npm.yml`
- `python3 -m pytest -q tests/test_tui_publish_workflow_security.py` (69 passed)
- `python3 -m unittest cmux-tui/bindings/tests/test_reconcile_registry_artifact.py -q` (58 passed)
- `python3 -m pytest -q tests/test_tui_package_contract.py tests/test_tui_npm_package_artifact.py` (9 passed)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789548021&installation_model_id=21920&pr_number=10268&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10268&signature=95f9506a275a5845b85eb6f3d3ba0caa790f4105aba4fe7f931fc8ab405aaad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies every TUI PyPI wheel after upload across release and nightly publishers so the registry exactly matches the built artifacts. Previously the jobs published without post-upload reconciliation; now each checks all six wheels and fails on any mismatch.

- Adds post-upload verification in `tui-publish-pypi.yml` and `cmux-tui-nightly.yml`, validating all six `cmux` wheels via PyPI JSON `digests.sha256`, passing the full allowed set, waiting up to 120 seconds, and requiring a match.
- Fails the workflow on any missing, unexpected, yanked, or mismatched wheel; never republishes.
- Keeps the npm publisher unchanged.
- Extends tests to require step names, order (publish before verify; nightly after policy), version wiring, and verification arguments in both workflows.

<sup>Written for commit 31896f13565971f947a0d0f83e2c9a67a6b258ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

