### PR TITLE
fix(ios): Tailscale-only must gate secondary-Mac and discovery Iroh dials

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -17,7 +17,10 @@ extension MobileShellComposite {
         generation: Int,
         excluding pairingIDs: Set<String>
     ) async -> [MobilePairedMac] {
-        guard let personalIrohDiscovery else { return [] }
+        // Discovery only yields Iroh-route candidates, which the Tailscale
+        // connection method can never dial; skip the broker round-trip.
+        guard connectionMethodStore?.method != .tailscale,
+              let personalIrohDiscovery else { return [] }
         let discovered = await personalIrohDiscovery.discoverLiveMacs()
         guard generation == storedMacReconnectGeneration,
               await isScopeCurrent(scope) else { return [] }
@@ -38,7 +41,10 @@ extension MobileShellComposite {
         scope: MobileShellScopeSnapshot,
         excluding pairingIDs: Set<String>
     ) async -> [MobilePairedMac] {
-        guard let personalIrohDiscovery else { return [] }
+        // Discovery only yields Iroh-route candidates, which the Tailscale
+        // connection method can never dial; skip the broker round-trip.
+        guard connectionMethodStore?.method != .tailscale,
+              let personalIrohDiscovery else { return [] }
         let discovered = await personalIrohDiscovery.discoverLiveMacs()
         guard await isScopeCurrent(scope) else { return [] }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4671,15 +4671,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// separates network failures, which share the pool retry budget, from
     /// authority/build/route incompatibilities, which wait for a new external
     /// edge instead of polling forever.
+    ///
+    /// Route selection honors the user's connection method exactly like the
+    /// foreground dial: with Tailscale selected, a Mac without a device-local
+    /// Tailscale grant fails closed here instead of opening a background Iroh
+    /// control session over public paths and managed relays.
     func makeSecondaryClient(
         for mac: MobilePairedMac
     ) async -> SecondaryClientAttempt {
         guard let runtime else { return .permanentFailure }
         let supportedKinds = runtime.supportedRouteKinds
-        let pinnedRoutes = Self.storedReconnectRoutes(
-            mac.routes,
-            supportedKinds: supportedKinds,
-            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        let pinnedRoutes = orderedReconnectRoutes(
+            for: mac,
+            supportedKinds: supportedKinds
         )
         guard let firstRoute = pinnedRoutes.first else {
             return .permanentFailure

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxMobilePairedMac
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -413,6 +414,38 @@ struct IrohZeroTouchDiscoveryTests {
         #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a", "iroh-mac-a"])
     }
 
+    /// Discovery hands back exclusively Iroh-route candidates, so the strict
+    /// Tailscale connection method must skip the broker lookup entirely: no
+    /// discovery request, no candidates, and therefore no Iroh dial downstream.
+    @Test func tailscaleOnlyMethodSkipsZeroTouchIrohDiscovery() async throws {
+        let live = try candidate(deviceID: "mac-a", endpointByte: "a")
+        let discovery = ScriptedIrohDiscovery(snapshots: [[live]])
+        let fixture = try await makeFixture(
+            discovery: discovery,
+            reportedDeviceID: "mac-a",
+            connectionMethod: .tailscale
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(
+            await fixture.shell.currentScopeSnapshot(userID: "user-1")
+        )
+
+        let secondary = await fixture.shell.discoverSecondaryZeroTouchIrohCandidates(
+            scope: scope,
+            excluding: []
+        )
+        let launch = await fixture.shell.discoverZeroTouchIrohCandidates(
+            scope: scope,
+            generation: fixture.shell.storedMacReconnectGeneration,
+            excluding: []
+        )
+
+        #expect(secondary.isEmpty)
+        #expect(launch.isEmpty)
+        #expect(discovery.callCount() == 0)
+        #expect(fixture.factory.attemptedRouteIDs().isEmpty)
+    }
+
     private func makeFixture(
         candidates: [MobileDiscoveredIrohMac],
         reportedDeviceID: String,
@@ -429,7 +462,8 @@ struct IrohZeroTouchDiscoveryTests {
         discovery: any MobileIrohMacDiscovering,
         reportedDeviceID: String,
         failingRouteIDs: Set<String> = [],
-        rateLimitedRouteIDs: Set<String> = []
+        rateLimitedRouteIDs: Set<String> = [],
+        connectionMethod: MobileConnectionMethod? = nil
     ) async throws -> ZeroTouchFixture {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -448,6 +482,16 @@ struct IrohZeroTouchDiscoveryTests {
             failingRouteIDs: failingRouteIDs,
             rateLimitedRouteIDs: rateLimitedRouteIDs
         )
+        let methodStore = connectionMethod.map { method in
+            let defaults = UserDefaults(
+                suiteName: "iroh-zero-touch-method-\(UUID().uuidString)"
+            )!
+            defaults.set(
+                method.rawValue,
+                forKey: MobileConnectionMethodStore.methodKey
+            )
+            return MobileConnectionMethodStore(defaults: defaults)
+        }
         let shell = MobileShellComposite(
             runtime: LivenessTestRuntime(
                 transportFactory: factory,
@@ -456,6 +500,7 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
+            connectionMethodStore: methodStore,
             personalIrohDiscovery: discovery,
             identityProvider: StaticIdentityProvider(userID: "user-1"),
             reachability: AlwaysOnlineReachability(),

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
@@ -2919,6 +2919,69 @@ import Testing
         #expect(factory.attemptedKinds().isEmpty)
     }
 
+    /// Failing closed on ungranted Iroh must not overshoot: a secondary Mac
+    /// whose stored Tailscale route carries the device-local grant still
+    /// aggregates over that exact route while the Tailscale method is selected.
+    @Test func tailscaleOnlySecondaryMacStillConnectsOverAuthorizedRoute()
+        async throws {
+        let route = try CmxAttachRoute(
+            id: "granted-tailscale",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.42", port: 56_584)
+        )
+        let mac = MobilePairedMac(
+            macDeviceID: "granted-mac",
+            displayName: "Granted Mac",
+            routes: [route],
+            createdAt: .distantPast,
+            lastSeenAt: .distantPast,
+            isActive: false,
+            stackUserID: "user-1",
+            teamID: "team-1",
+            instanceTag: "stable",
+            legacyTailscaleRoutes: [route]
+        )
+        let router = LivenessHostRouter()
+        await router.setHostIdentity(
+            deviceID: "granted-mac",
+            instanceTag: "stable",
+            displayName: "Granted Mac"
+        )
+        let factory = KindRecordingTransportFactory(
+            router: router,
+            box: TransportBox()
+        )
+        let methodDefaults = UserDefaults(
+            suiteName: "tailscale-only-granted-\(UUID().uuidString)"
+        )!
+        methodDefaults.set(
+            MobileConnectionMethod.tailscale.rawValue,
+            forKey: MobileConnectionMethodStore.methodKey
+        )
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Date() },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            isSignedIn: true,
+            connectionMethodStore: MobileConnectionMethodStore(
+                defaults: methodDefaults
+            )
+        )
+
+        switch await shell.makeSecondaryClient(for: mac) {
+        case let .connected(handle):
+            #expect(handle.storedInstanceTag == "stable")
+            await handle.client.disconnect()
+        case .transientFailure:
+            Issue.record("granted Tailscale secondary failed transiently")
+        case .permanentFailure:
+            Issue.record("granted Tailscale secondary was refused")
+        }
+        #expect(factory.attemptedKinds() == [.tailscale])
+    }
+
     @Test func identityFreeLegacyTailscaleStatusUsesValidatedRepair()
         async throws {
         let route = try CmxAttachRoute(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
@@ -2895,10 +2895,11 @@ import Testing
             MobileConnectionMethod.tailscale.rawValue,
             forKey: MobileConnectionMethodStore.methodKey
         )
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
         let shell = MobileShellComposite(
             runtime: LivenessTestRuntime(
                 transportFactory: factory,
-                now: { Date() },
+                now: { fixedNow },
                 supportedRouteKinds: [.iroh, .tailscale]
             ),
             isSignedIn: true,
@@ -2958,10 +2959,11 @@ import Testing
             MobileConnectionMethod.tailscale.rawValue,
             forKey: MobileConnectionMethodStore.methodKey
         )
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
         let shell = MobileShellComposite(
             runtime: LivenessTestRuntime(
                 transportFactory: factory,
-                now: { Date() },
+                now: { fixedNow },
                 supportedRouteKinds: [.iroh, .tailscale]
             ),
             isSignedIn: true,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
@@ -2850,6 +2850,75 @@ import Testing
         }
     }
 
+    /// The Tailscale connection method is a strict determinant for every dial,
+    /// not just the foreground reconnect. Background multi-Mac aggregation and
+    /// broker-discovered secondaries both build their client here, so a stored
+    /// Mac whose only routes are Iroh must fail closed instead of opening an
+    /// Iroh control session over public paths and managed relays.
+    @Test func tailscaleOnlyMethodNeverDialsIrohForSecondaryMac() async throws {
+        let iroh = try CmxAttachRoute(
+            id: "iroh-secondary",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(
+                    endpointID: String(repeating: "a", count: 64)
+                ),
+                pathHints: []
+            ),
+            priority: -10_000
+        )
+        let mac = MobilePairedMac(
+            macDeviceID: "iroh-mac",
+            displayName: "Iroh Mac",
+            routes: [iroh],
+            createdAt: .distantPast,
+            lastSeenAt: .distantPast,
+            isActive: false,
+            stackUserID: "user-1",
+            teamID: "team-1",
+            instanceTag: "stable"
+        )
+        let router = LivenessHostRouter()
+        await router.setHostIdentity(
+            deviceID: "iroh-mac",
+            instanceTag: "stable",
+            displayName: "Iroh Mac"
+        )
+        let factory = KindRecordingTransportFactory(
+            router: router,
+            box: TransportBox()
+        )
+        let methodDefaults = UserDefaults(
+            suiteName: "tailscale-only-secondary-\(UUID().uuidString)"
+        )!
+        methodDefaults.set(
+            MobileConnectionMethod.tailscale.rawValue,
+            forKey: MobileConnectionMethodStore.methodKey
+        )
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Date() },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            isSignedIn: true,
+            connectionMethodStore: MobileConnectionMethodStore(
+                defaults: methodDefaults
+            )
+        )
+
+        switch await shell.makeSecondaryClient(for: mac) {
+        case .permanentFailure:
+            break
+        case let .connected(handle):
+            Issue.record("Tailscale-only method dialed Iroh for a secondary Mac")
+            await handle.client.disconnect()
+        case .transientFailure:
+            Issue.record("Tailscale-only method left a secondary Iroh dial retrying")
+        }
+        #expect(factory.attemptedKinds().isEmpty)
+    }
+
     @Test func identityFreeLegacyTailscaleStatusUsesValidatedRepair()
         async throws {
         let route = try CmxAttachRoute(


### PR DESCRIPTION
## Problem

With Settings > Connection Method = Tailscale, the foreground dial is strictly gated (only grant-authorized Tailscale routes, fail closed), but `makeSecondaryClient` selected routes with a bare `storedReconnectRoutes` call, without the Tailscale requirement. The multi-Mac aggregation pool therefore pinned stored Iroh routes and opened background-control Iroh sessions over public paths and managed relays, and broker-discovered secondaries dialed through the same hole. A beta user's transport log shows exactly this under Tailscale Only: `Direct dial plan assembled (Public paths: 1, public_relay_urls: 1)` then `Selected network path changed (Path: Relay)` on build 1.0.4 (20260813194844).

## Fix

`makeSecondaryClient` now selects routes through `orderedReconnectRoutes`, the same method-honoring selector the foreground uses: grant-authorized Tailscale routes still aggregate (multi-Mac over Tailscale keeps working), everything else returns `.permanentFailure` and waits for a new external edge. Zero-touch Iroh discovery returns no candidates while Tailscale is selected, skipping broker round-trips whose iroh-only results could never be dialed. Principled fix: it closes the one dial path that bypassed the existing strict route filter rather than adding a parallel check.

Two commits per the regression convention: commit 1 is the failing test (secondary aggregation dials Iroh under Tailscale Only), commit 2 the fix plus companion coverage (granted route still connects, discovery skipped).

## Verification

`swift test` on `Packages/iOS/CmuxMobileShell` (macOS host): new tests red at commit 1, green at commit 2; `MobileMacConnectionPoolTests`, `IrohZeroTouchDiscoveryTests`, `IrohReconnectRouteSelectionTests`, `ReconnectRouteSelectionTests` pass (183 tests; a few known load-sensitive flakes in `IrohConnectionRecoveryOwnerTests` fail identically with the fix stashed, so they are pre-existing).

Caveat: the package test target at main tip does not compile because https://github.com/manaflow-ai/cmux/pull/10072 left `MobileShellCompositePreviewTests` referencing `selectMacSurface`/`selectedMacSurfaceID`, which exist nowhere; https://github.com/manaflow-ai/cmux/pull/10285 owns the revert. I verified with that one orphaned test method removed locally; the removal is deliberately not part of this PR. No tagged device build yet for the same reason: `CmuxMobileShellUI` references the same missing API, so the iOS app target cannot compile until 10285 (or an equivalent forward fix) lands.

## Not in scope

The iroh runtime itself (broker registration, presence, relay-policy fetch) still runs under Tailscale Only; those power the computer list and are a product decision, not a dial-path leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789598282&installation_model_id=21920&pr_number=10294&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10294&signature=195203006c5573bb69ef5ea8c3d4b3dde23f0d4a7a5393853c1249e6f48a4f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Tailscale-only for secondary Mac dials and zero-touch Iroh discovery. Previously only the foreground honored Tailscale-only; background aggregation and broker-discovered secondaries could open Iroh sessions over public paths/relays. Now secondary dials require a grant-authorized Tailscale route; other routes fail closed and discovery is skipped.

**Review notes**
- `makeSecondaryClient` now selects via `orderedReconnectRoutes`; unauthorized Iroh routes return `.permanentFailure`, grant-authorized Tailscale routes still connect.
- Zero-touch Iroh discovery short-circuits when the method is `.tailscale` (no broker call, no candidates, no Iroh dials).
- Tests in `Packages/iOS/CmuxMobileShell` cover refusal, granted-route success, and discovery skip; the runtime clock is pinned for deterministic route selection.

<sup>Written for commit 58416dcbd4ca1304aac5ea08d080465e59fb4a73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tailscale-only connection mode now skips unnecessary Iroh discovery and dialing.
  * Secondary connections now respect the selected connection method when choosing routes.
  * Authorized stored Tailscale routes continue to connect successfully without attempting incompatible Iroh routes.

* **Tests**
  * Added coverage for Tailscale connection behavior, including discovery, route selection, and secondary connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->