### PR TITLE
fix: require a pushed commit for Testbox benchmarks, and lead the skill with the workflow

### DIFF
--- a/.github/workflows/testbox-broker-guard.yml
+++ b/.github/workflows/testbox-broker-guard.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate Blacksmith Testbox broker trust boundary
         run: python3 tests/test_ci_testbox_broker_guard.py
 
+      - name: Validate receipt-bound cleanup ownership check
+        run: ./tests/test_testbox_cleanup_receipt_ref.sh
+
       - name: Lint the Testbox lane helpers
         run: shellcheck scripts/blacksmith-bounded-command.sh scripts/blacksmith-cmux-tui-testbox-stage.sh scripts/blacksmith-testbox-cleanup.sh scripts/blacksmith-testbox-keepalive.sh
 

--- a/.github/workflows/testbox-broker-guard.yml
+++ b/.github/workflows/testbox-broker-guard.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Validate receipt-bound cleanup ownership check
         run: ./tests/test_testbox_cleanup_receipt_ref.sh
 
+      - name: Validate the documented shell blocks
+        run: ./tests/test_testbox_doc_blocks.sh
+
       - name: Lint the Testbox lane helpers
         run: shellcheck scripts/blacksmith-bounded-command.sh scripts/blacksmith-cmux-tui-testbox-stage.sh scripts/blacksmith-testbox-cleanup.sh scripts/blacksmith-testbox-keepalive.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,4 @@ Detailed contributor rules live in `skills/`. Use the task-specific skill before
 - `cmux-shared-behavior`: shared action paths for multi-entrypoint behavior and optimistic updates.
 - `cmux-ghostty`: Ghostty submodule and GhosttyKit workflow.
 - `cmux-release`: release, version bump, changelog, pretag guard, release assets.
+- `blacksmith-testbox`: warm your own Linux Testbox before any cmux-tui Rust or Zig build, and never compile cmux-tui on the Mac.

--- a/scripts/blacksmith-cmux-tui-testbox-stage.sh
+++ b/scripts/blacksmith-cmux-tui-testbox-stage.sh
@@ -72,6 +72,23 @@ if [[ ! "$ghostty_entry" =~ ^160000[[:space:]]commit[[:space:]][0-9a-f]{40}[[:sp
   echo "HEAD:ghostty is not a gitlink" >&2
   exit 65
 fi
+# Blacksmith's sync copies file contents and only opportunistically fetches the
+# benchmarked commit; once the working files match it skips entirely. The box
+# therefore keeps the history the warmup job checked out, which is main. Fail
+# with the exact remedy instead of an unreadable `git rev-parse` error.
+require_benchmarked_commit() {
+  cat >&2 <<REMEDY
+the benchmarked commit is not checked out on this Testbox
+  expected: $expected_source_sha
+  present:  $(git rev-parse HEAD 2>/dev/null || echo unknown)
+Push the commit, then pin this box to it before running a stage:
+  git push origin <branch>
+  blacksmith testbox run --id $testbox_id 'set -euo pipefail; git fetch --no-tags origin $expected_source_sha; git reset --hard $expected_source_sha; git submodule update --init --depth 1 ghostty'
+REMEDY
+  exit 65
+}
+git rev-parse --verify --quiet "${expected_source_sha}^{commit}" >/dev/null || require_benchmarked_commit
+[[ "$(git rev-parse HEAD)" == "$expected_source_sha" ]] || require_benchmarked_commit
 expected_tree_sha="$(git rev-parse "${expected_source_sha}^{tree}")"
 if ! command -v timeout >/dev/null; then
   echo "timeout is required for bounded remote builds" >&2

--- a/scripts/blacksmith-cmux-tui-testbox-stage.sh
+++ b/scripts/blacksmith-cmux-tui-testbox-stage.sh
@@ -455,6 +455,20 @@ build_status=$?
 set -e
 end_epoch="$(python3 -c 'import time; print(time.time())')"
 
+# A zero exit proves cargo was happy, not that anything was produced. Record the
+# artifact so the evidence pack shows a binary existed on the box, which cannot
+# be checked after the box is destroyed.
+binary_path="$repo_root/cmux-tui/target/debug/cmux-tui"
+binary_bytes=""
+if (( build_status == 0 )); then
+  if [[ -x "$binary_path" ]]; then
+    binary_bytes="$(wc -c <"$binary_path" | tr -d ' ')"
+  else
+    echo "cargo exited 0 but $binary_path is missing or not executable" >&2
+    build_status=70
+  fi
+fi
+
 restore_status=0
 if ! restore_changed_file; then
   echo "failed to restore $changed_file" >&2
@@ -481,7 +495,7 @@ else
   final_status="$build_status"
 fi
 
-python3 - "$stage" "$start_epoch" "$end_epoch" "$build_status" "$final_status" "$time_path" "$pre_identity_path" "$post_identity_path" "$changed_file" "$expected_source_sha" "$expected_tree_sha" "$expected_ghostty_sha" "$testbox_id" "$runner_label" "$rust_toolchain" "$rustc_version" "$cargo_version" "$zig_bin" "$zig_version" "$rust_toolchain_file_sha256" "$cargo_lock_sha256" "$ghostty_zon_sha256" "$hydrated_source_ref" "$hydrated_source_sha" >"$json_path" <<'PY'
+python3 - "$stage" "$start_epoch" "$end_epoch" "$build_status" "$final_status" "$time_path" "$pre_identity_path" "$post_identity_path" "$changed_file" "$expected_source_sha" "$expected_tree_sha" "$expected_ghostty_sha" "$testbox_id" "$runner_label" "$rust_toolchain" "$rustc_version" "$cargo_version" "$zig_bin" "$zig_version" "$rust_toolchain_file_sha256" "$cargo_lock_sha256" "$ghostty_zon_sha256" "$hydrated_source_ref" "$hydrated_source_sha" "$binary_bytes" >"$json_path" <<'PY'
 import datetime as dt
 import json
 import os
@@ -514,6 +528,7 @@ import sys
     ghostty_zon_sha256,
     hydrated_source_ref,
     hydrated_source_sha,
+    binary_bytes,
 ) = sys.argv[1:]
 
 def read_json(path):
@@ -537,6 +552,11 @@ record = {
     "schema": 3,
     "stage": stage,
     "command": "cargo build -p cmux-tui --locked",
+    # Proof the build produced something, since the box is destroyed afterwards.
+    "artifact": {
+        "path": "cmux-tui/target/debug/cmux-tui",
+        "size_bytes": int(binary_bytes) if binary_bytes else None,
+    },
     "build_exit_code": int(build_status),
     "exit_code": int(final_status),
     "ok": int(final_status) == 0,

--- a/scripts/blacksmith-testbox-cleanup.sh
+++ b/scripts/blacksmith-testbox-cleanup.sh
@@ -85,6 +85,13 @@ import sys
 print(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["warmup_ref"])
 PY
 )"
+receipt_source_ref="$(python3 - "$receipt_path" <<'PY'
+import json
+import pathlib
+import sys
+print(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["source_ref"])
+PY
+)"
 receipt_source_sha="$(python3 - "$receipt_path" <<'PY'
 import json
 import pathlib
@@ -229,21 +236,25 @@ if (( status_absent == 0 )) && ! is_active "$status_value" && ! is_terminal "$st
 fi
 
 preview_path="$evidence_dir/cleanup-preview.json"
-python3 - "$preview_path" "$testbox_id" "${status_value:-absent}" "$inventory_row_present" "$receipt_workflow" "$receipt_job" "$receipt_ref" "$receipt_source_sha" "$receipt_source_tree_sha" "$receipt_ghostty_sha" <<'PY'
+python3 - "$preview_path" "$testbox_id" "${status_value:-absent}" "$inventory_row_present" "$receipt_workflow" "$receipt_job" "$receipt_ref" "$receipt_source_ref" "$receipt_source_sha" "$receipt_source_tree_sha" "$receipt_ghostty_sha" <<'PY'
 import json
 import pathlib
 import sys
 
-(path, testbox_id, status, inventory_present, workflow, job, ref,
- source_sha, source_tree_sha, ghostty_sha) = sys.argv[1:]
+(path, testbox_id, status, inventory_present, workflow, job, warmup_ref,
+ source_ref, source_sha, source_tree_sha, ghostty_sha) = sys.argv[1:]
 payload = {
-    "schema": 1,
+    "schema": 2,
     "testbox_id": testbox_id,
     "status": status,
     "inventory_row_present": bool(int(inventory_present)),
     "workflow": workflow,
     "job": job,
-    "source_ref": ref,
+    # The ref the box was warmed from, which is what the inventory row shows.
+    "warmup_ref": warmup_ref,
+    # The branch actually benchmarked. Pairing warmup_ref with source_sha made
+    # the destruction record claim a SHA that is not on the ref beside it.
+    "source_ref": source_ref,
     "source_sha": source_sha,
     "source_tree_sha": source_tree_sha,
     "ghostty_gitlink_sha": ghostty_sha,
@@ -266,6 +277,9 @@ if [[ "$operator_confirmation" != "PREVIEW" && "$expected_preview_sha" != "$prev
   exit 67
 fi
 
+# The pre-stop status is evidence of when the box was alive. The poll below
+# writes to its own file so it cannot overwrite that record.
+post_status_log="$evidence_dir/status-after-stop.log"
 stop_log="$evidence_dir/stop.log"
 list_log="$evidence_dir/list-after-stop.log"
 cleanup_status=0
@@ -292,18 +306,18 @@ fi
 # different row in the global inventory as proof that this ID is terminal.
 while :; do
   poll_attempt=$((poll_attempt + 1))
-  : >"$status_log"
+  : >"$post_status_log"
   set +e
-  bounded_command 20 blacksmith testbox status --id "$testbox_id" >"$status_log" 2>&1
+  bounded_command 20 blacksmith testbox status --id "$testbox_id" >"$post_status_log" 2>&1
   status_command_status=$?
   set -e
   if (( status_command_status == 0 )); then
     set +e
-    status_value="$(parse_cli_output "$status_log")"
+    status_value="$(parse_cli_output "$post_status_log")"
     status_parse_status=$?
     set -e
     if (( status_parse_status != 0 )); then
-      echo "could not parse post-stop status for $testbox_id; see $status_log" >&2
+      echo "could not parse post-stop status for $testbox_id; see $post_status_log" >&2
       (( cleanup_status == 0 )) && cleanup_status=66
       break
     fi
@@ -311,14 +325,14 @@ while :; do
       break
     fi
     if ! is_active "$status_value"; then
-      echo "unknown post-stop status for $testbox_id; see $status_log" >&2
+      echo "unknown post-stop status for $testbox_id; see $post_status_log" >&2
       (( cleanup_status == 0 )) && cleanup_status=66
       break
     fi
-  elif is_known_absence "$status_log"; then
+  elif is_known_absence "$post_status_log"; then
     break
   else
-    echo "failed to inspect Testbox $testbox_id after cleanup; see $status_log" >&2
+    echo "failed to inspect Testbox $testbox_id after cleanup; see $post_status_log" >&2
     (( cleanup_status == 0 )) && cleanup_status=$status_command_status
     break
   fi

--- a/scripts/blacksmith-testbox-cleanup.sh
+++ b/scripts/blacksmith-testbox-cleanup.sh
@@ -57,7 +57,10 @@ if receipt.get("testbox_id") != expected_id:
     raise SystemExit("cleanup ID does not match the warmup ownership receipt")
 if receipt.get("confirmation_token") != expected_token:
     raise SystemExit("ownership token does not match the warmup ownership receipt")
-for field in ("workflow", "job", "source_ref", "source_sha", "source_tree_sha", "ghostty_gitlink_sha"):
+# warmup_ref is what `blacksmith testbox list` shows and is always main in the
+# broker lane. source_ref is the branch being benchmarked and never appears in
+# the inventory. Conflating them made every receipt-bound cleanup exit 66.
+for field in ("workflow", "job", "warmup_ref", "source_ref", "source_sha", "source_tree_sha", "ghostty_gitlink_sha"):
     if not receipt.get(field):
         raise SystemExit(f"warmup ownership receipt is missing {field}")
 PY
@@ -79,7 +82,7 @@ receipt_ref="$(python3 - "$receipt_path" <<'PY'
 import json
 import pathlib
 import sys
-print(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["source_ref"])
+print(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["warmup_ref"])
 PY
 )"
 receipt_source_sha="$(python3 - "$receipt_path" <<'PY'

--- a/scripts/blacksmith-testbox-demo.sh
+++ b/scripts/blacksmith-testbox-demo.sh
@@ -11,7 +11,6 @@ WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
 JOB=cmux-tui-rust
 IDLE_TIMEOUT=30
 APPROVE=1
-ASSUME_YES=0
 STAGES=0
 
 usage() {
@@ -23,7 +22,6 @@ usage: scripts/blacksmith-testbox-demo.sh [options]
   --no-approve    do not approve the deployment gate; approve it yourself in
                   the GitHub UI when the script pauses
   --idle-timeout  minutes before Blacksmith reclaims the box (default 30)
-  --yes           skip the cost confirmation
 USAGE
 }
 
@@ -32,7 +30,6 @@ while (( $# )); do
     --stages) STAGES=1 ;;
     --no-approve) APPROVE=0 ;;
     --idle-timeout) shift; IDLE_TIMEOUT="${1:?--idle-timeout needs minutes}" ;;
-    --yes|-y) ASSUME_YES=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 64 ;;
   esac
@@ -87,15 +84,9 @@ echo "CLI           $(blacksmith --version)"
 say "Boxes currently running in the org (never adopt one you did not warm)"
 run_local blacksmith testbox list --all || true
 
-if (( ! ASSUME_YES )); then
-  cat <<EOF
-
-This warms one 32 vCPU Linux VM for roughly 4 minutes of hydration plus a few
-minutes of building, then stops it. Continue? [y/N]
-EOF
-  read -r reply
-  [[ "$reply" == [yY]* ]] || { echo "aborted"; exit 0; }
-fi
+echo
+echo "Warming one 32 vCPU Linux VM: about 4 minutes of hydration, a few minutes"
+echo "of building, then it stops itself. Ctrl-C also stops it."
 
 # ------------------------------------------------------------------- warmup --
 TBX=""

--- a/scripts/blacksmith-testbox-demo.sh
+++ b/scripts/blacksmith-testbox-demo.sh
@@ -104,7 +104,13 @@ trap cleanup EXIT INT TERM
 say "Warming a box from main"
 echo "The workflow refuses any ref but main: it is the trust boundary, because"
 echo "the CLI resolves the workflow definition from the same ref it hydrates."
-dispatch_epoch="$(date -u +%s)"
+# Snapshot the gates already waiting before dispatching. Set difference against
+# this identifies our run exactly; a time window cannot, because another agent
+# dispatching seconds later lands inside any window we pick.
+lane_runs_url="repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting"
+waiting_before="$(mktemp)"
+waiting_now="$(mktemp)"
+gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_before"
 warmup_log="$(mktemp)"
 printf '\033[2m$ blacksmith testbox warmup %s --ref main --job %s --idle-timeout %s\033[0m\n' \
   "$WORKFLOW" "$JOB" "$IDLE_TIMEOUT"
@@ -121,16 +127,13 @@ echo "approval is allowed on this environment."
 if (( APPROVE )); then
   approved=0
   for _ in $(seq 1 30); do
-    # Only consider runs dispatched around our own warmup, so this can never
-    # approve another operator's waiting run. Kept portable to bash 3.2, which
-    # is what macOS ships: no mapfile.
-    candidates="$(
-      gh api "repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting" \
-        --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= ${dispatch_epoch} - 120) | .id" 2>/dev/null || true
-    )"
+    # Our run is the one that appeared since the snapshot. Kept portable to bash
+    # 3.2, which is what macOS ships: no mapfile, no process substitution.
+    gh api "$lane_runs_url" --jq '.workflow_runs[].id' 2>/dev/null | sort >"$waiting_now" || true
+    candidates="$(comm -13 "$waiting_before" "$waiting_now")"
     candidate_count="$(printf '%s' "$candidates" | grep -c . || true)"
     if (( candidate_count > 1 )); then
-      echo "several runs are waiting; approve yours in the GitHub UI instead" >&2
+      echo "$candidate_count runs appeared at once; approve yours in the GitHub UI, or rerun this script" >&2
       break
     fi
     if (( candidate_count == 1 )); then

--- a/scripts/blacksmith-testbox-demo.sh
+++ b/scripts/blacksmith-testbox-demo.sh
@@ -90,12 +90,22 @@ echo "of building, then it stops itself. Ctrl-C also stops it."
 
 # ------------------------------------------------------------------- warmup --
 TBX=""
+RUN_ID=""
 cleanup() {
   local status=$?
   if [[ -n "$TBX" ]]; then
     say "Stopping the box this script created ($TBX)"
     blacksmith testbox stop --id "$TBX" || echo "stop failed; stop it by hand: blacksmith testbox stop --id $TBX" >&2
     blacksmith testbox list --all || true
+  fi
+  # Stopping the box does not end its run. The keepalive step keeps holding a
+  # 32 vCPU runner until the run itself ends, so cancel it too.
+  if [[ -n "$RUN_ID" ]]; then
+    say "Cancelling the warmup run this script approved ($RUN_ID)"
+    gh run cancel "$RUN_ID" --repo manaflow-ai/cmux >/dev/null 2>&1 \
+      || echo "cancel failed; cancel it by hand: gh run cancel $RUN_ID --repo manaflow-ai/cmux" >&2
+    echo "cancelling takes a few minutes to land; final state:"
+    gh api "repos/manaflow-ai/cmux/actions/runs/$RUN_ID" --jq '"\(.status) \(.conclusion // "pending")"' || true
   fi
   exit "$status"
 }
@@ -144,6 +154,7 @@ if (( APPROVE )); then
 {"environment_ids": [$env_id], "state": "approved", "comment": "blacksmith-testbox-demo"}
 JSON
       echo "approved run $run_id"
+      RUN_ID="$run_id"
       approved=1
       break
     fi

--- a/scripts/blacksmith-testbox-demo.sh
+++ b/scripts/blacksmith-testbox-demo.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Guided end-to-end tour of the cmux-tui Blacksmith Testbox lane.
+#
+# Warms a box from main, pins it to your pushed HEAD, builds cmux-tui twice to
+# show what the persistent disk buys, and always stops the box it created.
+# Every remote command is printed before it runs, so the tour doubles as the
+# documentation.
+set -euo pipefail
+
+WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
+JOB=cmux-tui-rust
+IDLE_TIMEOUT=30
+APPROVE=1
+ASSUME_YES=0
+STAGES=0
+
+usage() {
+  cat <<'USAGE'
+usage: scripts/blacksmith-testbox-demo.sh [options]
+
+  --stages        run the three measured benchmark stages instead of the two
+                  plain builds (slower, produces evidence JSON)
+  --no-approve    do not approve the deployment gate; approve it yourself in
+                  the GitHub UI when the script pauses
+  --idle-timeout  minutes before Blacksmith reclaims the box (default 30)
+  --yes           skip the cost confirmation
+USAGE
+}
+
+while (( $# )); do
+  case "$1" in
+    --stages) STAGES=1 ;;
+    --no-approve) APPROVE=0 ;;
+    --idle-timeout) shift; IDLE_TIMEOUT="${1:?--idle-timeout needs minutes}" ;;
+    --yes|-y) ASSUME_YES=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+say() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+run_local() { printf '\033[2m$ %s\033[0m\n' "$*"; "$@"; }
+
+cd "$(git rev-parse --show-toplevel)"
+BOUNDED=./scripts/blacksmith-bounded-command.sh
+
+# ---------------------------------------------------------------- preflight --
+say "Preflight"
+for tool in blacksmith gh git; do
+  command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 65; }
+done
+test -x "$BOUNDED" || { echo "missing $BOUNDED; run from a cmux worktree" >&2; exit 65; }
+test -f "$WORKFLOW" || { echo "missing $WORKFLOW; rebase onto a main that has the lane" >&2; exit 65; }
+
+if [[ ! -f ghostty/build.zig.zon ]]; then
+  say "Initializing the Ghostty submodule (one time, takes a moment)"
+  run_local git submodule update --init ghostty
+fi
+
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+[[ -n "$BRANCH" ]] || { echo "HEAD is detached; check out a branch first" >&2; exit 65; }
+SOURCE_SHA="$(git rev-parse HEAD)"
+GHOSTTY_SHA="$(git rev-parse HEAD:ghostty)"
+
+if [[ -n "$(git status --porcelain=v1 --untracked-files=normal)" ]]; then
+  echo "worktree is dirty; commit and push before benchmarking" >&2
+  git status --short >&2
+  exit 65
+fi
+remote_sha="$(git ls-remote --exit-code origin "refs/heads/$BRANCH" 2>/dev/null | awk 'NR == 1 { print $1 }' || true)"
+if [[ "$remote_sha" != "$SOURCE_SHA" ]]; then
+  cat >&2 <<EOF
+push this branch first. The box resolves your commit by fetching it from
+GitHub; a local-only commit fails there with 'upload-pack: not our ref'.
+  git push origin $BRANCH
+EOF
+  exit 65
+fi
+
+blacksmith auth whoami >/dev/null || { echo "run: blacksmith auth login" >&2; exit 65; }
+echo "branch        $BRANCH"
+echo "commit        $SOURCE_SHA"
+echo "ghostty       $GHOSTTY_SHA"
+echo "CLI           $(blacksmith --version)"
+
+say "Boxes currently running in the org (never adopt one you did not warm)"
+run_local blacksmith testbox list --all || true
+
+if (( ! ASSUME_YES )); then
+  cat <<EOF
+
+This warms one 32 vCPU Linux VM for roughly 4 minutes of hydration plus a few
+minutes of building, then stops it. Continue? [y/N]
+EOF
+  read -r reply
+  [[ "$reply" == [yY]* ]] || { echo "aborted"; exit 0; }
+fi
+
+# ------------------------------------------------------------------- warmup --
+TBX=""
+cleanup() {
+  local status=$?
+  if [[ -n "$TBX" ]]; then
+    say "Stopping the box this script created ($TBX)"
+    blacksmith testbox stop --id "$TBX" || echo "stop failed; stop it by hand: blacksmith testbox stop --id $TBX" >&2
+    blacksmith testbox list --all || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+say "Warming a box from main"
+echo "The workflow refuses any ref but main: it is the trust boundary, because"
+echo "the CLI resolves the workflow definition from the same ref it hydrates."
+dispatch_epoch="$(date -u +%s)"
+warmup_log="$(mktemp)"
+printf '\033[2m$ blacksmith testbox warmup %s --ref main --job %s --idle-timeout %s\033[0m\n' \
+  "$WORKFLOW" "$JOB" "$IDLE_TIMEOUT"
+"$BOUNDED" 300 blacksmith testbox warmup "$WORKFLOW" \
+  --ref main --job "$JOB" --idle-timeout "$IDLE_TIMEOUT" | tee "$warmup_log"
+TBX="$(grep -Eo 'tbx_[A-Za-z0-9_-]+' "$warmup_log" | head -1)"
+rm -f "$warmup_log"
+[[ -n "$TBX" ]] || { echo "warmup returned no Testbox ID" >&2; exit 66; }
+
+# ------------------------------------------------------------------ approve --
+say "Approving the deployment gate"
+echo "The run parks before its first step until a reviewer approves. Self-"
+echo "approval is allowed on this environment."
+if (( APPROVE )); then
+  approved=0
+  for _ in $(seq 1 30); do
+    # Only consider runs dispatched around our own warmup, so this can never
+    # approve another operator's waiting run. Kept portable to bash 3.2, which
+    # is what macOS ships: no mapfile.
+    candidates="$(
+      gh api "repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting" \
+        --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= ${dispatch_epoch} - 120) | .id" 2>/dev/null || true
+    )"
+    candidate_count="$(printf '%s' "$candidates" | grep -c . || true)"
+    if (( candidate_count > 1 )); then
+      echo "several runs are waiting; approve yours in the GitHub UI instead" >&2
+      break
+    fi
+    if (( candidate_count == 1 )); then
+      run_id="$candidates"
+      env_id="$(gh api "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" --jq '.[0].environment.id')"
+      gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" \
+        --input - >/dev/null <<JSON
+{"environment_ids": [$env_id], "state": "approved", "comment": "blacksmith-testbox-demo"}
+JSON
+      echo "approved run $run_id"
+      approved=1
+      break
+    fi
+    sleep 5
+  done
+  (( approved )) || echo "not approved automatically; approve the run in the GitHub UI now" >&2
+else
+  echo "approve the waiting run in the GitHub UI now"
+fi
+
+# -------------------------------------------------------------------- ready --
+say "Waiting for hydration (installs pinned Zig and Rust, fetches Cargo and Zig deps)"
+"$BOUNDED" 1200 blacksmith testbox status --id "$TBX" --wait --wait-timeout 15m
+
+# ---------------------------------------------------------------------- pin --
+say "Pinning the box to your commit"
+echo "The box is an exact checkout of main right now, because that is what CI"
+echo "hydrated. This makes it an exact checkout of $SOURCE_SHA."
+pin_command="set -euo pipefail; git fetch --no-tags origin $SOURCE_SHA; git reset --hard $SOURCE_SHA; git submodule update --init --depth 1 ghostty; git rev-parse HEAD"
+printf '\033[2m$ blacksmith testbox run --id %s "%s"\033[0m\n' "$TBX" "$pin_command"
+"$BOUNDED" 300 blacksmith testbox run --id "$TBX" "$pin_command"
+
+# -------------------------------------------------------------------- build --
+if (( STAGES )); then
+  say "Running the three measured stages"
+  out=".cmux-scratch/testbox-demo-$(git rev-parse --short HEAD)"
+  mkdir -p "$out/raw"
+  for stage in first-clean incremental-noop changed-file; do
+    say "Stage: $stage"
+    stage_command="CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=$TBX ./scripts/blacksmith-cmux-tui-testbox-stage.sh $stage $SOURCE_SHA $GHOSTTY_SHA"
+    printf '\033[2m$ blacksmith testbox run --id %s "%s"\033[0m\n' "$TBX" "$stage_command"
+    "$BOUNDED" 1500 blacksmith testbox run --id "$TBX" "$stage_command"
+    for suffix in json time log; do
+      "$BOUNDED" 120 blacksmith testbox download --id "$TBX" \
+        "testbox-benchmark/$stage.$suffix" "$out/raw/$stage.$suffix" >/dev/null
+    done
+  done
+  say "Timings"
+  python3 - "$out/raw" <<'PY'
+import json
+import pathlib
+import sys
+
+raw = pathlib.Path(sys.argv[1])
+for stage in ("first-clean", "incremental-noop", "changed-file"):
+    record = json.loads((raw / f"{stage}.json").read_text())
+    hydration = record["hydration"]
+    print(f"{stage:18} {record['wall_seconds']:>9.3f} s   ok={record['ok']}")
+    print(f"{'':18} hydrated from {hydration['ref']} {hydration['commit_sha'][:10]}, "
+          f"same commit as benchmarked: {hydration['matches_benchmarked_source']}")
+PY
+  echo "raw records: $out/raw"
+else
+  say "Build 1 of 2: cold target directory, warm dependency caches"
+  build_command="cd cmux-tui && cargo build -p cmux-tui --locked"
+  printf '\033[2m$ blacksmith testbox run --id %s "%s"\033[0m\n' "$TBX" "$build_command"
+  "$BOUNDED" 1500 blacksmith testbox run --id "$TBX" "$build_command"
+
+  say "Build 2 of 2: nothing changed, same VM, same disk"
+  echo "This is what the persistent box buys. Compare it to build 1."
+  "$BOUNDED" 600 blacksmith testbox run --id "$TBX" "$build_command"
+fi
+
+say "Done. The box stops next, on the way out."

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -108,7 +108,7 @@ WAITING=""
 for attempt in $(seq 1 30); do
   WAITING=$(gh api "repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting" \
     --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")
-  count=$(printf '%s' "$WAITING" | grep -c .)
+  count=$(printf '%s' "$WAITING" | grep -c . || true)   # grep -c exits 1 on zero
   if (( count > 1 )); then
     echo "$count runs waiting since your dispatch; approve yours in the UI" >&2
     exit 1
@@ -116,7 +116,7 @@ for attempt in $(seq 1 30); do
   (( count == 1 )) && break
   sleep 5   # not visible yet
 done
-test "$(printf '%s' "$WAITING" | grep -c .)" -eq 1 || { echo "no run appeared within 150s; check the Actions tab" >&2; exit 1; }
+test "$(printf '%s' "$WAITING" | grep -c . || true)" -eq 1 || { echo "no run appeared within 150s; check the Actions tab" >&2; exit 1; }
 ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" --jq '.[0].environment.id')
 gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" \
   --input - <<< "{\"environment_ids\":[$ENV],\"state\":\"approved\",\"comment\":\"warmup\"}"

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -97,33 +97,59 @@ approving the newest waiting run hands a stranger's deployment its gate. Bind
 the approval to a run that appeared after your own dispatch, and refuse to guess
 when more than one is waiting:
 
-GitHub does not surface the run the instant `warmup` returns, so poll. Zero
-runs visible means "not yet", and only two or more means genuinely ambiguous;
-treating those two cases alike aborts a warmup that was fine and strands a live
-box:
+Identify your run by set difference against a snapshot taken before you
+dispatch. A time window is not enough: another agent dispatching seconds after
+you lands inside any window, and nothing in the REST API binds a run to a
+Testbox ID. Never correlate a box to a run by timestamp either, because
+Blacksmith rewrites a box's `CREATED` value as it hydrates, so the pairing that
+looks obvious is wrong for any box past `queued`.
 
 ```bash
-DISPATCH_EPOCH=$(date -u +%s)   # capture this BEFORE calling warmup
-WAITING=""
+# Snapshot every gate already waiting in this lane BEFORE dispatching. Set
+# difference against this is exact; a time window is not, because a second
+# operator dispatching seconds after you lands inside any window you pick.
+lane_runs_url="repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting"
+waiting_before="$(mktemp)"
+gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_before"
+
+# ... run `blacksmith testbox warmup` here, then:
+
+# Your run is the one that appeared since the snapshot. GitHub does not surface
+# it instantly, so poll; zero new runs means "not yet".
+waiting_now="$(mktemp)"
+approval_run=""
 for attempt in $(seq 1 30); do
-  WAITING=$(gh api "repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting" \
-    --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")
-  count=$(printf '%s' "$WAITING" | grep -c . || true)   # grep -c exits 1 on zero
-  if (( count > 1 )); then
-    echo "$count runs waiting since your dispatch; approve yours in the UI" >&2
+  gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_now"
+  new_runs="$(comm -13 "$waiting_before" "$waiting_now")"
+  new_count="$(printf '%s' "$new_runs" | grep -c . || true)"
+  if (( new_count == 1 )); then
+    approval_run="$new_runs"
+    break
+  fi
+  if (( new_count > 1 )); then
+    # Two operators dispatched between polls. Nothing in the REST API binds a
+    # run to a Testbox ID, so do not guess and do not correlate by timestamp:
+    # Blacksmith rewrites a box's CREATED value as it hydrates. Stop your box,
+    # re-snapshot, and dispatch again; the next set difference is unambiguous.
+    echo "$new_count runs appeared at once; stop your box ($TBX), re-snapshot, and re-dispatch" >&2
     exit 1
   fi
-  (( count == 1 )) && break
-  sleep 5   # not visible yet
+  sleep 5
 done
-test "$(printf '%s' "$WAITING" | grep -c . || true)" -eq 1 || { echo "no run appeared within 150s; check the Actions tab" >&2; exit 1; }
-ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" --jq '.[0].environment.id')
-gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" \
-  --input - <<< "{\"environment_ids\":[$ENV],\"state\":\"approved\",\"comment\":\"warmup\"}"
+if [[ -z "$approval_run" ]]; then
+  echo "no run appeared within 150s; Testbox $TBX is running and you own it" >&2
+  exit 1
+fi
+approval_env="$(gh api "repos/manaflow-ai/cmux/actions/runs/$approval_run/pending_deployments" --jq '.[0].environment.id')"
+gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$approval_run/pending_deployments" \
+  --input - <<< "{\"environment_ids\":[$approval_env],\"state\":\"approved\",\"comment\":\"benchmark warmup\"}"
+printf 'approved run: %s\n' "$approval_run"
 ```
 
-If this aborts, a warmed box is already running and you own it. Stop it before
-retrying, or the next dispatch leaves two boxes and only one receipt.
+If this aborts, a warmed box is already running and you own it. Stop it, take a
+fresh snapshot, and dispatch again; the next set difference is unambiguous. Do
+not wait for a tie to break on its own, because the other operator is probably
+stuck at the same guard.
 
 `gh` has no native approve verb for deployments, so this uses REST. Self-approval
 is permitted on this environment. `scripts/blacksmith-testbox-demo.sh` implements

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -170,6 +170,11 @@ your run is still `in_progress` a couple of minutes after the stop, end it:
 gh run cancel <run-id> --repo manaflow-ai/cmux
 ```
 
+`gh run cancel` returns as soon as the request is accepted, and measured runs
+took about five minutes to actually reach `cancelled`. Seeing `in_progress`
+right after cancelling does not mean the cancel failed; poll until the run
+reports `completed`.
+
 Cancelling the run is a required step, not a fallback. Stopping the box does
 **not** reliably end its warmup run: measured runs sat `in_progress` for four
 minutes after the box reported `completed`, and every historical run in this

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -156,6 +156,18 @@ Any build command goes inside `blacksmith testbox run`:
 blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo build -p cmux-tui --locked"
 ```
 
+Tests and lints work the same way; only the quoted command changes:
+
+```bash
+blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo test --locked"
+blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo clippy --locked --all-targets -- -D warnings"
+blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo test -p cmux-tui-core --locked some_test_name"
+```
+
+Each of these reuses the same warm `target/`, so a second invocation compiles
+only what changed. Nothing here needs the stage helper; that is only for
+measured timings.
+
 For measured timings use the stage helper, which verifies VM identity, source
 identity, and clean status before and after each build:
 
@@ -192,53 +204,36 @@ your run is still `in_progress` a couple of minutes after the stop, end it:
 gh run cancel <run-id> --repo manaflow-ai/cmux
 ```
 
-`gh run cancel` returns as soon as the request is accepted, and measured runs
-took about five minutes to actually reach `cancelled`. Seeing `in_progress`
-right after cancelling does not mean the cancel failed; poll until the run
-reports `completed`.
+Cancelling is required, not a fallback. Stopping the box does **not** reliably
+end its run: measured runs sat `in_progress` for four minutes afterwards, and
+`gh run cancel` itself takes about five minutes to land, so `in_progress` right
+after either action is expected. Poll until the run reports `completed`. A
+`cancelled` conclusion is the healthy end state here; a run that never reached
+`Testbox ready` is the real failure.
 
-Cancelling the run is a required step, not a fallback. Stopping the box does
-**not** reliably end its warmup run: measured runs sat `in_progress` for four
-minutes after the box reported `completed`, and every historical run in this
-lane ended by explicit cancellation. Until you cancel it, the keepalive step
-holds a 32 vCPU runner, with a 120 minute job timeout as the only backstop.
-
-A `cancelled` conclusion is therefore the normal, healthy end state here, not a
-failed hydration. A run that never reached `Testbox ready` is the real failure.
-
-The bare `stop` above is the right cleanup for ordinary build work. The
-receipt-bound ceremony in `benchmark.md`, with an ownership token and a
-`STOP:<sha256>` confirmation, applies only when you are producing benchmark
-evidence that someone else will rely on; its point is that the box you destroy is
-provably the one your receipt describes. Do not fabricate a receipt to satisfy
-that guard, and do not run the ceremony for a throwaway build box.
+That bare `stop` is the right cleanup for ordinary build work. The receipt-bound
+ceremony in `benchmark.md` applies only to benchmark evidence someone else will
+rely on, where the point is proving the box you destroyed is the one your
+receipt describes. Never fabricate a receipt to satisfy that guard.
 
 Wrap any of these in `./scripts/blacksmith-bounded-command.sh <seconds> <cmd>`
-so a hung sync cannot stall a session. The full evidence-producing plan, with
-receipts and the ownership-token cleanup ceremony, is `benchmark.md`. Stage
-orchestration, cleanup, and how to read the two clocks are in
-`references/operations.md`.
+so a hung sync cannot stall a session. `benchmark.md` is the full evidence plan;
+`references/operations.md` covers stage orchestration, cleanup, and the two
+clocks.
 
-## Trust boundary
+## Trust boundary, in short
 
-`useblacksmith/begin-testbox` writes `/tmp/.testbox/auth_token` into the CI job,
-and `permissions: contents: read` does not stop a later step from reading it.
-`blacksmith testbox warmup` resolves the workflow definition and the hydrated
-source from the same `--ref`, so warming a candidate branch would run that
-branch's copy of the workflow beside the token, and the branch could delete its
-own guards.
-
-The lane hydrates `main` only. The first step refuses any other ref, no
-repository code runs before the token, and your revision arrives afterwards
-through `blacksmith testbox run` as an authenticated org member who could
-already reach the box. `tests/test_ci_testbox_broker_guard.py` enforces that
-shape on every pull request through
-`.github/workflows/testbox-broker-guard.yml`.
-
-A repository administrator owns the `blacksmith-testbox-trusted` environment:
-required reviewers, no secrets, admin bypass disabled, and a deployment branch
-rule of exactly `main`. If that drifts, disable the lane and stop. Never edit
-the workflow to work around a missing control.
+`begin-testbox` writes an auth token into the CI job, and `warmup` resolves the
+workflow definition and the hydrated source from the same `--ref`. Warming a
+candidate branch would therefore run that branch's copy of the workflow beside
+the token, and the branch could delete its own guards. So the lane hydrates
+`main` only, nothing from the repository runs before the token, and your
+revision arrives afterwards through `blacksmith testbox run`.
+`tests/test_ci_testbox_broker_guard.py` enforces that shape on every pull
+request. Never edit the workflow to work around a missing control; if the
+`blacksmith-testbox-trusted` environment drifts from required reviewers, no
+secrets, no admin bypass, and a branch rule of exactly `main`, disable the lane
+and stop. Full reasoning: `references/trust-boundary.md`.
 
 ## Rules
 

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -76,8 +76,8 @@ GHOSTTY_SHA="$(git rev-parse HEAD:ghostty)"
 
 ```bash
 blacksmith testbox warmup .github/workflows/cmux-tui-testbox-warmup.yml \
-  --ref main --job cmux-tui-rust --idle-timeout 30
-TBX=tbx_...    # the ID the command prints
+  --ref main --job cmux-tui-rust --idle-timeout 30   # minutes, not seconds
+TBX=tbx_...    # the ID the command prints; assign it once and never retype it
 ```
 
 `--ref main` is the trust boundary, not a preference. See the trust section
@@ -85,18 +85,29 @@ below. `--idle-timeout` is in minutes.
 
 ### Step 3: approve the deployment
 
-The run parks at the `blacksmith-testbox-trusted` environment gate before its
-first step. Approve it on the run page, or from the shell:
+`warmup` returns the ID immediately and does not block; the run then parks at
+the `blacksmith-testbox-trusted` environment gate before its first step.
+Approve it on the run page, or from the shell.
+
+Every run in this lane has the same title and the same `main` head branch, so
+**never approve `workflow_runs[0]`**. Two agents warm boxes minutes apart, and
+approving the newest waiting run hands a stranger's deployment its gate. Bind
+the approval to a run that appeared after your own dispatch, and refuse to guess
+when more than one is waiting:
 
 ```bash
-RUN=$(gh api repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs --jq '.workflow_runs[0].id')
-ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$RUN/pending_deployments" --jq '.[0].environment.id')
-gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$RUN/pending_deployments" \
+DISPATCH_EPOCH=$(date -u +%s)   # capture this BEFORE calling warmup
+WAITING=$(gh api "repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting" \
+  --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")
+test "$(printf '%s' "$WAITING" | grep -c .)" -eq 1 || { echo "more than one run waiting; approve yours in the UI"; exit 1; }
+ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" --jq '.[0].environment.id')
+gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" \
   --input - <<< "{\"environment_ids\":[$ENV],\"state\":\"approved\",\"comment\":\"warmup\"}"
 ```
 
 `gh` has no native approve verb for deployments, so this uses REST. Self-approval
-is permitted on this environment.
+is permitted on this environment. `scripts/blacksmith-testbox-demo.sh` implements
+exactly this guard if you would rather not hand-roll it.
 
 ### Step 4: wait for hydration, then read code
 
@@ -146,12 +157,29 @@ Download after each stage, because the next sync can delete remote output.
 ```bash
 blacksmith testbox download --id "$TBX" testbox-benchmark/first-clean.json ./first-clean.json
 blacksmith testbox stop --id "$TBX"
-blacksmith testbox list --all      # confirm nothing is left running
+blacksmith testbox list --all      # the box is gone from Blacksmith's inventory
+gh run list --repo manaflow-ai/cmux --workflow cmux-tui-testbox-warmup.yml --limit 3
+```
+
+Check both. `list --all` only shows boxes, and an empty list is **not** proof
+that nothing is burning: the warmup run's keepalive step keeps holding a 32 vCPU
+runner for a while after the box is gone, and it has a 120 minute job timeout. If
+your run is still `in_progress` a couple of minutes after the stop, end it:
+
+```bash
+gh run cancel <run-id> --repo manaflow-ai/cmux
 ```
 
 Stopping the box ends its warmup run with conclusion `cancelled`, because the
 keepalive step dies with the VM. That is the normal end state for this lane, not
 a failed hydration. A run that never reached `Testbox ready` is the real failure.
+
+The bare `stop` above is the right cleanup for ordinary build work. The
+receipt-bound ceremony in `benchmark.md`, with an ownership token and a
+`STOP:<sha256>` confirmation, applies only when you are producing benchmark
+evidence that someone else will rely on; its point is that the box you destroy is
+provably the one your receipt describes. Do not fabricate a receipt to satisfy
+that guard, and do not run the ceremony for a throwaway build box.
 
 Wrap any of these in `./scripts/blacksmith-bounded-command.sh <seconds> <cmd>`
 so a hung sync cannot stall a session. The full evidence-producing plan, with

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -22,7 +22,9 @@ at the end of your task means waiting; starting it in your first minute means it
 is ready by the time you know what to build. So:
 
 1. If your task might compile cmux-tui, dispatch the warmup **before** you open
-   a single source file, then read code while it hydrates.
+   a single source file, then read code while it hydrates. The exception is an
+   evidence run: `benchmark.md` requires its preflight, `OUT_ROOT`, and receipt
+   to exist before warmup, so read that plan first and accept the delay.
 2. Warm **your own** box. One box belongs to one worktree and one agent, because
    `blacksmith testbox run` synchronizes your worktree onto it with
    `rsync --delete`. Two agents on one ID overwrite each other's source and
@@ -95,15 +97,33 @@ approving the newest waiting run hands a stranger's deployment its gate. Bind
 the approval to a run that appeared after your own dispatch, and refuse to guess
 when more than one is waiting:
 
+GitHub does not surface the run the instant `warmup` returns, so poll. Zero
+runs visible means "not yet", and only two or more means genuinely ambiguous;
+treating those two cases alike aborts a warmup that was fine and strands a live
+box:
+
 ```bash
 DISPATCH_EPOCH=$(date -u +%s)   # capture this BEFORE calling warmup
-WAITING=$(gh api "repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting" \
-  --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")
-test "$(printf '%s' "$WAITING" | grep -c .)" -eq 1 || { echo "more than one run waiting; approve yours in the UI"; exit 1; }
+WAITING=""
+for attempt in $(seq 1 30); do
+  WAITING=$(gh api "repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting" \
+    --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")
+  count=$(printf '%s' "$WAITING" | grep -c .)
+  if (( count > 1 )); then
+    echo "$count runs waiting since your dispatch; approve yours in the UI" >&2
+    exit 1
+  fi
+  (( count == 1 )) && break
+  sleep 5   # not visible yet
+done
+test "$(printf '%s' "$WAITING" | grep -c .)" -eq 1 || { echo "no run appeared within 150s; check the Actions tab" >&2; exit 1; }
 ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" --jq '.[0].environment.id')
 gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$WAITING/pending_deployments" \
   --input - <<< "{\"environment_ids\":[$ENV],\"state\":\"approved\",\"comment\":\"warmup\"}"
 ```
+
+If this aborts, a warmed box is already running and you own it. Stop it before
+retrying, or the next dispatch leaves two boxes and only one receipt.
 
 `gh` has no native approve verb for deployments, so this uses REST. Self-approval
 is permitted on this environment. `scripts/blacksmith-testbox-demo.sh` implements
@@ -147,6 +167,8 @@ blacksmith testbox run --id "$TBX" \
 Stages are `first-clean` (wipes `target/`, dependencies stay warm),
 `incremental-noop` (rebuild with nothing changed), and `changed-file` (appends a
 comment to `cmux-tui/crates/cmux-tui/src/main.rs`, builds, restores the bytes).
+`changed-file` rebuilds two crates, `cmux-remote` and `cmux-tui`, so read its
+~8 s as a small-edit figure, not as a single-crate floor.
 `CMUX_TESTBOX_REMOTE=1` guards against an accidental local launch; it is not
 authentication. Add `--debug` to `run` to see the sync strategy.
 

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -1,400 +1,183 @@
 ---
 name: blacksmith-testbox
 description: >
-  Provision and reuse a trusted Blacksmith Testbox for cmux-tui Rust builds,
-  capture remote timings, download raw evidence, and clean up safely. Never run
-  cargo, rustc, or Zig builds on the local Mac.
+  Warm and drive a Blacksmith Testbox for cmux-tui Rust and Zig work on Linux.
+  Use whenever a task will compile cmux-tui (cargo build, cargo test, clippy,
+  startup benchmarks, Ghostty Zig deps) or when the user says testbox, warm a
+  box, blacksmith, remote build box, or benchmark cmux-tui. Never run cargo,
+  rustc, or zig build on the local Mac.
 ---
 
 # cmux-tui Blacksmith Testbox
 
-This lane is Linux-only. It uses
-`.github/workflows/cmux-tui-testbox-warmup.yml`, job
-`cmux-tui-rust`, on `blacksmith-32vcpu-ubuntu-2404`. The workflow is a
-setup-only entrypoint for a reusable Testbox. It refuses every ref except
-`refs/heads/main`, checks out and verifies that commit, initializes the
-`ghostty` source submodule, installs Linux C/LLVM headers, installs the
-repository-pinned Zig and Rust toolchains, fetches Zig and Cargo dependencies,
-records runner/toolchain/Ghostty identity in JSON, and then hands control back
-to Testbox. It does not run Rust tests or Rust compilation during warmup.
-`zig build --fetch` only hydrates Zig packages and exits before compilation.
+A Testbox is a persistent 32 vCPU Linux VM that keeps its disk between
+commands. CI warms it once, and every later build reuses the Cargo registry,
+the Zig cache, and `target/`. A clean cmux-tui build costs about 130 s on a warm
+box, a no-op about 0.2 s, and a one-file change about 8 s.
 
-The repository's single Rust toolchain source is
-`cmux-tui/rust-toolchain.toml`. The workflow invokes
-`./.github/actions/setup-cmux-tui-rust`, so a workflow-specific Rust version
-must never be added.
+## Warm your own box first, before you read code
 
-## Hard safety and trust boundary
+Warmup takes about four minutes of wall clock you cannot compress. Starting it
+at the end of your task means waiting; starting it in your first minute means it
+is ready by the time you know what to build. So:
 
-This is a main-controlled broker lane. `useblacksmith/begin-testbox` writes
-`/tmp/.testbox/auth_token` into the job, and `permissions: contents: read` does
-not stop any later step from reading it. The lane therefore holds one rule
-above all others: **nothing a candidate branch can edit ever runs inside that
-job.**
+1. If your task might compile cmux-tui, dispatch the warmup **before** you open
+   a single source file, then read code while it hydrates.
+2. Warm **your own** box. One box belongs to one worktree and one agent, because
+   `blacksmith testbox run` synchronizes your worktree onto it with
+   `rsync --delete`. Two agents on one ID overwrite each other's source and
+   corrupt each other's timings.
+3. Never adopt a box you find in `blacksmith testbox list --all`. A box you did
+   not warm is someone else's working state.
+4. Stop your box the moment you are done, and always pass `--idle-timeout` so a
+   crashed agent cannot leak a running VM.
 
-`blacksmith testbox warmup` resolves the workflow file and the hydrated source
-from the same `--ref`, so the two cannot be separated. The lane resolves that
-by hydrating `main` only. The first step fails any ref other than
-`refs/heads/main`, and every guard, the pinned `begin-testbox` SHA, and the
-keepalive all come from `main`. A candidate revision never becomes the workflow
-definition, and its `build.zig`, `rust-toolchain.toml`, and composite actions
-never execute in the token-bearing job.
+Skip the lane entirely for Swift, Xcode, XCUITest, GUI, and app-host work. That
+is macOS, and it belongs in the hosted macOS workflows.
 
-A candidate reaches the Testbox afterwards, through `blacksmith testbox run`,
-which synchronizes a maintainer's local worktree onto the warm VM. That command
-runs as an authenticated Blacksmith organization member who could already read
-the box, so it moves no trust boundary. It does mean the box holds one
-operator's revision at a time: a Testbox ID belongs to one worktree and one
-operator.
-
-Before using the lane, a repository administrator must create the
-`blacksmith-testbox-trusted` GitHub environment, configure required reviewers
-(or an equivalent manual approval rule), disable administrator bypass, leave
-the environment secret set empty, and set its deployment branch rule to exactly
-`main` with no wildcard and no fork rule. GitHub evaluates that approval and
-branch rule before the job's first step, so both precede `begin-testbox`. The
-approval is what authorizes spending a 32 vCPU box, because the code path is
-already fixed by `main`.
-
-This lane needs no `BLACKSMITH_TESTBOX_REVIEWED_REF` or
-`BLACKSMITH_TESTBOX_REVIEWED_SHA` environment variable. Those pins existed to
-make a candidate-controlled workflow safe. Delete them if they are still
-configured; the broker's `refs/heads/main` guard replaces them, and it cannot
-be edited from a pull request.
-
-If the environment is deleted, renamed, or loses its exact `main` branch rule,
-disable the lane and stop rather than changing the workflow to proceed. The
-workflow cannot manufacture those controls, so configuration drift makes the
-lane unavailable rather than safe.
-
-The helper retains the `CMUX_TESTBOX_REMOTE=1` guard for accidental local
-launches, and additionally requires the Blacksmith VM kernel metadata marker
-and matching `/tmp/.testbox` state. The environment flag remains caller
-controlled and is not an authentication mechanism.
-
-* Never run `cargo`, `rustc`, `rustup`, `zig build`, or another Rust/Zig build
-  command on Lawrence's Mac. This includes local fallback builds and local
-  test commands.
-* Run every Blacksmith CLI command from the root of the intended isolated
-  worktree. The CLI synchronizes that directory with `rsync --delete`; it can
-  delete remote files that are not represented locally.
-* Put remote build commands inside `blacksmith testbox run`. The benchmark
-  helper also requires the Testbox VM guard, so an accidental local launch
-  exits before invoking a compiler.
-* Use this Testbox only for Linux-compatible cmux-tui work. Use hosted macOS
-  workflows for Swift, Xcode, XCTest, GUI, and app-host verification.
-
-## Authentication and CLI installation
-
-Check authentication without printing credentials:
+## Prerequisites
 
 ```bash
-blacksmith auth whoami
-blacksmith --version
+blacksmith auth whoami     # confirms the manaflow-ai org; prints no secret
+blacksmith --version       # record this with any evidence
 ```
 
-Use the repository or organization-approved, pinned Blacksmith CLI artifact or
-package-manager version. Record its version in the evidence. Do not install a
-mutable remote script with `curl ... | sh`; if the approved pinned artifact is
-not available, stop and ask the tooling owner rather than weakening this lane.
-The repository does not currently pin a checksum-verified CLI artifact, so CLI
-provenance is a trusted-lane operational limitation: do not silently upgrade or
-substitute a version, and retain `blacksmith --version` with each evidence set.
+Use the organization-approved pinned CLI. Never install it with
+`curl ... | sh`. If the pinned artifact is unavailable, stop and ask the tooling
+owner rather than substituting a version.
 
-## Exact source contract
+Run every command from the root of an isolated cmux worktree, never from
+`repo/`. The directory you stand in is the directory that gets synchronized.
 
-Two commits matter and they are normally different. The **hydration commit** is
-`main`, and it is what the broker warmed the Cargo registry, Zig cache, and
-toolchains from. The **benchmarked commit** is your local HEAD, and it reaches
-the box through `blacksmith testbox run`. The stage helper records both and
-sets `hydration.matches_benchmarked_source` in each stage JSON.
+## Workflow
 
-Do not pass a commit SHA to `blacksmith testbox warmup --ref`. Blacksmith and
-GitHub reject a raw SHA with HTTP 422 (`No ref found`), and this lane accepts
-only `main` anyway.
+### Step 1: commit, push, and record identity
 
-Your local HEAD must be committed, clean, **and pushed**. `blacksmith testbox
-run` synchronizes file contents, not history: it attempts one opportunistic
-`git fetch` of your commit and then falls back to copying changed files, and it
-skips even that once the file fingerprints match. The box keeps whatever history
-the warmup job checked out, which is `main`. A commit that exists only on your
-disk fails on the box with `upload-pack: not our ref`, and the stage helper
-then refuses with the exact remedy.
-
-So push the branch, then pin the box to that commit once per box, before the
-first stage:
+The commit you benchmark must be pushed. `blacksmith testbox run` synchronizes
+file contents, not history: it makes one opportunistic `git fetch` of your
+commit, falls back to copying changed files, and skips even that once the file
+fingerprints match. A local-only commit fails on the box with
+`upload-pack: not our ref`.
 
 ```bash
-git push origin "$SOURCE_REF"
-blacksmith testbox run --id "$TBX" \
-  'set -euo pipefail; git fetch --no-tags origin '"$SOURCE_SHA"'; git reset --hard '"$SOURCE_SHA"'; git submodule update --init --depth 1 ghostty'
-```
-
-That reset makes the box an exact checkout of the benchmarked commit, including
-the helper scripts, so the timings describe a revision anyone can fetch. It also
-means an uncommitted local edit is never what gets built. Initialize the public
-Ghostty submodule once, then run this preflight from the clean worktree root:
-
-```bash
-set -euo pipefail
 git submodule update --init ghostty
-cd "$(git rev-parse --show-toplevel)"
-SOURCE_REF="$(git symbolic-ref --short HEAD)"
-if [[ ! "$SOURCE_REF" =~ ^[A-Za-z0-9._/-]+$ || "$SOURCE_REF" == *..* || "$SOURCE_REF" == */ || "$SOURCE_REF" == *//* ]]; then
-  echo "HEAD must name a plain branch" >&2
-  exit 1
-fi
+git push origin "$(git symbolic-ref --short HEAD)"
 SOURCE_SHA="$(git rev-parse HEAD)"
-ghostty_entry="$(git ls-tree HEAD ghostty)"
-[[ "$ghostty_entry" =~ ^160000[[:space:]]commit[[:space:]][0-9a-f]{40}[[:space:]]ghostty$ ]] || {
-  echo "HEAD:ghostty is not a gitlink" >&2
-  exit 1
-}
 GHOSTTY_SHA="$(git rev-parse HEAD:ghostty)"
-[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-[[ "$GHOSTTY_SHA" =~ ^[0-9a-f]{40}$ ]]
-[[ "$(git -C ghostty rev-parse HEAD)" == "$GHOSTTY_SHA" ]]
-[[ -z "$(git status --porcelain=v1 --untracked-files=normal)" ]]
-[[ -z "$(git -C ghostty status --porcelain=v1 --untracked-files=normal)" ]]
-remote_sha="$(git ls-remote --exit-code origin "refs/heads/$SOURCE_REF" | awk 'NR == 1 { print $1 }')"
-[[ "$remote_sha" == "$SOURCE_SHA" ]] || {
-  echo "push the exact clean branch head before warming a Testbox" >&2
-  exit 1
-}
-BROKER_SHA="$(git ls-remote --exit-code --heads https://github.com/manaflow-ai/cmux.git refs/heads/main | awk 'NR == 1 { print $1 }')"
-printf 'source_ref=%s\nsource_sha=%s\nghostty_gitlink_sha=%s\nbroker_main_sha=%s\n' \
-  "$SOURCE_REF" "$SOURCE_SHA" "$GHOSTTY_SHA" "$BROKER_SHA"
+[[ -z "$(git status --porcelain=v1 --untracked-files=normal)" ]] || exit 1
 ```
 
-`main` can move after this check, which only changes cache warmth, never
-correctness: the stage helper reads the hydration commit back out of the setup
-marker and records it. A moved or dirty benchmarked checkout still fails
-closed.
-
-The hydrated toolchain is a hard gate. If your branch pins a different Rust or
-Zig than `main`, the stage helper exits 66 rather than reporting a timing
-against caches it did not warm. Rebase onto `main` or warm a fresh box from a
-`main` that carries the same pins.
-
-## Warmup and identity capture
-
-Warm from `main`. The broker refuses every other ref, and your candidate does
-not belong here; it arrives later through the sync:
+### Step 2: warm the box
 
 ```bash
-WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
-JOB=cmux-tui-rust
-blacksmith testbox warmup "$WORKFLOW" \
-  --ref main \
-  --job "$JOB" \
-  --idle-timeout 30
+blacksmith testbox warmup .github/workflows/cmux-tui-testbox-warmup.yml \
+  --ref main --job cmux-tui-rust --idle-timeout 30
+TBX=tbx_...    # the ID the command prints
 ```
 
-Save the returned `tbx_...` ID. One ID belongs to one worktree and one
-operator. The workflow concurrency group keys every setup request by Testbox
-ID, including requests for different source SHAs. Source identity is validated
-separately, and each remote stage holds `testbox-benchmark/.stage.lock` through
-its build and artifact writes. Blacksmith's CLI exposes no pre-rsync lease, so
-that remote lock cannot serialize the CLI's initial sync. One Testbox ID must
-therefore have one owning worktree/operator; do not issue concurrent `run` or
-download commands from independent clients. This is an explicit trusted-lane
-limitation, not a claim of multi-client Testbox isolation.
+`--ref main` is the trust boundary, not a preference. See the trust section
+below. `--idle-timeout` is in minutes.
 
-Wait for setup and capture the exact run identity:
+### Step 3: approve the deployment
+
+The run parks at the `blacksmith-testbox-trusted` environment gate before its
+first step. Approve it on the run page, or from the shell:
+
+```bash
+RUN=$(gh api repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs --jq '.workflow_runs[0].id')
+ENV=$(gh api "repos/manaflow-ai/cmux/actions/runs/$RUN/pending_deployments" --jq '.[0].environment.id')
+gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$RUN/pending_deployments" \
+  --input - <<< "{\"environment_ids\":[$ENV],\"state\":\"approved\",\"comment\":\"warmup\"}"
+```
+
+`gh` has no native approve verb for deployments, so this uses REST. Self-approval
+is permitted on this environment.
+
+### Step 4: wait for hydration, then read code
 
 ```bash
 blacksmith testbox status --id "$TBX" --wait --wait-timeout 15m
 ```
 
-The setup job's `setup-identity.json` artifact and each stage helper's
-pre-build JSON record are the identity transcripts. The helper verifies the
-Testbox VM marker, claimed Testbox ID, the hydration marker's own consistency,
-the runner class, and then the synchronized source commit/tree, Ghostty
-gitlink/checkout, and clean status before it invokes Cargo, repeating the
-source checks after the build. Keep the setup artifact URL or download it into `$OUT`;
-it records runner/toolchain/Ghostty identity independently of the stage helper.
-The setup JSON contains the workflow run, the hydrated `main` ref/SHA/tree,
-Ghostty gitlink and checkout SHA, runner label/architecture/CPU identity, and pinned
-Rust/Zig/toolchain-file metadata. A successful setup also copies that JSON to
-`/tmp/.testbox/cmux-tui-rust-setup-identity.json`; the stage helper refuses a
-missing or mismatched marker, so a failed hydration cannot be benchmarked.
-Never print or download `/tmp/.testbox/auth_token`.
+This blocks while CI installs the pinned Zig and Rust and fetches Cargo and Zig
+dependencies. Do your reading now.
 
-## Remote benchmark stages
+### Step 5: pin the box to your commit
 
-The detailed, receipt-producing orchestration in `benchmark.md` is the required
-entry point for a complete benchmark. It creates the unique `OUT_ROOT`, receipt,
-cleanup token, setup artifact capture, and cleanup preview state. Do not copy
-only this stage loop into an ad hoc shell without those prerequisites.
-
-Before each stage, recompute `SOURCE_SHA` and `GHOSTTY_SHA` and repeat the
-clean pushed-branch preflight.
-Pass the expected values as validated arguments;
-the helper does not trust the remote checkout or a caller-supplied expected SHA
-without comparing it to Git metadata:
+The box is an exact checkout of `main`, because that is what CI hydrated. Make
+it an exact checkout of your revision. Once per box, before the first build:
 
 ```bash
-# Run this orchestration block in Bash, not an interactive zsh session.
-run_stage() {
-  local stage="$1"
-  local run_status download_status=0
-  set +e
-  printf -v remote_command \
-    'CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=%q %q %q %q %q' \
-    "$TBX" ./scripts/blacksmith-cmux-tui-testbox-stage.sh \
-    "$stage" "$SOURCE_SHA" "$GHOSTTY_SHA"
-  ./scripts/blacksmith-bounded-command.sh 1500 \
-    blacksmith testbox run --id "$TBX" --debug \
-    "$remote_command" >"$OUT/$stage.run.log" 2>&1
-  run_status=$?
-  set -e
-  cat "$OUT/$stage.run.log"
-
-  # Download immediately. Blacksmith's next rsync may delete or replace remote
-  # files, so a one-time download after all stages is insufficient.
-  : >"$OUT/$stage.download.log"
-  for suffix in json time log; do
-    if ! ./scripts/blacksmith-bounded-command.sh 120 \
-      blacksmith testbox download --id "$TBX" \
-      "testbox-benchmark/$stage.$suffix" "$OUT/raw/$stage.$suffix" \
-      >>"$OUT/$stage.download.log" 2>&1; then
-      download_status=1
-    fi
-  done
-  cat "$OUT/$stage.download.log"
-  if (( run_status != 0 )); then
-    return "$run_status"
-  fi
-  return "$download_status"
-}
+blacksmith testbox run --id "$TBX" \
+  "set -euo pipefail; git fetch --no-tags origin $SOURCE_SHA; git reset --hard $SOURCE_SHA; git submodule update --init --depth 1 ghostty"
 ```
 
-The helper supports exactly `first-clean`, `incremental-noop`, and
-`changed-file`. Each remote Cargo build is bounded to 20 minutes with a
-30-second kill grace period. It records a schema-2 JSON object for each stage
-containing:
+### Step 6: build or benchmark
 
-* expected and observed source commit/tree identity before and after the build;
-* expected and observed Ghostty gitlink and initialized submodule HEAD;
-* clean/dirty file lists and source restoration status;
-* Testbox ID and adopted workflow run ID;
-* runner label, hostname, architecture, CPU count, and `uname`; the setup
-  workflow fails closed unless the actual runner is x64 with 32 CPUs;
-* active Rust toolchain, `rustc`, Cargo, Zig, lockfile/toolchain hashes, and
-  Ghostty package-manifest hash; and
-* Cargo exit status, `/usr/bin/time -p` values, and CLI transcript timing.
-
-`first-clean` removes only the remote `cmux-tui/target` directory before a
-`cargo build -p cmux-tui --locked`. `incremental-noop` repeats that command
-without changing source. `changed-file` appends a comment to
-`cmux-tui/crates/cmux-tui/src/main.rs`, builds, and restores the original bytes
-before emitting its final record. A dirty or mismatched source before any
-stage, after restoration, or in the Ghostty submodule aborts the stage.
-
-After all successful downloads, aggregate and verify the records:
+Any build command goes inside `blacksmith testbox run`:
 
 ```bash
-python3 - "$OUT" "$SOURCE_SHA" "$GHOSTTY_SHA" "$TBX" <<'PY'
-import json
-import pathlib
-import subprocess
-import sys
-
-out = pathlib.Path(sys.argv[1])
-expected_source, expected_ghostty, testbox_id = sys.argv[2:]
-expected_tree = subprocess.check_output(
-    ["git", "rev-parse", f"{expected_source}^{{tree}}"], text=True
-).strip()
-required = {"first-clean", "incremental-noop", "changed-file"}
-records = []
-for path in sorted((out / "raw").glob("*.json")):
-    record = json.loads(path.read_text(encoding="utf-8"))
-    records.append(record)
-if {record.get("stage") for record in records} != required:
-    raise SystemExit("timing evidence is missing one or more benchmark stages")
-for record in records:
-    if record.get("testbox", {}).get("id") != testbox_id:
-        raise SystemExit(f"{record.get('stage')} has the wrong Testbox ID")
-    source = record.get("source", {})
-    if source.get("expected_commit_sha") != expected_source or source.get("expected_tree_sha") != expected_tree:
-        raise SystemExit(f"{record.get('stage')} has the wrong expected source identity")
-    for side in ("before", "after"):
-        snapshot = source.get(side, {})
-        if snapshot.get("commit_sha") != expected_source or snapshot.get("tree_sha") != expected_tree:
-            raise SystemExit(f"{record.get('stage')} has the wrong {side} source SHA")
-        if snapshot.get("dirty_files"):
-            raise SystemExit(f"{record.get('stage')} has dirty top-level source")
-        ghostty = snapshot.get("ghostty", {})
-        if ghostty.get("gitlink_sha") != expected_ghostty or ghostty.get("head_sha") != expected_ghostty:
-            raise SystemExit(f"{record.get('stage')} has mismatched Ghostty identity")
-        if ghostty.get("dirty_files"):
-            raise SystemExit(f"{record.get('stage')} has dirty Ghostty source")
-    if not record.get("ok"):
-        raise SystemExit(f"{record.get('stage')} did not complete successfully")
-with (out / "timings.json").open("w", encoding="utf-8") as handle:
-    json.dump({"schema": 2, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
-    handle.write("\n")
-PY
+blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo build -p cmux-tui --locked"
 ```
 
-Keep `raw/*.json`, `raw/*.time`, `raw/*.log`, every `*.run.log` and download
-log, the setup artifact, and the source manifest in a new, unique
-`.cmux-scratch/` evidence directory. Never reuse a prior SHA-only directory;
-refuse to overwrite historical records. Do not add credentials or private keys.
-
-## Fail-safe cleanup
-
-Always download before cleanup. Use the checked-in cleanup helper rather than
-ignoring errors with `|| true`. After an independent operator decides the exact
-box may be destroyed, pass the ownership token generated with the warmup receipt
-and the literal `STOP`; never print the token:
+For measured timings use the stage helper, which verifies VM identity, source
+identity, and clean status before and after each build:
 
 ```bash
-CLEANUP_TOKEN="${CLEANUP_TOKEN:-}"
-[[ "$CLEANUP_TOKEN" =~ ^[0-9a-f]{32}$ ]] || {
-  echo "use the ownership token emitted by the warmup receipt" >&2
-  exit 64
-}
-scripts/blacksmith-testbox-cleanup.sh "$TBX" "$OUT" "$CLEANUP_TOKEN" PREVIEW
-# Review cleanup-preview.json, then rerun with STOP:<sha256(cleanup-preview.json)>.
+blacksmith testbox run --id "$TBX" \
+  "CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=$TBX ./scripts/blacksmith-cmux-tui-testbox-stage.sh first-clean $SOURCE_SHA $GHOSTTY_SHA"
 ```
 
-It records a pre-stop status preview, stop result, post-stop status, and
-`list --all` output. The preview must match the receipt's workflow, job, and
-branch before any stop is attempted. Cleanup is destructive and requires a fresh `STOP:<sha256(cleanup-preview.json)>`
-confirmation after reviewing the current receipt-bound preview.
-It verifies that the specific Testbox ID is terminal or absent from the active
-inventory, accepts the known terminal states `completed`, `stopped`, `cancelled`,
-`failed`, `terminated`, and `hydration_failed`, plus a 409 saying the box is
-already stopped or completed, and polls for up to two minutes while cancellation
-propagates. Other stop, status, or list failures remain failures.
-Put it in an `EXIT` trap only after an independent operator exports
-`CONFIRM_TESTBOX_STOP_SHA` containing the SHA-256 of a separately reviewed
-`cleanup-preview.json`; otherwise preserve the benchmark's original exit status
-and leave the box for manual cleanup. The detailed benchmark writes a
-receipt and ownership token for the exact ID returned by warmup; cleanup refuses an ID
-or token that is not bound to that receipt. If warmup fails before returning an
-ID, retain before/after inventory but do not automatically stop a box, because
-an inventory diff cannot prove ownership across concurrent operators. Reconcile
-that orphan manually through the Blacksmith control plane.
+Stages are `first-clean` (wipes `target/`, dependencies stay warm),
+`incremental-noop` (rebuild with nothing changed), and `changed-file` (appends a
+comment to `cmux-tui/crates/cmux-tui/src/main.rs`, builds, restores the bytes).
+`CMUX_TESTBOX_REMOTE=1` guards against an accidental local launch; it is not
+authentication. Add `--debug` to `run` to see the sync strategy.
 
-## Timing interpretation
+### Step 7: download, then stop
 
-The benchmark reports two clocks. The local CLI transcript measures sync,
-transport, queueing, and the remote command. The downloaded `/usr/bin/time -p`
-record measures the remote `cargo build -p cmux-tui --locked` command. Compare
-remote `real` or `time_real_seconds` values for build performance, and retain
-CLI wall time when evaluating Testbox overhead.
+Download after each stage, because the next sync can delete remote output.
 
-`first-clean` is target-clean but dependency-warm: warmup runs `cargo fetch` and
-`zig build --fetch`, and the workflow may restore registry, git, and Zig caches.
-`incremental-noop` measures a second build on the same VM. `changed-file` is a
-controlled source change on that same VM. These are deliberately different
-from a cold-VM benchmark.
+```bash
+blacksmith testbox download --id "$TBX" testbox-benchmark/first-clean.json ./first-clean.json
+blacksmith testbox stop --id "$TBX"
+blacksmith testbox list --all      # confirm nothing is left running
+```
 
-The existing 32-vCPU evidence at
-`.cmux-scratch/blacksmith-testbox-e40704611ac35f4ffa153/` remains historical
-provenance for setup SHA `e40704611ac35f0e3a806841a9eae383f4ffa153`, Testbox
-`tbx_01kzxebn91nhatkv4ygevh06vs`, and workflow run `31696013711`. Its raw
-records and cleanup result must not be rewritten when validating this hardening
-change.
+Wrap any of these in `./scripts/blacksmith-bounded-command.sh <seconds> <cmd>`
+so a hung sync cannot stall a session. The full evidence-producing plan, with
+receipts and the ownership-token cleanup ceremony, is `benchmark.md`. Stage
+orchestration, cleanup, and how to read the two clocks are in
+`references/operations.md`.
+
+## Trust boundary
+
+`useblacksmith/begin-testbox` writes `/tmp/.testbox/auth_token` into the CI job,
+and `permissions: contents: read` does not stop a later step from reading it.
+`blacksmith testbox warmup` resolves the workflow definition and the hydrated
+source from the same `--ref`, so warming a candidate branch would run that
+branch's copy of the workflow beside the token, and the branch could delete its
+own guards.
+
+The lane hydrates `main` only. The first step refuses any other ref, no
+repository code runs before the token, and your revision arrives afterwards
+through `blacksmith testbox run` as an authenticated org member who could
+already reach the box. `tests/test_ci_testbox_broker_guard.py` enforces that
+shape on every pull request through
+`.github/workflows/testbox-broker-guard.yml`.
+
+A repository administrator owns the `blacksmith-testbox-trusted` environment:
+required reviewers, no secrets, admin bypass disabled, and a deployment branch
+rule of exactly `main`. If that drifts, disable the lane and stop. Never edit
+the workflow to work around a missing control.
+
+## Rules
+
+- MUST NOT run `cargo`, `rustc`, `rustup`, or `zig build` on the local Mac, including as a fallback when the box is unavailable.
+- MUST run every Blacksmith command from the intended worktree root. `rsync --delete` can remove remote files that are absent locally.
+- MUST push the benchmarked commit and pin the box to it. An unpushed commit silently leaves the box on `main` with your files written over it.
+- MUST NOT reuse another agent's Testbox ID, and MUST NOT run concurrent `run` or `download` commands against one ID from separate clients.
+- MUST stop the box and confirm with `list --all` when finished.
+- MUST NOT print or download `/tmp/.testbox/auth_token`.
+- MUST NOT dispatch the warmup for a pull request, a fork, or any ref other than `main`.
+- If the toolchain differs from what CI hydrated, the stage helper exits 66. Rebase onto `main` rather than reporting a cold-cache timing.

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -35,6 +35,11 @@ is ready by the time you know what to build. So:
 Skip the lane entirely for Swift, Xcode, XCUITest, GUI, and app-host work. That
 is macOS, and it belongs in the hosted macOS workflows.
 
+Run `./scripts/blacksmith-testbox-demo.sh` once to watch the whole lane work:
+it warms a box, pins it, builds cmux-tui twice to show what the persistent disk
+buys, prints every remote command before running it, and stops the box on the
+way out. `--stages` runs the three measured stages instead.
+
 ## Prerequisites
 
 ```bash
@@ -143,6 +148,10 @@ blacksmith testbox download --id "$TBX" testbox-benchmark/first-clean.json ./fir
 blacksmith testbox stop --id "$TBX"
 blacksmith testbox list --all      # confirm nothing is left running
 ```
+
+Stopping the box ends its warmup run with conclusion `cancelled`, because the
+keepalive step dies with the VM. That is the normal end state for this lane, not
+a failed hydration. A run that never reached `Testbox ready` is the real failure.
 
 Wrap any of these in `./scripts/blacksmith-bounded-command.sh <seconds> <cmd>`
 so a hung sync cannot stall a session. The full evidence-producing plan, with

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -170,9 +170,14 @@ your run is still `in_progress` a couple of minutes after the stop, end it:
 gh run cancel <run-id> --repo manaflow-ai/cmux
 ```
 
-Stopping the box ends its warmup run with conclusion `cancelled`, because the
-keepalive step dies with the VM. That is the normal end state for this lane, not
-a failed hydration. A run that never reached `Testbox ready` is the real failure.
+Cancelling the run is a required step, not a fallback. Stopping the box does
+**not** reliably end its warmup run: measured runs sat `in_progress` for four
+minutes after the box reported `completed`, and every historical run in this
+lane ended by explicit cancellation. Until you cancel it, the keepalive step
+holds a 32 vCPU runner, with a 120 minute job timeout as the only backstop.
+
+A `cancelled` conclusion is therefore the normal, healthy end state here, not a
+failed hydration. A run that never reached `Testbox ready` is the real failure.
 
 The bare `stop` above is the right cleanup for ordinary build work. The
 receipt-bound ceremony in `benchmark.md`, with an ownership token and a

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -113,12 +113,27 @@ Do not pass a commit SHA to `blacksmith testbox warmup --ref`. Blacksmith and
 GitHub reject a raw SHA with HTTP 422 (`No ref found`), and this lane accepts
 only `main` anyway.
 
-Your local HEAD must be committed and clean, because every remote stage
-verifies HEAD, its tree, the `ghostty` gitlink, the initialized Ghostty HEAD,
-and clean status before it builds. Pushing that commit is not required for the
-build, since the sync carries the objects, but push it anyway so the evidence
-names a fetchable revision. Initialize the public Ghostty submodule once, then
-run this preflight from the clean worktree root:
+Your local HEAD must be committed, clean, **and pushed**. `blacksmith testbox
+run` synchronizes file contents, not history: it attempts one opportunistic
+`git fetch` of your commit and then falls back to copying changed files, and it
+skips even that once the file fingerprints match. The box keeps whatever history
+the warmup job checked out, which is `main`. A commit that exists only on your
+disk fails on the box with `upload-pack: not our ref`, and the stage helper
+then refuses with the exact remedy.
+
+So push the branch, then pin the box to that commit once per box, before the
+first stage:
+
+```bash
+git push origin "$SOURCE_REF"
+blacksmith testbox run --id "$TBX" \
+  'set -euo pipefail; git fetch --no-tags origin '"$SOURCE_SHA"'; git reset --hard '"$SOURCE_SHA"'; git submodule update --init --depth 1 ghostty'
+```
+
+That reset makes the box an exact checkout of the benchmarked commit, including
+the helper scripts, so the timings describe a revision anyone can fetch. It also
+means an uncommitted local edit is never what gets built. Initialize the public
+Ghostty submodule once, then run this preflight from the clean worktree root:
 
 ```bash
 set -euo pipefail
@@ -141,6 +156,11 @@ GHOSTTY_SHA="$(git rev-parse HEAD:ghostty)"
 [[ "$(git -C ghostty rev-parse HEAD)" == "$GHOSTTY_SHA" ]]
 [[ -z "$(git status --porcelain=v1 --untracked-files=normal)" ]]
 [[ -z "$(git -C ghostty status --porcelain=v1 --untracked-files=normal)" ]]
+remote_sha="$(git ls-remote --exit-code origin "refs/heads/$SOURCE_REF" | awk 'NR == 1 { print $1 }')"
+[[ "$remote_sha" == "$SOURCE_SHA" ]] || {
+  echo "push the exact clean branch head before warming a Testbox" >&2
+  exit 1
+}
 BROKER_SHA="$(git ls-remote --exit-code --heads https://github.com/manaflow-ai/cmux.git refs/heads/main | awk 'NR == 1 { print $1 }')"
 printf 'source_ref=%s\nsource_sha=%s\nghostty_gitlink_sha=%s\nbroker_main_sha=%s\n' \
   "$SOURCE_REF" "$SOURCE_SHA" "$GHOSTTY_SHA" "$BROKER_SHA"
@@ -208,7 +228,7 @@ cleanup token, setup artifact capture, and cleanup preview state. Do not copy
 only this stage loop into an ad hoc shell without those prerequisites.
 
 Before each stage, recompute `SOURCE_SHA` and `GHOSTTY_SHA` and repeat the
-clean pushed-branch preflight, including the protected reviewed ref/SHA pins.
+clean pushed-branch preflight.
 Pass the expected values as validated arguments;
 the helper does not trust the remote checkout or a caller-supplied expected SHA
 without comparing it to Git metadata:

--- a/skills/blacksmith-testbox/SKILL.md
+++ b/skills/blacksmith-testbox/SKILL.md
@@ -185,10 +185,19 @@ blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo build -p cmux-tui --loc
 Tests and lints work the same way; only the quoted command changes:
 
 ```bash
-blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo test --locked"
+blacksmith testbox run --id "$TBX" "cd cmux-tui && umask 022 && cargo test --locked"
 blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo clippy --locked --all-targets -- -D warnings"
-blacksmith testbox run --id "$TBX" "cd cmux-tui && cargo test -p cmux-tui-core --locked some_test_name"
+blacksmith testbox run --id "$TBX" "cd cmux-tui && umask 022 && cargo test -p cmux-tui-core --locked some_test_name"
 ```
+
+**`cargo test` needs `umask 022`.** `blacksmith testbox run` gives you a shell
+at `umask 0002`, so test directories are created group-writable, and
+`cmux-remote`'s secure-directory check rejects any ancestor writable by other
+users without the sticky bit. Without the umask a fresh box fails 104 tests with
+`PermissionDenied ... has an ancestor writable by other users without
+sticky-directory protection`. Hosted CI runs at `umask 022`, so the suite passes
+there and fails here; the suite is not umask-independent. With it, 3504 tests
+pass in about 88 s. Builds and clippy are unaffected.
 
 Each of these reuses the same warm `target/`, so a second invocation compiles
 only what changed. Nothing here needs the stage helper; that is only for

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -130,7 +130,17 @@ start a new evidence directory. Do not silently substitute the new SHA.
 
 ## Warmup and setup identity
 
-Use the branch ref, not `SOURCE_SHA`, in warmup:
+Warm from `main`. The lane refuses every other ref, and a raw SHA is not a
+supported warmup ref. Your benchmarked branch never appears here; it reaches the
+box later, through the pin step.
+
+**Then approve the deployment gate, before you wait.** The run parks at the
+`blacksmith-testbox-trusted` environment gate before its first step, so the
+`status --wait` below simply times out after 15 minutes if nothing approves it.
+Use the `DISPATCH_EPOCH`-guarded approval in `SKILL.md` Step 3, which binds to a
+run created after your own dispatch and refuses when more than one is waiting.
+Never approve `workflow_runs[0]`: every run in this lane shares a title and a
+`main` head branch, so the newest waiting run may belong to another operator.
 
 ```bash
 WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
@@ -442,7 +452,14 @@ cleanup_token="${cleanup_token:-}"
   echo "use the confirmation token emitted by the warmup receipt" >&2
   exit 64
 }
+# PREVIEW exits 75 on success, meaning "preview written, nothing destroyed
+# yet". Run it outside `set -e`, which this plan otherwise enables, or it aborts
+# the orchestration immediately before cleanup.
+set +e
 scripts/blacksmith-testbox-cleanup.sh "$TBX" "$OUT" "$cleanup_token" PREVIEW
+preview_status=$?
+set -e
+(( preview_status == 75 )) || { echo "cleanup preview failed with $preview_status" >&2; exit "$preview_status"; }
 # Review cleanup-preview.json, then rerun with STOP:<sha256(cleanup-preview.json)>.
 ```
 

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -360,6 +360,23 @@ if (( benchmark_status != 0 )); then
 fi
 ```
 
+Pin the box to the benchmarked commit once, after readiness and before the
+first stage. `blacksmith testbox run` synchronizes file contents rather than
+history, and skips even that once fingerprints match, so the box otherwise keeps
+the `main` checkout the warmup job made:
+
+```bash
+./scripts/blacksmith-bounded-command.sh 300 \
+  blacksmith testbox run --id "$TBX" \
+  "set -euo pipefail; git fetch --no-tags origin $SOURCE_SHA; git reset --hard $SOURCE_SHA; git submodule update --init --depth 1 ghostty; git rev-parse HEAD" \
+  >"$OUT/pin-source.log" 2>&1
+cat "$OUT/pin-source.log"
+```
+
+The commit must already be pushed. A local-only commit fails on the box with
+`upload-pack: not our ref`, and the stage helper refuses rather than
+benchmarking `main` under a candidate's name.
+
 `first-clean` is target-clean but dependency-warm. `incremental-noop` repeats
 the exact build on the same VM. `changed-file` appends a comment to
 `cmux-tui/crates/cmux-tui/src/main.rs`, builds, and restores the original bytes.

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -222,21 +222,24 @@ if (( parse_status != 0 )); then
 fi
 umask 077
 set +e
-cleanup_token="$(python3 - "$OUT/testbox-receipt.json" "$warmup_testbox_id" "$WORKFLOW" "$JOB" "$SOURCE_REF" "$SOURCE_SHA" "$SOURCE_TREE_SHA" "$GHOSTTY_SHA" <<'PY'
+cleanup_token="$(python3 - "$OUT/testbox-receipt.json" "$warmup_testbox_id" "$WORKFLOW" "$JOB" main "$SOURCE_REF" "$SOURCE_SHA" "$SOURCE_TREE_SHA" "$GHOSTTY_SHA" <<'PY'
 import datetime as dt
 import json
 import pathlib
 import secrets
 import sys
 
-path, testbox_id, workflow, job, source_ref, source_sha, source_tree, ghostty_sha = sys.argv[1:]
+path, testbox_id, workflow, job, warmup_ref, source_ref, source_sha, source_tree, ghostty_sha = sys.argv[1:]
 token = secrets.token_hex(16)
 path = pathlib.Path(path)
 path.write_text(json.dumps({
-    "schema": 1,
+    "schema": 2,
     "testbox_id": testbox_id,
     "workflow": workflow,
     "job": job,
+    # What the inventory shows, always main in the broker lane.
+    "warmup_ref": warmup_ref,
+    # The branch being benchmarked, which never appears in the inventory.
     "source_ref": source_ref,
     "source_sha": source_sha,
     "source_tree_sha": source_tree,

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -308,12 +308,38 @@ and then the synchronized source commit/tree, Ghostty gitlink/checkout, and
 clean status before it invokes Cargo, repeating the source checks after the
 build. Each stage JSON carries a `hydration` block with the warmed ref and
 commit plus `matches_benchmarked_source`, which is normally `false`. Keep the
-setup artifact URL or download it into `$OUT`. A successful setup copies the
+setup artifact URL or download it into `$OUT`. The workflow uploads it under the
+name `cmux-tui-testbox-<run-id>`, so with the approved run's ID in `$RUN_ID`:
+`gh run download "$RUN_ID" --repo manaflow-ai/cmux --name "cmux-tui-testbox-setup-$RUN_ID" --dir "$OUT/setup-artifact"`.
+A successful setup copies the
 same JSON to `/tmp/.testbox/cmux-tui-rust-setup-identity.json`; the stage helper
 rejects a missing or malformed marker, so failed hydration cannot be
 benchmarked. The active Rust, Cargo, and Zig versions must still equal the
 hydrated ones, so a branch that repins its toolchain stops the run instead of
 reporting a cold-cache timing.
+
+## Pin the box, then take the three timings
+
+Pin the box to the benchmarked commit once, after readiness and before the
+first stage. `blacksmith testbox run` synchronizes file contents rather than
+history, and skips even that once fingerprints match, so the box otherwise keeps
+the `main` checkout the warmup job made:
+
+```bash
+./scripts/blacksmith-bounded-command.sh 300 \
+  blacksmith testbox run --id "$TBX" \
+  "set -euo pipefail; git fetch --no-tags origin $SOURCE_SHA; git reset --hard $SOURCE_SHA; git submodule update --init --depth 1 ghostty; git rev-parse HEAD" \
+  >"$OUT/pin-source.log" 2>&1
+cat "$OUT/pin-source.log"
+```
+
+The commit must already be pushed. A local-only commit fails on the box with
+`upload-pack: not our ref`, and the stage helper refuses rather than
+benchmarking `main` under a candidate's name.
+
+The warmup job only ever checks out `main`, so this pin is what makes the box an
+exact checkout of the revision you are benchmarking. Do it before the stage loop
+below. Running the loop first measures `main`, not your branch.
 
 ## Three remote build timings
 
@@ -375,23 +401,6 @@ if (( benchmark_status != 0 )); then
   exit "$benchmark_status"
 fi
 ```
-
-Pin the box to the benchmarked commit once, after readiness and before the
-first stage. `blacksmith testbox run` synchronizes file contents rather than
-history, and skips even that once fingerprints match, so the box otherwise keeps
-the `main` checkout the warmup job made:
-
-```bash
-./scripts/blacksmith-bounded-command.sh 300 \
-  blacksmith testbox run --id "$TBX" \
-  "set -euo pipefail; git fetch --no-tags origin $SOURCE_SHA; git reset --hard $SOURCE_SHA; git submodule update --init --depth 1 ghostty; git rev-parse HEAD" \
-  >"$OUT/pin-source.log" 2>&1
-cat "$OUT/pin-source.log"
-```
-
-The commit must already be pushed. A local-only commit fails on the box with
-`upload-pack: not our ref`, and the stage helper refuses rather than
-benchmarking `main` under a candidate's name.
 
 `first-clean` is target-clean but dependency-warm. `incremental-noop` repeats
 the exact build on the same VM. `changed-file` appends a comment to

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -145,6 +145,11 @@ run created after your own dispatch and refuses when more than one is waiting.
 Never approve `workflow_runs[0]`: every run in this lane shares a title and a
 `main` head branch, so the newest waiting run may belong to another operator.
 
+Write every approval attempt to its own `$OUT/approval-attempt-<n>.json` and
+never overwrite. A retry that clobbers the first attempt leaves a pack that
+looks like a clean single-approval run, hiding the fact that a box was live and
+unapproved in between.
+
 ```bash
 WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
 JOB=cmux-tui-rust
@@ -170,7 +175,7 @@ cleanup() {
     # to this invocation. Report inventory, but never stop another operator's box.
     set +e
     ./scripts/blacksmith-bounded-command.sh 60 \
-      blacksmith testbox list --all >"$OUT/list-after-warmup-failure.log" 2>&1
+      blacksmith testbox list --all >"$OUT/list-at-exit.log" 2>&1
     after_list_status=$?
     set -e
     if (( after_list_status != 0 )); then
@@ -178,7 +183,16 @@ cleanup() {
       echo "could not capture post-failure Testbox inventory" >&2
     else
       cleanup_status=1
-      echo "warmup returned no owned Testbox receipt; no automatic stop was attempted" >&2
+      # Say which of the two conditions actually held. Reporting "no receipt"
+      # when the receipt exists sends the operator hunting for the wrong thing,
+      # and the usual cause is simply that no stop was ever authorized.
+      if [[ -z "${TBX:-}" ]]; then
+        echo "no Testbox was created; nothing to stop" >&2
+      elif [[ -z "${CONFIRM_TESTBOX_STOP_SHA:-}" ]]; then
+        echo "Testbox ${TBX} is still running; no stop was authorized, so stop it yourself with the PREVIEW then STOP ceremony" >&2
+      else
+        echo "no owned Testbox receipt; refusing to stop a box this run cannot prove it owns" >&2
+      fi
     fi
   fi
   if (( result == 0 && cleanup_status != 0 )) && [[ -n "${CONFIRM_TESTBOX_STOP_SHA:-}" ]]; then

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -296,7 +296,9 @@ approval_run=""
 for attempt in $(seq 1 30); do
   waiting="$(gh api "repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting" \
     --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")"
-  waiting_count="$(printf '%s' "$waiting" | grep -c .)"
+  # grep -c exits 1 when the count is zero, which under set -e kills the script
+  # on the first poll, before the run is ever visible. Guard every count.
+  waiting_count="$(printf '%s' "$waiting" | grep -c . || true)"
   if (( waiting_count > 1 )); then
     echo "$waiting_count runs waiting since your dispatch; approve yours in the UI, then rerun from the wait step" >&2
     exit 1
@@ -351,8 +353,14 @@ clean status before it invokes Cargo, repeating the source checks after the
 build. Each stage JSON carries a `hydration` block with the warmed ref and
 commit plus `matches_benchmarked_source`, which is normally `false`. Keep the
 setup artifact URL or download it into `$OUT`. The workflow uploads it under the
-name `cmux-tui-testbox-setup-<run-id>`, so with the approved run's ID in `$RUN_ID`:
-`gh run download "$RUN_ID" --repo manaflow-ai/cmux --name "cmux-tui-testbox-setup-$RUN_ID" --dir "$OUT/setup-artifact"`.
+name `cmux-tui-testbox-setup-<run-id>`:
+
+```bash
+gh run download "$approval_run" --repo manaflow-ai/cmux \
+  --name "cmux-tui-testbox-setup-$approval_run" --dir "$OUT/setup-artifact"
+test -s "$OUT/setup-artifact/setup-identity.json"
+```
+
 A successful setup copies the
 same JSON to `/tmp/.testbox/cmux-tui-rust-setup-identity.json`; the stage helper
 rejects a missing or malformed marker, so failed hydration cannot be
@@ -499,6 +507,24 @@ PY
 ```
 
 ## Cleanup and evidence
+
+Stopping the box is only half of cleanup. The warmup run's keepalive step keeps
+holding a 32 vCPU runner afterwards, with a 120 minute job timeout as the only
+backstop, so cancel the run too and poll it to terminal state:
+
+```bash
+gh run cancel "$approval_run" --repo manaflow-ai/cmux >"$OUT/run-cancel.log" 2>&1 || true
+for attempt in $(seq 1 40); do
+  run_state="$(gh api "repos/manaflow-ai/cmux/actions/runs/$approval_run" --jq '"\(.status) \(.conclusion)"')"
+  printf '%s %s\n' "$(date -u +%FT%TZ)" "$run_state" >>"$OUT/run-cancel-poll.log"
+  [[ "$run_state" == completed* ]] && break
+  sleep 15
+done
+printf 'final run state: %s\n' "$run_state" | tee "$OUT/run-final-state.txt"
+```
+
+Cancelling takes about five minutes to land, so `in_progress` right after the
+request is expected, not a failed cancel.
 
 Download all raw files and `timings.json` before cleanup. Then, after an
 operator explicitly decides this exact box may be destroyed, call the fail-safe

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -79,7 +79,10 @@ remote_sha="$(git ls-remote --exit-code origin "refs/heads/$SOURCE_REF" | awk 'N
   exit 1
 }
 EVIDENCE_ROOT="$PWD/.cmux-scratch"
-if [[ -e "$EVIDENCE_ROOT/blacksmith-testbox-$SOURCE_SHA" ]]; then
+# Every evidence directory is blacksmith-testbox-<sha>-<suffix>, so test the
+# glob, not the bare name. The bare name never matched, so a second run of the
+# same SHA from the same PID collided instead of getting a timestamp.
+if compgen -G "$EVIDENCE_ROOT/blacksmith-testbox-$SOURCE_SHA-*" >/dev/null; then
   RUN_SUFFIX="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 else
   RUN_SUFFIX="initial-$$"
@@ -184,7 +187,7 @@ cleanup() {
   exit "$result"
 }
 trap cleanup EXIT
-blacksmith auth whoami
+blacksmith auth whoami 2>&1 | tee "$OUT/whoami.txt"   # whoami writes to stderr
 blacksmith --version >"$OUT/blacksmith-version.txt"
 cat "$OUT/blacksmith-version.txt"
 blacksmith runners catalog >"$OUT/runner-catalog.json"
@@ -433,7 +436,7 @@ for record in records:
     if not record.get("ok"):
         raise SystemExit(f"{stage}: build failed")
 with (out / "timings.json").open("w", encoding="utf-8") as handle:
-    json.dump({"schema": 2, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
+    json.dump({"schema": 2, "stage_record_schema": 3, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
     handle.write("\n")
 PY
 ```
@@ -494,13 +497,9 @@ Record these fields alongside `timings.json`:
 5. Cleanup stop/status/list output and whether the specific ID was absent from
    the active inventory.
 
-The historical 32-vCPU evidence at
-`.cmux-scratch/blacksmith-testbox-e40704611ac35f4ffa153/` remains unchanged and
-must never be selected as a writable `OUT` directory:
-setup SHA `e40704611ac35f0e3a806841a9eae383f4ffa153`, Testbox
-`tbx_01kzxebn91nhatkv4ygevh06vs`, workflow run `31696013711`, first-clean
-`161.47s`, incremental no-op `8.28s`, changed-file `9.13s`, and cleanup with no
-active box. Do not rewrite it while validating this hardening change.
+Never write into an evidence directory you did not create in this run. The
+`-e "$OUT_ROOT"` check above is that guard: if the path exists, stop and choose a
+new run suffix rather than merging two runs' records into one pack.
 
 Prior hosted cmux-tui correctness runs without Cargo durations are provenance,
 not performance comparisons. Prior Blacksmith macOS Swift/Xcode artifacts use

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -215,6 +215,7 @@ if (( before_list_status != 0 )); then
   echo "refusing to warm a Testbox without a baseline inventory" >&2
   exit "$before_list_status"
 fi
+DISPATCH_EPOCH=$(date -u +%s)   # binds the approval below to this dispatch
 set +e
 ./scripts/blacksmith-bounded-command.sh 1200 \
   blacksmith testbox warmup "$WORKFLOW" \
@@ -286,9 +287,36 @@ if (( receipt_status != 0 )); then
 fi
 TBX="$warmup_testbox_id"
 printf 'Testbox ID: %s\n' "$TBX" | tee "$OUT/testbox-id.txt"
-if (( warmup_status != 0 )); then
-  exit "$warmup_status"
+
+# Approve the deployment gate BEFORE waiting. The run parks before its first
+# step, so `status --wait` below would otherwise burn its full 15 minutes and
+# leave this warmed box running. GitHub does not surface the run instantly, so
+# poll; zero runs means "not yet", two or more means genuinely ambiguous.
+approval_run=""
+for attempt in $(seq 1 30); do
+  waiting="$(gh api "repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting" \
+    --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")"
+  waiting_count="$(printf '%s' "$waiting" | grep -c .)"
+  if (( waiting_count > 1 )); then
+    echo "$waiting_count runs waiting since your dispatch; approve yours in the UI, then rerun from the wait step" >&2
+    exit 1
+  fi
+  if (( waiting_count == 1 )); then
+    approval_run="$waiting"
+    break
+  fi
+  sleep 5
+done
+if [[ -z "$approval_run" ]]; then
+  echo "no run appeared within 150s; Testbox $TBX is running and you own it" >&2
+  exit 1
 fi
+approval_env="$(gh api "repos/manaflow-ai/cmux/actions/runs/$approval_run/pending_deployments" --jq '.[0].environment.id')"
+gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$approval_run/pending_deployments" \
+  --input - >"$OUT/approval-attempt-1.json" 2>&1 \
+  <<< "{\"environment_ids\":[$approval_env],\"state\":\"approved\",\"comment\":\"benchmark warmup\"}"
+printf 'approved run: %s\n' "$approval_run" | tee "$OUT/approval-run-id.txt"
+
 set +e
 blacksmith testbox status --id "$TBX" --wait --wait-timeout 15m \
   >"$OUT/status-ready.log" 2>&1

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -309,7 +309,7 @@ clean status before it invokes Cargo, repeating the source checks after the
 build. Each stage JSON carries a `hydration` block with the warmed ref and
 commit plus `matches_benchmarked_source`, which is normally `false`. Keep the
 setup artifact URL or download it into `$OUT`. The workflow uploads it under the
-name `cmux-tui-testbox-<run-id>`, so with the approved run's ID in `$RUN_ID`:
+name `cmux-tui-testbox-setup-<run-id>`, so with the approved run's ID in `$RUN_ID`:
 `gh run download "$RUN_ID" --repo manaflow-ai/cmux --name "cmux-tui-testbox-setup-$RUN_ID" --dir "$OUT/setup-artifact"`.
 A successful setup copies the
 same JSON to `/tmp/.testbox/cmux-tui-rust-setup-identity.json`; the stage helper
@@ -362,10 +362,16 @@ run_stage() {
     'CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=%q %q %q %q %q' \
     "$TBX" ./scripts/blacksmith-cmux-tui-testbox-stage.sh \
     "$stage" "$SOURCE_SHA" "$GHOSTTY_SHA"
+  # The second clock. The stage record's wall_seconds is measured on the box
+  # around cargo; this one includes sync, transport, and queueing, and the gap
+  # between them is the Testbox overhead.
+  cli_start="$(python3 -c 'import time; print(time.time())')"
   ./scripts/blacksmith-bounded-command.sh 1500 blacksmith testbox run --id "$TBX" --debug \
     "$remote_command" >"$OUT/$stage.run.log" 2>&1
   run_status=$?
   set -e
+  python3 -c "import sys; print(round(float(sys.argv[2]) - float(sys.argv[1]), 3))" \
+    "$cli_start" "$(python3 -c 'import time; print(time.time())')" >"$OUT/$stage.cli-wall.txt"
   cat "$OUT/$stage.run.log"
 
   # rsync --delete can remove remote output before the next run. Download each
@@ -498,8 +504,9 @@ Record these fields alongside `timings.json`:
    clean-status result before each stage.
 2. Requested runner label and catalog output. The setup job rejects any
    actual architecture or CPU count other than x64 and 32.
-3. Blacksmith CLI version, Testbox ID, setup workflow run/job IDs, identity run
-   ID, and each stage run/sync ID from raw transcripts.
+3. Blacksmith CLI version, Testbox ID, and the setup workflow run and job IDs.
+   There is no separate identity run: this plan forbids issuing one, and the
+   identity transcripts are the setup artifact plus each stage's own record.
 4. Whether the comparison was target-clean, registry/git-cache warm,
    Zig-cache warm, or a genuinely cold VM. Warmup deliberately hydrates
    dependencies, so `first-clean` is target-cold and dependency-warm.

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -188,7 +188,9 @@ cleanup() {
       # and the usual cause is simply that no stop was ever authorized.
       if [[ -z "${TBX:-}" ]]; then
         echo "no Testbox was created; nothing to stop" >&2
-      elif [[ -z "${CONFIRM_TESTBOX_STOP_SHA:-}" ]]; then
+      elif grep -q "$TBX" "$OUT/list-at-exit.log" 2>/dev/null; then
+        # Only claim the box is alive if the inventory just said so. Saying it
+        # after a completed stop ceremony reads as a failure on a clean run.
         echo "Testbox ${TBX} is still running; no stop was authorized, so stop it yourself with the PREVIEW then STOP ceremony" >&2
       else
         echo "no owned Testbox receipt; refusing to stop a box this run cannot prove it owns" >&2

--- a/skills/blacksmith-testbox/benchmark.md
+++ b/skills/blacksmith-testbox/benchmark.md
@@ -217,7 +217,12 @@ if (( before_list_status != 0 )); then
   echo "refusing to warm a Testbox without a baseline inventory" >&2
   exit "$before_list_status"
 fi
-DISPATCH_EPOCH=$(date -u +%s)   # binds the approval below to this dispatch
+# Snapshot every gate already waiting in this lane BEFORE dispatching. Set
+# difference against this is exact; a time window is not, because a second
+# operator dispatching seconds after you lands inside any window you pick.
+lane_runs_url="repos/manaflow-ai/cmux/actions/workflows/cmux-tui-testbox-warmup.yml/runs?event=workflow_dispatch&status=waiting"
+waiting_before="$(mktemp)"
+gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_before"
 set +e
 ./scripts/blacksmith-bounded-command.sh 1200 \
   blacksmith testbox warmup "$WORKFLOW" \
@@ -292,22 +297,26 @@ printf 'Testbox ID: %s\n' "$TBX" | tee "$OUT/testbox-id.txt"
 
 # Approve the deployment gate BEFORE waiting. The run parks before its first
 # step, so `status --wait` below would otherwise burn its full 15 minutes and
-# leave this warmed box running. GitHub does not surface the run instantly, so
-# poll; zero runs means "not yet", two or more means genuinely ambiguous.
+# leave this warmed box running.
+# Your run is the one that appeared since the snapshot. GitHub does not surface
+# it instantly, so poll; zero new runs means "not yet".
+waiting_now="$(mktemp)"
 approval_run=""
 for attempt in $(seq 1 30); do
-  waiting="$(gh api "repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting" \
-    --jq ".workflow_runs[] | select((.created_at | fromdateiso8601) >= $DISPATCH_EPOCH - 120) | .id")"
-  # grep -c exits 1 when the count is zero, which under set -e kills the script
-  # on the first poll, before the run is ever visible. Guard every count.
-  waiting_count="$(printf '%s' "$waiting" | grep -c . || true)"
-  if (( waiting_count > 1 )); then
-    echo "$waiting_count runs waiting since your dispatch; approve yours in the UI, then rerun from the wait step" >&2
-    exit 1
-  fi
-  if (( waiting_count == 1 )); then
-    approval_run="$waiting"
+  gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_now"
+  new_runs="$(comm -13 "$waiting_before" "$waiting_now")"
+  new_count="$(printf '%s' "$new_runs" | grep -c . || true)"
+  if (( new_count == 1 )); then
+    approval_run="$new_runs"
     break
+  fi
+  if (( new_count > 1 )); then
+    # Two operators dispatched between polls. Nothing in the REST API binds a
+    # run to a Testbox ID, so do not guess and do not correlate by timestamp:
+    # Blacksmith rewrites a box's CREATED value as it hydrates. Stop your box,
+    # re-snapshot, and dispatch again; the next set difference is unambiguous.
+    echo "$new_count runs appeared at once; stop your box ($TBX), re-snapshot, and re-dispatch" >&2
+    exit 1
   fi
   sleep 5
 done

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -1,0 +1,185 @@
+# Testbox operations reference
+
+Long-form detail for `skills/blacksmith-testbox/SKILL.md`: the stage
+orchestration loop, the receipt-bound cleanup ceremony, and how to read the two
+clocks a run produces. The full evidence-producing plan lives in
+`benchmark.md`.
+
+## Remote benchmark stages
+
+The detailed, receipt-producing orchestration in `benchmark.md` is the required
+entry point for a complete benchmark. It creates the unique `OUT_ROOT`, receipt,
+cleanup token, setup artifact capture, and cleanup preview state. Do not copy
+only this stage loop into an ad hoc shell without those prerequisites.
+
+Before each stage, recompute `SOURCE_SHA` and `GHOSTTY_SHA` and repeat the
+clean pushed-branch preflight.
+Pass the expected values as validated arguments;
+the helper does not trust the remote checkout or a caller-supplied expected SHA
+without comparing it to Git metadata:
+
+```bash
+# Run this orchestration block in Bash, not an interactive zsh session.
+run_stage() {
+  local stage="$1"
+  local run_status download_status=0
+  set +e
+  printf -v remote_command \
+    'CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=%q %q %q %q %q' \
+    "$TBX" ./scripts/blacksmith-cmux-tui-testbox-stage.sh \
+    "$stage" "$SOURCE_SHA" "$GHOSTTY_SHA"
+  ./scripts/blacksmith-bounded-command.sh 1500 \
+    blacksmith testbox run --id "$TBX" --debug \
+    "$remote_command" >"$OUT/$stage.run.log" 2>&1
+  run_status=$?
+  set -e
+  cat "$OUT/$stage.run.log"
+
+  # Download immediately. Blacksmith's next rsync may delete or replace remote
+  # files, so a one-time download after all stages is insufficient.
+  : >"$OUT/$stage.download.log"
+  for suffix in json time log; do
+    if ! ./scripts/blacksmith-bounded-command.sh 120 \
+      blacksmith testbox download --id "$TBX" \
+      "testbox-benchmark/$stage.$suffix" "$OUT/raw/$stage.$suffix" \
+      >>"$OUT/$stage.download.log" 2>&1; then
+      download_status=1
+    fi
+  done
+  cat "$OUT/$stage.download.log"
+  if (( run_status != 0 )); then
+    return "$run_status"
+  fi
+  return "$download_status"
+}
+```
+
+The helper supports exactly `first-clean`, `incremental-noop`, and
+`changed-file`. Each remote Cargo build is bounded to 20 minutes with a
+30-second kill grace period. It records a schema-2 JSON object for each stage
+containing:
+
+* expected and observed source commit/tree identity before and after the build;
+* expected and observed Ghostty gitlink and initialized submodule HEAD;
+* clean/dirty file lists and source restoration status;
+* Testbox ID and adopted workflow run ID;
+* runner label, hostname, architecture, CPU count, and `uname`; the setup
+  workflow fails closed unless the actual runner is x64 with 32 CPUs;
+* active Rust toolchain, `rustc`, Cargo, Zig, lockfile/toolchain hashes, and
+  Ghostty package-manifest hash; and
+* Cargo exit status, `/usr/bin/time -p` values, and CLI transcript timing.
+
+`first-clean` removes only the remote `cmux-tui/target` directory before a
+`cargo build -p cmux-tui --locked`. `incremental-noop` repeats that command
+without changing source. `changed-file` appends a comment to
+`cmux-tui/crates/cmux-tui/src/main.rs`, builds, and restores the original bytes
+before emitting its final record. A dirty or mismatched source before any
+stage, after restoration, or in the Ghostty submodule aborts the stage.
+
+After all successful downloads, aggregate and verify the records:
+
+```bash
+python3 - "$OUT" "$SOURCE_SHA" "$GHOSTTY_SHA" "$TBX" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+out = pathlib.Path(sys.argv[1])
+expected_source, expected_ghostty, testbox_id = sys.argv[2:]
+expected_tree = subprocess.check_output(
+    ["git", "rev-parse", f"{expected_source}^{{tree}}"], text=True
+).strip()
+required = {"first-clean", "incremental-noop", "changed-file"}
+records = []
+for path in sorted((out / "raw").glob("*.json")):
+    record = json.loads(path.read_text(encoding="utf-8"))
+    records.append(record)
+if {record.get("stage") for record in records} != required:
+    raise SystemExit("timing evidence is missing one or more benchmark stages")
+for record in records:
+    if record.get("testbox", {}).get("id") != testbox_id:
+        raise SystemExit(f"{record.get('stage')} has the wrong Testbox ID")
+    source = record.get("source", {})
+    if source.get("expected_commit_sha") != expected_source or source.get("expected_tree_sha") != expected_tree:
+        raise SystemExit(f"{record.get('stage')} has the wrong expected source identity")
+    for side in ("before", "after"):
+        snapshot = source.get(side, {})
+        if snapshot.get("commit_sha") != expected_source or snapshot.get("tree_sha") != expected_tree:
+            raise SystemExit(f"{record.get('stage')} has the wrong {side} source SHA")
+        if snapshot.get("dirty_files"):
+            raise SystemExit(f"{record.get('stage')} has dirty top-level source")
+        ghostty = snapshot.get("ghostty", {})
+        if ghostty.get("gitlink_sha") != expected_ghostty or ghostty.get("head_sha") != expected_ghostty:
+            raise SystemExit(f"{record.get('stage')} has mismatched Ghostty identity")
+        if ghostty.get("dirty_files"):
+            raise SystemExit(f"{record.get('stage')} has dirty Ghostty source")
+    if not record.get("ok"):
+        raise SystemExit(f"{record.get('stage')} did not complete successfully")
+with (out / "timings.json").open("w", encoding="utf-8") as handle:
+    json.dump({"schema": 2, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+```
+
+Keep `raw/*.json`, `raw/*.time`, `raw/*.log`, every `*.run.log` and download
+log, the setup artifact, and the source manifest in a new, unique
+`.cmux-scratch/` evidence directory. Never reuse a prior SHA-only directory;
+refuse to overwrite historical records. Do not add credentials or private keys.
+
+## Fail-safe cleanup
+
+Always download before cleanup. Use the checked-in cleanup helper rather than
+ignoring errors with `|| true`. After an independent operator decides the exact
+box may be destroyed, pass the ownership token generated with the warmup receipt
+and the literal `STOP`; never print the token:
+
+```bash
+CLEANUP_TOKEN="${CLEANUP_TOKEN:-}"
+[[ "$CLEANUP_TOKEN" =~ ^[0-9a-f]{32}$ ]] || {
+  echo "use the ownership token emitted by the warmup receipt" >&2
+  exit 64
+}
+scripts/blacksmith-testbox-cleanup.sh "$TBX" "$OUT" "$CLEANUP_TOKEN" PREVIEW
+# Review cleanup-preview.json, then rerun with STOP:<sha256(cleanup-preview.json)>.
+```
+
+It records a pre-stop status preview, stop result, post-stop status, and
+`list --all` output. The preview must match the receipt's workflow, job, and
+branch before any stop is attempted. Cleanup is destructive and requires a fresh `STOP:<sha256(cleanup-preview.json)>`
+confirmation after reviewing the current receipt-bound preview.
+It verifies that the specific Testbox ID is terminal or absent from the active
+inventory, accepts the known terminal states `completed`, `stopped`, `cancelled`,
+`failed`, `terminated`, and `hydration_failed`, plus a 409 saying the box is
+already stopped or completed, and polls for up to two minutes while cancellation
+propagates. Other stop, status, or list failures remain failures.
+Put it in an `EXIT` trap only after an independent operator exports
+`CONFIRM_TESTBOX_STOP_SHA` containing the SHA-256 of a separately reviewed
+`cleanup-preview.json`; otherwise preserve the benchmark's original exit status
+and leave the box for manual cleanup. The detailed benchmark writes a
+receipt and ownership token for the exact ID returned by warmup; cleanup refuses an ID
+or token that is not bound to that receipt. If warmup fails before returning an
+ID, retain before/after inventory but do not automatically stop a box, because
+an inventory diff cannot prove ownership across concurrent operators. Reconcile
+that orphan manually through the Blacksmith control plane.
+
+## Timing interpretation
+
+The benchmark reports two clocks. The local CLI transcript measures sync,
+transport, queueing, and the remote command. The downloaded `/usr/bin/time -p`
+record measures the remote `cargo build -p cmux-tui --locked` command. Compare
+remote `real` or `time_real_seconds` values for build performance, and retain
+CLI wall time when evaluating Testbox overhead.
+
+`first-clean` is target-clean but dependency-warm: warmup runs `cargo fetch` and
+`zig build --fetch`, and the workflow may restore registry, git, and Zig caches.
+`incremental-noop` measures a second build on the same VM. `changed-file` is a
+controlled source change on that same VM. These are deliberately different
+from a cold-VM benchmark.
+
+The existing 32-vCPU evidence at
+`.cmux-scratch/blacksmith-testbox-e40704611ac35f4ffa153/` remains historical
+provenance for setup SHA `e40704611ac35f0e3a806841a9eae383f4ffa153`, Testbox
+`tbx_01kzxebn91nhatkv4ygevh06vs`, and workflow run `31696013711`. Its raw
+records and cleanup result must not be rewritten when validating this hardening
+change.

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -189,6 +189,16 @@ Treat any evidence directory you did not create this run as read-only. Never
 select an existing one as a writable `OUT`, and never rewrite its raw records or
 cleanup result.
 
+After a stop, `blacksmith testbox status --id <id>` still prints a row reading
+`completed` while `list --all` reports no active testboxes. Both are correct:
+`status` answers about one ID including terminal ones, and `list` shows only
+live boxes. Cite both, and do not read the difference as a failed stop.
+
+The two identity transcripts spell the architecture differently for the same
+host: `setup-identity.json` records GitHub's `RUNNER_ARCH` (`X64`), while stage
+records use `uname` (`x86_64`). The verification block asserts the `uname`
+spelling. This is expected, not a mismatch.
+
 Blacksmith's `CREATED` column is not a creation time. It tracks the last state
 transition, so one box reports a different value while hydrating, at ready, and
 after stop. For elapsed hydration read the `status --wait` transcript, which

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -186,6 +186,13 @@ or `time_real_seconds` for build performance, and use the difference between the
 local and remote clocks for Testbox overhead. A pack without `cli-wall.txt`
 cannot measure overhead at all.
 
+Compare overhead only across `first-clean` and `incremental-noop`. The
+`changed-file` gap is several times larger (8.1 s against 1.2 s in one measured
+run, with all three stages syncing `strategy=skip`), because that stage's
+backup, edit, restore, and re-verify work runs inside the CLI call but outside
+`wall_seconds`. Its local-minus-remote figure is real but is not sync and
+transport, so do not read it as Testbox overhead.
+
 `first-clean` is target-clean but dependency-warm: warmup runs `cargo fetch` and
 `zig build --fetch`, and the workflow may restore registry, git, and Zig caches.
 `incremental-noop` measures a second build on the same VM. `changed-file` is a

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -140,7 +140,7 @@ CLEANUP_TOKEN="${CLEANUP_TOKEN:-}"
   echo "use the ownership token emitted by the warmup receipt" >&2
   exit 64
 }
-scripts/blacksmith-testbox-cleanup.sh "$TBX" "$OUT" "$CLEANUP_TOKEN" PREVIEW
+scripts/blacksmith-testbox-cleanup.sh "$TBX" "$OUT" "$CLEANUP_TOKEN" PREVIEW   # exits 75 on success: preview written, nothing destroyed
 # Review cleanup-preview.json, then rerun with STOP:<sha256(cleanup-preview.json)>.
 ```
 

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -187,11 +187,11 @@ local and remote clocks for Testbox overhead. A pack without `cli-wall.txt`
 cannot measure overhead at all.
 
 Compare overhead only across `first-clean` and `incremental-noop`. The
-`changed-file` gap is several times larger (8.1 s against 1.2 s in one measured
-run, with all three stages syncing `strategy=skip`), because that stage's
-backup, edit, restore, and re-verify work runs inside the CLI call but outside
-`wall_seconds`. Its local-minus-remote figure is real but is not sync and
-transport, so do not read it as Testbox overhead.
+`changed-file` gap is unstable across runs, measured at 8.1 s in one and 1.48 s
+in another with no change to the lane, because that stage's backup, edit,
+restore, and re-verify work runs inside the CLI call but outside `wall_seconds`.
+Its local-minus-remote figure is real but is not sync and transport, so do not
+read it as Testbox overhead and do not expect a repeatable magnitude.
 
 `first-clean` is target-clean but dependency-warm: warmup runs `cargo fetch` and
 `zig build --fetch`, and the workflow may restore registry, git, and Zig caches.

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -173,11 +173,18 @@ produce a `timings.json` at all.
 
 ## Timing interpretation
 
-The benchmark reports two clocks. The local CLI transcript measures sync,
-transport, queueing, and the remote command. The downloaded `/usr/bin/time -p`
-record measures the remote `cargo build -p cmux-tui --locked` command. Compare
-remote `real` or `time_real_seconds` values for build performance, and retain
-CLI wall time when evaluating Testbox overhead.
+The benchmark reports two clocks, and the stage record contains only one of
+them. `wall_seconds` in each stage JSON is measured **on the box**, around the
+cargo command, which is why it sits a few milliseconds above the
+`/usr/bin/time -p` `real` value rather than well above it. It is not the CLI
+clock.
+
+The second clock is local: the wall time of the `blacksmith testbox run`
+invocation itself, which also covers sync, transport, and queueing. The plan in
+`benchmark.md` writes it to `$OUT/<stage>.cli-wall.txt`. Compare remote `real`
+or `time_real_seconds` for build performance, and use the difference between the
+local and remote clocks for Testbox overhead. A pack without `cli-wall.txt`
+cannot measure overhead at all.
 
 `first-clean` is target-clean but dependency-warm: warmup runs `cargo fetch` and
 `zig build --fetch`, and the workflow may restore registry, git, and Zig caches.

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -56,7 +56,7 @@ run_stage() {
 
 The helper supports exactly `first-clean`, `incremental-noop`, and
 `changed-file`. Each remote Cargo build is bounded to 20 minutes with a
-30-second kill grace period. It records a schema-2 JSON object for each stage
+30-second kill grace period. It records a schema-3 JSON object for each stage
 containing:
 
 * expected and observed source commit/tree identity before and after the build;
@@ -117,7 +117,7 @@ for record in records:
     if not record.get("ok"):
         raise SystemExit(f"{record.get('stage')} did not complete successfully")
 with (out / "timings.json").open("w", encoding="utf-8") as handle:
-    json.dump({"schema": 2, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
+    json.dump({"schema": 2, "stage_record_schema": 3, "source_sha": expected_source, "ghostty_gitlink_sha": expected_ghostty, "testbox_id": testbox_id, "stages": records}, handle, indent=2, sort_keys=True)
     handle.write("\n")
 PY
 ```
@@ -185,9 +185,11 @@ CLI wall time when evaluating Testbox overhead.
 controlled source change on that same VM. These are deliberately different
 from a cold-VM benchmark.
 
-The existing 32-vCPU evidence at
-`.cmux-scratch/blacksmith-testbox-e40704611ac35f4ffa153/` remains historical
-provenance for setup SHA `e40704611ac35f0e3a806841a9eae383f4ffa153`, Testbox
-`tbx_01kzxebn91nhatkv4ygevh06vs`, and workflow run `31696013711`. Its raw
-records and cleanup result must not be rewritten when validating this hardening
-change.
+Treat any evidence directory you did not create this run as read-only. Never
+select an existing one as a writable `OUT`, and never rewrite its raw records or
+cleanup result.
+
+Blacksmith's `CREATED` column is not a creation time. It tracks the last state
+transition, so one box reports a different value while hydrating, at ready, and
+after stop. For elapsed hydration read the `status --wait` transcript, which
+prints the wait duration next to `Testbox ready!`.

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -213,7 +213,13 @@ host: `setup-identity.json` records GitHub's `RUNNER_ARCH` (`X64`), while stage
 records use `uname` (`x86_64`). The verification block asserts the `uname`
 spelling. This is expected, not a mismatch.
 
-Blacksmith's `CREATED` column is not a creation time. It tracks the last state
+**Never pair a box with a workflow run by timestamp.** Blacksmith's `CREATED`
+column is not a creation time. It tracks the last state
 transition, so one box reports a different value while hydrating, at ready, and
 after stop. For elapsed hydration read the `status --wait` transcript, which
-prints the wait duration next to `Testbox ready!`.
+prints the wait duration next to `Testbox ready!`. One measured box reported `05:54:43`,
+then `05:55:03`, then `05:58:48` as it hydrated, so a box whose value looks
+adjacent to a run's creation time is coincidence past the `queued` state. The
+authoritative binding appears only once the box is ready, as the RUN URL column
+of `blacksmith testbox list --all`. Before that, identify your run by set
+difference against a pre-dispatch snapshot.

--- a/skills/blacksmith-testbox/references/operations.md
+++ b/skills/blacksmith-testbox/references/operations.md
@@ -163,6 +163,14 @@ ID, retain before/after inventory but do not automatically stop a box, because
 an inventory diff cannot prove ownership across concurrent operators. Reconcile
 that orphan manually through the Blacksmith control plane.
 
+## Partial stage sets
+
+The verification and aggregation blocks require all three stages and raise
+`SystemExit` on any subset, because a `timings.json` that silently omits a stage
+reads as a complete result. Running one or two stages is fine, and common: read
+the per-stage `testbox-benchmark/<stage>.json` records directly and do not
+produce a `timings.json` at all.
+
 ## Timing interpretation
 
 The benchmark reports two clocks. The local CLI transcript measures sync,

--- a/skills/blacksmith-testbox/references/trust-boundary.md
+++ b/skills/blacksmith-testbox/references/trust-boundary.md
@@ -1,0 +1,25 @@
+# Why this lane hydrates main only
+
+Full reasoning behind the `--ref main` rule in `skills/blacksmith-testbox/SKILL.md`.
+Read this before changing the warmup workflow, the environment configuration, or
+anything that runs before `begin-testbox`.
+
+`useblacksmith/begin-testbox` writes `/tmp/.testbox/auth_token` into the CI job,
+and `permissions: contents: read` does not stop a later step from reading it.
+`blacksmith testbox warmup` resolves the workflow definition and the hydrated
+source from the same `--ref`, so warming a candidate branch would run that
+branch's copy of the workflow beside the token, and the branch could delete its
+own guards.
+
+The lane hydrates `main` only. The first step refuses any other ref, no
+repository code runs before the token, and your revision arrives afterwards
+through `blacksmith testbox run` as an authenticated org member who could
+already reach the box. `tests/test_ci_testbox_broker_guard.py` enforces that
+shape on every pull request through
+`.github/workflows/testbox-broker-guard.yml`.
+
+A repository administrator owns the `blacksmith-testbox-trusted` environment:
+required reviewers, no secrets, admin bypass disabled, and a deployment branch
+rule of exactly `main`. If that drifts, disable the lane and stop. Never edit
+the workflow to work around a missing control.
+

--- a/tests/test_testbox_cleanup_receipt_ref.sh
+++ b/tests/test_testbox_cleanup_receipt_ref.sh
@@ -84,4 +84,21 @@ test -s "$evidence/cleanup-preview.json" || {
   echo "FAIL: preview produced no cleanup-preview.json" >&2
   exit 1
 }
+# The destruction record must not pair the warmup ref with the benchmarked SHA.
+python3 - "$evidence/cleanup-preview.json" <<'PYCHK'
+import json
+import pathlib
+import sys
+
+record = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+errors = []
+if record.get("warmup_ref") != "main":
+    errors.append(f"warmup_ref is {record.get('warmup_ref')!r}, expected 'main'")
+if record.get("source_ref") != "feature-branch-under-test":
+    errors.append(f"source_ref is {record.get('source_ref')!r}, expected the benchmarked branch")
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    raise SystemExit(1)
+PYCHK
 echo "ok: receipt-bound cleanup preview accepts a main-warmed box benchmarked from a branch"

--- a/tests/test_testbox_cleanup_receipt_ref.sh
+++ b/tests/test_testbox_cleanup_receipt_ref.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# The Testbox inventory always shows the warmup ref, which the broker lane pins
+# to main, while the receipt also records the branch being benchmarked. Cleanup
+# must compare the inventory against the warmup ref. Comparing it against the
+# benchmarked branch made every receipt-bound cleanup exit 66, which pushed
+# operators toward a bare `blacksmith testbox stop` and away from the ownership
+# check.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cleanup="$root/scripts/blacksmith-testbox-cleanup.sh"
+test -x "$cleanup"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+tbx="tbx_01testfixture0000000000000"
+token="0123456789abcdef0123456789abcdef"
+workflow=".github/workflows/cmux-tui-testbox-warmup.yml"
+job="cmux-tui-rust"
+sha="1111111111111111111111111111111111111111"
+tree="2222222222222222222222222222222222222222"
+ghostty="3333333333333333333333333333333333333333"
+
+evidence="$work/evidence"
+mkdir -p "$evidence"
+cat >"$evidence/testbox-receipt.json" <<JSON
+{
+  "schema": 2,
+  "testbox_id": "$tbx",
+  "confirmation_token": "$token",
+  "workflow": "$workflow",
+  "job": "$job",
+  "warmup_ref": "main",
+  "source_ref": "feature-branch-under-test",
+  "source_sha": "$sha",
+  "source_tree_sha": "$tree",
+  "ghostty_gitlink_sha": "$ghostty"
+}
+JSON
+
+# Stub CLI: the inventory and status rows carry the warmup ref, exactly as the
+# real `blacksmith testbox list` does for a box warmed with --ref main.
+stub="$work/bin"
+mkdir -p "$stub"
+cat >"$stub/blacksmith" <<STUB
+#!/usr/bin/env bash
+case "\$2" in
+  list)
+    echo "ID STATUS REPO WORKFLOW JOB REF CREATED"
+    echo "$tbx stopped cmux $workflow $job main 2026-08-18T00:00:00.000000Z"
+    ;;
+  status)
+    echo "ID STATUS REPO WORKFLOW JOB REF CREATED"
+    echo "$tbx stopped cmux $workflow $job main 2026-08-18T00:00:00.000000Z"
+    ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$stub/blacksmith"
+
+set +e
+PATH="$stub:$PATH" "$cleanup" "$tbx" "$evidence" "$token" PREVIEW >"$work/preview.log" 2>&1
+status=$?
+set -e
+
+if (( status == 66 )); then
+  echo "FAIL: cleanup rejected its own receipt; it is comparing the inventory" >&2
+  echo "      against the benchmarked branch instead of the warmup ref." >&2
+  sed -n '1,20p' "$work/preview.log" >&2
+  exit 1
+fi
+# 75 is the preview's own "reviewed nothing yet, rerun with STOP:<sha>" exit.
+if (( status != 75 )); then
+  echo "FAIL: cleanup preview exited $status, expected 75" >&2
+  sed -n '1,20p' "$work/preview.log" >&2
+  exit 1
+fi
+grep -q 'ref=main' "$work/preview.log" || {
+  echo "FAIL: preview did not report the warmup ref it validated against" >&2
+  exit 1
+}
+test -s "$evidence/cleanup-preview.json" || {
+  echo "FAIL: preview produced no cleanup-preview.json" >&2
+  exit 1
+}
+echo "ok: receipt-bound cleanup preview accepts a main-warmed box benchmarked from a branch"

--- a/tests/test_testbox_doc_blocks.sh
+++ b/tests/test_testbox_doc_blocks.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# The Testbox plan is executable documentation: agents copy its shell blocks and
+# run them under the `set -euo pipefail` the plan itself mandates. Two separate
+# defects have shipped because a block was syntactically fine but died at
+# runtime, each time stranding a live 32 vCPU box:
+#
+#   * `grep -c .` exits 1 when the count is zero, so a poll loop that expects
+#     "not visible yet" as its normal first state killed the whole script.
+#
+# Syntax checking cannot see that. This test parses every documented block and
+# executes the fragile constructs for real.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+skill_dir="$root/skills/blacksmith-testbox"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+files=("$skill_dir/SKILL.md" "$skill_dir/benchmark.md" "$skill_dir/references/operations.md")
+for file in "${files[@]}"; do
+  test -f "$file" || { echo "FAIL: missing $file" >&2; exit 1; }
+done
+
+# 1. Every fenced bash block must parse under the shell the plan mandates.
+blocks=0
+while IFS= read -r block; do
+  blocks=$((blocks + 1))
+  printf 'set -euo pipefail\n%s\n' "$(cat "$block")" >"$work/block.sh"
+  if ! bash -n "$work/block.sh" 2>"$work/err"; then
+    echo "FAIL: $(basename "$block") does not parse:" >&2
+    cat "$work/err" >&2
+    exit 1
+  fi
+done < <(python3 - "$work" "${files[@]}" <<'PYX'
+import pathlib
+import re
+import sys
+
+out = pathlib.Path(sys.argv[1])
+index = 0
+for name in sys.argv[2:]:
+    text = pathlib.Path(name).read_text(encoding="utf-8")
+    for body in re.findall(r"```bash\n(.*?)```", text, re.S):
+        index += 1
+        path = out / f"{pathlib.Path(name).stem}-{index}.sh"
+        path.write_text(body, encoding="utf-8")
+        print(path)
+PYX
+)
+test "$blocks" -gt 0 || { echo "FAIL: no bash blocks found; the parser broke" >&2; exit 1; }
+
+# 2. Every counting construct must survive its normal zero case under set -e.
+#    Extract each line that counts with grep -c and run it with an empty input.
+found_counts=0
+while IFS= read -r line; do
+  found_counts=$((found_counts + 1))
+  cat >"$work/count.sh" <<COUNT
+set -euo pipefail
+WAITING=""
+waiting=""
+$line
+echo "survived"
+COUNT
+  if ! output="$(bash "$work/count.sh" 2>&1)" || [[ "$output" != *survived* ]]; then
+    echo "FAIL: this counting line dies under set -e when nothing matches, which" >&2
+    echo "      is its normal first state. Guard it with '|| true'." >&2
+    echo "      $line" >&2
+    exit 1
+  fi
+done < <(grep -rhE '^[[:space:]]*[A-Za-z_]+=.*grep -c' "${files[@]}" | sed 's/^[[:space:]]*//')
+test "$found_counts" -gt 0 || { echo "FAIL: no counting lines found; the extractor broke" >&2; exit 1; }
+
+echo "ok: $blocks documented bash blocks parse, $found_counts counting lines survive an empty result"


### PR DESCRIPTION
Two changes to the Testbox lane, both found by actually running it.

## 1. A pushed commit is required, and now enforced

Found by running the broker's cross-commit path on a live box, which #10303 never exercised (its one benchmark had hydrated and benchmarked commits equal).

I documented that pushing the benchmarked commit was optional because "the sync carries the objects". That is false. `blacksmith testbox run` synchronizes file *contents*, not history: it tries one opportunistic `git fetch` (which fails for a local-only commit with `upload-pack: not our ref`), falls back to copying changed files (`strategy=targeted files=12`), and on a second run skips entirely (`FP0: fingerprint match -> skip`), so the fetch is never retried. The box was left on `main` (`HEAD=2562c5ecfe`, `dirty=1`) and the helper died on a raw `fatal: ambiguous argument '<sha>^{tree}'`.

The fix is to push, then pin the box once with fetch plus `git reset --hard`. Verified on the live box: `HEAD=4c25af0b81`, ghostty `f76c132e52`, `dirty=0`, and the three stages then ran green with `hydration.matches_benchmarked_source: false` (128.798 s / 0.192 s / 9.358 s). The helper now checks the commit is present and checked out and prints the exact push and pin commands instead of a git internals error.

The tradeoff is deliberate: this lane produces benchmark evidence, so it gives up Testbox's "run against uncommitted local changes" mode. Ad-hoc iteration can still call `blacksmith testbox run` with its own commands.

## 2. The skill now leads with what to do

`SKILL.md` opened with its threat model and buried the commands, so an agent about to compile cmux-tui discovered the lane only after it had already waited. It now opens with the operating rule (warm your own box in the first minute, before reading code, because hydration takes about four minutes you can spend reading), then a seven-step CLI walkthrough, then the trust boundary, then hard rules.

19.7 KB to 8 KB. Stage orchestration, the cleanup ceremony, and the two-clock explanation move to `references/operations.md`; `benchmark.md` still holds the full evidence plan. Also indexes the skill in `CLAUDE.md`, which #10303 missed, so agents can find it at all.

Guard test and shellcheck are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided workflow for warming, validating, benchmarking, building, collecting evidence, and shutting down Testboxes.
  * Added an end-to-end demonstration workflow supporting benchmark stages or locked builds.

* **Bug Fixes**
  * Prevented benchmarks from running against an incorrect or unavailable source commit.
  * Added actionable guidance when the expected commit cannot be fetched or checked out.

* **Documentation**
  * Clarified synchronization, evidence collection, cleanup, source integrity, Ghostty updates, receipts, artifacts, timing, and Linux build requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->