### PR TITLE
fix(cli): validate ssh-session-attach session id and route to owning workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -860,14 +860,16 @@ jobs:
       - name: Run ssh-session-attach anchor regression
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
-          # Focused gate for https://github.com/manaflow-ai/cmux/issues/7367.
+          # Focused gate for https://github.com/manaflow-ai/cmux/issues/7367 and
+          # for ssh-session-attach session-id validation / owning-workspace
+          # routing.
           # The full "Run unit tests" step tolerates any xcodebuild failure
           # whose last test summary reports "(0 unexpected)", and test
           # assertion failures never increment the unexpected count on these
           # runners — so a failing regression assertion in the sharded run
           # cannot turn the shard red. Keep this targeted only-testing
           # invocation as a non-tolerant guard for the ssh-session-attach
-          # split-anchor regression.
+          # split-anchor and session-validation regressions.
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
           scripts/ci/run-in-console-session.sh \
@@ -879,6 +881,7 @@ jobs:
             -destination "platform=macOS" \
             CMUX_SKIP_ZIG_BUILD=1 \
             -only-testing:cmuxTests/CLISSHSessionAttachAnchorTests \
+            -only-testing:cmuxTests/CLISSHSessionAttachSessionValidationTests \
             test
 
       - name: Run focused browser regressions

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13077,33 +13077,65 @@ struct CMUXCLI {
         if paneOpt != nil, splitOpt != nil {
             throw CLIError(message: "ssh-session-attach: --pane cannot be combined with --split")
         }
-        let workspaceRaw = workspaceOpt ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
-        let workspaceID = try normalizeWorkspaceHandle(workspaceRaw, client: client)
+        // Resolve the session id against the app's persisted sessions before
+        // creating anything: a surface created for an unknown session, or in a
+        // workspace without the session's remote daemon, parks its
+        // `ssh-pty-attach --wait --require-existing` wrapper in
+        // `workspace.remote.pty_bridge` for up to 185s per attempt inside the
+        // unbounded SSHPTYAttachRetryScriptBuilder loop — a permanently hung pane.
+        let explicitWorkspaceID = try workspaceOpt.flatMap {
+            try normalizeWorkspaceHandle($0, client: client)
+        }
+        let owner = try sshSessionAttachOwningWorkspace(
+            sessionID: sessionID,
+            explicitWorkspaceID: explicitWorkspaceID,
+            explicitWorkspaceRaw: workspaceOpt,
+            client: client
+        )
+        let workspaceID = owner.workspaceID
         let initialCommand = sshSessionAttachStartupCommand(sessionID: sessionID)
         var params: [String: Any] = [
             "initial_command": initialCommand,
             "remote_pty_session_id": sessionID,
+            "workspace_id": workspaceID,
         ]
-        if let workspaceID {
-            params["workspace_id"] = workspaceID
-        }
         try applyFocusOption(focusOpt, defaultValue: true, to: &params)
 
         let payload: [String: Any]
         if let split = splitOpt?.trimmingCharacters(in: .whitespacesAndNewlines),
            !split.isEmpty {
             params["direction"] = split
-            let surfaceID = try normalizeSurfaceHandle(
-                surfaceOpt ?? (workspaceOpt == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil),
-                client: client,
-                workspaceHandle: workspaceID
-            )
+            // An explicit --surface must live in the owning workspace. The
+            // caller's own CMUX_SURFACE_ID anchor stays unvalidated: it is only
+            // consulted when the caller already sits in the owning workspace,
+            // and a stale env value must not turn a working attach into a hard
+            // failure.
+            let surfaceID: String?
+            if let surfaceOpt {
+                surfaceID = try sshSessionAttachSurfaceHandle(
+                    surfaceOpt,
+                    client: client,
+                    owner: owner,
+                    sessionID: sessionID
+                )
+            } else {
+                surfaceID = try normalizeSurfaceHandle(
+                    sshSessionAttachCallerSurfaceAnchor(workspaceOpt: workspaceOpt, owner: owner),
+                    client: client,
+                    workspaceHandle: workspaceID
+                )
+            }
             if let surfaceID {
                 params["surface_id"] = surfaceID
             }
             payload = try client.sendV2(method: "surface.split", params: params)
         } else {
-            let paneID = try normalizePaneHandle(paneOpt, client: client, workspaceHandle: workspaceID)
+            let paneID = try sshSessionAttachPaneHandle(
+                paneOpt,
+                client: client,
+                owner: owner,
+                sessionID: sessionID
+            )
             if let paneID {
                 params["pane_id"] = paneID
             }
@@ -13118,6 +13150,199 @@ struct CMUXCLI {
             idFormat: idFormat,
             fallbackText: v2CreationSummary(output, idFormat: idFormat, kinds: ["surface", "pane", "workspace"])
         )
+    }
+
+    /// The workspace that actually owns a persisted SSH PTY session, as reported
+    /// by `workspace.remote.pty_sessions`.
+    private struct SSHSessionAttachOwner {
+        let workspaceID: String
+        /// `workspace_ref` when the app supplied one. `ssh-session-list` prints
+        /// this ref, so an explicit `--workspace` may legitimately carry it
+        /// instead of the UUID.
+        let workspaceRef: String?
+        /// Label used only in user-facing messages.
+        var workspaceLabel: String { workspaceRef ?? workspaceID }
+    }
+
+    /// True when `handle` (a UUID, or a ref like `workspace:4`) designates
+    /// `owner`. `handlesMatch` cannot reconcile a ref against a UUID, so both
+    /// identities the app reported for the owning workspace are compared.
+    private func sshSessionAttachOwnerMatches(_ owner: SSHSessionAttachOwner, handle: String) -> Bool {
+        if handlesMatch(owner.workspaceID, handle) { return true }
+        guard let workspaceRef = owner.workspaceRef else { return false }
+        return handlesMatch(workspaceRef, handle)
+    }
+
+    /// Resolves `sessionID` against the app's persisted sessions and returns the
+    /// owning workspace. Uses the same `workspace.remote.pty_sessions` v2 call as
+    /// `ssh-session-list --all-workspaces`, so the CLI never guesses a workspace
+    /// and never creates a surface for a session that does not exist.
+    ///
+    /// Read-only: no focus or selection is mutated here, keeping
+    /// `ssh-session-attach` focus behavior entirely in `applyFocusOption`.
+    private func sshSessionAttachOwningWorkspace(
+        sessionID: String,
+        explicitWorkspaceID: String?,
+        explicitWorkspaceRaw: String?,
+        client: SocketClient
+    ) throws -> SSHSessionAttachOwner {
+        let response = try client.sendV2(
+            method: "workspace.remote.pty_sessions",
+            params: ["all_workspaces": true]
+        )
+        let sessions = response["sessions"] as? [[String: Any]] ?? []
+        let listErrors = response["errors"] as? [[String: Any]] ?? []
+
+        var owners: [SSHSessionAttachOwner] = []
+        var seenWorkspaces = Set<String>()
+        for session in sessions {
+            guard let candidate = trimmedDebugString(session["session_id"]),
+                  candidate == sessionID,
+                  let workspaceID = trimmedDebugString(session["workspace_id"]),
+                  seenWorkspaces.insert(workspaceID.lowercased()).inserted else {
+                continue
+            }
+            owners.append(
+                SSHSessionAttachOwner(
+                    workspaceID: workspaceID,
+                    workspaceRef: trimmedDebugString(session["workspace_ref"])
+                )
+            )
+        }
+
+        guard !owners.isEmpty else {
+            var message = String.localizedStringWithFormat(
+                String(
+                    localized: "cli.error.sshSessionAttachSessionNotFound",
+                    defaultValue: "ssh-session-attach: no persisted SSH PTY session with id '%@'. Run 'cmux ssh-session-list --all-workspaces' to see valid session ids.",
+                    bundle: CLIExecutableLocator.enclosingAppBundle() ?? .main
+                ),
+                sessionID
+            )
+            if !listErrors.isEmpty {
+                // The owning workspace may simply be disconnected, so say so
+                // instead of implying the session id is certainly wrong.
+                message += "\n" + sshSessionListFailureMessage()
+            }
+            throw CLIError(message: message)
+        }
+
+        if let explicitWorkspaceID {
+            guard let matched = owners.first(where: {
+                sshSessionAttachOwnerMatches($0, handle: explicitWorkspaceID)
+            }) else {
+                throw CLIError(message: String.localizedStringWithFormat(
+                    String(
+                        localized: "cli.error.sshSessionAttachWorkspaceMismatch",
+                        defaultValue: "ssh-session-attach: session '%1$@' belongs to workspace %2$@, but --workspace requested %3$@. Re-run without --workspace, or pass the owning workspace.",
+                        bundle: CLIExecutableLocator.enclosingAppBundle() ?? .main
+                    ),
+                    sessionID,
+                    owners.map(\.workspaceLabel).joined(separator: ", "),
+                    explicitWorkspaceRaw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? explicitWorkspaceID
+                ))
+            }
+            return matched
+        }
+
+        guard owners.count == 1 else {
+            throw CLIError(message: String.localizedStringWithFormat(
+                String(
+                    localized: "cli.error.sshSessionAttachWorkspaceAmbiguous",
+                    defaultValue: "ssh-session-attach: session '%1$@' exists in multiple workspaces (%2$@). Pass --workspace <workspace> to choose one.",
+                    bundle: CLIExecutableLocator.enclosingAppBundle() ?? .main
+                ),
+                sessionID,
+                owners.map(\.workspaceLabel).joined(separator: ", ")
+            ))
+        }
+        return owners[0]
+    }
+
+    /// The caller's `CMUX_SURFACE_ID` may only anchor a split when the caller's
+    /// own workspace is the one that owns the session — the owning workspace may
+    /// differ from the caller's even with no `--workspace` flag (the general
+    /// form of the anchor mismatch in issue #7367).
+    private func sshSessionAttachCallerSurfaceAnchor(
+        workspaceOpt: String?,
+        owner: SSHSessionAttachOwner
+    ) -> String? {
+        guard workspaceOpt == nil,
+              let callerWorkspaceID = Self.normalizedEnvValue(
+                  ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
+              ),
+              sshSessionAttachOwnerMatches(owner, handle: callerWorkspaceID) else {
+            return nil
+        }
+        return ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+    }
+
+    /// Resolves a `--surface` handle and confirms it lives in the owning
+    /// workspace. Index handles are already workspace-scoped by
+    /// `normalizeSurfaceHandle`; explicit UUID/ref handles are checked here so a
+    /// foreign anchor cannot silently place the attach outside the session's
+    /// workspace.
+    private func sshSessionAttachSurfaceHandle(
+        _ raw: String?,
+        client: SocketClient,
+        owner: SSHSessionAttachOwner,
+        sessionID: String
+    ) throws -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        guard isUUID(trimmed) || isHandleRef(trimmed) else {
+            return try normalizeSurfaceHandle(trimmed, client: client, workspaceHandle: owner.workspaceID)
+        }
+        let listed = try client.sendV2(
+            method: "surface.list",
+            params: ["workspace_id": owner.workspaceID]
+        )
+        let surfaces = listed["surfaces"] as? [[String: Any]] ?? []
+        for surface in surfaces where surfaceHandleMatches(trimmed, item: surface) {
+            return (surface["id"] as? String) ?? (surface["ref"] as? String) ?? trimmed
+        }
+        throw CLIError(message: String.localizedStringWithFormat(
+            String(
+                localized: "cli.error.sshSessionAttachSurfaceOutsideOwningWorkspace",
+                defaultValue: "ssh-session-attach: surface %1$@ is not in workspace %2$@, which owns session '%3$@'.",
+                bundle: CLIExecutableLocator.enclosingAppBundle() ?? .main
+            ),
+            trimmed,
+            owner.workspaceLabel,
+            sessionID
+        ))
+    }
+
+    /// `--pane` counterpart of `sshSessionAttachSurfaceHandle(_:client:owner:sessionID:)`.
+    private func sshSessionAttachPaneHandle(
+        _ raw: String?,
+        client: SocketClient,
+        owner: SSHSessionAttachOwner,
+        sessionID: String
+    ) throws -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        guard isUUID(trimmed) || isHandleRef(trimmed) else {
+            return try normalizePaneHandle(trimmed, client: client, workspaceHandle: owner.workspaceID)
+        }
+        let listed = try client.sendV2(
+            method: "pane.list",
+            params: ["workspace_id": owner.workspaceID]
+        )
+        let panes = listed["panes"] as? [[String: Any]] ?? []
+        for pane in panes where paneHandleMatches(trimmed, item: pane) {
+            return (pane["id"] as? String) ?? (pane["ref"] as? String) ?? trimmed
+        }
+        throw CLIError(message: String.localizedStringWithFormat(
+            String(
+                localized: "cli.error.sshSessionAttachPaneOutsideOwningWorkspace",
+                defaultValue: "ssh-session-attach: pane %1$@ is not in workspace %2$@, which owns session '%3$@'.",
+                bundle: CLIExecutableLocator.enclosingAppBundle() ?? .main
+            ),
+            trimmed,
+            owner.workspaceLabel,
+            sessionID
+        ))
     }
 
     private func sshSessionAttachStartupCommand(sessionID: String) -> String {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -38081,6 +38081,91 @@
         }
       }
     },
+    "cli.error.sshSessionAttachPaneOutsideOwningWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: pane %1$@ is not in workspace %2$@, which owns session '%3$@'."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: ペイン %1$@ は、セッション '%3$@' を所有するワークスペース %2$@ にありません。"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachSessionNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: no persisted SSH PTY session with id '%@'. Run 'cmux ssh-session-list --all-workspaces' to see valid session ids."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: ID '%@' の永続 SSH PTY セッションが見つかりません。有効なセッション ID を確認するには 'cmux ssh-session-list --all-workspaces' を実行してください。"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachSurfaceOutsideOwningWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: surface %1$@ is not in workspace %2$@, which owns session '%3$@'."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: サーフェス %1$@ は、セッション '%3$@' を所有するワークスペース %2$@ にありません。"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachWorkspaceAmbiguous": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: session '%1$@' exists in multiple workspaces (%2$@). Pass --workspace <workspace> to choose one."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: セッション '%1$@' は複数のワークスペース (%2$@) に存在します。--workspace <workspace> でいずれかを指定してください。"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachWorkspaceMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: session '%1$@' belongs to workspace %2$@, but --workspace requested %3$@. Re-run without --workspace, or pass the owning workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: セッション '%1$@' はワークスペース %2$@ に属していますが、--workspace では %3$@ が指定されました。--workspace を付けずに再実行するか、所有元のワークスペースを指定してください。"
+          }
+        }
+      }
+    },
     "cli.error.sshSessionAttachWorkspaceRequiresValue": {
       "extractionState": "manual",
       "localizations": {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 			C77070000000000000000004 /* CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77070000000000000000005 /* CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift */; };
 		6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */; };
 		A7367001A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */; };
+		A7367011A1B2C3D4E5F60718 /* CLISSHSessionAttachSessionValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7367012A1B2C3D4E5F60718 /* CLISSHSessionAttachSessionValidationTests.swift */; };
 		C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */; };
 		B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */; };
 		7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */; };
@@ -3436,6 +3437,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C77070000000000000000005 /* CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift; sourceTree = "<group>"; };
 		6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHPTYResizeInputTests.swift; sourceTree = "<group>"; };
 		A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHSessionAttachAnchorTests.swift; sourceTree = "<group>"; };
+		A7367012A1B2C3D4E5F60718 /* CLISSHSessionAttachSessionValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHSessionAttachSessionValidationTests.swift; sourceTree = "<group>"; };
 		C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIStdioSIGPIPERegressionTests.swift; sourceTree = "<group>"; };
 		B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatRemoteSplitTests.swift; sourceTree = "<group>"; };
 		7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatResizePaneTests.swift; sourceTree = "<group>"; };
@@ -8134,6 +8136,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE75890000000000000004 /* DeflatedAssetTestSupport.swift */,
 				1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */,
 				A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */,
+				A7367012A1B2C3D4E5F60718 /* CLISSHSessionAttachSessionValidationTests.swift */,
 				C0DEBACC0000000000000004 /* CodexTeamsAppServerFixture.swift */,
 				C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */,
 				C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */,
@@ -11141,6 +11144,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C77070000000000000000004 /* CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift in Sources */,
 				6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */,
 				A7367001A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift in Sources */,
+				A7367011A1B2C3D4E5F60718 /* CLISSHSessionAttachSessionValidationTests.swift in Sources */,
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -126,13 +126,13 @@ struct CLISSHSessionAttachAnchorTests {
                   let method = payload["method"] as? String else {
                 return Self.malformedRequestResponse(raw: line)
             }
+            let params = payload["params"] as? [String: Any] ?? [:]
             switch method {
             case "workspace.remote.pty_sessions":
                 // ssh-session-attach resolves the session's owning workspace
                 // before creating anything. A workspace-scoped lookup cannot see
                 // sessions owned elsewhere, so a session is only returned to the
                 // cross-workspace form.
-                let params = Self.jsonObject(line)?["params"] as? [String: Any] ?? [:]
                 guard params["all_workspaces"] as? Bool == true else {
                     return Self.v2Response(id: id, ok: true, result: [
                         "all_workspaces": false,
@@ -154,7 +154,7 @@ struct CLISSHSessionAttachAnchorTests {
                     "errors": [[String: Any]](),
                 ])
             case "surface.list":
-                let workspaceId = (Self.jsonObject(line)?["params"] as? [String: Any])?["workspace_id"] as? String
+                let workspaceId = params["workspace_id"] as? String
                 let surfaces: [[String: Any]] = workspaceId == sessionWorkspaceId
                     ? [["id": Self.targetSurfaceId, "ref": "surface:7", "index": 1]]
                     : []

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -18,14 +18,18 @@ struct CLISSHSessionAttachAnchorTests {
                 "--split", "right",
                 "--focus", "false",
             ],
-            responseWorkspaceId: Self.targetWorkspaceId
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionWorkspaceId: Self.targetWorkspaceId
         )
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(
+            methods == ["workspace.remote.pty_sessions", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
         #expect(params["direction"] as? String == "right")
         #expect(params["remote_pty_session_id"] as? String == "ssh-test")
@@ -42,14 +46,20 @@ struct CLISSHSessionAttachAnchorTests {
                 "--focus", "false",
                 "--surface", Self.targetSurfaceId,
             ],
-            responseWorkspaceId: Self.targetWorkspaceId
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionWorkspaceId: Self.targetWorkspaceId
         )
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        // An explicit surface must be confirmed to live in the owning workspace
+        // before the split is issued.
+        #expect(
+            methods == ["workspace.remote.pty_sessions", "surface.list", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
         #expect(params["surface_id"] as? String == Self.targetSurfaceId)
     }
@@ -62,14 +72,20 @@ struct CLISSHSessionAttachAnchorTests {
                 "--split", "right",
                 "--focus", "false",
             ],
-            responseWorkspaceId: Self.callerWorkspaceId
+            responseWorkspaceId: Self.callerWorkspaceId,
+            // The caller's own workspace owns the session here, so its
+            // CMUX_SURFACE_ID is still a legitimate split anchor.
+            sessionWorkspaceId: Self.callerWorkspaceId
         )
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(
+            methods == ["workspace.remote.pty_sessions", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.callerWorkspaceId)
         #expect(params["surface_id"] as? String == Self.callerSurfaceId)
     }
@@ -83,7 +99,8 @@ struct CLISSHSessionAttachAnchorTests {
                 "--split", "right",
                 "--focus", "false",
             ],
-            responseWorkspaceId: Self.targetWorkspaceId
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionWorkspaceId: Self.targetWorkspaceId
         )
         #expect(result.status != 0)
         #expect(requests.isEmpty)
@@ -92,7 +109,8 @@ struct CLISSHSessionAttachAnchorTests {
 
     private func runSSHSessionAttach(
         arguments: [String],
-        responseWorkspaceId: String
+        responseWorkspaceId: String,
+        sessionWorkspaceId: String
     ) throws -> ([[String: Any]], ProcessRunResult) {
         let socketPath = Self.makeSocketPath("ssh-anchor")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -109,6 +127,27 @@ struct CLISSHSessionAttachAnchorTests {
                 return Self.malformedRequestResponse(raw: line)
             }
             switch method {
+            case "workspace.remote.pty_sessions":
+                // ssh-session-attach resolves the session's owning workspace
+                // before creating anything.
+                return Self.v2Response(id: id, ok: true, result: [
+                    "all_workspaces": true,
+                    "workspace_count": 1,
+                    "sessions": [[
+                        "session_id": "ssh-test",
+                        "workspace_id": sessionWorkspaceId,
+                        "workspace_ref": "workspace:4",
+                        "workspace_title": "remote-box",
+                        "attachments": [[String: Any]](),
+                    ]],
+                    "errors": [[String: Any]](),
+                ])
+            case "surface.list":
+                let workspaceId = (Self.jsonObject(line)?["params"] as? [String: Any])?["workspace_id"] as? String
+                let surfaces: [[String: Any]] = workspaceId == sessionWorkspaceId
+                    ? [["id": Self.targetSurfaceId, "ref": "surface:7", "index": 1]]
+                    : []
+                return Self.v2Response(id: id, ok: true, result: ["surfaces": surfaces])
             case "surface.split":
                 return Self.v2Response(
                     id: id,

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -129,7 +129,18 @@ struct CLISSHSessionAttachAnchorTests {
             switch method {
             case "workspace.remote.pty_sessions":
                 // ssh-session-attach resolves the session's owning workspace
-                // before creating anything.
+                // before creating anything. A workspace-scoped lookup cannot see
+                // sessions owned elsewhere, so a session is only returned to the
+                // cross-workspace form.
+                let params = Self.jsonObject(line)?["params"] as? [String: Any] ?? [:]
+                guard params["all_workspaces"] as? Bool == true else {
+                    return Self.v2Response(id: id, ok: true, result: [
+                        "all_workspaces": false,
+                        "workspace_count": 1,
+                        "sessions": [[String: Any]](),
+                        "errors": [[String: Any]](),
+                    ])
+                }
                 return Self.v2Response(id: id, ok: true, result: [
                     "all_workspaces": true,
                     "workspace_count": 1,

--- a/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
+++ b/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
@@ -284,6 +284,16 @@ struct CLISSHSessionAttachSessionValidationTests {
             let params = payload["params"] as? [String: Any] ?? [:]
             switch method {
             case "workspace.remote.pty_sessions":
+                // A workspace-scoped lookup cannot see sessions owned elsewhere,
+                // so a session is only returned to the cross-workspace form.
+                guard params["all_workspaces"] as? Bool == true else {
+                    return Self.v2Response(id: id, ok: true, result: [
+                        "all_workspaces": false,
+                        "workspace_count": 1,
+                        "sessions": [[String: Any]](),
+                        "errors": [[String: Any]](),
+                    ])
+                }
                 return Self.v2Response(id: id, ok: true, result: [
                     "all_workspaces": true,
                     "workspace_count": 1,

--- a/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
+++ b/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
@@ -1,0 +1,574 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Regression coverage for `cmux ssh-session-attach --session-id <id>` accepting
+/// any session id without validation and attaching in the *caller's* workspace.
+///
+/// Repro: a user ran `cmux ssh-session-attach --session-id 10` from a local
+/// (non-remote) workspace. `10` is not a session id at all — real ids look like
+/// `ssh-<workspaceUUID>-<panelUUID>` and are listed by
+/// `cmux ssh-session-list --all-workspaces`. The CLI still created a surface in
+/// the caller's workspace whose startup wrapper runs
+/// `ssh-pty-attach --wait --require-existing --session-id 10`, so
+/// `workspace.remote.pty_bridge` parked for up to 185s waiting for a remote
+/// daemon that can never exist there, inside the unbounded
+/// `SSHPTYAttachRetryScriptBuilder` loop — a permanently hung pane.
+///
+/// These tests drive the real bundled CLI against a mock control socket and
+/// assert on the exact v2 requests it emits, so they cover the observable
+/// behavior (which methods run, with which params) rather than the source shape.
+///
+/// Gated by the dedicated non-tolerant focused CI step ("Run ssh-session-attach
+/// anchor regression"): the sharded unit-test run tolerates any failure summary
+/// reporting "(0 unexpected)", so a failing test there cannot red the shard.
+@Suite(.serialized)
+struct CLISSHSessionAttachSessionValidationTests {
+    /// The exact user repro: a bogus session id must fail fast and create nothing.
+    @Test func bogusSessionIDFailsWithoutCreatingAnySurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "10",
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(
+            !methods.contains("surface.create"),
+            Comment(rawValue: "bogus session id created a surface: \(methods.joined(separator: ","))")
+        )
+        #expect(
+            !methods.contains("surface.split"),
+            Comment(rawValue: "bogus session id split a surface: \(methods.joined(separator: ","))")
+        )
+        #expect(
+            result.stderr.contains("ssh-session-list"),
+            Comment(rawValue: result.stderr)
+        )
+    }
+
+    /// A bogus session id must not be smuggled through by an explicit workspace.
+    @Test func bogusSessionIDWithExplicitWorkspaceFailsWithoutCreatingAnySurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "10",
+                "--workspace", Self.remoteWorkspaceId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
+    /// A valid session id resolves to the workspace that owns it, not the
+    /// caller's `CMUX_WORKSPACE_ID`.
+    @Test func validSessionAttachesInOwningWorkspaceNotCallerWorkspace() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(
+            requests.last(where: { $0["method"] as? String == "surface.create" }),
+            "expected a surface.create request"
+        )
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(
+            params["workspace_id"] as? String == Self.remoteWorkspaceId,
+            Comment(rawValue: "attached in \(params["workspace_id"] as? String ?? "nil")")
+        )
+        #expect(params["remote_pty_session_id"] as? String == Self.remoteSessionId)
+        // applyFocusOption(defaultValue: true) semantics must be preserved.
+        #expect(params["focus"] as? Bool == true)
+    }
+
+    /// `--focus false` still suppresses focus on the resolved owning workspace.
+    @Test func validSessionHonorsExplicitFocusFalse() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(requests.last(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+        #expect(params["focus"] as? Bool == false)
+    }
+
+    /// Passing the owning workspace explicitly is accepted and used.
+    @Test func explicitOwningWorkspaceIsAccepted() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--workspace", Self.remoteWorkspaceId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(requests.last(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+    }
+
+    /// An explicit `--workspace` that does not own the session is an error in
+    /// both directions: the CLI must neither silently override the user nor
+    /// attach into the wrong workspace.
+    @Test func explicitNonOwningWorkspaceFailsWithoutCreatingAnySurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--workspace", Self.callerWorkspaceId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
+    /// An explicit `--surface` outside the owning workspace must be rejected
+    /// instead of anchoring the split somewhere the session cannot live.
+    @Test func explicitSurfaceOutsideOwningWorkspaceFailsWithoutSplitting() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--split", "right",
+                "--surface", Self.foreignSurfaceId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
+    /// An explicit `--surface` inside the owning workspace still anchors the split.
+    @Test func explicitSurfaceInsideOwningWorkspaceSplitsThere() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--split", "right",
+                "--surface", Self.remoteSurfaceId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let split = try #require(requests.last(where: { $0["method"] as? String == "surface.split" }))
+        let params = try #require(split["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+        #expect(params["surface_id"] as? String == Self.remoteSurfaceId)
+        #expect(params["direction"] as? String == "right")
+    }
+
+    /// An explicit `--pane` outside the owning workspace must be rejected.
+    @Test func explicitPaneOutsideOwningWorkspaceFailsWithoutCreatingAnySurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--pane", Self.foreignPaneId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
+    /// An explicit `--pane` inside the owning workspace still targets that pane.
+    @Test func explicitPaneInsideOwningWorkspaceCreatesThere() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--pane", Self.remotePaneId,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(requests.last(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+        #expect(params["pane_id"] as? String == Self.remotePaneId)
+    }
+
+    /// The caller's `CMUX_SURFACE_ID` may only anchor a split when the caller's
+    /// own workspace is the one that owns the session.
+    @Test func callerEnvSurfaceIsNotUsedWhenSessionLivesElsewhere() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--split", "right",
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let split = try #require(requests.last(where: { $0["method"] as? String == "surface.split" }))
+        let params = try #require(split["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+        #expect(
+            params["surface_id"] == nil,
+            Comment(rawValue: "leaked caller surface anchor: \(params["surface_id"] ?? "nil")")
+        )
+    }
+
+    // MARK: - Harness
+
+    /// Runs the bundled CLI against a mock control socket that models one remote
+    /// workspace owning `remoteSessionId` plus a local caller workspace with no
+    /// persisted sessions.
+    private func runSSHSessionAttach(
+        arguments: [String]
+    ) throws -> ([[String: Any]], ProcessRunResult) {
+        let socketPath = Self.makeSocketPath("ssh-valid")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            let params = payload["params"] as? [String: Any] ?? [:]
+            switch method {
+            case "workspace.remote.pty_sessions":
+                return Self.v2Response(id: id, ok: true, result: [
+                    "all_workspaces": true,
+                    "workspace_count": 1,
+                    "sessions": [Self.remoteSessionPayload],
+                    "errors": [[String: Any]](),
+                ])
+            case "surface.list":
+                let workspaceId = params["workspace_id"] as? String
+                let surfaces: [[String: Any]] = workspaceId == Self.remoteWorkspaceId
+                    ? [["id": Self.remoteSurfaceId, "ref": "surface:7", "index": 1]]
+                    : []
+                return Self.v2Response(id: id, ok: true, result: ["surfaces": surfaces])
+            case "pane.list":
+                let workspaceId = params["workspace_id"] as? String
+                let panes: [[String: Any]] = workspaceId == Self.remoteWorkspaceId
+                    ? [["id": Self.remotePaneId, "ref": "pane:4", "index": 1]]
+                    : []
+                return Self.v2Response(id: id, ok: true, result: ["panes": panes])
+            case "surface.create", "surface.split":
+                return Self.v2Response(id: id, ok: true, result: [
+                    "workspace_id": params["workspace_id"] as? String ?? Self.remoteWorkspaceId,
+                    "surface_id": "66666666-6666-6666-6666-666666666666",
+                    "surface_ref": "surface:9",
+                    "pane_id": "77777777-7777-7777-7777-777777777777",
+                    "pane_ref": "pane:3",
+                ])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: arguments,
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 60
+        )
+
+        #expect(handled.wait(timeout: .now() + 60) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+
+        return (try state.requestObjects(), result)
+    }
+
+    private func cliEnvironment(socketPath: String) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        environment.removeValue(forKey: "CMUX_SOCKET")
+        environment.removeValue(forKey: "CMUX_SOCKET_PASSWORD")
+        environment.removeValue(forKey: "CMUX_WINDOW_ID")
+        // The caller sits in a local workspace with no persisted SSH sessions,
+        // exactly as in the reported repro.
+        environment["CMUX_WORKSPACE_ID"] = Self.callerWorkspaceId
+        environment["CMUX_SURFACE_ID"] = Self.callerSurfaceId
+        return environment
+    }
+
+    private static let callerWorkspaceId = "11111111-1111-1111-1111-111111111111"
+    private static let callerSurfaceId = "22222222-2222-2222-2222-222222222222"
+    private static let remoteWorkspaceId = "44444444-4444-4444-4444-444444444444"
+    private static let remoteWindowId = "33333333-3333-3333-3333-333333333333"
+    private static let remoteSurfaceId = "55555555-5555-5555-5555-555555555555"
+    private static let remotePaneId = "88888888-8888-8888-8888-888888888888"
+    private static let foreignSurfaceId = "99999999-9999-9999-9999-999999999999"
+    private static let foreignPaneId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    private static let remoteSessionId = "ssh-44444444444444444444444444444444-abcdef0123456789"
+
+    private static var remoteSessionPayload: [String: Any] {
+        [
+            "session_id": remoteSessionId,
+            "window_id": remoteWindowId,
+            "window_ref": "window:1",
+            "workspace_id": remoteWorkspaceId,
+            "workspace_ref": "workspace:4",
+            "workspace_title": "remote-box",
+            "effective_cols": 120,
+            "effective_rows": 40,
+            "scrollback_bytes": 0,
+            "attachments": [[String: Any]](),
+        ]
+    }
+
+    private final class CLISSHSessionAttachSessionValidationBundleToken {}
+
+    // Records socket callbacks from a background queue; `lock` guards both arrays.
+    private final class ServerState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var requestLines: [String] = []
+        private var errors: [String] = []
+
+        func record(_ line: String) {
+            lock.lock()
+            requestLines.append(line)
+            lock.unlock()
+        }
+
+        func recordError(_ message: String) {
+            lock.lock()
+            errors.append(message)
+            lock.unlock()
+        }
+
+        func errorsSnapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return errors
+        }
+
+        func requestObjects() throws -> [[String: Any]] {
+            lock.lock()
+            let lines = requestLines
+            lock.unlock()
+            return try lines.map { line in
+                try #require(CLISSHSessionAttachSessionValidationTests.jsonObject(line))
+            }
+        }
+    }
+
+    private struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    private static func bundledCLIPath() throws -> String {
+        try BundledCLITestSupport.bundledCLIPath(for: CLISSHSessionAttachSessionValidationBundleToken.self)
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
+            ])
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return fd
+    }
+
+    private static func startMockServer(
+        listenerFD: Int32,
+        state: ServerState,
+        handler: @escaping @Sendable (String) -> String
+    ) -> DispatchSemaphore {
+        let handled = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.signal() }
+
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else {
+                state.recordError("mock socket server failed to accept a client")
+                return
+            }
+            defer { Darwin.close(clientFD) }
+
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    state.recordError("mock socket server read failed with errno \(errno)")
+                    return
+                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.record(line)
+                    let response = handler(line) + "\n"
+                    _ = response.withCString { pointer in
+                        Darwin.write(clientFD, pointer, strlen(pointer))
+                    }
+                }
+            }
+        }
+        return handled
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func malformedRequestResponse(id: String? = nil, raw: String) -> String {
+        v2Response(
+            id: id ?? "unknown",
+            ok: false,
+            error: ["code": "malformed_request", "message": "invalid or non-JSON payload", "raw": raw]
+        )
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
+++ b/cmuxTests/CLISSHSessionAttachSessionValidationTests.swift
@@ -126,6 +126,25 @@ struct CLISSHSessionAttachSessionValidationTests {
         #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
     }
 
+    /// `ssh-session-list --all-workspaces` prints the owning workspace as a
+    /// `workspace:<n>` ref, so passing that ref back as `--workspace` must be
+    /// accepted even though the session record's `workspace_id` is a UUID.
+    @Test func explicitOwningWorkspaceRefIsAccepted() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", Self.remoteSessionId,
+                "--workspace", Self.remoteWorkspaceRef,
+                "--focus", "false",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(requests.last(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.remoteWorkspaceId)
+    }
+
     /// An explicit `--workspace` that does not own the session is an error in
     /// both directions: the CLI must neither silently override the user nor
     /// attach into the wrong workspace.
@@ -332,6 +351,7 @@ struct CLISSHSessionAttachSessionValidationTests {
     private static let callerWorkspaceId = "11111111-1111-1111-1111-111111111111"
     private static let callerSurfaceId = "22222222-2222-2222-2222-222222222222"
     private static let remoteWorkspaceId = "44444444-4444-4444-4444-444444444444"
+    private static let remoteWorkspaceRef = "workspace:4"
     private static let remoteWindowId = "33333333-3333-3333-3333-333333333333"
     private static let remoteSurfaceId = "55555555-5555-5555-5555-555555555555"
     private static let remotePaneId = "88888888-8888-8888-8888-888888888888"
@@ -345,7 +365,7 @@ struct CLISSHSessionAttachSessionValidationTests {
             "window_id": remoteWindowId,
             "window_ref": "window:1",
             "workspace_id": remoteWorkspaceId,
-            "workspace_ref": "workspace:4",
+            "workspace_ref": remoteWorkspaceRef,
             "workspace_title": "remote-box",
             "effective_cols": 120,
             "effective_rows": 40,

--- a/scripts/ci/cmux_unit_test_shard.py
+++ b/scripts/ci/cmux_unit_test_shard.py
@@ -37,6 +37,7 @@ FALLBACK_TEST_MS = 200
 FOCUSED_GATE_SELECTORS = {
     "cmuxTests/BrowserSystemProxyMirrorTests",
     "cmuxTests/CLISSHSessionAttachAnchorTests",
+    "cmuxTests/CLISSHSessionAttachSessionValidationTests",
     "cmuxTests/GhosttyTerminalViewVisibilityPolicyTests",
     "cmuxTests/GhosttyOptionAsAltModsTests",
     "cmuxTests/RemoteTmuxMirrorLayoutIdentityTests",

--- a/tests/test_ci_cmux_unit_test_shard.py
+++ b/tests/test_ci_cmux_unit_test_shard.py
@@ -296,6 +296,7 @@ def main() -> int:
             for focused_selector in (
                 "-only-testing:cmuxTests/BrowserSystemProxyMirrorTests",
                 "-only-testing:cmuxTests/CLISSHSessionAttachAnchorTests",
+                "-only-testing:cmuxTests/CLISSHSessionAttachSessionValidationTests",
                 "-only-testing:cmuxTests/GhosttyTerminalViewVisibilityPolicyTests",
                 "-only-testing:cmuxTests/GhosttyOptionAsAltModsTests",
                 "-only-testing:cmuxTests/RemoteTmuxMirrorLayoutIdentityTests",


### PR DESCRIPTION
## Summary

- What changed? `cmux ssh-session-attach` now resolves the `--session-id` against the app's persisted sessions (`workspace.remote.pty_sessions`, `all_workspaces: true`) **before** creating anything: an unknown id fails fast with a pointer to `cmux ssh-session-list --all-workspaces`; a valid id attaches in the session's **owning** workspace (accepting either its UUID or its `workspace:<n>` ref for `--workspace`); an explicit `--workspace`/`--surface`/`--pane` that doesn't belong to the owning workspace is rejected with a clear error. New error strings are localized (en + ja).
- Why? Previously any string was accepted verbatim and the attach surface was created in the **caller's** workspace, whose `ssh-pty-attach --wait --require-existing` wrapper then parked up to 185s per attempt inside the unbounded retry loop — a permanently hung pane. Fixes #10323.

Commit structure follows the regression policy: commit 1 (`2b81737`) adds only the failing tests, commit 2 (`60992ce`) the fix, commit 3 (`aa6458c`) hardens the test mocks per review. Commit 1 also wires the new test file into `project.pbxproj` and the CI shard (`.github/workflows/ci.yml` + `scripts/ci/cmux_unit_test_shard.py`), including a dedicated non-tolerant focused step following the existing `CLISSHSessionAttachAnchorTests` pattern — that is the only reason this PR touches a code-owned workflow path.

## Testing

- New suite `cmuxTests/CLISSHSessionAttachSessionValidationTests.swift` (9 behavior-level tests) plus extensions to `CLISSHSessionAttachAnchorTests.swift`, driving the real CLI binary against a mock control socket (same seam as the existing anchor tests). Mocks only answer session lookups that carry `all_workspaces: true`.
- Verified red→green against the built CLI binary: on HEAD, `--session-id 10` exits 0 and creates a surface in the caller's workspace; with the fix it exits 1 (`no persisted SSH PTY session with id '10'...`) and issues no `surface.create`/`surface.split`. All nine expectations flip.
- Manual: `xcodebuild -scheme cmux-cli build` clean; `./scripts/lint-pbxproj-test-wiring.sh` ok (692 test files checked); `Localizable.xcstrings` parses, en/ja `%1$@`-style arity preserved.
- Note: the added `sendV2` lookup is bounded by the existing `responseTimeoutSeconds` (default 15s / `CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC`); no unbounded wait is introduced.

## Demo Video

Before/after terminal transcript (short video available on request):

```
# before                                          # after
❯ cmux ssh-session-attach --session-id 10         ❯ cmux ssh-session-attach --session-id 10
OK surface:35 pane:28 workspace:19                Error: ssh-session-attach: no persisted SSH PTY
  (hung pane in the caller's workspace)             session with id '10'. Run 'cmux ssh-session-list
                                                    --all-workspaces' to see valid session ids.
```

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no doc surface documents ssh-session-attach flags; error text is self-describing — none needed)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH session attachment by locating sessions across workspaces and routing attachments to the owning workspace.
  * Added validation for missing, ambiguous, or mismatched sessions, surfaces, panes, and workspace references.
  * Prevented incorrect caller-workspace routing and invalid split anchors.
  * Improved error messages for unavailable or disconnected sessions.

* **Localization**
  * Added English and Japanese translations for SSH session attachment errors.

* **Tests**
  * Added comprehensive regression coverage for session validation, workspace ownership, focus handling, and attachment anchoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->