### PR TITLE
Verify R2 nightly bytes before web redirects

### DIFF
--- a/web/app/lib/browser-nightly-download.ts
+++ b/web/app/lib/browser-nightly-download.ts
@@ -129,7 +129,7 @@ export async function resolveBrowserNightlyDownload(
   const url = assetLocation.kind === "r2"
     ? `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${encodeURIComponent(payload.version)}/${encodeURIComponent(target.assetName)}`
     : `${BROWSER_RELEASE_REPOSITORY_URL}/releases/download/${assetLocation.releaseTag}/${target.assetName}`;
-  await requirePublishedAsset(fetchImplementation, url);
+  await requirePublishedAsset(fetchImplementation, url, assetLocation);
 
   return { url, version: payload.version };
 }
@@ -215,7 +215,11 @@ export function verifyFeedEnvelope(
 
 type VerifiedAssetLocation =
   | { readonly kind: "github"; readonly releaseTag: string }
-  | { readonly kind: "r2" };
+  | {
+      readonly kind: "r2";
+      readonly sha256: string;
+      readonly size: string;
+    };
 
 function verifiedAssetLocation(
   rawEntry: unknown,
@@ -268,7 +272,11 @@ function verifiedAssetLocation(
     if (r2Version !== version || r2Archive !== expectedArchive) {
       throw invalidFeed();
     }
-    return { kind: "r2" };
+    return {
+      kind: "r2",
+      sha256: rawEntry.sha256,
+      size: rawEntry.size,
+    };
   }
 
   if (signedUrl.host !== "github.com") throw invalidFeed();
@@ -287,6 +295,7 @@ function verifiedAssetLocation(
 async function requirePublishedAsset(
   fetchImplementation: typeof globalThis.fetch,
   url: string,
+  location: VerifiedAssetLocation,
 ): Promise<void> {
   let response: Response;
   try {
@@ -308,6 +317,14 @@ async function requirePublishedAsset(
     ![301, 302, 303, 307, 308].includes(response.status)
   ) {
     throw new BrowserNightlyDownloadError("upstream_unavailable");
+  }
+  if (location.kind === "r2" && response.status === 200) {
+    if (
+      response.headers.get("x-cmux-sha256") !== location.sha256 ||
+      response.headers.get("x-cmux-size") !== location.size
+    ) {
+      throw new BrowserNightlyDownloadError("unavailable");
+    }
   }
 }
 

--- a/web/tests/browser-nightly-download-route.test.ts
+++ b/web/tests/browser-nightly-download-route.test.ts
@@ -115,7 +115,10 @@ describe("cmux Browser nightly download route", () => {
         "Contents/MacOS/cmux",
       ),
     });
-    const fetchMock = feedFetch(envelope, 200);
+    const fetchMock = feedFetch(envelope, 200, {
+      "X-Cmux-Sha256": "a".repeat(64),
+      "X-Cmux-Size": "651952521",
+    });
 
     const response = await handleBrowserNightlyDownloadRequest(
       { platform: "mac-arm64", artifact: "dmg" },
@@ -126,6 +129,31 @@ describe("cmux Browser nightly download route", () => {
     expect(response.headers.get("location")).toBe(
       `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.dmg`,
     );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects an R2 object whose signed hash or size headers differ", async () => {
+    const envelope = signedFeed({
+      "mac-arm64": platformEntry(
+        `${BROWSER_PUBLIC_ASSET_ORIGIN}/nightly/${VERSION}/cmux-macos-universal.zip`,
+        "cmux-browser.app",
+        "Contents/MacOS/cmux",
+      ),
+    });
+    const fetchMock = feedFetch(envelope, 200, {
+      "X-Cmux-Sha256": "b".repeat(64),
+      "X-Cmux-Size": "651952521",
+    });
+
+    const response = await handleBrowserNightlyDownloadRequest(
+      { platform: "mac-arm64", artifact: "dmg" },
+      { fetch: fetchMock, publicKeyPem: TEST_PUBLIC_KEY_PEM },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "browser_download_unavailable",
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -285,7 +313,11 @@ function signedFeed(
   });
 }
 
-function feedFetch(envelope: string, assetStatus: number) {
+function feedFetch(
+  envelope: string,
+  assetStatus: number,
+  assetHeaders?: Record<string, string>,
+) {
   return mock(async (...args: unknown[]) => {
     const input = args[0] as RequestInfo | URL;
     const init = args[1] as RequestInit | undefined;
@@ -299,13 +331,11 @@ function feedFetch(envelope: string, assetStatus: number) {
       });
     }
     expect(init?.method).toBe("HEAD");
-    return new Response(null, {
-      status: assetStatus,
-      headers:
-        assetStatus >= 300 && assetStatus < 400
-          ? { Location: "https://release-assets.githubusercontent.com/file" }
-          : undefined,
-    });
+    const headers = new Headers(assetHeaders);
+    if (assetStatus >= 300 && assetStatus < 400) {
+      headers.set("Location", "https://release-assets.githubusercontent.com/file");
+    }
+    return new Response(null, { status: assetStatus, headers });
   }) as unknown as typeof fetch;
 }
 


### PR DESCRIPTION
## Summary
- bind R2 public HEAD response SHA-256 and size headers to the signed feed entry
- return unavailable on object/feed mismatch instead of redirecting
- add regression coverage for a mismatched R2 object

This is the clean follow-up to merged PR #10309, based on current `main`.

## Validation
- `bun test tests/browser-nightly-download-route.test.ts tests/platform-downloads.test.ts` (18 pass)
- `./node_modules/.bin/eslint app/lib/browser-nightly-download.ts tests/browser-nightly-download-route.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789619101&installation_model_id=21920&pr_number=10317&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10317&signature=5fc480ee1c12e5cc26d4c03f1d13176fcd7ded781ccc14bd460dcf5cba9c9731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates R2 nightly downloads by checking SHA-256 and size from the signed feed before redirecting. Previously, a 200 HEAD from R2 triggered a redirect; now we redirect only if `X-Cmux-Sha256` and `X-Cmux-Size` match the feed. On mismatch, the route returns 404 (`browser_download_unavailable`) instead of redirecting.

- Binds `sha256` and `size` to R2 entries in the verified feed envelope and threads them to `requirePublishedAsset(fetch, url, location)`.
- For R2 with a 200 HEAD, compares `X-Cmux-Sha256`/`X-Cmux-Size` to the feed values; mismatch throws `unavailable`. 3xx redirects and non-2xx/3xx handling are unchanged.
- Adds a regression test rejecting mismatched R2 headers and updates the test fetch helper to set expected headers.

<sup>Written for commit 22145886b75a665fa2278db247394b68090b495c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of browser nightly downloads by checking file size and SHA-256 checksum metadata.
  * Rejects downloads when returned asset information does not match the verified metadata.
  * Preserves existing verification behavior for GitHub-hosted assets.

* **Tests**
  * Added coverage for valid asset headers and mismatched checksum responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->