### PR TITLE
Serve the MiniMax provider from the agent model catalog

### DIFF
--- a/web/app/api/agent-models/route.ts
+++ b/web/app/api/agent-models/route.ts
@@ -13,7 +13,7 @@ import {
 const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=86400";
 const ALLOW_METHODS = "GET, OPTIONS";
 const ALLOW_HEADERS = "If-None-Match, Content-Type";
-const REQUIRED_PROVIDERS = ["claude", "codex", "gemini", "opencode"] as const;
+const REQUIRED_PROVIDERS = ["claude", "codex", "gemini", "minimax", "opencode"] as const;
 const PAYLOAD = JSON.stringify(validateAndDeduplicateCatalog(agentModelCatalog));
 const ETAG = `"${createHash("sha256").update(PAYLOAD).digest("base64url")}"`;
 

--- a/web/data/agent-models.ts
+++ b/web/data/agent-models.ts
@@ -38,6 +38,7 @@ export interface AgentModelCatalog {
     claude: AgentModelProvider;
     codex: AgentModelProvider;
     gemini: AgentModelProvider;
+    minimax?: AgentModelProvider;
     opencode?: AgentModelProvider;
     pi?: AgentModelProvider;
   };
@@ -53,7 +54,7 @@ const CODEX_REASONING_EFFORTS: AgentModelChoice[] = [
 
 export const agentModelCatalog = {
   schemaVersion: 1,
-  updatedAt: "2026-08-09T00:00:00.000Z",
+  updatedAt: "2026-08-17T00:00:00.000Z",
   providers: {
     claude: {
       defaultModel: "claude-sonnet-5",
@@ -152,6 +153,22 @@ export const agentModelCatalog = {
         { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
         { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
         { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
+      ],
+    },
+    minimax: {
+      defaultModel: "MiniMax-M3",
+      models: [
+        {
+          id: "MiniMax-M3",
+          label: "MiniMax M3",
+          contextWindow: 1000000,
+          supportsOneMillion: true,
+        },
+        {
+          id: "MiniMax-M2.7",
+          label: "MiniMax M2.7",
+          contextWindow: 204800,
+        },
       ],
     },
   },

--- a/web/tests/agent-models-route.test.ts
+++ b/web/tests/agent-models-route.test.ts
@@ -67,6 +67,29 @@ describe("agent models route", () => {
         { id: "openai/gpt-5.5", label: "GPT-5.5" },
       ],
     });
+
+    expect(agentModelCatalog.providers.minimax).toEqual({
+      defaultModel: "MiniMax-M3",
+      models: [
+        {
+          id: "MiniMax-M3",
+          label: "MiniMax M3",
+          contextWindow: 1000000,
+          supportsOneMillion: true,
+        },
+        { id: "MiniMax-M2.7", label: "MiniMax M2.7", contextWindow: 204800 },
+      ],
+    });
+  });
+
+  test("rejects a catalog that drops a required provider", () => {
+    const { minimax: _minimax, ...withoutMinimax } = agentModelCatalog.providers;
+
+    expect(() => validateAndDeduplicateCatalog({
+      schemaVersion: 1,
+      updatedAt: agentModelCatalog.updatedAt,
+      providers: withoutMinimax,
+    })).toThrow("missing provider minimax");
   });
 
   test("uses the strong ETag for conditional revalidation", async () => {


### PR DESCRIPTION
Reason: The served agent model catalog omitted the MiniMax provider, so any successful catalog refresh replaced the client-side MiniMax fallbacks with an empty model list.

`agent-chat` reads its model choices from `https://cmux.com/api/agent-models` and only falls back to built-in entries while no remote payload has been stored. `mergeCatalogModels` drops the fallback list as soon as a payload exists but does not carry the provider, so `MiniMax-M3` and `MiniMax-M2.7` disappeared from the picker after the first refresh.

## Changes

- `web/data/agent-models.ts`: add the `minimax` provider to the checked-in catalog with `MiniMax-M3` (1,000,000-token context, `supportsOneMillion`) as the default model and `MiniMax-M2.7` (204,800-token context), and add the matching optional key to the `AgentModelCatalog` provider map.
- `web/data/agent-models.ts`: bump `updatedAt` so clients see the refreshed catalog revision.
- `web/app/api/agent-models/route.ts`: add `minimax` to `REQUIRED_PROVIDERS` so the route refuses to serve a payload that drops the provider again.

Only fields the catalog schema already models are set; no pricing or modality fields were invented.

## Checks

- `bun test tests/agent-models-route.test.ts` (run from `web/`) — 6 pass, 0 fail.
- `bunx @biomejs/biome@2.5.0 check web/data/agent-models.ts web/app/api/agent-models/route.ts web/tests/agent-models-route.test.ts` — clean.
- The new `rejects a catalog that drops a required provider` test was confirmed to fail when the `REQUIRED_PROVIDERS` entry is removed, and to pass with it.

Typecheck and the full `web` suite were not run here because this environment could not install the `web` dependency tree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789563627&installation_model_id=21920&pr_number=10274&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10274&signature=afad1e644c2973adce68dd9d7d8900ac7ced5ff637cddf1fcc061abfbe511d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore MiniMax models to the served agent model catalog so `agent-chat` keeps offering them after a catalog refresh. Previously, the first successful refresh dropped MiniMax fallbacks and removed `MiniMax-M3` and `MiniMax-M2.7` from the picker; now the server includes `minimax` and refuses payloads that omit it.

- Catalog: add `minimax` to `web/data/agent-models.ts` with `MiniMax-M3` (default, 1,000,000-token context, supportsOneMillion) and `MiniMax-M2.7` (204,800-token context); bump `updatedAt` so clients fetch the new revision.
- API guard: include `"minimax"` in `REQUIRED_PROVIDERS` so the route rejects catalogs that drop the provider.
- Tests: expand route tests to assert `minimax` is present and that omission throws.
- Rollout: no migration required; clients will refresh with the new ETag and repopulate MiniMax choices.

<sup>Written for commit f0506ab543d6e352b9b54701d8e93901f3b90a43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported AI provider.
  * Added MiniMax M3 and M2.7 models, including context-window and one-million-token support details.

* **Bug Fixes**
  * Catalog validation now rejects configurations that do not include MiniMax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->