### PR TITLE
Resolve the git branch through reftable storage instead of the .invalid HEAD marker

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -123,13 +123,14 @@ public struct GitMetadataService: Sendable {
             repository: repository,
             trackedPathEventGeneration: trackedPathEventGeneration
         )
+        let head = await headState(repository: repository)
         return GitWorkspaceMetadata(
             isRepository: true,
-            branch: resolvedBranchName(repository: repository),
+            branch: head.branch,
             isDirty: trackedChanges.isDirty,
             indexSignature: trackedChanges.indexSignature,
             indexContentSignature: trackedChanges.indexContentSignature,
-            headSignature: resolvedHeadSignature(repository: repository)
+            headSignature: head.headSignature
         )
     }
 
@@ -225,7 +226,7 @@ public struct GitMetadataService: Sendable {
         guard let repository = Self.resolveGitRepository(containing: directory) else {
             return .notARepository
         }
-        return resolvedCheckedOutBranch(repository: repository)
+        return await checkedOutBranch(repository: repository)
     }
 
     /// Whether this module's `nonisolated async` methods execute off the calling

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -30,6 +30,7 @@ import Foundation
 public struct GitMetadataService: Sendable {
     let fileStatusReader: any GitFileStatusReading
     let dirtyStatusReader: any GitDirtyStatusReading
+    let reftableHeadReader: any GitReftableHeadReading
     let degradationRecorder: GitMetadataDegradationRecorder
     let safetyConfiguration: GitMetadataSafetyConfiguration
     private let trackedChangesSnapshotCache: GitTrackedChangesSnapshotCache
@@ -41,6 +42,9 @@ public struct GitMetadataService: Sendable {
         self.dirtyStatusReader = SystemGitDirtyStatusReader(
             boundedCommandWallTimeLimit: safetyConfiguration.gitStatusWallTime
         )
+        self.reftableHeadReader = Self.systemReftableHeadReader(
+            safetyConfiguration: safetyConfiguration
+        )
         self.degradationRecorder = GitMetadataDegradationRecorder(
             gitStatusWallTime: safetyConfiguration.gitStatusWallTime
         )
@@ -51,6 +55,7 @@ public struct GitMetadataService: Sendable {
     init(
         fileStatusReader: any GitFileStatusReading,
         dirtyStatusReader: (any GitDirtyStatusReading)? = nil,
+        reftableHeadReader: (any GitReftableHeadReading)? = nil,
         degradationRecorder: GitMetadataDegradationRecorder? = nil,
         safetyConfiguration: GitMetadataSafetyConfiguration = GitMetadataSafetyConfiguration(),
         trackedChangesSnapshotCache: GitTrackedChangesSnapshotCache = GitTrackedChangesSnapshotCache()
@@ -59,11 +64,27 @@ public struct GitMetadataService: Sendable {
         self.dirtyStatusReader = dirtyStatusReader ?? SystemGitDirtyStatusReader(
             boundedCommandWallTimeLimit: safetyConfiguration.gitStatusWallTime
         )
+        self.reftableHeadReader = reftableHeadReader ?? Self.systemReftableHeadReader(
+            safetyConfiguration: safetyConfiguration
+        )
         self.degradationRecorder = degradationRecorder ?? GitMetadataDegradationRecorder(
             gitStatusWallTime: safetyConfiguration.gitStatusWallTime
         )
         self.safetyConfiguration = safetyConfiguration
         self.trackedChangesSnapshotCache = trackedChangesSnapshotCache
+    }
+
+    /// The reftable `HEAD` reader used by default: `git` behind a memo keyed by
+    /// the reftable stack, so a reftable workspace spawns a process only after
+    /// its refs change rather than on every metadata refresh.
+    private static func systemReftableHeadReader(
+        safetyConfiguration: GitMetadataSafetyConfiguration
+    ) -> any GitReftableHeadReading {
+        MemoizedGitReftableHeadReader(
+            base: SystemGitReftableHeadReader(
+                boundedCommandWallTimeLimit: safetyConfiguration.gitStatusWallTime
+            )
+        )
     }
 
     /// Reads a point-in-time git snapshot for `directory`.
@@ -104,11 +125,11 @@ public struct GitMetadataService: Sendable {
         )
         return GitWorkspaceMetadata(
             isRepository: true,
-            branch: Self.gitBranchName(repository: repository),
+            branch: resolvedBranchName(repository: repository),
             isDirty: trackedChanges.isDirty,
             indexSignature: trackedChanges.indexSignature,
             indexContentSignature: trackedChanges.indexContentSignature,
-            headSignature: Self.gitHeadSignature(repository: repository)
+            headSignature: resolvedHeadSignature(repository: repository)
         )
     }
 
@@ -204,7 +225,7 @@ public struct GitMetadataService: Sendable {
         guard let repository = Self.resolveGitRepository(containing: directory) else {
             return .notARepository
         }
-        return Self.gitCheckedOutBranch(repository: repository)
+        return resolvedCheckedOutBranch(repository: repository)
     }
 
     /// Whether this module's `nonisolated async` methods execute off the calling

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/GitReftableHead.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/GitReftableHead.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// `HEAD` as git resolves it in a repository whose refs live in reftable
+/// storage, where the on-disk `HEAD` file is only a placeholder.
+///
+/// The two fields are independent: a detached checkout has an object id and no
+/// symbolic name, and a branch that has no commit yet has a name and no object
+/// id.
+struct GitReftableHead: Equatable, Sendable {
+    /// The full symbolic ref `HEAD` points at (`refs/heads/main`), or `nil`
+    /// when `HEAD` is detached.
+    let symbolicFullName: String?
+
+    /// The object id `HEAD` resolves to, or `nil` on an unborn branch.
+    let objectID: String?
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
@@ -115,7 +115,7 @@ extension GitMetadataService {
             }
             let gitlinkMode: UInt32 = 0o160000
             if (entry.mode & 0o170000) == gitlinkMode {
-                guard let submoduleCommit = Self.gitlinkWorktreeCommit(
+                guard let submoduleCommit = gitlinkWorktreeCommit(
                     parentRepository: repository,
                     gitlinkPath: entry.path
                 ) else {
@@ -370,20 +370,23 @@ extension GitMetadataService {
     }
 
     /// The submodule's currently checked-out commit for a parent gitlink entry,
-    /// or `nil` when the submodule cannot be resolved.
-    nonisolated static func gitlinkWorktreeCommit(
+    /// or `nil` when the submodule cannot be resolved. An unresolved submodule
+    /// makes the parent read as dirty, so a reftable submodule has to resolve
+    /// through ``resolvedCurrentCommit(repository:)`` rather than the ref files
+    /// it does not have.
+    nonisolated func gitlinkWorktreeCommit(
         parentRepository: ResolvedGitRepository,
         gitlinkPath: String
     ) -> String? {
-        let gitlinkPath = joinedPath(
+        let gitlinkPath = Self.joinedPath(
             root: parentRepository.workTreeRoot,
             relativePath: gitlinkPath
         )
-        guard let submoduleRepository = resolveGitRepository(containing: gitlinkPath),
+        guard let submoduleRepository = Self.resolveGitRepository(containing: gitlinkPath),
               submoduleRepository.workTreeRoot == gitlinkPath else {
             return nil
         }
-        return gitCurrentCommit(repository: submoduleRepository)
+        return resolvedCurrentCommit(repository: submoduleRepository)
     }
 
     /// Maps a stat mode to the git index mode word for comparison

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
@@ -10,7 +10,8 @@ extension GitMetadataService {
     }
 
     /// The current branch name from `HEAD` (`ref: refs/heads/<name>`), or `nil`
-    /// for a detached HEAD or unreadable `HEAD`.
+    /// for a detached HEAD, an unreadable `HEAD`, or a `HEAD` holding the
+    /// reftable placeholder branch, whose real name only `git` can resolve.
     nonisolated static func gitBranchName(repository: ResolvedGitRepository) -> String? {
         let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
         guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
@@ -22,12 +23,17 @@ extension GitMetadataService {
             return nil
         }
         let branch = String(trimmed.dropFirst(branchPrefix.count))
-        return branch.isEmpty ? nil : branch
+        guard !branch.isEmpty, branch != reftablePlaceholderBranchName else {
+            return nil
+        }
+        return branch
     }
 
     /// Classifies the repository's `HEAD` into a ``GitCheckedOutBranch``,
     /// keeping a legitimate non-branch checkout (detached commit, non-branch
-    /// symbolic ref) distinct from a missing/unreadable/malformed `HEAD`.
+    /// symbolic ref) distinct from a missing/unreadable/malformed `HEAD`. The
+    /// reftable placeholder branch counts as unreadable: the file names no
+    /// checkout, and only `git` can resolve the real one.
     nonisolated static func gitCheckedOutBranch(repository: ResolvedGitRepository) -> GitCheckedOutBranch {
         let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
         guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
@@ -36,7 +42,8 @@ extension GitMetadataService {
         let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
         let branchPrefix = "ref: refs/heads/"
         if trimmed.hasPrefix(branchPrefix) {
-            guard let branch = normalizedBranchName(String(trimmed.dropFirst(branchPrefix.count))) else {
+            guard let branch = normalizedBranchName(String(trimmed.dropFirst(branchPrefix.count))),
+                  branch != reftablePlaceholderBranchName else {
                 return .unreadable
             }
             return .branch(branch)
@@ -59,6 +66,9 @@ extension GitMetadataService {
 
     /// A signature of `HEAD` plus the commit it resolves to: the symbolic ref
     /// text and the resolved ref value joined, or the detached SHA directly.
+    ///
+    /// `nil` for the reftable placeholder `HEAD`, which is a constant and so
+    /// would signal "nothing changed" no matter how often the checkout moved.
     nonisolated static func gitHeadSignature(repository: ResolvedGitRepository) -> String? {
         let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
         guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
@@ -72,6 +82,9 @@ extension GitMetadataService {
 
         let refName = String(trimmed.dropFirst(refPrefix.count))
         guard !refName.isEmpty else { return trimmed }
+        if branchName(fromSymbolicFullName: refName) == reftablePlaceholderBranchName {
+            return nil
+        }
         let refValue = gitRefValue(repository: repository, refName: refName) ?? ""
         return "\(trimmed)\n\(refValue)"
     }
@@ -80,6 +93,11 @@ extension GitMetadataService {
     /// and common directories, then `packed-refs`. A ref name is repo-controlled
     /// input from `HEAD`; names whose standardized path escapes the directory
     /// they are joined to (e.g. `../../outside`) are ignored rather than read.
+    ///
+    /// Only knows the files ref backend. A reftable repository keeps no ref
+    /// files at all, so every lookup here returns `nil` and the callers that
+    /// need `HEAD` go through ``resolvedCurrentCommit(repository:)`` and
+    /// ``resolvedHeadSignature(repository:)`` instead.
     nonisolated static func gitRefValue(repository: ResolvedGitRepository, refName: String) -> String? {
         let lookups = [
             (base: repository.gitDirectory, refURL: URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent(refName)),
@@ -134,6 +152,12 @@ extension GitMetadataService {
             value = trimmed
         }
 
+        return normalizedCommitID(value)
+    }
+
+    /// `value` as a commit id (40 lowercase hex chars), or `nil` when it is not
+    /// one.
+    nonisolated static func normalizedCommitID(_ value: String) -> String? {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard normalized.count == 40,
               normalized.allSatisfy({ $0.isHexDigit }) else {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
@@ -132,8 +132,8 @@ extension GitMetadataService {
         return nil
     }
 
-    /// The current commit SHA the repository's `HEAD` resolves to (40 lowercase
-    /// hex chars), or `nil` if it cannot be resolved to a commit.
+    /// The current commit id the repository's `HEAD` resolves to, lowercased,
+    /// or `nil` if it cannot be resolved to a commit.
     nonisolated static func gitCurrentCommit(repository: ResolvedGitRepository) -> String? {
         let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
         guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
@@ -155,11 +155,15 @@ extension GitMetadataService {
         return normalizedCommitID(value)
     }
 
-    /// `value` as a commit id (40 lowercase hex chars), or `nil` when it is not
-    /// one.
+    /// `value` as a lowercased commit id, or `nil` when it is not one.
+    ///
+    /// Accepts both object-id widths git uses, 40 hex for SHA-1 and 64 for
+    /// SHA-256, matching ``isLikelyCommitSHA(_:)``. A SHA-256 repository would
+    /// otherwise classify its detached `HEAD` as detached and then fail to name
+    /// the commit it is detached at.
     nonisolated static func normalizedCommitID(_ value: String) -> String? {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard normalized.count == 40,
+        guard normalized.count == 40 || normalized.count == 64,
               normalized.allSatisfy({ $0.isHexDigit }) else {
             return nil
         }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
@@ -30,7 +30,11 @@ extension GitMetadataService {
         let roots = repository.gitDirectory == repository.commonDirectory
             ? [repository.gitDirectory]
             : [repository.gitDirectory, repository.commonDirectory]
+        // One component per root, present or not, so a stack that appears or
+        // disappears cannot produce the same signature as its neighbour holding
+        // the same contents.
         var components: [String] = []
+        var foundStack = false
         for root in roots {
             let tablesListPath = joinedPath(
                 root: root,
@@ -40,11 +44,13 @@ extension GitMetadataService {
                 contentsOf: URL(fileURLWithPath: tablesListPath),
                 encoding: .utf8
             ) else {
+                components.append("")
                 continue
             }
+            foundStack = true
             components.append(contents.trimmingCharacters(in: .whitespacesAndNewlines))
         }
-        return components.isEmpty ? nil : components.joined(separator: "\n")
+        return foundStack ? components.joined(separator: "\n") : nil
     }
 
     /// The branch a full symbolic ref name refers to, or `nil` when it names

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+extension GitMetadataService {
+    /// The branch name git parks in a reftable repository's `HEAD` file.
+    ///
+    /// `extensions.refStorage = reftable` moves every ref, the `HEAD` symref
+    /// included, into a binary stack under `reftable/`. The `HEAD` file stays
+    /// behind only so that code which identifies a git directory by its
+    /// presence keeps working, and it permanently reads
+    /// `ref: refs/heads/.invalid`. `.invalid` is a name git itself refuses, so
+    /// it can never collide with a real branch.
+    static let reftablePlaceholderBranchName = ".invalid"
+
+    /// The `reftable` directory inside a git directory.
+    static let reftableDirectoryName = "reftable"
+
+    /// The stack index git rewrites on every ref update.
+    private static let reftableTablesListRelativePath = "reftable/tables.list"
+
+    /// Identity of the repository's reftable stack, or `nil` when the
+    /// repository does not use reftable ref storage.
+    ///
+    /// `tables.list` names every table in the stack, and git replaces it on
+    /// every ref update, so its contents serve as a cheap change signature for
+    /// everything the stack holds. Both the per-worktree stack (which holds
+    /// `HEAD`) and the common stack (which holds `refs/heads/*`) are included,
+    /// because a branch switch rewrites the first and a commit rewrites the
+    /// second.
+    nonisolated static func reftableStackSignature(repository: ResolvedGitRepository) -> String? {
+        let roots = repository.gitDirectory == repository.commonDirectory
+            ? [repository.gitDirectory]
+            : [repository.gitDirectory, repository.commonDirectory]
+        var components: [String] = []
+        for root in roots {
+            let tablesListPath = joinedPath(
+                root: root,
+                relativePath: reftableTablesListRelativePath
+            )
+            guard let contents = try? String(
+                contentsOf: URL(fileURLWithPath: tablesListPath),
+                encoding: .utf8
+            ) else {
+                continue
+            }
+            components.append(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return components.isEmpty ? nil : components.joined(separator: "\n")
+    }
+
+    /// The branch a full symbolic ref name refers to, or `nil` when it names
+    /// something other than a branch.
+    nonisolated static func branchName(fromSymbolicFullName symbolicFullName: String) -> String? {
+        let branchPrefix = "refs/heads/"
+        guard symbolicFullName.hasPrefix(branchPrefix) else { return nil }
+        return normalizedBranchName(String(symbolicFullName.dropFirst(branchPrefix.count)))
+    }
+
+    /// `HEAD` resolved through `git` for a reftable repository, or `nil` when
+    /// the repository does not use reftable storage or `git` could not answer.
+    nonisolated func reftableHead(repository: ResolvedGitRepository) -> GitReftableHead? {
+        guard let stackSignature = Self.reftableStackSignature(repository: repository) else {
+            return nil
+        }
+        return reftableHeadReader.head(
+            workTreeRoot: repository.workTreeRoot,
+            stackSignature: stackSignature
+        )
+    }
+
+    /// The current branch name, falling back to reftable storage when the
+    /// `HEAD` file cannot name one.
+    nonisolated func resolvedBranchName(repository: ResolvedGitRepository) -> String? {
+        if let branch = Self.gitBranchName(repository: repository) {
+            return branch
+        }
+        guard let symbolicFullName = reftableHead(repository: repository)?.symbolicFullName else {
+            return nil
+        }
+        return Self.branchName(fromSymbolicFullName: symbolicFullName)
+    }
+
+    /// The checked-out branch state, falling back to reftable storage when the
+    /// `HEAD` file cannot be classified.
+    nonisolated func resolvedCheckedOutBranch(
+        repository: ResolvedGitRepository
+    ) -> GitCheckedOutBranch {
+        let parsed = Self.gitCheckedOutBranch(repository: repository)
+        guard parsed == .unreadable, let head = reftableHead(repository: repository) else {
+            return parsed
+        }
+        guard let symbolicFullName = head.symbolicFullName else {
+            // No symbolic name: a detached checkout, as long as it resolves to
+            // a commit. Neither name nor commit means nothing was resolved.
+            return head.objectID == nil ? .unreadable : .detached
+        }
+        guard let branch = Self.branchName(fromSymbolicFullName: symbolicFullName) else {
+            // A symbolic ref outside refs/heads, which is not a branch.
+            return .detached
+        }
+        return .branch(branch)
+    }
+
+    /// A `HEAD` signature, falling back to reftable storage when the `HEAD`
+    /// file carries no usable one. Mirrors the file-backed format: the symbolic
+    /// ref text and the commit it resolves to, or the detached commit alone.
+    nonisolated func resolvedHeadSignature(repository: ResolvedGitRepository) -> String? {
+        if let signature = Self.gitHeadSignature(repository: repository) {
+            return signature
+        }
+        guard let head = reftableHead(repository: repository) else { return nil }
+        guard let symbolicFullName = head.symbolicFullName else {
+            return head.objectID
+        }
+        return "ref: \(symbolicFullName)\n\(head.objectID ?? "")"
+    }
+
+    /// The commit `HEAD` resolves to, falling back to reftable storage when the
+    /// ref files cannot resolve it.
+    nonisolated func resolvedCurrentCommit(repository: ResolvedGitRepository) -> String? {
+        if let commit = Self.gitCurrentCommit(repository: repository) {
+            return commit
+        }
+        guard let objectID = reftableHead(repository: repository)?.objectID else { return nil }
+        return Self.normalizedCommitID(objectID)
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
@@ -53,6 +53,12 @@ extension GitMetadataService {
         return foundStack ? components.joined(separator: "\n") : nil
     }
 
+    /// Whether the repository keeps its refs in a reftable stack rather than in
+    /// ref files.
+    nonisolated static func usesReftableRefStorage(repository: ResolvedGitRepository) -> Bool {
+        reftableStackSignature(repository: repository) != nil
+    }
+
     /// The branch a full symbolic ref name refers to, or `nil` when it names
     /// something other than a branch.
     nonisolated static func branchName(fromSymbolicFullName symbolicFullName: String) -> String? {
@@ -128,5 +134,54 @@ extension GitMetadataService {
         }
         guard let objectID = reftableHead(repository: repository)?.objectID else { return nil }
         return Self.normalizedCommitID(objectID)
+    }
+
+    /// The branch name and `HEAD` signature for a metadata snapshot.
+    ///
+    /// A reftable repository resolves them through a `git` process, so that
+    /// case runs on ``blockingStatusQueue`` like every other process this
+    /// service starts, instead of occupying a cooperative-executor thread for
+    /// the runner's wall-time bound. A repository on the files backend answers
+    /// inline from the same reads as before, with no hop.
+    nonisolated func headState(
+        repository: ResolvedGitRepository
+    ) async -> (branch: String?, headSignature: String?) {
+        let branch = Self.gitBranchName(repository: repository)
+        let headSignature = Self.gitHeadSignature(repository: repository)
+        guard branch == nil || headSignature == nil,
+              Self.usesReftableRefStorage(repository: repository) else {
+            return (branch: branch, headSignature: headSignature)
+        }
+        return await onBlockingStatusQueue {
+            (
+                branch: resolvedBranchName(repository: repository),
+                headSignature: resolvedHeadSignature(repository: repository)
+            )
+        }
+    }
+
+    /// The checked-out branch state, resolving reftable storage off the
+    /// cooperative executor for the same reason as ``headState(repository:)``.
+    nonisolated func checkedOutBranch(
+        repository: ResolvedGitRepository
+    ) async -> GitCheckedOutBranch {
+        let parsed = Self.gitCheckedOutBranch(repository: repository)
+        guard parsed == .unreadable, Self.usesReftableRefStorage(repository: repository) else {
+            return parsed
+        }
+        return await onBlockingStatusQueue {
+            resolvedCheckedOutBranch(repository: repository)
+        }
+    }
+
+    /// Runs `work` on the queue this service reserves for blocking I/O.
+    private nonisolated func onBlockingStatusQueue<T: Sendable>(
+        _ work: @escaping @Sendable () -> T
+    ) async -> T {
+        await withCheckedContinuation { continuation in
+            Self.blockingStatusQueue.async {
+                continuation.resume(returning: work())
+            }
+        }
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
@@ -15,7 +15,7 @@ extension GitMetadataService {
     static let reftableDirectoryName = "reftable"
 
     /// The stack index git rewrites on every ref update.
-    private static let reftableTablesListRelativePath = "reftable/tables.list"
+    private static let reftableTablesListRelativePath = reftableDirectoryName + "/tables.list"
 
     /// Identity of the repository's reftable stack, or `nil` when the
     /// repository does not use reftable ref storage.

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
@@ -107,8 +107,12 @@ extension GitMetadataService {
         )
     }
 
-    /// The metadata paths (`HEAD`, `index`, `refs`, `packed-refs`, every reachable
-    /// `config`) for a single resolved repository.
+    /// The metadata paths (`HEAD`, `index`, `refs`, `packed-refs`, `reftable`,
+    /// every reachable `config`) for a single resolved repository.
+    ///
+    /// A reftable repository changes none of the ref files when its checkout
+    /// moves, so its stack directories have to be watched too; they simply do
+    /// not exist on the files backend.
     nonisolated static func gitRepositoryMetadataWatchPaths(
         repository: ResolvedGitRepository
     ) -> [String] {
@@ -116,8 +120,10 @@ extension GitMetadataService {
             joinedPath(root: repository.gitDirectory, relativePath: "HEAD"),
             joinedPath(root: repository.gitDirectory, relativePath: "index"),
             joinedPath(root: repository.gitDirectory, relativePath: "refs"),
+            joinedPath(root: repository.gitDirectory, relativePath: reftableDirectoryName),
             joinedPath(root: repository.commonDirectory, relativePath: "refs"),
             joinedPath(root: repository.commonDirectory, relativePath: "packed-refs"),
+            joinedPath(root: repository.commonDirectory, relativePath: reftableDirectoryName),
         ] + gitConfigURLs(repository: repository).map(\.path)
     }
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitReftableHeadReading.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitReftableHeadReading.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Resolves `HEAD` for a repository that keeps its refs in git's reftable
+/// backend, a binary stack this package does not parse.
+///
+/// Consulted only when the `HEAD` file cannot answer, so a repository on the
+/// files backend still costs nothing beyond the file reads it always did.
+protocol GitReftableHeadReading: Sendable {
+    /// - Parameters:
+    ///   - workTreeRoot: The checkout whose `HEAD` to resolve.
+    ///   - stackSignature: Identity of that checkout's reftable stack, as
+    ///     produced by ``GitMetadataService/reftableStackSignature(repository:)``.
+    ///     It changes on every ref update, so an implementation may reuse a
+    ///     resolution for as long as the signature stays equal.
+    /// - Returns: The resolved `HEAD`, or `nil` when it could not be resolved.
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead?
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
@@ -4,40 +4,58 @@ import Foundation
 /// stack signature, so the sidebar's repeated metadata refreshes consult `git`
 /// only after the refs actually changed.
 ///
-/// Unresolved reads are remembered too: a repository `git` cannot answer for
-/// must not spawn a process on every refresh either.
+/// An unresolved read is kept too, or a repository `git` cannot answer for
+/// would spawn a process on every refresh — but only briefly. A read fails for
+/// transient reasons as well as permanent ones: the runner's wall-time bound,
+/// a cancelled tracked-changes scan, a failed spawn. Those must not pin a
+/// wrong answer until the next ref update, which for a quiet repository may
+/// never come.
 final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Sendable {
     private struct Entry {
         let stackSignature: String
         let head: GitReftableHead?
+        /// When an unresolved read stops being reused. `nil` for a resolved
+        /// one, which stays valid for as long as its signature does.
+        let expiresAt: Date?
     }
 
     private let base: any GitReftableHeadReading
+    private let unresolvedTimeToLive: TimeInterval
     private let maximumEntryCount: Int
+    private let now: @Sendable () -> Date
     private let lock = NSLock()
     private var entriesByWorkTreeRoot: [String: Entry] = [:]
     private var insertionOrder: [String] = []
 
-    init(base: any GitReftableHeadReading, maximumEntryCount: Int = 64) {
+    init(
+        base: any GitReftableHeadReading,
+        unresolvedTimeToLive: TimeInterval = 5,
+        maximumEntryCount: Int = 64,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
         self.base = base
+        self.unresolvedTimeToLive = max(0, unresolvedTimeToLive)
         self.maximumEntryCount = max(1, maximumEntryCount)
+        self.now = now
     }
 
     func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
         lock.lock()
         let cached = entriesByWorkTreeRoot[workTreeRoot]
         lock.unlock()
-        if let cached, cached.stackSignature == stackSignature {
+        if let cached, cached.stackSignature == stackSignature, isValid(cached) {
             return cached.head
         }
 
         let head = base.head(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
+        let entry = Entry(
+            stackSignature: stackSignature,
+            head: head,
+            expiresAt: head == nil ? now().addingTimeInterval(unresolvedTimeToLive) : nil
+        )
 
         lock.lock()
-        if entriesByWorkTreeRoot.updateValue(
-            Entry(stackSignature: stackSignature, head: head),
-            forKey: workTreeRoot
-        ) == nil {
+        if entriesByWorkTreeRoot.updateValue(entry, forKey: workTreeRoot) == nil {
             insertionOrder.append(workTreeRoot)
             while insertionOrder.count > maximumEntryCount {
                 entriesByWorkTreeRoot.removeValue(forKey: insertionOrder.removeFirst())
@@ -45,5 +63,10 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
         }
         lock.unlock()
         return head
+    }
+
+    private func isValid(_ entry: Entry) -> Bool {
+        guard let expiresAt = entry.expiresAt else { return true }
+        return now() < expiresAt
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Keeps one reftable `HEAD` resolution per checkout, keyed by the reftable
+/// stack signature, so the sidebar's repeated metadata refreshes consult `git`
+/// only after the refs actually changed.
+///
+/// Unresolved reads are remembered too: a repository `git` cannot answer for
+/// must not spawn a process on every refresh either.
+final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Sendable {
+    private struct Entry {
+        let stackSignature: String
+        let head: GitReftableHead?
+    }
+
+    private let base: any GitReftableHeadReading
+    private let maximumEntryCount: Int
+    private let lock = NSLock()
+    private var entriesByWorkTreeRoot: [String: Entry] = [:]
+    private var insertionOrder: [String] = []
+
+    init(base: any GitReftableHeadReading, maximumEntryCount: Int = 64) {
+        self.base = base
+        self.maximumEntryCount = max(1, maximumEntryCount)
+    }
+
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        lock.lock()
+        let cached = entriesByWorkTreeRoot[workTreeRoot]
+        lock.unlock()
+        if let cached, cached.stackSignature == stackSignature {
+            return cached.head
+        }
+
+        let head = base.head(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
+
+        lock.lock()
+        if entriesByWorkTreeRoot.updateValue(
+            Entry(stackSignature: stackSignature, head: head),
+            forKey: workTreeRoot
+        ) == nil {
+            insertionOrder.append(workTreeRoot)
+            while insertionOrder.count > maximumEntryCount {
+                entriesByWorkTreeRoot.removeValue(forKey: insertionOrder.removeFirst())
+            }
+        }
+        lock.unlock()
+        return head
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
@@ -30,6 +30,14 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
         let expiresAt: Date?
     }
 
+    /// What a resolution is in flight *for*. The signature belongs in the key:
+    /// two callers reading the stack either side of a ref update are asking
+    /// different questions, and neither should clear the other's slot.
+    private struct ResolutionKey: Hashable {
+        let workTreeRoot: String
+        let stackSignature: String
+    }
+
     private let base: any GitReftableHeadReading
     private let unresolvedTimeToLive: TimeInterval
     private let maximumEntryCount: Int
@@ -40,7 +48,7 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
     private let condition = NSCondition()
     private var entriesByWorkTreeRoot: [String: Entry] = [:]
     private var insertionOrder: [String] = []
-    private var resolvingWorkTreeRoots: Set<String> = []
+    private var resolutionsInFlight: Set<ResolutionKey> = []
     private var waitingCallCount = 0
 
     init(
@@ -56,6 +64,7 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
     }
 
     func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        let key = ResolutionKey(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
         condition.lock()
         while true {
             if let entry = entriesByWorkTreeRoot[workTreeRoot],
@@ -64,19 +73,19 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
                 condition.unlock()
                 return entry.head
             }
-            guard resolvingWorkTreeRoots.contains(workTreeRoot) else { break }
+            guard resolutionsInFlight.contains(key) else { break }
             waitingCallCount += 1
             condition.wait()
             waitingCallCount -= 1
         }
-        resolvingWorkTreeRoots.insert(workTreeRoot)
+        resolutionsInFlight.insert(key)
         condition.unlock()
 
         let head = base.head(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
 
         condition.lock()
         store(head, workTreeRoot: workTreeRoot, stackSignature: stackSignature)
-        resolvingWorkTreeRoots.remove(workTreeRoot)
+        resolutionsInFlight.remove(key)
         condition.broadcast()
         condition.unlock()
         return head

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
@@ -4,12 +4,23 @@ import Foundation
 /// stack signature, so the sidebar's repeated metadata refreshes consult `git`
 /// only after the refs actually changed.
 ///
+/// Resolutions are single-flighted per checkout: a caller that arrives while
+/// another is already resolving the same work tree waits for that result
+/// instead of starting a second pair of `git` commands.
+///
 /// An unresolved read is kept too, or a repository `git` cannot answer for
 /// would spawn a process on every refresh — but only briefly. A read fails for
-/// transient reasons as well as permanent ones: the runner's wall-time bound,
-/// a cancelled tracked-changes scan, a failed spawn. Those must not pin a
-/// wrong answer until the next ref update, which for a quiet repository may
-/// never come.
+/// transient reasons as well as permanent ones: the runner's wall-time bound, a
+/// cancelled tracked-changes scan, a failed spawn. Those must not pin a wrong
+/// answer until the next ref update, which for a quiet repository may never
+/// come.
+///
+/// Synchronous by design. Callers already run on
+/// ``GitMetadataService/blockingStatusQueue``, and the gitlink scan calls in
+/// from inside a `WorkspaceChangesCancellationSignal` binding, which lives in
+/// the thread dictionary — an actor hop would land on another thread and lose
+/// it. So the coordination is an `NSCondition`, and waiting parks a thread that
+/// is already in the blocking lane.
 final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Sendable {
     private struct Entry {
         let stackSignature: String
@@ -23,9 +34,14 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
     private let unresolvedTimeToLive: TimeInterval
     private let maximumEntryCount: Int
     private let now: @Sendable () -> Date
-    private let lock = NSLock()
+
+    /// Guards every stored property below it, and wakes waiters when a
+    /// resolution lands.
+    private let condition = NSCondition()
     private var entriesByWorkTreeRoot: [String: Entry] = [:]
     private var insertionOrder: [String] = []
+    private var resolvingWorkTreeRoots: Set<String> = []
+    private var waitingCallCount = 0
 
     init(
         base: any GitReftableHeadReading,
@@ -40,29 +56,58 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
     }
 
     func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
-        lock.lock()
-        let cached = entriesByWorkTreeRoot[workTreeRoot]
-        lock.unlock()
-        if let cached, cached.stackSignature == stackSignature, isValid(cached) {
-            return cached.head
+        condition.lock()
+        while true {
+            if let entry = entriesByWorkTreeRoot[workTreeRoot],
+               entry.stackSignature == stackSignature,
+               isValid(entry) {
+                condition.unlock()
+                return entry.head
+            }
+            guard resolvingWorkTreeRoots.contains(workTreeRoot) else { break }
+            waitingCallCount += 1
+            condition.wait()
+            waitingCallCount -= 1
         }
+        resolvingWorkTreeRoots.insert(workTreeRoot)
+        condition.unlock()
 
         let head = base.head(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
+
+        condition.lock()
+        store(head, workTreeRoot: workTreeRoot, stackSignature: stackSignature)
+        resolvingWorkTreeRoots.remove(workTreeRoot)
+        condition.broadcast()
+        condition.unlock()
+        return head
+    }
+
+    /// How many callers are parked waiting on another caller's resolution. A
+    /// seam for the single-flight test, which has no other way to know a waiter
+    /// arrived before releasing the resolver it is waiting on.
+    var waitingCallers: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return waitingCallCount
+    }
+
+    private func store(
+        _ head: GitReftableHead?,
+        workTreeRoot: String,
+        stackSignature: String
+    ) {
         let entry = Entry(
             stackSignature: stackSignature,
             head: head,
             expiresAt: head == nil ? now().addingTimeInterval(unresolvedTimeToLive) : nil
         )
-
-        lock.lock()
-        if entriesByWorkTreeRoot.updateValue(entry, forKey: workTreeRoot) == nil {
-            insertionOrder.append(workTreeRoot)
-            while insertionOrder.count > maximumEntryCount {
-                entriesByWorkTreeRoot.removeValue(forKey: insertionOrder.removeFirst())
-            }
+        guard entriesByWorkTreeRoot.updateValue(entry, forKey: workTreeRoot) == nil else {
+            return
         }
-        lock.unlock()
-        return head
+        insertionOrder.append(workTreeRoot)
+        while insertionOrder.count > maximumEntryCount {
+            entriesByWorkTreeRoot.removeValue(forKey: insertionOrder.removeFirst())
+        }
     }
 
     private func isValid(_ entry: Entry) -> Bool {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/MemoizedGitReftableHeadReader.swift
@@ -49,7 +49,6 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
     private var entriesByWorkTreeRoot: [String: Entry] = [:]
     private var insertionOrder: [String] = []
     private var resolutionsInFlight: Set<ResolutionKey> = []
-    private var waitingCallCount = 0
 
     init(
         base: any GitReftableHeadReading,
@@ -74,9 +73,7 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
                 return entry.head
             }
             guard resolutionsInFlight.contains(key) else { break }
-            waitingCallCount += 1
             condition.wait()
-            waitingCallCount -= 1
         }
         resolutionsInFlight.insert(key)
         condition.unlock()
@@ -89,15 +86,6 @@ final class MemoizedGitReftableHeadReader: GitReftableHeadReading, @unchecked Se
         condition.broadcast()
         condition.unlock()
         return head
-    }
-
-    /// How many callers are parked waiting on another caller's resolution. A
-    /// seam for the single-flight test, which has no other way to know a waiter
-    /// arrived before releasing the resolver it is waiting on.
-    var waitingCallers: Int {
-        condition.lock()
-        defer { condition.unlock() }
-        return waitingCallCount
     }
 
     private func store(

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/SystemGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/SystemGitReftableHeadReader.swift
@@ -39,7 +39,10 @@ struct SystemGitReftableHeadReader: GitReftableHeadReading {
         let symbolicFullName: String?
         switch symbolicRef.exitCode {
         case 0:
-            symbolicFullName = symbolicRef.text.isEmpty ? nil : symbolicRef.text
+            // Success with nothing to show would contradict itself; treat it as
+            // unresolved rather than as a detached HEAD.
+            guard !symbolicRef.text.isEmpty else { return nil }
+            symbolicFullName = symbolicRef.text
         case 1:
             symbolicFullName = nil
         default:

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/SystemGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/SystemGitReftableHeadReader.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Resolves `HEAD` by asking `git`, the only reader of the reftable stack.
+///
+/// Two plumbing commands rather than one: `git rev-parse` applies
+/// `--symbolic-full-name` to every revision that follows it, so a single run
+/// cannot return both a ref name and an object id. Both are cheap — neither
+/// reads the index or the working tree — and ``MemoizedGitReftableHeadReader``
+/// keeps them off repeated refreshes.
+struct SystemGitReftableHeadReader: GitReftableHeadReading {
+    /// A ref name and an object id are both far below this. The bound only
+    /// keeps a broken repository from streaming output into memory.
+    private static let maximumOutputByteCount = 4096
+
+    private let runner: any WorkspaceChangesGitRunning
+
+    init(
+        boundedCommandWallTimeLimit: TimeInterval = GitMetadataSafetyConfiguration().gitStatusWallTime
+    ) {
+        runner = SystemWorkspaceChangesGitRunner(
+            boundedCommandWallTimeLimit: boundedCommandWallTimeLimit
+        )
+    }
+
+    init(runner: any WorkspaceChangesGitRunning) {
+        self.runner = runner
+    }
+
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        let directory = URL(fileURLWithPath: workTreeRoot, isDirectory: true)
+
+        // `symbolic-ref --quiet` exits 1 for a detached HEAD and 128 for a
+        // repository it cannot read at all. That is exactly the distinction
+        // GitCheckedOutBranch draws between `detached` and `unreadable`, so
+        // any other exit code has to stay unresolved.
+        guard let symbolicRef = run(["symbolic-ref", "--quiet", "HEAD"], in: directory) else {
+            return nil
+        }
+        let symbolicFullName: String?
+        switch symbolicRef.exitCode {
+        case 0:
+            symbolicFullName = symbolicRef.text.isEmpty ? nil : symbolicRef.text
+        case 1:
+            symbolicFullName = nil
+        default:
+            return nil
+        }
+
+        // Exits 1 on an unborn branch, where the ref name exists but no commit
+        // does yet.
+        let revParse = run(["rev-parse", "--verify", "--quiet", "HEAD"], in: directory)
+        let objectID: String? = if let revParse, revParse.exitCode == 0, !revParse.text.isEmpty {
+            revParse.text
+        } else {
+            nil
+        }
+
+        guard symbolicFullName != nil || objectID != nil else { return nil }
+        return GitReftableHead(symbolicFullName: symbolicFullName, objectID: objectID)
+    }
+
+    private func run(
+        _ arguments: [String],
+        in directory: URL
+    ) -> (text: String, exitCode: Int32)? {
+        guard let result = try? runner.run(
+            arguments: arguments,
+            in: directory,
+            maximumOutputByteCount: Self.maximumOutputByteCount
+        ), !result.standardOutputWasTruncated else {
+            return nil
+        }
+        let text = String(decoding: result.output, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (text: text, exitCode: result.exitCode)
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/CountingGitReftableHeadReader.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/CountingGitReftableHeadReader.swift
@@ -1,0 +1,33 @@
+import Foundation
+@testable import CmuxGit
+
+/// A reftable `HEAD` reader that records every call and the signatures it saw,
+/// optionally delegating to a real reader.
+final class CountingGitReftableHeadReader: GitReftableHeadReading, @unchecked Sendable {
+    private let base: (any GitReftableHeadReading)?
+    private let lock = NSLock()
+    private var observedStackSignatures: [String] = []
+
+    init(base: (any GitReftableHeadReading)? = nil) {
+        self.base = base
+    }
+
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        lock.lock()
+        observedStackSignatures.append(stackSignature)
+        lock.unlock()
+        return base?.head(workTreeRoot: workTreeRoot, stackSignature: stackSignature)
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return observedStackSignatures.count
+    }
+
+    var distinctStackSignatureCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return Set(observedStackSignatures).count
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// A real on-disk repository created with git's reftable ref backend
+/// (`git init --ref-format=reftable`), for the metadata reads that cannot be
+/// answered from `.git/HEAD` alone.
+///
+/// Unlike ``GitRepositoryFixture`` this drives a `git` process, because the
+/// reftable stack is a binary format written only by git. It uses
+/// `/usr/bin/git` — the same binary ``SystemWorkspaceChangesGitRunner`` runs —
+/// with system and global config disabled, so the developer's own hooks,
+/// `core.hooksPath`, signing, and defaults cannot change the fixture. Removed
+/// on `deinit`.
+final class ReftableRepositoryFixture {
+    /// Whether the git this fixture drives can create reftable repositories.
+    /// `--ref-format` landed in git 2.45, so older toolchains (notably the
+    /// Xcode git on CI images) cannot host these tests; the suite skips on
+    /// `false` instead of failing.
+    static let isSupported: Bool = {
+        guard let probeRoot = try? makeTemporaryDirectory(prefix: "cmuxgit-reftable-probe") else {
+            return false
+        }
+        defer { try? FileManager.default.removeItem(at: probeRoot) }
+        guard (try? run(["init", "--ref-format=reftable", "."], in: probeRoot)) != nil else {
+            return false
+        }
+        return FileManager.default.fileExists(
+            atPath: probeRoot.appendingPathComponent(".git/reftable/tables.list").path
+        )
+    }()
+
+    private static let executableURL = URL(fileURLWithPath: "/usr/bin/git")
+
+    /// The working-tree root of the main checkout.
+    let root: URL
+
+    /// Enclosing scratch directory holding the main checkout and any linked
+    /// worktrees, so one removal cleans all of them up.
+    private let base: URL
+
+    /// Creates a reftable repository with one empty commit, checked out on
+    /// `branch`.
+    init(branch: String) throws {
+        base = try Self.makeTemporaryDirectory(prefix: "cmuxgit-reftable")
+        root = base.appendingPathComponent("main", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try run(["init", "--ref-format=reftable", "--initial-branch=main", "."])
+        try run(["commit", "--allow-empty", "--message", "init"])
+        if branch != "main" {
+            try run(["checkout", "-b", branch])
+        }
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: base)
+    }
+
+    /// Creates and checks out `branch` in the main working tree.
+    func checkoutNewBranch(_ branch: String) throws {
+        try run(["checkout", "-b", branch])
+    }
+
+    /// Detaches `HEAD` onto the commit it currently points at.
+    func detachHead() throws {
+        try run(["checkout", "--detach"])
+    }
+
+    /// Adds an empty commit so the checked-out branch advances.
+    func commitEmpty(message: String) throws {
+        try run(["commit", "--allow-empty", "--message", message])
+    }
+
+    /// Adds a linked worktree (`git worktree add`) on a new `branch` and
+    /// returns its working-tree root. Linked worktrees keep their own reftable
+    /// stack next to their per-worktree `HEAD` stub.
+    func addWorktree(name: String, branch: String) throws -> URL {
+        let worktreeRoot = base.appendingPathComponent(name, isDirectory: true)
+        try run(["worktree", "add", "-b", branch, worktreeRoot.path])
+        return worktreeRoot
+    }
+
+    /// The commit `HEAD` resolves to, as 40 lowercase hex characters.
+    func headCommit() throws -> String {
+        try run(["rev-parse", "HEAD"]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    @discardableResult
+    private func run(_ arguments: [String]) throws -> String {
+        try Self.run(arguments, in: root)
+    }
+
+    @discardableResult
+    private static func run(_ arguments: [String], in directory: URL) throws -> String {
+        let process = Process()
+        process.executableURL = executableURL
+        process.currentDirectoryURL = directory
+        process.arguments = [
+            "-c", "user.name=cmux tests",
+            "-c", "user.email=tests@cmux.invalid",
+            "-c", "commit.gpgsign=false",
+        ] + arguments
+        var environment = ProcessInfo.processInfo.environment
+        // Neutralize the developer's own git configuration and hooks.
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = environment
+
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+        try process.run()
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw Failure(
+                arguments: arguments,
+                exitCode: process.terminationStatus,
+                standardError: String(decoding: errorData, as: UTF8.self)
+            )
+        }
+        return String(decoding: outputData, as: UTF8.self)
+    }
+
+    private static func makeTemporaryDirectory(prefix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    struct Failure: Error, CustomStringConvertible {
+        let arguments: [String]
+        let exitCode: Int32
+        let standardError: String
+
+        var description: String {
+            "git \(arguments.joined(separator: " ")) failed with \(exitCode): \(standardError)"
+        }
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
@@ -99,6 +99,12 @@ final class ReftableRepositoryFixture {
             "-c", "commit.gpgsign=false",
         ] + arguments
         var environment = ProcessInfo.processInfo.environment
+        // Drop every inherited GIT_* variable first. GIT_DIR would point the
+        // fixture at another repository entirely, and GIT_TEMPLATE_DIR can
+        // install hooks that run during `commit`.
+        for key in environment.keys where key.hasPrefix("GIT_") {
+            environment.removeValue(forKey: key)
+        }
         // Neutralize the developer's own git configuration and hooks.
         environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
         environment["GIT_CONFIG_SYSTEM"] = "/dev/null"

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/ReftableRepositoryFixture.swift
@@ -106,15 +106,31 @@ final class ReftableRepositoryFixture {
         environment["GIT_TERMINAL_PROMPT"] = "0"
         process.environment = environment
 
-        let standardOutput = Pipe()
-        let standardError = Pipe()
-        process.standardOutput = standardOutput
-        process.standardError = standardError
+        // Both streams go to files rather than pipes: a pipe read sequence
+        // deadlocks whenever the stream being read second fills its buffer
+        // first, and a fixture has no reason to risk it.
+        let captureDirectory = try makeTemporaryDirectory(prefix: "cmuxgit-reftable-capture")
+        defer { try? FileManager.default.removeItem(at: captureDirectory) }
+        let outputURL = captureDirectory.appendingPathComponent("stdout")
+        let errorURL = captureDirectory.appendingPathComponent("stderr")
+        for url in [outputURL, errorURL] {
+            guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        let errorHandle = try FileHandle(forWritingTo: errorURL)
+        process.standardOutput = outputHandle
+        process.standardError = errorHandle
+
         try process.run()
-        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
-        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
+        try? outputHandle.close()
+        try? errorHandle.close()
+
+        let outputData = (try? Data(contentsOf: outputURL)) ?? Data()
         guard process.terminationStatus == 0 else {
+            let errorData = (try? Data(contentsOf: errorURL)) ?? Data()
             throw Failure(
                 arguments: arguments,
                 exitCode: process.terminationStatus,

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -453,6 +453,20 @@ import Testing
         #expect(GitMetadataService.gitRefValue(repository: repository, refName: "refs/heads/main") != nil)
     }
 
+    /// `gitCheckedOutBranch` already accepts a 64-hex `HEAD` as detached, so
+    /// the commit read has to name that commit rather than give up on it.
+    @Test func namesTheCommitOfADetachedSHA256Head() throws {
+        let fixture = try GitRepositoryFixture()
+        let commit = String(repeating: "a", count: 64)
+        try fixture.writeDetachedHead(commit: commit)
+        let repository = try #require(
+            GitMetadataService.resolveGitRepository(containing: fixture.root.path)
+        )
+
+        #expect(GitMetadataService.gitCheckedOutBranch(repository: repository) == .detached)
+        #expect(GitMetadataService.gitCurrentCommit(repository: repository) == commit)
+    }
+
     @Test func watchedPathsRecurseIntoNestedSubmodules() throws {
         let parent = try GitRepositoryFixture()
         try parent.writeBranch("main")

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
@@ -74,12 +74,39 @@ import Testing
         #expect(base.callCount == 3)
     }
 
-    @Test func memoRemembersAnUnresolvedRead() {
+    @Test func memoRemembersAnUnresolvedReadOnlyBriefly() {
         let base = CountingGitReftableHeadReader()
-        let memo = MemoizedGitReftableHeadReader(base: base)
+        let clock = TestClock(start: Date(timeIntervalSince1970: 1_000))
+        let memo = MemoizedGitReftableHeadReader(
+            base: base,
+            unresolvedTimeToLive: 5,
+            now: { clock.now }
+        )
 
         #expect(memo.head(workTreeRoot: "/repo", stackSignature: "a") == nil)
+        clock.advance(by: 4)
         #expect(memo.head(workTreeRoot: "/repo", stackSignature: "a") == nil)
+        #expect(base.callCount == 1)
+
+        // A read fails for transient reasons too, so the same signature has to
+        // become resolvable again rather than stay wrong until the refs move.
+        clock.advance(by: 2)
+        #expect(memo.head(workTreeRoot: "/repo", stackSignature: "a") == nil)
+        #expect(base.callCount == 2)
+    }
+
+    @Test func memoKeepsAResolvedReadRegardlessOfTime() {
+        let base = CountingGitReftableHeadReader(base: StubGitReftableHeadReader())
+        let clock = TestClock(start: Date(timeIntervalSince1970: 1_000))
+        let memo = MemoizedGitReftableHeadReader(
+            base: base,
+            unresolvedTimeToLive: 5,
+            now: { clock.now }
+        )
+
+        _ = memo.head(workTreeRoot: "/repo", stackSignature: "a")
+        clock.advance(by: 3_600)
+        _ = memo.head(workTreeRoot: "/repo", stackSignature: "a")
 
         #expect(base.callCount == 1)
     }
@@ -100,6 +127,28 @@ import Testing
 
         _ = memo.head(workTreeRoot: "/first", stackSignature: "a")
         #expect(base.callCount == 4)
+    }
+}
+
+/// A hand-advanced wall clock, so expiry is tested without waiting.
+private final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant: Date
+
+    init(start: Date) {
+        instant = start
+    }
+
+    var now: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return instant
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock()
+        instant += seconds
+        lock.unlock()
     }
 }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
@@ -111,27 +111,39 @@ import Testing
         #expect(base.callCount == 1)
     }
 
-    @Test func memoResolvesOnceWhenTwoCallersMissTheSameCheckout() async throws {
+    // Synchronous: the coordination is `DispatchGroup`/`DispatchSemaphore`, and
+    // their blocking waits are unavailable from an async context.
+    @Test func memoResolvesOnceWhenTwoCallersMissTheSameCheckout() throws {
         let base = BlockingGitReftableHeadReader()
         let memo = MemoizedGitReftableHeadReader(base: base)
         let results = ResultBox()
+        let finished = DispatchGroup()
 
+        finished.enter()
         let first = Thread {
             results.record(memo.head(workTreeRoot: "/repo", stackSignature: "a"))
+            finished.leave()
         }
         first.start()
+        // Every exit path frees the workers, including the failing ones: a
+        // caller parked in the base reader or on the memo's condition would
+        // otherwise outlive the test.
+        defer { base.release() }
         try #require(base.waitUntilEntered(withinSeconds: 5))
 
+        finished.enter()
         let second = Thread {
             results.record(memo.head(workTreeRoot: "/repo", stackSignature: "a"))
+            finished.leave()
         }
         second.start()
-        // Release the resolver only once the other caller is parked, or the
-        // two would simply run one after the other and prove nothing.
-        try #require(pollUntil(withinSeconds: 5) { memo.waitingCallers == 1 })
-        base.release()
+        // The base reader signals on entry, so a second signal means the memo
+        // let both callers resolve. This one has to not arrive; the deadline
+        // is the window the second caller gets to reach the reader.
+        #expect(base.waitUntilEntered(withinSeconds: 0.5) == false)
 
-        try #require(pollUntil(withinSeconds: 5) { results.count == 2 })
+        base.release()
+        try #require(finished.wait(timeout: .now() + 5) == .success)
         #expect(base.callCount == 1)
         #expect(results.values.allSatisfy { $0 == BlockingGitReftableHeadReader.resolvedHead })
     }
@@ -153,17 +165,6 @@ import Testing
         _ = memo.head(workTreeRoot: "/first", stackSignature: "a")
         #expect(base.callCount == 4)
     }
-}
-
-/// Polls `predicate` until it holds or `deadline` elapses. Returns whether it
-/// held; tests `#require` the result rather than sleeping a fixed amount.
-private func pollUntil(withinSeconds timeout: Double, _ predicate: () -> Bool) -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-        if predicate() { return true }
-        Thread.sleep(forTimeInterval: 0.005)
-    }
-    return predicate()
 }
 
 /// Blocks inside `head` until released, so a second caller is guaranteed to

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+
+/// The cost side of reftable support: the `git` fallback must stay off the
+/// files backend entirely, and must not run again while the reftable stack is
+/// unchanged.
+@Suite struct GitReftableHeadReaderTests {
+    @Test func filesBackendRepositoryNeverConsultsGit() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        let reader = CountingGitReftableHeadReader()
+        let service = GitMetadataService(
+            fileStatusReader: SystemGitFileStatusReader(),
+            reftableHeadReader: reader
+        )
+
+        let metadata = await service.workspaceMetadata(for: fixture.root.path)
+        let checkedOut = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(metadata.branch == "main")
+        #expect(checkedOut == .branch("main"))
+        #expect(reader.callCount == 0)
+    }
+
+    @Test func unreadableHeadOnFilesBackendNeverConsultsGit() async throws {
+        let fixture = try GitRepositoryFixture()
+        let reader = CountingGitReftableHeadReader()
+        let service = GitMetadataService(
+            fileStatusReader: SystemGitFileStatusReader(),
+            reftableHeadReader: reader
+        )
+
+        let checkedOut = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(checkedOut == .unreadable)
+        #expect(reader.callCount == 0)
+    }
+
+    @Test(.enabled(if: ReftableRepositoryFixture.isSupported, "requires git with --ref-format=reftable"))
+    func reftableStackSignatureChangesOnlyWhenRefsChange() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+        let reader = CountingGitReftableHeadReader(
+            base: MemoizedGitReftableHeadReader(base: SystemGitReftableHeadReader())
+        )
+        let service = GitMetadataService(
+            fileStatusReader: SystemGitFileStatusReader(),
+            reftableHeadReader: reader
+        )
+
+        for _ in 0..<3 {
+            #expect(await service.workspaceMetadata(for: fixture.root.path).branch == "main")
+        }
+        let signaturesBeforeCommit = reader.distinctStackSignatureCount
+        try fixture.commitEmpty(message: "second")
+        #expect(await service.workspaceMetadata(for: fixture.root.path).branch == "main")
+
+        #expect(signaturesBeforeCommit == 1)
+        #expect(reader.distinctStackSignatureCount == 2)
+    }
+
+    @Test func memoReusesResolutionUntilTheStackSignatureChanges() {
+        let base = CountingGitReftableHeadReader(base: StubGitReftableHeadReader())
+        let memo = MemoizedGitReftableHeadReader(base: base)
+
+        _ = memo.head(workTreeRoot: "/repo", stackSignature: "a")
+        _ = memo.head(workTreeRoot: "/repo", stackSignature: "a")
+        #expect(base.callCount == 1)
+
+        _ = memo.head(workTreeRoot: "/repo", stackSignature: "b")
+        #expect(base.callCount == 2)
+
+        _ = memo.head(workTreeRoot: "/other", stackSignature: "a")
+        #expect(base.callCount == 3)
+    }
+
+    @Test func memoRemembersAnUnresolvedRead() {
+        let base = CountingGitReftableHeadReader()
+        let memo = MemoizedGitReftableHeadReader(base: base)
+
+        #expect(memo.head(workTreeRoot: "/repo", stackSignature: "a") == nil)
+        #expect(memo.head(workTreeRoot: "/repo", stackSignature: "a") == nil)
+
+        #expect(base.callCount == 1)
+    }
+
+    @Test func memoEvictsTheOldestCheckoutBeyondItsBound() {
+        let base = CountingGitReftableHeadReader(base: StubGitReftableHeadReader())
+        let memo = MemoizedGitReftableHeadReader(base: base, maximumEntryCount: 2)
+
+        _ = memo.head(workTreeRoot: "/first", stackSignature: "a")
+        _ = memo.head(workTreeRoot: "/second", stackSignature: "a")
+        _ = memo.head(workTreeRoot: "/third", stackSignature: "a")
+        #expect(base.callCount == 3)
+
+        // The two most recent stay cached, the first is gone.
+        _ = memo.head(workTreeRoot: "/second", stackSignature: "a")
+        _ = memo.head(workTreeRoot: "/third", stackSignature: "a")
+        #expect(base.callCount == 3)
+
+        _ = memo.head(workTreeRoot: "/first", stackSignature: "a")
+        #expect(base.callCount == 4)
+    }
+}
+
+/// Resolves every checkout to the same fixed `HEAD`.
+private struct StubGitReftableHeadReader: GitReftableHeadReading {
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        GitReftableHead(
+            symbolicFullName: "refs/heads/main",
+            objectID: String(repeating: "a", count: 40)
+        )
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableHeadReaderTests.swift
@@ -111,6 +111,31 @@ import Testing
         #expect(base.callCount == 1)
     }
 
+    @Test func memoResolvesOnceWhenTwoCallersMissTheSameCheckout() async throws {
+        let base = BlockingGitReftableHeadReader()
+        let memo = MemoizedGitReftableHeadReader(base: base)
+        let results = ResultBox()
+
+        let first = Thread {
+            results.record(memo.head(workTreeRoot: "/repo", stackSignature: "a"))
+        }
+        first.start()
+        try #require(base.waitUntilEntered(withinSeconds: 5))
+
+        let second = Thread {
+            results.record(memo.head(workTreeRoot: "/repo", stackSignature: "a"))
+        }
+        second.start()
+        // Release the resolver only once the other caller is parked, or the
+        // two would simply run one after the other and prove nothing.
+        try #require(pollUntil(withinSeconds: 5) { memo.waitingCallers == 1 })
+        base.release()
+
+        try #require(pollUntil(withinSeconds: 5) { results.count == 2 })
+        #expect(base.callCount == 1)
+        #expect(results.values.allSatisfy { $0 == BlockingGitReftableHeadReader.resolvedHead })
+    }
+
     @Test func memoEvictsTheOldestCheckoutBeyondItsBound() {
         let base = CountingGitReftableHeadReader(base: StubGitReftableHeadReader())
         let memo = MemoizedGitReftableHeadReader(base: base, maximumEntryCount: 2)
@@ -127,6 +152,81 @@ import Testing
 
         _ = memo.head(workTreeRoot: "/first", stackSignature: "a")
         #expect(base.callCount == 4)
+    }
+}
+
+/// Polls `predicate` until it holds or `deadline` elapses. Returns whether it
+/// held; tests `#require` the result rather than sleeping a fixed amount.
+private func pollUntil(withinSeconds timeout: Double, _ predicate: () -> Bool) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if predicate() { return true }
+        Thread.sleep(forTimeInterval: 0.005)
+    }
+    return predicate()
+}
+
+/// Blocks inside `head` until released, so a second caller is guaranteed to
+/// arrive while the first resolution is still in flight.
+private final class BlockingGitReftableHeadReader: GitReftableHeadReading, @unchecked Sendable {
+    static let resolvedHead = GitReftableHead(
+        symbolicFullName: "refs/heads/main",
+        objectID: String(repeating: "b", count: 40)
+    )
+
+    private let entered = DispatchSemaphore(value: 0)
+    private let released = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var calls = 0
+
+    func head(workTreeRoot: String, stackSignature: String) -> GitReftableHead? {
+        lock.lock()
+        calls += 1
+        lock.unlock()
+        entered.signal()
+        released.wait()
+        return Self.resolvedHead
+    }
+
+    func waitUntilEntered(withinSeconds timeout: Double) -> Bool {
+        entered.wait(timeout: .now() + timeout) == .success
+    }
+
+    /// Two permits, so a regression that lets a second caller into `head` fails
+    /// the assertions instead of parking a thread forever.
+    func release() {
+        released.signal()
+        released.signal()
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+}
+
+/// Collects each caller's result across threads.
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [GitReftableHead?] = []
+
+    func record(_ head: GitReftableHead?) {
+        lock.lock()
+        results.append(head)
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return results.count
+    }
+
+    var values: [GitReftableHead?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return results
     }
 }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableRefsTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableRefsTests.swift
@@ -57,6 +57,26 @@ struct GitReftableRefsTests {
         #expect(afterBranchSwitch != afterCommit)
     }
 
+    @Test func reportsHeadCommitFromReftableStack() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+        let expected = try fixture.headCommit()
+        let repository = try #require(
+            GitMetadataService.resolveGitRepository(containing: fixture.root.path)
+        )
+
+        let commit = GitMetadataService().resolvedCurrentCommit(repository: repository)
+
+        #expect(commit == expected)
+    }
+
+    @Test func watchesTheReftableStackDirectory() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+
+        let paths = try #require(await GitMetadataService().watchedPaths(for: fixture.root.path))
+
+        #expect(paths.contains { $0.hasSuffix("/.git/reftable") })
+    }
+
     @Test func reportsBranchForLinkedReftableWorktree() async throws {
         let fixture = try ReftableRepositoryFixture(branch: "main")
         let worktreeRoot = try fixture.addWorktree(name: "linked", branch: "feature/linked")

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableRefsTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitReftableRefsTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+
+/// Ref reads against git's reftable ref backend.
+///
+/// A reftable repository keeps a permanent placeholder `HEAD`
+/// (`ref: refs/heads/.invalid`) and stores the real refs, including the `HEAD`
+/// symref, in a binary reftable stack. Parsing `HEAD` alone therefore reports
+/// `.invalid` as the branch and never changes when the checkout does
+/// (https://github.com/manaflow-ai/cmux/issues/10170).
+///
+/// Skipped, not failed, when the available git cannot create such a repository.
+@Suite(.enabled(if: ReftableRepositoryFixture.isSupported, "requires git with --ref-format=reftable"))
+struct GitReftableRefsTests {
+    @Test func reportsBranchFromReftableStackInsteadOfPlaceholder() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "theo.leruitte/support-dog/preprod")
+
+        let metadata = await GitMetadataService().workspaceMetadata(for: fixture.root.path)
+
+        #expect(metadata.isRepository)
+        #expect(metadata.branch == "theo.leruitte/support-dog/preprod")
+    }
+
+    @Test func classifiesReftableCheckoutAsItsRealBranch() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "feature/reftable")
+
+        let checkedOut = await GitMetadataService().checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(checkedOut == .branch("feature/reftable"))
+    }
+
+    @Test func classifiesDetachedReftableHeadAsDetached() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+        try fixture.detachHead()
+
+        let checkedOut = await GitMetadataService().checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(checkedOut == .detached)
+    }
+
+    @Test func headSignatureChangesWhenReftableCheckoutChanges() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+        let service = GitMetadataService()
+
+        let before = try #require(await service.workspaceMetadata(for: fixture.root.path).headSignature)
+        try fixture.checkoutNewBranch("feature/switched")
+        let afterBranchSwitch = try #require(
+            await service.workspaceMetadata(for: fixture.root.path).headSignature
+        )
+        try fixture.commitEmpty(message: "second")
+        let afterCommit = try #require(
+            await service.workspaceMetadata(for: fixture.root.path).headSignature
+        )
+
+        #expect(before != afterBranchSwitch)
+        #expect(afterBranchSwitch != afterCommit)
+    }
+
+    @Test func reportsBranchForLinkedReftableWorktree() async throws {
+        let fixture = try ReftableRepositoryFixture(branch: "main")
+        let worktreeRoot = try fixture.addWorktree(name: "linked", branch: "feature/linked")
+
+        let metadata = await GitMetadataService().workspaceMetadata(for: worktreeRoot.path)
+
+        #expect(metadata.branch == "feature/linked")
+    }
+}


### PR DESCRIPTION
Fixes #10170.

## What was wrong

A workspace in a repository with `extensions.refStorage = reftable` shows `.invalid` as its branch, and keeps showing it after every checkout.

## Why

`GitMetadataService` reads refs from files only. With the reftable backend there are no ref files to read: git writes `HEAD` once as `ref: refs/heads/.invalid` — a marker so that code identifying a git directory by `HEAD` keeps working, using a name git itself refuses so it cannot collide with a branch — and keeps every real ref, the `HEAD` symref included, in a binary stack under `reftable/`.

- `GitMetadataService+Refs.swift:14` `gitBranchName` strips `ref: refs/heads/` off the marker and hands `.invalid` to the sidebar as a branch name.
- `GitMetadataService+Refs.swift:31` `gitCheckedOutBranch` classifies it as `.branch(".invalid")`, so PR bookkeeping keys off a branch that does not exist.
- `GitMetadataService+Refs.swift:62` `gitHeadSignature` returns the marker text. It is a constant, so the signature says "HEAD never changed" no matter how often the checkout moves.
- `GitMetadataService+Refs.swift:83` `gitRefValue` knows loose refs and `packed-refs`, neither of which exists here, so `gitCurrentCommit` returns nil for every reftable repository.
- `GitMetadataService+WatchPaths.swift:112` watches `HEAD`, `refs`, and `packed-refs`. In a reftable repository none of them ever change, so nothing wakes the watcher on a branch switch.

## What changed

The parsers now treat the marker as a marker: `gitBranchName` returns nil, `gitCheckedOutBranch` returns `.unreadable`, `gitHeadSignature` returns nil.

Four instance resolvers (`GitMetadataService+Reftable.swift`) sit in front of them. Each keeps the file read as the fast path and falls back only when the files cannot name a checkout, so a repository on the files backend costs exactly what it did before — no process, no extra read. The fallback is gated on `reftable/tables.list` existing, so a merely corrupt `HEAD` on the files backend does not spawn anything either.

The fallback asks git, the only reader of the stack: `symbolic-ref --quiet HEAD` and `rev-parse --verify --quiet HEAD`. Their exit codes carry the distinctions the model already draws — 1 from `symbolic-ref` is a detached HEAD, 128 is a repository git cannot read, 1 from `rev-parse` is a branch with no commit yet — so a reftable checkout lands on `branch`, `detached`, or `unreadable` for the same reasons a files-backend one does. Two commands because `git rev-parse` applies `--symbolic-full-name` to every revision that follows it and so cannot return a name and an object id in one run.

Metadata refresh is frequent, so the resolution is memoized per checkout, keyed by the contents of `reftable/tables.list`, which git replaces on every ref update. A reftable workspace spawns git once per actual ref change rather than once per refresh, and resolutions are single-flighted per checkout so two overlapping refreshes on one work tree do not each start their own pair of commands. Both the per-worktree stack (holds `HEAD`) and the common stack (holds `refs/heads/*`) feed the key: a branch switch rewrites the first, a commit the second.

Unresolved reads are memoized too — otherwise a repository git cannot answer for spawns a process on every refresh — but expire after five seconds. Reads fail transiently as well as permanently: the runner's wall-time bound is 2s, `GitMetadataService+Index.swift:30` installs a cancellation signal the runner honours, and a spawn can fail under load. Without the expiry any of those pins a wrong answer until someone touches a ref, which on a quiet repository may be never, and for a submodule that reads as the parent being permanently dirty.

The git call runs on `blockingStatusQueue`, the lane this service reserves for blocking I/O — the same one the bounded `git status` fallback and the gitlink scan use. `workspaceMetadata` and `checkedOutBranch` are `nonisolated async` and so run on the cooperative pool, where a two-second bounded process would occupy a thread. The file reads still answer inline; only a repository that actually has a reftable stack hops.

Two consequences beyond the label:

- the watcher now watches the stack directories. Without that the sidebar would resolve the right branch once and never notice a switch, because no watched file would change.
- a reftable submodule resolves its checked-out commit through the same path. An unresolved gitlink marks the parent dirty, so before this every parent of one read as permanently dirty.

Left alone deliberately: `gitRefValue` still reads only loose refs and `packed-refs`, and `includeIf onbranch:` in `GitMetadataService+Config.swift:364` still matches off the `HEAD` file. Both are static, config-layer paths with no reader to reach; `onbranch:` previously matched against `.invalid` and now matches nothing in a reftable repository, which is wrong in a smaller way than before and out of scope for this issue.

The alternative design was to parse the reftable stack in Swift and keep everything file-based. That removes the process entirely but means hand-rolling a binary format — prefix-compressed keys, varints, restart tables, a stack of files — for a cosmetic label. The chosen shape leaves the hot path byte-for-byte unchanged for every repository that is not reftable, which is nearly all of them.

## Red then green

Commit 1 (`090981030`) adds the tests only. All five fail on it, against a real `git init --ref-format=reftable` fixture:

```
✘ reportsBranchFromReftableStackInsteadOfPlaceholder(): Expectation failed: (metadata.branch → ".invalid") == "theo.leruitte/support-dog/preprod"
✘ classifiesReftableCheckoutAsItsRealBranch(): Expectation failed: (checkedOut → .branch(".invalid")) == .branch("feature/reftable")
✘ classifiesDetachedReftableHeadAsDetached(): Expectation failed: (checkedOut → .branch(".invalid")) == .detached
✘ headSignatureChangesWhenReftableCheckoutChanges(): Expectation failed: (before → "ref: refs/heads/.invalid\n") != (afterBranchSwitch → "ref: refs/heads/.invalid\n")
✘ reportsBranchForLinkedReftableWorktree(): Expectation failed: (metadata.branch → ".invalid") == "feature/linked"
✘ Test run with 5 tests in 1 suite failed after 0.141 seconds with 6 issues.
```

`.invalid` is exactly what the reporter sees. The linked-worktree case is how they hit it.

Commit 2 (`c7d105a96`) adds the fix and six more tests: that a files-backend repository never reaches the reader even when its `HEAD` is missing, that the memo reuses a resolution until the signature moves and evicts by age past its bound, that the stack signature moves only when refs do, plus the head-commit and watch-path reads.

Commit 3 (`018c9b116`) adds the unresolved-read expiry described above, on a hand-advanced clock so the test needs no waiting. Commit 4 (`1d5108c49`) makes a missing `tables.list` contribute an empty component to the signature instead of being skipped — otherwise a worktree stack appearing or disappearing could collide with its common neighbour — and treats `symbolic-ref` exiting 0 with no output as unresolved rather than as a detached HEAD. Commit 5 (`578d1c79e`) moves the reftable resolution onto `blockingStatusQueue`. Commits 6 and 7 are cleanups: the tables.list path derives from the directory-name constant, and the fixture captures git's output through files rather than a pair of pipes read in sequence, which deadlocks if the second stream fills its buffer first. Commit 8 (`745667758`) answers the two CodeRabbit findings: single-flight resolution, and dropping the inherited `GIT_*` environment in the fixture so an ambient `GIT_DIR` or `GIT_TEMPLATE_DIR` cannot reach it. Commit 9 (`27032777a`) keys the in-flight set by `(workTreeRoot, stackSignature)`, since work-tree-only keying let two resolutions either side of a ref update clear each other's slot. Commit 10 (`c1a403794`) drops the waiter-count seam the single-flight test was reading and rebuilds that test on semaphores and a `DispatchGroup`, with the release in a `defer`; deleting the memo's `condition.wait()` fails it on `waitUntilEntered → true` and `base.callCount → 2`. Commit 11 (`9ffa3918c`) lets `normalizedCommitID` accept 64-hex as well as 40, matching `isLikelyCommitSHA` two functions above it, so a SHA-256 detached `HEAD` stops being classified as detached at a commit it then refuses to name.

## Validation

```
$ swift test --package-path Packages/macOS/CmuxGit
✔ Test run with 179 tests in 21 suites passed after 3.816 seconds.
```

`swift build --package-path Packages/macOS/CmuxSidebarGit` also passes, as the one consumer of this API.

Local package tests only. `main` does not currently build (#10225, `Sources/TerminalController+MobileSurfaces.swift`), so the `cmux` and `cmux-unit` schemes are not buildable here for reasons unrelated to this change; nothing in this diff touches the app target or `cmuxTests/`, so no pbxproj wiring is involved (`./scripts/lint-pbxproj-test-wiring.sh` and `scripts/check-package-resolved-policy.py` both pass). CI workflows on fork PRs sit in `action_required`, so nothing has run on GitHub CI either.

The reftable fixture drives `/usr/bin/git` — the same binary `SystemWorkspaceChangesGitRunner` runs — so a test cannot create a repository the code under test is unable to read. `--ref-format` needs git 2.45; the suite probes for it and skips rather than fails on older toolchains, which is what will happen on a CI image whose `/usr/bin/git` is older. Local runs were on `git version 2.50.1 (Apple Git-155)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Git repositories using reftable storage.
  - Improved detection of branches, detached HEAD states, current commits, linked worktrees, and submodule revisions.
  - Added support for 64-character SHA-256 commit IDs.
  - Repository metadata updates now respond to changes in reftable directories.

- **Bug Fixes**
  - Corrected handling of unresolved and unborn branches.
  - Improved metadata resolution when traditional reference files are unavailable.
  - Added caching to reduce repeated HEAD resolution while correctly expiring unresolved results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->