### PR TITLE
fix(ios): public import for MobileWorkspacePreview.ID in capabilities API

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -1,5 +1,5 @@
 import CMUXMobileCore
-import CmuxMobileShellModel
+public import CmuxMobileShellModel
 
 extension MobileShellComposite {
     /// Whether the connected Mac supports browser-pane streaming.


### PR DESCRIPTION
Third compile break from https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9, behind the two switches fixed in https://github.com/manaflow-ai/cmux/pull/10287: `MobileShellComposite+Capabilities.swift:147` declares `public func supportsPanelArtifacts(in: MobileWorkspacePreview.ID)` while importing `CmuxMobileShellModel` with a plain (internal-by-default) import. Only the Release device archive rejects it, so test-ios simulator lanes stayed green while the TestFlight archive died: https://github.com/manaflow-ai/cmux/actions/runs/32072777777.

One line: `public import CmuxMobileShellModel`, matching the 24 sibling files in the package. Verifying with a fleet Release beta archive before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595952&installation_model_id=21920&pr_number=10290&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10290&signature=4a88b77f97261555c77a005a09fb1f66a2f9c7bf39d76861ac1cd12fba3d1a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the capabilities API buildable in Release by changing the import of `CmuxMobileShellModel` to a public import. Previously, `supportsPanelArtifacts(in: MobileWorkspacePreview.ID)` was public while the import made the parameter type internal, causing Release device archives to fail; this aligns the import with the API without changing runtime behavior.

- One-line change: `public import CmuxMobileShellModel` in MobileShellComposite+Capabilities.swift, matching sibling files.
- Impacts only Release/TestFlight builds; Debug simulator builds were already green.
- No migrations or behavior changes; verify by creating a Release device archive.

<sup>Written for commit 789585ef2f859c82f011782b8a55adfa20ca007e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Made the mobile shell model module available to downstream integrations through the public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->