### PR TITLE
docs: define shared fleet capacity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,14 @@ A tag gives the app its own name, bundle ID, socket, and derived data path, so i
 
 Other variants: `reloadp.sh` (Release), `reloads.sh` (Release as isolated "cmux STAGING"), `reload2.sh --tag <tag>` (both).
 
+## Shared Mac fleet capacity
+
+Every healthy slot in the canonical Mac fleet is general-purpose. Builds, iOS archives, tests, profiling, simulator and UI verification, and any other resource-intensive workload may use any available slot. Do not wait for an AWS-only builder or infer capacity from a workload label. Use the shared lease state and slot-isolated paths supplied by the fleet tooling.
+
+## Agent messaging
+
+Coding agents must not send iMessage or SMS messages to the `cmux` group conversation. Do not use `imsg`, Messages.app, or `cmux-imsg` for status, bug reports, handoffs, alerts, or coordination. Use the cmux workspace, GitHub PR or issue, or the current agent conversation instead.
+
 Compile-only check, no launch:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,6 @@ Other variants: `reloadp.sh` (Release), `reloads.sh` (Release as isolated "cmux 
 
 Every healthy slot in the canonical Mac fleet is general-purpose. Builds, iOS archives, tests, profiling, simulator and UI verification, and any other resource-intensive workload may use any available slot. Do not wait for an AWS-only builder or infer capacity from a workload label. Use the shared lease state and slot-isolated paths supplied by the fleet tooling.
 
-## Agent messaging
-
-Coding agents must not send iMessage or SMS messages to the `cmux` group conversation. Do not use `imsg`, Messages.app, or `cmux-imsg` for status, bug reports, handoffs, alerts, or coordination. Use the cmux workspace, GitHub PR or issue, or the current agent conversation instead.
-
 Compile-only check, no launch:
 
 ```bash


### PR DESCRIPTION
Document the shared Mac fleet policy for cmux agents:

- Every healthy Mac fleet slot is general-purpose for builds, archives, tests, profiling, simulator and UI verification, and other resource-intensive work.
- Agents should use shared lease state and slot-isolated paths instead of waiting for an AWS-only builder.

AGENTS.md is the repository symlink to CLAUDE.md. Verification: `git diff --check`; `wc -c CLAUDE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that healthy shared Mac fleet slots support resource-intensive workloads.
  * Specified that capacity decisions should be based on shared lease state rather than workload labels or builder assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->