### PR TITLE
Support signed R2 browser nightly assets

### DIFF
--- a/web/app/lib/browser-nightly-download.ts
+++ b/web/app/lib/browser-nightly-download.ts
@@ -6,6 +6,9 @@ import { BROWSER_RELEASE_REPOSITORY_URL } from "./download";
 export const BROWSER_NIGHTLY_FEED_URL =
   `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/nightly/update.json`;
 
+/** Immutable public R2 origin used by signed production feed entries. */
+export const BROWSER_PUBLIC_ASSET_ORIGIN = "https://browser-assets.cmux.com";
+
 /**
  * P-256 update public key compiled into cmux Browser's updater.
  *
@@ -118,12 +121,14 @@ export async function resolveBrowserNightlyDownload(
     throw new BrowserNightlyDownloadError("unavailable");
   }
 
-  const releaseTag = verifiedReleaseTag(
+  const assetLocation = verifiedAssetLocation(
     rawEntry,
     target.config.signedArchive,
     payload.version,
   );
-  const url = `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${releaseTag}/${target.assetName}`;
+  const url = assetLocation.kind === "r2"
+    ? `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${encodeURIComponent(payload.version)}/${encodeURIComponent(target.assetName)}`
+    : `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${assetLocation.releaseTag}/${target.assetName}`;
   await requirePublishedAsset(fetchImplementation, url);
 
   return { url, version: payload.version };
@@ -208,11 +213,15 @@ export function verifyFeedEnvelope(
   }
 }
 
-function verifiedReleaseTag(
+type VerifiedAssetLocation =
+  | { readonly kind: "github"; readonly releaseTag: string }
+  | { readonly kind: "r2" };
+
+function verifiedAssetLocation(
   rawEntry: unknown,
   expectedArchive: string,
   version: string,
-): string {
+): VerifiedAssetLocation {
   if (!isRecord(rawEntry)) throw invalidFeed();
   if (
     typeof rawEntry.sha256 !== "string" ||
@@ -234,14 +243,35 @@ function verifiedReleaseTag(
   }
   if (
     signedUrl.protocol !== "https:" ||
-    signedUrl.host !== "github.com" ||
     signedUrl.username !== "" ||
     signedUrl.password !== "" ||
+    signedUrl.port !== "" ||
     signedUrl.search !== "" ||
     signedUrl.hash !== ""
   ) {
     throw invalidFeed();
   }
+
+  if (signedUrl.host === "browser-assets.cmux.com") {
+    const r2Path = signedUrl.pathname.match(
+      /^\/nightly\/([^/]+)\/([^/]+)$/u,
+    );
+    if (!r2Path) throw invalidFeed();
+    let r2Version: string;
+    let r2Archive: string;
+    try {
+      r2Version = decodeURIComponent(r2Path[1]);
+      r2Archive = decodeURIComponent(r2Path[2]);
+    } catch {
+      throw invalidFeed();
+    }
+    if (r2Version !== version || r2Archive !== expectedArchive) {
+      throw invalidFeed();
+    }
+    return { kind: "r2" };
+  }
+
+  if (signedUrl.host !== "github.com") throw invalidFeed();
 
   const releasePath = signedUrl.pathname.match(
     /^\/manaflow-ai\/cmux-v2\/releases\/download\/([^/]+)\/([^/]+)$/u,
@@ -251,7 +281,7 @@ function verifiedReleaseTag(
   if (releaseTag !== "nightly" && releaseTag !== `nightly-${version}`) {
     throw invalidFeed();
   }
-  return releaseTag;
+  return { kind: "github", releaseTag };
 }
 
 async function requirePublishedAsset(

--- a/web/tests/browser-nightly-download-route.test.ts
+++ b/web/tests/browser-nightly-download-route.test.ts
@@ -5,6 +5,7 @@ import {
 } from "node:crypto";
 
 import {
+  BROWSER_PUBLIC_ASSET_ORIGIN,
   BROWSER_NIGHTLY_FEED_URL,
   resolveBrowserNightlyDownload,
 } from "../app/lib/browser-nightly-download";
@@ -106,6 +107,28 @@ describe("cmux Browser nightly download route", () => {
     }
   });
 
+  test("resolves Universal 2 assets from an immutable R2 feed URL", async () => {
+    const envelope = signedFeed({
+      "mac-arm64": platformEntry(
+        `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.zip`,
+        "cmux-browser.app",
+        "Contents/MacOS/cmux",
+      ),
+    });
+    const fetchMock = feedFetch(envelope, 200);
+
+    const response = await handleBrowserNightlyDownloadRequest(
+      { platform: "mac-arm64", artifact: "dmg" },
+      { fetch: fetchMock, publicKeyPem: TEST_PUBLIC_KEY_PEM },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.dmg`,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test("keeps both Mac architectures unavailable in the current production feed", async () => {
     for (const platform of ["mac-arm64", "mac-x64"]) {
       const fetchMock = feedFetch(PRODUCTION_SIGNED_FEED, 302);
@@ -196,6 +219,10 @@ describe("cmux Browser nightly download route", () => {
       "https://github.com/manaflow-ai/cmux-v2/releases/download/nightly/cmux-linux-x64.zip?redirect=attacker",
       "https://github.com/manaflow-ai//cmux-v2/releases/download/nightly/cmux-linux-x64.zip",
       `https://github.com/manaflow-ai/cmux-v2/releases/download/nightly-${VERSION}.1/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}.1/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/other.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}.evil/nightly/${VERSION}/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-linux-x64.zip?x=1`,
     ]) {
       const fetchMock = feedFetch(signedFeed({
         "linux-x64": platformEntry(url),


### PR DESCRIPTION
## Summary
- accept signed immutable nightly asset URLs from `browser-assets.cmux.com`
- keep GitHub nightly URLs supported for rollback and mixed feeds
- resolve companion Mac/Linux/Windows assets from the same verified R2 version
- reject wrong R2 host, path, version, filename, query, and port

## Validation
- `bun test web/tests/browser-nightly-download-route.test.ts web/tests/platform-downloads.test.ts`
- `./node_modules/.bin/eslint app/lib/browser-nightly-download.ts tests/browser-nightly-download-route.test.ts`
- `git diff --check`

The Mac availability flag remains disabled until a real signed all-platform nightly is published. This PR only makes the route safe for the R2 feed after that publication.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789612550&installation_model_id=21920&pr_number=10309&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10309&signature=e0feca5e056d78359bca0c980630cacf04a0b2f8544abb44c61c987e4cd9cfcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for signed, immutable R2-hosted nightly assets in the browser download route. Previously we only accepted GitHub release URLs; now we also accept https://browser-assets.cmux.com/nightly/{version}/{archive} while keeping GitHub URLs for rollback and mixed feeds, with stricter URL validation.

- **Reviewer notes**
  - Replaces release-tag parsing with `verifiedAssetLocation` that returns `r2` or `github` and builds the redirect accordingly.
  - Accepts only `https://browser-assets.cmux.com/nightly/<version>/<archive>` with an exact version/archive match; rejects wrong host/path/filename and any username/password, port, query, or fragment; still preflights with `requirePublishedAsset`.
  - Adds tests for the R2 happy path and rejection cases (wrong version/archive/host/query).
  - Mac downloads remain disabled until a signed all-platform nightly is published.

- **Rollout**
  - No client changes. Feed publishers can move nightly entries to R2 when ready; GitHub entries continue to work for rollback.

<sup>Written for commit 8e6db2b55ac91657a6b53e87d2f96e70ef382ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading nightly browser assets from the public asset storage.
  * Improved asset resolution for both public storage and GitHub release downloads.

* **Bug Fixes**
  * Strengthened download URL validation to reject incorrect versions, filenames, hosts, and query parameters.
  * Added support for Universal 2 DMG downloads from verified public storage URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->