### PR TITLE
perf: read listening ports from the kernel instead of spawning lsof

### DIFF
--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -74,6 +74,17 @@ extension SidebarWorkspaceDetailDefaults {
         )
     }
 
+    /// Whether listening-port discovery may run at all. The ports detail is the
+    /// only thing that displays the result, so when it is hidden the scans have
+    /// nothing to populate. Mirrors the sidebar's own precedence, where
+    /// `sidebar.hideAllDetails` wins over `sidebar.showPorts` (issue #6123).
+    static func portScanningEnabled(defaults: UserDefaults = .standard) -> Bool {
+        let sidebar = SidebarCatalogSection()
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let details = SidebarWorkspaceDetailSettings(defaults: defaults)
+        return details.showPorts && !settings.value(for: sidebar.hideAllDetails)
+    }
+
     static func gitMetadataPollingEnabled(defaults: UserDefaults) -> Bool {
         gitMetadataActivity(defaults: defaults).performsActivePolling
     }

--- a/Sources/ListeningPortLookup.swift
+++ b/Sources/ListeningPortLookup.swift
@@ -1,0 +1,76 @@
+import Darwin
+import Foundation
+
+/// What the kernel could tell us about one process's listening TCP ports.
+enum ListeningPortLookupResult: Sendable, Equatable {
+    /// The kernel described every descriptor this process owns.
+    case ports(Set<Int>)
+    /// We are not allowed to inspect this process.
+    case denied
+    /// The process is gone, or the kernel would not describe it.
+    case unavailable
+}
+
+/// Reads listening TCP ports from the kernel with libproc.
+///
+/// "lsof" answers the same question, but it first calls close() on every
+/// descriptor number up to "kern.maxfilesperproc" (138,240 on current macOS),
+/// and it forks a child that repeats the sweep. That is far more work than the
+/// lookup itself, and this scan runs every couple of seconds.
+enum ListeningPortLookup {
+    /// Extra descriptor slots so a process that opens files between the
+    /// sizing call and the read still fits in one pass.
+    private static let capacityHeadroom = 32
+
+    static func ports(pid: pid_t) -> ListeningPortLookupResult {
+        guard pid > 0 else { return .unavailable }
+
+        errno = 0
+        let sizeNeeded = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        if sizeNeeded < 0 { return classify(errno) }
+        if sizeNeeded == 0 { return errno == 0 ? .ports([]) : classify(errno) }
+
+        let stride = MemoryLayout<proc_fdinfo>.stride
+        let capacity = Int(sizeNeeded) / stride + capacityHeadroom
+        var descriptors = [proc_fdinfo](repeating: proc_fdinfo(), count: capacity)
+
+        errno = 0
+        let written = descriptors.withUnsafeMutableBytes { buffer in
+            proc_pidinfo(pid, PROC_PIDLISTFDS, 0, buffer.baseAddress, Int32(buffer.count))
+        }
+        if written < 0 { return classify(errno) }
+        if written == 0 { return errno == 0 ? .ports([]) : classify(errno) }
+
+        var ports: Set<Int> = []
+        let usable = min(Int(written) / stride, capacity)
+        for index in 0..<usable {
+            let descriptor = descriptors[index]
+            guard descriptor.proc_fdtype == UInt32(PROX_FDTYPE_SOCKET) else { continue }
+            if let port = listeningPort(pid: pid, fd: descriptor.proc_fd) {
+                ports.insert(port)
+            }
+        }
+        return .ports(ports)
+    }
+
+    private static func listeningPort(pid: pid_t, fd: Int32) -> Int? {
+        var info = socket_fdinfo()
+        let expected = Int32(MemoryLayout<socket_fdinfo>.size)
+        let read = proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, &info, expected)
+        // A descriptor closed mid-scan returns a short read; skip it.
+        guard read == expected else { return nil }
+        guard info.psi.soi_kind == SOCKINFO_TCP else { return nil }
+
+        let tcp = info.psi.soi_proto.pri_tcp
+        guard tcp.tcpsi_state == TSI_S_LISTEN else { return nil }
+
+        // "insi_lport" holds a 16-bit port in network byte order.
+        let port = Int(UInt16(bigEndian: UInt16(truncatingIfNeeded: tcp.tcpsi_ini.insi_lport)))
+        guard port > 0, port <= 65_535 else { return nil }
+        return port
+    }
+
+    private static func classify(_ code: Int32) -> ListeningPortLookupResult {
+        code == EPERM || code == EACCES ? .denied : .unavailable
+    }
+}

--- a/Sources/PortListenerScanResult.swift
+++ b/Sources/PortListenerScanResult.swift
@@ -2,7 +2,7 @@ import CmuxCore
 import Foundation
 
 /// Parsed `lsof` output plus the scope of evidence that could not be inspected.
-struct PortLsofScanResult: Sendable {
+struct PortListenerScanResult: Sendable {
     let values: [Int: Set<Int>]
     let globallyComplete: Bool
     let incompletePIDs: Set<Int>

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -23,7 +23,7 @@ extension PortScanner {
         panelTTYs: [PanelKey: String],
         pidToTTY: [Int: String],
         psCompleteness: PortScanCompleteness,
-        lsofScan: PortLsofScanResult?
+        lsofScan: PortListenerScanResult?
     ) -> [PanelKey: PortScanCompleteness] {
         let pidsByTTY = pidToTTY.reduce(into: [String: Set<Int>]()) { result, item in
             result[canonicalTTYName(item.value), default: []].insert(item.key)
@@ -295,7 +295,7 @@ extension PortScanner {
 
     func agentLsofCompleteness(
         ownershipByPID: [Int: Set<UUID>],
-        lsofScan: PortLsofScanResult,
+        lsofScan: PortListenerScanResult,
         workspaceIds: Set<UUID>
     ) -> [UUID: PortScanCompleteness] {
         var pidsByWorkspace: [UUID: Set<Int>] = [:]
@@ -433,87 +433,43 @@ extension PortScanner {
         return (mapping, complete ? .complete : .incomplete)
     }
 
-    func runLsof(pidsCsv: String) async -> PortLsofScanResult {
-        let result = await commandRunner.run(
-            directory: "/",
-            executable: "/usr/sbin/lsof",
-            // A PID-scoped TCP query does not depend on filesystem mount
-            // metadata. Suppress warning-class diagnostics such as lsof's
-            // Time Machine `can't stat()` warning so unrelated mounts cannot
-            // make every port miss permanently incomplete.
-            arguments: ["-nP", "-w", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"],
-            timeout: Self.processScanTimeout
-        )
-
+    /// Reads listening TCP ports for each requested PID directly from the
+    /// kernel. Every PID answers for itself, so one unreadable process no
+    /// longer costs the whole scan its evidence.
+    ///
+    /// The callers are async, so this blocks a cooperative thread. That is safe
+    /// at the current scale: the libproc calls measure about 1.25us per process,
+    /// so a scan holds one thread for well under a millisecond every couple of
+    /// seconds, and scans never overlap. Give it its own queue if that stops
+    /// being true — if scans start running concurrently, or if a process with a
+    /// very large descriptor table makes one scan slow, since the cost is per
+    /// descriptor rather than per PID.
+    func scanListeningPorts(pidsCsv: String) -> PortListenerScanResult {
+        let requestedPIDs = Set(pidsCsv.split(separator: ",").compactMap { Int($0) })
         var portsByPID: [Int: Set<Int>] = [:]
-        var currentPID: Int?
-        var parsedEveryRow = true
-        var parseIncompletePIDs: Set<Int> = []
-        for line in (result.stdout ?? "").split(separator: "\n") {
-            guard let first = line.first else { continue }
-            switch first {
-            case "p":
-                guard let pid = Int(line.dropFirst()), pid > 0 else {
-                    currentPID = nil
-                    parsedEveryRow = false
-                    continue
+        var incompletePIDs: Set<Int> = []
+
+        for pid in requestedPIDs {
+            switch listeningPortsProvider(pid_t(pid)) {
+            case .ports(let ports):
+                if !ports.isEmpty {
+                    portsByPID[pid] = ports
                 }
-                currentPID = pid
-            case "n":
-                guard let currentPID else {
-                    parsedEveryRow = false
-                    continue
-                }
-                var name = String(line.dropFirst())
-                if let arrow = name.range(of: "->") {
-                    name = String(name[..<arrow.lowerBound])
-                }
-                guard let colon = name.lastIndex(of: ":") else {
-                    parseIncompletePIDs.insert(currentPID)
-                    continue
-                }
-                let portText = name[name.index(after: colon)...]
-                guard portText.allSatisfy(\.isNumber),
-                      let port = Int(portText),
-                      port > 0,
-                      port <= 65_535 else {
-                    parseIncompletePIDs.insert(currentPID)
-                    continue
-                }
-                portsByPID[currentPID, default: []].insert(port)
-            case "f":
-                if line.dropFirst().isEmpty {
-                    if let currentPID {
-                        parseIncompletePIDs.insert(currentPID)
-                    } else {
-                        parsedEveryRow = false
-                    }
-                }
-            default:
-                if let currentPID {
-                    parseIncompletePIDs.insert(currentPID)
-                } else {
-                    parsedEveryRow = false
+            case .denied, .unavailable:
+                // An unprivileged caller cannot read a root-owned process's
+                // sockets, and neither could lsof. Only a PID whose identity is
+                // unreadable while it is still present counts as a miss, so a
+                // panel behind the root `login` process can still retire ports.
+                if processIdentityProvider(pid_t(pid)) == nil
+                    && processPresenceProvider(pid_t(pid)) != .absent {
+                    incompletePIDs.insert(pid)
                 }
             }
         }
-        // lsof exits 1 both for "no selected files" and when one requested PID
-        // disappears. Keep the failure scoped to the PIDs that can no longer be
-        // inspected so unrelated workspaces can still consume complete evidence.
-        let requestedPIDs = Set(pidsCsv.split(separator: ",").compactMap { Int($0) })
-        var incompletePIDs = parseIncompletePIDs
-        incompletePIDs.formUnion(requestedPIDs.filter {
-            processIdentityProvider(pid_t($0)) == nil
-                && processPresenceProvider(pid_t($0)) != .absent
-        })
-        let globallyComplete = result.executionError == nil
-            && !result.timedOut
-            && (result.exitStatus == 0 || result.exitStatus == 1)
-            && (result.stderr ?? "").isEmpty
-            && parsedEveryRow
-        return PortLsofScanResult(
+
+        return PortListenerScanResult(
             values: portsByPID,
-            globallyComplete: globallyComplete,
+            globallyComplete: true,
             incompletePIDs: incompletePIDs
         )
     }

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -50,6 +50,9 @@ final class PortScanner: @unchecked Sendable {
     var agentSnapshotReplacementState = AgentPortSnapshotReplacementState()
     var forceAgentResultWorkspaces: Set<UUID> = []
     private var trackedAgentScanningPaused = false
+    /// Mirrors the sidebar ports-visibility settings. Nothing displays or
+    /// reports ports while they are hidden, so no scan needs to run.
+    private var scanningEnabled = SidebarWorkspaceDetailDefaults.portScanningEnabled()
     let publicationState = PortScanPublicationState()
     var publicationBuffer = PortScanPublicationBuffer()
 
@@ -149,6 +152,7 @@ final class PortScanner: @unchecked Sendable {
 
     func kick(workspaceId: UUID, panelId: UUID) {
         queue.async { [self] in
+            guard scanningEnabled else { return }
             let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
             guard ttyNames[key] != nil else { return }
             pendingKicks.insert(key)
@@ -194,6 +198,23 @@ final class PortScanner: @unchecked Sendable {
         queue.async { [self] in
             guard trackedAgentScanningPaused != paused else { return }
             trackedAgentScanningPaused = paused
+            updateAgentScanTimerLocked()
+        }
+    }
+
+    /// Turns local scanning on and off with the sidebar ports detail, the way
+    /// remote scanning already follows it (issue #6123).
+    func setScanningEnabled(_ enabled: Bool) {
+        queue.async { [self] in
+            guard scanningEnabled != enabled else { return }
+            scanningEnabled = enabled
+            if !enabled {
+                pendingKicks.removeAll()
+                scansRemainingForPendingKicks = 0
+                coalesceTimer?.cancel()
+                coalesceTimer = nil
+                burstActive = false
+            }
             updateAgentScanTimerLocked()
         }
     }
@@ -503,7 +524,7 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func updateAgentScanTimerLocked() {
-        guard !trackedAgentScanningPaused, !trackedAgentWorkspaces.isEmpty else {
+        guard scanningEnabled, !trackedAgentScanningPaused, !trackedAgentWorkspaces.isEmpty else {
             agentScanTimer?.cancel()
             agentScanTimer = nil
             return
@@ -548,7 +569,7 @@ final class PortScanner: @unchecked Sendable {
         agentRootsByWorkspace: [UUID: Set<AgentPortRootIdentity>],
         agentRevisions: [UUID: UInt64]
     ) {
-        guard !workspaceIds.isEmpty else { return }
+        guard scanningEnabled, !workspaceIds.isEmpty else { return }
         let request = AgentPortScanRequest(
             workspaceIds: workspaceIds,
             rootInput: AgentPortScanRootInput(rootsByWorkspace: agentRootsByWorkspace),

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -30,6 +30,7 @@ final class PortScanner: @unchecked Sendable {
     let queue = DispatchQueue(label: "com.cmux.port-scanner", qos: .utility)
     let processIdentityProvider: @Sendable (pid_t) -> AgentPIDProcessIdentity?
     let processPresenceProvider: @Sendable (pid_t) -> PIDPresence
+    let listeningPortsProvider: @Sendable (pid_t) -> ListeningPortLookupResult
     @MainActor let ttySessionIdentityProvider: @MainActor @Sendable (String) -> TerminalTTYSessionIdentity?
 
     private var ttyNames: [PanelKey: String] = [:]
@@ -83,6 +84,9 @@ final class PortScanner: @unchecked Sendable {
         processPresenceProvider: @escaping @Sendable (pid_t) -> PIDPresence = {
             PIDPresence.current(pid: $0)
         },
+        listeningPortsProvider: @escaping @Sendable (pid_t) -> ListeningPortLookupResult = {
+            ListeningPortLookup.ports(pid: $0)
+        },
         ttySessionIdentityProvider: @escaping @MainActor @Sendable (String) -> TerminalTTYSessionIdentity? = {
             TerminalTTYSessionIdentity(ttyName: $0)
         }
@@ -90,6 +94,7 @@ final class PortScanner: @unchecked Sendable {
         self.commandRunner = commandRunner
         self.processIdentityProvider = processIdentityProvider
         self.processPresenceProvider = processPresenceProvider
+        self.listeningPortsProvider = listeningPortsProvider
         self.ttySessionIdentityProvider = ttySessionIdentityProvider
     }
 
@@ -314,7 +319,7 @@ final class PortScanner: @unchecked Sendable {
         let allPids = Set(capturedPanelPIDs.identitiesByPID.keys).union(agentOwnershipBeforeLsof.keys)
         guard !allPids.isEmpty else {
             let panelResults = panelSnapshot.map { ($0.key, [Int]()) }
-            let panelLsofEvidence = PortLsofScanResult(
+            let panelLsofEvidence = PortListenerScanResult(
                 values: [:],
                 globallyComplete: true,
                 incompletePIDs: capturedPanelPIDs.incompletePIDs
@@ -343,7 +348,7 @@ final class PortScanner: @unchecked Sendable {
 
         // 2. lsof -nP -a -p <all_pids> -iTCP -sTCP:LISTEN -F pn
         let pidsCsv = allPids.sorted().map(String.init).joined(separator: ",")
-        let lsofScan = await runLsof(pidsCsv: pidsCsv)
+        let lsofScan = scanListeningPorts(pidsCsv: pidsCsv)
         let pidToPorts = lsofScan.values
         async let finalizedAgentPIDTask = finalizeAgentPIDOwnership(
             rootsByWorkspace: agentRootsByWorkspace,
@@ -400,7 +405,7 @@ final class PortScanner: @unchecked Sendable {
             ),
             workspaceIds: workspaceIds
         )
-        let panelLsofEvidence = PortLsofScanResult(
+        let panelLsofEvidence = PortListenerScanResult(
             values: lsofScan.values,
             globallyComplete: lsofScan.globallyComplete,
             incompletePIDs: lsofScan.incompletePIDs
@@ -589,7 +594,7 @@ final class PortScanner: @unchecked Sendable {
                 .sorted()
                 .map(String.init)
                 .joined(separator: ",")
-            let lsofScan = await self.runLsof(pidsCsv: pidsCsv)
+            let lsofScan = self.scanListeningPorts(pidsCsv: pidsCsv)
             let pidToPorts = lsofScan.values
             let finalizedAgentPIDs = await self.finalizeAgentPIDOwnership(
                 rootsByWorkspace: agentRootsByWorkspace,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -724,16 +724,17 @@ class TabManager: ObservableObject {
     /// the `UserDefaults.didChangeNotification` firehose to actual transitions.
     private var lastRemotePortScanningEnabled: Bool?
 
-    /// Propagates the sidebar ports-visibility settings to every live remote
-    /// session so that disabling `sidebar.showPorts` (or enabling
-    /// `sidebar.hideAllDetails`) actually stops the backend ssh port-scan loop,
-    /// not just the sidebar display (issue #6123). New remote workspaces pick
-    /// up the current value at creation, so this only needs to react to a
-    /// change for already-connected sessions.
+    /// Propagates the sidebar ports-visibility settings to the local scanner and
+    /// to every live remote session, so that disabling `sidebar.showPorts` (or
+    /// enabling `sidebar.hideAllDetails`) actually stops the scans, not just the
+    /// sidebar display (issue #6123). New remote workspaces pick up the current
+    /// value at creation, so this only needs to react to a change for
+    /// already-connected sessions.
     private func refreshRemotePortScanningEnablement() {
         let enabled = Workspace.remotePortScanningEnabledFromSettings()
         guard enabled != lastRemotePortScanningEnabled else { return }
         lastRemotePortScanningEnabled = enabled
+        PortScanner.shared.setScanningEnabled(enabled)
         for tab in tabs where tab.isRemoteWorkspace {
             tab.applyRemotePortScanningEnabled(enabled)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5770,18 +5770,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         remoteSessionController?.kickRemotePortScan(panelId: panelId, reason: reason)
     }
 
-    /// Whether remote listening-port discovery may run, derived from the global
-    /// sidebar ports-visibility settings. Mirrors the sidebar's own precedence
-    /// (`sidebar.hideAllDetails` wins over `sidebar.showPorts`, see
-    /// `SidebarWorkspaceAuxiliaryDetailVisibility.resolved`): when the ports
-    /// detail is not displayed there is nothing for the remote scans to
-    /// populate, so the backend ssh port-scan loop is suspended (issue #6123).
+    /// Whether remote listening-port discovery may run. Local and remote scans
+    /// share one rule, so both stop when the ports detail is hidden
+    /// (issue #6123).
     static func remotePortScanningEnabledFromSettings(defaults: UserDefaults = .standard) -> Bool {
-        let settings = UserDefaultsSettingsClient(defaults: defaults)
-        let catalog = SettingCatalog()
-        let showsPorts = settings.value(for: catalog.sidebar.showPorts)
-        let hidesAllDetails = settings.value(for: catalog.sidebar.hideAllDetails)
-        return showsPorts && !hidesAllDetails
+        SidebarWorkspaceDetailDefaults.portScanningEnabled(defaults: defaults)
     }
 
     /// Pushes the current remote port-scanning enablement to this workspace's

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1310,6 +1310,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */; };
 		9492CAFE0000000000000002 /* LastTerminalChildExitRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9492CAFE0000000000000001 /* LastTerminalChildExitRecoveryTests.swift */; };
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
+		B79500310000000000000101 /* ListeningPortLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500310000000000000102 /* ListeningPortLookup.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
 		D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */; };
@@ -1599,7 +1600,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
 		D0C658660000000000000002 /* PortalSplitDividerRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000001 /* PortalSplitDividerRegion.swift */; };
 		D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */; };
-		B79500310000000000000001 /* PortLsofScanResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500310000000000000002 /* PortLsofScanResult.swift */; };
+		B79500310000000000000001 /* PortListenerScanResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500310000000000000002 /* PortListenerScanResult.swift */; };
 		B79500030000000000000001 /* PortScanCoordination.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500030000000000000002 /* PortScanCoordination.swift */; };
 		B79500070000000000000001 /* PortScanner+PanelKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500070000000000000002 /* PortScanner+PanelKey.swift */; };
 		B79500010000000000000001 /* PortScanner+Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500010000000000000002 /* PortScanner+Process.swift */; };
@@ -4094,6 +4095,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSurfaceClosePreferenceTests.swift; sourceTree = "<group>"; };
 		9492CAFE0000000000000001 /* LastTerminalChildExitRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastTerminalChildExitRecoveryTests.swift; sourceTree = "<group>"; };
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
+		B79500310000000000000102 /* ListeningPortLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningPortLookup.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
 		D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupBody.swift; sourceTree = "<group>"; };
@@ -4382,7 +4384,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
 		D0C658660000000000000001 /* PortalSplitDividerRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerRegion.swift; sourceTree = "<group>"; };
 		D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalTabDragRoutingTests.swift; sourceTree = "<group>"; };
-		B79500310000000000000002 /* PortLsofScanResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortLsofScanResult.swift; sourceTree = "<group>"; };
+		B79500310000000000000002 /* PortListenerScanResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortListenerScanResult.swift; sourceTree = "<group>"; };
 		B79500030000000000000002 /* PortScanCoordination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanCoordination.swift; sourceTree = "<group>"; };
 		B79500070000000000000002 /* PortScanner+PanelKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortScanner+PanelKey.swift"; sourceTree = "<group>"; };
 		B79500010000000000000002 /* PortScanner+Process.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortScanner+Process.swift"; sourceTree = "<group>"; };
@@ -6842,7 +6844,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001541 /* PortScanner.swift */,
 				B79500070000000000000002 /* PortScanner+PanelKey.swift */,
 				B79500010000000000000002 /* PortScanner+Process.swift */,
-				B79500310000000000000002 /* PortLsofScanResult.swift */,
+				B79500310000000000000002 /* PortListenerScanResult.swift */,
+				B79500310000000000000102 /* ListeningPortLookup.swift */,
 				B79500090000000000000002 /* PortScanner+Publication.swift */,
 				6313B1A1 /* PaneMemoryDescriptor.swift */,
 				6313A1A1 /* PaneMemoryGuardrail.swift */,
@@ -9692,6 +9695,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5F10011A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift in Sources */,
 				C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
 				8561C0128561C0128561C012 /* KeyboardShortcutSettingsObserver.swift in Sources */,
+				B79500310000000000000101 /* ListeningPortLookup.swift in Sources */,
 				53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */,
 				D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */,
 				D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */,
@@ -9904,7 +9908,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B79500210000000000000001 /* PIDPresence.swift in Sources */,
 				D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */,
 				D0C658660000000000000002 /* PortalSplitDividerRegion.swift in Sources */,
-				B79500310000000000000001 /* PortLsofScanResult.swift in Sources */,
+				B79500310000000000000001 /* PortListenerScanResult.swift in Sources */,
 				B79500030000000000000001 /* PortScanCoordination.swift in Sources */,
 				B79500070000000000000001 /* PortScanner+PanelKey.swift in Sources */,
 				B79500010000000000000001 /* PortScanner+Process.swift in Sources */,

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -13,6 +13,14 @@ import Testing
 
 @Suite("Port scanner process capture")
 struct PortScannerProcessCaptureTests {
+    private static let idleCommandResult = CommandResult(
+        stdout: "",
+        stderr: "",
+        exitStatus: 0,
+        timedOut: false,
+        executionError: nil
+    )
+
     @Test("Malformed ps rows preserve valid mappings but make the scan incomplete")
     func malformedPSRowsAreIncomplete() async {
         let runner = StubCommandRunner(result: CommandResult(
@@ -28,111 +36,90 @@ struct PortScannerProcessCaptureTests {
         #expect(scan.completeness == .incomplete)
     }
 
-    @Test("Malformed lsof rows are incomplete only for their owning PID")
-    func malformedLsofRowsArePIDScoped() async {
-        let runner = StubCommandRunner(result: CommandResult(
-            stdout: "p123\nf3\nn*:4200\nnmalformed\np456\nf3\nn*:4300\n",
-            stderr: "",
-            exitStatus: 0,
-            timedOut: false,
-            executionError: nil
-        ))
-        let scan = await PortScanner(
-            commandRunner: runner,
+    @Test("Ports read from the kernel are complete evidence")
+    func kernelPortsAreCompleteEvidence() {
+        let scan = PortScanner(
+            commandRunner: StubCommandRunner(result: Self.idleCommandResult),
             processIdentityProvider: {
                 AgentPIDProcessIdentity(pid: $0, startSeconds: 1, startMicroseconds: 0)
-            }
-        ).runLsof(pidsCsv: "123,456")
-
-        #expect(scan.values == [123: [4200], 456: [4300]])
-        #expect(scan.completeness(for: [123]) == .incomplete)
-        #expect(scan.completeness(for: [456]) == .complete)
-    }
-
-    @Test("A clean lsof field stream is complete")
-    func cleanLsofRowsAreComplete() async {
-        let runner = StubCommandRunner(result: CommandResult(
-            stdout: "p123\nf3\nn*:4200\n",
-            stderr: "",
-            exitStatus: 0,
-            timedOut: false,
-            executionError: nil
-        ))
-        let scan = await PortScanner(
-            commandRunner: runner,
-            processIdentityProvider: {
-                AgentPIDProcessIdentity(pid: $0, startSeconds: 1, startMicroseconds: 0)
-            }
-        ).runLsof(pidsCsv: "123")
+            },
+            listeningPortsProvider: { $0 == 123 ? .ports([4200]) : .ports([]) }
+        ).scanListeningPorts(pidsCsv: "123")
 
         #expect(scan.values == [123: [4200]])
         #expect(scan.completeness == .complete)
     }
 
-    @Test("lsof diagnostics preserve valid ports but make the scan incomplete")
-    func lsofDiagnosticsAreIncomplete() async {
-        let runner = StubCommandRunner(result: CommandResult(
-            stdout: "p123\nf3\nn*:4200\n",
-            stderr: "lsof: permission denied\n",
-            exitStatus: 0,
-            timedOut: false,
-            executionError: nil
-        ))
-        let scan = await PortScanner(commandRunner: runner).runLsof(pidsCsv: "123")
+    @Test("An unreadable live PID is incomplete only for itself")
+    func unreadablePIDIsPIDScoped() {
+        let scan = PortScanner(
+            commandRunner: StubCommandRunner(result: Self.idleCommandResult),
+            processIdentityProvider: {
+                $0 == 456
+                    ? AgentPIDProcessIdentity(pid: $0, startSeconds: 1, startMicroseconds: 0)
+                    : nil
+            },
+            processPresenceProvider: { _ in .present },
+            listeningPortsProvider: { $0 == 456 ? .ports([4300]) : .denied }
+        ).scanListeningPorts(pidsCsv: "123,456")
 
-        #expect(scan.values == [123: [4200]])
-        #expect(scan.completeness == .incomplete)
+        #expect(scan.values == [456: [4300]])
+        #expect(scan.completeness(for: [123]) == .incomplete)
+        #expect(scan.completeness(for: [456]) == .complete)
     }
 
-    @Test("Filesystem warnings do not poison lsof TCP evidence")
-    func filesystemWarningsAreSuppressedForLsofTCPScan() async {
-        let pid = 123
-        let identity = AgentPIDProcessIdentity(
-            pid: pid_t(pid),
-            startSeconds: 1,
-            startMicroseconds: 0
-        )
-        let runner = PortLifecycleCommandRunner(
-            ttyName: "ttys001",
-            sessionLeaderPID: 1,
-            pid: pid,
-            port: 4200
-        )
-        let scan = await PortScanner(
-            commandRunner: runner,
-            processIdentityProvider: { $0 == identity.pid ? identity : nil },
-            processPresenceProvider: { $0 == identity.pid ? .present : .absent }
-        ).runLsof(pidsCsv: String(pid))
-        let arguments = await runner.lastLsofArguments
+    @Test("A root-owned PID we may not read still has a readable identity, so it stays complete")
+    func deniedPIDWithReadableIdentityStaysComplete() {
+        // The root `login` process heads every terminal's process group. An
+        // unprivileged reader never sees its sockets, and treating that as a
+        // miss would stop the panel behind it from ever retiring its ports.
+        let scan = PortScanner(
+            commandRunner: StubCommandRunner(result: Self.idleCommandResult),
+            processIdentityProvider: {
+                AgentPIDProcessIdentity(pid: $0, startSeconds: 1, startMicroseconds: 0)
+            },
+            processPresenceProvider: { _ in .present },
+            listeningPortsProvider: { _ in .denied }
+        ).scanListeningPorts(pidsCsv: "1")
 
-        #expect(scan.values == [pid: [4200]])
-        #expect(scan.completeness(for: [pid]) == .complete)
-        #expect(arguments?.contains("-w") == true)
+        #expect(scan.values.isEmpty)
+        #expect(scan.completeness(for: [1]) == .complete)
     }
 
-    @Test("A confirmed absent PID is safe negative lsof evidence")
-    func absentPIDIsCompleteNegativeEvidence() async {
-        let runner = StubCommandRunner(result: CommandResult(
-            stdout: "p100\nf3\nn*:4200\n",
-            stderr: "",
-            exitStatus: 1,
-            timedOut: false,
-            executionError: nil
-        ))
+    @Test("A confirmed absent PID is safe negative evidence")
+    func absentPIDIsCompleteNegativeEvidence() {
         let liveIdentity = AgentPIDProcessIdentity(
             pid: 100,
             startSeconds: 1,
             startMicroseconds: 0
         )
-        let scan = await PortScanner(
-            commandRunner: runner,
+        let scan = PortScanner(
+            commandRunner: StubCommandRunner(result: Self.idleCommandResult),
             processIdentityProvider: { $0 == liveIdentity.pid ? liveIdentity : nil },
-            processPresenceProvider: { $0 == liveIdentity.pid ? .present : .absent }
-        ).runLsof(pidsCsv: "100,200")
+            processPresenceProvider: { $0 == liveIdentity.pid ? .present : .absent },
+            listeningPortsProvider: { $0 == liveIdentity.pid ? .ports([4200]) : .unavailable }
+        ).scanListeningPorts(pidsCsv: "100,200")
 
         #expect(scan.values == [100: [4200]])
         #expect(scan.completeness(for: [100]) == .complete)
         #expect(scan.completeness(for: [200]) == .complete)
+    }
+
+    @Test("Reading listening ports spawns no subprocess")
+    func listeningPortScanSpawnsNoSubprocess() async {
+        // The scan used to shell out to lsof, which closes every descriptor up
+        // to `kern.maxfilesperproc` before it answers. Keep it out of the path.
+        let runner = StubCommandRunner(result: Self.idleCommandResult)
+        let scan = PortScanner(
+            commandRunner: runner,
+            processIdentityProvider: {
+                AgentPIDProcessIdentity(pid: $0, startSeconds: 1, startMicroseconds: 0)
+            },
+            listeningPortsProvider: { _ in .ports([4200]) }
+        ).scanListeningPorts(pidsCsv: "123")
+
+        #expect(scan.values == [123: [4200]])
+        #expect(await runner.lastTimeout == nil)
     }
 
     @Test("A process owned by another user still has a readable birth identity")
@@ -186,7 +173,7 @@ struct PortScannerProcessCaptureTests {
     @Test("A zombie on a panel's TTY does not withhold negative port evidence")
     func zombieProcessIsAuthoritativeAbsence() async throws {
         // Rejecting zombies as identities is only half the story: a zombie is
-        // still signalable, so presence read it as live and `runLsof` filed it
+        // still signalable, so presence read it as live and the scan filed it
         // as a PID whose ports might have gone unseen. That is the same
         // incompleteness that froze every panel behind the root `login`, and a
         // zombie can hold no socket at all.
@@ -213,7 +200,7 @@ struct PortScannerProcessCaptureTests {
             timedOut: false,
             executionError: nil
         ))
-        let lsofScan = await PortScanner(commandRunner: runner).runLsof(pidsCsv: String(pid))
+        let lsofScan = PortScanner(commandRunner: runner).scanListeningPorts(pidsCsv: String(pid))
         let completeness = PortScanner.panelCompletenessByKey(
             panelTTYs: [panel: "ttys001"],
             pidToTTY: [Int(pid): "ttys001"],
@@ -241,7 +228,7 @@ struct PortScannerProcessCaptureTests {
     }
 
     @Test("A panel hosting a root-owned process can still retire its ports")
-    func panelWithRootOwnedProcessStaysComplete() async {
+    func panelWithRootOwnedProcessStaysComplete() {
         let panel = PortScanner.PanelKey(workspaceId: UUID(), panelId: UUID())
         let rootOwnedPID = 1
         let runner = StubCommandRunner(result: CommandResult(
@@ -251,8 +238,8 @@ struct PortScannerProcessCaptureTests {
             timedOut: false,
             executionError: nil
         ))
-        let lsofScan = await PortScanner(commandRunner: runner)
-            .runLsof(pidsCsv: String(rootOwnedPID))
+        let lsofScan = PortScanner(commandRunner: runner)
+            .scanListeningPorts(pidsCsv: String(rootOwnedPID))
 
         let completeness = PortScanner.panelCompletenessByKey(
             panelTTYs: [panel: "ttys001"],
@@ -270,7 +257,7 @@ struct PortScannerProcessCaptureTests {
         let workspaceID = UUID()
         let healthyPanel = PortScanner.PanelKey(workspaceId: workspaceID, panelId: UUID())
         let failedPanel = PortScanner.PanelKey(workspaceId: workspaceID, panelId: UUID())
-        let lsofScan = PortLsofScanResult(
+        let lsofScan = PortListenerScanResult(
             values: [100: [4200]],
             globallyComplete: true,
             incompletePIDs: [200]
@@ -740,7 +727,7 @@ struct AgentProcessIdentityValidationTests {
 
     @Test("lsof incompleteness is scoped to workspaces that own the failed PID")
     func lsofCompletenessIsPIDScoped() {
-        let scan = PortLsofScanResult(
+        let scan = PortListenerScanResult(
             values: [100: [4200]],
             globallyComplete: true,
             incompletePIDs: [200]
@@ -960,6 +947,7 @@ struct PortScannerPortRetirementTests {
         let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
         let scanner = PortScanner(
             commandRunner: runner,
+            listeningPortsProvider: { runner.listeningPorts(pid: $0) },
             ttySessionIdentityProvider: { _ in sessionIdentity }
         )
         let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
@@ -983,7 +971,7 @@ struct PortScannerPortRetirementTests {
         // Only publications recorded after the port stops being held count as
         // retirement; an earlier empty publication is registration noise.
         let publicationsBeforeStop = publishedPorts.withLock { $0.count }
-        await runner.stopListening()
+        runner.stopListening()
 
         let didRetirePort = await Self.waitForPublication(
             in: publishedPorts,
@@ -1015,6 +1003,7 @@ struct PortScannerPortRetirementTests {
         let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
         let scanner = PortScanner(
             commandRunner: runner,
+            listeningPortsProvider: { runner.listeningPorts(pid: $0) },
             ttySessionIdentityProvider: { _ in sessionIdentity }
         )
         let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
@@ -1038,10 +1027,10 @@ struct PortScannerPortRetirementTests {
         // The fifth scan is at 7.5 seconds in the six-scan burst. Stopping here
         // leaves only the 10-second scan in the original burst, so clearing the
         // kick at that scan strands the port after only one complete miss.
-        let reachedFifthScan = await runner.waitForLsofInvocation(5)
+        let reachedFifthScan = await runner.waitForPortScan(5)
         try #require(reachedFifthScan, "the scanner did not reach the fifth burst scan")
         let publicationsBeforeStop = publishedPorts.withLock { $0.count }
-        await runner.stopListening()
+        runner.stopListening()
         scanner.kick(workspaceId: workspaceId, panelId: panelId)
 
         let didRetirePort = await Self.waitForPublication(
@@ -1077,6 +1066,7 @@ struct PortScannerPortRetirementTests {
         let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
         let scanner = PortScanner(
             commandRunner: runner,
+            listeningPortsProvider: { runner.listeningPorts(pid: $0) },
             ttySessionIdentityProvider: { _ in sessionIdentity }
         )
         let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
@@ -1138,22 +1128,20 @@ struct PortScannerPortRetirementTests {
 
 /// Reports one listening port on one TTY until `stopListening()`, after which
 /// the process is still alive but owns no sockets.
-private actor PortLifecycleCommandRunner: CommandRunning {
+/// Stubs the `ps` half of a scan and stands in for the kernel port lookup, so a
+/// panel's whole port lifecycle can be driven without a real listening socket.
+private final class PortLifecycleCommandRunner: CommandRunning, @unchecked Sendable {
+    private struct State {
+        var isListening = true
+        var portScanCount = 0
+    }
+
     private let ttyName: String
     private let processTTYName: String
     private let sessionLeaderPID: Int
     private let pid: Int
     private let port: Int
-    private var isListening = true
-    private(set) var lastLsofArguments: [String]?
-    private var lsofInvocationCount = 0
-
-    private static let filesystemWarning = """
-    lsof: WARNING: can't stat() smbfs file system /Volumes/.timemachine/example
-          Output information may be incomplete.
-          assuming "dev=deadbeef" from mount table
-
-    """
+    private let state = OSAllocatedUnfairLock(initialState: State())
 
     init(
         ttyName: String,
@@ -1170,19 +1158,28 @@ private actor PortLifecycleCommandRunner: CommandRunning {
     }
 
     func stopListening() {
-        isListening = false
+        state.withLock { $0.isListening = false }
     }
 
-    func waitForLsofInvocation(_ target: Int, timeout: Duration = .seconds(15)) async -> Bool {
+    /// The port lookup the scanner calls instead of spawning lsof.
+    func listeningPorts(pid queryPID: pid_t) -> ListeningPortLookupResult {
+        state.withLock { current in
+            current.portScanCount += 1
+            guard Int(queryPID) == pid, current.isListening else { return .ports([]) }
+            return .ports([port])
+        }
+    }
+
+    func waitForPortScan(_ target: Int, timeout: Duration = .seconds(15)) async -> Bool {
         let deadline = ContinuousClock.now + timeout
-        while lsofInvocationCount < target, ContinuousClock.now < deadline {
+        while state.withLock({ $0.portScanCount }) < target, ContinuousClock.now < deadline {
             do {
                 try await Task.sleep(for: .milliseconds(50))
             } catch {
                 return false
             }
         }
-        return lsofInvocationCount >= target
+        return state.withLock { $0.portScanCount } >= target
     }
 
     func run(
@@ -1191,28 +1188,17 @@ private actor PortLifecycleCommandRunner: CommandRunning {
         arguments: [String],
         timeout: TimeInterval?
     ) async -> CommandResult {
-        if executable.hasSuffix("ps") {
-            if arguments.first == "-ax" {
-                return Self.output("\(pid) 1\n")
-            }
-            // Honor the `-t` selector: a scan that asks about another terminal
-            // must not be handed this panel's processes.
-            let selectedTTYs = Self.selection(for: "-t", in: arguments)
-            guard selectedTTYs.contains(ttyName) || selectedTTYs.contains(processTTYName) else {
-                return Self.noSelectedFiles()
-            }
-            return Self.output("\(sessionLeaderPID) \(processTTYName)\n\(pid) \(processTTYName)\n")
+        guard executable.hasSuffix("ps") else { return Self.noSelectedFiles() }
+        if arguments.first == "-ax" {
+            return Self.output("\(pid) 1\n")
         }
-        lsofInvocationCount += 1
-        lastLsofArguments = arguments
-        // `lsof -w` suppresses filesystem warnings. They are unrelated to a
-        // PID-scoped TCP socket query, but any stderr currently makes the
-        // scanner globally incomplete and prevents stale ports from aging out.
-        let stderr = arguments.contains("-w") ? "" : Self.filesystemWarning
-        guard isListening, Self.selection(for: "-p", in: arguments).contains(String(pid)) else {
-            return Self.noSelectedFiles(stderr: stderr)
+        // Honor the `-t` selector: a scan that asks about another terminal
+        // must not be handed this panel's processes.
+        let selectedTTYs = Self.selection(for: "-t", in: arguments)
+        guard selectedTTYs.contains(ttyName) || selectedTTYs.contains(processTTYName) else {
+            return Self.noSelectedFiles()
         }
-        return Self.output("p\(pid)\nf3\nn127.0.0.1:\(port)\n", stderr: stderr)
+        return Self.output("\(sessionLeaderPID) \(processTTYName)\n\(pid) \(processTTYName)\n")
     }
 
     /// The comma-separated values the command was asked to select on.

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -924,7 +924,39 @@ struct PortScannerPortRetirementTests {
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,
     /// reconcile, publish — so a break anywhere in that chain surfaces even
     /// when every individual stage still passes its own test.
-    @Test("A published port retires despite unrelated lsof filesystem warnings")
+    /// The scan is not free, so hiding the ports detail has to stop it running,
+    /// not just stop it being displayed (issue #6123).
+    @Test("Hiding the ports detail stops the local scan")
+    func disabledPortScanningNeverScans() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let ttyName = "ttys903"
+        let listenerPID = Int(getpid())
+        let runner = PortLifecycleCommandRunner(
+            ttyName: ttyName,
+            sessionLeaderPID: 1,
+            pid: listenerPID,
+            port: 4323
+        )
+        let listenerIdentity = try #require(AgentPIDProcessIdentity(pid: pid_t(listenerPID)))
+        let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            listeningPortsProvider: { runner.listeningPorts(pid: $0) },
+            ttySessionIdentityProvider: { _ in sessionIdentity }
+        )
+        scanner.setScanningEnabled(false)
+
+        await MainActor.run {
+            scanner.registerTTY(workspaceId: workspaceId, panelId: panelId, ttyName: ttyName)
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let scanned = await runner.waitForPortScan(1, timeout: .seconds(2))
+        #expect(scanned == false, "a disabled scanner must not read any process's ports")
+    }
+
+    @Test("A published port retires after the process stops listening")
     func publishedPortIsRetiredAfterProcessStopsListening() async throws {
         let workspaceId = UUID()
         let panelId = UUID()


### PR DESCRIPTION
Replaces the local port scan's `lsof` subprocess with a direct libproc lookup, and stops the scan entirely when the ports detail is hidden.

`PortScanner.runLsof` ran `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` about every two seconds. Before answering, `lsof` calls `close()` on every descriptor number up to `kern.maxfilesperproc` (138,240 on current macOS) and forks a child that repeats the sweep. Measured with `fs_usage`: **806,978 `close()` in 3.85 s — 86.7% of all filesystem events on the machine.**

`ListeningPortLookup` reads the same information through `PROC_PIDLISTFDS` + `PROC_PIDFDSOCKETINFO`, keeping TCP sockets in `TSI_S_LISTEN`.

| | lsof | libproc |
|---|---|---|
| one scan | ~200 ms | ~0.05 ms |
| results across 483 PIDs | identical | identical |

The second commit gates local scanning on `sidebar.showPorts`, which remote scanning already does (#6123); both now read one shared helper. This also blanks `listeningPorts` in the control-socket and CLI summaries for local workspaces while ports are hidden — the same trade remote workspaces already make.

Completeness semantics are unchanged: a PID we may not read counts as a miss only when its identity is also unreadable while it is still present, so a panel behind the root `login` process can still retire its ports.

Related: #7791 — same root cause, though its proposed `-b -w` addresses the blocking stats and leaves the descriptor sweep in place. Also #4313.

Verified on 5734a451cc, because `main` does not currently compile: 04ff18eea6 leaves `cleanupSurfaceState(surfaceIds:workspaceID:)` and `panelArtifactAuthorizationStore` undefined.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789580540&installation_model_id=21920&pr_number=10277&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10277&signature=07fce3911d4af0d010ed5df838696b91aa3f07c78c5a0e69319ae479f58fbbd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional listening-port scanning, controlled by sidebar settings.
  * Port scanning now identifies active listening ports directly and handles unavailable or permission-restricted processes.
  * Disabling scanning immediately stops pending and scheduled scans.

* **Improvements**
  * Local and remote workspace scanning now consistently follows the effective port-scanning preference.
  * Improved scan completeness reporting for unreadable and unavailable processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->