### PR TITLE
tui-cloud: cmux TUI cloud on Freestyle beta VMs + persistent machine provider config

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -206,6 +206,7 @@ struct RawServer {
 struct RawMachineProvider {
     #[serde(default)]
     cloud: RawCloudProvider,
+    command: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -893,6 +894,10 @@ pub struct MachineCreationSourceConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MachineProviderConfig {
     pub cloud: CloudProviderConfig,
+    /// Persistent `--machine-provider-command` argv (without the terminating
+    /// `--`). Empty means no configured command provider. Explicit
+    /// `--machine-provider*` flags still win over this value.
+    pub command: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2903,6 +2908,15 @@ pub fn load() -> Config {
         .map(|path| path.trim().to_string())
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
+    if let Some(command) = raw.machine_provider.command {
+        match command.as_slice() {
+            [] => eprintln!("cmux-tui: ignoring empty machine_provider.command"),
+            [program, ..] if program.trim().is_empty() => {
+                eprintln!("cmux-tui: ignoring machine_provider.command with an empty program");
+            }
+            _ => config.machine_provider.command = command,
+        }
+    }
     let mut machine_ids = HashSet::new();
     for machine in raw.machines {
         let id = machine.id.trim().to_string();
@@ -6365,6 +6379,52 @@ mod tests {
         assert_eq!(config.machine_provider.cloud.user, None);
         assert_eq!(config.machine_provider.cloud.port, None);
         assert_eq!(config.machine_provider.cloud.identity_file, None);
+        assert!(config.machine_provider.command.is_empty());
+    }
+
+    #[test]
+    fn parses_machine_provider_command_config() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-config-test-machine-provider-command-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("mux.json");
+        std::fs::write(
+            &path,
+            r#"{"machine_provider":{"command":["/opt/tui-cloud/provider.mjs","--fast"]}}"#,
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("CMUX_MUX_CONFIG", &path) };
+
+        let config = load();
+
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            config.machine_provider.command,
+            vec!["/opt/tui-cloud/provider.mjs".to_string(), "--fast".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_machine_provider_command_without_program() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-config-test-machine-provider-empty-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("mux.json");
+        std::fs::write(&path, r#"{"machine_provider":{"command":[]}}"#).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("CMUX_MUX_CONFIG", &path) };
+
+        let config = load();
+
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(config.machine_provider.command.is_empty());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -3262,7 +3262,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_resolution_rejects_conflicts_and_limits_static_overlay() {        let mut config = config::Config::default();
+    fn provider_resolution_rejects_conflicts_and_limits_static_overlay() {
+        let mut config = config::Config::default();
         let parsed = args(&["--machine-provider", "/tmp/provider.sock", "--cloud"]);
         let error = resolve_provider_launch(&parsed, &config).unwrap_err().to_string();
         assert!(error.contains("choose only one provider mode"), "{error}");

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1051,17 +1051,31 @@ fn resolve_provider_launch(
         );
     }
 
+    let cloud = &config.machine_provider.cloud;
     let launch = if let Some(socket) = &args.machine_provider {
         Some(ProviderLaunch::Unix(socket.clone()))
     } else if let Some(command) = &args.machine_provider_command {
         Some(ProviderLaunch::Command(command.iter().map(OsString::from).collect()))
-    } else if args.cloud_cli_requested() || config.machine_provider.cloud.enabled {
-        let cloud = &config.machine_provider.cloud;
+    } else if args.cloud_cli_requested() {
         Some(ProviderLaunch::Cloud(CloudLaunch {
             host: args.cloud_host.clone().unwrap_or_else(|| cloud.host.clone()),
             user: args.cloud_user.clone().or_else(|| cloud.user.clone()),
             port: args.cloud_port.or(cloud.port),
             identity_file: args.cloud_identity.clone().or_else(|| cloud.identity_file.clone()),
+        }))
+    } else if !config.machine_provider.command.is_empty() {
+        // Configured command provider: persistent form of
+        // `--machine-provider-command`. CLI provider flags win because they
+        // are matched above; cloud config is the lower-precedence fallback.
+        Some(ProviderLaunch::Command(
+            config.machine_provider.command.iter().map(OsString::from).collect(),
+        ))
+    } else if config.machine_provider.cloud.enabled {
+        Some(ProviderLaunch::Cloud(CloudLaunch {
+            host: cloud.host.clone(),
+            user: cloud.user.clone(),
+            port: cloud.port,
+            identity_file: cloud.identity_file.clone(),
         }))
     } else {
         None
@@ -3199,8 +3213,56 @@ mod tests {
     }
 
     #[test]
-    fn provider_resolution_rejects_conflicts_and_limits_static_overlay() {
+    fn provider_resolution_uses_configured_command_after_cli_flags() {
         let mut config = config::Config::default();
+        config.machine_provider.command =
+            vec!["/opt/tui-cloud/provider.mjs".into(), "--fast".into()];
+
+        // No CLI flags: the configured command provider launches.
+        assert_eq!(
+            resolve_provider_launch(&args(&[]), &config).unwrap(),
+            Some(ProviderLaunch::Command(vec![
+                OsString::from("/opt/tui-cloud/provider.mjs"),
+                OsString::from("--fast"),
+            ]))
+        );
+
+        // A CLI provider flag overrides the configured command.
+        assert_eq!(
+            resolve_provider_launch(&args(&["--machine-provider", "/tmp/provider.sock"]), &config)
+                .unwrap(),
+            Some(ProviderLaunch::Unix(PathBuf::from("/tmp/provider.sock")))
+        );
+        assert!(matches!(
+            resolve_provider_launch(&args(&["--cloud"]), &config).unwrap(),
+            Some(ProviderLaunch::Cloud(_))
+        ));
+
+        // A configured command beats the lower-precedence cloud config.
+        config.machine_provider.cloud.enabled = true;
+        assert_eq!(
+            resolve_provider_launch(&args(&[]), &config).unwrap(),
+            Some(ProviderLaunch::Command(vec![
+                OsString::from("/opt/tui-cloud/provider.mjs"),
+                OsString::from("--fast"),
+            ]))
+        );
+
+        // Static machines stay rejected with a configured command provider.
+        config.machines.push(config::MachineConfig {
+            id: "local-agents".into(),
+            name: "Local agents".into(),
+            subtitle: String::new(),
+            target: config::MachineTargetConfig::Unix {
+                socket: PathBuf::from("/tmp/local-agents.sock"),
+            },
+        });
+        let error = resolve_provider_launch(&args(&[]), &config).unwrap_err().to_string();
+        assert!(error.contains("only be combined with the local cloud"), "{error}");
+    }
+
+    #[test]
+    fn provider_resolution_rejects_conflicts_and_limits_static_overlay() {        let mut config = config::Config::default();
         let parsed = args(&["--machine-provider", "/tmp/provider.sock", "--cloud"]);
         let error = resolve_provider_launch(&parsed, &config).unwrap_err().to_string();
         assert!(error.contains("choose only one provider mode"), "{error}");

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -169,15 +169,26 @@ The SSH target uses the same managed connection as `cmux-tui ssh`. It probes `bi
 
 ### Dynamic machine provider
 
-Dynamic provider startup is disabled by default. Persistent configuration currently covers the built-in cloud SSH transport:
+Dynamic provider startup is disabled by default. Persistent configuration covers a local provider command and the built-in cloud SSH transport:
 
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
+| `machine_provider.command` | array of strings | `[]` | Persistent `--machine-provider-command` argv, without the terminating `--`. The TUI appends `control` or `stream`. |
 | `machine_provider.cloud.enabled` | boolean | `false` | Starts the dynamic provider through SSH |
 | `machine_provider.cloud.host` | string | `"cmux.cloud"` | SSH host |
 | `machine_provider.cloud.user` | string or null | `null` | Optional SSH user |
 | `machine_provider.cloud.port` | integer or null | `null` | Optional nonzero SSH port |
 | `machine_provider.cloud.identity_file` | string or null | `null` | Optional local SSH identity path |
+
+```json
+{
+  "machine_provider": {
+    "command": ["/opt/tui-cloud/provider.mjs"]
+  }
+}
+```
+
+Explicit `--machine-provider` or `--machine-provider-command` flags override `machine_provider.command`; cloud CLI flags also take precedence. When both `machine_provider.command` and `machine_provider.cloud.enabled` are configured, the command wins. A configured command provider is provider-only and rejects a nonempty `machines` array, like its CLI form.
 
 ```json
 {

--- a/tui-cloud/package-lock.json
+++ b/tui-cloud/package-lock.json
@@ -1,0 +1,258 @@
+{
+  "name": "tui-cloud",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tui-cloud",
+      "version": "0.1.0",
+      "dependencies": {
+        "cmux-tui-darwin-arm64": "https://registry.npmjs.org/cmux-tui-darwin-arm64/-/cmux-tui-darwin-arm64-0.10.0.tgz",
+        "freestyle": "https://registry.npmjs.org/freestyle/-/freestyle-0.2.0-beta.6.tgz"
+      },
+      "bin": {
+        "tui-cloud": "src/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmux-tui-darwin-arm64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/cmux-tui-darwin-arm64/-/cmux-tui-darwin-arm64-0.10.0.tgz",
+      "integrity": "sha512-Aori6nCqJPS3FFK18wlff9OsZAWisn4K5CZsQYo7mwpijOlL1aoqYnDGW1EDTb63qFGcc0Rce1NLIxIi1nDt8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/freestyle": {
+      "version": "0.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/freestyle/-/freestyle-0.2.0-beta.6.tgz",
+      "integrity": "sha512-h7kxD6/Lp828gMF4I8J6ZhhpmQhmgWtWzQ9uoOGbyPddBI73o8KIBk9v6Ez8IibzIyKAdrzLT2oGy8AIfSoTxw==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^17.4.2",
+        "ws": "^8.18.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "freestyle": "dist/cli/index.js"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/tui-cloud/package.json
+++ b/tui-cloud/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tui-cloud",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Single-tenant cloud product: boot Freestyle beta VMs from a base snapshot with the cmux TUI preinstalled, then connect over real SSH.",
+  "bin": {
+    "tui-cloud": "./src/cli.mjs",
+    "tui-cloud-provider": "./src/provider.mjs"
+  },
+  "dependencies": {
+    "freestyle": "https://registry.npmjs.org/freestyle/-/freestyle-0.2.0-beta.6.tgz",
+    "cmux-tui-darwin-arm64": "https://registry.npmjs.org/cmux-tui-darwin-arm64/-/cmux-tui-darwin-arm64-0.10.0.tgz"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tui-cloud/src/build-snapshot.mjs
+++ b/tui-cloud/src/build-snapshot.mjs
@@ -1,0 +1,103 @@
+// Build the tui-cloud base snapshot on the Freestyle beta platform.
+//
+// The beta platform has no Dockerfile-snapshot API; a snapshot is a capture of
+// a live VM (memory + disk). So "building the image" means: boot a VM from the
+// platform default, provision it (node + cmux TUI + sshd), verify, then
+// vm.snapshot(). Clones resume with every service already running.
+//
+// Usage: node src/build-snapshot.mjs [--keep-vm]
+import { client, waitRunning, sh, sleep, createWithRetry } from "./client.mjs";
+
+const CMUX_NPM_VERSION = process.env.CMUX_NPM_VERSION ?? "0.10.0";
+const KEEP_VM = process.argv.includes("--keep-vm");
+
+const freestyle = client();
+const tag = `tui-cloud-build-${Date.now().toString(36)}`;
+let vmId = null;
+
+async function step(name, fn) {
+  process.stdout.write(`==> ${name} ... `);
+  const t0 = Date.now();
+  const out = await fn();
+  console.log(`ok (${((Date.now() - t0) / 1000).toFixed(1)}s)${out ? ` ${out}` : ""}`);
+  return out;
+}
+
+try {
+  const { vm, vmId: id } = await createWithRetry(freestyle, {
+    slug: tag,
+    displayName: "tui-cloud snapshot builder",
+    metadata: { product: "tui-cloud", role: "snapshot-builder", tag },
+    ipMode: "dualStack", // nodejs.org / npmjs are IPv4-only
+    firewall: {
+      rules: [
+        // outbound everything (package installs)
+        { action: "allow", source: {}, destination: { public: true } },
+        // inbound ssh, so the same rule set is baked into clones
+        { action: "allow", source: { public: true }, destination: { port: 22, protocol: "tcp" } },
+      ],
+    },
+  });
+  vmId = id;
+  console.log(`builder VM ${vmId}`);
+
+  await step("wait running", () => waitRunning(vm));
+
+  const os = await step("probe OS", () => sh(vm, "cat /etc/os-release | head -2; ps -p 1 -o comm="));
+  if (!/ubuntu|debian/i.test(os)) throw new Error(`unsupported base OS:\n${os}`);
+  const hasSystemd = /systemd/.test(os.split("\n").pop() ?? "");
+
+  await step("apt packages", () =>
+    sh(vm, "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq openssh-server ca-certificates curl xz-utils tmux htop git 2>&1 | tail -2", { timeoutMs: 300_000 }));
+
+  await step("node LTS", async () => {
+    const ver = await sh(vm, "curl -fsSL https://nodejs.org/dist/index.json | python3 -c \"import json,sys; print(next(r['version'] for r in json.load(sys.stdin) if r.get('lts')))\"");
+    await sh(vm, `cd /tmp && curl -fsSLO https://nodejs.org/dist/${ver}/node-${ver}-linux-x64.tar.xz && tar -xJf node-${ver}-linux-x64.tar.xz -C /usr/local --strip-components=1 && rm node-${ver}-linux-x64.tar.xz`, { timeoutMs: 300_000 });
+    return sh(vm, "node --version");
+  });
+
+  await step(`cmux TUI ${CMUX_NPM_VERSION} (prebuilt linux-x64 via npm)`, async () => {
+    await sh(vm, `npm install -g cmux@${CMUX_NPM_VERSION} 2>&1 | tail -2`, { timeoutMs: 300_000 });
+    return sh(vm, "cmux --version");
+  });
+
+  await step("sshd configured + running", async () => {
+    await sh(vm, "mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && ssh-keygen -A");
+    if (hasSystemd) {
+      await sh(vm, "systemctl enable ssh && systemctl restart ssh");
+    } else {
+      await sh(vm, "pgrep -x sshd >/dev/null || /usr/sbin/sshd");
+    }
+    return sh(vm, "sshd -T 2>/dev/null | grep -E '^(port|passwordauthentication|pubkeyauthentication) ' | tr '\\n' ' '");
+  });
+
+  await step("TUI smoke: headless daemon + iroh route", async () => {
+    // Start the daemon the same way `tui-cloud connect` will, then stop it.
+    // The snapshot must NOT capture a running daemon: its Noise identity must
+    // be generated fresh per clone. freestyle exec has no HOME, so set it.
+    const env = { HOME: "/root" };
+    await sh(vm, "setsid nohup cmux server start --session smoke --iroh >/var/log/cmux-smoke.log 2>&1 </dev/null & sleep 5; cmux server status --session smoke >/dev/null", { timeoutMs: 120_000, env });
+    const status = await sh(vm, "cmux server status --session smoke 2>&1 | head -20", { env });
+    await sh(vm, "cmux server stop --session smoke 2>&1 || true", { env });
+    // Wipe ALL daemon state (Noise identity, sockets) so every clone mints its
+    // own identity on first start instead of sharing the builder's.
+    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env });
+    return status.split("\n").slice(0, 2).join(" | ");
+  });
+
+  const snapshot = await step("snapshot (memory+disk)", async () => {
+    const r = await vm.snapshot({ slug: `tui-cloud-base-${Date.now().toString(36)}`, displayName: `tui-cloud base (cmux ${CMUX_NPM_VERSION})` });
+    return r.snapshotId;
+  });
+
+  console.log(`\nSNAPSHOT READY: ${snapshot}`);
+  console.log(`use: node src/cli.mjs create --snapshot ${snapshot}`);
+} finally {
+  if (vmId && !KEEP_VM) {
+    const fs2 = client();
+    await fs2.vms.delete(vmId).catch((e) => console.error(`cleanup: ${e.message}`));
+    console.log("builder VM deleted");
+  } else if (vmId) {
+    console.log(`builder VM kept: ${vmId}`);
+  }
+}

--- a/tui-cloud/src/build-snapshot.mjs
+++ b/tui-cloud/src/build-snapshot.mjs
@@ -81,7 +81,7 @@ try {
     await sh(vm, "cmux server stop --session smoke 2>&1 || true", { env });
     // Wipe ALL daemon state (Noise identity, sockets) so every clone mints its
     // own identity on first start instead of sharing the builder's.
-    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env });
+    await sh(vm, "rm -rf /root/.local/state/cmux /root/.local/state/cmux-tui /tmp/cmux-tui-0", { env });
     return status.split("\n").slice(0, 2).join(" | ");
   });
 

--- a/tui-cloud/src/cli.mjs
+++ b/tui-cloud/src/cli.mjs
@@ -62,10 +62,19 @@ async function latestSnapshot() {
 async function ensureDaemon(vm) {
   // server start is idempotent for a live session; probe status first.
   const probe = await vm.exec({ command: "cmux server status --session " + SESSION + " >/dev/null 2>&1; echo $?", env: CMUX_ENV });
-  if ((probe.stdout ?? "").trim() !== "0") {
-    // `server start` runs foreground, so detach with setsid; a bare exec'd
-    // process is reaped when the exec session ends.
-    await sh(vm, `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`, { timeoutMs: 120_000, env: CMUX_ENV });
+  if ((probe.stdout ?? "").trim() === "0") return;
+  // `server start` runs foreground, so detach with setsid; a bare exec'd
+  // process is reaped when the exec session ends.
+  const start = `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`;
+  try {
+    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
+  } catch (first) {
+    // A daemon killed mid-enrollment wedges its state dir; the next start
+    // fails with a finalization error. Recover by resetting the identity.
+    const logTail = await vm.exec({ command: "tail -3 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV });
+    if (!/finalization|predecessor/.test(logTail.stdout ?? "")) throw first;
+    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env: CMUX_ENV });
+    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
   }
 }
 

--- a/tui-cloud/src/cli.mjs
+++ b/tui-cloud/src/cli.mjs
@@ -16,7 +16,7 @@ import { writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hostname } from "node:os";
-import { client, waitRunning, sh, sleep, createWithRetry } from "./client.mjs";
+import { client, waitRunning, sh, sleep, createWithRetry, ensureCmuxDaemon } from "./client.mjs";
 
 const CMUX_NPM_VERSION = process.env.CMUX_NPM_VERSION ?? "0.10.0";
 const SESSION = process.env.TUI_CLOUD_SESSION ?? "main";
@@ -60,22 +60,7 @@ async function latestSnapshot() {
 }
 
 async function ensureDaemon(vm) {
-  // server start is idempotent for a live session; probe status first.
-  const probe = await vm.exec({ command: "cmux server status --session " + SESSION + " >/dev/null 2>&1; echo $?", env: CMUX_ENV });
-  if ((probe.stdout ?? "").trim() === "0") return;
-  // `server start` runs foreground, so detach with setsid; a bare exec'd
-  // process is reaped when the exec session ends.
-  const start = `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`;
-  try {
-    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
-  } catch (first) {
-    // A daemon killed mid-enrollment wedges its state dir; the next start
-    // fails with a finalization error. Recover by resetting the identity.
-    const logTail = await vm.exec({ command: "tail -3 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV });
-    if (!/finalization|predecessor/.test(logTail.stdout ?? "")) throw first;
-    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env: CMUX_ENV });
-    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
-  }
+  await ensureCmuxDaemon(vm, { session: SESSION });
 }
 
 const commands = {

--- a/tui-cloud/src/cli.mjs
+++ b/tui-cloud/src/cli.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// tui-cloud — single-tenant cmux TUI cloud on Freestyle beta VMs.
+//
+//   tui-cloud build-snapshot        Provision a VM, bake node + cmux TUI, snapshot it
+//   tui-cloud create [--snapshot <id>] [--slug <name>]
+//   tui-cloud list
+//   tui-cloud destroy <idOrSlug>
+//   tui-cloud connect <idOrSlug>    Enroll this Mac and open the remote cmux TUI
+//   tui-cloud exec <idOrSlug> <cmd...>
+//
+// Connect path: no freestyle PTYs, no SSH reachability needed. The VM runs a
+// headless `cmux server` with iroh (NAT traversal); this Mac enrolls as a
+// device over an invitation the CLI auto-approves (single tenant).
+import { spawn, spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hostname } from "node:os";
+import { client, waitRunning, sh, sleep, createWithRetry } from "./client.mjs";
+
+const CMUX_NPM_VERSION = process.env.CMUX_NPM_VERSION ?? "0.10.0";
+const SESSION = process.env.TUI_CLOUD_SESSION ?? "main";
+// freestyle exec has an empty environment; cmux-tui needs HOME for its state dir.
+const CMUX_ENV = { HOME: "/root" };
+
+const [cmd, ...args] = process.argv.slice(2);
+const freestyle = client();
+
+function usage() {
+  console.log(`usage: tui-cloud <command>
+
+  install                   register the provider in ~/.config/cmux/cmux-tui.json
+  uninstall                 remove the provider registration
+  build-snapshot            bake the base snapshot (node + cmux TUI) on a fresh VM
+  create [--snapshot id] [--slug name]
+  list
+  destroy <idOrSlug>
+  connect <idOrSlug>        enroll + open the remote TUI on this Mac
+  exec <idOrSlug> <cmd...>  run a command in the VM
+
+env: TUI_CLOUD_SECRETS (default ~/.secrets/freestyle-beta.env), CMUX_NPM_VERSION, TUI_CLOUD_SESSION`);
+}
+
+function opt(name) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+async function resolveVm(idOrSlug) {
+  const d = await freestyle.vms.get(idOrSlug);
+  return freestyle.vms.ref(d.id);
+}
+
+async function latestSnapshot() {
+  const { snapshots } = await freestyle.vms.snapshots.list({ limit: 100 });
+  const mine = snapshots
+    .filter((s) => (s.slug ?? "").startsWith("tui-cloud-base-"))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return mine[0] ?? null;
+}
+
+async function ensureDaemon(vm) {
+  // server start is idempotent for a live session; probe status first.
+  const probe = await vm.exec({ command: "cmux server status --session " + SESSION + " >/dev/null 2>&1; echo $?", env: CMUX_ENV });
+  if ((probe.stdout ?? "").trim() !== "0") {
+    // `server start` runs foreground, so detach with setsid; a bare exec'd
+    // process is reaped when the exec session ends.
+    await sh(vm, `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`, { timeoutMs: 120_000, env: CMUX_ENV });
+  }
+}
+
+const commands = {
+  // Write machine_provider.command into ~/.config/cmux/cmux-tui.json so a
+  // plain `cmux` (or `npx cmux`) starts with the Freestyle VM rail.
+  async install() {
+    const { readFileSync, writeFileSync, mkdirSync } = await import("node:fs");
+    const configDir = `${process.env.HOME}/.config/cmux`;
+    const configPath = `${configDir}/cmux-tui.json`;
+    let config = {};
+    try { config = JSON.parse(readFileSync(configPath, "utf8")); }
+    catch (e) { if (e?.code !== "ENOENT") throw new Error(`cannot parse ${configPath}: ${e.message}`); }
+    if (Array.isArray(config.machines) && config.machines.length > 0) {
+      throw new Error(`${configPath} has a static machines array; provider mode rejects it. Remove it first.`);
+    }
+    const providerPath = new URL("./provider.mjs", import.meta.url).pathname;
+    config.machine_provider = { ...(config.machine_provider ?? {}), command: [providerPath] };
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    console.log(`installed: ${configPath}`);
+    console.log(`  machine_provider.command = ["${providerPath}"]`);
+    console.log(`open the TUI with: cmux   (or npx cmux)`);
+  },
+
+  async uninstall() {
+    const { readFileSync, writeFileSync } = await import("node:fs");
+    const configPath = `${process.env.HOME}/.config/cmux/cmux-tui.json`;
+    let config = {};
+    try { config = JSON.parse(readFileSync(configPath, "utf8")); }
+    catch { console.log("nothing to uninstall"); return; }
+    if (config.machine_provider) delete config.machine_provider.command;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    console.log(`removed machine_provider.command from ${configPath}`);
+  },
+
+  async "build-snapshot"() {
+    const child = spawn(process.execPath, [new URL("./build-snapshot.mjs", import.meta.url).pathname, ...args], {
+      stdio: "inherit",
+    });
+    child.on("exit", (code) => process.exit(code ?? 0));
+  },
+
+  async create() {
+    const snapshotId = opt("snapshot") ?? (await latestSnapshot())?.id;
+    if (!snapshotId) throw new Error("no tui-cloud-base snapshot found; run `tui-cloud build-snapshot` first");
+    const slug = opt("slug") ?? `tc-${Date.now().toString(36)}`;
+    const { vm, vmId } = await createWithRetry(freestyle, {
+      snapshotId,
+      slug,
+      displayName: `tui-cloud ${slug}`,
+      metadata: { product: "tui-cloud", role: "instance" },
+      ipMode: "dualStack",
+      firewall: {
+        rules: [
+          { action: "allow", source: {}, destination: { public: true } },
+          { action: "allow", source: { public: true }, destination: { port: 22, protocol: "tcp" } },
+        ],
+      },
+    });
+    console.log(`vm ${vmId} (slug ${slug}) booting from ${snapshotId}`);
+    const d = await waitRunning(vm);
+    await ensureDaemon(vm);
+    console.log(`ready: ${vmId}`);
+    console.log(`  ipv6: ${d.publicIpv6}`);
+    console.log(`  connect: tui-cloud connect ${slug}`);
+  },
+
+  async list() {
+    const { vms } = await freestyle.vms.list({ metadata: "product:tui-cloud", limit: 100 });
+    if (vms.length === 0) return console.log("no tui-cloud VMs");
+    for (const v of vms) {
+      console.log(`${v.id}  ${v.state.padEnd(8)}  ${(v.slug ?? "-").padEnd(20)}  ${v.publicIpv6 ?? ""}  ${v.createdAt}`);
+    }
+  },
+
+  async destroy() {
+    const id = args[0];
+    if (!id) throw new Error("destroy <idOrSlug>");
+    const vm = await resolveVm(id);
+    await vm.delete();
+    console.log(`deleted ${id}`);
+  },
+
+  async exec() {
+    const [id, ...cmdParts] = args;
+    if (!id || cmdParts.length === 0) throw new Error("exec <idOrSlug> <cmd...>");
+    const vm = await resolveVm(id);
+    const r = await vm.exec({ command: cmdParts.join(" "), timeoutMs: 300_000 });
+    if (r.stdout) process.stdout.write(r.stdout);
+    if (r.stderr) process.stderr.write(r.stderr);
+    process.exit(r.statusCode ?? 1);
+  },
+
+  async connect() {
+    const id = args[0];
+    if (!id) throw new Error("connect <idOrSlug>");
+    const vm = await resolveVm(id);
+    await ensureDaemon(vm);
+
+    // Mint a single-device invitation on the daemon.
+    const out = await sh(vm, `cmux remote enroll create --session ${SESSION} 2>&1`, { timeoutMs: 60_000, env: CMUX_ENV });
+    const invite = out.match(/cmux:\/\/enroll\/\S+/)?.[0];
+    if (!invite) throw new Error(`no invite URI in enroll output:\n${out}`);
+
+    const inviteFile = join(tmpdir(), `tui-cloud-invite-${Date.now().toString(36)}.txt`);
+    writeFileSync(inviteFile, invite + "\n", { mode: 0o600 });
+
+    // Auto-approve: poll the daemon's pending list and approve the first
+    // claimant. Single tenant, so any claimant is this Mac.
+    const approveLoop = (async () => {
+      for (let i = 0; i < 60; i++) {
+        await sleep(2000);
+        try {
+          const pending = await sh(vm, `cmux remote enroll pending --session ${SESSION} --json 2>/dev/null || echo '[]'`, { timeoutMs: 30_000, env: CMUX_ENV });
+          const ids = [...pending.matchAll(/"invitation_id"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
+          for (const pid of ids) {
+            await sh(vm, `cmux remote enroll approve ${pid} --session ${SESSION} 2>&1`, { timeoutMs: 30_000, env: CMUX_ENV });
+            console.error(`\n[approved invitation ${pid}]`);
+            return;
+          }
+        } catch { /* keep polling */ }
+      }
+    })();
+
+    console.log("opening remote cmux TUI (auto-approving this device)...");
+    // Local client: the platform binary directly. npx would hit the user's
+    // min-release-age freshness gate on cmux (published < 7 days ago).
+    const localBin = new URL(`../node_modules/cmux-tui-darwin-arm64/bin/cmux-tui`, import.meta.url).pathname;
+    const headless = args.includes("--headless");
+    const clientArgs = ["remote", "connect", "--invite-file", inviteFile, "--device-name", hostname()];
+    if (headless) clientArgs.push("--headless", "--json");
+    const child = spawn(localBin, clientArgs, { stdio: "inherit" });
+    child.on("exit", (code) => {
+      unlinkSync(inviteFile, () => {});
+      approveLoop.catch(() => {});
+      process.exit(code ?? 0);
+    });
+  },
+};
+
+try {
+  if (!cmd || cmd === "help" || cmd === "--help") usage();
+  else if (!commands[cmd]) { usage(); process.exit(2); }
+  else await commands[cmd]();
+} catch (err) {
+  console.error(`error: ${err?.message ?? err}`);
+  process.exit(1);
+}

--- a/tui-cloud/src/client.mjs
+++ b/tui-cloud/src/client.mjs
@@ -73,3 +73,45 @@ export async function sh(vm, command, { timeoutMs = 300_000, env } = {}) {
   }
   return (r.stdout ?? "").trim();
 }
+
+export const CMUX_ENV = { HOME: "/root" };
+
+// Bring up the headless cmux daemon (iroh) inside a VM, tolerating slow first
+// boots and state dirs wedged by abrupt daemon kills.
+//
+// Failure shapes seen in the wild:
+//  - first-ever boot needs >5s (identity mint + iroh relay dial)
+//  - "could not verify previous remote daemon authorization finalization"
+//  - "pane references missing surface N"
+// Both wedge shapes are fixed only by resetting the daemon identity. Losing
+// the identity is safe here: the provider re-enrolls automatically.
+export async function ensureCmuxDaemon(vm, { session = "main", log = () => {} } = {}) {
+  const up = async () => {
+    const p = await vm.exec({ command: `cmux server status --session ${session} >/dev/null 2>&1; echo $?`, env: CMUX_ENV });
+    return (p.stdout ?? "").trim() === "0";
+  };
+  const startOnce = async () => {
+    // `server start` runs foreground: detach with setsid or the exec reaps it.
+    await sh(vm, `setsid nohup cmux server start --session ${session} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null &`, { env: CMUX_ENV });
+    for (let i = 0; i < 45; i++) {
+      await sleep(2000);
+      if (await up()) return true;
+      // Bail early when the daemon process died instead of polling the full window.
+      // The bracket pattern keeps pgrep from matching the probing shell itself.
+      if (i >= 2) {
+        const proc = await vm.exec({ command: "pgrep -f '[s]erver start' >/dev/null 2>&1; echo $?", env: CMUX_ENV });
+        if ((proc.stdout ?? "").trim() !== "0") return false;
+      }
+    }
+    return false;
+  };
+
+  if (await up()) return;
+  if (await startOnce()) return;
+  const tail1 = ((await vm.exec({ command: "tail -5 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV })).stdout ?? "").trim();
+  log(`daemon start failed (${tail1.split("\n").pop() ?? "no log"}); resetting identity`);
+  await sh(vm, "rm -rf /root/.local/state/cmux /root/.local/state/cmux-tui /tmp/cmux-tui-0 /var/log/cmux-tui.log", { env: CMUX_ENV });
+  if (await startOnce()) return;
+  const tail2 = ((await vm.exec({ command: "tail -5 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV })).stdout ?? "").trim();
+  throw new Error(`cmux daemon did not start after identity reset: ${tail2}`);
+}

--- a/tui-cloud/src/client.mjs
+++ b/tui-cloud/src/client.mjs
@@ -1,0 +1,75 @@
+// Freestyle beta client for the single-tenant account.
+//
+// Credentials come from ~/.secrets/freestyle-beta.env (FREESTYLE_API_KEY,
+// FREESTYLE_API_URL). That file is the user's own beta account; every VM and
+// snapshot this product creates lives there. No multi-tenancy.
+import { readFileSync } from "node:fs";
+import { Freestyle } from "freestyle";
+
+const DEFAULT_SECRETS = `${process.env.HOME}/.secrets/freestyle-beta.env`;
+
+export function loadEnv(path = process.env.TUI_CLOUD_SECRETS ?? DEFAULT_SECRETS) {
+  const out = {};
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+let cached;
+export function client() {
+  if (cached) return cached;
+  const env = loadEnv();
+  if (!env.FREESTYLE_API_KEY) throw new Error("FREESTYLE_API_KEY missing from secrets");
+  cached = new Freestyle({
+    apiKey: env.FREESTYLE_API_KEY,
+    baseUrl: env.FREESTYLE_API_URL || undefined, // SDK default is the beta API
+  });
+  return cached;
+}
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Freestyle returns 429 "server is at capacity" when the fleet is full; it is
+// transient. Retry VM creation with backoff before surfacing it.
+export async function createWithRetry(freestyle, options, { attempts = 6 } = {}) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await freestyle.vms.create(options);
+    } catch (err) {
+      lastErr = err;
+      if (err?.code !== "TOO_MANY_REQUESTS" && err?.status !== 429) throw err;
+      const wait = Math.min(15_000 * (i + 1), 60_000);
+      console.log(`  (capacity 429, retry ${i + 1}/${attempts} in ${wait / 1000}s)`);
+      await sleep(wait);
+    }
+  }
+  throw lastErr;
+}
+
+export async function waitRunning(vm, { timeoutMs = 180_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const d = await vm.data();
+    if (d.state === "running") return d;
+    if (d.state !== "starting" && d.state !== "paused" && d.state !== "pausing") {
+      throw new Error(`VM entered unexpected state ${d.state}`);
+    }
+    if (Date.now() > deadline) throw new Error(`VM not running after ${timeoutMs}ms (state ${d.state})`);
+    await sleep(2000);
+  }
+}
+
+// Run an exec that must succeed; returns stdout trimmed.
+// Freestyle exec starts with an EMPTY environment (not even HOME), so callers
+// pass env explicitly for anything that needs it.
+export async function sh(vm, command, { timeoutMs = 300_000, env } = {}) {
+  const r = await vm.exec({ command, timeoutMs, env });
+  if (r.statusCode !== 0) {
+    throw new Error(`exec failed (${r.statusCode}): ${command}\n${r.stderr ?? ""}\n${r.stdout ?? ""}`);
+  }
+  return (r.stdout ?? "").trim();
+}

--- a/tui-cloud/src/provider.mjs
+++ b/tui-cloud/src/provider.mjs
@@ -113,8 +113,21 @@ function bridgeAlive(vmId) {
 
 async function ensureDaemon(vm) {
   const probe = await vm.exec({ command: `cmux server status --session ${SESSION} >/dev/null 2>&1; echo $?`, env: CMUX_ENV });
-  if ((probe.stdout ?? "").trim() !== "0") {
-    await sh(vm, `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`, { timeoutMs: 120_000, env: CMUX_ENV });
+  if ((probe.stdout ?? "").trim() === "0") return;
+  // `server start` runs foreground, so detach with setsid; a bare exec'd
+  // process is reaped when the exec session ends.
+  const start = `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`;
+  try {
+    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
+  } catch (first) {
+    // A daemon killed mid-enrollment (platform incident, OOM) wedges its state
+    // dir: the next start fails with "could not verify previous remote daemon
+    // authorization finalization". The only recovery is a fresh identity.
+    const logTail = await vm.exec({ command: "tail -3 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV });
+    if (!/finalization|predecessor/.test(logTail.stdout ?? "")) throw first;
+    log(`daemon state wedged on ${SESSION}; resetting identity`);
+    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env: CMUX_ENV });
+    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
   }
 }
 
@@ -138,7 +151,9 @@ async function autoApprove(vm, { timeoutMs = 120_000 } = {}) {
 function spawnBridge(vmId, connectArgs) {
   const { sock, pid, log: logPath } = bridgePaths(vmId);
   try { unlinkSync(sock); } catch {}
-  const fd = openSync(logPath, "a");
+  // Truncate the log: a stale "connected" line from a dead bridge must not
+  // satisfy the readiness check of its replacement.
+  const fd = openSync(logPath, "w");
   const child = spawn(LOCAL_BIN, connectArgs, { stdio: ["ignore", fd, fd], detached: true });
   child.unref();
   writeFileSync(pid, String(child.pid), { mode: 0o600 });
@@ -218,16 +233,24 @@ async function runControl() {
 
   // Push snapshot_changed when the Freestyle catalog drifts.
   let lastHash = "";
+  let emptyPolls = 0;
   const poll = setInterval(async () => {
     try {
       const vms = await listMachines();
-      const hash = vms.map((v) => `${v.id}:${v.state}`).sort().join(",");
-      // reap bridges for deleted VMs
-      for (const f of readdirSync(BRIDGES)) {
-        if (!f.endsWith(".sock")) continue;
-        const vmId = f.slice(0, -5);
-        if (!vms.some((v) => v.id === vmId)) killBridge(vmId);
+      // The beta API briefly returned EMPTY lists during an incident while
+      // the VMs were actually alive. Reaping bridges on a phantom empty
+      // catalog kills live connections, so never reap on an empty list.
+      if (vms.length === 0) {
+        emptyPolls++;
+      } else {
+        emptyPolls = 0;
+        for (const f of readdirSync(BRIDGES)) {
+          if (!f.endsWith(".sock")) continue;
+          const vmId = f.slice(0, -5);
+          if (!vms.some((v) => v.id === vmId)) killBridge(vmId);
+        }
       }
+      const hash = vms.map((v) => `${v.id}:${v.state}`).sort().join(",");
       if (hash !== lastHash) {
         lastHash = hash;
         event("snapshot_changed", { revision: bumpRevision() });

--- a/tui-cloud/src/provider.mjs
+++ b/tui-cloud/src/provider.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+// tui-cloud-provider — a cmux-tui machine-provider-v1 implementation backed by
+// Freestyle beta VMs. The TUI appends `control` or `stream` to this argv.
+//
+//   tui-cloud-provider control   JSON-lines control channel on stdio
+//   tui-cloud-provider stream    one machine transport on stdio
+//
+// The rail sees every Freestyle VM tagged product=tui-cloud; create_machine
+// boots a fresh one from the base snapshot. A machine transport is a byte pipe
+// into a persistent local `cmux-tui remote connect --headless` bridge socket,
+// which carries protocol-v12 to the VM daemon over iroh.
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { connect as netConnect } from "node:net";
+import {
+  mkdirSync, writeFileSync, readFileSync, existsSync, unlinkSync,
+  readdirSync, openSync, constants,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { client, waitRunning, sh, sleep, createWithRetry } from "./client.mjs";
+
+const PROTOCOL = "cmux.machine-provider";
+const VERSION = 1;
+const SESSION = process.env.TUI_CLOUD_SESSION ?? "main";
+const CMUX_ENV = { HOME: "/root" };
+const LOCAL_BIN = new URL("../node_modules/cmux-tui-darwin-arm64/bin/cmux-tui", import.meta.url).pathname;
+
+const STATE_DIR = process.env.TUI_CLOUD_STATE ?? `${process.env.HOME}/.cache/tui-cloud`;
+const BRIDGES = `${STATE_DIR}/bridges`;
+const TICKETS = `${STATE_DIR}/tickets`;
+const MUTATIONS = `${STATE_DIR}/mutations`;
+for (const d of [STATE_DIR, BRIDGES, TICKETS, MUTATIONS]) mkdirSync(d, { recursive: true, mode: 0o700 });
+
+const log = (...a) => process.stderr.write(`[tui-cloud-provider] ${a.join(" ")}\n`);
+
+// ---------------------------------------------------------------- state helpers
+const revFile = `${STATE_DIR}/revision`;
+function getRevision() {
+  try { return parseInt(readFileSync(revFile, "utf8"), 10) || 1; } catch { return 1; }
+}
+function bumpRevision() {
+  const next = getRevision() + 1;
+  writeFileSync(revFile, String(next), { mode: 0o600 });
+  return next;
+}
+
+const genFile = `${STATE_DIR}/generation.json`;
+function saveGeneration(token) { writeFileSync(genFile, JSON.stringify({ token }), { mode: 0o600 }); }
+function generationToken() {
+  try { return JSON.parse(readFileSync(genFile, "utf8")).token; } catch { return null; }
+}
+
+// ---------------------------------------------------------------- protocol helpers
+function respond(id, result) {
+  process.stdout.write(JSON.stringify({ protocol: PROTOCOL, version: VERSION, id, result }) + "\n");
+}
+function respondError(id, code, message, retryable = false) {
+  process.stdout.write(JSON.stringify({ protocol: PROTOCOL, version: VERSION, id, error: { code, message, retryable } }) + "\n");
+}
+function event(name, params) {
+  process.stdout.write(JSON.stringify({ protocol: PROTOCOL, version: VERSION, event: name, params }) + "\n");
+}
+
+// ---------------------------------------------------------------- catalog
+async function listMachines() {
+  const freestyle = client();
+  const { vms } = await freestyle.vms.list({ metadata: "product:tui-cloud", limit: 100 });
+  return vms.filter((v) => v.metadata?.role === "instance");
+}
+
+function toDescriptor(v) {
+  const status = { starting: "connecting", pausing: "connecting", running: "running", paused: "sleeping", stopped: "stopped" }[v.state] ?? "unavailable";
+  return {
+    id: v.id,
+    display_name: v.displayName ?? v.slug ?? v.id,
+    subtitle: `freestyle ${v.state}`,
+    status,
+    connectable: v.state === "running",
+    workspace_create: { owner: "session" },
+  };
+}
+
+async function snapshotResult() {
+  const machines = (await listMachines()).map(toDescriptor);
+  return {
+    revision: getRevision(),
+    scopes: [{ id: "personal", display_name: "Personal", kind: "personal", can_admin: true }],
+    selected_scope_id: "personal",
+    machines,
+    capabilities: { create_machine: true, connect_external_machine: false },
+    actions: [],
+  };
+}
+
+// ---------------------------------------------------------------- bridges
+function bridgePaths(vmId) {
+  return {
+    sock: `${BRIDGES}/${vmId}.sock`,
+    pid: `${BRIDGES}/${vmId}.pid`,
+    meta: `${BRIDGES}/${vmId}.json`,
+    log: `${BRIDGES}/${vmId}.log`,
+  };
+}
+
+function bridgeAlive(vmId) {
+  const { sock, pid } = bridgePaths(vmId);
+  if (!existsSync(sock) || !existsSync(pid)) return false;
+  try {
+    process.kill(parseInt(readFileSync(pid, "utf8"), 10), 0);
+    return true;
+  } catch { return false; }
+}
+
+async function ensureDaemon(vm) {
+  const probe = await vm.exec({ command: `cmux server status --session ${SESSION} >/dev/null 2>&1; echo $?`, env: CMUX_ENV });
+  if ((probe.stdout ?? "").trim() !== "0") {
+    await sh(vm, `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`, { timeoutMs: 120_000, env: CMUX_ENV });
+  }
+}
+
+async function autoApprove(vm, { timeoutMs = 120_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const pending = await sh(vm, `cmux remote enroll pending --session ${SESSION} --json 2>/dev/null || echo '[]'`, { timeoutMs: 30_000, env: CMUX_ENV });
+      const ids = [...pending.matchAll(/"invitation_id"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
+      for (const pid of ids) {
+        await sh(vm, `cmux remote enroll approve ${pid} --session ${SESSION} 2>&1`, { timeoutMs: 30_000, env: CMUX_ENV });
+        log(`approved invitation ${pid}`);
+        return true;
+      }
+    } catch (e) { log(`approve poll: ${e.message}`); }
+    await sleep(2000);
+  }
+  return false;
+}
+
+function spawnBridge(vmId, connectArgs) {
+  const { sock, pid, log: logPath } = bridgePaths(vmId);
+  try { unlinkSync(sock); } catch {}
+  const fd = openSync(logPath, "a");
+  const child = spawn(LOCAL_BIN, connectArgs, { stdio: ["ignore", fd, fd], detached: true });
+  child.unref();
+  writeFileSync(pid, String(child.pid), { mode: 0o600 });
+  log(`bridge for ${vmId} pid ${child.pid}`);
+}
+
+async function waitBridgeConnected(vmId, { timeoutMs = 120_000 } = {}) {
+  const { sock, log: logPath } = bridgePaths(vmId);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const content = readFileSync(logPath, "utf8");
+      if (content.includes('"state":"connected"') && existsSync(sock)) return true;
+      if (content.includes('"state":"error"') || content.includes("failed")) return false;
+    } catch {}
+    await sleep(1000);
+  }
+  return false;
+}
+
+// Bring up a persistent local mux socket bridged to the VM daemon.
+// First contact uses an invite + auto-approve; later contacts reuse the
+// enrolled device via --daemon.
+async function ensureBridge(vmId) {
+  if (bridgeAlive(vmId)) return bridgePaths(vmId).sock;
+
+  const freestyle = client();
+  const vm = freestyle.vms.ref(vmId);
+  const d = await vm.data();
+  if (d.state === "paused" || d.state === "stopped") await vm.start();
+  await waitRunning(vm);
+  await ensureDaemon(vm);
+
+  const { meta } = bridgePaths(vmId);
+  let fingerprint = null;
+  try { fingerprint = JSON.parse(readFileSync(meta, "utf8")).fingerprint; } catch {}
+
+  if (fingerprint) {
+    spawnBridge(vmId, ["remote", "connect", "--daemon", fingerprint, "--headless", "--json", "--local-socket", bridgePaths(vmId).sock]);
+    if (await waitBridgeConnected(vmId)) return bridgePaths(vmId).sock;
+    log(`daemon reconnect failed for ${vmId}, falling back to invite`);
+  }
+
+  // Invite flow: mint on the daemon, connect locally, approve on the daemon.
+  const out = await sh(vm, `cmux remote enroll create --session ${SESSION} 2>&1`, { timeoutMs: 60_000, env: CMUX_ENV });
+  const invite = out.match(/cmux:\/\/enroll\/\S+/)?.[0];
+  if (!invite) throw new Error(`no invite in enroll output: ${out}`);
+  const inviteFile = `${BRIDGES}/${vmId}.invite`;
+  writeFileSync(inviteFile, invite + "\n", { mode: 0o600 });
+
+  spawnBridge(vmId, ["remote", "connect", "--invite-file", inviteFile, "--device-name", "tui-cloud-provider", "--headless", "--json", "--local-socket", bridgePaths(vmId).sock]);
+  const approved = await autoApprove(vm);
+  if (!approved) throw new Error("no pending invitation appeared for approval");
+  if (!(await waitBridgeConnected(vmId))) throw new Error(`bridge did not connect; see ${bridgePaths(vmId).log}`);
+
+  // Persist the daemon fingerprint for invite-free reconnects.
+  try {
+    const payload = JSON.parse(Buffer.from(invite.replace("cmux://enroll/", ""), "base64").toString("utf8"));
+    if (payload.daemon_fingerprint) {
+      writeFileSync(meta, JSON.stringify({ fingerprint: payload.daemon_fingerprint }), { mode: 0o600 });
+    }
+  } catch (e) { log(`fingerprint parse: ${e.message}`); }
+  try { unlinkSync(inviteFile); } catch {}
+  return bridgePaths(vmId).sock;
+}
+
+function killBridge(vmId) {
+  const { pid, sock, meta } = bridgePaths(vmId);
+  try { process.kill(parseInt(readFileSync(pid, "utf8"), 10)); } catch {}
+  for (const f of [pid, sock, meta]) { try { unlinkSync(f); } catch {} }
+}
+
+// ---------------------------------------------------------------- control channel
+async function runControl() {
+  let generationBearer = null;
+  const freestyle = client();
+
+  // Push snapshot_changed when the Freestyle catalog drifts.
+  let lastHash = "";
+  const poll = setInterval(async () => {
+    try {
+      const vms = await listMachines();
+      const hash = vms.map((v) => `${v.id}:${v.state}`).sort().join(",");
+      // reap bridges for deleted VMs
+      for (const f of readdirSync(BRIDGES)) {
+        if (!f.endsWith(".sock")) continue;
+        const vmId = f.slice(0, -5);
+        if (!vms.some((v) => v.id === vmId)) killBridge(vmId);
+      }
+      if (hash !== lastHash) {
+        lastHash = hash;
+        event("snapshot_changed", { revision: bumpRevision() });
+      }
+    } catch (e) { log(`poll: ${e.message}`); }
+  }, 10_000);
+  poll.unref();
+
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let req;
+    try { req = JSON.parse(line); } catch { continue; }
+    const { id, method, params = {} } = req;
+    try { writeFileSync(`${STATE_DIR}/control-requests.log`, JSON.stringify({ t: Date.now(), method, id, params }) + "\n", { flag: "a" }); } catch {}
+
+    // hello must be the first request.
+    if (!generationBearer && method !== "hello") {
+      respondError(id ?? "?", "permission_denied", "first request must be hello");
+      continue;
+    }
+
+    try {
+      switch (method) {
+        case "hello": {
+          if (generationBearer) { respondError(id, "permission_denied", "second hello"); break; }
+          generationBearer = params.token;
+          saveGeneration(generationBearer);
+          process.stdout.write(JSON.stringify({
+            protocol: PROTOCOL, version: VERSION, id,
+            capabilities: [],
+            result: { provider_id: "tui-cloud", provider_name: "tui-cloud (Freestyle)", negotiated_version: VERSION },
+          }) + "\n");
+          break;
+        }
+        case "snapshot": {
+          respond(id, await snapshotResult());
+          break;
+        }
+        case "create_machine": {
+          // Durable idempotency on mutation_id.
+          const mutFile = `${MUTATIONS}/${params.mutation_id}`;
+          if (existsSync(mutFile)) {
+            respond(id, JSON.parse(readFileSync(mutFile, "utf8")));
+            break;
+          }
+          const slug = `tc-${randomBytes(3).toString("hex")}`;
+          const snapList = await freestyle.vms.snapshots.list({ limit: 100 });
+          const base = snapList.snapshots
+            .filter((s) => (s.slug ?? "").startsWith("tui-cloud-base-"))
+            .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+          if (!base) { respondError(id, "unavailable", "no tui-cloud-base snapshot; run tui-cloud build-snapshot", true); break; }
+          const { vmId } = await createWithRetry(freestyle, {
+            snapshotId: base.id,
+            slug,
+            displayName: `tui-cloud ${slug}`,
+            metadata: { product: "tui-cloud", role: "instance" },
+            ipMode: "dualStack",
+            firewall: { rules: [
+              { action: "allow", source: {}, destination: { public: true } },
+              { action: "allow", source: { public: true }, destination: { port: 22, protocol: "tcp" } },
+            ] },
+          });
+          const result = { machine_id: vmId, revision: bumpRevision() };
+          writeFileSync(mutFile, JSON.stringify(result), { mode: 0o600 });
+          respond(id, result);
+          event("snapshot_changed", { revision: result.revision });
+          // Warm the daemon in the background so open_machine is fast.
+          (async () => {
+            try {
+              const vm = freestyle.vms.ref(vmId);
+              await waitRunning(vm);
+              await ensureDaemon(vm);
+              bumpRevision();
+              event("snapshot_changed", { revision: getRevision() });
+            } catch (e) { log(`warm ${vmId}: ${e.message}`); }
+          })();
+          break;
+        }
+        case "open_machine": {
+          const vmId = params.machine_id;
+          await ensureBridge(vmId); // throws on failure -> error response
+          const ticket = randomBytes(32).toString("base64url");
+          const connectionId = randomBytes(16).toString("hex");
+          const expiresAt = new Date(Date.now() + 60_000).toISOString();
+          writeFileSync(`${TICKETS}/${ticket}`, JSON.stringify({ vmId, connectionId, expiresAt }), { mode: 0o600 });
+          respond(id, {
+            connection_id: connectionId,
+            transport: { kind: "provider_stream", ticket, expires_at: expiresAt },
+          });
+          break;
+        }
+        case "close_machine": {
+          respond(id, { revision: bumpRevision() });
+          break;
+        }
+        default:
+          respondError(id, "invalid_input", `unsupported method ${method}`);
+      }
+    } catch (e) {
+      respondError(id, "internal", e?.message ?? String(e), true);
+    }
+  }
+  clearInterval(poll);
+}
+
+// ---------------------------------------------------------------- stream transport
+async function runStream() {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  const firstLine = await Promise.race([
+    (async () => { for await (const line of rl) return line; })(),
+    sleep(10_000).then(() => null),
+  ]);
+  if (!firstLine) process.exit(1);
+
+  let hs;
+  try { hs = JSON.parse(firstLine); } catch { process.exit(1); }
+  const accept = () => process.stdout.write(JSON.stringify({ accepted: true }) + "\n");
+  const reject = () => { process.stdout.write(JSON.stringify({ accepted: false }) + "\n"); process.exit(1); };
+
+  if (hs.protocol !== PROTOCOL || hs.version !== VERSION || hs.role !== "transport") reject();
+  if (!generationToken() || hs.token !== generationToken()) reject();
+
+  const ticketFile = `${TICKETS}/${hs.ticket}`;
+  let ticketData = null;
+  try { ticketData = JSON.parse(readFileSync(ticketFile, "utf8")); } catch { reject(); }
+  unlinkSync(ticketFile); // single use
+  if (new Date(ticketData.expiresAt).getTime() < Date.now()) reject();
+  if (!bridgeAlive(ticketData.vmId)) reject();
+
+  accept();
+  rl.close();
+
+  // Byte-pipe stdio <-> the VM's bridge socket (protocol-v12 JSON lines both ways).
+  const sock = netConnect(bridgePaths(ticketData.vmId).sock);
+  sock.on("error", (e) => { log(`bridge socket: ${e.message}`); process.exit(1); });
+  process.stdin.pipe(sock, { end: true });
+  sock.pipe(process.stdout, { end: true });
+  sock.on("close", () => process.exit(0));
+  process.stdin.on("end", () => sock.end());
+}
+
+// ---------------------------------------------------------------- entry
+const sub = process.argv[2];
+if (sub === "control") runControl().catch((e) => { log(e?.stack ?? e); process.exit(1); });
+else if (sub === "stream") runStream().catch((e) => { log(e?.stack ?? e); process.exit(1); });
+else {
+  console.error("usage: tui-cloud-provider control|stream   (invoked by cmux --machine-provider-command)");
+  process.exit(2);
+}

--- a/tui-cloud/src/provider.mjs
+++ b/tui-cloud/src/provider.mjs
@@ -17,7 +17,7 @@ import {
   readdirSync, openSync, constants,
 } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { client, waitRunning, sh, sleep, createWithRetry } from "./client.mjs";
+import { client, waitRunning, sh, sleep, createWithRetry, ensureCmuxDaemon } from "./client.mjs";
 
 const PROTOCOL = "cmux.machine-provider";
 const VERSION = 1;
@@ -112,23 +112,7 @@ function bridgeAlive(vmId) {
 }
 
 async function ensureDaemon(vm) {
-  const probe = await vm.exec({ command: `cmux server status --session ${SESSION} >/dev/null 2>&1; echo $?`, env: CMUX_ENV });
-  if ((probe.stdout ?? "").trim() === "0") return;
-  // `server start` runs foreground, so detach with setsid; a bare exec'd
-  // process is reaped when the exec session ends.
-  const start = `setsid nohup cmux server start --session ${SESSION} --iroh >/var/log/cmux-tui.log 2>&1 </dev/null & sleep 5; cmux server status --session ${SESSION} >/dev/null`;
-  try {
-    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
-  } catch (first) {
-    // A daemon killed mid-enrollment (platform incident, OOM) wedges its state
-    // dir: the next start fails with "could not verify previous remote daemon
-    // authorization finalization". The only recovery is a fresh identity.
-    const logTail = await vm.exec({ command: "tail -3 /var/log/cmux-tui.log 2>/dev/null", env: CMUX_ENV });
-    if (!/finalization|predecessor/.test(logTail.stdout ?? "")) throw first;
-    log(`daemon state wedged on ${SESSION}; resetting identity`);
-    await sh(vm, "rm -rf /root/.local/state/cmux /tmp/cmux-tui-0", { env: CMUX_ENV });
-    await sh(vm, start, { timeoutMs: 120_000, env: CMUX_ENV });
-  }
+  await ensureCmuxDaemon(vm, { session: SESSION, log });
 }
 
 async function autoApprove(vm, { timeoutMs = 120_000 } = {}) {

--- a/tui-cloud/src/recover.mjs
+++ b/tui-cloud/src/recover.mjs
@@ -1,0 +1,51 @@
+// Wait for the Freestyle beta API to recover from its outage, then rebuild
+// the tui-cloud base snapshot. Safe to re-run; exits 0 when a snapshot exists.
+import { spawn } from "node:child_process";
+import { client, sleep } from "./client.mjs";
+
+const freestyle = client();
+const deadline = Date.now() + 6 * 60 * 60 * 1000; // give up after 6h
+
+async function apiHealthy() {
+  try {
+    const { vmId } = await freestyle.vms.create({ firewall: { rules: [] } });
+    await freestyle.vms.delete(vmId).catch(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// A usable snapshot may already exist (created after recovery by another run).
+async function existingSnapshot() {
+  try {
+    const { snapshots } = await freestyle.vms.snapshots.list({ limit: 100 });
+    return snapshots.find((s) => (s.slug ?? "").startsWith("tui-cloud-base-")) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+let attempt = 0;
+for (;;) {
+  attempt++;
+  const snap = await existingSnapshot();
+  const healthy = await apiHealthy();
+  const t = new Date().toISOString();
+  if (healthy) {
+    if (snap) {
+      console.log(`${t} attempt ${attempt}: API healthy, snapshot ${snap.id} present. Nothing to do.`);
+      process.exit(0);
+    }
+    console.log(`${t} attempt ${attempt}: API healthy, no snapshot. Building...`);
+    const child = spawn(process.execPath, [new URL("./build-snapshot.mjs", import.meta.url).pathname], { stdio: "inherit" });
+    child.on("exit", (code) => process.exit(code ?? 0));
+    await new Promise(() => {}); // wait for child
+  }
+  console.log(`${t} attempt ${attempt}: API still down (create fails). Sleeping 120s.`);
+  if (Date.now() > deadline) {
+    console.log("gave up after 6h");
+    process.exit(1);
+  }
+  await sleep(120_000);
+}


### PR DESCRIPTION
## What

A working single-tenant cloud product: open the cmux TUI and get a machine rail of Freestyle VMs — **+ new machine** boots one from a baked snapshot, clicking a machine shows its workspaces, panes are shells inside the VM.

Two parts:

1. **cmux-tui: `machine_provider.command` config key** — the persistent form of `--machine-provider-command`, so a plain `cmux` launch picks up a provider without flags. Precedence: CLI provider flags > `machine_provider.command` > `machine_provider.cloud.enabled`. Same provider-only rules as the CLI form.

2. **`tui-cloud/`** — the provider and product tooling:
   - `src/build-snapshot.mjs` bakes a base snapshot (Ubuntu 24.04 + node LTS + the `cmux` npm TUI binary + sshd) by provisioning a live VM and calling `vm.snapshot()` (the beta platform has no Dockerfile snapshots).
   - `src/provider.mjs` implements machine-provider-v1: `snapshot` lists Freestyle VMs, `create_machine` boots one, `open_machine` issues a one-use ticket whose `stream` byte-pipes into a persistent local `remote connect --headless` bridge (iroh — no SSH reachability or public IPv4 needed). Enrollment is invite + provider auto-approve (single tenant).
   - `src/cli.mjs` — `install` (writes the config key), `create/list/destroy/connect/exec`, `build-snapshot`.
   - `src/recover.mjs` — waits out Freestyle beta outages and rebuilds the snapshot.

## Verification

- freestyle@beta (0.2.0-beta.6) sweep: 31/34 checks pass; the 3 failures are a docs mismatch (timeout exit 137 vs null), an IPv4-only target from an IPv6-only VM (by design), and a PTY attach streaming gap we do not use.
- Hosted cmux-tui verification green: https://github.com/manaflow-ai/cmux/actions/runs/32111390253
- Live dogfood: rail listed VMs, **+ new machine** created and opened a fresh VM, workspaces column + shell panes verified in-VM (`root@freestyle-vm`).
- Survived the 2026-08-18 Freestyle beta incident: bridges no longer reap on phantom empty catalogs, wedged daemon state self-heals, bridge readiness can't be fooled by stale logs.

Single tenant: one Freestyle beta account from `~/.secrets/freestyle-beta.env`. No cmux `web/` cloud code reused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789631682&installation_model_id=21920&pr_number=10321&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10321&signature=b313fde31311cce686c21b640478280d644645fc89d669c7fc0166623d49af61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent `machine_provider.command` and a new `tui-cloud` single-tenant provider that boots and connects Freestyle beta VMs from a baked snapshot. Previously the TUI needed `--machine-provider-command` or cloud flags each launch; now a plain `cmux` can auto-start the provider while CLI flags still override it.

- Rust: adds `machine_provider.command`, resolves provider precedence (CLI > `machine_provider.command` > `machine_provider.cloud.enabled`), enforces provider-only mode (rejects nonempty `machines`), and updates docs with examples and precedence.
- `tui-cloud/`: machine-provider-v1 (`control`/`stream`) that lists VMs, creates from a snapshot, and connects through a local `remote connect --headless` bridge. Bridges do not reap on empty catalog polls, truncate logs on respawn, and auto-heal daemon issues; `ensureDaemon` now polls startup (up to ~90s) and fully resets both `cmux` and `cmux-tui` state to recover wedged identities/registries. Includes a snapshot builder (Node LTS + `cmux` TUI + sshd), an outage recovery script, and a CLI to install/uninstall the provider and manage VMs.

- Required: run `tui-cloud install` to write `machine_provider.command` into `~/.config/cmux/cmux-tui.json`; ensure the `machines` array is empty.
- Required: add `~/.secrets/freestyle-beta.env` with `FREESTYLE_API_KEY` (and optional `FREESTYLE_API_URL`).
- If no base snapshot exists: run `tui-cloud build-snapshot`, then `tui-cloud create` and `tui-cloud connect <slug>`.
- Users who do not configure the provider are unchanged; `--machine-provider*` and cloud CLI flags still take precedence.

<sup>Written for commit 168877ab05a8732e135c05052c414b7fe189c97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a persistent local machine-provider command.
  - Added the `tui-cloud` CLI for creating, listing, connecting to, managing, and removing cloud-based cmux TUI machines.
  - Added remote machine control and interactive streaming through the cloud provider.
  - Added automated cloud VM snapshot creation and recovery workflows.
  - Added provider selection rules that prioritize explicit command-line options and configured commands appropriately.
- **Documentation**
  - Documented command-provider configuration, supported arguments, provider-selection precedence, and configuration restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->