### PR TITLE
ci: accept Xcode 26.5 Swift Testing summaries in the selected-test guard

### DIFF
--- a/scripts/ci/require_selected_test_execution.sh
+++ b/scripts/ci/require_selected_test_execution.sh
@@ -20,8 +20,8 @@ fi
 
 summary_kind="$(
   awk '
-    /Executed [0-9]+ tests?,/ || /Test run with [0-9]+ tests? (passed|failed)/ {
-      if ($0 ~ /Executed 0 tests?,/ || $0 ~ /Test run with 0 tests? (passed|failed)/) {
+    /Executed [0-9]+ tests?,/ || /Test run with [0-9]+ tests?( in [0-9]+ suites?)? (passed|failed)/ {
+      if ($0 ~ /Executed 0 tests?,/ || $0 ~ /Test run with 0 tests?( in [0-9]+ suites?)? (passed|failed)/) {
         zero = 1
       } else {
         positive = 1


### PR DESCRIPTION
Every `test-ios.yml` dispatch with a `test_filter` fails on the new Xcode 26.5 runner image even when the selected tests pass. Swift Testing there prints `Test run with 1 test in 1 suite passed after 0.510 seconds.`, and `scripts/ci/require_selected_test_execution.sh` only matched `Test run with N test(s) passed|failed` with no `in N suite(s)` segment, so the guard saw no positive summary, fell through to the XCTest bridge's `Executed 0 tests` lines, and reported "selected iOS test filter matched zero tests" (observed in run [32080052853](https://github.com/manaflow-ai/cmux/actions/runs/32080052853), where the job failed seconds after `** TEST SUCCEEDED **`).

The fix makes the `in N suite(s)` segment optional in both the positive and zero-match patterns. Verified against all four summary shapes: new-style pass, new-style zero, XCTest `Executed N tests`, and old-style `Test run with N tests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789603211&installation_model_id=21920&pr_number=10300&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10300&signature=e50bda5469e135c187e3415a09396f2c88cac20b71d8a2c6712238acf768b020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the selected test guard to accept Swift Testing summaries from Xcode 26.5, preventing false “zero tests matched” failures when `test_filter` runs pass. Previously the guard only matched “Test run with N tests passed|failed”; now it also matches “Test run with N tests in M suites passed|failed.”

- Update `scripts/ci/require_selected_test_execution.sh` to make the “in N suite(s)” segment optional in both positive and zero-match patterns.
- Continues to recognize XCTest “Executed N tests” and old-style summaries; no workflow or config changes required.

<sup>Written for commit 0efa18861fbc5fccecbe158253fa866ed37885a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test result parsing for Xcode output that includes suite counts.
  * Correctly handles test runs reporting zero executed tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->