### PR TITLE
feat(tui): add new column to pane context menu

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -26436,7 +26436,7 @@ mod tests {
             .position(|item| item.action() == Some(MenuAction::CopyPaneId(pane)))
             .unwrap();
 
-        assert_eq!(menu.levels[0].items.len(), 20);
+        assert_eq!(menu.levels[0].items.len(), 21);
         assert_eq!(
             menu.levels[0].items.iter().filter(|item| **item == MenuItem::Separator).count(),
             4
@@ -26445,7 +26445,7 @@ mod tests {
         assert_eq!(menu.levels[0].items.len(), 18);
         assert_eq!(
             menu.levels[0].items.iter().filter(|item| **item == MenuItem::Separator).count(),
-            2
+            1
         );
         assert_eq!(menu.selected_action(), Some(MenuAction::CopyPaneId(pane)));
         assert_eq!(menu.levels[0].rect.height, 20);
@@ -26454,7 +26454,7 @@ mod tests {
         assert_eq!(menu.levels[0].items.len(), 20);
         assert_eq!(
             menu.levels[0].items.iter().filter(|item| **item == MenuItem::Separator).count(),
-            4
+            3
         );
         assert_eq!(menu.selected_action(), Some(MenuAction::CopyPaneId(pane)));
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4115,6 +4115,7 @@ pub enum MenuAction {
     CopyPaneId(PaneId),
     CopyStatusMessage,
     NewPaneSmart(PaneId),
+    NewPaneRight(PaneId),
     NewTab(PaneId),
     NewBrowserTab(PaneId),
     SplitRight(PaneId),
@@ -4191,6 +4192,9 @@ impl MenuAction {
             MenuAction::NewPaneSmart(_) => {
                 localization::catalog().action_label(Action::NewPaneSmart)
             }
+            MenuAction::NewPaneRight(_) => {
+                localization::catalog().action_label(Action::NewPaneRight)
+            }
             MenuAction::NewTab(_) => localization::catalog().action_label(Action::NewTab),
             MenuAction::NewBrowserTab(_) => {
                 localization::catalog().action_label(Action::NewBrowserTab)
@@ -4239,6 +4243,7 @@ fn keyboard_action_for_menu(action: MenuAction) -> Option<Action> {
         MenuAction::BrowserEditUrl(_) => Some(Action::BrowserEditUrl),
         MenuAction::RenameTab(_) => Some(Action::RenameTab),
         MenuAction::NewPaneSmart(_) => Some(Action::NewPaneSmart),
+        MenuAction::NewPaneRight(_) => Some(Action::NewPaneRight),
         MenuAction::NewTab(_) => Some(Action::NewTab),
         MenuAction::NewBrowserTab(_) => Some(Action::NewBrowserTab),
         MenuAction::SplitRight(_) => Some(Action::SplitRight),
@@ -4886,6 +4891,7 @@ fn pane_context_menu_groups(
         ],
         browser_actions,
         vec![
+            MenuAction::NewPaneRight(pane),
             MenuAction::SplitRight(pane),
             MenuAction::SplitDown(pane),
             MenuAction::ClosePane(pane),
@@ -17319,6 +17325,10 @@ impl App {
                 self.run_action_for_pane(Action::NewPaneSmart, Some(pane))?;
                 return Ok(());
             }
+            MenuAction::NewPaneRight(pane) => {
+                self.run_action_for_pane(Action::NewPaneRight, Some(pane))?;
+                return Ok(());
+            }
             MenuAction::NewTab(pane) => {
                 self.run_action_for_pane(Action::NewTab, Some(pane))?;
                 return Ok(());
@@ -17457,6 +17467,7 @@ impl App {
             }
             MenuAction::CopyStatusMessage => self.copy_status_message(),
             MenuAction::NewPaneSmart(_)
+            | MenuAction::NewPaneRight(_)
             | MenuAction::NewTab(_)
             | MenuAction::NewBrowserTab(_)
             | MenuAction::SplitRight(_)
@@ -20479,6 +20490,7 @@ impl App {
             | MenuAction::BrowserEditUrl(pane)
             | MenuAction::RenameTab(pane)
             | MenuAction::NewPaneSmart(pane)
+            | MenuAction::NewPaneRight(pane)
             | MenuAction::NewTab(pane)
             | MenuAction::NewBrowserTab(pane)
             | MenuAction::SplitRight(pane)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22465,6 +22465,7 @@ mod tests {
                 MenuItem::Action(MenuAction::NewTab(pane)),
                 MenuItem::Action(MenuAction::NewBrowserTab(pane)),
                 MenuItem::Separator,
+                MenuItem::Action(MenuAction::NewPaneRight(pane)),
                 MenuItem::Action(MenuAction::SplitRight(pane)),
                 MenuItem::Action(MenuAction::SplitDown(pane)),
                 MenuItem::Action(MenuAction::ClosePane(pane)),
@@ -22500,6 +22501,7 @@ mod tests {
             items.iter().find(|item| item.action() == Some(target)).and_then(MenuItem::shortcut)
         };
         assert_eq!(shortcut(MenuAction::NewPaneSmart(2)), Some("Alt-n"));
+        assert_eq!(shortcut(MenuAction::NewPaneRight(2)), Some("Ctrl-b g"));
         assert_eq!(shortcut(MenuAction::CloseTab(2)), Some("Ctrl-b x"));
         assert_eq!(shortcut(MenuAction::ClosePane(2)), Some("Ctrl-b X"));
         assert_eq!(
@@ -22687,6 +22689,52 @@ mod tests {
     }
 
     #[test]
+    fn pane_context_new_column_runs_the_viewport_layout_action() {
+        let (mux, _) = test_mux("context-new-column-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.config.viewport.animation = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((120, 30));
+        let pane = app.active_pane().unwrap();
+        let before = app.tree.active_screen().unwrap().panes.len();
+        let content = app.pane_areas.iter().find(|area| area.pane == pane).unwrap().content;
+
+        app.open_context_menu(content.x, content.y);
+        assert!(
+            app.menu.as_ref().unwrap().levels[0]
+                .items
+                .iter()
+                .any(|item| item.action() == Some(MenuAction::NewPaneRight(pane)))
+        );
+        app.activate_menu(MenuAction::NewPaneRight(pane)).unwrap();
+        while app.session.has_pending_mutations() {
+            let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
+            app.handle(event).unwrap();
+        }
+        app.replace_tree(app.session.tree());
+        app.sync_layout((120, 30));
+        while app.session.has_pending_mutations() {
+            let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
+            app.handle(event).unwrap();
+        }
+
+        let screen = app.tree.active_screen().unwrap();
+        assert_eq!(screen.panes.len(), before + 1);
+        assert_eq!(screen.viewport_splits.len(), 1);
+        let new_pane = screen.panes.iter().map(|pane| pane.id).find(|id| *id != pane).unwrap();
+        assert!(matches!(
+            screen.layout.viewport_column_owner(new_pane, &screen.viewport_splits),
+            Some(cmux_tui_core::ViewportColumn::Split(_))
+        ));
+
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    #[test]
     fn pane_context_maximize_focuses_the_explicit_inactive_pane() {
         let (mux, first) = test_mux("context-maximize-focus-test", None);
         let first_pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
@@ -22773,6 +22821,7 @@ mod tests {
                     item.action(),
                     Some(
                         MenuAction::NewPaneSmart(_)
+                            | MenuAction::NewPaneRight(_)
                             | MenuAction::NewTab(_)
                             | MenuAction::NewBrowserTab(_)
                             | MenuAction::SplitRight(_)

--- a/cmux-tui/docs/mouse.md
+++ b/cmux-tui/docs/mouse.md
@@ -47,7 +47,7 @@ Drag a rail border to resize that rail for the current TUI session. Dragging the
 
 ## Context Menus
 
-Right-click a pane for rename tab, close tab, new pane, new tab, new browser tab, browser actions when applicable, split right, split down, close pane, maximize/restore, and ID copying. New pane runs the same smart-layout action as `Alt-n`. Every right-click menu, including blank status-bar space, contains Show/Hide Sidebar. When an inner PTY app enables mouse tracking, right-click is forwarded to the app; hold Shift while right-clicking to open the cmux menu.
+Right-click a pane for rename tab, close tab, new pane, new tab, new browser tab, new column to the right, browser actions when applicable, split right, split down, close pane, maximize/restore, and ID copying. New pane runs the same smart-layout action as `Alt-n`. Every right-click menu, including blank status-bar space, contains Show/Hide Sidebar. When an inner PTY app enables mouse tracking, right-click is forwarded to the app; hold Shift while right-clicking to open the cmux menu.
 
 Right-click anywhere inside the sidebar, including its header, empty space, file rows, projected tree rows, and divider, for show/hide, compact/full, and focus actions. Workspace rows also include rename, close, and copy-ID actions. Tab and agent rows rename the exact surface represented by that row. Switching between files and workspaces remains a keyboard action (`Ctrl-b e` by default) and is not in the context menu. Right-click a status-bar screen for its screen actions plus Show/Hide Sidebar.
 

--- a/cmux-tui/scripts/test_check_spec_inventory.py
+++ b/cmux-tui/scripts/test_check_spec_inventory.py
@@ -619,6 +619,21 @@ class InventoryContractTests(unittest.TestCase):
     def inventory(self) -> dict:
         return json.loads((CHECKER.SPEC / "inventory.json").read_text())
 
+    def test_new_pane_right_menu_action_has_inventory_metadata(self) -> None:
+        inventory = self.inventory()
+        menu_actions = {
+            action["variant"]: action for action in inventory["menu_actions"]
+        }
+        self.assertEqual(
+            menu_actions["NewPaneRight"],
+            {
+                "variant": "NewPaneRight",
+                "classification": "direct",
+                "route": "new-pane-right",
+            },
+        )
+        CHECKER.validate_menu_actions(inventory)
+
     def test_private_protocol_domain_ids_match_inventory_version(self) -> None:
         inventory = self.inventory()
         private_domains = {

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -399,6 +399,7 @@
     {"variant": "CopyPaneId", "classification": "presentation-only", "route": "tree snapshot + frontend clipboard"},
     {"variant": "CopyStatusMessage", "classification": "presentation-only", "route": "status snapshot + frontend clipboard"},
     {"variant": "NewPaneSmart", "classification": "composite", "route": "list-workspaces + new-pane"},
+    {"variant": "NewPaneRight", "classification": "direct", "route": "new-pane-right"},
     {"variant": "NewTab", "classification": "direct", "route": "new-tab"},
     {"variant": "NewBrowserTab", "classification": "composite", "route": "frontend omnibar + new-browser-tab"},
     {"variant": "SplitRight", "classification": "direct", "route": "split dir:right"},


### PR DESCRIPTION
Right-click pane menus now expose the existing New column to the right action. The menu uses the shared NewPaneRight action path, keeps its Ctrl-b g shortcut, and hides it in single-surface mode. Added behavior coverage for menu activation and viewport-column creation, plus mouse documentation.\n\nHosted focused verification is running for the exact branch head.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789619328&installation_model_id=21920&pr_number=10318&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10318&signature=fad910b77054cb7576bdb343a26ccf3f3ee225907184d50aee481c5623c7537a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “New column to the right” to the pane context menu to improve discoverability for mouse users. Previously this action was keyboard-only; now it appears in the pane menu, invokes the same Action::NewPaneRight, shows the Ctrl-b g shortcut, and stays hidden in single-surface mode.

- Introduces MenuAction::NewPaneRight and wires it through localization, keyboard mapping, handlers, and the pane context menu.
- Registers inventory metadata for NewPaneRight (classification: direct, route: new-pane-right) with a contract test.
- Adds a UI test that the menu item exists, displays the shortcut, and creates a new viewport column; updates context menu overflow expectations for item/separator counts.
- Updates docs/mouse.md to list the action. No config changes or migrations required.

<sup>Written for commit f80099a188a51bf8cafd1872f92d2b5fd9069276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

