### PR TITLE
fix: many-pane workspace wedges the main thread in SwiftUI focus navigation (#10311)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3486,7 +3486,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // the snapshot to session-<bundle>-recovered.json first, so nothing is lost.
         if let snapshotURL = sessionSnapshotStore.defaultSnapshotFileURL(),
            SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL) {
-            UpdateLogStore.shared.append(
+            updateLog.append(
                 "session restore skipped: previous launch did not finish restoring; "
                     + "snapshot preserved as \(SessionRestoreGuard.recoveredSnapshotFileURL(for: snapshotURL).lastPathComponent)"
             )

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2257,6 +2257,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
         }
         ClosedItemHistoryStore.shared.flushPendingSaves()
+        // A graceful quit is proof the main thread was never stuck, even if it happened inside the
+        // liveness window. Without this, quitting within seconds of launch would make the next
+        // launch skip restore for no reason.
+        if let snapshotURL = sessionSnapshotStore.defaultSnapshotFileURL() {
+            SessionRestoreGuard.markRestoreFinished(snapshotFileURL: snapshotURL)
+        }
         terminationWatchdog.arm()
         sentryStopMemoryContextRefresh()
         // Plain quit detaches local ssh clients; explicit close already killed marked sessions.
@@ -3475,6 +3481,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         syncManualRestoreSnapshotCachePruningCrashDiagnostics()
         let sanitizedStartupSnapshot = loadStartupSessionSnapshotPruningCrashDiagnostics()
         guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        // The previous launch began a restore it never finished, so restoring the same snapshot
+        // would most likely wedge this launch the same way. Come up clean instead. The guard copies
+        // the snapshot to session-<bundle>-recovered.json first, so nothing is lost.
+        if let snapshotURL = sessionSnapshotStore.defaultSnapshotFileURL(),
+           SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL) {
+            UpdateLogStore.shared.append(
+                "session restore skipped: previous launch did not finish restoring; "
+                    + "snapshot preserved as \(SessionRestoreGuard.recoveredSnapshotFileURL(for: snapshotURL).lastPathComponent)"
+            )
+            return
+        }
         startupSessionSnapshot = sanitizedStartupSnapshot
     }
 
@@ -3631,6 +3648,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let primaryContext = contextForMainTerminalWindow(primaryWindow) else { return false }
 
         let startupSnapshot = startupSessionSnapshot
+        if startupSnapshot != nil, let snapshotURL = sessionSnapshotStore.defaultSnapshotFileURL() {
+            // Cleared by completeSessionRestoreOperation() once the main thread proves it survived
+            // the restore. If this launch never gets that far, the next one comes up clean.
+            SessionRestoreGuard.markRestoreStarted(snapshotFileURL: snapshotURL)
+        }
         primaryContext.tabManager.prepareLegacyWorkspaceCustomizationMigration(
             afterRestoring: startupSnapshot?.windows.flatMap(\.tabManager.workspaces) ?? []
         )
@@ -3724,6 +3746,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             // Auto-resume input can be queued before tmux has spawned; preserve
             // restored process-detected bindings until a later live scan.
             _ = saveSessionSnapshot(includeScrollback: false)
+        }
+        // Clearing the guard here would be too early: reaching this line only means the snapshot was
+        // handed to SwiftUI, and the restored panes mount later during layout - which is exactly
+        // where a many-pane workspace wedges the main thread. Require proof of liveness instead. If
+        // the main thread is stuck, this block never runs and the marker survives to the next launch.
+        if let snapshotURL = sessionSnapshotStore.defaultSnapshotFileURL() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + SessionRestoreGuard.livenessConfirmationDelay) {
+                SessionRestoreGuard.markRestoreFinished(snapshotFileURL: snapshotURL)
+            }
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9276,6 +9276,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // cmux persists and restores main windows itself. Disable AppKit window
         // restoration so the OS cannot resurrect stale duplicate main windows.
         window.isRestorable = false
+        // Disable AppKit's automatic key-view-loop recalculation. Every pane is wrapped in its own
+        // NSHostingController (bonsplit's SinglePaneWrapper), so a many-pane workspace stacks ~15
+        // nested NSHostingViews. AppKit rebuilds the default key view loop on *every* subview
+        // insertion (AppKitPlatformViewHost.viewDidMoveToSuperview -> -[NSView _setDefaultKeyViewLoop]),
+        // and SwiftUI answers each nested host's acceptsFirstResponder by running a fresh
+        // FocusNavigationSequence over the subtree below it. That work multiplies across the nesting
+        // levels, so mounting a 21-pane workspace pins the main thread for 9s+ and the window never
+        // becomes visible - both on session restore and on workspace switch.
+        // cmux never reads this loop (no nextKeyView / selectNextKeyView / canBecomeKeyView anywhere):
+        // Tab belongs to the shell and pane focus is driven by our own focus system, so turning the
+        // recalculation off removes the trigger without changing observable focus behavior.
+        // Must be set before `contentView` is assigned below, i.e. before any pane mounts.
+        window.autorecalculatesKeyViewLoop = false
         configureCmuxMainWindowDragBehavior(window)
         let explicitInitialFrame = restoredFrame ?? persistedGeometryFrame
         if let explicitInitialFrame {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -176,6 +176,75 @@ enum SessionRestorePolicy {
     }
 }
 
+/// Guards against relaunching straight back into a session snapshot the previous launch could not
+/// survive.
+///
+/// A wedged main thread cannot rescue itself: anything scheduled on it waits for the stall to end,
+/// which for a hung restore never happens. So rather than trying to interrupt a stuck restore
+/// in-process, this records that a restore *started* and clears that record only once the main
+/// thread has proven it is still alive afterwards. A marker still present at the next launch means
+/// the previous launch never got through its restore - hang, force quit or crash - so that launch
+/// comes up clean instead of walking into the same state again.
+///
+/// The snapshot itself is never discarded. It is copied aside before the clean session can overwrite
+/// it, so the workspaces stay recoverable.
+enum SessionRestoreGuard {
+    /// How long the main thread must keep servicing work after a restore before the attempt counts
+    /// as successful. Reaching the end of the restore call is not sufficient - the restored panes
+    /// mount later, during SwiftUI layout.
+    static let livenessConfirmationDelay: TimeInterval = 5
+
+    static func markerFileURL(for snapshotFileURL: URL) -> URL {
+        let base = snapshotFileURL.deletingPathExtension().lastPathComponent
+        return snapshotFileURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(base)-restore-in-progress", isDirectory: false)
+    }
+
+    static func recoveredSnapshotFileURL(for snapshotFileURL: URL) -> URL {
+        let base = snapshotFileURL.deletingPathExtension().lastPathComponent
+        let fileExtension = snapshotFileURL.pathExtension
+        let name = fileExtension.isEmpty ? "\(base)-recovered" : "\(base)-recovered.\(fileExtension)"
+        return snapshotFileURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(name, isDirectory: false)
+    }
+
+    static func markRestoreStarted(snapshotFileURL: URL) {
+        let marker = markerFileURL(for: snapshotFileURL)
+        try? FileManager.default.createDirectory(
+            at: marker.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        try? Data(stamp.utf8).write(to: marker, options: .atomic)
+    }
+
+    static func markRestoreFinished(snapshotFileURL: URL) {
+        try? FileManager.default.removeItem(at: markerFileURL(for: snapshotFileURL))
+    }
+
+    static func hasInterruptedRestore(snapshotFileURL: URL) -> Bool {
+        FileManager.default.fileExists(atPath: markerFileURL(for: snapshotFileURL).path)
+    }
+
+    /// Reports whether the previous launch started a restore it never finished. Always clears the
+    /// marker, and copies the snapshot aside first so that skipping the restore is not destructive.
+    @discardableResult
+    static func consumeInterruptedRestore(snapshotFileURL: URL) -> Bool {
+        guard hasInterruptedRestore(snapshotFileURL: snapshotFileURL) else { return false }
+        try? FileManager.default.removeItem(at: markerFileURL(for: snapshotFileURL))
+
+        if FileManager.default.fileExists(atPath: snapshotFileURL.path) {
+            let recovered = recoveredSnapshotFileURL(for: snapshotFileURL)
+            try? FileManager.default.removeItem(at: recovered)
+            try? FileManager.default.copyItem(at: snapshotFileURL, to: recovered)
+        }
+        return true
+    }
+}
+
 struct SessionRectSnapshot: Codable, Equatable, Sendable {
     let x: Double
     let y: Double

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1846,6 +1846,66 @@ final class SessionPersistenceTests: XCTestCase {
         return RestorableAgentSessionIndex.load(homeDirectory: home.path)
     }
 
+    func testRestoreGuardReportsNothingAfterACompletedRestore() throws {
+        let (snapshotURL, cleanup) = try makeGuardFixture()
+        defer { cleanup() }
+
+        SessionRestoreGuard.markRestoreStarted(snapshotFileURL: snapshotURL)
+        SessionRestoreGuard.markRestoreFinished(snapshotFileURL: snapshotURL)
+
+        XCTAssertFalse(SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: SessionRestoreGuard.recoveredSnapshotFileURL(for: snapshotURL).path
+            ),
+            "A clean restore should not leave a recovery copy behind"
+        )
+    }
+
+    func testRestoreGuardDetectsARestoreThatNeverFinished() throws {
+        let (snapshotURL, cleanup) = try makeGuardFixture()
+        defer { cleanup() }
+
+        // Launch begins restoring and is then wedged or killed: no finish call ever happens.
+        SessionRestoreGuard.markRestoreStarted(snapshotFileURL: snapshotURL)
+
+        XCTAssertTrue(SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL))
+        // Consuming clears the marker, so a launch that then succeeds is not punished for it.
+        XCTAssertFalse(SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL))
+    }
+
+    func testRestoreGuardPreservesTheSnapshotItRefusesToRestore() throws {
+        let (snapshotURL, cleanup) = try makeGuardFixture()
+        defer { cleanup() }
+
+        let store = sessionStore(appSupportDirectory: snapshotURL.deletingLastPathComponent())
+        let original = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+        XCTAssertTrue(store.save(original, fileURL: snapshotURL))
+
+        SessionRestoreGuard.markRestoreStarted(snapshotFileURL: snapshotURL)
+        XCTAssertTrue(SessionRestoreGuard.consumeInterruptedRestore(snapshotFileURL: snapshotURL))
+
+        // Skipping restore means the app comes up clean, and the clean session is persisted over the
+        // snapshot moments later. That must not be what destroys the user's workspaces.
+        var replacement = original
+        replacement.createdAt = 12_345
+        XCTAssertTrue(store.save(replacement, fileURL: snapshotURL))
+
+        let recoveredURL = SessionRestoreGuard.recoveredSnapshotFileURL(for: snapshotURL)
+        let recovered = try XCTUnwrap(store.load(fileURL: recoveredURL))
+        XCTAssertEqual(recovered.createdAt, original.createdAt, accuracy: 0.0001)
+        XCTAssertEqual(recovered.windows.count, original.windows.count)
+        XCTAssertEqual(recovered.windows.first?.tabManager.workspaces.first?.customTitle, "Restored")
+    }
+
+    private func makeGuardFixture() throws -> (snapshotURL: URL, cleanup: () -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-restore-guard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        return (snapshotURL, { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
     private func makeSnapshot(version: Int) -> AppSessionSnapshot {
         let workspace = SessionWorkspaceSnapshot(
             processTitle: "Terminal",


### PR DESCRIPTION
Fixes the hang reported in #10311: a many-pane workspace pins the main thread and the window never becomes visible, on both session restore and workspace switch.

### The hang

Every pane is wrapped in its own `NSHostingController` by bonsplit's `SinglePaneWrapper`, so a many-pane workspace stacks ~15 nested `NSHostingView`s. AppKit rebuilds the default key view loop on **every subview insertion**, and SwiftUI answers each nested host's `acceptsFirstResponder` by running a fresh full `FocusNavigationSequence` over the subtree beneath it. That work multiplies across the nesting levels.

Both failing paths converge on one trigger; only the outer frames differ (`makeKeyAndOrderFront` vs. the display cycle):

```
AppKitPlatformViewHost.viewDidMoveToSuperview()
  → -[NSView _setDefaultKeyViewLoop]              ← the trigger, both paths
    → -[NSView _recursiveSetDefaultKeyViewLoop] ×3
      → NSHostingView._recursiveSetDefaultKeyViewLoop()
        → FocusBridge.updateDefaultKeyViewLoop()
          → FocusNavigationSequence.next()
            → NSHostingView.acceptsFirstResponder.getter
              → FocusBridge.hostAcceptsFirstResponder.getter
                → FocusNavigator.firstNavigableItem.getter
                  → FocusNavigationSequence.next()      … ×15
```

Worth stating precisely: this is **not** infinite recursion. Both hang samples show the cycle repeating exactly 15 times at a stack depth of only ~220–240 frames — bounded nesting with exponential work per level. The 5 MB sample files come from the call graph being wide, not deep. A 21-pane workspace stalls the main thread for 9s+; 1–3 panes are instant.

The first commit sets `window.autorecalculatesKeyViewLoop = false` in `createMainWindow`, before `contentView` is assigned so it lands before any pane mounts. `autorecalculatesKeyViewLoop` is the documented switch for exactly this recalculation, and it is currently never set anywhere in the tree.

This should be safe because cmux never reads that loop: there are no uses of `nextKeyView`, `selectNextKeyView` or `canBecomeKeyView` anywhere in the repository. Tab belongs to the shell, and pane focus is driven by cmux's own focus system.

### The self-perpetuating relaunch

The second commit addresses a separable problem from the same report. A workspace that wedges the main thread during restore is self-perpetuating: `selectedWorkspaceIndex` still points at it, so force-quit and relaunch walks straight back in, indefinitely, with no user-facing route out.

A watchdog cannot fix this by aborting the restore — a wedged main thread will not run anything scheduled on it, so any main-thread recovery path is dead by construction. Instead `SessionRestoreGuard` records that a restore *started* and clears that record only once the main thread has proven it is still servicing work afterwards. Reaching the end of `completeSessionRestoreOperation` is not sufficient, since the restored panes mount later during layout — which is exactly where the stall happens — so the clear is deferred behind a liveness delay. If the main thread is stuck, that block never runs and the marker survives to the next launch, which then comes up clean.

Coming up clean is itself destructive without care: `registerMainWindow` saves a snapshot unconditionally, so an empty session would overwrite the good one within seconds. That is the data loss described in #8267. The guard therefore copies the snapshot to `session-<bundle>-recovered.json` before skipping restore. A graceful quit clears the marker immediately, so quitting inside the liveness window does not cost restore on the next launch.

Tests cover three behaviours through the real file-backed path: a completed restore leaves nothing behind, an unfinished restore is detected exactly once, and the recovered copy still holds the original workspaces after the primary snapshot has been overwritten.

### Verification status

Please treat this as needing maintainer verification.

What is verified: the Swift side of the app **compiles cleanly** with these changes applied on top of `5734a451c` (the commit before `04ff18eea` introduced the file that currently breaks `main`). The three commits cherry-pick onto that base without conflict.

What is not verified: the runtime behaviour. The new tests have not been executed, and the hang itself has not been confirmed fixed on a live many-pane workspace.

Two corrections worth stating plainly, since an earlier revision of this description overstated things:

- I previously claimed `AppDelegate.swift` type-checked cleanly against the real module graph. That was wrong. On `main` the build dies on `TerminalController+MobileSurfaces.swift` before this file finishes type-checking, so a compile-batch line was not evidence of success. Building from a base that actually compiles caught a genuine bug in this change — a call to a nonexistent `UpdateLogStore.shared` — fixed in the third commit.
- The one inference behind the first commit that I still cannot confirm by running: that `-[NSView _setDefaultKeyViewLoop]` is gated by `autorecalculatesKeyViewLoop`. That is the documented purpose of the flag and both hang stacks are consistent with it, but a runtime check on a many-pane workspace would be worth doing before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against interrupted session restores.
  * Preserves affected session snapshots for recovery.
  * Automatically skips problematic restores on the next launch.
* **Bug Fixes**
  * Improved startup reliability after crashes or unexpected termination during session restoration.
* **Tests**
  * Added coverage for restore completion, interruption handling, cleanup, and snapshot preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->