### PR TITLE
Fix false needs-attention on Claude SubagentStop

### DIFF
--- a/CLI/CMUXCLI+AgentHookPayload.swift
+++ b/CLI/CMUXCLI+AgentHookPayload.swift
@@ -1,6 +1,38 @@
 import Foundation
 
 extension CMUXCLI {
+    /// Returns the hook event explicitly reported by an agent payload.
+    ///
+    /// Claude's hook command is selected by the installed settings, but the
+    /// payload also carries its lifecycle discriminator. Keeping that
+    /// discriminator available lets a stale or duplicated hook entry fail
+    /// closed instead of turning a child-agent event into a parent mutation.
+    func reportedHookEventName(from input: ClaudeHookParsedInput) -> String? {
+        let object = input.rawObject ?? input.object
+        return object.flatMap {
+            firstString(
+                in: $0,
+                keys: ["hook_event_name", "hookEventName", "event", "event_name"]
+            )
+        }
+    }
+
+    /// Whether a Claude `stop` invocation is allowed to settle the parent.
+    ///
+    /// Payloads from current Claude Code versions identify their hook event;
+    /// only an explicit top-level `Stop` may run the visible completion path.
+    /// Older payloads omitted the discriminator, so those retain the legacy
+    /// command-driven behavior.
+    func shouldApplyClaudeStopVisibleMutation(_ input: ClaudeHookParsedInput) -> Bool {
+        guard let rawEvent = reportedHookEventName(from: input) else { return true }
+        let normalized = rawEvent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
+        return normalized == "stop"
+    }
+
     func parseClaudeHookInput(rawInput: String) -> ClaudeHookParsedInput {
         let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25248,6 +25248,19 @@ struct CMUXCLI {
                     currentAgentPID: claudePid,
                     env: ProcessInfo.processInfo.environment
                 )
+
+                // A stale or duplicated Claude hook configuration can invoke
+                // this command for a child-agent lifecycle event. The command
+                // name alone is not enough to establish a parent turn stop:
+                // only an explicit top-level `Stop` may settle status or emit
+                // completion attention. Keep the event in Feed as telemetry.
+                guard shouldApplyClaudeStopVisibleMutation(parsedInput) else {
+                    telemetry.breadcrumb("claude-hook.stop.non-parent-event")
+                    sendClaudeFeedTelemetry(workspaceId: workspaceId, surfaceId: surfaceId)
+                    printClaudeHookAck()
+                    return
+                }
+
                 sendClaudeFeedTelemetry(workspaceId: workspaceId, surfaceId: surfaceId)
 
                 guard shouldApplyClaudeHookVisibleMutation(
@@ -33207,22 +33220,17 @@ export default CMUXSessionRestore;
         socketPassword: String? = nil
     ) {
         let fallbackHookEventName = Self.feedEventName(forClaudeSubcommand: subcommand)
-        let reportedHookEventName = parsedInput.object.flatMap {
-            firstString(in: $0, keys: ["hook_event_name", "hookEventName", "event", "event_name"])
-        } ?? parsedInput.rawObject.flatMap {
-            firstString(in: $0, keys: ["hook_event_name", "hookEventName", "event", "event_name"])
-        }
+        let reportedEvent = reportedHookEventName(from: parsedInput)
         let hookEventName: String
-        if source == "codex",
-           let reportedHookEventName,
-           reportedHookEventName.replacingOccurrences(of: "_", with: "").lowercased()
-               == "permissionrequest" {
-            // A single notification handler now owns Codex PermissionRequest.
-            // Preserve the existing non-blocking Feed classification while that
-            // same handler drives the needs-input lifecycle and alert.
+        if let reportedEvent,
+           (source == "claude" || source == "codex") {
+            // Preserve an explicit lifecycle discriminator when a command
+            // entrypoint was selected by stale/duplicated settings. The
+            // classifier keeps approval semantics (including Codex's native
+            // PermissionRequest) non-blocking where required.
             hookEventName = FeedEventClassifier.classify(
                 source: source,
-                event: reportedHookEventName,
+                event: reportedEvent,
                 toolName: ""
             ).hookEventName
         } else {

--- a/cmuxTests/ClaudeHookLiveDeliveryTargetTests.swift
+++ b/cmuxTests/ClaudeHookLiveDeliveryTargetTests.swift
@@ -24,6 +24,70 @@ struct ClaudeHookLiveDeliveryTargetTests {
     private static let otherSurfaceId = "55555555-5555-5555-5555-555555555555"
     private static let fallbackSurfaceId = "44444444-4444-4444-4444-444444444444"
 
+    /// A Claude `SubagentStop` must remain telemetry even if an older or
+    /// duplicated hook configuration invokes the visible `stop` command for
+    /// that event. Only the parent `Stop` event may publish completion
+    /// attention or settle the parent lifecycle.
+    ///
+    /// https://github.com/manaflow-ai/cmux/issues/10233
+    @Test func subagentStopDoesNotPublishParentCompletionAttention() throws {
+        let context = try Harness.makeContext(name: "subagent-stop-parent-running")
+        defer { context.cleanup() }
+        let sessionId = "subagent-stop-parent-running-session"
+
+        try Harness.writeSessionStore(
+            to: context.storeURL,
+            sessionId: sessionId,
+            workspaceId: Self.liveWorkspaceId,
+            surfaceId: Self.liveSurfaceId,
+            cwd: context.root.path,
+            pid: 43209
+        )
+        let serverHandled = Harness.startDeliveryTargetServer(
+            context: context,
+            surfacesByWorkspace: [Self.liveWorkspaceId: [Self.liveSurfaceId]],
+            pidTarget: (workspaceId: Self.liveWorkspaceId, surfaceId: Self.liveSurfaceId)
+        )
+
+        var environment = Harness.hookEnvironment(context: context)
+        environment["CMUX_WORKSPACE_ID"] = Self.liveWorkspaceId
+        environment["CMUX_SURFACE_ID"] = Self.liveSurfaceId
+        environment["CMUX_CLAUDE_PID"] = "43209"
+
+        let result = Harness.runHookProcess(
+            context: context,
+            arguments: ["hooks", "claude", "stop"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionId)","hook_event_name":"SubagentStop","cwd":"\#(context.root.path)","last_assistant_message":"subagent finished"}"#
+        )
+
+        #expect(serverHandled.wait(timeout: .now() + 5) == .success)
+        assertSuccessfulHook(result)
+
+        let commands = context.state.snapshot()
+        let feedEventNames = commands.compactMap { command -> String? in
+            guard let data = command.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  object["method"] as? String == "feed.push",
+                  let params = object["params"] as? [String: Any],
+                  let event = params["event"] as? [String: Any] else {
+                return nil
+            }
+            return event["hook_event_name"] as? String
+        }
+
+        #expect(feedEventNames.contains("SubagentStop"), "Subagent completion must stay distinct telemetry; saw \(feedEventNames)")
+        #expect(!feedEventNames.contains("Stop"), "SubagentStop must not be rewritten as parent Stop; saw \(feedEventNames)")
+        #expect(
+            !commands.contains { $0.hasPrefix("notify_target_async ") },
+            "A subagent completion must not publish the parent's completion notification; saw \(commands)"
+        )
+        #expect(
+            !commands.contains { $0.hasPrefix("set_agent_lifecycle ") || $0.hasPrefix("set_status ") },
+            "A subagent completion must not settle the parent lifecycle/status; saw \(commands)"
+        )
+    }
+
     /// Two Claude agents in two workspaces: the session record for this agent
     /// was polluted to point at the OTHER agent's pane (issue #7391 drift).
     /// The live pid target must win and the record must self-heal.


### PR DESCRIPTION
Closes #10233

## Summary

Claude's visible `stop` hook could trust the command name even when its payload identified a `SubagentStop`. That let a child completion be rewritten as a parent `Stop`, publishing completion attention and settling the parent lifecycle/status while the parent turn was still running.

## Root cause

The Claude hook telemetry helper used the subcommand fallback (`stop` → `Stop`) instead of the payload's explicit lifecycle discriminator. The visible stop handler likewise had no guard against a non-parent event reaching it through stale or duplicated hook settings.

## Fix

- Preserve explicit Claude/Codex hook event names when constructing Feed telemetry.
- Allow the visible Claude completion path only for an explicit top-level `Stop`; non-parent events remain telemetry-only.
- Add an end-to-end regression that asserts `SubagentStop` stays distinct and emits no parent status or completion notification.

## Testing

- Regression-only commit `e9a7797a26` failed remotely as expected: the test observed `Stop`, `set_agent_lifecycle`, `set_status`, and `notify_target_async`.
- Fix commit `d3d69db690` passed the focused remote macOS suite on two independent runners: 7/7 `ClaudeHookLiveDeliveryTargetTests`.
- Local validation: `git diff --check`, Swift parse checks, test-wiring lint, Package.resolved policy, and workspace package-group checks.
- No local app build or Xcode test was run.
- The manual dispatch-only full CI run was attempted and retried. Its required PR checks are green; the broad run's unrelated failures were a pre-existing warning-budget drift (`BrowserPanelView.swift`, 10 vs budget 9), an unrelated package-test timeout, and unrelated flaky SSH/session tests. Neither changed production file produced a new warning.

## Demo video

Not applicable: this is a hook/CLI lifecycle regression covered by the remote behavior test.

## Review trigger

Please review the two-commit regression/fix sequence and the payload-vs-command event boundary.

## Checklist

- [x] Failing regression test committed separately from the fix.
- [x] No user-facing strings or localization catalogs changed.
- [x] No new keyboard shortcuts.
- [x] Required PR checks green; PR reports MERGEABLE.