### PR TITLE
Fix persistent SSH replayed terminal queries

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13492,7 +13492,10 @@ struct CMUXCLI {
             if count > 0 {
                 outputProgress.recordOutput(byteCount: count)
                 reconnectInputFilterControl?.stopFilteringBeforeFirstOutput(unlessAlreadyRequested: &reconnectInputFilterStopRequested)
-                cliWriteStdout(replayOutputFilter.filter(Data(outputBuffer.prefix(count))))
+                let output = replayOutputFilter.filter(Data(outputBuffer.prefix(count)))
+                if !output.isEmpty {
+                    cliWriteStdout(output)
+                }
             } else if count == 0 {
                 let trailingReplay = replayOutputFilter.finish()
                 if !trailingReplay.isEmpty {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13464,6 +13464,14 @@ struct CMUXCLI {
         }
         var reconnectInputFilterStopRequested = false
         var outputProgress = SSHPTYAttachOutputProgress(replayBytes: bridgeReplayBytes)
+        // A persistent reattach's initial bytes are historical remote PTY
+        // output. Strip terminal queries before Ghostty parses them; otherwise
+        // its replies can arrive after the reconnect stdin filter hands off to
+        // live input and land in the remote shell.
+        let filtersReplayOutput = requireExisting && command == nil
+        var replayOutputFilter = SSHPTYReplayOutputFilter(
+            replayBytes: filtersReplayOutput ? bridgeReplayBytes : 0
+        )
         func finishBridgeClosedNormally() throws {
             resizeMonitor.cancel()
             readinessDelivery?.cancel()
@@ -13484,12 +13492,20 @@ struct CMUXCLI {
             if count > 0 {
                 outputProgress.recordOutput(byteCount: count)
                 reconnectInputFilterControl?.stopFilteringBeforeFirstOutput(unlessAlreadyRequested: &reconnectInputFilterStopRequested)
-                cliWriteStdout(Data(outputBuffer.prefix(count)))
+                cliWriteStdout(replayOutputFilter.filter(Data(outputBuffer.prefix(count))))
             } else if count == 0 {
+                let trailingReplay = replayOutputFilter.finish()
+                if !trailingReplay.isEmpty {
+                    cliWriteStdout(trailingReplay)
+                }
                 try finishBridgeClosedNormally()
                 return
             } else if errno != EINTR {
                 if sshPTYBridgeReadErrorIsEOF(errno) {
+                    let trailingReplay = replayOutputFilter.finish()
+                    if !trailingReplay.isEmpty {
+                        cliWriteStdout(trailingReplay)
+                    }
                     try finishBridgeClosedNormally()
                     return
                 }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReconnectInputByteFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReconnectInputByteFilter.swift
@@ -152,11 +152,10 @@ public struct SSHPTYReconnectInputByteFilter: Sendable {
     ) -> SequenceMatch {
         // XTVERSION replies are DCS `>|text ST`. The payload is deliberately
         // treated as opaque: only the protocol prefix identifies this reply.
-        guard start + 3 < bytes.count,
-              bytes[start + 2] == 0x3E,
-              bytes[start + 3] == 0x7C else {
-            return start + 3 >= bytes.count ? .incomplete : .passThrough
-        }
+        guard start + 2 < bytes.count else { return .incomplete }
+        guard bytes[start + 2] == 0x3E else { return .passThrough }
+        guard start + 3 < bytes.count else { return .incomplete }
+        guard bytes[start + 3] == 0x7C else { return .passThrough }
         var cursor = start + 4
         while cursor < bytes.count {
             if bytes[cursor] == escape {

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReconnectInputByteFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReconnectInputByteFilter.swift
@@ -11,6 +11,7 @@ public struct SSHPTYReconnectInputByteFilter: Sendable {
     private static let bell: UInt8 = 0x07
     private static let leftBracket: UInt8 = 0x5B
     private static let rightBracket: UInt8 = 0x5D
+    private static let dcs: UInt8 = 0x50
     private static let backslash: UInt8 = 0x5C
     private static let semicolon: UInt8 = 0x3B
     private static let questionMark: UInt8 = 0x3F
@@ -138,9 +139,35 @@ public struct SSHPTYReconnectInputByteFilter: Sendable {
             return oscColorReplySequence(in: bytes, at: start)
         case leftBracket:
             return csiProbeReplySequence(in: bytes, at: start)
+        case dcs:
+            return xtversionReplySequence(in: bytes, at: start)
         default:
             return .passThrough
         }
+    }
+
+    private static func xtversionReplySequence(
+        in bytes: [UInt8],
+        at start: Int
+    ) -> SequenceMatch {
+        // XTVERSION replies are DCS `>|text ST`. The payload is deliberately
+        // treated as opaque: only the protocol prefix identifies this reply.
+        guard start + 3 < bytes.count,
+              bytes[start + 2] == 0x3E,
+              bytes[start + 3] == 0x7C else {
+            return start + 3 >= bytes.count ? .incomplete : .passThrough
+        }
+        var cursor = start + 4
+        while cursor < bytes.count {
+            if bytes[cursor] == escape {
+                guard cursor + 1 < bytes.count else { return .incomplete }
+                if bytes[cursor + 1] == backslash {
+                    return .strip(length: cursor - start + 2)
+                }
+            }
+            cursor += 1
+        }
+        return .incomplete
     }
 
     private static func oscColorReplySequence(

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
@@ -1,0 +1,288 @@
+public import Foundation
+
+/// Removes terminal query requests from the initial replay of a persistent SSH PTY.
+///
+/// The remote PTY owns the captured scrollback. Replaying a query into the local
+/// terminal emulator would make the emulator answer it against the live shell,
+/// so only the declared replay prefix is inspected. Bytes after that boundary
+/// are forwarded byte-for-byte and live terminal negotiation remains unchanged.
+public struct SSHPTYReplayOutputFilter: Sendable {
+    private static let escape: UInt8 = 0x1B
+    private static let enquiry: UInt8 = 0x05
+    private static let leftBracket: UInt8 = 0x5B
+    private static let rightBracket: UInt8 = 0x5D
+    private static let dcs: UInt8 = 0x50
+    private static let apc: UInt8 = 0x5F
+    private static let bell: UInt8 = 0x07
+    private static let backslash: UInt8 = 0x5C
+    private static let semicolon: UInt8 = 0x3B
+    private static let maxPendingBytes = 4 * 1024
+
+    private enum SequenceMatch {
+        case strip(length: Int)
+        case incomplete
+        case passThrough
+    }
+
+    private var replayBytesRemaining: Int
+    private var pending = [UInt8]()
+
+    /// Creates a filter for one ordered PTY attachment output stream.
+    ///
+    /// - Parameter replayBytes: Number of leading output bytes belonging to
+    ///   the daemon's scrollback replay. Negative values are treated as zero.
+    public init(replayBytes: Int) {
+        replayBytesRemaining = max(0, replayBytes)
+    }
+
+    /// Filters one output chunk, stripping only query sequences that begin in replay.
+    ///
+    /// A candidate may span output chunks and the replay/live boundary. The
+    /// candidate stays bounded; malformed or oversized input fails open so
+    /// visible output is not lost.
+    ///
+    /// - Parameter data: Ordered bytes received from the PTY bridge.
+    /// - Returns: Bytes safe to deliver to the local terminal emulator.
+    public mutating func filter(_ data: Data) -> Data {
+        guard !data.isEmpty else { return Data() }
+        guard replayBytesRemaining > 0 || !pending.isEmpty else { return data }
+
+        var bytes = pending
+        pending.removeAll(keepingCapacity: true)
+        bytes.append(contentsOf: data)
+
+        var output = Data()
+        var index = 0
+        let replayBytesInBuffer = min(replayBytesRemaining, bytes.count)
+        while index < bytes.count {
+            let startsInReplay = index < replayBytesInBuffer
+            if bytes[index] == Self.enquiry, startsInReplay {
+                index += 1
+                replayBytesRemaining -= 1
+                continue
+            }
+
+            guard bytes[index] == Self.escape else {
+                output.append(bytes[index])
+                if startsInReplay { replayBytesRemaining -= 1 }
+                index += 1
+                continue
+            }
+
+            switch Self.querySequence(in: bytes, at: index) {
+            case .strip(let length) where startsInReplay:
+                index += length
+                replayBytesRemaining -= min(length, replayBytesRemaining)
+            case .incomplete where startsInReplay:
+                let suffix = bytes[index...]
+                guard suffix.count <= Self.maxPendingBytes else {
+                    output.append(contentsOf: suffix)
+                    replayBytesRemaining -= min(suffix.count, replayBytesRemaining)
+                    return output
+                }
+                pending.append(contentsOf: suffix)
+                return output
+            case .passThrough, .strip(_):
+                output.append(bytes[index])
+                if startsInReplay { replayBytesRemaining -= 1 }
+                index += 1
+            case .incomplete:
+                output.append(contentsOf: bytes[index...])
+                return output
+            }
+        }
+        return output
+    }
+
+    /// Flushes an unterminated candidate when the bridge closes.
+    ///
+    /// Unterminated bytes cannot produce a terminal response, so they are
+    /// returned unchanged to preserve the replay artifact.
+    public mutating func finish() -> Data {
+        guard !pending.isEmpty else { return Data() }
+        let value = Data(pending)
+        pending.removeAll(keepingCapacity: false)
+        replayBytesRemaining = max(0, replayBytesRemaining - value.count)
+        return value
+    }
+
+    /// Number of replay bytes not yet consumed by the filter.
+    public var remainingReplayBytes: Int { replayBytesRemaining }
+
+    private static func querySequence(in bytes: [UInt8], at start: Int) -> SequenceMatch {
+        guard start < bytes.count, bytes[start] == Self.escape else {
+            return .passThrough
+        }
+        guard start + 1 < bytes.count else { return .incomplete }
+        switch bytes[start + 1] {
+        case Self.leftBracket:
+            return csiQuery(in: bytes, at: start)
+        case Self.rightBracket:
+            return oscQuery(in: bytes, at: start)
+        case Self.dcs:
+            return dcsQuery(in: bytes, at: start)
+        case Self.apc:
+            return apcQuery(in: bytes, at: start)
+        case 0x5A: // DECID (ESC Z)
+            return .strip(length: 2)
+        default:
+            return .passThrough
+        }
+    }
+
+    private static func csiQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
+        var cursor = start + 2
+        var intermediates = [UInt8]()
+        var parameters = [UInt8]()
+        var sawParameter = false
+
+        while cursor < bytes.count {
+            let byte = bytes[cursor]
+            if byte >= 0x40, byte <= 0x7E {
+                return isCSIQuery(
+                    parameters: parameters,
+                    intermediates: intermediates,
+                    final: byte,
+                    sawParameter: sawParameter
+                )
+                    ? .strip(length: cursor - start + 1)
+                    : .passThrough
+            }
+            if byte >= 0x30, byte <= 0x3B {
+                parameters.append(byte)
+                sawParameter = true
+                cursor += 1
+                continue
+            }
+            if (byte >= 0x20 && byte <= 0x2F) || (byte >= 0x3C && byte <= 0x3F) {
+                intermediates.append(byte)
+                cursor += 1
+                continue
+            }
+            return .passThrough
+        }
+        return .incomplete
+    }
+
+    private static func isCSIQuery(
+        parameters: [UInt8],
+        intermediates: [UInt8],
+        final: UInt8,
+        sawParameter: Bool
+    ) -> Bool {
+        switch final {
+        case 0x63: // DA1/DA2/DA3
+            return intermediates.isEmpty || intermediates == [0x3E] || intermediates == [0x3D]
+        case 0x6E: // DSR
+            return (intermediates.isEmpty || intermediates == [0x3F]) && sawSingleNumericParameter(parameters)
+        case 0x70: // DECRQM / DECRQM-ANSI
+            return (intermediates == [0x24] || intermediates == [0x3F, 0x24]) &&
+                sawSingleNumericParameter(parameters)
+        case 0x71: // XTVERSION (CSI > q)
+            return intermediates == [0x3E] && !sawParameter
+        case 0x74: // XTWINOPS size queries
+            return intermediates.isEmpty && [
+                Array("14".utf8), Array("16".utf8), Array("18".utf8), Array("21".utf8),
+            ].contains(parameters)
+        case 0x75: // Kitty keyboard query (CSI ? u)
+            return intermediates == [0x3F] && !sawParameter
+        default:
+            return false
+        }
+    }
+
+    private static func sawSingleNumericParameter(_ parameters: [UInt8]) -> Bool {
+        !parameters.isEmpty && parameters.allSatisfy { byte in
+            byte >= 0x30 && byte <= 0x39
+        }
+    }
+
+    private static func oscQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
+        var cursor = start + 2
+        var command = [UInt8]()
+        while cursor < bytes.count, bytes[cursor] >= 0x30, bytes[cursor] <= 0x39 {
+            command.append(bytes[cursor])
+            cursor += 1
+        }
+        guard cursor < bytes.count, bytes[cursor] == Self.semicolon else {
+            return cursor == bytes.count ? .incomplete : .passThrough
+        }
+        cursor += 1
+        let payloadStart = cursor
+        while cursor < bytes.count {
+            if bytes[cursor] == Self.bell {
+                return isColorQuery(command: command, payload: Array(bytes[payloadStart..<cursor]))
+                    ? .strip(length: cursor - start + 1)
+                    : .passThrough
+            }
+            if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
+               bytes[cursor + 1] == Self.backslash {
+                return isColorQuery(command: command, payload: Array(bytes[payloadStart..<cursor]))
+                    ? .strip(length: cursor - start + 2)
+                    : .passThrough
+            }
+            cursor += 1
+        }
+        return .incomplete
+    }
+
+    private static func isColorQuery(command: [UInt8], payload: [UInt8]) -> Bool {
+        guard command == [0x34] || command == [0x31, 0x30] ||
+            command == [0x31, 0x31] || command == [0x31, 0x32] else {
+            return false
+        }
+        return payload.first == 0x3F
+    }
+
+    private static func dcsQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
+        let payloadStart = start + 2
+        guard payloadStart < bytes.count else { return .incomplete }
+        var cursor = payloadStart
+        while cursor < bytes.count {
+            if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
+               bytes[cursor + 1] == Self.backslash {
+                let payload = bytes[payloadStart..<cursor]
+                let isQuery = payload.starts(with: [0x2B, 0x71]) ||
+                    payload.starts(with: [0x24, 0x71])
+                return isQuery ? .strip(length: cursor - start + 2) : .passThrough
+            }
+            cursor += 1
+        }
+        return .incomplete
+    }
+
+    private static func apcQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
+        let payloadStart = start + 2
+        guard payloadStart < bytes.count else { return .incomplete }
+        var cursor = payloadStart
+        while cursor < bytes.count {
+            if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
+               bytes[cursor + 1] == Self.backslash {
+                let payload = bytes[payloadStart..<cursor]
+                // Kitty graphics query commands use `a=q`; leave image and
+                // drawing commands intact so replayed visuals are preserved.
+                let isQuery = payload.starts(with: [0x47]) && containsSubsequence(
+                    payload,
+                    [0x61, 0x3D, 0x71]
+                )
+                return isQuery ? .strip(length: cursor - start + 2) : .passThrough
+            }
+            cursor += 1
+        }
+        return .incomplete
+    }
+
+    private static func containsSubsequence(_ value: ArraySlice<UInt8>, _ needle: [UInt8]) -> Bool {
+        guard !needle.isEmpty, needle.count <= value.count else { return false }
+        var index = value.startIndex
+        while index < value.endIndex {
+            guard let end = value.index(index, offsetBy: needle.count, limitedBy: value.endIndex),
+                  end <= value.endIndex else {
+                return false
+            }
+            if Array(value[index..<end]) == needle { return true }
+            index = value.index(after: index)
+        }
+        return false
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
@@ -203,7 +203,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         case 0x71: // XTVERSION (CSI > q)
             return intermediateCount == 1 && firstIntermediate == 0x3E && !hasParameter
         case 0x74: // XTWINOPS size queries
-            return intermediateCount == 0 && singleNumericParameter && parameterDigitCount == 2 && (
+            return intermediateCount == 0 && singleNumericParameter && (
                 parameterValue == 14 || parameterValue == 16 ||
                 parameterValue == 18 || parameterValue == 21 ||
                 parameterValue == 11 || parameterValue == 13 ||
@@ -290,8 +290,9 @@ public struct SSHPTYReplayOutputFilter: Sendable {
                 let payload = bytes[payloadStart..<cursor]
                 // Kitty graphics query commands use `a=q`; leave image and
                 // drawing commands intact so replayed visuals are preserved.
+                let headerEnd = payload.firstIndex(of: Self.semicolon) ?? payload.endIndex
                 let isQuery = payload.starts(with: [0x47]) && containsSubsequence(
-                    payload,
+                    payload[..<headerEnd],
                     [0x61, 0x3D, 0x71]
                 )
                 return isQuery ? .strip(length: cursor - start + 2) : .passThrough

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
@@ -106,9 +106,6 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         return value
     }
 
-    /// Number of replay bytes not yet consumed by the filter.
-    public var remainingReplayBytes: Int { replayBytesRemaining }
-
     private static func querySequence(in bytes: [UInt8], at start: Int) -> SequenceMatch {
         guard start < bytes.count, bytes[start] == Self.escape else {
             return .passThrough
@@ -208,7 +205,10 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         case 0x74: // XTWINOPS size queries
             return intermediateCount == 0 && singleNumericParameter && parameterDigitCount == 2 && (
                 parameterValue == 14 || parameterValue == 16 ||
-                parameterValue == 18 || parameterValue == 21
+                parameterValue == 18 || parameterValue == 21 ||
+                parameterValue == 11 || parameterValue == 13 ||
+                parameterValue == 15 || parameterValue == 19 ||
+                parameterValue == 20
             )
         case 0x75: // Kitty keyboard query (CSI ? u)
             return intermediateCount == 1 && firstIntermediate == 0x3F && !hasParameter

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
@@ -132,31 +132,46 @@ public struct SSHPTYReplayOutputFilter: Sendable {
 
     private static func csiQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
         var cursor = start + 2
-        var intermediates = [UInt8]()
-        var parameters = [UInt8]()
-        var sawParameter = false
+        var intermediateCount = 0
+        var firstIntermediate: UInt8 = 0
+        var secondIntermediate: UInt8 = 0
+        var parameterDigitCount = 0
+        var parameterSeparatorCount = 0
+        var parameterValue = 0
 
         while cursor < bytes.count {
             guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             let byte = bytes[cursor]
             if byte >= 0x40, byte <= 0x7E {
                 return isCSIQuery(
-                    parameters: parameters,
-                    intermediates: intermediates,
+                    intermediateCount: intermediateCount,
+                    firstIntermediate: firstIntermediate,
+                    secondIntermediate: secondIntermediate,
+                    parameterDigitCount: parameterDigitCount,
+                    parameterSeparatorCount: parameterSeparatorCount,
+                    parameterValue: parameterValue,
                     final: byte,
-                    sawParameter: sawParameter
                 )
                     ? .strip(length: cursor - start + 1)
                     : .passThrough
             }
-            if byte >= 0x30, byte <= 0x3B {
-                parameters.append(byte)
-                sawParameter = true
+            if byte >= 0x30, byte <= 0x39 {
+                parameterDigitCount += 1
+                if parameterValue <= 100_000 {
+                    parameterValue = min(100_001, parameterValue * 10 + Int(byte - 0x30))
+                }
+                cursor += 1
+                continue
+            }
+            if byte == 0x3A || byte == Self.semicolon {
+                parameterSeparatorCount += 1
                 cursor += 1
                 continue
             }
             if (byte >= 0x20 && byte <= 0x2F) || (byte >= 0x3C && byte <= 0x3F) {
-                intermediates.append(byte)
+                intermediateCount += 1
+                if intermediateCount == 1 { firstIntermediate = byte }
+                if intermediateCount == 2 { secondIntermediate = byte }
                 cursor += 1
                 continue
             }
@@ -166,64 +181,68 @@ public struct SSHPTYReplayOutputFilter: Sendable {
     }
 
     private static func isCSIQuery(
-        parameters: [UInt8],
-        intermediates: [UInt8],
+        intermediateCount: Int,
+        firstIntermediate: UInt8,
+        secondIntermediate: UInt8,
+        parameterDigitCount: Int,
+        parameterSeparatorCount: Int,
+        parameterValue: Int,
         final: UInt8,
-        sawParameter: Bool
     ) -> Bool {
+        let hasParameter = parameterDigitCount > 0 || parameterSeparatorCount > 0
+        let singleNumericParameter = parameterDigitCount > 0 && parameterSeparatorCount == 0
         switch final {
         case 0x63: // DA1/DA2/DA3
-            return intermediates.isEmpty || intermediates == [0x3E] || intermediates == [0x3D]
+            return intermediateCount == 0 ||
+                (intermediateCount == 1 && (firstIntermediate == 0x3E || firstIntermediate == 0x3D))
         case 0x6E: // DSR
-            return (intermediates.isEmpty || intermediates == [0x3F]) && sawSingleNumericParameter(parameters)
+            return (intermediateCount == 0 || (intermediateCount == 1 && firstIntermediate == 0x3F)) &&
+                singleNumericParameter
         case 0x70: // DECRQM / DECRQM-ANSI
-            return (intermediates == [0x24] || intermediates == [0x3F, 0x24]) &&
-                sawSingleNumericParameter(parameters)
+            return (
+                (intermediateCount == 1 && firstIntermediate == 0x24) ||
+                (intermediateCount == 2 && firstIntermediate == 0x3F && secondIntermediate == 0x24)
+            ) && singleNumericParameter
         case 0x71: // XTVERSION (CSI > q)
-            return intermediates == [0x3E] && !sawParameter
+            return intermediateCount == 1 && firstIntermediate == 0x3E && !hasParameter
         case 0x74: // XTWINOPS size queries
-            return intermediates.isEmpty && (
-                parameters == [0x31, 0x34] ||
-                parameters == [0x31, 0x36] ||
-                parameters == [0x31, 0x38] ||
-                parameters == [0x32, 0x31]
+            return intermediateCount == 0 && singleNumericParameter && parameterDigitCount == 2 && (
+                parameterValue == 14 || parameterValue == 16 ||
+                parameterValue == 18 || parameterValue == 21
             )
         case 0x75: // Kitty keyboard query (CSI ? u)
-            return intermediates == [0x3F] && !sawParameter
+            return intermediateCount == 1 && firstIntermediate == 0x3F && !hasParameter
         default:
             return false
         }
     }
 
-    private static func sawSingleNumericParameter(_ parameters: [UInt8]) -> Bool {
-        !parameters.isEmpty && parameters.allSatisfy { byte in
-            byte >= 0x30 && byte <= 0x39
-        }
-    }
-
     private static func oscQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {
         var cursor = start + 2
-        var command = [UInt8]()
+        var command = 0
+        var commandDigitCount = 0
         while cursor < bytes.count, bytes[cursor] >= 0x30, bytes[cursor] <= 0x39 {
             guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
-            command.append(bytes[cursor])
+            commandDigitCount += 1
+            command = min(100_001, command * 10 + Int(bytes[cursor] - 0x30))
             cursor += 1
         }
         guard cursor < bytes.count, bytes[cursor] == Self.semicolon else {
             return cursor == bytes.count ? .incomplete : .passThrough
         }
         cursor += 1
-        let payloadStart = cursor
+        var payloadFirst: UInt8?
         while cursor < bytes.count {
             guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
+            if payloadFirst == nil { payloadFirst = bytes[cursor] }
             if bytes[cursor] == Self.bell {
-                return isColorQuery(command: command, payload: Array(bytes[payloadStart..<cursor]))
+                return isColorQuery(command: command, commandDigitCount: commandDigitCount, payloadFirst: payloadFirst)
                     ? .strip(length: cursor - start + 1)
                     : .passThrough
             }
             if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
                bytes[cursor + 1] == Self.backslash {
-                return isColorQuery(command: command, payload: Array(bytes[payloadStart..<cursor]))
+                return isColorQuery(command: command, commandDigitCount: commandDigitCount, payloadFirst: payloadFirst)
                     ? .strip(length: cursor - start + 2)
                     : .passThrough
             }
@@ -232,12 +251,14 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         return .incomplete
     }
 
-    private static func isColorQuery(command: [UInt8], payload: [UInt8]) -> Bool {
-        guard command == [0x34] || command == [0x31, 0x30] ||
-            command == [0x31, 0x31] || command == [0x31, 0x32] else {
-            return false
-        }
-        return payload.first == 0x3F
+    private static func isColorQuery(
+        command: Int,
+        commandDigitCount: Int,
+        payloadFirst: UInt8?
+    ) -> Bool {
+        commandDigitCount > 0 &&
+            (command == 4 || command == 10 || command == 11 || command == 12) &&
+            payloadFirst == 0x3F
     }
 
     private static func dcsQuery(in bytes: [UInt8], at start: Int) -> SequenceMatch {

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYReplayOutputFilter.swift
@@ -137,6 +137,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         var sawParameter = false
 
         while cursor < bytes.count {
+            guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             let byte = bytes[cursor]
             if byte >= 0x40, byte <= 0x7E {
                 return isCSIQuery(
@@ -181,9 +182,12 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         case 0x71: // XTVERSION (CSI > q)
             return intermediates == [0x3E] && !sawParameter
         case 0x74: // XTWINOPS size queries
-            return intermediates.isEmpty && [
-                Array("14".utf8), Array("16".utf8), Array("18".utf8), Array("21".utf8),
-            ].contains(parameters)
+            return intermediates.isEmpty && (
+                parameters == [0x31, 0x34] ||
+                parameters == [0x31, 0x36] ||
+                parameters == [0x31, 0x38] ||
+                parameters == [0x32, 0x31]
+            )
         case 0x75: // Kitty keyboard query (CSI ? u)
             return intermediates == [0x3F] && !sawParameter
         default:
@@ -201,6 +205,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         var cursor = start + 2
         var command = [UInt8]()
         while cursor < bytes.count, bytes[cursor] >= 0x30, bytes[cursor] <= 0x39 {
+            guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             command.append(bytes[cursor])
             cursor += 1
         }
@@ -210,6 +215,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         cursor += 1
         let payloadStart = cursor
         while cursor < bytes.count {
+            guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             if bytes[cursor] == Self.bell {
                 return isColorQuery(command: command, payload: Array(bytes[payloadStart..<cursor]))
                     ? .strip(length: cursor - start + 1)
@@ -239,6 +245,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         guard payloadStart < bytes.count else { return .incomplete }
         var cursor = payloadStart
         while cursor < bytes.count {
+            guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
                bytes[cursor + 1] == Self.backslash {
                 let payload = bytes[payloadStart..<cursor]
@@ -256,6 +263,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
         guard payloadStart < bytes.count else { return .incomplete }
         var cursor = payloadStart
         while cursor < bytes.count {
+            guard cursor - start <= Self.maxPendingBytes else { return .passThrough }
             if bytes[cursor] == Self.escape, cursor + 1 < bytes.count,
                bytes[cursor + 1] == Self.backslash {
                 let payload = bytes[payloadStart..<cursor]
@@ -280,7 +288,7 @@ public struct SSHPTYReplayOutputFilter: Sendable {
                   end <= value.endIndex else {
                 return false
             }
-            if Array(value[index..<end]) == needle { return true }
+            if value[index..<end].elementsEqual(needle) { return true }
             index = value.index(after: index)
         }
         return false

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReconnectInputByteFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReconnectInputByteFilterTests.swift
@@ -98,6 +98,15 @@ struct SSHPTYReconnectInputByteFilterTests {
         #expect(filter.isFilteringActive)
     }
 
+    @Test("passes through a mismatching DCS prefix without waiting")
+    func passesThroughMismatchingDCSPrefix() {
+        var filter = SSHPTYReconnectInputByteFilter(enabled: true)
+        let input = Data("\u{1B}Px".utf8)
+
+        #expect(filter.filter(input) == input)
+        #expect(!filter.isFilteringActive)
+    }
+
     @Test func stopsFilteringAndForwardsPendingInputWhenNoContinuationArrives() {
         var filter = SSHPTYReconnectInputByteFilter(enabled: true)
         let escape = Data([0x1B])

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReconnectInputByteFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReconnectInputByteFilterTests.swift
@@ -85,6 +85,19 @@ struct SSHPTYReconnectInputByteFilterTests {
         #expect(filter.filter(freshControlCAndEnter) == freshControlCAndEnter)
     }
 
+    @Test("strips XTVERSION DCS replies alongside CSI replies")
+    func stripsXtversionReply() {
+        var filter = SSHPTYReconnectInputByteFilter(enabled: true)
+        let replies = Data((
+            "\u{1B}P>|ghostty 1.3.2-HEAD\u{1B}\\" +
+            "\u{1B}[?62;22;52c" +
+            "\u{1B}[?2026;2$y"
+        ).utf8)
+
+        #expect(filter.filter(replies).isEmpty)
+        #expect(filter.isFilteringActive)
+    }
+
     @Test func stopsFilteringAndForwardsPendingInputWhenNoContinuationArrives() {
         var filter = SSHPTYReconnectInputByteFilter(enabled: true)
         let escape = Data([0x1B])

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import CmuxFoundation
+
+@Suite("SSH PTY replay output filter")
+struct SSHPTYReplayOutputFilterTests {
+    @Test("reported terminal queries are removed without changing visible replay text")
+    func stripsTerminalQueriesFromReplay() {
+        let replay = Data(
+            (
+                "before\n" +
+                "\u{1B}[>q" +
+                "\u{1B}[c" +
+                "\u{1B}[?2026$p" +
+                "\u{1B}]11;?\u{07}" +
+                "\u{1B}P+q544e" + "\u{1B}\\" +
+                "after\n"
+            ).utf8
+        )
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
+        var output = Data()
+        for byte in replay {
+            output.append(filter.filter(Data([byte])))
+        }
+
+        #expect(String(decoding: output, as: UTF8.self) == "before\nafter\n")
+        #expect(filter.remainingReplayBytes == 0)
+    }
+
+    @Test("live terminal negotiation after replay remains byte-for-byte")
+    func preservesLiveQueriesAfterReplayBoundary() {
+        let replay = Data("replay\n\u{1B}[>q".utf8)
+        let live = Data("\u{1B}[>q\u{1B}[c".utf8)
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
+
+        let replayOutput = filter.filter(replay)
+        let liveOutput = filter.filter(live)
+
+        #expect(String(decoding: replayOutput, as: UTF8.self) == "replay\n")
+        #expect(liveOutput == live)
+    }
+
+    @Test("a query split at the replay boundary is still removed")
+    func stripsQueryThatCrossesReplayBoundary() {
+        let replayPrefix = Data("replay\n\u{1B}[>".utf8)
+        let queryTailAndLive = Data("q\u{1B}[cLIVE".utf8)
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replayPrefix.count + 1)
+
+        let first = filter.filter(replayPrefix)
+        let second = filter.filter(queryTailAndLive)
+
+        #expect(first == Data("replay\n".utf8))
+        #expect(second == Data("\u{1B}[cLIVE".utf8))
+    }
+
+    @Test("non-query terminal controls remain in replay")
+    func preservesNonQueryControls() {
+        let replay = Data("\u{1B}[31mred\u{1B}]0;title\u{07}\n".utf8)
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
+
+        #expect(filter.filter(replay) == replay)
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
@@ -27,6 +27,25 @@ struct SSHPTYReplayOutputFilterTests {
         #expect(filter.remainingReplayBytes == 0)
     }
 
+    @Test("all supported Ghostty query families are removed from replay")
+    func stripsAdditionalGhosttyQueryFamilies() {
+        let replay = Data(
+            (
+                "before" +
+                "\u{1B}Z" +
+                "\u{1B}[14t" +
+                "\u{1B}[?6n" +
+                "\u{1B}[?u" +
+                "\u{1B}P$qm\u{1B}\\" +
+                "\u{1B}_Ga=q,i=1;\u{1B}\\" +
+                "after"
+            ).utf8
+        )
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
+
+        #expect(filter.filter(replay) == Data("beforeafter".utf8))
+    }
+
     @Test("live terminal negotiation after replay remains byte-for-byte")
     func preservesLiveQueriesAfterReplayBoundary() {
         let replay = Data("replay\n\u{1B}[>q".utf8)

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYReplayOutputFilterTests.swift
@@ -24,7 +24,6 @@ struct SSHPTYReplayOutputFilterTests {
         }
 
         #expect(String(decoding: output, as: UTF8.self) == "before\nafter\n")
-        #expect(filter.remainingReplayBytes == 0)
     }
 
     @Test("all supported Ghostty query families are removed from replay")
@@ -40,6 +39,17 @@ struct SSHPTYReplayOutputFilterTests {
                 "\u{1B}_Ga=q,i=1;\u{1B}\\" +
                 "after"
             ).utf8
+        )
+        var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
+
+        #expect(filter.filter(replay) == Data("beforeafter".utf8))
+    }
+
+    @Test("additional XTWINOPS report queries are removed")
+    func stripsAdditionalXTWINOPSReports() {
+        let reportValues = [11, 13, 15, 19, 20]
+        let replay = Data(
+            ("before" + reportValues.map { "\u{1B}[\($0)t" }.joined() + "after").utf8
         )
         var filter = SSHPTYReplayOutputFilter(replayBytes: replay.count)
 

--- a/cmuxTests/CLINotifyProcessTestSupport.swift
+++ b/cmuxTests/CLINotifyProcessTestSupport.swift
@@ -283,8 +283,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 return
             }
             status.append(0x0A)
-            writeAll(fd: clientFD, data: status)
-            writeAll(fd: clientFD, data: replay)
+            Self.writeAll(fd: clientFD, data: status)
+            Self.writeAll(fd: clientFD, data: replay)
         }
         return handled
     }
@@ -522,5 +522,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
             isDirectory: true
         ).appendingPathComponent(".config", isDirectory: true).path
         return resolved
+    }
+
+    private static func writeAll(fd: Int32, data: Data) {
+        data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return }
+            var remaining = rawBuffer.count
+            var cursor = base
+            while remaining > 0 {
+                let written = Darwin.write(fd, cursor, remaining)
+                if written > 0 {
+                    remaining -= written
+                    cursor = cursor.advanced(by: written)
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    return
+                }
+            }
+        }
     }
 }

--- a/cmuxTests/CLINotifyProcessTestSupport.swift
+++ b/cmuxTests/CLINotifyProcessTestSupport.swift
@@ -244,6 +244,51 @@ extension CLINotifyProcessIntegrationRegressionTests {
         return handled
     }
 
+    func startBridgeReadySendingReplayServer(
+        listenerFD: Int32,
+        replay: Data
+    ) -> XCTestExpectation {
+        let handled = expectation(description: "pty bridge replay server handled")
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.fulfill() }
+
+            var clientAddr = sockaddr_in()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while !pending.contains(0x0A) {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return
+                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+            }
+
+            let payload: [String: Any] = [
+                "type": "ready",
+                "attachment_token": "attach-token",
+                "replay_bytes": replay.count,
+            ]
+            guard var status = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+                return
+            }
+            status.append(0x0A)
+            writeAll(fd: clientFD, data: status)
+            writeAll(fd: clientFD, data: replay)
+        }
+        return handled
+    }
+
     func startBridgeReadyThenResetAfterClientEOFServer(
         listenerFD: Int32,
         waitBeforeClientEOF: [DispatchSemaphore] = []

--- a/cmuxTests/CLISSHPTYAttachProbeReplyRegressionTests.swift
+++ b/cmuxTests/CLISSHPTYAttachProbeReplyRegressionTests.swift
@@ -10,6 +10,95 @@ import Testing
 #endif
 
 extension CLINotifyProcessIntegrationRegressionTests {
+    func testSSHPTYAttachDoesNotReplayTerminalQueriesIntoTheLocalTerminal() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("sshptyreplay")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let bridge = try bindLoopbackTCP()
+        let state = MockSocketServerState()
+        let workspaceID = "22222222-2222-2222-2222-222222222222"
+        let surfaceID = "33333333-3333-3333-3333-333333333333"
+        let sessionID = "ssh-\(workspaceID)-\(surfaceID)"
+        let replay = Data(
+            (
+                "remote prompt\n" +
+                "\u{1B}[>q" + // XTVERSION query
+                "\u{1B}[c" + // primary device-attributes query
+                "\u{1B}[?2026$p" + // DECRQM query
+                "\u{1B}]11;?\u{07}" + // OSC background-color query
+                "visible after replay\n"
+            ).utf8
+        )
+
+        defer {
+            Darwin.close(listenerFD)
+            Darwin.close(bridge.fd)
+            unlink(socketPath)
+        }
+
+        let socketHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.remote.pty_bridge":
+                return self.v2Response(id: id, ok: true, result: [
+                    "host": "127.0.0.1",
+                    "port": bridge.port,
+                    "token": "bridge-token",
+                    "session_id": sessionID,
+                    "attachment_id": surfaceID,
+                ])
+            case "workspace.remote.pty_resize":
+                return self.v2Response(id: id, ok: true, result: ["resized": true])
+            case "workspace.remote.pty_sessions":
+                return self.v2Response(id: id, ok: true, result: [
+                    "sessions": [],
+                    "errors": [],
+                ])
+            case "workspace.remote.pty_attach_end":
+                return self.v2Response(id: id, ok: true, result: ["ended": true])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+        let bridgeHandled = startBridgeReadySendingReplayServer(
+            listenerFD: bridge.fd,
+            replay: replay
+        )
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: [
+                "ssh-pty-attach",
+                "--require-existing",
+                "--workspace", workspaceID,
+                "--session-id", sessionID,
+                "--attachment-id", surfaceID,
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [socketHandled, bridgeHandled], timeout: 5)
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stderr.isEmpty, Comment(rawValue: result.stderr))
+        #expect(
+            result.stdout == "remote prompt\nvisible after replay\n",
+            Comment(rawValue: result.stdout.debugDescription)
+        )
+    }
+
     func testSSHPTYReconciliationPreservesSessionForReattach() throws {
         let cliPath = try bundledCLIPath()
         let scenarios: [(name: String, wrapperRetry: String?, confirmsRunning: Bool)] = [


### PR DESCRIPTION
Closes #10159

## Summary

Persistent-SSH reattach now treats the daemon-declared scrollback replay as historical terminal output: terminal query requests are stripped before they reach the local Ghostty parser, while visible replay and all post-replay live bytes remain unchanged. The reconnect stdin defense also recognizes XTVERSION DCS replies that may already be queued during handoff.

## Root cause

`cmuxd-remote` sends `replay_bytes` worth of retained PTY output before live output. The CLI previously forwarded that prefix verbatim and stopped its reconnect stdin filter on the first output byte. Ghostty consequently re-interpreted stored XTVERSION/DA/DECRQM (and related) queries, generated fresh replies, and wrote those replies through the bridge into the live remote shell.

## Fix

- Add `SSHPTYReplayOutputFilter` in `CmuxFoundation`, bounded and chunk-split safe, scoped strictly to commandless `--require-existing` attaches and the authoritative replay prefix.
- Strip the query families Ghostty can answer (XTVERSION, DA/DSR, DECRQM, XTWINOPS reports, Kitty keyboard, color, XTGETTCAP/DECRQSS, Kitty graphics queries, DECID, and ENQ) without altering visible text or later live negotiation.
- Extend `SSHPTYReconnectInputByteFilter` for `DCS >|... ST` XTVERSION replies and pass mismatching DCS prefixes through immediately.

## Testing

- `swift test --package-path Packages/macOS/CmuxFoundation --filter SSHPTY` — pass (31 tests).
- Swift 6 warnings-as-errors typecheck on both changed filter sources — pass.
- `./scripts/lint-pbxproj-test-wiring.sh`, `./scripts/check-pbxproj.sh`, package/workspace policy checks, and `git diff --check` — pass.
- Focused remote E2E run [32293906970](https://github.com/manaflow-ai/cmux/actions/runs/32293906970) passed `testSSHPTYAttachDoesNotReplayTerminalQueriesIntoTheLocalTerminal` on commit `b764dd09`.
- Full manual CI run [32293903929](https://github.com/manaflow-ai/cmux/actions/runs/32293903929) exercised the change; the focused SSH test passed again, while the aggregate remains blocked by unrelated pre-existing runner/test debt:
  - `tests-build-and-lag`: `BrowserPanelView.swift` emits 10 deprecated `onChange` warnings against a budget of 9 (the warning budget was not changed).
  - `swift-package-tests`: `CmxConnectivityPeerSessionTests` timed out twice at 300 seconds.
  - App-host shards 1/2/4 hit unrelated hook, browser-layout, SSH-startup, and timeout failures; shard 3 passed.
- The full local package suite also has an unrelated pre-existing `SSHForegroundAuthenticationRetryPolicyTests.processTreeTerminationUsesOneOverallDeadline` timing/cleanup failure.

No local app build, launch, XCUITest, or bare `xcodebuild` was run.

## Demo Video

N/A: this is a CLI/PTY protocol fix with no UI change. The focused remote test is the behavioral verification.

## Review trigger

Actionable automated review findings were addressed: no public test seam remains, XTVERSION prefix mismatches fail open immediately, and the complete XTWINOPS report allowlist is covered by regression tests.

## Checklist

- [x] Test-only regression commit precedes the fix commits.
- [x] No local app build, launch, XCUITest, or bare `xcodebuild` was run.
- [x] No user-facing strings or shortcuts changed; localization audit is not applicable.
- [x] Branch targets `main` and is pushed to `manaflow-ai/cmux`.
