### PR TITLE
Verify R2 nightly bytes before web redirects

### DIFF
--- a/web/app/lib/browser-nightly-download.ts
+++ b/web/app/lib/browser-nightly-download.ts
@@ -6,6 +6,9 @@ import { BROWSER_RELEASE_REPOSITORY_URL } from "./download";
 export const BROWSER_NIGHTLY_FEED_URL =
   `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/nightly/update.json`;
 
+/** Immutable public R2 origin used by signed production feed entries. */
+export const BROWSER_PUBLIC_ASSET_ORIGIN = "https://browser-assets.cmux.com";
+
 /**
  * P-256 update public key compiled into cmux Browser's updater.
  *
@@ -118,12 +121,14 @@ export async function resolveBrowserNightlyDownload(
     throw new BrowserNightlyDownloadError("unavailable");
   }
 
-  const releaseTag = verifiedReleaseTag(
+  const assetLocation = verifiedAssetLocation(
     rawEntry,
     target.config.signedArchive,
     payload.version,
   );
-  const url = `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${releaseTag}/${target.assetName}`;
+  const url = assetLocation.kind === "r2"
+    ? `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${encodeURIComponent(payload.version)}/${encodeURIComponent(target.assetName)}`
+    : `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${assetLocation.releaseTag}/${target.assetName}`;
   await requirePublishedAsset(fetchImplementation, url);
 
   return { url, version: payload.version };
@@ -208,11 +213,15 @@ export function verifyFeedEnvelope(
   }
 }
 
-function verifiedReleaseTag(
+type VerifiedAssetLocation =
+  | { readonly kind: "github"; readonly releaseTag: string }
+  | { readonly kind: "r2" };
+
+function verifiedAssetLocation(
   rawEntry: unknown,
   expectedArchive: string,
   version: string,
-): string {
+): VerifiedAssetLocation {
   if (!isRecord(rawEntry)) throw invalidFeed();
   if (
     typeof rawEntry.sha256 !== "string" ||
@@ -234,14 +243,35 @@ function verifiedReleaseTag(
   }
   if (
     signedUrl.protocol !== "https:" ||
-    signedUrl.host !== "github.com" ||
     signedUrl.username !== "" ||
     signedUrl.password !== "" ||
+    signedUrl.port !== "" ||
     signedUrl.search !== "" ||
     signedUrl.hash !== ""
   ) {
     throw invalidFeed();
   }
+
+  if (signedUrl.host === "browser-assets.cmux.com") {
+    const r2Path = signedUrl.pathname.match(
+      /^\/nightly\/([^/]+)\/([^/]+)$/u,
+    );
+    if (!r2Path) throw invalidFeed();
+    let r2Version: string;
+    let r2Archive: string;
+    try {
+      r2Version = decodeURIComponent(r2Path[1]);
+      r2Archive = decodeURIComponent(r2Path[2]);
+    } catch {
+      throw invalidFeed();
+    }
+    if (r2Version !== version || r2Archive !== expectedArchive) {
+      throw invalidFeed();
+    }
+    return { kind: "r2" };
+  }
+
+  if (signedUrl.host !== "github.com") throw invalidFeed();
 
   const releasePath = signedUrl.pathname.match(
     /^\/manaflow-ai\/cmux-v2\/releases\/download\/([^/]+)\/([^/]+)$/u,
@@ -251,7 +281,7 @@ function verifiedReleaseTag(
   if (releaseTag !== "nightly" && releaseTag !== `nightly-${version}`) {
     throw invalidFeed();
   }
-  return releaseTag;
+  return { kind: "github", releaseTag };
 }
 
 async function requirePublishedAsset(

--- a/web/app/lib/browser-nightly-download.ts
+++ b/web/app/lib/browser-nightly-download.ts
@@ -129,7 +129,7 @@ export async function resolveBrowserNightlyDownload(
   const url = assetLocation.kind === "r2"
     ? `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${encodeURIComponent(payload.version)}/${encodeURIComponent(target.assetName)}`
     : `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${assetLocation.releaseTag}/${target.assetName}`;
-  await requirePublishedAsset(fetchImplementation, url);
+  await requirePublishedAsset(fetchImplementation, url, assetLocation);
 
   return { url, version: payload.version };
 }
@@ -215,7 +215,11 @@ export function verifyFeedEnvelope(
 
 type VerifiedAssetLocation =
   | { readonly kind: "github"; readonly releaseTag: string }
-  | { readonly kind: "r2" };
+  | {
+      readonly kind: "r2";
+      readonly sha256: string;
+      readonly size: string;
+    };
 
 function verifiedAssetLocation(
   rawEntry: unknown,
@@ -268,7 +272,11 @@ function verifiedAssetLocation(
     if (r2Version !== version || r2Archive !== expectedArchive) {
       throw invalidFeed();
     }
-    return { kind: "r2" };
+    return {
+      kind: "r2",
+      sha256: rawEntry.sha256,
+      size: rawEntry.size,
+    };
   }
 
   if (signedUrl.host !== "github.com") throw invalidFeed();
@@ -287,6 +295,7 @@ function verifiedAssetLocation(
 async function requirePublishedAsset(
   fetchImplementation: typeof globalThis.fetch,
   url: string,
+  location: VerifiedAssetLocation,
 ): Promise<void> {
   let response: Response;
   try {
@@ -308,6 +317,14 @@ async function requirePublishedAsset(
     ![301, 302, 303, 307, 308].includes(response.status)
   ) {
     throw new BrowserNightlyDownloadError("upstream_unavailable");
+  }
+  if (location.kind === "r2" && response.status === 200) {
+    if (
+      response.headers.get("x-cmux-sha256") !== location.sha256 ||
+      response.headers.get("x-cmux-size") !== location.size
+    ) {
+      throw new BrowserNightlyDownloadError("unavailable");
+    }
   }
 }
 

--- a/web/tests/browser-nightly-download-route.test.ts
+++ b/web/tests/browser-nightly-download-route.test.ts
@@ -5,6 +5,7 @@ import {
 } from "node:crypto";
 
 import {
+  BROWSER_PUBLIC_ASSET_ORIGIN,
   BROWSER_NIGHTLY_FEED_URL,
   resolveBrowserNightlyDownload,
 } from "../app/lib/browser-nightly-download";
@@ -106,6 +107,28 @@ describe("cmux Browser nightly download route", () => {
     }
   });
 
+  test("resolves Universal 2 assets from an immutable R2 feed URL", async () => {
+    const envelope = signedFeed({
+      "mac-arm64": platformEntry(
+        `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.zip`,
+        "cmux-browser.app",
+        "Contents/MacOS/cmux",
+      ),
+    });
+    const fetchMock = feedFetch(envelope, 200);
+
+    const response = await handleBrowserNightlyDownloadRequest(
+      { platform: "mac-arm64", artifact: "dmg" },
+      { fetch: fetchMock, publicKeyPem: TEST_PUBLIC_KEY_PEM },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.dmg`,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test("keeps both Mac architectures unavailable in the current production feed", async () => {
     for (const platform of ["mac-arm64", "mac-x64"]) {
       const fetchMock = feedFetch(PRODUCTION_SIGNED_FEED, 302);
@@ -196,6 +219,10 @@ describe("cmux Browser nightly download route", () => {
       "https://github.com/manaflow-ai/cmux-v2/releases/download/nightly/cmux-linux-x64.zip?redirect=attacker",
       "https://github.com/manaflow-ai//cmux-v2/releases/download/nightly/cmux-linux-x64.zip",
       `https://github.com/manaflow-ai/cmux-v2/releases/download/nightly-${VERSION}.1/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}.1/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/other.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}.evil/nightly/${VERSION}/cmux-linux-x64.zip`,
+      `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-linux-x64.zip?x=1`,
     ]) {
       const fetchMock = feedFetch(signedFeed({
         "linux-x64": platformEntry(url),

--- a/web/tests/browser-nightly-download-route.test.ts
+++ b/web/tests/browser-nightly-download-route.test.ts
@@ -115,7 +115,10 @@ describe("cmux Browser nightly download route", () => {
         "Contents/MacOS/cmux",
       ),
     });
-    const fetchMock = feedFetch(envelope, 200);
+    const fetchMock = feedFetch(envelope, 200, {
+      "X-Cmux-Sha256": "a".repeat(64),
+      "X-Cmux-Size": "651952521",
+    });
 
     const response = await handleBrowserNightlyDownloadRequest(
       { platform: "mac-arm64", artifact: "dmg" },
@@ -126,6 +129,31 @@ describe("cmux Browser nightly download route", () => {
     expect(response.headers.get("location")).toBe(
       `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.dmg`,
     );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects an R2 object whose signed hash or size headers differ", async () => {
+    const envelope = signedFeed({
+      "mac-arm64": platformEntry(
+        `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.zip`,
+        "cmux-browser.app",
+        "Contents/MacOS/cmux",
+      ),
+    });
+    const fetchMock = feedFetch(envelope, 200, {
+      "X-Cmux-Sha256": "b".repeat(64),
+      "X-Cmux-Size": "651952521",
+    });
+
+    const response = await handleBrowserNightlyDownloadRequest(
+      { platform: "mac-arm64", artifact: "dmg" },
+      { fetch: fetchMock, publicKeyPem: TEST_PUBLIC_KEY_PEM },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "browser_download_unavailable",
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -285,7 +313,11 @@ function signedFeed(
   });
 }
 
-function feedFetch(envelope: string, assetStatus: number) {
+function feedFetch(
+  envelope: string,
+  assetStatus: number,
+  assetHeaders?: Record<string, string>,
+) {
   return mock(async (...args: unknown[]) => {
     const input = args[0] as RequestInfo | URL;
     const init = args[1] as RequestInit | undefined;
@@ -299,13 +331,11 @@ function feedFetch(envelope: string, assetStatus: number) {
       });
     }
     expect(init?.method).toBe("HEAD");
-    return new Response(null, {
-      status: assetStatus,
-      headers:
-        assetStatus >= 300 && assetStatus < 400
-          ? { Location: "https://release-assets.githubusercontent.com/file" }
-          : undefined,
-    });
+    const headers = new Headers(assetHeaders);
+    if (assetStatus >= 300 && assetStatus < 400) {
+      headers.set("Location", "https://release-assets.githubusercontent.com/file");
+    }
+    return new Response(null, { status: assetStatus, headers });
   }) as unknown as typeof fetch;
 }
 


### PR DESCRIPTION
## Summary
- bind R2 public HEAD response SHA-256 and size headers to the signed feed entry
- return unavailable on object/feed mismatch instead of redirecting
- add regression coverage for a mismatched R2 object

## Validation
- `bun test tests/browser-nightly-download-route.test.ts tests/platform-downloads.test.ts`
- `./node_modules/.bin/eslint app/lib/browser-nightly-download.ts tests/browser-nightly-download-route.test.ts`
- `bun run typecheck`
- `git diff --check`

This is a follow-up to #10309. The Mac availability flag remains disabled until a real signed all-platform nightly is published.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789618688&installation_model_id=21920&pr_number=10316&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10316&signature=2e60253e274e28de882ee8ea70bfdf108c0a8271709d4c05b6e21bcc9bc00369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies nightly R2 bytes before redirecting and supports immutable R2 asset URLs in the signed feed. Previously we redirected to GitHub assets after a basic HEAD check; now, for R2, we require matching SHA-256 and size headers and return 404 (browser_download_unavailable) on mismatch.

- Feed entries may now use `https://browser-assets.cmux.com/nightly/<version>/<archive>`; GitHub-based entries continue to work as before.
- For R2, the object must include `x-cmux-sha256` and `x-cmux-size` headers that match the signed feed. We perform a HEAD to confirm and only then redirect.
- Invalid or tampered feed URLs (including altered hosts, paths, or queries) are rejected.
- Added tests for R2 success and mismatch cases; Mac nightly remains disabled until a real signed all-platform build is published.

<sup>Written for commit c9488086785ed2e7224e80ed60988caaa5caa50d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly browser downloads can now be delivered from an additional trusted asset source.
  * Download links continue to support GitHub releases while validating the requested version and archive.
* **Bug Fixes**
  * Improved download verification using asset checksums and file sizes.
  * Invalid, mismatched, or tampered download locations are now rejected more reliably.
* **Tests**
  * Expanded coverage for alternate-host downloads, redirects, invalid links, and checksum mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->