### PR TITLE
Stop a finished Claude subagent from flipping the pane to needs-input

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25578,6 +25578,13 @@ struct CMUXCLI {
             case "permission_prompt":
                 notifyCategory = .needsPermission
                 notifyPending = false
+            case "agent_completed":
+                // The user-facing form of SubagentStop: a Task subagent finished
+                // while the parent agent keeps working on its turn. Classified
+                // explicitly (rather than through the completion cue below) so a
+                // localized or reworded message cannot resurface it as attention.
+                notifyCategory = .turnComplete
+                notifyPending = false
             case "idle_prompt":
                 notifyCategory = .idleReminder
                 // The cached Stop-time flag is not stale in practice: a completed
@@ -25607,12 +25614,24 @@ struct CMUXCLI {
                 }
             }
 
+            // A completion notification reports progress, not a state that needs
+            // the user. Claude Code raises it when a Task subagent finishes
+            // (`agent_completed`), so the parent agent is still mid-turn: flipping
+            // the pane to "Needs input" here made the workspace infer
+            // needs-attention while work was still running, and the ping duplicated
+            // the one the parent's own Stop delivers at the real turn boundary.
+            // The Stop hook stays the sole owner of the turn-complete transition,
+            // so a subagent that finishes last still hands the pane whatever state
+            // that Stop produces. https://github.com/manaflow-ai/cmux/issues/10233
+            let isAgentCompletionNotification = (notifyCategory == .turnComplete)
+
             // An idle reminder while background work is still pending is not a
             // real "waiting for input" state: the pane is still running (the Stop
             // hook set it to Running) and the app suppresses this banner. Skip the
             // "Needs input" pill/lifecycle so the idle nag can't undo the Running
             // status; the app still gates the (tagged) notification itself.
-            let suppressNeedsInputState = (notifyCategory == .idleReminder && notifyPending)
+            let suppressNeedsInputState = isAgentCompletionNotification
+                || (notifyCategory == .idleReminder && notifyPending)
 
             // `.other` means "ungated, always deliver" — identical to an untagged
             // payload, so don't put it on the wire: the app parser accepts only
@@ -25655,7 +25674,9 @@ struct CMUXCLI {
                     color: "#4C8DFF", pid: claudePid
                 )
             }
-            _ = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
+            if !isAgentCompletionNotification {
+                _ = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
+            }
             printClaudeHookAck()
         case "push-notification": try runClaudePushNotificationHook(client: client, telemetry: telemetry, parsedInput: parsedInput, sessionStore: sessionStore, routing: hookRouting, markFeedTelemetryHandled: { didSendFeedTelemetry = true }, sendFeedTelemetry: sendClaudeFeedTelemetry)
         case "session-end":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25623,14 +25623,19 @@ struct CMUXCLI {
             // The Stop hook stays the sole owner of the turn-complete transition,
             // so a subagent that finishes last still hands the pane whatever state
             // that Stop produces. https://github.com/manaflow-ai/cmux/issues/10233
-            let isAgentCompletionNotification = (notifyCategory == .turnComplete)
+            //
+            // Deliberately keyed on the CATEGORY, not on the `agent_completed`
+            // tag: the untyped fallback above classifies an older client's
+            // completion cue the same way, and the Notification hook never owns
+            // turn completion regardless of which path resolved it.
+            let isTurnCompleteCategoryNotification = (notifyCategory == .turnComplete)
 
             // An idle reminder while background work is still pending is not a
             // real "waiting for input" state: the pane is still running (the Stop
             // hook set it to Running) and the app suppresses this banner. Skip the
             // "Needs input" pill/lifecycle so the idle nag can't undo the Running
             // status; the app still gates the (tagged) notification itself.
-            let suppressNeedsInputState = isAgentCompletionNotification
+            let suppressNeedsInputState = isTurnCompleteCategoryNotification
                 || (notifyCategory == .idleReminder && notifyPending)
 
             // `.other` means "ungated, always deliver" — identical to an untagged
@@ -25674,7 +25679,7 @@ struct CMUXCLI {
                     color: "#4C8DFF", pid: claudePid
                 )
             }
-            if !isAgentCompletionNotification {
+            if !isTurnCompleteCategoryNotification {
                 _ = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
             }
             printClaudeHookAck()

--- a/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
+++ b/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
@@ -21,6 +21,13 @@ struct ClaudeBackgroundWorkNotifyTests {
         snapshot.first { $0.hasPrefix("set_agent_lifecycle claude_code \(value) ") }
     }
 
+    /// The pane state a hook sequence LEFT behind: the socket verbs are
+    /// last-write-wins, so only the final `set_status` / `set_agent_lifecycle`
+    /// of a run describes what the sidebar ends up showing.
+    private func lastLine(_ snapshot: [String], prefix: String) -> String? {
+        snapshot.last { $0.hasPrefix(prefix) }
+    }
+
     private func runStopHook(
         name: String,
         sessionId: String,
@@ -299,6 +306,18 @@ struct ClaudeBackgroundWorkNotifyTests {
             ttyName: "ttys-notif-subagent",
             storeURL: context.root.appendingPathComponent("claude-hook-sessions.json")
         )
+        // Seed the working pane the parent agent is mid-turn in, so the
+        // assertions below distinguish "left the pane Running" from "published
+        // some other state" or "published nothing at all".
+        let promptResult = harness.runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            environment: environment,
+            standardInput: #"{"session_id":"notif-subagent-session","cwd":"/tmp/x","hook_event_name":"UserPromptSubmit","prompt":"review this"}"#,
+            timeout: 5
+        )
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        harness.assertSuccessfulHook(promptResult)
         let result = harness.runProcess(
             executablePath: context.cliPath,
             arguments: ["hooks", "claude", "notification"],
@@ -315,6 +334,18 @@ struct ClaudeBackgroundWorkNotifyTests {
                 "A finished subagent must not publish a needs-input lifecycle; saw \(snapshot)")
         #expect(snapshot.first { $0.hasPrefix("notify_target_async ") } == nil,
                 "A finished subagent must not fire a turn-complete ping; saw \(snapshot)")
+        let lastStatus = try #require(
+            lastLine(snapshot, prefix: "set_status claude_code "),
+            "Expected the seeded Running pill in \(snapshot)"
+        )
+        #expect(lastStatus.hasPrefix("set_status claude_code Running "),
+                "The pane must be left Running after a subagent finishes; saw \(lastStatus)")
+        let lastLifecycle = try #require(
+            lastLine(snapshot, prefix: "set_agent_lifecycle claude_code "),
+            "Expected the seeded running lifecycle in \(snapshot)"
+        )
+        #expect(lastLifecycle.hasPrefix("set_agent_lifecycle claude_code running "),
+                "The lifecycle must be left running after a subagent finishes; saw \(lastLifecycle)")
     }
 
     @Test func agentCompletedNotificationDoesNotSwallowTheParentStop() throws {

--- a/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
+++ b/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
@@ -388,11 +388,25 @@ struct ClaudeBackgroundWorkNotifyTests {
         #expect(handled.wait(timeout: .now() + 5) == .success)
         harness.assertSuccessfulHook(stopResult)
         let snapshot = context.state.snapshot()
-        #expect(notifyLine(snapshot, containing: "c=turn-complete;p=0") != nil,
-                "The parent Stop must still fire its turn-complete ping; saw \(snapshot)")
-        #expect(statusLine(snapshot, value: "Idle") != nil,
-                "The parent Stop must still set the Idle pill; saw \(snapshot)")
-        #expect(lifecycleLine(snapshot, value: "idle") != nil,
-                "The parent Stop must still publish an idle lifecycle; saw \(snapshot)")
+        // Exactly one ping, and it carries the parent's own last assistant
+        // message — asserting mere presence would be satisfied by the
+        // subagent's ping, which is the thing this fix removes.
+        let notifyLines = snapshot.filter { $0.hasPrefix("notify_target_async ") }
+        #expect(notifyLines.count == 1,
+                "Only the parent Stop may ping for this turn; saw \(notifyLines)")
+        #expect(notifyLines.first?.contains("|ok|c=turn-complete;p=0") == true,
+                "The surviving ping must be the parent Stop's turn-complete; saw \(notifyLines)")
+        let lastStatus = try #require(
+            lastLine(snapshot, prefix: "set_status claude_code "),
+            "Expected the parent Stop's pill in \(snapshot)"
+        )
+        #expect(lastStatus.hasPrefix("set_status claude_code Idle "),
+                "The parent Stop must leave the Idle pill; saw \(lastStatus)")
+        let lastLifecycle = try #require(
+            lastLine(snapshot, prefix: "set_agent_lifecycle claude_code "),
+            "Expected the parent Stop's lifecycle in \(snapshot)"
+        )
+        #expect(lastLifecycle.hasPrefix("set_agent_lifecycle claude_code idle "),
+                "The parent Stop must leave an idle lifecycle; saw \(lastLifecycle)")
     }
 }

--- a/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
+++ b/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
@@ -276,4 +276,92 @@ struct ClaudeBackgroundWorkNotifyTests {
         #expect(statusLine(snapshot, value: "Needs input") != nil,
                 "Idle idle_prompt must still set the Needs input pill; saw \(snapshot)")
     }
+
+    @Test func agentCompletedNotificationLeavesPaneRunning() throws {
+        // `agent_completed` is Claude Code's user-facing form of SubagentStop: a
+        // Task subagent finished while the parent agent keeps working on its
+        // turn. It is progress, not an attention state, so it must not flip the
+        // pane to "Needs input" (which makes the workspace infer
+        // needs-attention) and must not fire a turn-complete ping.
+        // https://github.com/manaflow-ai/cmux/issues/10233
+        let harness = ClaudeHookSurfaceResolutionSwiftTests()
+        let context = try harness.makeClaudeHookContext(name: "notif-subagent")
+        defer { context.cleanup() }
+        let handled = harness.startClaudeSurfaceResolutionServer(
+            context: context,
+            surfaces: [(context.surfaceId, "surface:1", true)],
+            ttyName: "ttys-notif-subagent",
+            ttySurfaceId: context.surfaceId
+        )
+        let environment = harness.claudeHookEnvironment(
+            context: context,
+            surfaceId: context.surfaceId,
+            ttyName: "ttys-notif-subagent",
+            storeURL: context.root.appendingPathComponent("claude-hook-sessions.json")
+        )
+        let result = harness.runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", "claude", "notification"],
+            environment: environment,
+            standardInput: #"{"session_id":"notif-subagent-session","cwd":"/tmp/x","hook_event_name":"Notification","message":"Agent code-reviewer completed","notification_type":"agent_completed"}"#,
+            timeout: 5
+        )
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        harness.assertSuccessfulHook(result)
+        let snapshot = context.state.snapshot()
+        #expect(statusLine(snapshot, value: "Needs input") == nil,
+                "A finished subagent must not set the Needs input pill; saw \(snapshot)")
+        #expect(lifecycleLine(snapshot, value: "needsInput") == nil,
+                "A finished subagent must not publish a needs-input lifecycle; saw \(snapshot)")
+        #expect(snapshot.first { $0.hasPrefix("notify_target_async ") } == nil,
+                "A finished subagent must not fire a turn-complete ping; saw \(snapshot)")
+    }
+
+    @Test func agentCompletedNotificationDoesNotSwallowTheParentStop() throws {
+        // The subagent that finishes LAST still hands the turn back to the
+        // parent, whose own Stop owns the real turn-complete transition. The
+        // suppressed `agent_completed` must leave that signal intact.
+        // https://github.com/manaflow-ai/cmux/issues/10233
+        let session = "subagent-then-stop"
+        let harness = ClaudeHookSurfaceResolutionSwiftTests()
+        let context = try harness.makeClaudeHookContext(name: "notif-subagent-stop")
+        defer { context.cleanup() }
+        let handled = harness.startClaudeSurfaceResolutionServer(
+            context: context,
+            surfaces: [(context.surfaceId, "surface:1", true)],
+            ttyName: "ttys-notif-subagent-stop",
+            ttySurfaceId: context.surfaceId
+        )
+        let environment = harness.claudeHookEnvironment(
+            context: context,
+            surfaceId: context.surfaceId,
+            ttyName: "ttys-notif-subagent-stop",
+            storeURL: context.root.appendingPathComponent("claude-hook-sessions.json")
+        )
+        let notifResult = harness.runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", "claude", "notification"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(session)","cwd":"/tmp/x","hook_event_name":"Notification","message":"Agent code-reviewer completed","notification_type":"agent_completed"}"#,
+            timeout: 5
+        )
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        harness.assertSuccessfulHook(notifResult)
+        let stopResult = harness.runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", "claude", "stop"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(session)","cwd":"/tmp/x","hook_event_name":"Stop","last_assistant_message":"ok","background_tasks":[],"session_crons":[]}"#,
+            timeout: 5
+        )
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        harness.assertSuccessfulHook(stopResult)
+        let snapshot = context.state.snapshot()
+        #expect(notifyLine(snapshot, containing: "c=turn-complete;p=0") != nil,
+                "The parent Stop must still fire its turn-complete ping; saw \(snapshot)")
+        #expect(statusLine(snapshot, value: "Idle") != nil,
+                "The parent Stop must still set the Idle pill; saw \(snapshot)")
+        #expect(lifecycleLine(snapshot, value: "idle") != nil,
+                "The parent Stop must still publish an idle lifecycle; saw \(snapshot)")
+    }
 }


### PR DESCRIPTION
Fixes #10233.

## Where the two events were conflated

Not in the `Stop` / `SubagentStop` hook wiring — that part is already clean. The cmux Claude wrapper routes `SubagentStop` to `cmux hooks feed --source claude` only (`Resources/bin/cmux-claude-wrapper:968`), the feed classifier keeps it distinct telemetry (`CLI/FeedEventClassifier.swift:272`), and the session-state machine leaves the parent untouched (`Sources/Mobile/AgentChat/AgentChatSessionRegistry+Lifecycle.swift:92`).

The conflation is one layer over: Claude Code also surfaces a finished subagent to the user as a **`Notification` with `notification_type: "agent_completed"`** (one of the documented `Notification` matcher values, alongside `permission_prompt` / `idle_prompt` / `agent_needs_input`). `cmux hooks claude notification` treated *every* notification as a state that needs the user (`CLI/cmux.swift:25577-25622`): the typed switch knew only `permission_prompt` and `idle_prompt`, everything else fell through to cue classification, and `agent_completed` tokenizes to a completion cue → `"Completed"` → `.turnComplete`. `suppressNeedsInputState` only covered the pending idle nag, so the handler then published a needs-input lifecycle, the "Needs input" pill, and a turn-complete ping — exactly what a real top-level `Stop` produces — while the parent agent was still mid-turn. `Workspace.taskStatusSignals()` reads that lifecycle into `anyAgentNeedsInput`, and `WorkspaceTaskStatus.inferred` turns it into `needs-attention`.

## What the transition does now

`CLI/cmux.swift`:

- `agent_completed` is classified explicitly in the typed switch (`.turnComplete`, not pending), so a reworded or localized message cannot resurface it as attention.
- Any completion-classified notification — typed, or cue-classified for older clients — is treated as progress: `suppressNeedsInputState` is true, so no needs-input lifecycle, no session-record `.needsInput`, no "Needs input" pill.
- The same flag skips `notify_target_async`, so a finished subagent no longer fires a turn-complete ping. That ping belongs to the real turn boundary and was a duplicate here.

Genuine attention states are untouched: `permission_prompt` and permission-cue notifications still flip to needs-input, and an `idle_prompt` with no pending background work still sets the "Needs input" pill (covered by the existing tests in the same suite).

## Why the parent's real attention signal still survives

The `Stop` handler (`CLI/cmux.swift:25227`) is not touched — it still owns the turn boundary: `agentLifecycle: .idle` (or `.running` with pending background work), the "Idle" pill, and the `c=turn-complete` ping. A subagent that finishes as the *last* thing before the parent's turn ends now leaves no state behind, so the pane lands in whatever the parent's `Stop` produces. Previously the ordering could actually go the other way and an `agent_completed` arriving after `Stop` would overwrite `.idle` with `.needsInput`. `agentCompletedNotificationDoesNotSwallowTheParentStop` pins this.

## Red/green evidence

Two commits: `test:` then `fix:`.

Failing on the test-only commit (real output, `-only-testing:cmuxTests/ClaudeBackgroundWorkNotifyTests`):

```
✘ Test agentCompletedNotificationLeavesPaneRunning() recorded an issue at
  ClaudeBackgroundWorkNotifyTests.swift:312:9: Expectation failed:
  (statusLine(snapshot, value: "Needs input") →
   "set_status claude_code Needs input --icon=bell.fill --color=#4C8DFF --tab=... --panel=...") == nil
↳ A finished subagent must not set the Needs input pill

✘ ... :314:9: Expectation failed:
  (lifecycleLine(snapshot, value: "needsInput") →
   "set_agent_lifecycle claude_code needsInput --tab=... --panel=...") == nil
↳ A finished subagent must not publish a needs-input lifecycle

✘ ... :316:9: Expectation failed:
  (snapshot.first { $0.hasPrefix("notify_target_async ") } →
   "notify_target_async ... Claude Code|Completed|Agent code-reviewer completed|c=turn-complete;p=0") == nil
↳ A finished subagent must not fire a turn-complete ping

✘ Test agentCompletedNotificationLeavesPaneRunning() failed after 0.068 seconds with 3 issues.
```

`agentCompletedNotificationDoesNotSwallowTheParentStop` passes on both commits by design — it is the guard that the fix does not swallow the parent's signal.

The tests drive the real `cmux` CLI against the suite's mock socket server and assert on the actual wire commands, so they exercise the hook end to end rather than the classifier in isolation. They go in the already-wired `cmuxTests/ClaudeBackgroundWorkNotifyTests.swift`, so no `project.pbxproj` change is needed.

## Validation

```
./scripts/test-unit.sh test -only-testing:cmuxTests/ClaudeBackgroundWorkNotifyTests \
  -derivedDataPath /tmp/cmux-subagent-stop
```
→ `** TEST SUCCEEDED **`, 10 tests in 1 suite (8 pre-existing + 2 new).

```
./scripts/test-unit.sh test \
  -only-testing:cmuxTests/AgentHookNotificationPolicyTests \
  -only-testing:cmuxTests/ClaudeNotificationStatusLifecycleTests \
  -only-testing:cmuxTests/ClaudeHookFeedTelemetrySwiftTests \
  -only-testing:cmuxTests/CLINotifyClaudeHookWorkspaceRoutingTests \
  -only-testing:cmuxTests/AgentNotificationGateTests \
  -derivedDataPath /tmp/cmux-subagent-stop
```
→ `** TEST SUCCEEDED **`.

One note on flakiness seen locally and unrelated to this change: on a cold `-derivedDataPath` the first hook subprocess in the suite can exceed the harness's 5s `timeout` (`ProcessRunResult(status: 0, stdout: "{}\n", timedOut: true)`). It hit a different test on each cold run and never recurred on a warm one.

## Notes

- Related but distinct: #7520 (pending background work at a real `Stop`) and #10209 (making agent-completion notifications configurable). This change makes the subagent case silent by default, which is the behavior #10233 asks for; a user-facing toggle would layer on top.
- Fork-PR workflows sit in `action_required`, so GitHub CI has not run on this PR yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789651403&installation_model_id=21920&pr_number=10343&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10343&signature=5f399f0901797d5e99bd66d858fdc2afab19fa9607862d3793a1bf6b38c558c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a finished Claude subagent from flipping a running pane to Needs input or sending a duplicate turn-complete ping. Previously all Claude notifications, including `agent_completed`, were treated as attention; now completion-classified notifications count as progress and leave the pane Running until the parent’s Stop.

**Reviewer notes**
- `CLI/cmux.swift`: explicitly maps `agent_completed` to `.turnComplete` and treats any `.turnComplete`-category notification as progress; suppresses the needs-input pill/lifecycle and skips `notify_target_async`. The Stop hook remains the sole owner of the turn-complete transition. The suppression keys on category (not the tag) so cue-classified completions from older clients are also covered.
- `cmuxTests/ClaudeBackgroundWorkNotifyTests.swift`: seeds a Running pane; asserts `agent_completed` leaves it Running with no needs-input lifecycle and no ping. Verifies the parent `stop` sets Idle and emits the single surviving turn-complete ping carrying the parent’s last assistant message, and pins that the final pill/lifecycle are the parent’s (last-write-wins).

<sup>Written for commit c9852989a0543a2e5446d90752d91fde32e05b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Claude subagent completion events.
  * Completed subagents no longer incorrectly show “Needs input” or trigger duplicate completion notifications.
  * Parent agent completion continues to provide the final turn-complete notification and returns the pane to an idle state.

* **Tests**
  * Added coverage for subagent completion, needs-input state transitions, notification behavior, and parent turn completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->