### PR TITLE
ios: changelog entry for the 1.0.4 external re-cut

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -44,6 +44,20 @@ for a different version), so bump the beta version with
 
 ---
 
+## [1.0.4] - 2026-08-17
+
+### Internal
+
+- External re-cut of `1.0.4` from current main via the ios-testflight.yml marketing-version override lane (no new Beta App Review). The previous beta build `20260814211222` (Aug 14) predates the scroll-crash fix; every lane run since failed on 04ff18eea6's non-exhaustive switches, fixed by #10287.
+- Delta since `20260814211222`: scroll-drain watchdog crash fix (#10186), push alerts opt-out toggle fix (#10112), artifact failure/scope exhaustive switches with an unknown-error presentation (#10287), dogfood auth identity pin (#10185, no user-visible effect).
+- Known rough edge: after sustained fast scrolling the terminal can render-freeze until workspace re-entry (fix #10284 in dogfood). The 0x8BADF00D watchdog crash itself is fixed.
+- Dogfood focus: sustained fast terminal scrolling (crash gone, freeze known), toggling notification alerts off and confirming pushes stop.
+
+### External
+
+- Fixed a crash during fast terminal scrolling.
+- Turning off notification alerts now reliably stops them.
+
 ## [1.0.4] - 2026-07-09
 
 ### Internal

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -48,8 +48,8 @@ for a different version), so bump the beta version with
 
 ### Internal
 
-- External re-cut of `1.0.4` from current main via the ios-testflight.yml marketing-version override lane (no new Beta App Review). The previous beta build `20260814211222` (Aug 14) predates the scroll-crash fix; every lane run since failed on 04ff18eea6's non-exhaustive switches, fixed by #10287.
-- Delta since `20260814211222`: scroll-drain watchdog crash fix (#10186), push alerts opt-out toggle fix (#10112), artifact failure/scope exhaustive switches with an unknown-error presentation (#10287), dogfood auth identity pin (#10185, no user-visible effect).
+- External re-cut of `1.0.4` (shipped as build `20260817224846`) from current main via the ios-testflight.yml marketing-version override lane (no new Beta App Review). The previous beta build `20260814211222` (Aug 14) predates the scroll-crash fix; every lane run since failed on 04ff18eea6's Release-archive compile fallout, fixed across #10287 (exhaustive switches), #10290 (public import for a public API type), and #10295 (implement the missing selectedMacSurfaceID store selection). The last two only break the Release device archive, not simulator builds, so test-ios stayed green throughout.
+- Delta since `20260814211222`: scroll-drain watchdog crash fix (#10186), push alerts opt-out toggle fix (#10112), the compile fixes above (#10287 adds an unknown-artifact-error presentation, #10295 makes Mac-surface selection real store state cleared on workspace switch), dogfood auth identity pin (#10185, no user-visible effect).
 - Known rough edge: after sustained fast scrolling the terminal can render-freeze until workspace re-entry (fix #10284 in dogfood). The 0x8BADF00D watchdog crash itself is fixed.
 - Dogfood focus: sustained fast terminal scrolling (crash gone, freeze known), toggling notification alerts off and confirming pushes stop.
 


### PR DESCRIPTION
Durable record for today's founders re-cut of 1.0.4 (override lane, build dispatched from 21c48914dd6b): scroll-drain watchdog crash fix (#10186), push alerts opt-out fix (#10112), the #10287 archive unbreak, plus the known residual fast-scroll render freeze (#10284 pending). The TestFlight "What to Test" notes for the shipped build are applied from this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595264&installation_model_id=21920&pr_number=10288&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10288&signature=25fccb8138e71a251461d1deb70b2f9a1c20a99b84622a55ec57f016a2d505e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the iOS changelog entry for the 1.0.4 external re‑cut so TestFlight notes and release history match the shipped build. No runtime or build behavior changes in this PR.

- Docs-only edit in `ios/CHANGELOG.md`.
- Records shipped build `20260817224846` and the marketing‑version override lane (no new Beta App Review).
- Captures the delta since build `20260814211222`: scroll‑drain watchdog crash fix (#10186), notification alerts opt‑out reliability fix (#10112), and all three Release‑archive fixes (#10287, #10290, #10295); dogfood auth identity pin (#10185) has no user‑visible impact.
- Notes a known residual fast‑scroll render freeze (#10284); the crash itself is fixed.

<sup>Written for commit 8ebe5ca41c388bf742a3b4e185e99f71bb487e6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opting out of notifications.
  * Fixed crashes during fast terminal scrolling.
  * Included additional build and release fixes.

* **Known Issues**
  * A scrolling freeze remains under investigation.

* **Release Information**
  * iOS version 1.0.4 released on August 17, 2026.
  * This release includes an externally re-cut build and focused testing ahead of wider availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->