### PR TITLE
Make the topology own tab identity

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/model.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/model.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::resource::{
     ContentPublicId, PanePublicId, PublicSlotIndexes, ScreenPublicId, TabPublicId,
-    TerminalPublicId, WorkspacePublicId,
+    TabResourceIdentity, TerminalPublicId, WorkspacePublicId,
 };
 use crate::{PaneId, ScreenId, SplitDir, SplitId, Surface, SurfaceId, WorkspaceId};
 
@@ -941,6 +941,43 @@ impl State {
         }
     }
 
+    /// Record the durable identity of one tab slot. This is the only writer
+    /// of tab identity, so a slot can never disagree with the topology it is
+    /// placed in.
+    pub(crate) fn register_tab_identity(
+        &mut self,
+        slot: SurfaceId,
+        identity: &TabResourceIdentity,
+    ) {
+        self.resource_indexes.tabs.insert(identity.tab_id.clone(), slot);
+        self.resource_indexes.tab_ids.insert(slot, identity.tab_id.clone());
+        let placements = self
+            .resource_indexes
+            .content_placements
+            .entry(identity.content_id.clone())
+            .or_default();
+        if !placements.contains(&slot) {
+            placements.push(slot);
+        }
+        self.resource_indexes.content_ids.insert(slot, identity.content_id.clone());
+    }
+
+    /// Every placed tab must carry a durable identity. Losing one would make
+    /// the next projection tombstone live durable rows, so this fails the
+    /// mutation instead of silently dropping the tab.
+    pub(crate) fn ensure_tab_identity_coverage(&self) -> anyhow::Result<()> {
+        for pane in self.panes.values() {
+            for slot in &pane.tabs {
+                anyhow::ensure!(
+                    self.resource_indexes.tab_ids.contains_key(slot)
+                        && self.resource_indexes.content_ids.contains_key(slot),
+                    "tab slot {slot} has no durable identity"
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn rebuild_resource_indexes(&mut self) {
         let mut indexes = PublicSlotIndexes::default();
         let mut live_split_slots = self.split_screens.keys().copied().collect::<HashSet<_>>();
@@ -961,20 +998,15 @@ impl State {
                         indexes.pane_ids.insert(pane.id, pane.public_id.clone());
                         indexes.pane_screen.insert(pane.id, screen.id);
                         for surface_id in &pane.tabs {
-                            let identity = self
-                                .surfaces
-                                .get(surface_id)
-                                .and_then(|surface| surface.resource_identity())
-                                .map(|identity| {
-                                    (identity.tab_id.clone(), identity.content_id.clone())
-                                })
-                                .or_else(|| {
-                                    Some((
-                                        self.resource_indexes.tab_ids.get(surface_id)?.clone(),
-                                        self.resource_indexes.content_ids.get(surface_id)?.clone(),
-                                    ))
-                                });
-                            let Some((tab_id, content_id)) = identity else { continue };
+                            // Tab identity is owned by the topology, never by
+                            // the live surface. A restored or detached tab has
+                            // no surface, and rebuilding must not lose it.
+                            let (Some(tab_id), Some(content_id)) = (
+                                self.resource_indexes.tab_ids.get(surface_id).cloned(),
+                                self.resource_indexes.content_ids.get(surface_id).cloned(),
+                            ) else {
+                                continue;
+                            };
                             let old = indexes.tabs.insert(tab_id.clone(), *surface_id);
                             debug_assert!(old.is_none(), "duplicate tab public id");
                             indexes.tab_ids.insert(*surface_id, tab_id);

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -11662,6 +11662,9 @@ impl Mux {
                     pane.active_tab = pane.tabs.len() - 1;
                     pane.active_at = active_at;
                     fence_layout_undo_for_tab_membership(&mut state, &[pane_id]);
+                    if let Some(identity) = surface.resource_identity().cloned() {
+                        state.register_tab_identity(surface.id, &identity);
+                    }
                     state.surfaces.insert(surface.id, surface.clone());
                     let delta = (|| {
                         let (wi, si) = state.screen_of(pane_id)?;
@@ -15136,6 +15139,12 @@ fn insert_surface_checked(state: &mut State, surface: Arc<Surface>) -> anyhow::R
         );
     }
     register_terminal_runtime_checked(state, &surface)?;
+    // Surface insertion is the only way a tab placement enters live state, so
+    // it is also where the topology takes ownership of that tab's identity.
+    // Every later reader takes identity from the topology, never from here.
+    if let Some(identity) = surface.resource_identity().cloned() {
+        state.register_tab_identity(surface.id, &identity);
+    }
     state.surfaces.insert(surface.id, surface);
     Ok(())
 }
@@ -16197,13 +16206,6 @@ fn layout_undo_confirmation_details(
                 .tab_ids
                 .get(surface)
                 .cloned()
-                .or_else(|| {
-                    state
-                        .surfaces
-                        .get(surface)
-                        .and_then(|surface| surface.resource_identity())
-                        .map(|identity| identity.tab_id.clone())
-                })
                 .with_context(|| format!("tab {surface} has no public identity"))?;
             update_layout_undo_token_part(&mut hasher, tab_id.to_string().as_bytes());
         }
@@ -17181,6 +17183,51 @@ mod tests {
         assert_eq!(state.surfaces.len(), 0);
         assert_eq!(restored.contents.len(), 6);
         assert!(restored.next_id > 100);
+    }
+
+    #[test]
+    fn restored_tabs_keep_durable_identity_without_any_live_surface() {
+        let (snapshot, topology) = resource_restore_fixture();
+        let mut restored = restore_resource_state(snapshot, topology.clone()).unwrap();
+        assert!(restored.state.surfaces.is_empty(), "restore must not fabricate runtime");
+
+        restored.state.rebuild_resource_indexes();
+        restored.state.ensure_tab_identity_coverage().unwrap();
+
+        for tab in &topology.tabs {
+            let slot = restored
+                .state
+                .resource_indexes
+                .tabs
+                .get(&tab.public_id)
+                .copied()
+                .expect("restored tab lost its slot");
+            assert_eq!(
+                restored.state.resource_indexes.content_ids.get(&slot),
+                Some(&tab.content_id),
+                "restored tab lost its content identity"
+            );
+        }
+    }
+
+    #[test]
+    fn a_tab_without_durable_identity_fails_loudly_instead_of_vanishing() {
+        let (snapshot, topology) = resource_restore_fixture();
+        let mut restored = restore_resource_state(snapshot, topology).unwrap();
+        let slot = *restored
+            .state
+            .panes
+            .values()
+            .find(|pane| !pane.tabs.is_empty())
+            .expect("fixture has a placed tab")
+            .tabs
+            .first()
+            .expect("checked above");
+
+        restored.state.resource_indexes.tab_ids.remove(&slot);
+
+        let error = restored.state.ensure_tab_identity_coverage().unwrap_err();
+        assert!(error.to_string().contains("has no durable identity"), "unexpected error: {error}");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
@@ -606,6 +606,7 @@ impl Mux {
         // their reverse indexes are populated. Full projection is the
         // reconciliation boundary, so rebuild from the live tree first.
         state.rebuild_resource_indexes();
+        state.ensure_tab_identity_coverage()?;
         ensure_split_public_ids(state)?;
         let terminal_tab_order = ordered_terminal_tab_ids(state)?;
 
@@ -693,15 +694,10 @@ impl Mux {
                         .get(&pane_slot)
                         .with_context(|| format!("screen references missing pane {pane_slot}"))?;
                     live_panes.insert(pane.public_id.clone());
-                    let active_tab = pane.tabs.get(pane.active_tab).and_then(|surface| {
-                        state.resource_indexes.tab_ids.get(surface).cloned().or_else(|| {
-                            state
-                                .surfaces
-                                .get(surface)
-                                .and_then(|surface| surface.resource_identity())
-                                .map(|identity| identity.tab_id.clone())
-                        })
-                    });
+                    let active_tab = pane
+                        .tabs
+                        .get(pane.active_tab)
+                        .and_then(|slot| state.resource_indexes.tab_ids.get(slot).cloned());
                     let creation_ordinal =
                         before_pane_ordinals.get(&pane.public_id).copied().unwrap_or(pane.id);
                     changes.push(ResourceChange::UpsertPane(RegistryPane {
@@ -762,29 +758,33 @@ impl Mux {
                                 (None, Some(host_id), first_terminal_placement)
                             }
                             ContentPublicId::Browser(browser_id) => {
-                                let surface = surface.with_context(|| {
-                                    format!("browser tab {surface_slot} has no live surface")
-                                })?;
+                                // A browser view can also outlive its runtime,
+                                // so the durable row is the fallback rather
+                                // than a hard requirement.
                                 live_browsers.insert(browser_id.clone());
+                                let durable = before_browsers.get(browser_id).cloned();
                                 let url = surface
-                                    .browser_url()
-                                    .or_else(|| {
-                                        before_browsers
-                                            .get(browser_id)
-                                            .map(|browser| browser.url.clone())
-                                    })
+                                    .and_then(|surface| surface.browser_url())
+                                    .or_else(|| durable.as_ref().map(|browser| browser.url.clone()))
+                                    .or_else(|| before_tab.and_then(|tab| tab.browser_url.clone()))
                                     .unwrap_or_else(|| "about:blank".to_string());
-                                let (cols, rows) = surface.size();
-                                let live_status = surface.browser_status();
-                                let mut browser =
-                                    before_browsers.get(browser_id).cloned().unwrap_or_else(|| {
-                                        RegistryBrowser::recreate(
-                                            browser_id.clone(),
-                                            url.clone(),
-                                            cols.max(1),
-                                            rows.max(1),
-                                        )
-                                    });
+                                let (cols, rows) = match surface {
+                                    Some(surface) => surface.size(),
+                                    None => durable
+                                        .as_ref()
+                                        .map(|browser| (browser.cols, browser.rows))
+                                        .unwrap_or((1, 1)),
+                                };
+                                let live_status =
+                                    surface.and_then(|surface| surface.browser_status());
+                                let mut browser = durable.unwrap_or_else(|| {
+                                    RegistryBrowser::recreate(
+                                        browser_id.clone(),
+                                        url.clone(),
+                                        cols.max(1),
+                                        rows.max(1),
+                                    )
+                                });
                                 browser.url = url.clone();
                                 browser.cols = cols.max(1);
                                 browser.rows = rows.max(1);
@@ -794,10 +794,14 @@ impl Mux {
                                     }
                                     Some(BrowserStatus::Live) => RegistryBrowserStatus::Live,
                                     Some(BrowserStatus::Failed(_)) => RegistryBrowserStatus::Failed,
-                                    None if surface.is_dead() => RegistryBrowserStatus::Failed,
+                                    None if surface.is_some_and(|surface| surface.is_dead()) => {
+                                        RegistryBrowserStatus::Failed
+                                    }
                                     None => browser.status,
                                 };
-                                if let Some(source) = surface.browser_source() {
+                                if let Some(source) =
+                                    surface.and_then(|surface| surface.browser_source())
+                                {
                                     browser.source = match source {
                                         BrowserSource::External => RegistryBrowserSource::External,
                                         BrowserSource::Launched => RegistryBrowserSource::Launched,
@@ -857,15 +861,28 @@ impl Mux {
                             }
                             ContentPublicId::Terminal(_) => {}
                             ContentPublicId::Browser(id) => {
-                                let surface = surface.expect("browser surface validated above");
-                                let (cols, rows) = surface.size();
-                                let status = surface.browser_status();
+                                let durable = before_browsers.get(id);
+                                let (cols, rows) = match surface {
+                                    Some(surface) => surface.size(),
+                                    None => durable
+                                        .map(|browser| (browser.cols, browser.rows))
+                                        .unwrap_or((1, 1)),
+                                };
+                                let status = surface.and_then(|surface| surface.browser_status());
                                 let status_name = status
                                     .as_ref()
                                     .map(|status| status.as_str())
-                                    .unwrap_or(if surface.is_dead() { "failed" } else { "live" });
+                                    .unwrap_or(match surface {
+                                        Some(surface) if surface.is_dead() => "failed",
+                                        Some(_) => "live",
+                                        None => match durable.map(|browser| &browser.status) {
+                                            Some(RegistryBrowserStatus::Starting) => "starting",
+                                            Some(RegistryBrowserStatus::Live) => "live",
+                                            Some(RegistryBrowserStatus::Failed) | None => "failed",
+                                        },
+                                    });
                                 let source = surface
-                                    .browser_source()
+                                    .and_then(|surface| surface.browser_source())
                                     .map(|source| source.as_str())
                                     .or_else(|| {
                                         before_browsers.get(id).map(|browser| {
@@ -891,12 +908,13 @@ impl Mux {
                                         "id":id,
                                         "tab_id":tab.public_id,
                                         "url":tab.browser_url,
-                                        "title":surface.title(),
+                                        "title":surface.map(|surface| surface.title()),
                                         "loading":status_name == "starting",
                                         "source":source,
                                         "status":status_name,
                                         "error":status.and_then(|status| status.error()),
-                                        "frames_stalled":surface.browser_frames_stalled()
+                                        "frames_stalled":surface
+                                            .and_then(|surface| surface.browser_frames_stalled())
                                             .unwrap_or(false),
                                         "size":{
                                             "cols":cols.max(1),
@@ -1061,16 +1079,11 @@ impl Mux {
     }
 }
 
-/// Durable identity of one pane tab. Restored tabs exist in the topology
-/// before their host runtime is adopted, and an unadoptable host never gets a
-/// surface at all, so the durable indexes are the authority here. A live
-/// surface is only the faster path to the same identity.
+/// Durable identity of one pane tab. The topology owns this, written once by
+/// `State::register_tab_identity`. Restored tabs exist before their host is
+/// adopted and an unadoptable host never gets a surface at all, so identity
+/// must never be read back out of live runtime state.
 fn tab_resource_identity(state: &State, surface_slot: SurfaceId) -> Option<TabResourceIdentity> {
-    if let Some(identity) =
-        state.surfaces.get(&surface_slot).and_then(|surface| surface.resource_identity().cloned())
-    {
-        return Some(identity);
-    }
     Some(TabResourceIdentity::new(
         state.resource_indexes.tab_ids.get(&surface_slot)?.clone(),
         state.resource_indexes.content_ids.get(&surface_slot)?.clone(),


### PR DESCRIPTION
Stacked on #10299, which repairs the reported startup wedge. This removes the cause behind it.

Root cause: a tab's durable identity was not stored on the tab. It was re-derived on every read from either the live surface or the slot indexes, so each reader invented its own missing-data policy. `resource_content.rs` failed hard, `rebuild_resource_indexes` silently dropped the tab, and the browser branch required a live surface. The silent drop is the worst of the three, because a dropped tab makes the next projection tombstone durable rows that are still live.

`State::register_tab_identity` is the writer every placement path uses, including `insert_surface_checked` and the browser attach path, which previously left identity to be harvested from the surface at the next index rebuild. Every reader takes identity from the topology: the index rebuild no longer consults surfaces, the projection resolver reads the owner, and the layout-undo token and active-tab lookup lose their surface fallbacks. `State::ensure_tab_identity_coverage` runs at the projection boundary, so a missing identity fails that one mutation by name instead of erasing durable rows.

Browser tabs now project from their durable row when their runtime is gone, matching terminals. That closes the same failure class for a browser view whose surface never materialized, which #10299 did not cover.

Invariant established: durable topology never depends on live runtime being present. Tabs, panes, screens, and workspaces project from state that survives a daemon restart; surfaces only refine live attributes such as title, size, and status.

Verified on hosted CI at 70f2e14: `daemon_restart_prunes_every_dead_host_behind_one_pane` passes, and the two new unit tests pass (`restored_tabs_keep_durable_identity_without_any_live_surface`, `a_tab_without_durable_identity_fails_loudly_instead_of_vanishing`). The built binary also repairs a copy of the reported wedged session: both terminals reach `exited`, both dead tabs are pruned, all four workspaces survive.

Known gaps: the reserved-placement install in `resource_project_terminal_selected` still writes its own placement order rather than going through the shared writer, and there is no test for a browser tab without a surface, because browser runtime is not available in unit tests. A follow-up can fold the slot to identity map into `Pane.tabs: Vec<Tab>` so a tab without identity cannot be constructed at all.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789605014&installation_model_id=21920&pr_number=10304&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10304&signature=82a7597bb54108ae2487f94c22e12a93557e6125bc688e9a8d27c4f159f6f3ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores each tab’s durable identity in the topology and makes every reader use it. This removes silent drops during index rebuild and lets browser tabs project from durable state when runtime is absent.

- Behavior changes
  - Old: readers re-derived tab identity from surfaces or partial indexes, causing hard failures or silent drops. New: `State::register_tab_identity` writes identity at placement, and all readers use topology only; missing identity fails the mutation.
  - Browser tabs project from their durable row when runtime is gone (previously required a live surface). Restored or detached browser views keep URL/size/status from durable state.
  - Invariant: durable topology does not depend on live runtime for tabs, panes, screens, or workspaces.

- Review notes
  - Writers: `insert_surface_checked` and the browser attach path call `state.register_tab_identity(...)`.
  - Readers: `rebuild_resource_indexes`, projection resolver, layout-undo token, and active-tab lookup stop consulting surfaces for identity.
  - Safety gate: `state.ensure_tab_identity_coverage()` runs at projection; violations error with “tab slot {slot} has no durable identity”.
  - Tests: `restored_tabs_keep_durable_identity_without_any_live_surface`, `a_tab_without_durable_identity_fails_loudly_instead_of_vanishing`. Known gap: reserved-placement install still writes its own placement order; follow-up will unify this.

<sup>Written for commit 70f2e14f44d8324beb05bbb2722ead2d61dc04fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

