### PR TITLE
fix(ios): implement selectedMacSurfaceID selection state, unhide effectiveConnectionStatus

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SurfaceFocus.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SurfaceFocus.swift
@@ -4,6 +4,13 @@ public import CmuxMobileShellModel
 extension MobileShellComposite {
     public nonisolated static let surfaceFocusCapability = "surface.focus.v1"
 
+    /// Shows a Mac surface in the workspace detail. Deliberately leaves
+    /// ``selectedTerminalID`` alone so the terminal selection (and composer
+    /// draft) survives the surface visit.
+    public func selectMacSurface(_ surfaceID: MobileSurfacePreview.ID) {
+        selectedMacSurfaceID = surfaceID
+    }
+
     /// Whether the workspace's owning Mac advertises surface focus.
     public func supportsSurfaceFocus(in workspaceID: MobileWorkspacePreview.ID) -> Bool {
         let target = workspaceMutationTarget(for: workspaceID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -822,9 +822,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @ObservationIgnored var signInGeneration = 0
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
+            if selectedWorkspaceID != oldValue {
+                selectedMacSurfaceID = nil
+            }
             syncSelectedTerminalForWorkspace()
         }
     }
+    /// The Mac surface shown in the workspace detail instead of the selected
+    /// terminal, or nil when the terminal is visible. Independent of
+    /// ``selectedTerminalID`` (so dismissing the surface returns to the same
+    /// terminal and composer draft) and cleared when the workspace changes.
+    public var selectedMacSurfaceID: MobileSurfacePreview.ID?
     /// The terminal whose surface (and composer draft) is currently shown.
     ///
     /// Changing it swaps the composer draft: `willSet` captures the outgoing

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -518,7 +518,7 @@ struct WorkspaceDetailView: View {
     /// with a working keyboard. Hidden retained details keep their raw
     /// status: the guard only applies to the selected workspace on the
     /// foreground connection.
-    private var effectiveConnectionStatus: MobileMacConnectionStatus {
+    var effectiveConnectionStatus: MobileMacConnectionStatus {
         if store.selectedWorkspaceID == workspace.id,
            store.selectedWorkspaceUsesForegroundConnection {
             if store.connectionRecoveryFailed {


### PR DESCRIPTION
Rounds four and five of https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9 compile fallout, after https://github.com/manaflow-ai/cmux/pull/10287 and https://github.com/manaflow-ai/cmux/pull/10290: the Release archive now dies in CmuxMobileShellUI (https://github.com/manaflow-ai/cmux/actions/runs/32075242301) because WorkspaceDetailView references `store.selectedMacSurfaceID` / `store.selectMacSurface(_:)` which were never implemented on `MobileShellComposite`, and `effectiveConnectionStatus` is `private` in `WorkspaceDetailView.swift` but used from `WorkspaceDetailView+Surfaces.swift`.

The already-committed `MobileShellCompositePreviewTests.macSurfaceSelectionIsExplicitAndIndependentFromTerminalSelection` encodes the intended contract, so this implements exactly that: stored `selectedMacSurfaceID` starting nil, `selectMacSurface(_:)` setting it without touching `selectedTerminalID`, and a clear on workspace switch. Every remaining error line in the failed run resolves to these three defects; a sweep of all `store.<member>` references in CmuxMobileShellUI found no other missing members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789598320&installation_model_id=21920&pr_number=10295&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10295&signature=7d512d179605cde5e3559d7fec88eb84047ef758a5e81d6ac36ed72efb93b2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `selectedMacSurfaceID` state and `selectMacSurface(_:)` on `MobileShellComposite`, and makes `effectiveConnectionStatus` accessible from `WorkspaceDetailView` extensions. This resolves Release archive failures in `CmuxMobileShellUI` caused by missing store members and a `private` property.

- New behavior: `selectedMacSurfaceID` starts nil, `selectMacSurface(_:)` sets it without touching `selectedTerminalID`, and changing `selectedWorkspaceID` clears it. Dismissing a surface returns to the same terminal and composer draft.
- API visibility: `effectiveConnectionStatus` in `WorkspaceDetailView` is now internal (not private) so `WorkspaceDetailView+Surfaces.swift` can use it.
- Scope of change: `CmuxMobileShell` adds the stored property and mutator; `CmuxMobileShellUI` adjusts only visibility. No migration required for callers.

<sup>Written for commit a8a68fd9c3ffb6b6e3eb65465408fe0c42a86e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

