### PR TITLE
Add `cmux themes here` for per-surface theming

### DIFF
--- a/CLI/CMUXCLI+Themes.swift
+++ b/CLI/CMUXCLI+Themes.swift
@@ -279,6 +279,11 @@ extension CMUXCLI {
                 targetBundleIdentifier: targetBundleIdentifier,
                 explicitPassword: explicitPassword
             )
+        case "here":
+            try runThemesHere(
+                args: Array(commandArgs.dropFirst()),
+                jsonOutput: jsonOutput
+            )
         case "clear":
             if commandArgs.count > 1 {
                 throw CLIError(message: "themes clear does not take any positional arguments")
@@ -459,6 +464,68 @@ extension CMUXCLI {
         print("OK cleared config=\(configURL.path) reload=requested")
     }
 
+    /// Applies a theme to the invoking terminal surface only, by writing OSC dynamic-color
+    /// sequences to stdout. Unlike `themes set` this touches no config file and affects no
+    /// other surface, window, or future session.
+    private func runThemesHere(args: [String], jsonOutput: Bool) throws {
+        guard !jsonOutput else {
+            throw CLIError(
+                message: "themes here writes escape sequences to the terminal and does not support --json"
+            )
+        }
+
+        var remaining = args
+        var shouldReset = false
+        if let resetIndex = remaining.firstIndex(of: "--reset") {
+            shouldReset = true
+            remaining.remove(at: resetIndex)
+        }
+
+        if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
+            throw CLIError(message: "themes here: unknown flag '\(unknown)'. Known flags: --reset")
+        }
+
+        if shouldReset {
+            guard remaining.isEmpty else {
+                throw CLIError(message: "themes here: --reset does not take a theme name")
+            }
+            print(Self.paneThemeResetSequence, terminator: "")
+            return
+        }
+
+        let requestedTheme = remaining.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !requestedTheme.isEmpty else {
+            throw CLIError(message: "themes here requires a theme name or a path to a theme file")
+        }
+
+        let contents = try paneThemeContents(forRequestedTheme: requestedTheme)
+        let sequence = Self.paneThemeSequence(forThemeContents: contents)
+        guard !sequence.isEmpty else {
+            throw CLIError(message: "Theme '\(requestedTheme)' does not define any terminal colors")
+        }
+        print(sequence, terminator: "")
+    }
+
+    /// Resolves a `themes here` argument as either a path to a theme file or the name of a
+    /// theme in one of the known theme directories.
+    private func paneThemeContents(forRequestedTheme requestedTheme: String) throws -> String {
+        let candidatePath = resolvePath(requestedTheme)
+        if FileManager.default.fileExists(atPath: candidatePath),
+           let contents = try? String(contentsOfFile: candidatePath, encoding: .utf8) {
+            return contents
+        }
+
+        let themeName = try validatedThemeName(requestedTheme, availableThemes: availableThemeNames())
+        for directoryURL in themeDirectoryURLs() {
+            let themeURL = directoryURL.appendingPathComponent(themeName, isDirectory: false)
+            if let contents = try? String(contentsOf: themeURL, encoding: .utf8) {
+                return contents
+            }
+        }
+
+        throw CLIError(message: "Unable to read theme '\(requestedTheme)'")
+    }
+
     private func currentThemeSelection(targetBundleIdentifier: String) -> ThemeSelection {
         var rawValue: String?
         var sourcePath: String?
@@ -519,6 +586,70 @@ extension CMUXCLI {
         let resolvedLight = lightTheme ?? fallbackTheme
         let resolvedDark = darkTheme ?? fallbackTheme
         return ThemeSelection(rawValue: rawValue, light: resolvedLight, dark: resolvedDark, sourcePath: sourcePath)
+    }
+
+    /// OSC 110/111/112/104: drop surface-local background, foreground, cursor, and palette
+    /// overrides so the surface falls back to the colors its config specifies.
+    static let paneThemeResetSequence = "\u{1B}]110\u{07}\u{1B}]111\u{07}\u{1B}]112\u{07}\u{1B}]104\u{07}"
+
+    /// Translates a Ghostty theme file into the OSC dynamic-color sequences that apply it to a
+    /// single terminal surface. Returns an empty string when the file declares no usable colors.
+    static func paneThemeSequence(forThemeContents contents: String) -> String {
+        var sequence = ""
+        for line in contents.components(separatedBy: .newlines) {
+            guard let (key, value) = paneThemeAssignment(from: line) else { continue }
+            switch key {
+            case "background":
+                guard let color = paneThemeHexColor(value) else { continue }
+                sequence += "\u{1B}]11;\(color)\u{07}"
+            case "foreground":
+                guard let color = paneThemeHexColor(value) else { continue }
+                sequence += "\u{1B}]10;\(color)\u{07}"
+            case "cursor-color":
+                guard let color = paneThemeHexColor(value) else { continue }
+                sequence += "\u{1B}]12;\(color)\u{07}"
+            case "palette":
+                let paletteParts = value.split(separator: "=", maxSplits: 1).map(String.init)
+                guard paletteParts.count == 2,
+                      let index = Int(paletteParts[0].trimmingCharacters(in: .whitespacesAndNewlines)),
+                      (0...255).contains(index),
+                      let color = paneThemeHexColor(paletteParts[1]) else { continue }
+                sequence += "\u{1B}]4;\(index);\(color)\u{07}"
+            default:
+                continue
+            }
+        }
+        return sequence
+    }
+
+    private static func paneThemeAssignment(from line: String) -> (key: String, value: String)? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
+
+        let parts = trimmed.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            .map(String.init)
+        guard parts.count == 2 else { return nil }
+
+        let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let value = parts[1]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        guard !key.isEmpty else { return nil }
+        return (key, value)
+    }
+
+    private static func paneThemeHexColor(_ rawValue: String) -> String? {
+        var hex = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard !hex.isEmpty, hex.allSatisfy(\.isHexDigit) else { return nil }
+
+        if hex.count == 3 {
+            hex = hex.map { "\($0)\($0)" }.joined()
+        }
+        guard hex.count == 6 else { return nil }
+        return "#\(hex.lowercased())"
     }
 
     private func encodedThemeValue(light: String?, dark: String?) -> String? {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16325,6 +16325,8 @@ struct CMUXCLI {
                    cmux themes set <theme>
                    cmux themes set --light <theme> [--dark <theme>]
                    cmux themes set --dark <theme> [--light <theme>]
+                   cmux themes here <theme|path>
+                   cmux themes here --reset
                    cmux themes clear
 
             When run in a TTY, `cmux themes` opens an interactive theme picker with
@@ -16333,11 +16335,19 @@ struct CMUXCLI {
             The picker previews the selected theme across the running cmux app and
             lets you apply it to the light theme, dark theme, or both defaults.
 
+            `set` and `clear` change the app-wide default for every window and future
+            session. `here` instead recolors only the terminal surface it runs in, by
+            writing OSC dynamic-color sequences to that surface: it writes no config,
+            leaves other surfaces untouched, and lasts until the surface closes or is
+            restored.
+
             Commands:
               list                      List available themes and mark the current light/dark defaults
               set <theme>               Set the same theme for both light and dark appearance
               set --light <theme>       Set the light appearance theme
               set --dark <theme>        Set the dark appearance theme
+              here <theme|path>         Recolor only the current surface, by name or theme-file path
+              here --reset              Restore the current surface to its configured colors
               clear                     Remove the cmux theme override and fall back to other config
 
             Examples:
@@ -16345,6 +16355,9 @@ struct CMUXCLI {
               cmux themes list
               cmux themes set "Catppuccin Mocha"
               cmux themes set --light "Catppuccin Latte" --dark "Catppuccin Mocha"
+              cmux themes here "Catppuccin Mocha"
+              cmux themes here ~/my-themes/custom
+              cmux themes here --reset
               cmux themes clear
             """
         case "claude-teams":

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -577,6 +577,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */; };
 		A7367001A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */; };
 		C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */; };
+		C0DE7A010000000000000001 /* CLIThemesHereTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7A010000000000000002 /* CLIThemesHereTests.swift */; };
 		B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */; };
 		7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */; };
 		773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000002 /* CLIWindowCommandMockServer.swift */; };
@@ -3435,6 +3436,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHPTYResizeInputTests.swift; sourceTree = "<group>"; };
 		A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHSessionAttachAnchorTests.swift; sourceTree = "<group>"; };
 		C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIStdioSIGPIPERegressionTests.swift; sourceTree = "<group>"; };
+		C0DE7A010000000000000002 /* CLIThemesHereTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIThemesHereTests.swift; sourceTree = "<group>"; };
 		B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatRemoteSplitTests.swift; sourceTree = "<group>"; };
 		7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatResizePaneTests.swift; sourceTree = "<group>"; };
 		773600000000000000000002 /* CLIWindowCommandMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowCommandMockServer.swift; sourceTree = "<group>"; };
@@ -8142,6 +8144,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
 				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 				C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
+				C0DE7A010000000000000002 /* CLIThemesHereTests.swift */,
 				C0DE6495000000000000000A /* CMUXCLISessionsListForkDiagnosticsTests.swift */,
 					C0DE64970000000000000002 /* CMUXCLISessionsListOpenCodeTrustTests.swift */,
 					C0DE64970000000000000004 /* CMUXCLISessionsListProcessArgumentTests.swift */,
@@ -11136,6 +11139,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */,
 				A7367001A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift in Sources */,
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
+					C0DE7A010000000000000001 /* CLIThemesHereTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,
 					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,

--- a/cmuxTests/CLIThemesHereTests.swift
+++ b/cmuxTests/CLIThemesHereTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// `cmux themes here` recolors only the surface it runs in, so its whole contract is the byte
+/// stream it writes to stdout. These tests read that stream directly rather than asserting on
+/// config files, which `here` deliberately never touches.
+extension CMUXCLIErrorOutputRegressionTests {
+    private static let sampleThemeContents = """
+        # Sample theme
+        background = #1E1E2E
+        foreground = cdd6f4
+        cursor-color = #f5e0dc
+        palette = 1=#f38ba8
+        """
+
+    private static let sampleThemeSequence =
+        "\u{1B}]11;#1e1e2e\u{07}"
+        + "\u{1B}]10;#cdd6f4\u{07}"
+        + "\u{1B}]12;#f5e0dc\u{07}"
+        + "\u{1B}]4;1;#f38ba8\u{07}"
+
+    /// Writes a throwaway Ghostty resources tree holding one theme, and returns the environment
+    /// that pins the CLI to it plus a home directory it cannot escape.
+    private func themesHereEnvironment(
+        root: URL,
+        themeName: String,
+        themeContents: String
+    ) throws -> [String: String] {
+        let themesDirectory = root
+            .appendingPathComponent("resources", isDirectory: true)
+            .appendingPathComponent("themes", isDirectory: true)
+        try FileManager.default.createDirectory(at: themesDirectory, withIntermediateDirectories: true)
+        try themeContents.write(
+            to: themesDirectory.appendingPathComponent(themeName, isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+
+        return [
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_SOCKET_PATH": root.appendingPathComponent("cmux.sock").path,
+            "CFFIXED_USER_HOME": home.path,
+            "HOME": home.path,
+            "GHOSTTY_RESOURCES_DIR": root.appendingPathComponent("resources", isDirectory: true).path,
+            "PATH": "/usr/bin:/bin",
+        ]
+    }
+
+    @Test func testThemesHereWritesOnlyDynamicColorSequencesForTheNamedTheme() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-themes-here-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = try themesHereEnvironment(
+            root: root,
+            themeName: "Sample Theme",
+            themeContents: Self.sampleThemeContents
+        )
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["themes", "here", "Sample Theme"],
+            environment: environment,
+            timeout: 30
+        )
+
+        #expect(result.status == 0, "\(result.diagnostics)")
+        // Exact match, with no trailing newline: `here` writes into a live surface, so any stray
+        // byte it emits would scroll that surface or land in the user's shell prompt.
+        #expect(result.stdout == Self.sampleThemeSequence, "\(result.diagnostics)")
+    }
+
+    @Test func testThemesHereResetWritesResetSequenceWithoutRequiringATheme() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-themes-here-reset-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = try themesHereEnvironment(
+            root: root,
+            themeName: "Sample Theme",
+            themeContents: Self.sampleThemeContents
+        )
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["themes", "here", "--reset"],
+            environment: environment,
+            timeout: 30
+        )
+
+        #expect(result.status == 0, "\(result.diagnostics)")
+        #expect(result.stdout == CMUXCLI.paneThemeResetSequence, "\(result.diagnostics)")
+    }
+
+    @Test func testThemesHereRejectsUnknownThemeWithoutWritingToStdout() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-themes-here-unknown-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = try themesHereEnvironment(
+            root: root,
+            themeName: "Sample Theme",
+            themeContents: Self.sampleThemeContents
+        )
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["themes", "here", "No Such Theme"],
+            environment: environment,
+            timeout: 30
+        )
+
+        #expect(result.status != 0, "\(result.diagnostics)")
+        // A half-applied theme is worse than none: a failed lookup must leave the surface alone.
+        #expect(result.stdout.isEmpty, "\(result.diagnostics)")
+    }
+
+    @Test func testPaneThemeSequenceSkipsCommentsAndUnparseableColors() {
+        let contents = """
+            # background = #000000
+            background = #123
+            foreground = not-a-color
+            palette = 300=#ffffff
+            palette = 2 = #00FF00
+            selection-background = #abcdef
+            """
+
+        // Short hex expands, the commented and malformed entries drop out, the out-of-range
+        // palette slot drops out, and keys with no OSC equivalent are ignored.
+        #expect(
+            CMUXCLI.paneThemeSequence(forThemeContents: contents)
+                == "\u{1B}]11;#112233\u{07}\u{1B}]4;2;#00ff00\u{07}"
+        )
+    }
+}

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -72,7 +72,7 @@ Environment:
 | `open` | Open files, directories, or URLs in cmux. |
 | `feedback` | Open feedback UI or submit feedback with `--email`, `--body`, and repeated `--image`. |
 | `feed` | Open the keyboard-first Feed TUI or manage persisted Feed workstream history. |
-| `themes` | List, set, clear, or interactively pick Ghostty themes. |
+| `themes` | List, set, clear, or interactively pick Ghostty themes; `themes here` recolors just the calling surface. |
 | `claude-teams` | Launch Claude Code with cmux/tmux-style agent team integration. |
 | `codex-teams` | Launch Codex with cmux-managed subagent panes. |
 | `omo` | Launch OpenCode with oh-my-openagent integration. |
@@ -219,6 +219,8 @@ Theme subcommands:
 | `themes set <theme>` | Set the same theme for light and dark appearance. |
 | `themes set --light <theme>` | Set the light appearance theme. |
 | `themes set --dark <theme>` | Set the dark appearance theme. |
+| `themes here <theme\|path>` | Recolor only the calling surface, by writing OSC dynamic colors to stdout. Writes no config. Rejects `--json`. |
+| `themes here --reset` | Restore the calling surface to its configured colors. |
 | `themes clear` | Remove the cmux theme override. |
 
 Workspace and tab action names:


### PR DESCRIPTION
## Problem

`cmux themes set` is the only way to change terminal colors, and it is global by
construction: it writes a managed `theme` override into the cmux-owned Ghostty config
and posts a reload, so it repaints every window, every split, and every future session.

That leaves no way to make one window look different from the rest — a common wish when
you keep prod and dev shells side by side, or want an agent pane visually distinct from
the one you type in. Today the only recourse is hand-writing OSC escape sequences.

## Change

Adds `cmux themes here <theme|path>`, which recolors **only the surface it runs in**.

It resolves a theme the same way `themes set` does — by bundled name, through the
existing `themeDirectoryURLs()` search path — and writes OSC dynamic-color sequences to
stdout:

| Key in theme file | Sequence |
| --- | --- |
| `background` | OSC 11 |
| `foreground` | OSC 10 |
| `cursor-color` | OSC 12 |
| `palette = N=#hex` | OSC 4;N |

libghostty scopes those to the surface they are written into, which gives the property
this command is for: no config file is touched, no other surface changes, and the effect
ends with the pane. `cmux themes here --reset` writes the matching resets
(OSC 110/111/112/104) to fall back to whatever the config specifies.

```bash
cmux themes here "Catppuccin Mocha"   # this pane only
cmux themes here ~/my-themes/custom   # a theme file by path
cmux themes here --reset              # back to configured colors
```

The argument accepts a bundled theme name or a path to a theme file. `--json` is
rejected, since the command's entire output is raw escape bytes.

## Notes

- **Nothing existing changes.** `set`, `list`, `clear`, and the interactive picker are
  untouched; `here` is a new subcommand alongside them.
- **Colors do not survive session restore.** A restored pane comes back with the config
  theme. That is inherent to OSC-scoped color, and the help text says so.
- **No broadcast.** `here` themes one surface. Fanning out across a window would need a
  socket-side primitive to write bytes to a surface without going through typed input;
  that felt like a separate change, so this PR stays deliberately small.
- Help text and `docs/cli-contract.md` are updated.

## Testing

`cmuxTests/CLIThemesHereTests.swift` (wired into `project.pbxproj`; `lint-pbxproj-test-wiring.sh`
passes) covers, through the built CLI against a pinned `GHOSTTY_RESOURCES_DIR`:

- a named theme produces exactly the expected sequences, with no trailing newline — a
  stray byte here would scroll the user's surface
- `--reset` emits the reset sequence with no theme argument
- an unknown theme exits non-zero and writes nothing to stdout, so a failed lookup cannot
  leave a half-applied theme
- parsing skips comments, malformed colors, and out-of-range palette slots, and expands
  short hex

**I could not build or run these locally** — this machine has only Command Line Tools (no
full Xcode) and no `zig`, so `GhosttyKit.xcframework` cannot be built. The changed files
pass `swiftc -parse`, and the logic mirrors the existing Ghostty theme-file parser in
`CLI/cmux_open.swift`, but CI is the first real compile and test run. Happy to fix
whatever it turns up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cmux themes here` to recolor only the calling terminal surface. Previously, `themes set` changed colors globally; now, `here` writes OSC dynamic-color sequences to stdout for per-pane theming without touching config or other surfaces.

- Resolves a theme by bundled name (via the existing search path) or a file path, then emits OSC 10/11/12/4 for `foreground`, `background`, `cursor-color`, and `palette N` respectively; `--reset` sends OSC 110/111/112/104.
- Parser trims quotes/comments, expands short hex, enforces palette index 0–255, and ignores unknown keys. Unknown flags error; `--json` is rejected because output is raw escape bytes. Unknown theme exits non-zero and writes nothing; no trailing newline is emitted.
- No behavior changes to `set`, `list`, `clear`, or the picker. Per-surface colors do not survive session restore.
- Tests added in `cmuxTests/CLIThemesHereTests.swift` (exact byte stream, reset, unknown theme, parser); wired in `cmux.xcodeproj`; CLI help and `docs/cli-contract.md` updated.

<sup>Written for commit 29081cb52d2ba17dd36d2fb053cd582628e44cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

