### PR TITLE
test(tui): make skipped coverage explicit

### DIFF
--- a/.github/scripts/run-cmux-tui-core-tests-isolated.py
+++ b/.github/scripts/run-cmux-tui-core-tests-isolated.py
@@ -61,9 +61,12 @@ def test_binaries(cargo_messages: Path, core_root: Path) -> list[Path]:
     return sorted(binaries)
 
 
-def tests_in(binary: Path) -> list[str]:
+def tests_in(binary: Path, *, ignored: bool = False) -> list[str]:
+    command = [str(binary), "--list"]
+    if ignored:
+        command.append("--ignored")
     result = subprocess.run(
-        [str(binary), "--list"],
+        command,
         check=True,
         stdout=subprocess.PIPE,
         text=True,
@@ -80,14 +83,39 @@ def tests_in(binary: Path) -> list[str]:
     return tests
 
 
+def partition_tests(all_tests: list[str], ignored_tests: list[str]) -> tuple[list[str], list[str]]:
+    all_test_set = set(all_tests)
+    ignored_test_set = set(ignored_tests)
+    unknown = sorted(ignored_test_set - all_test_set)
+    if unknown:
+        raise ValueError(
+            "libtest reported ignored tests that were absent from its complete list: "
+            + ", ".join(unknown)
+        )
+    ignored = [test_name for test_name in all_tests if test_name in ignored_test_set]
+    runnable = [test_name for test_name in all_tests if test_name not in ignored_test_set]
+    return runnable, ignored
+
+
 def main() -> int:
     args = parse_args()
     core_root = args.core_root.resolve()
     binaries = test_binaries(args.cargo_messages, core_root)
     total = 0
+    skipped = 0
     for binary in binaries:
-        tests = tests_in(binary)
+        all_tests = tests_in(binary)
+        ignored_tests = tests_in(binary, ignored=True)
+        try:
+            tests, ignored = partition_tests(all_tests, ignored_tests)
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
         print(f"Running {len(tests)} tests from {binary.name} in fresh processes")
+        if ignored:
+            print(f"Skipping {len(ignored)} ignored/manual tests from {binary.name}:")
+            for test_name in ignored:
+                print(f"  {test_name}")
+            skipped += len(ignored)
         for index, test_name in enumerate(tests, start=1):
             print(f"[{index}/{len(tests)}] {test_name}", flush=True)
             subprocess.run(
@@ -96,6 +124,7 @@ def main() -> int:
             )
             total += 1
     print(f"Passed {total} isolated cmux-tui-core tests")
+    print(f"Skipped {skipped} ignored/manual cmux-tui-core tests")
     return 0
 
 

--- a/.github/scripts/run-cmux-tui-core-tests-isolated.py
+++ b/.github/scripts/run-cmux-tui-core-tests-isolated.py
@@ -76,6 +76,8 @@ def tests_in(binary: Path, *, ignored: bool = False) -> list[str]:
         name, separator, kind = line.rpartition(": ")
         if separator and kind == "test":
             tests.append(name)
+    if not tests and ignored:
+        return []
     if not tests:
         raise SystemExit(f"{binary.name} did not list any tests")
     if len(tests) != len(set(tests)):

--- a/.github/scripts/run-cmux-tui-core-tests-isolated.py
+++ b/.github/scripts/run-cmux-tui-core-tests-isolated.py
@@ -96,6 +96,10 @@ def partition_tests(all_tests: list[str], ignored_tests: list[str]) -> tuple[lis
         )
     ignored = [test_name for test_name in all_tests if test_name in ignored_test_set]
     runnable = [test_name for test_name in all_tests if test_name not in ignored_test_set]
+    if all_tests and not runnable:
+        raise ValueError(
+            f"all listed tests are ignored ({len(ignored)}); refusing an ignored-only run"
+        )
     return runnable, ignored
 
 

--- a/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
+++ b/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 import unittest
 
 
@@ -28,6 +30,12 @@ class PartitionTests(unittest.TestCase):
     def test_unknown_ignored_test_is_rejected(self) -> None:
         with self.assertRaises(ValueError):
             MODULE.partition_tests(["active_test"], ["missing_probe"])
+
+
+class InventoryTests(unittest.TestCase):
+    def test_empty_ignored_inventory_is_allowed(self) -> None:
+        with patch.object(MODULE.subprocess, "run", return_value=SimpleNamespace(stdout="")):
+            self.assertEqual(MODULE.tests_in(Path("empty"), ignored=True), [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
+++ b/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Behavior tests for the isolated cmux-tui-core test runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("run-cmux-tui-core-tests-isolated.py")
+SPEC = importlib.util.spec_from_file_location("isolated_runner", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PartitionTests(unittest.TestCase):
+    def test_ignored_tests_are_manual_and_not_runnable(self) -> None:
+        runnable, ignored = MODULE.partition_tests(
+            ["active_test", "manual_probe"],
+            ["manual_probe"],
+        )
+        self.assertEqual(runnable, ["active_test"])
+        self.assertEqual(ignored, ["manual_probe"])
+
+    def test_unknown_ignored_test_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.partition_tests(["active_test"], ["missing_probe"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
+++ b/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
@@ -31,6 +31,10 @@ class PartitionTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             MODULE.partition_tests(["active_test"], ["missing_probe"])
 
+    def test_ignored_only_inventory_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "all listed tests are ignored"):
+            MODULE.partition_tests(["manual_probe"], ["manual_probe"])
+
 
 class InventoryTests(unittest.TestCase):
     def test_empty_ignored_inventory_is_allowed(self) -> None:

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -464,6 +464,73 @@ jobs:
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
+  cdp-browser-smoke:
+    name: CDP browser smoke (${{ matrix.os }})
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: blacksmith-6vcpu-macos-15
+          - os: linux
+            runner: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install pinned Playwright dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install pinned Playwright Chromium (Linux)
+        if: runner.os == 'Linux'
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install pinned Playwright Chromium (macOS)
+        if: runner.os == 'macOS'
+        working-directory: web
+        run: bunx playwright install chromium
+
+      - name: Resolve Playwright Chromium executable
+        id: chromium
+        working-directory: web
+        shell: bash
+        run: |
+          path="$(bun -e 'const { chromium } = require("@playwright/test"); process.stdout.write(chromium.executablePath())')"
+          test -n "$path"
+          test -x "$path"
+          printf 'path=%s\n' "$path" >> "$GITHUB_OUTPUT"
+          echo "Using Playwright Chromium at $path"
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Run configured Chrome CDP smoke
+        working-directory: cmux-tui
+        env:
+          CMUX_MUX_BROWSER_TEST: "1"
+          CMUX_MUX_BROWSER_TEST_CHROME: ${{ steps.chromium.outputs.path }}
+        run: >-
+          cargo test -p cmux-tui-cdp --test chrome_smoke --locked --
+          --ignored --exact chrome_smoke_requires_configured_browser
+
   bindings-e2e:
     needs: validate-inputs
     if: inputs.mode == 'full'
@@ -579,6 +646,7 @@ jobs:
       - web-frontend
       - valgrind-leak-check
       - test
+      - cdp-browser-smoke
       - bindings-e2e
       - build-artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -589,6 +657,7 @@ jobs:
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
       TEST_RESULT: ${{ needs.test.result }}
+      CDP_BROWSER_RESULT: ${{ needs.cdp-browser-smoke.result }}
       BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
       ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
     steps:
@@ -610,5 +679,6 @@ jobs:
           if [[ "$MODE" == "full" ]]; then
             require_success "web frontend" "$WEB_RESULT"
             require_success "Valgrind" "$VALGRIND_RESULT"
+            require_success "Chrome CDP smoke" "$CDP_BROWSER_RESULT"
             require_success "binding end-to-end tests" "$BINDINGS_RESULT"
           fi

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -358,6 +358,9 @@ jobs:
       - name: Set up pinned Rust
         uses: ./.github/actions/setup-cmux-tui-rust
 
+      - name: Test isolated TUI test-runner policy
+        run: python3 .github/scripts/test_run_cmux_tui_core_tests_isolated.py
+
       - name: cargo fmt
         id: rustfmt-check
         working-directory: cmux-tui

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -522,6 +522,73 @@ jobs:
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
+  cdp-browser-smoke:
+    name: CDP browser smoke (${{ matrix.os }})
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: blacksmith-6vcpu-macos-15
+          - os: linux
+            runner: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install pinned Playwright dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install pinned Playwright Chromium (Linux)
+        if: runner.os == 'Linux'
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install pinned Playwright Chromium (macOS)
+        if: runner.os == 'macOS'
+        working-directory: web
+        run: bunx playwright install chromium
+
+      - name: Resolve Playwright Chromium executable
+        id: chromium
+        working-directory: web
+        shell: bash
+        run: |
+          path="$(bun -e 'const { chromium } = require("@playwright/test"); process.stdout.write(chromium.executablePath())')"
+          test -n "$path"
+          test -x "$path"
+          printf 'path=%s\n' "$path" >> "$GITHUB_OUTPUT"
+          echo "Using Playwright Chromium at $path"
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Run configured Chrome CDP smoke
+        working-directory: cmux-tui
+        env:
+          CMUX_MUX_BROWSER_TEST: "1"
+          CMUX_MUX_BROWSER_TEST_CHROME: ${{ steps.chromium.outputs.path }}
+        run: >-
+          cargo test -p cmux-tui-cdp --test chrome_smoke --locked --
+          --ignored --exact chrome_smoke_requires_configured_browser
+
   bindings-e2e:
     needs: validate-inputs
     if: inputs.mode == 'full'
@@ -640,6 +707,7 @@ jobs:
       - web-frontend
       - valgrind-leak-check
       - test
+      - cdp-browser-smoke
       - bindings-e2e
       - build-artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -651,6 +719,7 @@ jobs:
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
       TEST_RESULT: ${{ needs.test.result }}
+      CDP_BROWSER_RESULT: ${{ needs.cdp-browser-smoke.result }}
       BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
       ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
     steps:
@@ -673,5 +742,6 @@ jobs:
           if [[ "$MODE" == "full" ]]; then
             require_success "web frontend" "$WEB_RESULT"
             require_success "Valgrind" "$VALGRIND_RESULT"
+            require_success "Chrome CDP smoke" "$CDP_BROWSER_RESULT"
             require_success "binding end-to-end tests" "$BINDINGS_RESULT"
           fi

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -396,6 +396,9 @@ jobs:
       - name: Set up pinned Rust
         uses: ./.github/actions/setup-cmux-tui-rust
 
+      - name: Test isolated TUI test-runner policy
+        run: python3 .github/scripts/test_run_cmux_tui_core_tests_isolated.py
+
       - name: cargo fmt
         id: rustfmt-check
         working-directory: cmux-tui

--- a/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
@@ -5,7 +5,12 @@ fn chrome_smoke_requires_configured_browser() -> anyhow::Result<()> {
         std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref(),
         std::env::var_os("CMUX_MUX_BROWSER_TEST_CHROME"),
     )?;
-    let chrome = cmux_tui_cdp::Chrome::launch(binary.into()).unwrap();
+    let chrome = cmux_tui_cdp::Chrome::launch_with(&cmux_tui_cdp::ChromeLaunchOptions {
+        binary,
+        mode: cmux_tui_cdp::BrowserMode::Headless,
+        user_data_dir: None,
+        ephemeral: true,
+    })?;
     let (tx, _rx) = std::sync::mpsc::sync_channel(cmux_tui_cdp::CDP_EVENT_QUEUE_CAPACITY);
     let client = cmux_tui_cdp::CdpClient::connect(chrome.web_socket_url(), tx).unwrap();
     client.set_discover_targets(true).unwrap();

--- a/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
@@ -1,4 +1,5 @@
 #[test]
+#[ignore = "requires a configured Chrome or Chromium binary; invoke explicitly with --ignored"]
 fn chrome_smoke_requires_configured_browser() -> anyhow::Result<()> {
     let binary = configured_browser_binary(
         std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref(),
@@ -18,4 +19,21 @@ fn chrome_smoke_requires_configured_browser() -> anyhow::Result<()> {
 fn missing_browser_configuration_is_an_error_when_explicitly_requested() {
     assert!(configured_browser_binary(None, None).is_err());
     assert!(configured_browser_binary(Some("1"), None).is_err());
+}
+
+fn configured_browser_binary(
+    enabled: Option<&str>,
+    binary: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if enabled != Some("1") {
+        anyhow::bail!(
+            "Chrome smoke requires CMUX_MUX_BROWSER_TEST=1; run this ignored test explicitly when a browser is configured"
+        );
+    }
+    let binary = binary.filter(|value| !value.is_empty()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Chrome smoke requires CMUX_MUX_BROWSER_TEST_CHROME to name a Chrome or Chromium binary"
+        )
+    })?;
+    Ok(binary.into())
 }

--- a/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
@@ -1,16 +1,9 @@
 #[test]
-fn chrome_smoke_is_env_gated() {
-    if std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref() != Some("1") {
-        eprintln!("skipping Chrome smoke test; set CMUX_MUX_BROWSER_TEST=1 to run it");
-        return;
-    }
-
-    let Some(binary) = std::env::var_os("CMUX_MUX_BROWSER_TEST_CHROME") else {
-        eprintln!(
-            "skipping Chrome smoke test; set CMUX_MUX_BROWSER_TEST_CHROME to a Chrome binary"
-        );
-        return;
-    };
+fn chrome_smoke_requires_configured_browser() -> anyhow::Result<()> {
+    let binary = configured_browser_binary(
+        std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref(),
+        std::env::var_os("CMUX_MUX_BROWSER_TEST_CHROME"),
+    )?;
     let chrome = cmux_tui_cdp::Chrome::launch(binary.into()).unwrap();
     let (tx, _rx) = std::sync::mpsc::sync_channel(cmux_tui_cdp::CDP_EVENT_QUEUE_CAPACITY);
     let client = cmux_tui_cdp::CdpClient::connect(chrome.web_socket_url(), tx).unwrap();
@@ -18,4 +11,11 @@ fn chrome_smoke_is_env_gated() {
     let target = client.create_target("about:blank").unwrap();
     let session = client.attach_to_target(&target).unwrap();
     client.page_enable(&session).unwrap();
+    Ok(())
+}
+
+#[test]
+fn missing_browser_configuration_is_an_error_when_explicitly_requested() {
+    assert!(configured_browser_binary(None, None).is_err());
+    assert!(configured_browser_binary(Some("1"), None).is_err());
 }


### PR DESCRIPTION
## Scope

This CI-only follow-up closes two false-green paths in the TUI hosted suite:

- The isolated `cmux-tui-core` runner queries libtest's ignored list, excludes those tests from execution and the pass count, and reports each one as a skipped manual probe. It permits binaries with no ignored probes, rejects an inconsistent ignored-test inventory, and keeps complete inventories non-empty.
- The Chrome CDP smoke test is ignored by the normal workspace suite. An explicit `--ignored` run fails with an actionable error unless both browser environment values are configured.
- Full hosted verification runs the ignored Chrome smoke against the exact Playwright Chromium pinned by `web/bun.lock`, on separate Linux and macOS jobs. The job resolves `chromium.executablePath()` after the pinned install, sets `CMUX_MUX_BROWSER_TEST=1` and `CMUX_MUX_BROWSER_TEST_CHROME`, and invokes only `chrome_smoke_requires_configured_browser` with `--ignored --exact`. Linux uses Playwright's existing `--with-deps` setup; macOS uses the same pinned browser install without Linux package setup.

The dedicated browser job is separate from the normal TUI matrix because browser installation is an explicit hosted prerequisite and must not make ordinary focused runs or local development install a browser. The full hosted verification gate requires both browser matrix legs to succeed.

## Regression history

- `9788d33de1` adds the failing behavior tests and workflow wiring.
- `f48a1ef24a` implements ignored-test partitioning and explicit CDP configuration errors.
- `863a4d9743` adds headless CDP launch and the pinned Playwright browser job.
- `2800adf141` adds the failing empty-ignored-inventory behavior test after full hosted verification exposed binaries with no ignored probes.
- `dd0a91de50` permits an empty ignored inventory while retaining complete-inventory and unknown-name validation.

## Verification

- First full run `32019420432` failed only because binaries with zero ignored tests were treated as an error; both CDP jobs, artifacts, web, bindings, and Valgrind were green.
- Corrected exact full run: https://github.com/manaflow-ai/cmux/actions/runs/32020745688
- Corrected exact SDK run: https://github.com/manaflow-ai/cmux/actions/runs/32020722598
- Corrected exact spec run: https://github.com/manaflow-ai/cmux/actions/runs/32020724142
- Local Python behavior tests, YAML actionlint, syntax checks, and `git diff --check` pass. No local Cargo, Rust, Zig, browser install, or Xcode commands were run.
