### PR TITLE
fix(ios): keep workspace-list viewport when exiting a workspace

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -58,9 +58,15 @@ extension WorkspaceListView {
         filterMachines: [WorkspaceFilterMachine]
     ) -> some View {
         #if os(iOS)
-            if showsNavigationToolbar {
-                content
-                    .toolbar {
+            // `showsNavigationToolbar` flips on every compact-stack workspace
+            // push/pop, so the conditional must stay INSIDE the toolbar
+            // builder. A structural `if` around `content` gives the two states
+            // different view identities: SwiftUI then dismantles the
+            // UITableView-backed list on each flip and the viewport resets to
+            // the top when the user exits a workspace.
+            content
+                .toolbar {
+                    if showsNavigationToolbar {
                         if !usesExternalSharedToolbar {
                             ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
                                 settingsMenu
@@ -89,9 +95,7 @@ extension WorkspaceListView {
                             }
                         }
                     }
-            } else {
-                content
-            }
+                }
         #else
             content
                 .toolbar {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListViewportRestorationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListViewportRestorationTests.swift
@@ -1,0 +1,106 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import SwiftUI
+import Testing
+import UIKit
+@testable import CmuxMobileShellUI
+
+/// Entering a workspace on the compact push stack flips
+/// `showsNavigationToolbar` false, and exiting flips it back true. That flip
+/// must not change the structural identity of the list subtree: when it does,
+/// SwiftUI dismantles the UITableView-backed list on every enter/exit, so the
+/// recreated table opens at the top instead of the rows the user left.
+@MainActor
+@Suite struct WorkspaceListViewportRestorationTests {
+    @Test func navigationToolbarFlipKeepsTableViewportAcrossWorkspaceEnterExit() throws {
+        let filterState = WorkspaceListFilterState()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let controller = UIHostingController(
+            rootView: WorkspaceListToolbarFlipHarness(
+                showsNavigationToolbar: true,
+                filterState: filterState
+            )
+        )
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        let table = try #require(firstWorkspaceTable(in: window))
+        #expect(table.contentSize.height > table.bounds.height * 2)
+        table.setContentOffset(CGPoint(x: 0, y: 600), animated: false)
+        table.layoutIfNeeded()
+        let savedOffset = table.contentOffset
+
+        // Entering a workspace hides the list toolbar…
+        controller.rootView = WorkspaceListToolbarFlipHarness(
+            showsNavigationToolbar: false,
+            filterState: filterState
+        )
+        controller.view.layoutIfNeeded()
+
+        // …and exiting the workspace restores it.
+        controller.rootView = WorkspaceListToolbarFlipHarness(
+            showsNavigationToolbar: true,
+            filterState: filterState
+        )
+        controller.view.layoutIfNeeded()
+
+        let tableAfterExit = try #require(firstWorkspaceTable(in: window))
+        #expect(
+            tableAfterExit === table,
+            "The toolbar flip recreated the workspace table, so the viewport cannot survive workspace exit."
+        )
+        #expect(tableAfterExit.contentOffset == savedOffset)
+        window.isHidden = true
+    }
+
+    private func firstWorkspaceTable(in view: UIView) -> WorkspaceListUITableView? {
+        if let table = view as? WorkspaceListUITableView {
+            return table
+        }
+        for subview in view.subviews {
+            if let table = firstWorkspaceTable(in: subview) {
+                return table
+            }
+        }
+        return nil
+    }
+}
+
+/// Mirrors the live compact shell: `usesExternalSharedToolbar` is true and
+/// `showsNavigationToolbar` follows the navigation path, so re-rendering with
+/// a flipped flag is exactly what a workspace push/pop does to the list.
+private struct WorkspaceListToolbarFlipHarness: View {
+    var showsNavigationToolbar: Bool
+    let filterState: WorkspaceListFilterState
+
+    private static let workspaces: [MobileWorkspacePreview] = (1...60).map { index in
+        MobileWorkspacePreview(
+            id: .init(rawValue: "workspace-\(index)"),
+            name: "workspace-\(index)",
+            previewText: "Build succeeded",
+            terminals: []
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            WorkspaceListView(
+                workspaces: Self.workspaces,
+                selectedWorkspaceID: nil,
+                host: "Test Mac",
+                connectionStatus: .connected,
+                navigationStyle: .push,
+                showsNavigationToolbar: showsNavigationToolbar,
+                usesExternalSharedToolbar: true,
+                wrapWorkspaceTitles: false,
+                selectWorkspace: { _ in },
+                createWorkspace: {},
+                macSelection: .constant(.all),
+                filterState: filterState,
+                searchText: ""
+            )
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Exiting a workspace on iPhone reset the workspace list to the top. The compact push stack flips `showsNavigationToolbar` on every workspace enter/exit, and `WorkspaceListView+Toolbar.swift` used a structural `if` around the list content, so each flip changed the subtree's view identity. SwiftUI dismantled the UITableView-backed list (`WorkspaceListTable`) and the recreated table opened at offset zero.

Fix: keep one stable subtree and move the conditional inside the `ToolbarContentBuilder` (the same idiom `WorkspaceShellView.stackLayout` already uses for `rootToolbarContent`). With stable identity the same `UITableView` survives push/pop and UIKit preserves the exact scroll position natively. Toolbar behavior is unchanged: items still disappear while a workspace is open.

Two commits so CI proves the test catches the bug: commit 1 adds `WorkspaceListViewportRestorationTests` (hosts the real `WorkspaceListView`, scrolls, flips the flag both ways, asserts same table instance and same content offset) and fails; commit 2 adds the fix and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789597645&installation_model_id=21920&pr_number=10292&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10292&signature=ba553f1480bb81d23f87d717432e70928faf8afe0a21995cb39be7c697d29a40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the workspace list viewport on iPhone when exiting a workspace. Previously, exiting reset the list to the top; now the scroll position is preserved by keeping the list subtree identity stable.

- Moves the `showsNavigationToolbar` check inside the `.toolbar` builder so the list view isn’t structurally replaced during push/pop; matches the pattern used in `WorkspaceShellView.stackLayout`.
- Adds `WorkspaceListViewportRestorationTests` that flips the flag around the real `WorkspaceListView` and asserts the same `UITableView` instance and content offset.
- iOS-only; toolbar behavior is unchanged (items still hide in-workspace). No migrations or config changes.

<sup>Written for commit 722aa9f5affcdc46a49ab15f75acfad18a3ebcdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace list content now remains stable when the navigation toolbar is shown or hidden.
  * Preserved workspace list position and scroll offset when entering or leaving a workspace while toggling the toolbar.

* **Tests**
  * Added coverage verifying workspace list state and content position are retained during toolbar changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->