### PR TITLE
ci: run the Testbox broker guard on every pull request

### DIFF
--- a/.github/workflows/testbox-broker-guard.yml
+++ b/.github/workflows/testbox-broker-guard.yml
@@ -1,0 +1,59 @@
+name: Testbox broker guard
+
+# The main CI suite is dispatch-only right now, so the trust-boundary guard for
+# the Blacksmith Testbox lane gets its own always-on workflow. It must run on
+# every pull request, with no path filter: a path filter is exactly the thing a
+# change that moves the guard could slip past.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: testbox-broker-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Testbox broker trust boundary
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install guard dependencies
+        run: python3 -m pip install --disable-pip-version-check --no-input PyYAML==6.0.3
+
+      - name: Validate Blacksmith Testbox broker trust boundary
+        run: python3 tests/test_ci_testbox_broker_guard.py
+
+      - name: Lint the Testbox lane helpers
+        run: shellcheck scripts/blacksmith-bounded-command.sh scripts/blacksmith-cmux-tui-testbox-stage.sh scripts/blacksmith-testbox-cleanup.sh scripts/blacksmith-testbox-keepalive.sh
+
+      - name: Lint the Testbox warmup workflow
+        env:
+          ACTIONLINT_VERSION: "1.7.7"
+          ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/actionlint.tar.gz"
+          curl -fsSL -o "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xzf "$archive" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" \
+            .github/workflows/cmux-tui-testbox-warmup.yml \
+            .github/workflows/testbox-broker-guard.yml

--- a/scripts/blacksmith-cmux-tui-testbox-stage.sh
+++ b/scripts/blacksmith-cmux-tui-testbox-stage.sh
@@ -236,7 +236,8 @@ restore_changed_file() {
 # Always restore the deliberately changed source, including when Cargo exits
 # non-zero. Do not let cleanup replace the build result unless restoration
 # itself fails.
-# shellcheck disable=SC2329 # invoked indirectly by the signal/EXIT traps
+# SC2317 is what shellcheck 0.9 (Ubuntu 24.04) calls this; SC2329 is the 0.10+ name.
+# shellcheck disable=SC2317,SC2329 # invoked indirectly by the signal/EXIT traps
 finish_source() {
   local result=$?
   if [[ -n "$changed_backup" ]]; then
@@ -249,7 +250,7 @@ finish_source() {
 }
 # Signals must remain failures even when they arrive after a successful command.
 # The EXIT trap performs the actual restoration exactly once.
-# shellcheck disable=SC2329 # invoked indirectly by signal traps
+# shellcheck disable=SC2317,SC2329 # invoked indirectly by signal traps
 interrupt_source() {
   local signal_name="$1"
   trap - TERM INT HUP


### PR DESCRIPTION
Follow-up to #10303.

`tests/test_ci_testbox_broker_guard.py` is wired into `ci.yml`, but `ci.yml` is currently dispatch-only ("CI pause"), so the guard would not have run on a pull request that weakened the very lane it protects. This gives it a small always-on workflow.

It runs on every pull request with no path filter, on purpose: a change that renames or moves the guard is exactly what a path filter would let through. The job also shellchecks the four `scripts/blacksmith-*.sh` helpers and actionlints the warmup workflow, neither of which any existing job covers.

actionlint is downloaded pinned by version and verified against a sha256 I checked against the real release artifact (`023070a2...0757` for `actionlint_1.7.7_linux_amd64.tar.gz`).

The `ci.yml` entry from #10303 stays, so the guard still runs with the full suite whenever CI resumes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789606970&installation_model_id=21920&pr_number=10305&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10305&signature=b820df2a017101415609211398ac201e80ba4e4644a9f75ffee706c78be1290e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Testbox broker guard on every pull request and pushes to main to prevent trust-boundary regressions while CI is dispatch-only. Previously the guard ran only in `ci.yml`; now a dedicated workflow enforces it and adds linting.

- Adds `testbox-broker-guard.yml` that triggers on `pull_request` and `push` to `main` with no path filter.
- Uses concurrency to cancel superseded runs per ref.
- Executes `tests/test_ci_testbox_broker_guard.py` on Python 3.12 with `PyYAML==6.0.3`.
- Shellchecks the four Testbox helper scripts; updates `blacksmith-cmux-tui-testbox-stage.sh` to disable both SC2317 and SC2329 for trap-invoked helpers to satisfy ShellCheck 0.9/0.10.
- Runs `actionlint` on the warmup and guard workflows, downloading `actionlint` `1.7.7` and verifying it via SHA-256.
- Keeps the `ci.yml` entry so the guard still runs with the full suite when CI resumes.

<sup>Written for commit 86f14c0997355abfb6669976124ca9b1d521e6c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for Testbox broker trust-boundary protections.
  * Pull requests and changes to the main branch now receive consistent security checks.
  * Added workflow linting and verification to help detect configuration errors before changes are integrated.
  * Superseded checks are canceled automatically to keep validation results current.
  * Updated shell-script validation compatibility across supported ShellCheck versions without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->