### PR TITLE
Show more notification rows in onboarding

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
@@ -32,6 +32,7 @@ struct OnboardingScreenshot: View {
         }
             .aspectRatio(contentMode: .fill)
             .frame(maxWidth: .infinity)
+            .offset(y: content.cropYOffset)
             .frame(height: 330, alignment: .top)
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
@@ -110,6 +111,17 @@ struct OnboardingScreenshot: View {
         language: OnboardingScreenshotLanguage
     ) -> String {
         "Onboarding-\(content.rawValue)-\(language.rawValue)"
+    }
+}
+
+private extension OnboardingScreenshot.Content {
+    var cropYOffset: CGFloat {
+        switch self {
+        case .workspaces:
+            0
+        case .notifications:
+            -140
+        }
     }
 }
 


### PR DESCRIPTION
The iOS onboarding notifications screenshot cropped to the top of the full-screen Simulator capture, so the 330pt frame showed mostly navigation chrome and only a sliver of the notification feed. This shifts the notifications capture up by 140pt before cropping, so the visible window lands on the notification rows themselves. The workspaces screenshot keeps its original framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifts the onboarding notifications screenshot up by 140pt before the 330pt crop so the visible area shows notification rows instead of navigation chrome. The workspaces screenshot keeps its original framing.

- Adds `offset(y: content.cropYOffset)` to `OnboardingScreenshot` to control vertical crop.
- Implements `cropYOffset` so `.notifications` uses -140pt and `.workspaces` uses 0.
- Keeps existing frame, clipping, and corner radius unchanged.

<sup>Written for commit 62c93142987f2543f3ac283d749180e5c756e17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

