### PR TITLE
fix(ios): pass selectSimulatorStream in the DEBUG Mac-surface gallery preview

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
@@ -86,6 +86,7 @@ public struct MacSurfaceGalleryPreviewView: View {
                         createTerminal: {},
                         openBrowser: {},
                         selectBrowserStream: { _ in },
+                        selectSimulatorStream: { _ in },
                         openTextSheet: {},
                         copyDebugLogs: {},
                         sendFeedback: {}


### PR DESCRIPTION
Last remaining compile break from https://github.com/manaflow-ai/cmux/pull/10072 / 04ff18eea6 after https://github.com/manaflow-ai/cmux/pull/10287, https://github.com/manaflow-ai/cmux/pull/10290, https://github.com/manaflow-ai/cmux/pull/10295, and https://github.com/manaflow-ai/cmux/pull/10234: `MacSurfaceGalleryPreviewView` (wrapped in `#if canImport(UIKit) && DEBUG`) constructs `TerminalPickerMenuActions` without the `selectSimulatorStream` argument that landed with the simulator-stream work. Release archives compile the file out, which is why the TestFlight lane went green without this, but every Debug simulator build (test-ios lane, local dev) still fails on it. Pass an inert action, matching the other preview stubs.

Originally this PR also restored the store members and `TerminalController.panelArtifactAuthorizationStore`; those landed independently in #10295 and #10234, and the branch is rebased to just this line.

Verified: `CmuxMobileShellUI` compiles for `arm64-apple-ios18.0-simulator` with this change (it fails without it). Known-red on main not from this PR: `package-conventions-lint` debt, `mobile-core-package` DiagnosticEventPresentationTests drift, and `MobileInjectedAttachStartupTests` #expect Sendable errors in the CmuxMobileShellUITests test target (fails the test-ios sim legs even on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)