### PR TITLE
Render panel header glyphs through the resolved-icon path (#8558)

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -369,7 +369,6 @@ private struct FileExternalOpenHeaderMenuButton: View {
             PanelHeaderIconGlyph(systemName: "square.and.arrow.up")
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .disabled(isDisabled)
         .help(helpText)
         .accessibilityLabel(helpText)

--- a/Sources/Panels/MarkdownTypographyControl.swift
+++ b/Sources/Panels/MarkdownTypographyControl.swift
@@ -45,7 +45,6 @@ struct MarkdownTypographyControl: View {
             PanelHeaderIconGlyph(systemName: "textformat.size")
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .help(buttonLabel)
         .accessibilityLabel(buttonLabel)
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -382,9 +382,12 @@ struct PanelFilePathHeader<TrailingContent: View>: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            CmuxSystemSymbolImage(systemName: iconSystemName, pointSize: 16)
-                .foregroundStyle(.secondary)
-                .frame(width: 16)
+            CmuxResolvedIconImage(request: CmuxResolvedIconRequest(
+                source: .systemSymbol(name: iconSystemName, accessibilityDescription: nil),
+                size: NSSize(width: 16, height: 16),
+                tintColor: PanelHeaderIconGlyph.tint(headerForeground: foregroundColor)
+            ))
+            .frame(width: 16, height: 16)
             Text(filePath)
                 .cmuxFont(size: 11, design: .monospaced)
                 .foregroundStyle(Color(nsColor: foregroundColor).opacity(0.68))
@@ -397,6 +400,7 @@ struct PanelFilePathHeader<TrailingContent: View>: View {
         .padding(.horizontal, 12)
         .frame(height: 30)
         .background(Color.clear)
+        .environment(\.panelHeaderIconTint, PanelHeaderIconGlyph.tint(headerForeground: foregroundColor))
     }
 }
 
@@ -411,19 +415,71 @@ struct PanelHeaderIconButton: View {
             PanelHeaderIconGlyph(systemName: systemName)
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .disabled(isDisabled)
         .help(label)
         .accessibilityLabel(label)
     }
 }
 
+/// Panel-header glyph drawn through the appearance-resolved AppKit renderer.
+///
+/// The SwiftUI symbol path (`Image(systemName:)` and the shared template
+/// `NSImage` behind `CmuxSystemSymbolImage`) rasterizes fully transparent in
+/// this header on macOS 15 while the button keeps its frame and hit area, so
+/// the controls stay clickable but invisible (#8558, #8352, #7725, #4476).
+/// `CmuxResolvedIconRenderer` draws into an explicit bitmap context under the
+/// resolved appearance, verifies the output has visible pixels, and re-renders
+/// when the window or effective appearance changes.
 struct PanelHeaderIconGlyph: View {
     let systemName: String
+    @Environment(\.panelHeaderIconTint) private var headerTint
+    @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
-        CmuxSystemSymbolImage(systemName: systemName, pointSize: 13)
-            .frame(width: 20, height: 20, alignment: .center)
-            .contentShape(Rectangle())
+        CmuxResolvedIconImage(
+            request: Self.request(systemName: systemName, tint: headerTint, isEnabled: isEnabled)
+        )
+        .frame(width: 13, height: 13)
+        .frame(width: 20, height: 20, alignment: .center)
+        .contentShape(Rectangle())
+    }
+
+    /// Builds one header glyph's render request.
+    ///
+    /// The tint is always an explicit color rather than a semantic style: the
+    /// AppKit-backed icon resolves the window appearance, not the panel's
+    /// SwiftUI `colorScheme` override, so a hierarchical style would not track
+    /// the panel theme. Disabled glyphs keep the color and drop alpha.
+    @MainActor
+    static func request(systemName: String, tint: NSColor?, isEnabled: Bool) -> CmuxResolvedIconRequest {
+        let baseTint = tint ?? .secondaryLabelColor
+        let resolvedTint = isEnabled
+            ? baseTint
+            : baseTint.withAlphaComponent(baseTint.alphaComponent * 0.45)
+        return CmuxResolvedIconRequest(
+            source: .systemSymbol(name: systemName, accessibilityDescription: nil),
+            size: NSSize(width: 13, height: 13),
+            tintColor: resolvedTint
+        )
+    }
+
+    /// Secondary-emphasis tint derived from the header's theme foreground,
+    /// matching the emphasis the previous `.secondary` template tint produced.
+    static func tint(headerForeground: NSColor) -> NSColor {
+        headerForeground.withAlphaComponent(headerForeground.alphaComponent * 0.55)
+    }
+}
+
+/// Explicit glyph tint published by ``PanelFilePathHeader`` so header controls
+/// follow the panel's theme foreground. `nil` falls back to the
+/// appearance-resolved secondary label color.
+private struct PanelHeaderIconTintKey: EnvironmentKey {
+    static let defaultValue: NSColor? = nil
+}
+
+extension EnvironmentValues {
+    var panelHeaderIconTint: NSColor? {
+        get { self[PanelHeaderIconTintKey.self] }
+        set { self[PanelHeaderIconTintKey.self] = newValue }
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1546,6 +1546,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
+		C58558010000000000000001 /* PanelHeaderIconGlyphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58558010000000000000002 /* PanelHeaderIconGlyphTests.swift */; };
 		986900050000000000000001 /* PanelHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986900050000000000000002 /* PanelHost.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
@@ -4326,6 +4327,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
+		C58558010000000000000002 /* PanelHeaderIconGlyphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelHeaderIconGlyphTests.swift; sourceTree = "<group>"; };
 		986900050000000000000002 /* PanelHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelHost.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
@@ -7865,6 +7867,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
+				C58558010000000000000002 /* PanelHeaderIconGlyphTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
 				859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
@@ -11350,6 +11353,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
+				C58558010000000000000001 /* PanelHeaderIconGlyphTests.swift in Sources */,
 					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 				B88350000000000000000003 /* PasteboardThreadSignalingDataProvider.swift in Sources */,

--- a/cmuxTests/PanelHeaderIconGlyphTests.swift
+++ b/cmuxTests/PanelHeaderIconGlyphTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import CmuxAppKitSupportUI
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Panel header icon glyphs")
+struct PanelHeaderIconGlyphTests {
+    /// Every symbol the markdown viewer and file preview headers render.
+    private static let headerSymbols = [
+        "doc.richtext",
+        "textformat.size",
+        "arrow.clockwise",
+        "arrow.counterclockwise",
+        "square.and.arrow.down",
+        "square.and.arrow.up",
+        "doc.plaintext",
+        "doc.on.doc",
+        "chevron.left.forwardslash.chevron.right",
+        "eye",
+    ]
+
+    @Test func requestCarriesAnExplicitTintAtGlyphSize() {
+        let tint = NSColor.systemTeal
+        let request = PanelHeaderIconGlyph.request(systemName: "eye", tint: tint, isEnabled: true)
+
+        #expect(request.size == NSSize(width: 13, height: 13))
+        #expect(request.tintColor == tint)
+        guard case .systemSymbol(let name, _) = request.source else {
+            Issue.record("expected a system symbol source")
+            return
+        }
+        #expect(name == "eye")
+    }
+
+    @Test func requestFallsBackToSecondaryLabelWhenHeaderTintIsMissing() {
+        let request = PanelHeaderIconGlyph.request(systemName: "eye", tint: nil, isEnabled: true)
+
+        #expect(request.tintColor == NSColor.secondaryLabelColor)
+    }
+
+    @Test func disabledRequestKeepsTheColorAndDropsAlpha() throws {
+        let tint = NSColor.white.withAlphaComponent(0.8)
+        let request = PanelHeaderIconGlyph.request(systemName: "eye", tint: tint, isEnabled: false)
+        let resolved = try #require(request.tintColor)
+
+        #expect(abs(resolved.alphaComponent - 0.8 * 0.45) < 0.0001)
+    }
+
+    @Test func themeTintKeepsSecondaryEmphasis() {
+        let foreground = NSColor(calibratedWhite: 0.9, alpha: 1)
+        let tint = PanelHeaderIconGlyph.tint(headerForeground: foreground)
+
+        #expect(abs(tint.alphaComponent - 0.55) < 0.0001)
+    }
+
+    /// Regression guard for #8558: the SwiftUI symbol path rasterized these
+    /// glyphs fully transparent while their buttons stayed clickable. The
+    /// resolved renderer must produce visible pixels in either appearance.
+    @Test(arguments: headerSymbols)
+    func headerSymbolsRenderVisiblePixels(symbol: String) throws {
+        let renderer = CmuxResolvedIconRenderer()
+        let request = PanelHeaderIconGlyph.request(
+            systemName: symbol,
+            tint: PanelHeaderIconGlyph.tint(headerForeground: .white),
+            isEnabled: true
+        )
+
+        for appearanceName in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: appearanceName))
+            switch renderer.render(for: request, appearance: appearance) {
+            case .success(let image):
+                #expect(visiblePixelCount(in: image) > 0)
+            case .failure(let failure):
+                Issue.record("\(symbol) failed to render in \(appearanceName.rawValue): \(failure)")
+            }
+        }
+    }
+
+    private func visiblePixelCount(in image: NSImage) -> Int {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return 0
+        }
+        let representation = NSBitmapImageRep(cgImage: cgImage)
+        var count = 0
+        for y in 0..<representation.pixelsHigh {
+            for x in 0..<representation.pixelsWide {
+                if let color = representation.colorAt(x: x, y: y), color.alphaComponent > 0.01 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** The markdown viewer and file preview headers (`PanelFilePathHeader`) now draw their leading file icon and every trailing action glyph through `CmuxResolvedIconImage` instead of the SwiftUI symbol path. The glyph tint becomes an explicit `NSColor` carried by a new `panelHeaderIconTint` environment value, so `.foregroundColor(.secondary)` is dropped from `PanelHeaderIconButton`, `MarkdownTypographyControl`, and `FileExternalOpenHeaderMenuButton`.
- **Why?** Fixes #8558. On macOS 15 the SwiftUI symbol path rasterizes these glyphs fully transparent while the buttons keep their frames and hit areas, so the entire upper-right action group is invisible but still responds to clicks.

## Root cause

Reproduced deterministically on macOS 15.7.4 (Apple Silicon), Xcode 16.4. In a markdown panel the whole header action group and the leading `doc.richtext` icon render blank, in every state — before and after the app-activation cycle from the report.

Three instrumented builds narrowed it down:

1. **The controls exist.** Giving `PanelHeaderIconGlyph` a colored background shows all six button frames laid out and empty. The 20×20 frame and `contentShape(Rectangle())` survive whether or not a glyph draws, which is exactly the "invisible but clickable" symptom.
2. **It is not the tint.** Forcing `.foregroundStyle(.red)` on the glyph changes nothing, so this is not a tint resolving to the background color.
3. **It is not `CmuxSystemSymbolImage`'s image resolution.** Painting the nil-image fallback branch green shows it is never taken — the `NSImage` resolves fine. Setting `cacheMode = .never` plus `recache()` on the cached image does not help either, so a poisoned shared raster is not the cause.

A side-by-side render of all three paths in the live header settles it:

| path | result |
|---|---|
| `Image(systemName:)` | blank |
| `CmuxSystemSymbolImage` (shared template `NSImage`) | blank |
| `CmuxResolvedIconImage` | glyph renders |

So the SwiftUI symbol path itself fails to rasterize in this header context, and the AppKit renderer introduced in #7729 does not. `CmuxResolvedIconRenderer` draws into an explicit bitmap context under `appearance.performAsCurrentDrawingAppearance`, verifies the output contains visible pixels, and re-renders on window attachment and effective-appearance changes.

The tint has to be explicit rather than a hierarchical style: the AppKit-backed icon resolves the window appearance, not the panel's SwiftUI `colorScheme` override, so `.secondary` would no longer track the panel theme. `PanelFilePathHeader` publishes the panel's theme foreground at 0.55 alpha; disabled glyphs keep the color at reduced alpha.

## Relationship to existing work

This is the same surface and the same approach as #9144, which has been open since 29 July and is currently conflicting with `main`. That PR's analysis and its choice of the resolved-icon path informed this one; close whichever you prefer. Related reports of the same class: #8352, #7725, #4476.

Scope is deliberately limited to the panel header. Other `CmuxSystemSymbolImage` call sites are untouched.

## Testing

- **Local dogfood.** Tagged debug build, markdown panel opened via the debug CLI. Before: leading icon and all six action glyphs blank. After: all render, and they survive deactivating and reactivating the app.
- **Added** `cmuxTests/PanelHeaderIconGlyphTests.swift` (Swift Testing, wired into the `cmuxTests` target; `scripts/lint-pbxproj-test-wiring.sh` passes): request construction (symbol source, size, explicit tint, disabled alpha, fallback tint), theme-tint derivation, and a parameterized pass rendering every header symbol under both `aqua` and `darkAqua`, asserting the renderer reports visible pixels.
- **I could not execute the unit tests locally.** `xcodebuild test -scheme cmux-unit` aborts in `swift-frontend` while deserializing the `cmux_DEV` module (`While finishing conformance for protocol conformance GhosttyNSView: TerminalRenderedFrameReceiving` → `While cross-referencing conformance for 'NSResponder'` → `abort`). I verified this is not caused by this change: the identical crash reproduces on the unmodified base commit, on a clean `derivedDataPath`, in a compile batch that contains none of my files. It is Xcode 16.4 / Swift 6.1.2 on my machine; CI pins its own Xcode. Please let CI run the suite.
- **No red/green regression commit pair.** The failure is an OS-level rasterization failure in the SwiftUI symbol path that a unit test cannot observe — the same symbols render fine in an isolated SwiftUI harness on this machine. The renderer-level visibility assertions are the meaningful guard.
- **Localization audit:** icon rendering only. No user-facing strings added, changed, or removed; all `String(localized:)` labels, help text, and accessibility labels are untouched, so no `Resources/Localizable.xcstrings` or `web/messages/*.json` changes are needed.

## Note on the base commit

This branch is based on `5734a451c` rather than current `main` because `main` has not compiled since `04ff18eea` (14 Aug):

- `Sources/Workspace+PanelLifecycle.swift:455` passes `workspaceID:` to `TerminalController.cleanupSurfaceState`, which takes `(surfaceIds:paneIds:)`.
- `Sources/TerminalController+MobileSurfaces.swift` references `panelArtifactAuthorizationStore`, which is not declared anywhere in the repository, plus three non-exhaustive switches over the new `MobileSurfaceKind` cases.

`5734a451c` is an ancestor of `main`, so this PR's diff is just the one commit. Happy to rebase once `main` builds again.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (none needed)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

Fixes #8558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789559657&installation_model_id=21920&pr_number=10272&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10272&signature=e627ea817941cb70ae53e702956ac42d87800ac1be9f5c0341daf433be189670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render panel header icons through the resolved AppKit path with an explicit tint to fix invisible-but-clickable glyphs on macOS 15. Old: SwiftUI symbol path produced transparent glyphs; new: `CmuxResolvedIconImage` draws visible pixels; side effect: tint now comes from a new environment value.

- Switches the leading file icon and all trailing header actions in `PanelFilePathHeader` to `CmuxResolvedIconImage` (16×16 lead, 13×13 glyphs) and publishes `panelHeaderIconTint`.
- Drops `.foregroundColor(.secondary)` from header buttons; derives tint from the header theme foreground at 0.55 alpha; disabled state keeps color, reduces alpha by 0.45; falls back to `NSColor.secondaryLabelColor`.
- Adds `PanelHeaderIconGlyphTests` covering request construction, tint derivation, and visible-pixel rendering for all header symbols in `aqua` and `darkAqua`.
- Scope limited to panel headers; other `CmuxSystemSymbolImage` call sites unchanged.

Fixes #8558.

<sup>Written for commit 40824fb2cdad39f0e3591f28a1046fd9f8b94f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved panel header icon appearance across light and dark themes.
  * Applied consistent tinting, sizing, disabled-state transparency, and secondary emphasis to header icons.
  * Updated file preview and typography controls to use the resolved icon appearance.

* **Tests**
  * Added coverage for icon tinting, sizing, disabled states, theme changes, and visible rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->