### PR TITLE
fix(ios): restore exhaustive artifact switches so TestFlight can archive

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
@@ -258,6 +258,13 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
                 systemImage: "doc.badge.ellipsis",
                 allowsRetry: false
             )
+        case .unknown(let code):
+            self = Self(
+                title: Self.localized("chat.artifact.failure.unknown.title", defaultValue: "Unexpected error"),
+                message: Self.unknownMessage(code: code),
+                systemImage: "questionmark.circle",
+                allowsRetry: true
+            )
         }
     }
 
@@ -289,6 +296,20 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
         defaultValue: String.LocalizationValue
     ) -> String {
         String(localized: key, defaultValue: defaultValue, bundle: .module)
+    }
+
+    private static func unknownMessage(code: String?) -> String {
+        guard let code, !code.isEmpty else {
+            return localized(
+                "chat.artifact.failure.unknown.message",
+                defaultValue: "The Mac reported an error this version of cmux doesn't recognize. Try again, then update cmux on both devices."
+            )
+        }
+        let format = localized(
+            "chat.artifact.failure.unknown.coded_message",
+            defaultValue: "The Mac reported an error this version of cmux doesn't recognize (%@). Try again, then update cmux on both devices."
+        )
+        return String.localizedStringWithFormat(format, code)
     }
 
     private static func tooLargeMessage(actualSize: Int64?, limit: Int64) -> String {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
@@ -165,6 +165,8 @@ public struct ChatArtifactInlineViewer: View {
             .chat
         case .terminal:
             .terminal
+        case .panel:
+            .panel
         case .workspaceChanges:
             .workspaceChanges
         case .unsupported:

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -339,7 +339,7 @@ final class ChatArtifactViewerModel {
         await temporaryFileStore.remove(temporaryFileURL)
     }
 
-    private static func state(
+    static func state(
         for error: any Error,
         stat: ChatArtifactStat?
     ) -> ChatArtifactViewerState {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -330,6 +330,27 @@
         "ja": { "stringUnit": { "state": "translated", "value": "転送が中断されました" } }
       }
     },
+    "chat.artifact.failure.unknown.coded_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this version of cmux doesn't recognize (%@). Try again, then update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのバージョンのcmuxでは認識できないエラーを報告しました（%@）。再試行し、両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this version of cmux doesn't recognize. Try again, then update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのバージョンのcmuxでは認識できないエラーを報告しました。再試行し、両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unexpected error" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "予期しないエラー" } }
+      }
+    },
     "chat.artifact.failure.unsupported.message": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
The iOS TestFlight (CMUX INTERNAL) upload on main fails to archive: https://github.com/manaflow-ai/cmux/actions/runs/32053999924

[04ff18eea6](https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9) added `ChatArtifactError.unknown(code:)` and `ChatArtifactLoaderScope.panel` but left two exhaustive switches behind, so the Release archive (and any clean build of CmuxAgentChatUI) fails with "switch must be exhaustive".

Fixes, all in `Packages/iOS/CmuxAgentChatUI`:

- `ChatArtifactFailurePresentation` handles `.unknown(code:)` with retryable copy that names the unrecognized Mac error code and never blames connectivity (the case's documented contract). Localized en + ja in `Localizable.xcstrings`.
- `ChatArtifactInlineViewer.viewerScope` maps loader scope `.panel` to viewer scope `.panel`, so panel-scoped forbidden errors show the panel message instead of terminal copy.
- `ChatArtifactViewerModel.state(for:stat:)` goes from private to internal: `ChatArtifactViewerErrorStateTests` (added by the same commit) calls it and never compiled.

Verified with `swift build` and the full `swift test` suite in the package: 132 tests pass, including the previously never-compiling ChatArtifactViewerErrorStateTests.

Localization audit: the three new keys (`chat.artifact.failure.unknown.title/.message/.coded_message`) have en and ja entries; no other user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789584544&installation_model_id=21920&pr_number=10282&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10282&signature=166f955404a8becb5f6276a9604c607f1ae58c31df5ed46d7511b8f2f4be8b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores exhaustive artifact `switch`es in `Packages/iOS/CmuxAgentChatUI` so iOS Release/TestFlight archives succeed. Previously, adding `ChatArtifactError.unknown(code:)` and `ChatArtifactLoaderScope.panel` left two switches incomplete, causing “switch must be exhaustive” build failures; now the app compiles and shows correct copy for unknown and panel-scoped errors.

**Changes**
- `ChatArtifactFailurePresentation`: handles `.unknown(code:)` with retryable, localized copy that includes the Mac error code when present and does not blame connectivity (en, ja).
- `ChatArtifactInlineViewer.viewerScope`: maps loader scope `.panel` to viewer scope `.panel` so panel-scoped forbidden errors render the panel message instead of terminal copy.
- `ChatArtifactViewerModel.state(for:stat:)`: private → internal to enable `ChatArtifactViewerErrorStateTests` to compile; no public API change.
- Localizations: add `chat.artifact.failure.unknown.title`, `.message`, `.coded_message` (en, ja). Verified with `swift build` and `swift test` (132 tests).

<sup>Written for commit d7ac22175b3badbb010a5cf098c0d97b76da4d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact failure messages, including clearer handling of unexpected errors and error codes.
  * Added retry support and a question-mark icon for unknown artifact failures.
  * Corrected panel scope handling in the inline artifact viewer.

* **Localization**
  * Added English and Japanese translations for unexpected artifact errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->