### PR TITLE
spec(tui): aggregate several machine providers in one machines column

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -51,6 +51,16 @@
 //!     "max_width": 0,
 //!     "create_sources": []
 //!   },
+//!   "machine_providers": [
+//!     {"id": "ssh", "kind": "builtin-ssh", "name": "SSH"},
+//!     {
+//!       "id": "e2b",
+//!       "kind": "command",
+//!       "name": "E2B",
+//!       "command": ["cmux-provider-e2b"],
+//!       "env_passthrough": ["E2B_API_KEY"]
+//!     }
+//!   ],
 //!   "machine_provider": {
 //!     "cloud": {
 //!       "enabled": false,
@@ -176,6 +186,8 @@ struct RawConfig {
     machine_sidebar: RawMachineSidebar,
     #[serde(default)]
     machine_provider: RawMachineProvider,
+    #[serde(default)]
+    machine_providers: Vec<crate::machine_registry::RawMachineProviderEntry>,
     #[serde(default)]
     machines: Vec<RawMachine>,
     #[serde(default)]
@@ -2535,6 +2547,9 @@ pub struct Config {
     pub sidebar: Sidebar,
     pub machine_sidebar: MachineSidebar,
     pub machine_provider: MachineProviderConfig,
+    /// Ordered providers behind the machines column. Registry position
+    /// assigns the provider slot of every machine key.
+    pub machine_providers: Vec<crate::machine_registry::MachineProviderEntry>,
     pub machines: Vec<MachineConfig>,
     pub browser: Browser,
     pub scrollbar: Scrollbar,
@@ -2903,6 +2918,10 @@ pub fn load() -> Config {
         .map(|path| path.trim().to_string())
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
+    // Resolve the registry after the cloud block, because an enabled cloud
+    // desugars into one of its entries.
+    config.machine_providers =
+        crate::machine_registry::resolve(raw.machine_providers, &config.machine_provider.cloud);
     let mut machine_ids = HashSet::new();
     for machine in raw.machines {
         let id = machine.id.trim().to_string();

--- a/cmux-tui/crates/cmux-tui/src/machine_key.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_key.rs
@@ -1,0 +1,246 @@
+//! Slot-scoped process-local machine keys.
+//!
+//! One client aggregates machines from several providers. A key must therefore
+//! identify the owning provider as well as the machine, so an action can never
+//! reach a provider that does not own its row.
+//!
+//! A key splits into a provider slot in the high [`SLOT_BITS`] bits and a
+//! per-provider ordinal in the low [`ORDINAL_BITS`] bits. Slot [`LOCAL_SLOT`]
+//! belongs to the built-in current-session entry, so the local machine keeps
+//! the first position in the column. Registry order assigns the later slots.
+//!
+//! Keys route UI actions only. They are process-local and must never be
+//! persisted or sent to a provider. Reconciliation across snapshots uses the
+//! slot together with the provider-stable id, because two providers may return
+//! the same opaque id.
+
+// The aggregator that consumes these keys lands in the next slice. The
+// namespace ships first so the key layout is fixed and tested before any
+// caller depends on it.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use crate::machine::MachineKey;
+
+/// Width of the provider slot field.
+pub const SLOT_BITS: u32 = 16;
+/// Width of the per-provider ordinal field.
+pub const ORDINAL_BITS: u32 = 64 - SLOT_BITS;
+/// Largest ordinal one provider can address.
+pub const MAX_ORDINAL: u64 = (1u64 << ORDINAL_BITS) - 1;
+/// Slot of the built-in current-session entry.
+pub const LOCAL_SLOT: ProviderSlot = ProviderSlot(0);
+
+/// Position of one provider in the resolved registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ProviderSlot(u16);
+
+impl ProviderSlot {
+    /// Builds the slot for a registry position. Returns `None` when the
+    /// registry holds more entries than the field can address.
+    pub fn from_index(index: usize) -> Option<Self> {
+        u16::try_from(index).ok().map(Self)
+    }
+
+    pub fn index(self) -> usize {
+        usize::from(self.0)
+    }
+
+    pub fn is_local(self) -> bool {
+        self == LOCAL_SLOT
+    }
+}
+
+impl MachineKey {
+    /// Builds a key from a slot and an ordinal. Returns `None` when the
+    /// ordinal does not fit, so exhaustion fails closed instead of aliasing
+    /// another provider's rows.
+    pub fn from_parts(slot: ProviderSlot, ordinal: u64) -> Option<Self> {
+        if ordinal > MAX_ORDINAL {
+            return None;
+        }
+        Some(Self((u64::from(slot.0) << ORDINAL_BITS) | ordinal))
+    }
+
+    pub fn slot(self) -> ProviderSlot {
+        ProviderSlot((self.0 >> ORDINAL_BITS) as u16)
+    }
+
+    pub fn ordinal(self) -> u64 {
+        self.0 & MAX_ORDINAL
+    }
+}
+
+/// Hands out stable keys for one provider.
+///
+/// The same provider-stable id keeps the same key for the life of the
+/// allocator, so a snapshot refresh does not move a row or invalidate a
+/// pending action. [`Self::retain`] drops the ids a provider no longer
+/// reports. An id that returns after removal receives a fresh key, and an
+/// action that still carries the removed key fails closed.
+#[derive(Debug)]
+pub struct SlotKeyAllocator {
+    slot: ProviderSlot,
+    next_ordinal: u64,
+    assigned: HashMap<String, MachineKey>,
+}
+
+impl SlotKeyAllocator {
+    pub fn new(slot: ProviderSlot) -> Self {
+        Self { slot, next_ordinal: 0, assigned: HashMap::new() }
+    }
+
+    pub fn slot(&self) -> ProviderSlot {
+        self.slot
+    }
+
+    /// Returns the key for a provider-stable id, and assigns one when the id
+    /// is new. Returns `None` only when this provider exhausted its ordinals.
+    pub fn key_for(&mut self, provider_id: &str) -> Option<MachineKey> {
+        if let Some(key) = self.assigned.get(provider_id) {
+            return Some(*key);
+        }
+        let key = MachineKey::from_parts(self.slot, self.next_ordinal)?;
+        self.next_ordinal += 1;
+        self.assigned.insert(provider_id.to_string(), key);
+        Some(key)
+    }
+
+    /// Looks a key up without assigning one.
+    pub fn peek(&self, provider_id: &str) -> Option<MachineKey> {
+        self.assigned.get(provider_id).copied()
+    }
+
+    /// Drops every id the provider no longer reports, so a long session with
+    /// machine churn cannot grow the map without bound.
+    pub fn retain<F>(&mut self, mut live: F)
+    where
+        F: FnMut(&str) -> bool,
+    {
+        self.assigned.retain(|id, _| live(id.as_str()));
+    }
+
+    #[cfg(test)]
+    pub fn tracked(&self) -> usize {
+        self.assigned.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_key_round_trips_slot_and_ordinal() {
+        let slot = ProviderSlot::from_index(3).expect("slot");
+        let key = MachineKey::from_parts(slot, 42).expect("key");
+        assert_eq!(key.slot(), slot);
+        assert_eq!(key.ordinal(), 42);
+    }
+
+    #[test]
+    fn machine_key_separates_equal_ordinals_in_different_slots() {
+        let first = ProviderSlot::from_index(1).expect("slot");
+        let second = ProviderSlot::from_index(2).expect("slot");
+        let left = MachineKey::from_parts(first, 7).expect("key");
+        let right = MachineKey::from_parts(second, 7).expect("key");
+        assert_ne!(left, right);
+        assert_eq!(left.ordinal(), right.ordinal());
+        assert_ne!(left.slot(), right.slot());
+    }
+
+    #[test]
+    fn machine_key_rejects_an_ordinal_that_would_reach_the_next_slot() {
+        let slot = ProviderSlot::from_index(1).expect("slot");
+        assert!(MachineKey::from_parts(slot, MAX_ORDINAL).is_some());
+        assert!(MachineKey::from_parts(slot, MAX_ORDINAL + 1).is_none());
+    }
+
+    #[test]
+    fn local_slot_holds_the_first_position() {
+        assert!(LOCAL_SLOT.is_local());
+        assert_eq!(ProviderSlot::from_index(0), Some(LOCAL_SLOT));
+        assert!(!ProviderSlot::from_index(1).expect("slot").is_local());
+    }
+
+    #[test]
+    fn provider_slot_rejects_an_index_beyond_the_field() {
+        assert!(ProviderSlot::from_index(usize::from(u16::MAX)).is_some());
+        assert!(ProviderSlot::from_index(usize::from(u16::MAX) + 1).is_none());
+    }
+
+    #[test]
+    fn allocator_keeps_one_key_for_one_provider_id() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(2).expect("slot"));
+        let first = allocator.key_for("sandbox-a").expect("key");
+        let again = allocator.key_for("sandbox-a").expect("key");
+        assert_eq!(first, again);
+        assert_eq!(allocator.tracked(), 1);
+    }
+
+    #[test]
+    fn allocator_gives_every_id_its_own_key_inside_one_slot() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(2).expect("slot"));
+        let first = allocator.key_for("sandbox-a").expect("key");
+        let second = allocator.key_for("sandbox-b").expect("key");
+        assert_ne!(first, second);
+        assert_eq!(first.slot(), second.slot());
+    }
+
+    #[test]
+    fn allocator_stamps_every_key_with_its_own_slot() {
+        let slot = ProviderSlot::from_index(5).expect("slot");
+        let mut allocator = SlotKeyAllocator::new(slot);
+        let key = allocator.key_for("sandbox-a").expect("key");
+        assert_eq!(key.slot(), slot);
+        assert_eq!(allocator.slot(), slot);
+    }
+
+    #[test]
+    fn two_providers_may_share_a_stable_id_without_colliding() {
+        let mut left = SlotKeyAllocator::new(ProviderSlot::from_index(1).expect("slot"));
+        let mut right = SlotKeyAllocator::new(ProviderSlot::from_index(2).expect("slot"));
+        let from_left = left.key_for("default").expect("key");
+        let from_right = right.key_for("default").expect("key");
+        assert_ne!(from_left, from_right);
+    }
+
+    #[test]
+    fn peek_does_not_assign_a_key() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(1).expect("slot"));
+        assert_eq!(allocator.peek("sandbox-a"), None);
+        assert_eq!(allocator.tracked(), 0);
+        let key = allocator.key_for("sandbox-a").expect("key");
+        assert_eq!(allocator.peek("sandbox-a"), Some(key));
+    }
+
+    #[test]
+    fn retain_drops_ids_the_provider_stopped_reporting() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(1).expect("slot"));
+        let kept = allocator.key_for("kept").expect("key");
+        allocator.key_for("removed").expect("key");
+        assert_eq!(allocator.tracked(), 2);
+        allocator.retain(|id| id == "kept");
+        assert_eq!(allocator.tracked(), 1);
+        assert_eq!(allocator.peek("kept"), Some(kept));
+        assert_eq!(allocator.peek("removed"), None);
+    }
+
+    #[test]
+    fn a_returning_id_does_not_reuse_the_removed_key() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(1).expect("slot"));
+        let original = allocator.key_for("flaky").expect("key");
+        allocator.retain(|_| false);
+        let replacement = allocator.key_for("flaky").expect("key");
+        assert_ne!(original, replacement);
+    }
+
+    #[test]
+    fn allocator_fails_closed_when_one_provider_exhausts_its_ordinals() {
+        let mut allocator = SlotKeyAllocator::new(ProviderSlot::from_index(1).expect("slot"));
+        allocator.next_ordinal = MAX_ORDINAL;
+        assert!(allocator.key_for("last").is_some());
+        assert!(allocator.key_for("overflow").is_none());
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/machine_registry.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_registry.rs
@@ -212,7 +212,9 @@ fn resolve_entry(raw: RawMachineProviderEntry) -> Option<MachineProviderEntry> {
             if other.is_empty() {
                 eprintln!("cmux-tui: ignoring machine_providers[{id}] because it has no kind");
             } else {
-                eprintln!("cmux-tui: ignoring machine_providers[{id}] with unknown kind \"{other}\"");
+                eprintln!(
+                    "cmux-tui: ignoring machine_providers[{id}] with unknown kind \"{other}\""
+                );
             }
             return None;
         }

--- a/cmux-tui/crates/cmux-tui/src/machine_registry.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_registry.rs
@@ -1,0 +1,451 @@
+//! The ordered registry of machine providers.
+//!
+//! One client shows machines from several providers in one column. The
+//! registry fixes their order, and that order assigns the provider slot of
+//! every key in [`crate::machine_key`]. Slot 0 belongs to the current session,
+//! so the first registry entry takes slot 1.
+//!
+//! A legacy configuration keeps working without an edit. The built-in SSH
+//! entry always exists and owns the `machines` array, and an enabled
+//! `machine_provider.cloud` becomes an SSH entry. Explicit
+//! `machine_providers` entries come first, and a desugared entry is appended
+//! only when its id is still free, so an explicit entry can replace it.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::config::CloudProviderConfig;
+use crate::machine_key::ProviderSlot;
+
+/// Id of the entry that owns the static SSH and Unix catalog.
+pub const BUILTIN_SSH_ID: &str = "ssh";
+/// Id of the entry desugared from `machine_provider.cloud`.
+pub const CLOUD_ID: &str = "cloud";
+
+const MAX_ID_LEN: usize = 64;
+
+/// Registry entry before validation.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawMachineProviderEntry {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    pub socket: Option<String>,
+    pub command: Option<Vec<String>>,
+    pub env_passthrough: Option<Vec<String>>,
+    pub host: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<u16>,
+    pub identity_file: Option<String>,
+}
+
+/// One provider in the resolved registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MachineProviderEntry {
+    pub id: String,
+    pub name: String,
+    pub kind: MachineProviderKind,
+}
+
+/// How the client reaches one provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MachineProviderKind {
+    /// The static catalog, in process.
+    BuiltinSsh,
+    Unix {
+        socket: PathBuf,
+    },
+    Command {
+        command: Vec<String>,
+        /// Names of environment variables the provider process inherits.
+        /// Values never appear in configuration.
+        env_passthrough: Vec<String>,
+    },
+    Ssh {
+        host: String,
+        user: Option<String>,
+        port: Option<u16>,
+        identity_file: Option<PathBuf>,
+    },
+}
+
+impl MachineProviderKind {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::BuiltinSsh => "builtin-ssh",
+            Self::Unix { .. } => "unix",
+            Self::Command { .. } => "command",
+            Self::Ssh { .. } => "ssh",
+        }
+    }
+}
+
+/// Returns the slot of the registry entry at `index`. Slot 0 stays with the
+/// current session, so the first entry takes slot 1. Returns `None` when the
+/// registry holds more entries than the slot field can address.
+pub fn provider_slot(index: usize) -> Option<ProviderSlot> {
+    ProviderSlot::from_index(index.checked_add(1)?)
+}
+
+/// Largest registry the slot field can address.
+pub fn max_providers() -> usize {
+    usize::from(u16::MAX)
+}
+
+fn valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_ID_LEN
+        && id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+}
+
+fn valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn trimmed(value: Option<String>) -> Option<String> {
+    value.map(|value| value.trim().to_string()).filter(|value| !value.is_empty())
+}
+
+/// Reports fields that do not belong to the selected kind, so a misplaced key
+/// is visible instead of silently inert.
+fn warn_unused_fields(id: &str, kind: &str, raw: &RawMachineProviderEntry, used: &[&str]) {
+    let present: [(&str, bool); 7] = [
+        ("socket", raw.socket.is_some()),
+        ("command", raw.command.is_some()),
+        ("env_passthrough", raw.env_passthrough.is_some()),
+        ("host", raw.host.is_some()),
+        ("user", raw.user.is_some()),
+        ("port", raw.port.is_some()),
+        ("identity_file", raw.identity_file.is_some()),
+    ];
+    for (field, is_present) in present {
+        if is_present && !used.contains(&field) {
+            eprintln!(
+                "cmux-tui: ignoring machine_providers[{id}].{field}, which does not apply to kind \"{kind}\""
+            );
+        }
+    }
+}
+
+fn resolve_entry(raw: RawMachineProviderEntry) -> Option<MachineProviderEntry> {
+    let id = trimmed(raw.id.clone()).unwrap_or_default();
+    if !valid_id(&id) {
+        eprintln!(
+            "cmux-tui: ignoring a machine_providers entry whose id is missing or invalid; use lowercase letters, digits, \"-\", and \"_\""
+        );
+        return None;
+    }
+    let kind_name = trimmed(raw.kind.clone()).unwrap_or_default();
+    let kind = match kind_name.as_str() {
+        "builtin-ssh" => {
+            warn_unused_fields(&id, &kind_name, &raw, &[]);
+            MachineProviderKind::BuiltinSsh
+        }
+        "unix" => {
+            warn_unused_fields(&id, &kind_name, &raw, &["socket"]);
+            let socket = trimmed(raw.socket.clone()).map(PathBuf::from)?;
+            if !socket.is_absolute() {
+                eprintln!(
+                    "cmux-tui: ignoring machine_providers[{id}] because its socket is not an absolute path"
+                );
+                return None;
+            }
+            MachineProviderKind::Unix { socket }
+        }
+        "command" => {
+            warn_unused_fields(&id, &kind_name, &raw, &["command", "env_passthrough"]);
+            let command: Vec<String> = raw
+                .command
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|part| part.trim().to_string())
+                .collect();
+            if command.first().map(String::is_empty).unwrap_or(true) {
+                eprintln!(
+                    "cmux-tui: ignoring machine_providers[{id}] because its command has no program"
+                );
+                return None;
+            }
+            let mut env_passthrough = Vec::new();
+            for name in raw.env_passthrough.clone().unwrap_or_default() {
+                let name = name.trim().to_string();
+                if valid_env_name(&name) {
+                    env_passthrough.push(name);
+                } else {
+                    eprintln!(
+                        "cmux-tui: ignoring an invalid machine_providers[{id}].env_passthrough name"
+                    );
+                }
+            }
+            MachineProviderKind::Command { command, env_passthrough }
+        }
+        "ssh" => {
+            warn_unused_fields(&id, &kind_name, &raw, &["host", "user", "port", "identity_file"]);
+            let Some(host) = trimmed(raw.host.clone()) else {
+                eprintln!("cmux-tui: ignoring machine_providers[{id}] because its host is empty");
+                return None;
+            };
+            let port = match raw.port {
+                Some(0) => {
+                    eprintln!("cmux-tui: ignoring zero machine_providers[{id}].port");
+                    None
+                }
+                port => port,
+            };
+            MachineProviderKind::Ssh {
+                host,
+                user: trimmed(raw.user.clone()),
+                port,
+                identity_file: trimmed(raw.identity_file.clone()).map(PathBuf::from),
+            }
+        }
+        other => {
+            if other.is_empty() {
+                eprintln!("cmux-tui: ignoring machine_providers[{id}] because it has no kind");
+            } else {
+                eprintln!("cmux-tui: ignoring machine_providers[{id}] with unknown kind \"{other}\"");
+            }
+            return None;
+        }
+    };
+    let name = trimmed(raw.name).unwrap_or_else(|| id.clone());
+    Some(MachineProviderEntry { id, name, kind })
+}
+
+/// Builds the ordered registry from explicit entries and the legacy keys.
+pub fn resolve(
+    raw: Vec<RawMachineProviderEntry>,
+    cloud: &CloudProviderConfig,
+) -> Vec<MachineProviderEntry> {
+    let mut entries: Vec<MachineProviderEntry> = Vec::new();
+    let mut ids: HashSet<String> = HashSet::new();
+    for entry in raw.into_iter().filter_map(resolve_entry) {
+        if !ids.insert(entry.id.clone()) {
+            eprintln!("cmux-tui: ignoring duplicate machine_providers id \"{}\"", entry.id);
+            continue;
+        }
+        entries.push(entry);
+    }
+
+    // Truncate the explicit entries before the desugared ones are appended, so
+    // an oversized registry cannot push the static catalog out. That catalog
+    // also carries the current session and the SSH host discovery the footer
+    // needs, so it must always survive.
+    let explicit_capacity = max_providers() - 1;
+    if entries.len() > explicit_capacity {
+        eprintln!(
+            "cmux-tui: ignoring machine_providers entries after the first {explicit_capacity}"
+        );
+        entries.truncate(explicit_capacity);
+        ids = entries.iter().map(|entry| entry.id.clone()).collect();
+    }
+
+    if ids.insert(BUILTIN_SSH_ID.to_string()) {
+        entries.push(MachineProviderEntry {
+            id: BUILTIN_SSH_ID.to_string(),
+            name: "SSH".to_string(),
+            kind: MachineProviderKind::BuiltinSsh,
+        });
+    }
+
+    if cloud.enabled && entries.len() < max_providers() && ids.insert(CLOUD_ID.to_string()) {
+        entries.push(MachineProviderEntry {
+            id: CLOUD_ID.to_string(),
+            name: "cmux Cloud".to_string(),
+            kind: MachineProviderKind::Ssh {
+                host: cloud.host.clone(),
+                user: cloud.user.clone(),
+                port: cloud.port,
+                identity_file: cloud.identity_file.clone(),
+            },
+        });
+    }
+
+    debug_assert!(entries.len() <= max_providers());
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cloud(enabled: bool) -> CloudProviderConfig {
+        CloudProviderConfig { enabled, ..CloudProviderConfig::default() }
+    }
+
+    fn raw(id: &str, kind: &str) -> RawMachineProviderEntry {
+        RawMachineProviderEntry {
+            id: Some(id.to_string()),
+            kind: Some(kind.to_string()),
+            ..RawMachineProviderEntry::default()
+        }
+    }
+
+    fn ids(entries: &[MachineProviderEntry]) -> Vec<&str> {
+        entries.iter().map(|entry| entry.id.as_str()).collect()
+    }
+
+    #[test]
+    fn an_empty_configuration_still_provides_the_static_catalog() {
+        let entries = resolve(Vec::new(), &cloud(false));
+        assert_eq!(ids(&entries), vec![BUILTIN_SSH_ID]);
+        assert_eq!(entries[0].kind, MachineProviderKind::BuiltinSsh);
+    }
+
+    #[test]
+    fn enabled_cloud_desugars_into_an_ssh_entry_after_the_static_catalog() {
+        let entries = resolve(Vec::new(), &cloud(true));
+        assert_eq!(ids(&entries), vec![BUILTIN_SSH_ID, CLOUD_ID]);
+        let MachineProviderKind::Ssh { host, .. } = &entries[1].kind else {
+            panic!("cloud must desugar to an ssh entry");
+        };
+        assert_eq!(host, &cloud(true).host);
+    }
+
+    #[test]
+    fn explicit_entries_keep_their_order_and_precede_desugared_ones() {
+        let mut command = raw("e2b", "command");
+        command.command = Some(vec!["cmux-provider-e2b".into()]);
+        let mut unix = raw("lab", "unix");
+        unix.socket = Some("/run/cmux/provider.sock".into());
+        let entries = resolve(vec![command, unix], &cloud(true));
+        assert_eq!(ids(&entries), vec!["e2b", "lab", BUILTIN_SSH_ID, CLOUD_ID]);
+    }
+
+    #[test]
+    fn an_explicit_entry_replaces_the_desugared_one_with_the_same_id() {
+        let mut explicit = raw(CLOUD_ID, "ssh");
+        explicit.host = Some("edge.example.com".into());
+        let entries = resolve(vec![explicit], &cloud(true));
+        assert_eq!(ids(&entries), vec![CLOUD_ID, BUILTIN_SSH_ID]);
+        let MachineProviderKind::Ssh { host, .. } = &entries[0].kind else {
+            panic!("expected the explicit ssh entry");
+        };
+        assert_eq!(host, "edge.example.com");
+    }
+
+    #[test]
+    fn a_duplicate_id_keeps_only_the_first_entry() {
+        let mut first = raw("dup", "ssh");
+        first.host = Some("first.example.com".into());
+        let mut second = raw("dup", "ssh");
+        second.host = Some("second.example.com".into());
+        let entries = resolve(vec![first, second], &cloud(false));
+        assert_eq!(ids(&entries), vec!["dup", BUILTIN_SSH_ID]);
+        let MachineProviderKind::Ssh { host, .. } = &entries[0].kind else {
+            panic!("expected an ssh entry");
+        };
+        assert_eq!(host, "first.example.com");
+    }
+
+    #[test]
+    fn an_entry_without_a_usable_id_is_dropped() {
+        assert!(resolve_entry(raw("", "builtin-ssh")).is_none());
+        assert!(resolve_entry(raw("Upper", "builtin-ssh")).is_none());
+        assert!(resolve_entry(raw("has space", "builtin-ssh")).is_none());
+        assert!(resolve_entry(raw(&"a".repeat(MAX_ID_LEN + 1), "builtin-ssh")).is_none());
+        assert!(resolve_entry(raw(&"a".repeat(MAX_ID_LEN), "builtin-ssh")).is_some());
+    }
+
+    #[test]
+    fn an_unknown_or_missing_kind_is_dropped() {
+        assert!(resolve_entry(raw("x", "docker")).is_none());
+        assert!(resolve_entry(raw("x", "")).is_none());
+    }
+
+    #[test]
+    fn a_unix_entry_requires_an_absolute_socket() {
+        let mut relative = raw("lab", "unix");
+        relative.socket = Some("provider.sock".into());
+        assert!(resolve_entry(relative).is_none());
+        let mut absolute = raw("lab", "unix");
+        absolute.socket = Some("/run/cmux/provider.sock".into());
+        assert!(resolve_entry(absolute).is_some());
+        assert!(resolve_entry(raw("lab", "unix")).is_none());
+    }
+
+    #[test]
+    fn a_command_entry_requires_a_program() {
+        assert!(resolve_entry(raw("e2b", "command")).is_none());
+        let mut empty = raw("e2b", "command");
+        empty.command = Some(vec!["   ".into()]);
+        assert!(resolve_entry(empty).is_none());
+        let mut valid = raw("e2b", "command");
+        valid.command = Some(vec!["cmux-provider-e2b".into(), "--profile".into()]);
+        let resolved = resolve_entry(valid).expect("entry");
+        let MachineProviderKind::Command { command, .. } = resolved.kind else {
+            panic!("expected a command entry");
+        };
+        assert_eq!(command, vec!["cmux-provider-e2b", "--profile"]);
+    }
+
+    #[test]
+    fn env_passthrough_keeps_only_valid_variable_names() {
+        let mut entry = raw("e2b", "command");
+        entry.command = Some(vec!["cmux-provider-e2b".into()]);
+        entry.env_passthrough =
+            Some(vec!["E2B_API_KEY".into(), "_ok9".into(), "9bad".into(), "BAD=VALUE".into()]);
+        let resolved = resolve_entry(entry).expect("entry");
+        let MachineProviderKind::Command { env_passthrough, .. } = resolved.kind else {
+            panic!("expected a command entry");
+        };
+        assert_eq!(env_passthrough, vec!["E2B_API_KEY", "_ok9"]);
+    }
+
+    #[test]
+    fn an_ssh_entry_requires_a_host_and_drops_a_zero_port() {
+        assert!(resolve_entry(raw("cloud", "ssh")).is_none());
+        let mut entry = raw("cloud", "ssh");
+        entry.host = Some("edge.example.com".into());
+        entry.port = Some(0);
+        entry.user = Some("  ".into());
+        let resolved = resolve_entry(entry).expect("entry");
+        let MachineProviderKind::Ssh { host, user, port, .. } = resolved.kind else {
+            panic!("expected an ssh entry");
+        };
+        assert_eq!(host, "edge.example.com");
+        assert_eq!(user, None);
+        assert_eq!(port, None);
+    }
+
+    #[test]
+    fn a_missing_name_falls_back_to_the_id() {
+        let mut entry = raw("e2b", "command");
+        entry.command = Some(vec!["cmux-provider-e2b".into()]);
+        assert_eq!(resolve_entry(entry).expect("entry").name, "e2b");
+    }
+
+    #[test]
+    fn the_first_registry_entry_takes_the_slot_after_the_current_session() {
+        assert_eq!(provider_slot(0), ProviderSlot::from_index(1));
+        assert!(!provider_slot(0).expect("slot").is_local());
+        assert_eq!(provider_slot(max_providers() - 1), ProviderSlot::from_index(max_providers()));
+        assert_eq!(provider_slot(max_providers()), None);
+    }
+
+    #[test]
+    fn a_registry_larger_than_the_slot_field_keeps_the_static_catalog() {
+        let raw_entries: Vec<RawMachineProviderEntry> = (0..max_providers() + 2)
+            .map(|index| {
+                let mut entry = raw(&format!("p{index}"), "unix");
+                entry.socket = Some("/run/cmux/provider.sock".into());
+                entry
+            })
+            .collect();
+        let entries = resolve(raw_entries, &cloud(true));
+        assert_eq!(entries.len(), max_providers());
+        assert!(provider_slot(entries.len() - 1).is_some());
+        // The static catalog survives, and the cloud entry is the one dropped.
+        assert_eq!(entries.last().expect("entry").id, BUILTIN_SSH_ID);
+        assert!(!entries.iter().any(|entry| entry.id == CLOUD_ID));
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -18,6 +18,7 @@ mod keys;
 mod layout_undo;
 mod localization;
 mod machine;
+mod machine_key;
 #[cfg(unix)]
 mod machine_agent;
 mod machine_provider_client;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -18,9 +18,9 @@ mod keys;
 mod layout_undo;
 mod localization;
 mod machine;
-mod machine_key;
 #[cfg(unix)]
 mod machine_agent;
+mod machine_key;
 mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -24,6 +24,7 @@ mod machine_key;
 mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;
+mod machine_registry;
 mod machine_runtime;
 mod plugin_manager;
 mod process_diagnostics;

--- a/cmux-tui/spec/machine-provider-aggregation.md
+++ b/cmux-tui/spec/machine-provider-aggregation.md
@@ -1,0 +1,176 @@
+# Machine Provider Aggregation
+
+This document specifies how one cmux-tui client presents machines from several
+providers in the machines column at the same time. It extends
+[Machine Provider Contract](machine-provider.md).
+
+## Problem
+
+The machines column is the leftmost native rail, and `sidebar.views` selects it
+by default. The catalog behind that column supports exactly one source. The
+client rejects more than one of `--machine-provider`,
+`--machine-provider-command`, and `--cloud`, and it refuses a static `machines`
+array together with a socket or command provider. The only composition that
+exists is a special case that stacks the static v0 catalog over one v1 cloud
+catalog, using a hardcoded key split at `2^63`.
+
+A user with SSH remotes and several sandbox vendors therefore has to choose one
+source per launch.
+
+## Scope
+
+Aggregation is a client concern. The wire contract does not change: every
+provider still speaks `machine-provider-v1`, negotiates its own version, and
+owns its own bearer. This document adds a client-side registry, a key
+namespace, per-provider failure isolation, and provider-scoped capabilities. A
+provider written against the existing contract works unchanged under an
+aggregating client.
+
+## Provider registry
+
+`~/.config/cmux/cmux-tui.json` gains an ordered `machine_providers` array:
+
+```json
+{
+  "machine_providers": [
+    {"id": "ssh", "kind": "builtin-ssh", "name": "SSH"},
+    {"id": "cloud", "kind": "ssh", "name": "cmux Cloud", "host": "cmux.cloud"},
+    {
+      "id": "e2b",
+      "kind": "command",
+      "name": "E2B",
+      "command": ["cmux-provider-e2b"],
+      "env_passthrough": ["E2B_API_KEY"]
+    },
+    {"id": "lab", "kind": "unix", "socket": "/run/cmux/provider.sock"}
+  ]
+}
+```
+
+`id` is stable, matches `[a-z0-9-_]+`, and must be unique. It names the provider
+in state paths and diagnostics. `kind` is one of `builtin-ssh`, `unix`,
+`command`, or `ssh`, matching the existing connectors.
+
+`env_passthrough` is an allowlist of variable names, never values. A provider
+process starts with a minimal environment plus exactly those inherited
+variables. API keys stay in the user's environment or in the provider's own
+credential file. They never enter `cmux-tui.json`, the client, or diagnostics.
+
+Compatibility: an enabled `machine_provider.cloud` desugars into one `kind:
+"ssh"` entry with id `cloud`. A `machines` array desugars into the
+`builtin-ssh` provider. `--machine-provider`, `--machine-provider-command`, and
+`--cloud` each append one process-local entry instead of selecting the single
+mode, so the mutual-exclusion error is removed. Explicit `machine_providers`
+plus legacy keys is an error, because the intended order would be ambiguous.
+
+## Key namespace
+
+`MachineKey` stays a process-local `u64` that is never persisted. Its layout
+becomes a slot in the high 16 bits and a per-provider ordinal in the low 48
+bits. Slot 0 is reserved for the built-in current-session entry, so the local
+machine keeps its position at the top of the column. Slots 1 upward follow
+registry order. This replaces the `2^63` overlay split.
+
+Reconciliation across snapshots uses the pair of slot and provider-stable id.
+Two providers may return the same opaque id, and the slot keeps them distinct.
+
+## Isolation
+
+Each registry entry owns one control generation, one bearer, one connector, and
+one private SSH control directory. Failure is contained:
+
+- A provider that cannot connect renders its own group with an error row. Other
+  groups still render, and the client still attaches machines from them.
+- `snapshot_changed` invalidates only the emitting provider. The aggregator
+  refetches that provider's snapshot and leaves the others untouched.
+- A control timeout, a disconnect, or a decode failure drops one generation.
+  The aggregator retries that entry with a bounded backoff.
+- One slow provider must not delay the first paint. The column renders each
+  group as it arrives.
+
+## Capabilities and actions
+
+Capabilities are per provider today but are read as if they were global. The
+aggregator scopes them: capability checks, provider actions, scopes, and
+lifecycle mutations resolve through the slot of the row they act on. The footer
+shows the union of enabled creation and connection actions, and each entry
+routes to its own provider. An action from one provider can never be sent to
+another.
+
+Exactly one machine is attached at a time, because `RemoteSession` is single.
+The aggregator holds one active key, so at most one provider has an active
+machine.
+
+## Presentation
+
+The column groups rows by provider, in registry order, with the provider `name`
+as a group header. A registry with one entry renders without a header, so a
+single-provider setup looks exactly as it does today. Group headers collapse.
+Rows keep the existing status, subtitle, and rename behavior.
+
+## SSH as a provider
+
+The static v0 catalog becomes a built-in provider behind the same client-side
+trait as the wire client, so the aggregator has one code path. It keeps
+`~/.ssh/config` discovery including `Include` following, keeps wildcard and
+negated pattern omission, keeps process-local temporary targets, and implements
+the footer through `connect_external_machine`. It does not serialize to JSON,
+because it runs in process.
+
+The v0 name is retained in [Machine Provider Contract](machine-provider.md) for
+the historical record. After this change there is one provider abstraction.
+
+## State ownership
+
+Session state lives in the sandbox. `open_machine` returns a one-use ticket, and
+that transport becomes an ordinary protocol-v12 stream for `RemoteSession`, so
+the headless mux runs on the machine and owns its workspaces, panes, scrollback,
+and journal. A provider that can attach persistent storage must place the mux
+`--state-dir` on it, so a stop and start preserves the journal.
+
+Catalog state lives in the vendor. A provider derives its snapshot from the
+vendor's list operation on every refresh, and it tags the sandboxes it creates
+through vendor metadata or labels. It must filter to its own tag, and it must
+never act on an untagged row, because those accounts hold sandboxes owned by
+other work.
+
+Tombstones are the one exception and already exist in the contract. When a
+vendor reclaims a sandbox, the machine becomes recoverable rather than absent,
+through `machine_lifecycle_snapshot`, `restore_machine`, and `purge_machine`.
+That record is the only client-side state, and it lives under
+`~/.local/state/cmux/machine-providers/<id>/`.
+
+Credentials live in the provider process only.
+
+## Guest requirement
+
+A machine is connectable only when it runs a cmux-tui whose protocol matches the
+client. A provider satisfies this in one of two ways:
+
+1. It bakes the pinned cmux-tui into its vendor template, snapshot, or image.
+   This is the fast path, and the image tag moves with each cmux release.
+2. It falls back to the existing probe. `remote-probe --json` reports a missing
+   or incompatible binary, and `SshBootstrapConfig` installs the pinned npm
+   build at `~/.local/bin/cmux-tui`. Installation is gated on
+   `CMUX_TUI_NPM_BOOTSTRAP_VERSION`, so packaged releases self-install and
+   source builds refuse.
+
+A provider reports a machine whose guest cannot be made compatible as
+`unavailable` with a subtitle, instead of failing at attach time.
+
+## Distribution
+
+`cmux-plugin.toml` accepts `kind = "machine-provider"` in addition to
+`kind = "sidebar"`. Install, name validation, build, and the executable check are
+unchanged. A machine-provider install writes its resolved absolute command into
+a `machine_providers` entry instead of `sidebar.plugin`. One manifest format and
+one installer then cover both plugin kinds.
+
+## Security
+
+A provider process is a trust boundary. The client passes it no cmux
+credentials, no other provider's bearer, and no environment beyond the
+allowlist. Bearer values, external-machine specifiers, and mux authorities stay
+redacted in diagnostics, per the base contract. A provider cannot enumerate or
+address another provider's machines, because keys are slot-scoped and every
+request routes through the owning entry.


### PR DESCRIPTION
## Summary

The machines column is already the leftmost native rail, but its catalog supports exactly one source. `main.rs` rejects more than one of `--machine-provider`, `--machine-provider-command`, and `--cloud`, and it refuses a static `machines` array beside a socket or command provider. The only composition that exists stacks the static v0 catalog over one v1 cloud catalog with a hardcoded `2^63` key split. So SSH remotes and sandbox suppliers cannot appear together.

The wire contract does not change. Every provider still speaks `machine-provider-v1`, negotiates its own version, and owns its own bearer, so a provider written against the existing contract works unchanged. Aggregation is a client concern.

## What has landed

**Specification** — `cmux-tui/spec/machine-provider-aggregation.md` describes the registry, the key namespace, per-provider isolation and capability scoping, the port of the static SSH catalog onto the same abstraction, the `machine-provider` plugin manifest kind, and where sandbox state lives.

**Slice 1a, the key namespace** — `machine_key.rs` splits `MachineKey` into a 16-bit provider slot and a 48-bit per-provider ordinal, replacing the `2^63` split. Slot 0 stays the current session. A per-provider allocator keeps one key for one provider-stable id across snapshot refreshes, so a refresh cannot move a row or invalidate a pending action. It fails closed on ordinal exhaustion and on a registry larger than the slot field, rather than alias another provider's rows.

**Slice 1b, the registry** — `machine_registry.rs` resolves an ordered `machine_providers` array with `builtin-ssh`, `unix`, `command`, and `ssh` kinds. `env_passthrough` lists variable names only, so an API key stays in the provider process and never enters `cmux-tui.json`. A legacy configuration keeps working with no edit: the built-in SSH entry always exists, and an enabled `machine_provider.cloud` desugars into an `ssh` entry. Explicit entries come first and can replace a desugared one by reusing its id. Truncation of an oversized registry happens before the desugared entries are appended, so it cannot push the static catalog out.

## Verification

`./scripts/verify-cmux-tui-hosted.sh --filter machine_` passes on hosted Linux and macOS. 13 `machine_key` tests and 14 `machine_registry` tests run there.

## Do not merge yet

Nothing consumes the registry yet, so `machine_providers` parses without an effect. The aggregator lands in the next slice and removes the `allow(dead_code)` on `machine_key`. `docs/configuration.md` deliberately does not document the key until it does something. This stays a draft until then.

## Remaining slices

2. Per-provider generations, isolation, and capability scoping in `machine_provider_runtime.rs`. This is the real refactor and the point where the registry starts to matter.
3. Port the static SSH catalog onto the provider trait.
4. `kind = "machine-provider"` in `cmux-plugin.toml`, reusing the existing installer.
5. The first supplier provider.