### PR TITLE
fix(ios): pass selectSimulatorStream in the surface gallery preview

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
@@ -86,6 +86,7 @@ public struct MacSurfaceGalleryPreviewView: View {
                         createTerminal: {},
                         openBrowser: {},
                         selectBrowserStream: { _ in },
+                        selectSimulatorStream: { _ in },
                         openTextSheet: {},
                         copyDebugLogs: {},
                         sendFeedback: {}


### PR DESCRIPTION
One more compile break from the https://github.com/manaflow-ai/cmux/pull/10072 partial merge, same family as https://github.com/manaflow-ai/cmux/pull/10287 / https://github.com/manaflow-ai/cmux/pull/10290 / https://github.com/manaflow-ai/cmux/pull/10295: `MacSurfaceGalleryPreviewView` builds `TerminalPickerMenuActions` without the required `selectSimulatorStream` closure. The file is `#if canImport(UIKit) && DEBUG`, so Release/TestFlight archives skip it and stay green while every Debug dev build of `CmuxMobileShellUI` fails (`missing argument for parameter 'selectSimulatorStream' in call`). Verified with a local `swift build --triple arm64-apple-ios18.0` of the package: red before, clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789616456&installation_model_id=21920&pr_number=10313&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10313&signature=e2076532e75037b041fd81250b01dc88d2173b3cc13800ee8a4168a2e7dd6614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Debug-only iOS build break by passing the required selectSimulatorStream closure when constructing TerminalPickerMenuActions in MacSurfaceGalleryPreviewView. Previously, Debug builds of `CmuxMobileShellUI` failed with “missing argument for parameter 'selectSimulatorStream'”; now they compile. Release/TestFlight builds remain unaffected.

**Review notes**
- One-line change in MacSurfaceGalleryPreviewView.swift: add selectSimulatorStream: { _ in } to TerminalPickerMenuActions.
- The file is gated by `#if canImport(UIKit) && DEBUG`; no production behavior changes and no migration required.

<sup>Written for commit bd8d3133838efe476b4e1572a9fcc226c1179eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved picker fixture compatibility by supporting simulator stream selection without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->