### PR TITLE
fix(ghostty-vt-sys): default CPU target to baseline to prevent AVX-512 SIGILL on older x86-64 CPUs

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -476,7 +476,7 @@ jobs:
             export CMUX_TUI_NPM_BOOTSTRAP_VERSION
           fi
           cd ghostty
-          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
+          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu -Dcpu=baseline --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
           cd ../cmux-tui
           cargo build -p cmux-tui --bin cmux-tui --bin cmux-tui-hook --release --locked --target x86_64-pc-windows-gnu
 

--- a/cmux-tui/crates/ghostty-vt-sys/build.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build.rs
@@ -42,7 +42,6 @@ fn main() {
     let zig = env::var("ZIG").unwrap_or_else(|_| "zig".to_string());
     let prefix = out_dir.join("ghostty-vt");
     let target = env::var("TARGET").unwrap();
-    let host = env::var("HOST").unwrap();
     let mut command = Command::new(&zig);
     command
         .current_dir(&ghostty_dir)
@@ -50,19 +49,17 @@ fn main() {
         .arg("-Demit-lib-vt=true")
         .arg("-Demit-xcframework=false")
         .arg("-Doptimize=ReleaseFast");
-    if target != host
-        && let Some(zig_target) = zig_target_for_rust_target(&target)
-    {
+    if let Some(zig_target) = zig_target_for_rust_target(&target) {
         command.arg(format!("-Dtarget={zig_target}"));
     }
-    // Valgrind's instruction emulation doesn't cover every CPU-native SIMD
-    // extension zig's default target detection can select (e.g. some AVX-512
-    // variants), which SIGILLs under valgrind. CI's valgrind job sets this to
-    // "baseline" to match the same workaround ghostty's own build.zig uses
-    // for its valgrind step (see `Config.baselineTarget()`).
-    if let Ok(cpu) = env::var("CMUX_GHOSTTY_VT_ZIG_CPU") {
-        command.arg(format!("-Dcpu={cpu}"));
-    }
+    // When compiling libghostty-vt, ensure SIMD codegen defaults to the target's
+    // baseline architecture unless an explicit CPU target is requested via
+    // CMUX_GHOSTTY_VT_ZIG_CPU. Without an explicit -Dcpu, zig's default target
+    // detection on native-architecture builds selects host-native SIMD features
+    // (such as AVX-512 on CI builders), causing SIGILL on standard x86-64 CPUs
+    // (e.g., Haswell, Zen 1-3) and under Valgrind emulation.
+    let cpu = env::var("CMUX_GHOSTTY_VT_ZIG_CPU").unwrap_or_else(|_| "baseline".to_string());
+    command.arg(format!("-Dcpu={cpu}"));
     let status = command.arg("--prefix").arg(&prefix).status().unwrap_or_else(|e| {
         panic!("failed to run `{zig} build` in {}: {e}", ghostty_dir.display())
     });


### PR DESCRIPTION
### Problem
When `ghostty-vt-sys/build.rs` compiles `libghostty-vt.a` via `zig build`, Zig defaults to `-Dcpu=native` when the target architecture matches the host architecture (e.g. x86_64 builder -> x86_64 target).

On modern CI runners equipped with AVX-512 (such as AMD Zen 4 or Intel Sapphire Rapids/Emerald Rapids), Zig's compiler-rt and bundled static routines emit AVX-512 instructions (e.g. `vmovups (%rsi), %zmm0` in `memcpy`). When the resulting binaries are distributed and executed on standard x86-64 processors that lack AVX-512 (e.g. Intel Haswell, Broadwell, Skylake client, AMD Zen 1–3, and standard cloud VPS instances), the binary immediately crashes on startup with:
```
Program received signal SIGILL, Illegal instruction.
0x0000555555be52f8 in memcpy ()
=> 0x555555be52f8 <memcpy+184>:  vmovups (%rsi),%zmm0
```

### Solution
1. **`ghostty-vt-sys/build.rs`**:
   - Always pass `-Dtarget={zig_target}` when mapping is available.
   - Default `-Dcpu` to `"baseline"` when `CMUX_GHOSTTY_VT_ZIG_CPU` is not explicitly set in the environment. This ensures static `libghostty-vt.a` artifacts use portable baseline SIMD instructions (SSE2 on x86_64, NEON on ARM64) matching standard Rust target triples.
2. **`.github/workflows/cmux-tui-build-package.yml`**:
   - Add `-Dcpu=baseline` to the standalone Windows GNU `zig build` step for parity.

### Verification
- Built on an Intel Haswell VPS lacking AVX-512 without setting any environment variables.
- Verified under `gdb` that `memcpy` in the resulting binary contains zero `%zmm` / AVX-512 instructions.
- Verified that `cmux remote-probe --json` and full startup execute cleanly without `SIGILL`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789603803&installation_model_id=21920&pr_number=10301&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10301&signature=d67076ac3ac621f90bd90b59b224fa003d767b57323d5bf36f07fed7b23f2c55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the Zig CPU target for `ghostty-vt` to baseline and always pass a known `-Dtarget`, preventing AVX-512 instructions that cause SIGILL on older x86-64 CPUs and under Valgrind. Previously Zig used host-native features (`cpu=native`) on same-arch builds; now we emit portable baseline SIMD by default.

**Review and rollout**
- `cmux-tui/crates/ghostty-vt-sys/build.rs`: Always pass `-Dtarget={zig_target}` when available; set `-Dcpu=baseline` unless `CMUX_GHOSTTY_VT_ZIG_CPU` is set. Side effect: less aggressive codegen only for the static `libghostty-vt.a` when building on AVX-512 hosts.
- `.github/workflows/cmux-tui-build-package.yml`: Add `-Dcpu=baseline` to the Windows GNU `zig build` step.
- To opt into a specific CPU, set `CMUX_GHOSTTY_VT_ZIG_CPU`; no other changes required.

<sup>Written for commit 97a684be9be4c24b5563d59605ab38b6f4e0e7d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows GNU build compatibility.
  * Enhanced support for building across different target environments.
  * Added more consistent default CPU configuration to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->