### PR TITLE
fix(ios): land the Mac-surface selection store state the UI already uses

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -822,8 +822,26 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @ObservationIgnored var signInGeneration = 0
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
+            // A surface id is only meaningful inside the workspace it was
+            // picked in; crossing workspaces must not let a stale id from the
+            // previous workspace render into the next one.
+            if selectedWorkspaceID != oldValue {
+                selectedMacSurfaceID = nil
+            }
             syncSelectedTerminalForWorkspace()
         }
+    }
+    /// The Mac-native surface (markdown panel, file preview, todo board) the
+    /// user explicitly chose from the picker, or `nil` when the terminal is
+    /// shown. Selection is explicit and independent of terminal selection:
+    /// choosing a surface leaves ``selectedTerminalID`` (and its composer
+    /// draft) untouched, and the UI layer clears this when a terminal is
+    /// chosen. Reset on workspace switch.
+    public var selectedMacSurfaceID: MobileSurfacePreview.ID?
+
+    /// Shows the given Mac surface without disturbing the terminal selection.
+    public func selectMacSurface(_ surfaceID: MobileSurfacePreview.ID) {
+        selectedMacSurfaceID = surfaceID
     }
     /// The terminal whose surface (and composer draft) is currently shown.
     ///

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
@@ -86,6 +86,7 @@ public struct MacSurfaceGalleryPreviewView: View {
                         createTerminal: {},
                         openBrowser: {},
                         selectBrowserStream: { _ in },
+                        selectSimulatorStream: { _ in },
                         openTextSheet: {},
                         copyDebugLogs: {},
                         sendFeedback: {}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -518,7 +518,7 @@ struct WorkspaceDetailView: View {
     /// with a working keyboard. Hidden retained details keep their raw
     /// status: the guard only applies to the selected workspace on the
     /// foreground connection.
-    private var effectiveConnectionStatus: MobileMacConnectionStatus {
+    var effectiveConnectionStatus: MobileMacConnectionStatus {
         if store.selectedWorkspaceID == workspace.id,
            store.selectedWorkspaceUsesForegroundConnection {
             if store.connectionRecoveryFailed {


### PR DESCRIPTION
Layer 5-6 of the never-compiled https://github.com/manaflow-ai/cmux/commit/04ff18eea6ceb793252583e5c8f9df74b130a5e9 push that has kept the iOS TestFlight lane red since Aug 14. After https://github.com/manaflow-ai/cmux/pull/10287 and https://github.com/manaflow-ai/cmux/pull/10290 fixed the modules that compile first, `CmuxMobileShellUI` still fails: the commit shipped UI driving `store.selectedMacSurfaceID` / `selectMacSurface(_:)` but the store state never landed, `WorkspaceDetailView+Surfaces.swift` reads a `private`(file-scoped) `effectiveConnectionStatus` from another file, and a `TerminalPickerMenuActions` preview call is missing the `selectSimulatorStream` argument.

This implements `selectedMacSurfaceID`/`selectMacSurface(_:)` on `MobileShellComposite` to the contract its own (also never-landed-into-CI) test `MobileShellCompositePreviewTests.macSurfaceSelectionIsExplicitAndIndependentFromTerminalSelection` specifies: explicit selection, independent of terminal selection, cleared on workspace switch. The other two are mechanical (drop `private`, add a no-op closure).

Found by compiling the package closure locally for `arm64-apple-ios18.0-simulator` instead of peeling one module per CI round trip; `CmuxMobileShell` (with tests) and `CmuxMobileShellUI` now build clean locally. This should be the last missing layer in the iOS packages: the only remaining 04ff18eea6 iOS-side artifact is an xcstrings resource, and the debug failure-scenario picker intentionally omits an `.unknown` case (its own enum stays exhaustive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789599129&installation_model_id=21920&pr_number=10296&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10296&signature=dddd3813ef02c637ea3b17739326deda87a2873ccef04b8297194ba5d141817c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Mac-surface selection state in `CmuxMobileShell` so `CmuxMobileShellUI` compiles and the UI’s picker works. Previously the UI referenced `selectedMacSurfaceID` and `selectMacSurface(_:)` that the store did not define; builds failed.

- Adds `selectedMacSurfaceID` and `selectMacSurface(_:)` on MobileShellComposite. Selection is explicit, independent of terminal selection, and resets when `selectedWorkspaceID` changes.
- Widens `WorkspaceDetailView.effectiveConnectionStatus` visibility to allow cross-file access.
- Fixes a preview by adding a no-op `selectSimulatorStream` closure.
- Verified local build for arm64 iOS simulator; expected to unblock the iOS lane.

<sup>Written for commit b83dbe0f1979ead6329161253a1188c2c731eea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent Mac surface selection, allowing users to choose a Mac surface without changing the active terminal or draft.
* **Bug Fixes**
  * Switching workspaces now clears any previously selected Mac surface.
* **Tests**
  * Updated picker preview behavior to support simulator stream selection actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->