### PR TITLE
build: make the package graph resolvable and unpin a rejected sentry-cocoa

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Package.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Package.swift
@@ -23,8 +23,16 @@ let package = Package(
     targets: [
         // The same libghostty the Mac links; iOS feeds raw PTY bytes straight
         // into ghostty_surface_* so the phone runs the identical terminal core.
+        //
+        // Named distinctly from CmuxTerminalCore's binary target for the same
+        // xcframework: SwiftPM requires target names to be unique across the whole
+        // package graph, and any workspace that resolves the iOS and macOS packages
+        // together sees both. CmuxTerminalCore cannot be reused here - it is a macOS
+        // package - so the one xcframework is referenced twice under distinct target
+        // names. The module imported in source is still GhosttyKit; that name comes
+        // from the xcframework, not from this target.
         .binaryTarget(
-            name: "GhosttyKit",
+            name: "GhosttyKitMobile",
             path: "../../../GhosttyKit.xcframework"
         ),
         .target(
@@ -35,7 +43,7 @@ let package = Package(
                 "CmuxMobileDiagnostics",
                 "CmuxMobileSupport",
                 "CmuxMobileTerminalKit",
-                "GhosttyKit",
+                "GhosttyKitMobile",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/Packages/macOS/CmuxTerminalCore/Package.swift
+++ b/Packages/macOS/CmuxTerminalCore/Package.swift
@@ -53,15 +53,22 @@ let package = Package(
         // GhosttyRuntimeCInterop: SwiftPM cannot link the GhosttyKit macOS
         // archive (its binary lacks the lib prefix), so the test runner
         // satisfies the link with a stub. The app links the real GhosttyKit.
+        // Named distinctly from CmuxTerminal's stub target: SwiftPM requires target
+        // names to be unique across the whole package graph, and CmuxTerminal depends
+        // on this package, so two targets both called GhosttyRuntimeTestStubs collide
+        // and break resolution for any client that sees both. The two stubs are not
+        // interchangeable - this one is a small set of *weak* fallbacks so xcodebuild
+        // can prefer GhosttyKit's real symbols, while CmuxTerminal's is a large set of
+        // strong instrumented fakes its tests inspect - so they cannot simply be shared.
         .target(
-            name: "GhosttyRuntimeTestStubs",
+            name: "GhosttyRuntimeCoreTestStubs",
             path: "Tests/GhosttyRuntimeTestStubs"
         ),
         .testTarget(
             name: "CmuxTerminalCoreTests",
             dependencies: [
                 "CmuxTerminalCore",
-                "GhosttyRuntimeTestStubs",
+                "GhosttyRuntimeCoreTestStubs",
                 .product(name: "CmuxFoundation", package: "CmuxFoundation"),
             ],
             swiftSettings: [

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "a24b98028b0b6e81bfd0526967468ba4ba60303c",
-        "version" : "9.3.0"
+        "revision" : "cd213f98af160e6497eeff0707bc3f6a205b159c",
+        "version" : "9.26.0"
       }
     },
     {


### PR DESCRIPTION
Three independent blockers stop `xcodebuild` from resolving the package graph. Details and full error output are in #10311.

### Duplicate SPM target names

SwiftPM requires target names to be unique across the whole package graph, and two pairs collide:

| Target | Declared by |
|---|---|
| `GhosttyRuntimeTestStubs` | `CmuxTerminal` and `CmuxTerminalCore` |
| `GhosttyKit` | `CmuxMobileTerminal` and `CmuxTerminalCore` |

The two `GhosttyRuntimeTestStubs` targets are **not interchangeable**, so sharing one is not a fix: `CmuxTerminalCore`'s is a small set of *weak* fallbacks (so `xcodebuild` can prefer GhosttyKit's real symbols) plus a `dlsym` runtime init, while `CmuxTerminal`'s is a much larger set of strong instrumented fakes its tests inspect directly.

This renames one side of each pair — `GhosttyRuntimeCoreTestStubs` and `GhosttyKitMobile` — leaving `path:` untouched so no sources move. Nothing imports the Core stub module from Swift (only its own `.c` names it), and the binary target rename is invisible to source because the imported module name comes from the xcframework, not the target.

Both collisions only surface through `cmux.xcworkspace`. CI builds via `-project cmux.xcodeproj`, which is presumably why they have gone unnoticed.

### `Package.resolved` pins a sentry-cocoa that SwiftPM rejects

This one blocks **both** entry points:

```
Disabled default traits on package 'sentry-cocoa' (Sentry) that declares no traits.
This is prohibited to allow packages to adopt traits initially without causing an API break.
fatalError
xcodebuild: error: Could not resolve package dependencies
```

The checked-in `Package.resolved` pins `sentry-cocoa` at `9.3.0`; this bumps it to `9.26.0`, which resolves cleanly.

### Verification

`scripts/check-package-resolved-policy.py` and `scripts/check-workspace-package-groups.py` both pass. Package resolution completes cleanly afterwards on Xcode 27.0 beta / macOS 27.0.

Note that the build then fails on unrelated source breakage in `Sources/TerminalController+MobileSurfaces.swift`, which this PR does not touch — reported separately in #10311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789618393&installation_model_id=21920&pr_number=10314&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10314&signature=80d6376d75cf8d8184545280227ad44aa2a1abdf0b692754172845d896a42b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks SwiftPM resolution by fixing two target-name collisions and updating `sentry-cocoa` to a version SwiftPM accepts. Previously, `xcodebuild` failed during dependency resolution; now package resolution completes (subsequent build still fails in TerminalController+MobileSurfaces.swift; see #10311).

- Renames CmuxTerminalCore’s test stub target from GhosttyRuntimeTestStubs to GhosttyRuntimeCoreTestStubs to satisfy unique target names. The two stub suites differ (Core = weak fallbacks; App = strong fakes), so they cannot be shared. No sources moved; only the target name changed.
- Renames the iOS binary target for the GhosttyKit xcframework from GhosttyKit to GhosttyKitMobile to avoid colliding with the macOS package’s target. Source continues to import the GhosttyKit module (module name comes from the xcframework).
- Bumps `sentry-cocoa` from 9.3.0 to 9.26.0 to resolve SwiftPM’s “Disabled default traits” fatal error. Workspace and project entry points now resolve.
- Notes: The name collisions appeared only via the workspace (CI uses -project). Verification: both package-check scripts pass; resolution is clean on Xcode 27.0 beta. No app/source migrations required.

<sup>Written for commit d87a35e111b8311e8fb14741bc63e64195107c0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package integration for iOS and macOS builds by clarifying and separating similarly named targets.
  * Updated test support dependencies to use the correct macOS runtime stubs.
  * Added documentation clarifying shared framework usage and test stub distinctions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->