### PR TITLE
Fix iOS TestFlight archive: handle ChatArtifactError.unknown and panel scope

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
@@ -258,6 +258,13 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
                 systemImage: "doc.badge.ellipsis",
                 allowsRetry: false
             )
+        case .unknown(let code):
+            self = Self(
+                title: Self.localized("chat.artifact.failure.unknown.title", defaultValue: "Unrecognized file error"),
+                message: Self.unknownMessage(code: code),
+                systemImage: "questionmark.circle",
+                allowsRetry: true
+            )
         }
     }
 
@@ -289,6 +296,20 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
         defaultValue: String.LocalizationValue
     ) -> String {
         String(localized: key, defaultValue: defaultValue, bundle: .module)
+    }
+
+    private static func unknownMessage(code: String?) -> String {
+        guard let code, !code.isEmpty else {
+            return localized(
+                "chat.artifact.failure.unknown.message",
+                defaultValue: "The Mac reported an error this version of cmux doesn't recognize. Try again, then update cmux on both devices."
+            )
+        }
+        let format = localized(
+            "chat.artifact.failure.unknown.coded_message",
+            defaultValue: "The Mac reported an error this version of cmux doesn't recognize (%@). Try again, then update cmux on both devices."
+        )
+        return String.localizedStringWithFormat(format, code)
     }
 
     private static func tooLargeMessage(actualSize: Int64?, limit: Int64) -> String {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
@@ -165,6 +165,8 @@ public struct ChatArtifactInlineViewer: View {
             .chat
         case .terminal:
             .terminal
+        case .panel:
+            .panel
         case .workspaceChanges:
             .workspaceChanges
         case .unsupported:

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -339,7 +339,7 @@ final class ChatArtifactViewerModel {
         await temporaryFileStore.remove(temporaryFileURL)
     }
 
-    private static func state(
+    static func state(
         for error: any Error,
         stat: ChatArtifactStat?
     ) -> ChatArtifactViewerState {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -330,6 +330,27 @@
         "ja": { "stringUnit": { "state": "translated", "value": "転送が中断されました" } }
       }
     },
+    "chat.artifact.failure.unknown.coded_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this version of cmux doesn't recognize (%@). Try again, then update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのバージョンのcmuxでは認識できないエラーを報告しました（%@）。もう一度お試しのうえ、両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this version of cmux doesn't recognize. Try again, then update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのバージョンのcmuxでは認識できないエラーを報告しました。もう一度お試しのうえ、両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unrecognized file error" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "認識できないファイルエラー" } }
+      }
+    },
     "chat.artifact.failure.unsupported.message": {
       "extractionState": "manual",
       "localizations": {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFailurePresentationTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFailurePresentationTests.swift
@@ -43,6 +43,8 @@ struct ChatArtifactFailurePresentationTests {
             (.localStorageUnavailable, "Local storage unavailable", true),
             (.loadFailed, "Couldn't load file", true),
             (.tooLarge(limitBytes: 1_024), "File too large to preview", false),
+            (.unknown(code: "future_error"), "Unrecognized file error", true),
+            (.unknown(code: nil), "Unrecognized file error", true),
         ]
 
         #expect(unreachable.title == "Mac unreachable")


### PR DESCRIPTION
Every scheduled iOS TestFlight run since https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9 fails at the archive step with two `switch must be exhaustive` errors (example: https://github.com/manaflow-ai/cmux/actions/runs/32053999924). That commit added `ChatArtifactError.unknown(code:)` and `ChatArtifactLoader.Scope.panel` but did not update the exhaustive switches in `CmuxAgentChatUI`, and the CI compile lanes don't build that iOS package, so the break only surfaced in the archive.

Changes:
- `ChatArtifactFailurePresentation` handles `.unknown(code:)` with localized copy (en/ja) that names the unrecognized code, doesn't blame connectivity, and allows retry.
- `ChatArtifactInlineViewer.viewerScope` maps loader `.panel` to viewer scope `.panel`.
- `ChatArtifactViewerModel.state(for:stat:)` is now internal: `ChatArtifactViewerErrorStateTests` (added in the same commit) calls it and never compiled while it was private.
- `ChatArtifactFailurePresentationTests` covers `.unknown` with and without a code.

Verified: `xcodebuild build` of the CmuxAgentChatUI package for `generic/platform=iOS` succeeds, and `swift test --filter 'ChatArtifactFailurePresentationTests|ChatArtifactViewerErrorStateTests'` passes (5 tests).

Localization audit: the three new keys (`chat.artifact.failure.unknown.title/.message/.coded_message`) have en and ja entries in `Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings`; no other user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS TestFlight archive failures by making `CmuxAgentChatUI` handle new chat artifact cases. Previously, adding `ChatArtifactError.unknown(code:)` and `ChatArtifactLoader.Scope.panel` caused “switch must be exhaustive” compile errors; now the switches are updated and archives succeed.

**Changes to review**
- Present `.unknown(code:)` in `ChatArtifactFailurePresentation` with localized title/message (en/ja); includes the code when available and allows retry.
- Map loader scope `.panel` to viewer scope `.panel` in `ChatArtifactInlineViewer`.
- Expose `ChatArtifactViewerModel.state(for:stat:)` as internal to support `ChatArtifactViewerErrorStateTests`.
- Add three new localization keys and extend tests for `.unknown` with and without a code; verified `xcodebuild` for iOS and targeted `swift test` pass.

<sup>Written for commit 630250e29172f826e56f7dfda3ba7e08b8de7e5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unrecognized artifact file errors.
  - Displays a localized error title, helpful message, and returned error code when available.
  - Added a retry option for recoverable artifact loading failures.
  - Improved support for viewing artifacts in panel mode.

- **Localization**
  - Added English and Japanese translations for new artifact error messages.

- **Tests**
  - Added coverage for coded and uncoded artifact errors and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->