### PR TITLE
docs(tui): require manual R2 artifact dispatch

### DIFF
--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -124,8 +124,10 @@ Use `.github/workflows/cmux-tui-release-cut.yml` from `main`.
   each run ID to finish, and fails the release if either conclusion is not
   successful. This keeps the configured trusted-publisher identities while
   avoiding registry-specific rebuilds.
-- A manual `git push origin cmux-tui-vX.Y.Z` runs the artifact workflow without
-  publishing. Use the release-cut workflow for a coordinated stable release.
+- `.github/workflows/cmux-tui-artifacts.yml` is manual-dispatch only. A tag push
+  does not trigger this workflow. To publish raw R2 artifacts without registry
+  publishing, run `gh workflow run cmux-tui-artifacts.yml --ref <ref>` for the
+  intended ref. Use the release-cut workflow for a coordinated stable release.
 
 ## Publishing
 

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1530,6 +1530,26 @@ def test_nightly_channel_is_manual_only_and_documented_as_such() -> None:
     assert "daily schedule" not in nightly_docs.lower()
 
 
+def test_r2_artifact_workflow_is_manual_only_and_documented_as_such() -> None:
+    text = workflow("cmux-tui-artifacts.yml")
+    docs = (ROOT / "cmux-tui" / "dist" / "RELEASING-TUI.md").read_text()
+    release_docs = docs.split("## Cutting a Stable Release", 1)[1].split(
+        "## Publishing", 1
+    )[0]
+    triggers = workflow_triggers(text)
+
+    assert set(triggers) == {"workflow_dispatch"}
+    assert "push" not in triggers
+    assert "cmux-tui-artifacts.yml" in release_docs
+    assert "manual-dispatch only" in release_docs
+    assert "gh workflow run cmux-tui-artifacts.yml" in release_docs
+    assert "does not trigger" in release_docs.lower()
+    assert (
+        "manual `git push origin cmux-tui-vX.Y.Z` runs the artifact workflow"
+        not in release_docs
+    )
+
+
 def test_sdk_publish_conformance_runs_live_against_exact_built_binary() -> None:
     for name, language in (
         ("sdk-publish-crates.yml", "rust"),


### PR DESCRIPTION
## Summary\n\nCorrect the R2 artifact release guide to match cmux-tui-artifacts.yml. The workflow is workflow_dispatch-only, so a tag push does not start it. The guide now gives the explicit gh workflow run command for an intentional raw-artifact publish and keeps npm/PyPI publishing separate.\n\n## Red/green history\n\n- 7932fe6f9d adds the failing manual-dispatch documentation contract.\n- 1fbbf22655 documents the required manual dispatch and removes the stale tag-push claim.\n\n## Dependency\n\nThis PR is based on the current P2/postpublish head 31896f1356 from PR 10268.\n\n## Verification\n\n- 71 TUI publish workflow security tests\n- 8 published-manifest tests\n- 9 TUI package contract tests\n- actionlint for cmux-tui-artifacts.yml\n- Python compile and git diff checks\n\nNo R2 workflow dispatch, tag, package publish, merge, or settings change was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789548526&installation_model_id=21920&pr_number=10269&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10269&signature=5cb7fb92baf9b25dcef9c2efb37fef6af44f80ae553aa86736aa04bbb1306e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the TUI release docs to require manual dispatch for R2 artifact publishing and adds tests that enforce this. Previously we claimed a tag push ran the artifact workflow; now only `workflow_dispatch` triggers it, and the docs show the `gh workflow run` command.

- Verify `cmux-tui-artifacts.yml` uses only `workflow_dispatch` and not `push`.
- Confirm `cmux-tui/dist/RELEASING-TUI.md` removes the tag-push claim and documents `gh workflow run cmux-tui-artifacts.yml --ref <ref>`.
- Review the new security test that checks triggers and documentation for the artifact workflow.
- No change to npm/PyPI publishing; use the release-cut workflow for coordinated stable releases.
- Migration: when publishing raw R2 artifacts, run `gh workflow run cmux-tui-artifacts.yml --ref <ref>`; a tag push will not start the workflow.

<sup>Written for commit 1fbbf22655e61c3c0b05a75f5d561148de94f097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

