### PR TITLE
Fix persistent SSH disconnect/reconnect wedge

### DIFF
--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -127,6 +127,10 @@ extension Workspace {
         )
         activeRemoteSessionControllerID = controllerID
         remoteSessionController = controller
+        // Configure/disconnect notifications can fire before this async
+        // handoff installs the controller; wake PTY attach waiters at the
+        // actual availability boundary as well.
+        TerminalController.shared.notifyRemotePTYControllerAvailabilityChanged()
         controller.updateRemotePortScanningEnabled(Self.remotePortScanningEnabledFromSettings())
         syncRemotePortScanTTYs()
         syncRemoteRelayIDAliasesToController()
@@ -137,6 +141,10 @@ extension Workspace {
     func reconnectRemoteConnection(surfaceId: UUID? = nil) -> Bool {
         guard let configuration = remoteConfiguration else { return false }
         var didRespawnTerminal = false
+        // Persistent SSH wrappers must not be launched while the management
+        // controller is disconnected: their first bridge request would race
+        // the replacement controller and can retire the reconnect transition.
+        let remoteControllerIsReady = remoteControllerConnectionState == .connected
         let reconnectingSurfaceId: UUID?
         if let surfaceId {
             guard panels[surfaceId] is TerminalPanel else { return false }
@@ -145,8 +153,10 @@ extension Workspace {
             reconnectingSurfaceId = remoteReconnectTerminalSurfaceId(requestedSurfaceId: nil)
         }
         if configuration.preserveAfterTerminalExit {
-            let reattached = reattachPersistentRemotePTYPanels(requestedSurfaceId: surfaceId, restartEndedSessions: true)
-            didRespawnTerminal = surfaceId.map(reattached.contains) ?? !reattached.isEmpty
+            if remoteControllerIsReady {
+                let reattached = reattachPersistentRemotePTYPanels(requestedSurfaceId: surfaceId, restartEndedSessions: true)
+                didRespawnTerminal = surfaceId.map(reattached.contains) ?? !reattached.isEmpty
+            }
         } else if let startupCommand = effectiveRemoteTerminalStartupCommand(from: configuration),
                   !startupCommand.isEmpty,
                   let reconnectingSurfaceId {
@@ -172,7 +182,7 @@ extension Workspace {
             }
             if didRespawnTerminal || !shouldRespawnSurface { trackRemoteTerminalSurface(reconnectingSurfaceId) }
         }
-        if reconnectingSurfaceId != nil, remoteConnectionState == .connected { return didRespawnTerminal }
+        if reconnectingSurfaceId != nil, remoteControllerIsReady { return didRespawnTerminal }
         guard remoteConnectionState != .connecting, remoteConnectionState != .reconnecting else { return didRespawnTerminal }
         configureRemoteConnection(configuration, autoConnect: true)
         return didRespawnTerminal

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -135,6 +135,9 @@ extension Workspace {
         syncRemotePortScanTTYs()
         syncRemoteRelayIDAliasesToController()
         controller.start()
+        if remoteControllerConnectionState == .connected {
+            _ = reattachPersistentRemotePTYPanels()
+        }
     }
 
     @discardableResult

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6933,6 +6933,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         target: String,
         externalRemoteTerminalDocks: [DockSplitStore] = []
     ) {
+        let reconnectWasInFlight = remoteControllerConnectionState == .connecting ||
+            remoteControllerConnectionState == .reconnecting
         let trimmedDetail = detail?.trimmingCharacters(in: .whitespacesAndNewlines)
         let proxyOnlyError = trimmedDetail.map(Self.isProxyOnlyRemoteError) ?? false
         let preservesProxyFailureForLiveTerminal =
@@ -6961,7 +6963,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         remoteControllerConnectionDetail = detail
         remoteConnectionState = effectiveState
         remoteConnectionDetail = detail
-        if state == .connected, remoteSessionController != nil {
+        if state == .connected,
+           (remoteSessionController != nil || !reconnectWasInFlight) {
             _ = reattachPersistentRemotePTYPanels()
         }
         applyBrowserRemoteWorkspaceStatusToPanels()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6961,7 +6961,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         remoteControllerConnectionDetail = detail
         remoteConnectionState = effectiveState
         remoteConnectionDetail = detail
-        if state == .connected { _ = reattachPersistentRemotePTYPanels() }
+        if state == .connected, remoteSessionController != nil {
+            _ = reattachPersistentRemotePTYPanels()
+        }
         applyBrowserRemoteWorkspaceStatusToPanels()
 
         if suppressProxyOnlySidebarError {

--- a/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
+++ b/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
@@ -59,22 +59,22 @@ struct RemoteSessionCleanupLifecycleTests {
         #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
         #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
 
+        runner.blockNextCleanup()
         let reattachedBeforeControllerReady = workspace.reconnectRemoteConnection(surfaceId: panel.id)
-
-        #expect(!reattachedBeforeControllerReady)
-        #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
-        #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
-
-        _ = try #require(await Self.nextCleanupCommand(runner))
-        _ = try #require(await Self.nextBootstrapRequest(runner))
-        await workspace.remoteSessionTransitionTask?.value
-        #expect(workspace.remoteSessionController != nil)
-
         workspace.applyRemoteConnectionStateUpdate(
             .connected,
             detail: "Connected to cmux-macmini",
             target: "cmux-macmini"
         )
+        _ = try #require(await Self.nextCleanupCommand(runner))
+
+        #expect(!reattachedBeforeControllerReady)
+        #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
+        #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
+
+        runner.releaseBlockedCleanup()
+        await workspace.remoteSessionTransitionTask?.value
+        #expect(workspace.remoteSessionController != nil)
 
         #expect(workspace.terminalPanel(for: panel.id)?.surface !== disconnectedSurface)
         #expect(!workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))

--- a/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
+++ b/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
@@ -69,6 +69,7 @@ struct RemoteSessionCleanupLifecycleTests {
         _ = try #require(await Self.nextCleanupCommand(runner))
 
         #expect(!reattachedBeforeControllerReady)
+        #expect(workspace.remoteSessionController == nil)
         #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
         #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
 
@@ -85,7 +86,6 @@ struct RemoteSessionCleanupLifecycleTests {
         await workspace.remoteSessionTransitionTask?.value
         workspace.teardownAllPanels()
     }
-
     @Test
     func replacementStartsOnlyAfterPriorTransportCleanupFinishes() async throws {
         let runner = CleanupLifecycleRecordingRunner()

--- a/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
+++ b/cmuxTests/RemoteSessionCleanupLifecycleTests.swift
@@ -38,6 +38,55 @@ struct RemoteSessionCleanupLifecycleTests {
     }
 
     @Test
+    func manualReconnectWaitsForControllerBeforeReattachingPersistentPanel() async throws {
+        let runner = CleanupLifecycleRecordingRunner()
+        let workspace = Workspace()
+        workspace.remoteSessionProcessRunnerOverrideForTesting = runner
+        workspace.configureRemoteConnection(Self.configuration(), autoConnect: true)
+        _ = try #require(await Self.nextBootstrapRequest(runner))
+
+        let panel = try #require(workspace.focusedTerminalPanel)
+        let disconnectedSurface = panel.surface
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to cmux-macmini",
+            target: "cmux-macmini"
+        )
+        workspace.disconnectRemoteConnection(clearConfiguration: false)
+        _ = try #require(await Self.nextCleanupCommand(runner))
+        await workspace.remoteSessionTransitionTask?.value
+
+        #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
+        #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
+
+        let reattachedBeforeControllerReady = workspace.reconnectRemoteConnection(surfaceId: panel.id)
+
+        #expect(!reattachedBeforeControllerReady)
+        #expect(workspace.terminalPanel(for: panel.id)?.surface === disconnectedSurface)
+        #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
+
+        _ = try #require(await Self.nextCleanupCommand(runner))
+        _ = try #require(await Self.nextBootstrapRequest(runner))
+        await workspace.remoteSessionTransitionTask?.value
+        #expect(workspace.remoteSessionController != nil)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to cmux-macmini",
+            target: "cmux-macmini"
+        )
+
+        #expect(workspace.terminalPanel(for: panel.id)?.surface !== disconnectedSurface)
+        #expect(!workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
+
+        workspace.disconnectRemoteConnection(clearConfiguration: true)
+        _ = try #require(await Self.nextCleanupCommand(runner))
+        _ = try #require(await Self.nextCleanupCommand(runner))
+        await workspace.remoteSessionTransitionTask?.value
+        workspace.teardownAllPanels()
+    }
+
+    @Test
     func replacementStartsOnlyAfterPriorTransportCleanupFinishes() async throws {
         let runner = CleanupLifecycleRecordingRunner()
         let workspace = Workspace()


### PR DESCRIPTION
Closes #10160

## Summary

Persistent-SSH reconnect could respawn a preserved pane attach wrapper while the replacement management controller was still being cleaned up or installed. The wrapper raced that handoff, received a transient remote-daemon-unavailable response, and left the workspace without a live attach path.

## Fix

- Gate persistent-SSH pane reattachment on the controller connection state.
- Let the reconnect transition install the replacement controller before replaying preserved panes.
- Notify PTY-controller waiters at the actual asynchronous controller-install boundary.
- Reconcile a connected state received during the handoff after controller installation.

## Verification

- Regression test is the first commit: `manualReconnectWaitsForControllerBeforeReattachingPersistentPanel` covers disconnect → reconnect ordering, preserved placeholder ownership, delayed controller installation, and final reattachment.
- Hosted focused run [32133682176](https://github.com/manaflow-ai/cmux/actions/runs/32133682176) passed all 13 `RemoteSessionCleanupLifecycleTests` tests.
- Local parse, diff, and test-wiring checks pass; no local app build or Xcode test was run.
- Full CI run [32294102775](https://github.com/manaflow-ai/cmux/actions/runs/32294102775) was retried once. Remaining failures are unrelated to this diff: the existing `BrowserPanelView.swift` warning-budget overage (10 vs 9), two timeouts in `CmxConnectivityPeerSessionTests`, and pre-existing browser/CLI app-host flakes.

Localization audit: no user-facing strings changed.