### PR TITLE
iOS: remove New Task Composer beta toggle

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
@@ -27,7 +27,6 @@ public final class MobileDisplaySettings {
     private static let showAltScreenNoticeKey = "cmux.mobile.showAltScreenNotice"
     private static let showMissingFilesKey = "cmux.mobile.showMissingFiles"
     private static let terminalFolderTapEnabledKey = "cmux.mobile.terminalFolderTapEnabled"
-    private static let taskComposerEnabledKey = "cmux.mobile.taskComposerEnabled"
     private static let workspacePreviewLineCountKey = "cmux.mobile.workspacePreviewLineCount"
     private static let unreadIndicatorLeftShiftKey = "cmux.mobile.debug.unreadIndicatorLeftShift.v2"
     #if DEBUG
@@ -79,15 +78,6 @@ public final class MobileDisplaySettings {
     public var hapticFeedbackEnabled: Bool {
         didSet {
             defaults.set(hapticFeedbackEnabled, forKey: MobileHapticFeedback.enabledDefaultsKey)
-        }
-    }
-
-    /// Whether the beta New Task composer is available from the workspace list.
-    /// Defaults to `false`. Mutating this writes through to the injected
-    /// ``UserDefaults``.
-    public var taskComposerEnabled: Bool {
-        didSet {
-            defaults.set(taskComposerEnabled, forKey: Self.taskComposerEnabledKey)
         }
     }
 
@@ -157,7 +147,6 @@ public final class MobileDisplaySettings {
         self.showMissingFiles = defaults.bool(forKey: Self.showMissingFilesKey)
         self.terminalFolderTapEnabled = defaults.object(forKey: Self.terminalFolderTapEnabledKey) as? Bool ?? true
         self.hapticFeedbackEnabled = haptics.isEnabled
-        self.taskComposerEnabled = defaults.bool(forKey: Self.taskComposerEnabledKey)
         self.terminalScrollbackRows = MobileTerminalScrollbackPreference.resolve(from: defaults)
         let storedPreviewLines = defaults.object(forKey: Self.workspacePreviewLineCountKey) as? Int
         self.workspacePreviewLineCount = Self.clampedWorkspacePreviewLineCount(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -239,17 +239,6 @@ struct MobileSettingsView: View {
                     ))
                 }
 
-                Section(L10n.string("mobile.settings.betaFeatures", defaultValue: "Beta Features")) {
-                    Toggle(isOn: $displaySettings.taskComposerEnabled) {
-                        Text(L10n.string(
-                            "mobile.settings.taskComposer",
-                            defaultValue: "New Task Composer"
-                        ))
-                    }
-                    .accessibilityIdentifier("MobileSettingsTaskComposer")
-
-                }
-
                 #if DEBUG
                 Section(L10n.string("mobile.settings.developer", defaultValue: "Developer")) {
                     Button {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
@@ -108,22 +108,6 @@ import Testing
         #expect(!MobileDisplaySettings(defaults: defaults).terminalFolderTapEnabled)
     }
 
-    @Test func taskComposerDefaultsToFalseWithoutAWrite() throws {
-        let defaults = try makeDefaults("taskComposerDefaults")
-        let settings = MobileDisplaySettings(defaults: defaults)
-        #expect(!settings.taskComposerEnabled)
-        #expect(defaults.object(forKey: "cmux.mobile.taskComposerEnabled") == nil)
-    }
-
-    @Test func taskComposerPersistsAcrossInstances() throws {
-        let defaults = try makeDefaults("taskComposerPersists")
-        let settings = MobileDisplaySettings(defaults: defaults)
-        settings.taskComposerEnabled = true
-        #expect(MobileDisplaySettings(defaults: defaults).taskComposerEnabled)
-        settings.taskComposerEnabled = false
-        #expect(!MobileDisplaySettings(defaults: defaults).taskComposerEnabled)
-    }
-
     @Test func previewLineCountPersistsAcrossInstances() throws {
         let defaults = try makeDefaults("persists")
         let settings = MobileDisplaySettings(defaults: defaults)

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6954,23 +6954,6 @@
         }
       }
     },
-    "mobile.settings.betaFeatures": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beta Features"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ベータ機能"
-          }
-        }
-      }
-    },
     "mobile.settings.deleteAccount": {
       "extractionState": "manual",
       "localizations": {
@@ -8301,23 +8284,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "トーストギャラリー"
-          }
-        }
-      }
-    },
-    "mobile.settings.taskComposer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Task Composer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新規タスク作成"
           }
         }
       }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3866,7 +3866,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testSettingsDoesNotExposeTerminalFilesChipAsBetaToggle() throws {
+    func testSettingsDoesNotExposeTaskComposerOrTerminalFilesBetaToggles() throws {
         let app = launchApp(
             mockData: false,
             environment: ["CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1"]
@@ -3877,13 +3877,26 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(settings.waitForExistence(timeout: 8))
         tap(settings, in: app)
 
+        let taskComposerToggle = app.switches["MobileSettingsTaskComposer"]
+        let terminalFilesToggle = app.switches["MobileSettingsTerminalFilesChip"]
+        let betaFeaturesHeader = app.staticTexts["Beta Features"]
+        var exposedTaskComposerToggle = taskComposerToggle.exists
+        var exposedTerminalFilesToggle = terminalFilesToggle.exists
+        var exposedBetaFeaturesHeader = betaFeaturesHeader.exists
         let toastsToggle = app.switches["MobileSettingsToastsEnabled"]
         for _ in 0..<6 where !toastsToggle.exists || !toastsToggle.isHittable {
             app.swipeUp(velocity: .slow)
+            exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
+            exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
+            exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         }
         XCTAssertTrue(toastsToggle.waitForExistence(timeout: 4))
-        XCTAssertTrue(app.switches["MobileSettingsTaskComposer"].exists)
-        XCTAssertFalse(app.switches["MobileSettingsTerminalFilesChip"].exists)
+        exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
+        exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
+        exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
+        XCTAssertFalse(exposedTaskComposerToggle)
+        XCTAssertFalse(exposedTerminalFilesToggle)
+        XCTAssertFalse(exposedBetaFeaturesHeader)
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3866,7 +3866,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testSettingsDoesNotExposeTaskComposerOrTerminalFilesBetaToggles() throws {
+    func testSettingsDoesNotExposeTaskComposerBetaToggle() throws {
         let app = launchApp(
             mockData: false,
             environment: ["CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1"]
@@ -3878,24 +3878,19 @@ final class cmuxUITests: XCTestCase {
         tap(settings, in: app)
 
         let taskComposerToggle = app.switches["MobileSettingsTaskComposer"]
-        let terminalFilesToggle = app.switches["MobileSettingsTerminalFilesChip"]
         let betaFeaturesHeader = app.staticTexts["Beta Features"]
         var exposedTaskComposerToggle = taskComposerToggle.exists
-        var exposedTerminalFilesToggle = terminalFilesToggle.exists
         var exposedBetaFeaturesHeader = betaFeaturesHeader.exists
-        let toastsToggle = app.switches["MobileSettingsToastsEnabled"]
-        for _ in 0..<6 where !toastsToggle.exists || !toastsToggle.isHittable {
+        let versionRow = app.descendants(matching: .any)["MobileSettingsVersionRow"]
+        for _ in 0..<12 where !versionRow.exists || !versionRow.isHittable {
             app.swipeUp(velocity: .slow)
             exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
-            exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
             exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         }
-        XCTAssertTrue(toastsToggle.waitForExistence(timeout: 4))
+        XCTAssertTrue(versionRow.waitForExistence(timeout: 4))
         exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
-        exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
         exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         XCTAssertFalse(exposedTaskComposerToggle)
-        XCTAssertFalse(exposedTerminalFilesToggle)
         XCTAssertFalse(exposedBetaFeaturesHeader)
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3866,7 +3866,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testSettingsDoesNotExposeTaskComposerBetaToggle() throws {
+    func testSettingsDoesNotExposeRetiredBetaToggles() throws {
         let app = launchApp(
             mockData: false,
             environment: ["CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1"]
@@ -3878,19 +3878,29 @@ final class cmuxUITests: XCTestCase {
         tap(settings, in: app)
 
         let taskComposerToggle = app.switches["MobileSettingsTaskComposer"]
+        let terminalFilesToggle = app.switches["MobileSettingsTerminalFilesChip"]
+        let retiredToastsToggle = app.switches["MobileSettingsToastsEnabled"]
         let betaFeaturesHeader = app.staticTexts["Beta Features"]
         var exposedTaskComposerToggle = taskComposerToggle.exists
+        var exposedTerminalFilesToggle = terminalFilesToggle.exists
+        var exposedRetiredToastsToggle = retiredToastsToggle.exists
         var exposedBetaFeaturesHeader = betaFeaturesHeader.exists
         let versionRow = app.descendants(matching: .any)["MobileSettingsVersionRow"]
         for _ in 0..<12 where !versionRow.exists || !versionRow.isHittable {
             app.swipeUp(velocity: .slow)
             exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
+            exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
+            exposedRetiredToastsToggle = exposedRetiredToastsToggle || retiredToastsToggle.exists
             exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         }
         XCTAssertTrue(versionRow.waitForExistence(timeout: 4))
         exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
+        exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
+        exposedRetiredToastsToggle = exposedRetiredToastsToggle || retiredToastsToggle.exists
         exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         XCTAssertFalse(exposedTaskComposerToggle)
+        XCTAssertFalse(exposedTerminalFilesToggle)
+        XCTAssertFalse(exposedRetiredToastsToggle)
         XCTAssertFalse(exposedBetaFeaturesHeader)
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3866,7 +3866,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testSettingsDoesNotExposeRetiredBetaToggles() throws {
+    func testSettingsDoesNotExposeTaskComposerOrTerminalFilesBetaToggles() throws {
         let app = launchApp(
             mockData: false,
             environment: ["CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1"]
@@ -3879,28 +3879,23 @@ final class cmuxUITests: XCTestCase {
 
         let taskComposerToggle = app.switches["MobileSettingsTaskComposer"]
         let terminalFilesToggle = app.switches["MobileSettingsTerminalFilesChip"]
-        let retiredToastsToggle = app.switches["MobileSettingsToastsEnabled"]
         let betaFeaturesHeader = app.staticTexts["Beta Features"]
         var exposedTaskComposerToggle = taskComposerToggle.exists
         var exposedTerminalFilesToggle = terminalFilesToggle.exists
-        var exposedRetiredToastsToggle = retiredToastsToggle.exists
         var exposedBetaFeaturesHeader = betaFeaturesHeader.exists
         let versionRow = app.descendants(matching: .any)["MobileSettingsVersionRow"]
         for _ in 0..<12 where !versionRow.exists || !versionRow.isHittable {
             app.swipeUp(velocity: .slow)
             exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
             exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
-            exposedRetiredToastsToggle = exposedRetiredToastsToggle || retiredToastsToggle.exists
             exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         }
         XCTAssertTrue(versionRow.waitForExistence(timeout: 4))
         exposedTaskComposerToggle = exposedTaskComposerToggle || taskComposerToggle.exists
         exposedTerminalFilesToggle = exposedTerminalFilesToggle || terminalFilesToggle.exists
-        exposedRetiredToastsToggle = exposedRetiredToastsToggle || retiredToastsToggle.exists
         exposedBetaFeaturesHeader = exposedBetaFeaturesHeader || betaFeaturesHeader.exists
         XCTAssertFalse(exposedTaskComposerToggle)
         XCTAssertFalse(exposedTerminalFilesToggle)
-        XCTAssertFalse(exposedRetiredToastsToggle)
         XCTAssertFalse(exposedBetaFeaturesHeader)
     }
 


### PR DESCRIPTION
## Summary
- Remove the iOS Beta Features section and New Task Composer toggle.
- Remove the obsolete persisted display-setting property, tests, and localization entries.
- Add UI coverage proving the task composer and terminal files are not exposed as beta toggles.

## Testing
- `git diff --check`
- Hosted `test-e2e.yml` run for `cmuxUITests/testSettingsDoesNotExposeTaskComposerOrTerminalFilesBetaToggles` dispatched on the test-only commit, followed by this fix commit.

## Issues
- No linked issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789596656&installation_model_id=21920&pr_number=10291&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10291&signature=de2e3f9908cb45b6af5d8f0b2b241ba565d45b0495808980170ae8e405645daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the iOS Settings “Beta Features” section and the “New Task Composer” toggle. Previously, users could enable the composer via Settings with `cmux.mobile.taskComposerEnabled`; now the section and toggle are gone, the key is no longer read or written, and the composer cannot be enabled from Settings.

- Removes `taskComposerEnabled` from `MobileDisplaySettings`, its bindings from `MobileSettingsView`, related unit tests, and `Localizable.xcstrings` entries for “Beta Features” and “New Task Composer”.
- Updates `cmuxUITests` with `testSettingsDoesNotExposeTaskComposerOrTerminalFilesBetaToggles`, using the Version row as a scroll anchor and asserting the “Beta Features” header, Task Composer toggle, and Terminal Files chip toggle never appear.

- No migration required: any existing `UserDefaults` value for `cmux.mobile.taskComposerEnabled` is ignored.

<sup>Written for commit c39a1630d1eb17467e0f6461fb2ee95dd848618c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the Beta Features section and Task Composer toggle from mobile settings.
  * Task Composer is no longer available or exposed in the mobile app.
  * Removed related English and Japanese labels from the settings interface.
  * Removed the associated saved preference.

* **Tests**
  * Updated settings checks to confirm retired options and sections remain hidden while browsing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->