### PR TITLE
fix(ios): make artifact failure and scope switches exhaustive

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFailurePresentation.swift
@@ -258,6 +258,14 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
                 systemImage: "doc.badge.ellipsis",
                 allowsRetry: false
             )
+        case .unknown(let code):
+            // The Mac replied, so this copy must not blame connectivity.
+            self = Self(
+                title: Self.localized("chat.artifact.failure.unknown.title", defaultValue: "Unrecognized error"),
+                message: Self.unknownMessage(code: code),
+                systemImage: "questionmark.circle",
+                allowsRetry: false
+            )
         }
     }
 
@@ -309,5 +317,19 @@ public struct ChatArtifactFailurePresentation: Equatable, Sendable {
             ByteCountFormatter.string(fromByteCount: actualSize, countStyle: .file),
             limitText
         )
+    }
+
+    private static func unknownMessage(code: String?) -> String {
+        guard let code else {
+            return localized(
+                "chat.artifact.failure.unknown.message",
+                defaultValue: "The Mac reported an error this app doesn't recognize. Update cmux on both devices."
+            )
+        }
+        let format = localized(
+            "chat.artifact.failure.unknown.message_with_code",
+            defaultValue: "The Mac reported an error this app doesn't recognize (%@). Update cmux on both devices."
+        )
+        return String.localizedStringWithFormat(format, code)
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactInlineViewer.swift
@@ -165,6 +165,8 @@ public struct ChatArtifactInlineViewer: View {
             .chat
         case .terminal:
             .terminal
+        case .panel:
+            .panel
         case .workspaceChanges:
             .workspaceChanges
         case .unsupported:

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -330,6 +330,27 @@
         "ja": { "stringUnit": { "state": "translated", "value": "転送が中断されました" } }
       }
     },
+    "chat.artifact.failure.unknown.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this app doesn't recognize. Update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのアプリで認識できないエラーを返しました。両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.message_with_code": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The Mac reported an error this app doesn't recognize (%@). Update cmux on both devices." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macがこのアプリで認識できないエラーを返しました（%@）。両方のデバイスでcmuxをアップデートしてください。" } }
+      }
+    },
+    "chat.artifact.failure.unknown.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unrecognized error" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "認識できないエラー" } }
+      }
+    },
     "chat.artifact.failure.unsupported.message": {
       "extractionState": "manual",
       "localizations": {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFailurePresentationTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFailurePresentationTests.swift
@@ -43,6 +43,7 @@ struct ChatArtifactFailurePresentationTests {
             (.localStorageUnavailable, "Local storage unavailable", true),
             (.loadFailed, "Couldn't load file", true),
             (.tooLarge(limitBytes: 1_024), "File too large to preview", false),
+            (.unknown(code: "artifact_rev_gone"), "Unrecognized error", false),
         ]
 
         #expect(unreachable.title == "Mac unreachable")
@@ -60,6 +61,18 @@ struct ChatArtifactFailurePresentationTests {
             #expect(presentation.title != unreachable.title)
             #expect(presentation.message != unreachable.message)
         }
+    }
+
+    @Test
+    func unknownCopySurfacesTheCodeWithoutBlamingConnectivity() {
+        let coded = ChatArtifactFailurePresentation(error: .unknown(code: "artifact_rev_gone"), scope: .chat)
+        let uncoded = ChatArtifactFailurePresentation(error: .unknown(code: nil), scope: .chat)
+
+        // The Mac replied, so the copy must not send the user to check connectivity.
+        #expect(coded.message.contains("artifact_rev_gone"))
+        #expect(!coded.message.contains("Check the connection"))
+        #expect(!uncoded.message.contains("Check the connection"))
+        #expect(!uncoded.message.isEmpty)
     }
 
     @Test

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MarkdownSurfaceModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MarkdownSurfaceModel.swift
@@ -121,6 +121,8 @@ final class MarkdownSurfaceModel {
             // A markdown panel path that stops decoding as text is a data
             // problem on the Mac side, not connectivity.
             return .loadFailed(code: nil)
+        case .unknown(let code):
+            return .loadFailed(code: code)
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MarkdownSurfaceModelFailureTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MarkdownSurfaceModelFailureTests.swift
@@ -1,0 +1,17 @@
+#if os(iOS)
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellUI
+
+@Suite
+struct MarkdownSurfaceModelFailureTests {
+    @Test
+    @MainActor
+    func unknownErrorKeepsItsCodeInsteadOfBlamingConnectivity() {
+        #expect(MarkdownSurfaceModel.failure(for: ChatArtifactError.unknown(code: "artifact_rev_gone")) == .loadFailed(code: "artifact_rev_gone"))
+        #expect(MarkdownSurfaceModel.failure(for: ChatArtifactError.unknown(code: nil)) == .loadFailed(code: nil))
+    }
+}
+#endif


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9 added `ChatArtifactError.unknown(code:)` and the `.panel` loader scope but missed two switches, so the cmux-ios scheme stopped compiling on Aug 14 at 9:18 PM, three minutes after the last successful TestFlight upload (build 20260814211222). Every iOS TestFlight run since has failed with `switch must be exhaustive` in `ChatArtifactFailurePresentation.swift:26` and `ChatArtifactInlineViewer.swift:163`, which is why the scroll-drain watchdog crash fix from https://github.com/manaflow-ai/cmux/pull/10186 never reached any TestFlight device.

This adds the `.unknown` failure presentation (localized en/ja; copy names the unrecognized code and never blames connectivity, matching the case's doc contract) and routes the `.panel` loader scope to the `.panel` viewer scope. Test coverage: `.unknown` joins the every-case presentation table and a new test asserts the code appears in the message without connectivity blame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789594473&installation_model_id=21920&pr_number=10287&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10287&signature=4e939500dcb117a65e9fb820074dd7282e34fa91541ba9ff79a18c219b17ab21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the iOS build by making artifact failure and scope switches exhaustive in `CmuxAgentChatUI` and `CmuxMobileShellUI`. Previously, `ChatArtifactError.unknown(code:)` and the `.panel` loader scope were unhandled; now unknown errors render with their code and `.panel` routes to the `.panel` viewer. Also maps unknown errors in markdown panels to `.loadFailed(code:)` instead of suggesting connectivity issues.

- Adds a `.unknown` failure presentation (en/ja), shows the diagnostic code when available, uses a question-mark icon, and disables retry; copy never blames connectivity.
- Routes the `.panel` loader scope to the `.panel` viewer in `ChatArtifactInlineViewer`.
- Maps `.unknown(code:)` to `.loadFailed(code:)` in `MarkdownSurfaceModel.failure(for:)`, preserving the code for display.
- Updates tests to cover the `.unknown` case and verify no connectivity hint; adds new string resources and a `MarkdownSurfaceModelFailureTests` suite.
- No migration required; callers and senders are unchanged.

<sup>Written for commit 25bc1a5834216dbea0024b5df1811e1ccc9eb457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact-loading error handling with clear localized messaging for unrecognized errors.
  * Error messages may include a diagnostic code when available.
  * Added a question-mark icon and disabled retry for errors that cannot be recovered automatically.
  * Improved inline artifact viewer handling for panel-scoped content.
* **Localization**
  * Added English and Japanese translations for new artifact error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->