### PR TITLE
Fix startup wedge when several terminal hosts are unadoptable

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2724,16 +2724,20 @@ impl Mux {
                 return Err(error);
             }
             if terminal_host_record_liveness(&record_path, &record) == TerminalHostLiveness::Dead {
-                let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
-                    &record_path,
-                    &record,
-                );
+                // Commit the durable exit before deleting the record. The
+                // record is the only proof that this host ever existed, so a
+                // failed commit must leave the next startup able to retry
+                // instead of facing a lifecycle row with no evidence.
                 self.mark_terminal_exited_and_detach(
                     &terminal_id,
                     "terminal-host-proven-dead",
                     "host-process-ended-before-adoption",
                     &options,
                 )?;
+                let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                    &record_path,
+                    &record,
+                );
                 handled_terminals.insert(terminal_id.clone());
                 continue;
             }
@@ -2751,16 +2755,16 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
-                            &record_path,
-                            &record,
-                        );
                         self.mark_terminal_exited_and_detach(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
                             &options,
                         )?;
+                        let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                            &record_path,
+                            &record,
+                        );
                         handled_terminals.insert(terminal_id.clone());
                     } else {
                         // Socket loss and descriptor pressure are not process

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
@@ -17,7 +17,7 @@ use crate::workspace_registry::{
     RegistryViewportColumn, RegistryWorkspace, ResourceChange, ResourcePatch, ResourcePatchCommit,
     WorkspaceMutation, WorkspaceRegistry,
 };
-use crate::{ResourceSelectors, ResourceTarget};
+use crate::{ResourceSelectors, ResourceTarget, SurfaceId};
 
 impl Mux {
     pub(crate) fn resource_project_terminal_selected(
@@ -727,20 +727,9 @@ impl Mux {
 
                     let mut tab_order = Vec::with_capacity(pane.tabs.len());
                     for (position, surface_slot) in pane.tabs.iter().enumerate() {
-                        // Restored terminal tabs exist in the topology before
-                        // their host runtime is adopted. A structural commit
-                        // must preserve those durable views instead of making
-                        // unrelated host adoption a precondition.
                         let surface = state.surfaces.get(surface_slot);
-                        let identity = surface
-                            .and_then(|surface| surface.resource_identity().cloned())
-                            .or_else(|| {
-                                Some(TabResourceIdentity::new(
-                                    state.resource_indexes.tab_ids.get(surface_slot)?.clone(),
-                                    state.resource_indexes.content_ids.get(surface_slot)?.clone(),
-                                ))
-                            })
-                            .with_context(|| {
+                        let identity =
+                            tab_resource_identity(state, *surface_slot).with_context(|| {
                                 format!("pane surface {surface_slot} has no resource identity")
                             })?;
                         let before_tab = before_tabs.get(&identity.tab_id);
@@ -1072,18 +1061,29 @@ impl Mux {
     }
 }
 
+/// Durable identity of one pane tab. Restored tabs exist in the topology
+/// before their host runtime is adopted, and an unadoptable host never gets a
+/// surface at all, so the durable indexes are the authority here. A live
+/// surface is only the faster path to the same identity.
+fn tab_resource_identity(state: &State, surface_slot: SurfaceId) -> Option<TabResourceIdentity> {
+    if let Some(identity) =
+        state.surfaces.get(&surface_slot).and_then(|surface| surface.resource_identity().cloned())
+    {
+        return Some(identity);
+    }
+    Some(TabResourceIdentity::new(
+        state.resource_indexes.tab_ids.get(&surface_slot)?.clone(),
+        state.resource_indexes.content_ids.get(&surface_slot)?.clone(),
+    ))
+}
+
 fn ordered_terminal_tab_ids(
     state: &State,
 ) -> anyhow::Result<HashMap<crate::resource::TerminalPublicId, Vec<TabPublicId>>> {
     let mut tabs = Vec::new();
     for pane in state.panes.values() {
         for (position, surface_slot) in pane.tabs.iter().enumerate() {
-            let surface = state
-                .surfaces
-                .get(surface_slot)
-                .with_context(|| format!("pane references missing surface {surface_slot}"))?;
-            let identity = surface
-                .resource_identity()
+            let identity = tab_resource_identity(state, *surface_slot)
                 .with_context(|| format!("pane surface {surface_slot} has no resource identity"))?;
             if let ContentPublicId::Terminal(terminal_id) = &identity.content_id {
                 tabs.push((

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3088,6 +3088,80 @@ fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal(
     );
 }
 
+#[test]
+fn daemon_restart_prunes_every_dead_host_behind_one_pane() {
+    let mut harness = RecoveryHarness::start("dead-hosts-restart");
+    let first = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "cols":80,"rows":24,
+        }),
+    );
+    let pane = first["pane"].as_u64().unwrap();
+    let workspace_id = first["workspace"].as_u64().unwrap();
+    let first_terminal = first["terminal_id"].as_str().unwrap().to_string();
+    let second = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":2,"cmd":"run","argv":["/bin/cat"],"pane":pane,
+            "cols":80,"rows":24,
+        }),
+    );
+    let second_terminal = second["terminal_id"].as_str().unwrap().to_string();
+    assert_eq!(second["pane"].as_u64(), Some(pane), "second terminal left the first pane");
+    let tree = request(&harness.socket, serde_json::json!({"id":3,"cmd":"list-workspaces"}));
+    let workspace_key = tree["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["id"].as_u64() == Some(workspace_id))
+        .unwrap()["key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let records = wait_for_host_records(&harness.host_root(), 2);
+
+    // Stop the mux first so it observes neither Exit. Startup then has to
+    // reconcile two dead hosts behind the same pane. Recovery of the first
+    // one must not depend on the second one already having a live surface.
+    harness.signal_daemon(libc::SIGSTOP);
+    for (_, record) in &records {
+        // SAFETY: the record PIDs are the harness-owned terminal hosts.
+        assert_eq!(unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) }, 0);
+    }
+    harness.sigkill();
+    harness.restart();
+
+    for terminal_id in [&first_terminal, &second_terminal] {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let resolved = request(
+                &harness.socket,
+                serde_json::json!({"id":4,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+            );
+            if resolved["lifecycle"] == "exited" {
+                assert_eq!(resolved["surface"], serde_json::Value::Null);
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "dead startup host {terminal_id} was not projected as Exited"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+    wait_for_no_host_records(&harness.host_root());
+    let recovered = request(&harness.socket, serde_json::json!({"id":5,"cmd":"list-workspaces"}));
+    let workspace = recovered["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
+        .expect("original workspace was not recovered");
+    assert!(first_tab(workspace).is_none(), "Exited terminals were rematerialized after restart");
+}
+
 fn request(path: &Path, value: serde_json::Value) -> serde_json::Value {
     let response = request_response(path, value);
     assert_eq!(response["ok"], true, "request failed: {response}");


### PR DESCRIPTION
A session that restarts with two or more unadoptable terminal hosts behind the same pane never opens again. `cmux` exits with `cmux-tui: pane references missing surface <slot>` and writes nothing, so every later start repeats it. Reported from `uvx cmux` 0.10.0 against a real session; reproduced deterministically against a copy of that session state.

Cause: `ordered_terminal_tab_ids` required a live surface for every pane tab, while the projection loop directly below it already accepted a restored tab with no surface yet (that fallback landed with the multiview work in #9387). Startup restores tabs before adoption, so an unadoptable host leaves a tab with no surface. The abort happened inside `persist_terminal_exit`, which builds the exit-detach projection before it commits, so the commit that was supposed to prune that terminal was the one that failed. One orphan host still recovered, because removing it made the tree consistent. Two behind one pane wedged the session permanently.

Both call sites now resolve tab identity through one helper: live surface first, durable indexes as the authority.

Also reorders the two startup paths that prove a host dead so the durable exit commits before the host record is deleted. The record is the only evidence that the host existed, and the old order erased it whenever the commit failed. That is why the reported session ended with no host records and two rows still in `adopting`.

Regression test in the first commit, fix in the second, so CI shows red then green. `daemon_restart_prunes_every_dead_host_behind_one_pane` kills two hosts behind one pane while the daemon is stopped, restarts, and requires both terminals to reach `exited` with the pane pruned.

Deliberately not in this PR: making startup non-fatal (quarantine unprojectable state instead of refusing to start). That would hide real corruption, and it deserves its own change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789601263&installation_model_id=21920&pr_number=10299&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10299&signature=0d8d1100e5fcbdc1a8b8303b8101290379a714ff8654f821123a8d248761f70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a startup wedge when multiple unadoptable terminal hosts share a pane. Previously startup aborted with “pane references missing surface <slot>” during the first exit–detach commit and the session never opened; now restored tabs use durable indexes when no live surface exists, so startup prunes all dead hosts and completes.

- Resolve tab identity via a single helper that prefers the live surface and falls back to durable tab/content indexes; used in both `ordered_terminal_tab_ids` and the projection loop.
- On startup, commit the durable exit before deleting the host record in both dead-host paths to preserve evidence for a retry if the commit fails.
- Adds regression test `daemon_restart_prunes_every_dead_host_behind_one_pane`.

<sup>Written for commit b455a4cb12536dc9b9068d2241bacb0f61329c9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of exited terminals after a daemon restart.
  * Preserved tab identity for restored terminals when their live surfaces are unavailable.
  * Prevented stale terminal records from being removed before exit state is safely saved.

* **Tests**
  * Added coverage for recovering multiple dead terminal hosts in the same pane without recreating unwanted tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->