### PR TITLE
Install Kimi hooks in the config the installed Kimi CLI reads

### DIFF
--- a/CLI/CMUXCLI+AgentHookCatalog.swift
+++ b/CLI/CMUXCLI+AgentHookCatalog.swift
@@ -231,8 +231,10 @@ extension CMUXCLI {
         ),
         AgentHookDef(
             name: "kimi", displayName: "Kimi Code", statusKey: "kimi",
-            configDir: ".kimi", configFile: "config.toml", configDirEnvOverride: "KIMI_SHARE_DIR",
-            createConfigDirIfMissing: true, binaryName: "kimi",
+            configDir: kimiCodeConfigDirectory, configFile: kimiConfigFileName,
+            createConfigDirIfMissing: true,
+            configDirResolver: { CMUXCLI.resolvedKimiConfigDirectory().path },
+            binaryName: "kimi",
             sessionStoreSuffix: "kimi", disableEnvVar: "CMUX_KIMI_HOOKS_DISABLED",
             hookMarker: "cmux hooks kimi", format: .tomlArrayTable,
             events: [

--- a/CLI/CMUXCLI+AgentHookCatalog.swift
+++ b/CLI/CMUXCLI+AgentHookCatalog.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
@@ -231,7 +232,8 @@ extension CMUXCLI {
         ),
         AgentHookDef(
             name: "kimi", displayName: "Kimi Code", statusKey: "kimi",
-            configDir: kimiCodeConfigDirectory, configFile: kimiConfigFileName,
+            configDir: KimiConfigLocationResolver.kimiCodeConfigDirectory,
+            configFile: KimiConfigLocationResolver.configFileName,
             createConfigDirIfMissing: true,
             configDirResolver: { CMUXCLI.resolvedKimiConfigDirectory().path },
             binaryName: "kimi",

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -65,7 +65,7 @@ extension CMUXCLI {
             case antigravityJSON(timeoutSeconds: Int) // ~/.gemini/config/hooks.json named hook groups
             case rovoDevYAML
             case hermesAgentYAML
-            case tomlArrayTable // ~/.kimi/config.toml [[hooks]] array-of-tables
+            case tomlArrayTable // Kimi config.toml [[hooks]] array-of-tables
         }
 
         enum HookDispatch {

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -6,40 +6,8 @@ extension CMUXCLI {
     private static let kimiLifecycleHookTimeoutSeconds = 10
     private static let kimiFeedHookTimeoutSeconds = 120
 
-    /// Config file name shared by every Kimi installation.
-    static let kimiConfigFileName = "config.toml"
-
-    /// Kimi Code CLI (current) reads `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`.
-    /// Kimi CLI 1.49 and earlier read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`.
-    /// Both installations are supported; the first entry wins ties.
-    static let kimiCodeConfigDirectory = ".kimi-code"
-    private static let kimiConfigDirectorySpecs: [KimiConfigDirectorySpec] = [
-        KimiConfigDirectorySpec(
-            environmentOverride: "KIMI_CODE_HOME",
-            homeRelativeDirectory: kimiCodeConfigDirectory
-        ),
-        KimiConfigDirectorySpec(
-            environmentOverride: "KIMI_SHARE_DIR",
-            homeRelativeDirectory: ".kimi"
-        ),
-    ]
-
     /// `kimi doctor` only reports paths; it must never stall a hook install.
     private static let kimiDoctorProbeTimeoutSeconds: Double = 3
-
-    private struct KimiConfigDirectorySpec {
-        let environmentOverride: String
-        let homeRelativeDirectory: String
-    }
-
-    /// Every Kimi config file cmux manages: the one the installed CLI reads,
-    /// plus the well-known locations belonging to the other installation.
-    struct KimiConfigLocations {
-        let active: URL
-        let secondary: [URL]
-
-        var all: [URL] { [active] + secondary }
-    }
 
     private struct KimiConfigEdit {
         let url: URL
@@ -183,16 +151,18 @@ extension CMUXCLI {
     func uninstallKimiHooks(_ def: AgentHookDef) throws {
         let fm = FileManager.default
         let locations = Self.kimiConfigLocations(for: def)
+        let targets: [(url: URL, isActive: Bool)] =
+            [(url: locations.active, isActive: true)]
+            + locations.secondary.map { (url: $0, isActive: false) }
 
         var foundConfig = false
-        for (index, configURL) in locations.all.enumerated()
-        where fm.fileExists(atPath: configURL.path) {
+        for target in targets where fm.fileExists(atPath: target.url.path) {
             foundConfig = true
             do {
-                _ = try removeKimiHooks(at: configURL, def: def, reportNoChange: true)
+                _ = try removeKimiHooks(at: target.url, def: def, reportNoChange: true)
             } catch {
-                guard index > 0 else { throw error }
-                reportKimiSecondaryUninstallWarning(secondaryConfigURL: configURL)
+                guard !target.isActive else { throw error }
+                reportKimiSecondaryUninstallWarning(secondaryConfigURL: target.url)
             }
         }
         guard !foundConfig else { return }
@@ -276,102 +246,30 @@ extension CMUXCLI {
 
     // MARK: Config discovery
 
-    /// The Kimi config file cmux installs into, plus the other well-known Kimi
-    /// configs it keeps consistent.
-    ///
-    /// The active file is the one the installed CLI reports through
-    /// `kimi doctor`; when the binary cannot answer, it is the first well-known
-    /// location that already exists, defaulting to the current Kimi Code CLI
-    /// path. See https://github.com/manaflow-ai/cmux/issues/10255.
-    static func kimiConfigLocations(for def: AgentHookDef) -> KimiConfigLocations {
-        let candidates = kimiConfigDirectoryCandidates().map { directory in
-            directory.appendingPathComponent(def.configFile, isDirectory: false)
-        }
-        let active = kimiDoctorReportedConfigURL(
-            binaryName: def.binaryName,
+    /// The config directory used when the installed binary reports none.
+    static func resolvedKimiConfigDirectory() -> URL {
+        KimiConfigLocationResolver(environment: ProcessInfo.processInfo.environment)
+            .fallbackConfigDirectory()
+    }
+
+    /// The Kimi config files cmux manages, resolved from the installed binary.
+    static func kimiConfigLocations(for def: AgentHookDef) -> KimiConfigLocationResolver.Locations {
+        let resolver = KimiConfigLocationResolver(
+            environment: ProcessInfo.processInfo.environment,
             configFileName: def.configFile
-        ) ?? URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
-            .appendingPathComponent(def.configFile, isDirectory: false)
-
-        var seen: Set<URL> = [canonicalKimiConfigURL(active)]
-        var secondary: [URL] = []
-        for candidate in candidates where seen.insert(canonicalKimiConfigURL(candidate)).inserted {
-            secondary.append(candidate)
+        )
+        let reported = runKimiDoctor(binaryName: def.binaryName).flatMap { output in
+            resolver.reportedConfigURL(inDoctorOutput: output)
         }
-        return KimiConfigLocations(active: active, secondary: secondary)
+        return resolver.locations(reportedConfigURL: reported)
     }
 
-    /// The config directory used when the installed binary cannot report one.
-    static func resolvedKimiConfigDirectory(
-        environment: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default
-    ) -> URL {
-        let candidates = kimiConfigDirectoryCandidates(environment: environment)
-        if let configured = candidates.first(where: { directory in
-            kimiRegularFileExists(
-                directory.appendingPathComponent(kimiConfigFileName, isDirectory: false),
-                fileManager: fileManager
-            )
-        }) {
-            return configured
-        }
-        if let installed = candidates.first(where: {
-            kimiDirectoryExists($0, fileManager: fileManager)
-        }) {
-            return installed
-        }
-        return candidates.first ?? kimiHomeURL(environment: environment)
-            .appendingPathComponent(kimiCodeConfigDirectory, isDirectory: true)
-    }
-
-    private static func kimiConfigDirectoryCandidates(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> [URL] {
-        let home = kimiHomeURL(environment: environment)
-        return kimiConfigDirectorySpecs.map { spec in
-            if let override = nonEmptyKimiEnvironmentValue(
-                environment[spec.environmentOverride]
-            ) {
-                return URL(
-                    fileURLWithPath: NSString(string: override).expandingTildeInPath,
-                    isDirectory: true
-                )
-            }
-            return home.appendingPathComponent(spec.homeRelativeDirectory, isDirectory: true)
-        }
-    }
-
-    /// The absolute `config.toml` path `kimi doctor` reports, when it reports a
-    /// usable one. A binary that is missing, does not know the subcommand, or
-    /// prints no path leaves the well-known locations in charge.
-    private static func kimiDoctorReportedConfigURL(
-        binaryName: String,
-        configFileName: String,
-        fileManager: FileManager = .default
-    ) -> URL? {
-        guard let output = runKimiDoctor(binaryName: binaryName),
-              let reported = kimiConfigURL(inDoctorOutput: output, configFileName: configFileName),
-              kimiDirectoryExists(reported.deletingLastPathComponent(), fileManager: fileManager)
-        else {
-            return nil
-        }
-        return reported
-    }
-
-    static func kimiConfigURL(inDoctorOutput output: String, configFileName: String) -> URL? {
-        let trimmed = CharacterSet(charactersIn: "\"'`,;:()[]{}<>")
-        for token in output.split(whereSeparator: { $0.isWhitespace }) {
-            let candidate = String(token).trimmingCharacters(in: trimmed)
-            guard !candidate.isEmpty else { continue }
-            let expanded = NSString(string: candidate).expandingTildeInPath
-            guard expanded.hasPrefix("/") else { continue }
-            let url = URL(fileURLWithPath: expanded, isDirectory: false).standardizedFileURL
-            guard url.lastPathComponent == configFileName else { continue }
-            return url
-        }
-        return nil
-    }
-
+    /// Runs `<binary> doctor` and returns its combined output.
+    ///
+    /// The probe writes to a temporary file rather than a pipe so a chatty
+    /// binary cannot deadlock the wait, and it is bounded so a hung binary
+    /// cannot stall `cmux hooks setup`. A binary that is missing or does not
+    /// know the subcommand simply produces no usable path.
     private static func runKimiDoctor(binaryName: String) -> String? {
         let fm = FileManager.default
         let outputURL = fm.temporaryDirectory
@@ -402,31 +300,5 @@ extension CMUXCLI {
             }
         }
         return try? String(contentsOf: outputURL, encoding: .utf8)
-    }
-
-    private static func kimiHomeURL(environment: [String: String]) -> URL {
-        let home = nonEmptyKimiEnvironmentValue(environment["HOME"]) ?? NSHomeDirectory()
-        return URL(fileURLWithPath: home, isDirectory: true)
-    }
-
-    private static func nonEmptyKimiEnvironmentValue(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private static func kimiDirectoryExists(_ url: URL, fileManager: FileManager) -> Bool {
-        var isDirectory = ObjCBool(false)
-        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
-    }
-
-    private static func kimiRegularFileExists(_ url: URL, fileManager: FileManager) -> Bool {
-        var isDirectory = ObjCBool(false)
-        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
-            && !isDirectory.boolValue
-    }
-
-    private static func canonicalKimiConfigURL(_ url: URL) -> URL {
-        url.resolvingSymlinksInPath().standardizedFileURL
     }
 }

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -1,11 +1,51 @@
 import CMUXAgentLaunch
+import Darwin
 import Foundation
 
 extension CMUXCLI {
     private static let kimiLifecycleHookTimeoutSeconds = 10
     private static let kimiFeedHookTimeoutSeconds = 120
-    private static let legacyKimiConfigDirectory = ".kimi-code"
-    private static let legacyKimiConfigDirectoryOverride = "KIMI_CODE_HOME"
+
+    /// Config file name shared by every Kimi installation.
+    static let kimiConfigFileName = "config.toml"
+
+    /// Kimi Code CLI (current) reads `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`.
+    /// Kimi CLI 1.49 and earlier read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`.
+    /// Both installations are supported; the first entry wins ties.
+    static let kimiCodeConfigDirectory = ".kimi-code"
+    private static let kimiConfigDirectorySpecs: [KimiConfigDirectorySpec] = [
+        KimiConfigDirectorySpec(
+            environmentOverride: "KIMI_CODE_HOME",
+            homeRelativeDirectory: kimiCodeConfigDirectory
+        ),
+        KimiConfigDirectorySpec(
+            environmentOverride: "KIMI_SHARE_DIR",
+            homeRelativeDirectory: ".kimi"
+        ),
+    ]
+
+    /// `kimi doctor` only reports paths; it must never stall a hook install.
+    private static let kimiDoctorProbeTimeoutSeconds: Double = 3
+
+    private struct KimiConfigDirectorySpec {
+        let environmentOverride: String
+        let homeRelativeDirectory: String
+    }
+
+    /// Every Kimi config file cmux manages: the one the installed CLI reads,
+    /// plus the well-known locations belonging to the other installation.
+    struct KimiConfigLocations {
+        let active: URL
+        let secondary: [URL]
+
+        var all: [URL] { [active] + secondary }
+    }
+
+    private struct KimiConfigEdit {
+        let url: URL
+        let oldContent: String
+        let newContent: String
+    }
 
     func kimiCodeHookEvents(def: AgentHookDef) -> [KimiCodeHookConfig.Event] {
         var events = def.events.map { event in
@@ -27,10 +67,11 @@ extension CMUXCLI {
 
     func installKimiHooks(_ def: AgentHookDef) throws {
         let fm = FileManager.default
-        let configDir = def.resolvedConfigDir()
-        let filePath = "\(configDir)/\(def.configFile)"
-        let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
-        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
+        let locations = Self.kimiConfigLocations(for: def)
+        let activeConfigURL = locations.active
+        let configDir = activeConfigURL.deletingLastPathComponent().path
+        let filePath = activeConfigURL.path
+        let events = kimiCodeHookEvents(def: def)
         let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
             || ProcessInfo.processInfo.arguments.contains("-y")
 
@@ -48,10 +89,10 @@ extension CMUXCLI {
         }
 
         let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
-        let newString = KimiCodeHookConfig.installing(events: kimiCodeHookEvents(def: def), in: oldString)
-        let activeEdit: (url: URL, oldContent: String, newContent: String)? = oldString == newString
+        let newString = KimiCodeHookConfig.installing(events: events, in: oldString)
+        let activeEdit: KimiConfigEdit? = oldString == newString
             ? nil
-            : (url: activeConfigURL, oldContent: oldString, newContent: newString)
+            : KimiConfigEdit(url: activeConfigURL, oldContent: oldString, newContent: newString)
         if activeEdit == nil {
             print(String.localizedStringWithFormat(
                 String(
@@ -63,28 +104,31 @@ extension CMUXCLI {
             ))
         }
 
-        var legacyEdit: (url: URL, oldContent: String, newContent: String)?
-        var legacyCleanupFailed = false
-        if Self.canonicalKimiConfigURL(activeConfigURL) != Self.canonicalKimiConfigURL(legacyConfigURL) {
+        // A config the active CLI does not read still belongs to a Kimi install
+        // the user may switch back to, so an existing cmux block there is
+        // refreshed in place and a config without one is left untouched.
+        var secondaryEdits: [KimiConfigEdit] = []
+        var unrefreshedSecondaryURLs: [URL] = []
+        for configURL in locations.secondary where fm.fileExists(atPath: configURL.path) {
             do {
-                let legacyOldString = try readAgentHookConfig(
-                    filePath: legacyConfigURL.path,
+                let oldSecondary = try readAgentHookConfig(
+                    filePath: configURL.path,
                     displayName: def.displayName
                 )
-                let legacyNewString = KimiCodeHookConfig.uninstalling(from: legacyOldString)
-                if legacyOldString != legacyNewString {
-                    legacyEdit = (
-                        url: legacyConfigURL,
-                        oldContent: legacyOldString,
-                        newContent: legacyNewString
-                    )
-                }
+                guard KimiCodeHookConfig.containsCmuxBlock(in: oldSecondary) else { continue }
+                let newSecondary = KimiCodeHookConfig.installing(events: events, in: oldSecondary)
+                guard oldSecondary != newSecondary else { continue }
+                secondaryEdits.append(KimiConfigEdit(
+                    url: configURL,
+                    oldContent: oldSecondary,
+                    newContent: newSecondary
+                ))
             } catch {
-                legacyCleanupFailed = true
+                unrefreshedSecondaryURLs.append(configURL)
             }
         }
 
-        let edits = [activeEdit, legacyEdit].compactMap { $0 }
+        let edits = [activeEdit].compactMap { $0 } + secondaryEdits
         if !skipConfirm, !edits.isEmpty {
             for edit in edits {
                 Self.printInstallPreview(
@@ -116,60 +160,39 @@ extension CMUXCLI {
                 }
             }
             try activeEdit.newContent.write(to: activeEdit.url, atomically: true, encoding: .utf8)
-            print(String.localizedStringWithFormat(
-                String(
-                    localized: "cli.hooks.kimi.installed",
-                    defaultValue: "%@ hooks installed at %@"
-                ),
-                def.displayName,
-                filePath
-            ))
+            printKimiHooksInstalled(def: def, path: activeEdit.url.path)
         }
 
-        if let legacyEdit {
+        for edit in secondaryEdits {
             do {
-                try legacyEdit.newContent.write(to: legacyEdit.url, atomically: true, encoding: .utf8)
-                print(String.localizedStringWithFormat(
-                    String(
-                        localized: "cli.hooks.kimi.removed",
-                        defaultValue: "Removed Kimi Code cmux hooks from %@"
-                    ),
-                    legacyEdit.url.path
-                ))
+                try edit.newContent.write(to: edit.url, atomically: true, encoding: .utf8)
+                printKimiHooksInstalled(def: def, path: edit.url.path)
             } catch {
-                legacyCleanupFailed = true
+                unrefreshedSecondaryURLs.append(edit.url)
             }
         }
-        if legacyCleanupFailed {
-            reportKimiLegacyCleanupWarning(
+
+        for configURL in unrefreshedSecondaryURLs {
+            reportKimiSecondaryRefreshWarning(
                 activeConfigURL: activeConfigURL,
-                legacyConfigURL: legacyConfigURL
+                secondaryConfigURL: configURL
             )
         }
     }
 
     func uninstallKimiHooks(_ def: AgentHookDef) throws {
-        let configDir = def.resolvedConfigDir()
-        let activeConfigURL = URL(fileURLWithPath: configDir, isDirectory: true)
-            .appendingPathComponent(def.configFile, isDirectory: false)
-        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
-        let configURLs = [
-            (url: activeConfigURL, isLegacy: false),
-            (url: legacyConfigURL, isLegacy: true),
-        ].reduce(into: [(url: URL, isLegacy: Bool)]()) { configs, config in
-            let canonicalURL = Self.canonicalKimiConfigURL(config.url)
-            guard !configs.contains(where: { Self.canonicalKimiConfigURL($0.url) == canonicalURL }) else { return }
-            configs.append(config)
-        }
+        let fm = FileManager.default
+        let locations = Self.kimiConfigLocations(for: def)
 
         var foundConfig = false
-        for config in configURLs where FileManager.default.fileExists(atPath: config.url.path) {
+        for (index, configURL) in locations.all.enumerated()
+        where fm.fileExists(atPath: configURL.path) {
             foundConfig = true
             do {
-                _ = try removeKimiHooks(at: config.url, def: def, reportNoChange: true)
+                _ = try removeKimiHooks(at: configURL, def: def, reportNoChange: true)
             } catch {
-                guard config.isLegacy else { throw error }
-                reportKimiLegacyUninstallWarning(legacyConfigURL: config.url)
+                guard index > 0 else { throw error }
+                reportKimiSecondaryUninstallWarning(secondaryConfigURL: configURL)
             }
         }
         guard !foundConfig else { return }
@@ -180,7 +203,7 @@ extension CMUXCLI {
                 defaultValue: "No %@ found at %@"
             ),
             def.configFile,
-            activeConfigURL.path
+            locations.active.path
         ))
     }
 
@@ -214,45 +237,193 @@ extension CMUXCLI {
         return true
     }
 
-    private func reportKimiLegacyCleanupWarning(
+    private func printKimiHooksInstalled(def: AgentHookDef, path: String) {
+        print(String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.kimi.installed",
+                defaultValue: "%@ hooks installed at %@"
+            ),
+            def.displayName,
+            path
+        ))
+    }
+
+    private func reportKimiSecondaryRefreshWarning(
         activeConfigURL: URL,
-        legacyConfigURL: URL
+        secondaryConfigURL: URL
     ) {
         let warning = String.localizedStringWithFormat(
             String(
-                localized: "cli.hooks.kimi.legacyCleanupWarning",
-                defaultValue: "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
+                localized: "cli.hooks.kimi.secondaryRefreshWarning",
+                defaultValue: "Warning: cmux hooks are installed at %@, but cmux could not refresh its existing hook block in %@. Check that path and re-run `cmux hooks setup kimi` to finish the update."
             ),
             activeConfigURL.path,
-            legacyConfigURL.path
+            secondaryConfigURL.path
         )
         cliWriteStderr(warning + "\n")
     }
 
-    private func reportKimiLegacyUninstallWarning(legacyConfigURL: URL) {
+    private func reportKimiSecondaryUninstallWarning(secondaryConfigURL: URL) {
         let warning = String.localizedStringWithFormat(
             String(
-                localized: "cli.hooks.kimi.legacyUninstallWarning",
-                defaultValue: "Warning: cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
+                localized: "cli.hooks.kimi.secondaryUninstallWarning",
+                defaultValue: "Warning: cmux could not remove its hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
             ),
-            legacyConfigURL.path
+            secondaryConfigURL.path
         )
         cliWriteStderr(warning + "\n")
     }
 
-    private static func legacyKimiConfigURL(fileName: String) -> URL {
-        let environment = ProcessInfo.processInfo.environment
-        let home = environment["HOME"].flatMap { value -> String? in
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        } ?? NSHomeDirectory()
-        let legacyDirectory = environment[legacyKimiConfigDirectoryOverride].flatMap { value -> String? in
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
-        }.map { URL(fileURLWithPath: $0, isDirectory: true) }
-            ?? URL(fileURLWithPath: home, isDirectory: true)
-                .appendingPathComponent(legacyKimiConfigDirectory, isDirectory: true)
-        return legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
+    // MARK: Config discovery
+
+    /// The Kimi config file cmux installs into, plus the other well-known Kimi
+    /// configs it keeps consistent.
+    ///
+    /// The active file is the one the installed CLI reports through
+    /// `kimi doctor`; when the binary cannot answer, it is the first well-known
+    /// location that already exists, defaulting to the current Kimi Code CLI
+    /// path. See https://github.com/manaflow-ai/cmux/issues/10255.
+    static func kimiConfigLocations(for def: AgentHookDef) -> KimiConfigLocations {
+        let candidates = kimiConfigDirectoryCandidates().map { directory in
+            directory.appendingPathComponent(def.configFile, isDirectory: false)
+        }
+        let active = kimiDoctorReportedConfigURL(
+            binaryName: def.binaryName,
+            configFileName: def.configFile
+        ) ?? URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent(def.configFile, isDirectory: false)
+
+        var seen: Set<URL> = [canonicalKimiConfigURL(active)]
+        var secondary: [URL] = []
+        for candidate in candidates where seen.insert(canonicalKimiConfigURL(candidate)).inserted {
+            secondary.append(candidate)
+        }
+        return KimiConfigLocations(active: active, secondary: secondary)
+    }
+
+    /// The config directory used when the installed binary cannot report one.
+    static func resolvedKimiConfigDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let candidates = kimiConfigDirectoryCandidates(environment: environment)
+        if let configured = candidates.first(where: { directory in
+            kimiRegularFileExists(
+                directory.appendingPathComponent(kimiConfigFileName, isDirectory: false),
+                fileManager: fileManager
+            )
+        }) {
+            return configured
+        }
+        if let installed = candidates.first(where: {
+            kimiDirectoryExists($0, fileManager: fileManager)
+        }) {
+            return installed
+        }
+        return candidates.first ?? kimiHomeURL(environment: environment)
+            .appendingPathComponent(kimiCodeConfigDirectory, isDirectory: true)
+    }
+
+    private static func kimiConfigDirectoryCandidates(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [URL] {
+        let home = kimiHomeURL(environment: environment)
+        return kimiConfigDirectorySpecs.map { spec in
+            if let override = nonEmptyKimiEnvironmentValue(
+                environment[spec.environmentOverride]
+            ) {
+                return URL(
+                    fileURLWithPath: NSString(string: override).expandingTildeInPath,
+                    isDirectory: true
+                )
+            }
+            return home.appendingPathComponent(spec.homeRelativeDirectory, isDirectory: true)
+        }
+    }
+
+    /// The absolute `config.toml` path `kimi doctor` reports, when it reports a
+    /// usable one. A binary that is missing, does not know the subcommand, or
+    /// prints no path leaves the well-known locations in charge.
+    private static func kimiDoctorReportedConfigURL(
+        binaryName: String,
+        configFileName: String,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        guard let output = runKimiDoctor(binaryName: binaryName),
+              let reported = kimiConfigURL(inDoctorOutput: output, configFileName: configFileName),
+              kimiDirectoryExists(reported.deletingLastPathComponent(), fileManager: fileManager)
+        else {
+            return nil
+        }
+        return reported
+    }
+
+    static func kimiConfigURL(inDoctorOutput output: String, configFileName: String) -> URL? {
+        let trimmed = CharacterSet(charactersIn: "\"'`,;:()[]{}<>")
+        for token in output.split(whereSeparator: { $0.isWhitespace }) {
+            let candidate = String(token).trimmingCharacters(in: trimmed)
+            guard !candidate.isEmpty else { continue }
+            let expanded = NSString(string: candidate).expandingTildeInPath
+            guard expanded.hasPrefix("/") else { continue }
+            let url = URL(fileURLWithPath: expanded, isDirectory: false).standardizedFileURL
+            guard url.lastPathComponent == configFileName else { continue }
+            return url
+        }
+        return nil
+    }
+
+    private static func runKimiDoctor(binaryName: String) -> String? {
+        let fm = FileManager.default
+        let outputURL = fm.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-doctor-\(UUID().uuidString)", isDirectory: false)
+        guard fm.createFile(atPath: outputURL.path, contents: nil) else { return nil }
+        defer { try? fm.removeItem(at: outputURL) }
+        guard let outputHandle = try? FileHandle(forWritingTo: outputURL) else { return nil }
+        defer { try? outputHandle.close() }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [binaryName, "doctor"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = outputHandle
+        process.standardError = outputHandle
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try cliRunProcess(process)
+        } catch {
+            return nil
+        }
+        if exited.wait(timeout: .now() + kimiDoctorProbeTimeoutSeconds) == .timedOut {
+            process.terminate()
+            if exited.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 1)
+            }
+        }
+        return try? String(contentsOf: outputURL, encoding: .utf8)
+    }
+
+    private static func kimiHomeURL(environment: [String: String]) -> URL {
+        let home = nonEmptyKimiEnvironmentValue(environment["HOME"]) ?? NSHomeDirectory()
+        return URL(fileURLWithPath: home, isDirectory: true)
+    }
+
+    private static func nonEmptyKimiEnvironmentValue(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func kimiDirectoryExists(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+
+    private static func kimiRegularFileExists(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
     }
 
     private static func canonicalKimiConfigURL(_ url: URL) -> URL {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -101,6 +101,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         "KIRO_HOME",
         "KIRO_LOG_LEVEL",
         "KIRO_LOG_NO_COLOR",
+        "KIMI_CODE_HOME",
         "KIMI_SHARE_DIR",
         "NODE_OPTIONS",
         "OPENCODE_CONFIG_DIR",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiCodeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiCodeHookConfig.swift
@@ -130,10 +130,26 @@ public enum KimiCodeHookConfig {
         return escaped
     }
 
+    /// Splits TOML content into lines, tolerating CRLF endings.
+    ///
+    /// TOML permits CRLF newlines, but splitting on `"\n"` alone would leave a
+    /// trailing `\r` on every line, which the marker comparisons below do not
+    /// strip, so a CRLF-formatted config would never match `beginMarker` or
+    /// `endMarker`. The output is always rejoined with a bare `"\n"`
+    /// (`tomlContent(from:)`), which already normalizes line endings on any
+    /// content this type rewrites.
     private static func tomlLines(from content: String) -> [String] {
         guard !content.isEmpty else { return [] }
-        var lines = content.components(separatedBy: "\n")
-        if content.hasSuffix("\n"), lines.last == "" {
+        var lines = content.components(separatedBy: "\n").map { line in
+            line.hasSuffix("\r") ? String(line.dropLast()) : line
+        }
+        // `components(separatedBy:)` only ever leaves a trailing empty element
+        // when `content` ends with the separator, so this alone is equivalent
+        // to (and, unlike `content.hasSuffix("\n")`, correct for) a trailing
+        // "\n" or "\r\n": Swift treats "\r\n" as a single Character, so
+        // `content.hasSuffix("\n")` is false for CRLF-terminated content even
+        // though `components(separatedBy:)` still split on it.
+        if lines.last == "" {
             lines.removeLast()
         }
         return lines

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiCodeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiCodeHookConfig.swift
@@ -51,6 +51,15 @@ public enum KimiCodeHookConfig {
         return tomlContent(from: lines)
     }
 
+    /// Returns whether the content already carries a cmux-owned Kimi Code hooks block.
+    /// - Parameter existing: Existing TOML config content.
+    /// - Returns: `true` when a cmux marker block is present.
+    public static func containsCmuxBlock(in existing: String) -> Bool {
+        tomlLines(from: existing).contains { line in
+            line.trimmingCharacters(in: .whitespaces) == beginMarker
+        }
+    }
+
     /// Returns TOML content after removing cmux-owned Kimi Code hooks blocks.
     /// - Parameter existing: Existing TOML config content.
     /// - Returns: The TOML content without cmux-owned Kimi Code hook blocks.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
@@ -67,6 +67,13 @@ public struct KimiConfigLocationResolver {
     /// Characters that may follow a path in a report line without belonging to it.
     private static let pathDelimiters: Set<Character> = ["\"", "'", "`", ",", ";", ":", ")", "]", "}", ">"]
 
+    /// A `kimi doctor` report is a handful of short lines naming a config file.
+    /// Anything larger is not a report, so parsing stops at these bounds instead
+    /// of scanning arbitrary output from an unrelated binary.
+    private static let maximumReportCharacters = 8_192
+    private static let maximumReportLineCharacters = 1_024
+    private static let maximumPathStartsPerLine = 32
+
     private let environment: [String: String]
     private let fileManager: FileManager
     private let directorySpecs: [DirectorySpec]
@@ -142,7 +149,9 @@ public struct KimiConfigLocationResolver {
     /// - Parameter output: Combined standard output and error of `kimi doctor`.
     /// - Returns: The reported config file URL, or `nil`.
     public func reportedConfigURL(inDoctorOutput output: String) -> URL? {
-        for line in output.split(whereSeparator: { $0.isNewline }) {
+        let bounded = output.prefix(Self.maximumReportCharacters)
+        for line in bounded.split(whereSeparator: { $0.isNewline })
+        where line.count <= Self.maximumReportLineCharacters {
             if let url = reportedConfigURL(inDoctorOutputLine: String(line)) {
                 return url
             }
@@ -157,8 +166,16 @@ public struct KimiConfigLocationResolver {
     /// first candidate whose parent directory exists wins. That keeps a path
     /// containing spaces intact, which whitespace tokenization would split,
     /// while a label or prose before the path is rejected by the same directory
-    /// check. Work is bounded by the length of a single line.
+    /// check.
+    ///
+    /// Path starts are collected in one pass and capped, so the candidate work
+    /// stays bounded by `maximumPathStartsPerLine * maximumReportLineCharacters`
+    /// even for output that is not a report at all. A real report line opens one
+    /// or two paths.
     private func reportedConfigURL(inDoctorOutputLine line: String) -> URL? {
+        let pathStarts = pathStarts(in: line)
+        guard !pathStarts.isEmpty else { return nil }
+
         var nameSearchStart = line.startIndex
         while let nameRange = line.range(
             of: configFileName,
@@ -172,8 +189,7 @@ public struct KimiConfigLocationResolver {
                 }
             }
 
-            for start in line.indices[line.startIndex..<nameRange.lowerBound]
-            where startsPath(at: start, in: line) {
+            for start in pathStarts where start < nameRange.lowerBound {
                 if let url = usableConfigURL(String(line[start..<nameRange.upperBound])) {
                     return url
                 }
@@ -182,14 +198,22 @@ public struct KimiConfigLocationResolver {
         return nil
     }
 
-    /// Whether a path could begin at this index: a `/` or `~` that opens a
-    /// token rather than sitting inside one.
-    private func startsPath(at index: String.Index, in line: String) -> Bool {
-        let character = line[index]
-        guard character == "/" || character == "~" else { return false }
-        guard index > line.startIndex else { return true }
-        let preceding = line[line.index(before: index)]
-        return preceding.isWhitespace || Self.pathDelimiters.contains(preceding)
+    /// Indices where a path could begin: a `/` or `~` that opens a token rather
+    /// than sitting inside one.
+    private func pathStarts(in line: String) -> [String.Index] {
+        var starts: [String.Index] = []
+        var previous: Character?
+        for index in line.indices {
+            let character = line[index]
+            defer { previous = character }
+            guard character == "/" || character == "~" else { continue }
+            if let previous, !previous.isWhitespace, !Self.pathDelimiters.contains(previous) {
+                continue
+            }
+            starts.append(index)
+            if starts.count == Self.maximumPathStartsPerLine { break }
+        }
+        return starts
     }
 
     private func usableConfigURL(_ candidate: String) -> URL? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
@@ -64,6 +64,9 @@ public struct KimiConfigLocationResolver {
         ),
     ]
 
+    /// Characters that may follow a path in a report line without belonging to it.
+    private static let pathDelimiters: Set<Character> = ["\"", "'", "`", ",", ";", ":", ")", "]", "}", ">"]
+
     private let environment: [String: String]
     private let fileManager: FileManager
     private let directorySpecs: [DirectorySpec]
@@ -139,18 +142,63 @@ public struct KimiConfigLocationResolver {
     /// - Parameter output: Combined standard output and error of `kimi doctor`.
     /// - Returns: The reported config file URL, or `nil`.
     public func reportedConfigURL(inDoctorOutput output: String) -> URL? {
-        let punctuation = CharacterSet(charactersIn: "\"'`,;:()[]{}<>")
-        for token in output.split(whereSeparator: { $0.isWhitespace }) {
-            let candidate = String(token).trimmingCharacters(in: punctuation)
-            guard !candidate.isEmpty else { continue }
-            let expanded = NSString(string: candidate).expandingTildeInPath
-            guard expanded.hasPrefix("/") else { continue }
-            let url = URL(fileURLWithPath: expanded, isDirectory: false).standardizedFileURL
-            guard url.lastPathComponent == configFileName,
-                  isDirectory(url.deletingLastPathComponent()) else { continue }
-            return url
+        for line in output.split(whereSeparator: { $0.isNewline }) {
+            if let url = reportedConfigURL(inDoctorOutputLine: String(line)) {
+                return url
+            }
         }
         return nil
+    }
+
+    /// Scans one report line for a config path.
+    ///
+    /// The report format is not specified, so each occurrence of the file name
+    /// is extended leftwards to every earlier token-opening `/` or `~`, and the
+    /// first candidate whose parent directory exists wins. That keeps a path
+    /// containing spaces intact, which whitespace tokenization would split,
+    /// while a label or prose before the path is rejected by the same directory
+    /// check. Work is bounded by the length of a single line.
+    private func reportedConfigURL(inDoctorOutputLine line: String) -> URL? {
+        var nameSearchStart = line.startIndex
+        while let nameRange = line.range(
+            of: configFileName,
+            range: nameSearchStart..<line.endIndex
+        ) {
+            nameSearchStart = nameRange.upperBound
+            if nameRange.upperBound < line.endIndex {
+                let following = line[nameRange.upperBound]
+                guard following.isWhitespace || Self.pathDelimiters.contains(following) else {
+                    continue
+                }
+            }
+
+            for start in line.indices[line.startIndex..<nameRange.lowerBound]
+            where startsPath(at: start, in: line) {
+                if let url = usableConfigURL(String(line[start..<nameRange.upperBound])) {
+                    return url
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Whether a path could begin at this index: a `/` or `~` that opens a
+    /// token rather than sitting inside one.
+    private func startsPath(at index: String.Index, in line: String) -> Bool {
+        let character = line[index]
+        guard character == "/" || character == "~" else { return false }
+        guard index > line.startIndex else { return true }
+        let preceding = line[line.index(before: index)]
+        return preceding.isWhitespace || Self.pathDelimiters.contains(preceding)
+    }
+
+    private func usableConfigURL(_ candidate: String) -> URL? {
+        let expanded = NSString(string: candidate).expandingTildeInPath
+        guard expanded.hasPrefix("/") else { return nil }
+        let url = URL(fileURLWithPath: expanded, isDirectory: false).standardizedFileURL
+        guard url.lastPathComponent == configFileName,
+              isDirectory(url.deletingLastPathComponent()) else { return nil }
+        return url
     }
 
     /// The config files cmux manages for this installation.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/KimiConfigLocationResolver.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// Resolves which Kimi `config.toml` files cmux manages.
+///
+/// Kimi ships under two config layouts: Kimi Code CLI reads
+/// `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`, and Kimi CLI 1.49 and earlier
+/// read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. cmux installs into the file
+/// the installed binary reports, and keeps the other one intact rather than
+/// deleting a block the other CLI still reads.
+/// See https://github.com/manaflow-ai/cmux/issues/10255.
+public struct KimiConfigLocationResolver {
+    /// A well-known Kimi config directory and the variable that relocates it.
+    public struct DirectorySpec: Equatable, Sendable {
+        /// Environment variable that moves this installation's config directory.
+        public let environmentOverride: String
+        /// Directory name under the home directory when the variable is unset.
+        public let homeRelativeDirectory: String
+
+        /// Creates a directory spec.
+        /// - Parameters:
+        ///   - environmentOverride: Variable that relocates the directory.
+        ///   - homeRelativeDirectory: Directory name relative to the home directory.
+        public init(environmentOverride: String, homeRelativeDirectory: String) {
+            self.environmentOverride = environmentOverride
+            self.homeRelativeDirectory = homeRelativeDirectory
+        }
+    }
+
+    /// The config file cmux installs into, plus the other files it manages.
+    public struct Locations: Equatable, Sendable {
+        /// Config file the installed Kimi CLI reads.
+        public let active: URL
+        /// Well-known config files belonging to the other installation.
+        public let secondary: [URL]
+
+        /// Creates a location set.
+        /// - Parameters:
+        ///   - active: Config file the installed Kimi CLI reads.
+        ///   - secondary: Other well-known config files.
+        public init(active: URL, secondary: [URL]) {
+            self.active = active
+            self.secondary = secondary
+        }
+
+        /// The active config file followed by every secondary one.
+        public var all: [URL] { [active] + secondary }
+    }
+
+    /// Config file name shared by every Kimi installation.
+    public static let configFileName = "config.toml"
+    /// Home-relative config directory of the current Kimi Code CLI.
+    public static let kimiCodeConfigDirectory = ".kimi-code"
+    /// Home-relative config directory of Kimi CLI 1.49 and earlier.
+    public static let kimiCLIConfigDirectory = ".kimi"
+    /// Well-known config directories, most current first.
+    public static let defaultDirectorySpecs = [
+        DirectorySpec(
+            environmentOverride: "KIMI_CODE_HOME",
+            homeRelativeDirectory: kimiCodeConfigDirectory
+        ),
+        DirectorySpec(
+            environmentOverride: "KIMI_SHARE_DIR",
+            homeRelativeDirectory: kimiCLIConfigDirectory
+        ),
+    ]
+
+    private let environment: [String: String]
+    private let fileManager: FileManager
+    private let directorySpecs: [DirectorySpec]
+    private let configFileName: String
+
+    /// Creates a resolver.
+    /// - Parameters:
+    ///   - environment: Environment used for `HOME` and directory overrides.
+    ///   - fileManager: File manager used for existence checks.
+    ///   - directorySpecs: Well-known directories, most current first.
+    ///   - configFileName: Config file name inside each directory.
+    public init(
+        environment: [String: String],
+        fileManager: FileManager = .default,
+        directorySpecs: [DirectorySpec] = KimiConfigLocationResolver.defaultDirectorySpecs,
+        configFileName: String = KimiConfigLocationResolver.configFileName
+    ) {
+        self.environment = environment
+        self.fileManager = fileManager
+        self.directorySpecs = directorySpecs
+        self.configFileName = configFileName
+    }
+
+    /// Every well-known config directory, most current first.
+    /// - Returns: Candidate directories after applying environment overrides.
+    public func candidateDirectories() -> [URL] {
+        let home = homeDirectory()
+        return directorySpecs.map { spec in
+            if let override = Self.nonEmptyValue(environment[spec.environmentOverride]) {
+                return URL(
+                    fileURLWithPath: NSString(string: override).expandingTildeInPath,
+                    isDirectory: true
+                )
+            }
+            return home.appendingPathComponent(spec.homeRelativeDirectory, isDirectory: true)
+        }
+    }
+
+    /// Every well-known config file, most current first.
+    /// - Returns: Candidate config file URLs.
+    public func candidateConfigURLs() -> [URL] {
+        candidateDirectories().map { directory in
+            directory.appendingPathComponent(configFileName, isDirectory: false)
+        }
+    }
+
+    /// The config directory to use when the installed binary reports none.
+    ///
+    /// Prefers a candidate that already holds a config file, then one whose
+    /// directory exists, then the current Kimi Code CLI location.
+    /// - Returns: The chosen config directory.
+    public func fallbackConfigDirectory() -> URL {
+        let candidates = candidateDirectories()
+        if let configured = candidates.first(where: { directory in
+            isRegularFile(directory.appendingPathComponent(configFileName, isDirectory: false))
+        }) {
+            return configured
+        }
+        if let installed = candidates.first(where: { isDirectory($0) }) {
+            return installed
+        }
+        return candidates.first
+            ?? homeDirectory().appendingPathComponent(
+                Self.kimiCodeConfigDirectory,
+                isDirectory: true
+            )
+    }
+
+    /// The config file path a `kimi doctor` report names, when it names a usable one.
+    ///
+    /// Output that carries no absolute config path, or one whose parent
+    /// directory does not exist, leaves the well-known locations in charge.
+    /// - Parameter output: Combined standard output and error of `kimi doctor`.
+    /// - Returns: The reported config file URL, or `nil`.
+    public func reportedConfigURL(inDoctorOutput output: String) -> URL? {
+        let punctuation = CharacterSet(charactersIn: "\"'`,;:()[]{}<>")
+        for token in output.split(whereSeparator: { $0.isWhitespace }) {
+            let candidate = String(token).trimmingCharacters(in: punctuation)
+            guard !candidate.isEmpty else { continue }
+            let expanded = NSString(string: candidate).expandingTildeInPath
+            guard expanded.hasPrefix("/") else { continue }
+            let url = URL(fileURLWithPath: expanded, isDirectory: false).standardizedFileURL
+            guard url.lastPathComponent == configFileName,
+                  isDirectory(url.deletingLastPathComponent()) else { continue }
+            return url
+        }
+        return nil
+    }
+
+    /// The config files cmux manages for this installation.
+    /// - Parameter reportedConfigURL: Path reported by the installed binary, if any.
+    /// - Returns: The active config file and the remaining well-known ones.
+    public func locations(reportedConfigURL: URL?) -> Locations {
+        let active = reportedConfigURL
+            ?? fallbackConfigDirectory().appendingPathComponent(configFileName, isDirectory: false)
+        var seen: Set<URL> = [Self.canonical(active)]
+        var secondary: [URL] = []
+        for candidate in candidateConfigURLs() where seen.insert(Self.canonical(candidate)).inserted {
+            secondary.append(candidate)
+        }
+        return Locations(active: active, secondary: secondary)
+    }
+
+    private func homeDirectory() -> URL {
+        let home = Self.nonEmptyValue(environment["HOME"]) ?? NSHomeDirectory()
+        return URL(fileURLWithPath: home, isDirectory: true)
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+
+    private func isRegularFile(_ url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+    }
+
+    /// Canonical identity of a config path.
+    ///
+    /// `resolvingSymlinksInPath()` alone leaves an intermediate symlink in
+    /// place when the file itself does not exist yet, so the parent directory
+    /// is resolved separately; otherwise a symlinked config directory would
+    /// look like a second, distinct config file.
+    private static func canonical(_ url: URL) -> URL {
+        let resolved = url.resolvingSymlinksInPath()
+        return resolved
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(resolved.lastPathComponent, isDirectory: false)
+            .standardizedFileURL
+    }
+
+    private static func nonEmptyValue(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -108,11 +108,15 @@ struct KimiAgentResumeTests {
         #expect(
             AgentLaunchEnvironmentPolicy().selectedEnvironment(
                 from: [
+                    "KIMI_CODE_HOME": "/Users/example/.local/share/kimi-code-custom",
                     "KIMI_SHARE_DIR": "/Users/example/.local/share/kimi-custom",
                     "MOONSHOT_API_KEY": "secret",
                 ],
                 kind: "kimi"
-            ) == ["KIMI_SHARE_DIR": "/Users/example/.local/share/kimi-custom"]
+            ) == [
+                "KIMI_CODE_HOME": "/Users/example/.local/share/kimi-code-custom",
+                "KIMI_SHARE_DIR": "/Users/example/.local/share/kimi-custom",
+            ]
         )
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
@@ -184,6 +184,16 @@ struct KimiCodeHookConfigTests {
         ]
         let crlfExisting = "model = \"kimi-k2\"\r\ntelemetry = false\r\n"
 
+        // Isolates the line-count half of the bug, independent of marker
+        // matching: normalizing CRLF content with no cmux block at all must
+        // not gain a trailing blank line. `content.hasSuffix("\n")` is false
+        // for CRLF-terminated content (Swift treats "\r\n" as one Character),
+        // so the naive fix leaves the split's trailing empty element in place.
+        #expect(
+            KimiCodeHookConfig.uninstalling(from: crlfExisting)
+                == "model = \"kimi-k2\"\ntelemetry = false\n"
+        )
+
         let installed = KimiCodeHookConfig.installing(events: eventsV1, in: crlfExisting)
         #expect(KimiCodeHookConfig.containsCmuxBlock(in: installed))
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
@@ -177,6 +177,39 @@ struct KimiCodeHookConfigTests {
         """)
     }
 
+    @Test("Detects, refreshes, and removes a cmux block written with CRLF line endings")
+    func handlesCRLFLineEndings() {
+        let eventsV1 = [
+            KimiCodeHookConfig.Event(name: "Stop", command: "cmux hooks kimi stop", timeout: 10),
+        ]
+        let crlfExisting = "model = \"kimi-k2\"\r\ntelemetry = false\r\n"
+
+        let installed = KimiCodeHookConfig.installing(events: eventsV1, in: crlfExisting)
+        #expect(KimiCodeHookConfig.containsCmuxBlock(in: installed))
+
+        // Reconstruct the installed config with CRLF endings, as a CRLF-editing
+        // tool would leave it, and confirm a refresh still finds and replaces
+        // the existing block instead of appending a second one.
+        let crlfInstalled = installed.replacingOccurrences(of: "\n", with: "\r\n")
+        #expect(KimiCodeHookConfig.containsCmuxBlock(in: crlfInstalled))
+
+        let eventsV2 = [
+            KimiCodeHookConfig.Event(name: "Stop", command: "cmux hooks kimi stop", timeout: 20),
+        ]
+        let refreshed = KimiCodeHookConfig.installing(events: eventsV2, in: crlfInstalled)
+        #expect(refreshed.components(separatedBy: "# cmux-kimi-hooks-7c3a9f12-4e8b-4d2a-9f15-6b8c0d1e2a3f begin").count == 2)
+        #expect(refreshed.contains("timeout = 20"))
+        #expect(!refreshed.contains("timeout = 10"))
+
+        // Round-tripping through CRLF must land on the same normalized (LF)
+        // content as the plain-LF path — CR handling must not add or drop a line.
+        #expect(
+            KimiCodeHookConfig.uninstalling(from: crlfInstalled)
+                == KimiCodeHookConfig.uninstalling(from: installed)
+        )
+        #expect(KimiCodeHookConfig.uninstalling(from: crlfInstalled) == "model = \"kimi-k2\"\ntelemetry = false\n\n")
+    }
+
     @Test("Escapes TOML basic string content")
     func escapesTOMLBasicStringContent() {
         let events = [

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiCodeHookConfigTests.swift
@@ -117,6 +117,35 @@ struct KimiCodeHookConfigTests {
         #expect(KimiCodeHookConfig.uninstalling(from: existing) == existing)
     }
 
+    @Test("Detects whether a config carries a cmux block")
+    func detectsWhetherConfigCarriesCmuxBlock() {
+        let userOnly = """
+        model = "kimi-k2"
+
+        [[hooks]]
+        event = "Stop"
+        command = "vibe-island"
+
+        """
+        let installed = KimiCodeHookConfig.installing(
+            events: [
+                KimiCodeHookConfig.Event(
+                    name: "Stop",
+                    command: "cmux hooks kimi stop",
+                    timeout: 10
+                ),
+            ],
+            in: userOnly
+        )
+
+        #expect(!KimiCodeHookConfig.containsCmuxBlock(in: ""))
+        #expect(!KimiCodeHookConfig.containsCmuxBlock(in: userOnly))
+        #expect(KimiCodeHookConfig.containsCmuxBlock(in: installed))
+        #expect(!KimiCodeHookConfig.containsCmuxBlock(
+            in: KimiCodeHookConfig.uninstalling(from: installed)
+        ))
+    }
+
     @Test("Uninstall removes orphaned begin marker without dropping following TOML")
     func uninstallRemovesOrphanedBeginMarkerWithoutDroppingFollowingTOML() {
         let existing = """

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
@@ -134,6 +134,39 @@ struct KimiConfigLocationResolverTests {
         )
     }
 
+    @Test("A reported path keeps spaces and survives a labelled line")
+    func doctorReportKeepsPathsWithSpaces() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+        let resolver = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+        let spaced = home.config("Kimi Code")
+        try makeDirectory(spaced.deletingLastPathComponent())
+
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "config.toml: \(spaced.path) ok\n"
+            ) == spaced
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "checked \"\(spaced.path)\"\n"
+            ) == spaced
+        )
+        #expect(
+            resolver.reportedConfigURL(inDoctorOutput: "\(spaced.path)\n") == spaced
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "ran /usr/bin/env kimi, read \(spaced.path)\n"
+            ) == spaced
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "config.toml: \(home.directory("Kimi Code").path)/xconfig.toml\n"
+            ) == nil
+        )
+    }
+
     @Test("Locations keep the reported config active and list the rest once")
     func locationsDedupeAgainstTheActiveConfig() throws {
         let home = try makeHome()

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
@@ -57,10 +57,12 @@ struct KimiConfigLocationResolverTests {
             "HOME": home.root.path,
             "KIMI_SHARE_DIR": "~/relocated-kimi",
         ])
+        // Tilde overrides expand against the process HOME, not the injected one.
         #expect(
             tilde.candidateDirectories().last?.path
-                == NSString(string: "~/relocated-kimi").expandingTildeInPath
+                == NSHomeDirectory() + "/relocated-kimi"
         )
+        #expect(tilde.candidateDirectories().last?.path != home.directory("relocated-kimi").path)
     }
 
     @Test("Fallback prefers an existing config, then an existing directory, then Kimi Code")
@@ -164,6 +166,46 @@ struct KimiConfigLocationResolverTests {
             resolver.reportedConfigURL(
                 inDoctorOutput: "config.toml: \(home.directory("Kimi Code").path)/xconfig.toml\n"
             ) == nil
+        )
+    }
+
+    @Test("A doctor report respects its parsing bounds")
+    func doctorReportRespectsParsingBounds() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+        let resolver = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+        let reported = home.config("bounded")
+        try makeDirectory(reported.deletingLastPathComponent())
+
+        // A usable path past the 8 KB report bound is never reached.
+        let padding = String(repeating: "x", count: 8_200)
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "\(padding)\nconfig.toml: \(reported.path) ok\n"
+            ) == nil
+        )
+
+        // A usable path on a line over the 1 KB line bound is skipped.
+        let longLinePrefix = String(repeating: "y", count: 1_100)
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "\(longLinePrefix) config.toml: \(reported.path) ok\n"
+            ) == nil
+        )
+
+        // A usable path preceded by more than 32 candidate path starts on the
+        // same line falls outside the capped scan and is not found.
+        let decoys = (0..<32).map { "/decoy\($0)" }.joined(separator: " ")
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "\(decoys) \(reported.path) ok\n"
+            ) == nil
+        )
+
+        // The same path, reported alone, is found — confirming the bound,
+        // not the fixture, is what rejects it above.
+        #expect(
+            resolver.reportedConfigURL(inDoctorOutput: "\(reported.path)\n") == reported
         )
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiConfigLocationResolverTests.swift
@@ -1,0 +1,178 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite("KimiConfigLocationResolver")
+struct KimiConfigLocationResolverTests {
+    private struct Home {
+        let root: URL
+
+        func directory(_ name: String) -> URL {
+            root.appendingPathComponent(name, isDirectory: true)
+        }
+
+        func config(_ name: String) -> URL {
+            directory(name).appendingPathComponent("config.toml", isDirectory: false)
+        }
+    }
+
+    private func makeHome() throws -> Home {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-resolver-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return Home(root: root)
+    }
+
+    private func makeDirectory(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    private func writeConfig(_ url: URL) throws {
+        try makeDirectory(url.deletingLastPathComponent())
+        try "default_model = \"user-model\"\n".write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    @Test("Candidate directories put Kimi Code first and honor overrides")
+    func candidateDirectoriesHonorOverrides() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+
+        let plain = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+        #expect(plain.candidateDirectories().map(\.path) == [
+            home.directory(".kimi-code").path,
+            home.directory(".kimi").path,
+        ])
+
+        let overridden = KimiConfigLocationResolver(environment: [
+            "HOME": home.root.path,
+            "KIMI_CODE_HOME": "/opt/kimi-code",
+            "KIMI_SHARE_DIR": "  ",
+        ])
+        #expect(overridden.candidateDirectories().map(\.path) == [
+            "/opt/kimi-code",
+            home.directory(".kimi").path,
+        ])
+
+        let tilde = KimiConfigLocationResolver(environment: [
+            "HOME": home.root.path,
+            "KIMI_SHARE_DIR": "~/relocated-kimi",
+        ])
+        #expect(
+            tilde.candidateDirectories().last?.path
+                == NSString(string: "~/relocated-kimi").expandingTildeInPath
+        )
+    }
+
+    @Test("Fallback prefers an existing config, then an existing directory, then Kimi Code")
+    func fallbackFollowsExistenceOrder() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+        let environment = ["HOME": home.root.path]
+
+        #expect(
+            KimiConfigLocationResolver(environment: environment).fallbackConfigDirectory().path
+                == home.directory(".kimi-code").path
+        )
+
+        try makeDirectory(home.directory(".kimi"))
+        #expect(
+            KimiConfigLocationResolver(environment: environment).fallbackConfigDirectory().path
+                == home.directory(".kimi").path
+        )
+
+        try makeDirectory(home.directory(".kimi-code"))
+        #expect(
+            KimiConfigLocationResolver(environment: environment).fallbackConfigDirectory().path
+                == home.directory(".kimi-code").path
+        )
+
+        try writeConfig(home.config(".kimi"))
+        try FileManager.default.createDirectory(
+            at: home.config(".kimi-code"),
+            withIntermediateDirectories: true
+        )
+        #expect(
+            KimiConfigLocationResolver(environment: environment).fallbackConfigDirectory().path
+                == home.directory(".kimi").path
+        )
+    }
+
+    @Test("A doctor report is trusted only when it names a config in an existing directory")
+    func doctorReportIsTrustedOnlyWhenUsable() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+        let resolver = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+        let reported = home.config("probed")
+        try makeDirectory(reported.deletingLastPathComponent())
+
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "config.toml: \(reported.path) ok\ntui.toml: skipped\n"
+            ) == reported
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "checking \"\(reported.path)\", ok\n"
+            ) == reported
+        )
+        #expect(resolver.reportedConfigURL(inDoctorOutput: "") == nil)
+        #expect(resolver.reportedConfigURL(inDoctorOutput: "config.toml: skipped\n") == nil)
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "error: unknown command \"doctor\"\n"
+            ) == nil
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "config.toml: \(home.config("never-created").path)\n"
+            ) == nil
+        )
+        #expect(
+            resolver.reportedConfigURL(
+                inDoctorOutput: "tui.toml: \(home.directory("probed").path)/tui.toml\n"
+            ) == nil
+        )
+    }
+
+    @Test("Locations keep the reported config active and list the rest once")
+    func locationsDedupeAgainstTheActiveConfig() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+        let resolver = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+
+        let reported = home.config("probed")
+        let probed = resolver.locations(reportedConfigURL: reported)
+        #expect(probed.active == reported)
+        #expect(probed.secondary.map(\.path) == [
+            home.config(".kimi-code").path,
+            home.config(".kimi").path,
+        ])
+        #expect(probed.all.count == 3)
+
+        try makeDirectory(home.directory(".kimi"))
+        let fallback = KimiConfigLocationResolver(environment: ["HOME": home.root.path])
+            .locations(reportedConfigURL: nil)
+        #expect(fallback.active.path == home.config(".kimi").path)
+        #expect(fallback.secondary.map(\.path) == [home.config(".kimi-code").path])
+    }
+
+    @Test("Locations collapse config paths that resolve to the same file")
+    func locationsCollapseSymlinkedDirectories() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home.root) }
+
+        let real = home.directory("kimi-code-home")
+        let link = home.directory("kimi-share-link")
+        try makeDirectory(real)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        let locations = KimiConfigLocationResolver(environment: [
+            "HOME": home.root.path,
+            "KIMI_CODE_HOME": real.path,
+            "KIMI_SHARE_DIR": link.path,
+        ]).locations(reportedConfigURL: nil)
+
+        #expect(locations.active.path == real.appendingPathComponent("config.toml").path)
+        #expect(locations.secondary.isEmpty)
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43516,6 +43516,12 @@
             "value": "警告: cmux hooks は %@ にインストールされましたが、%@ にある既存の hook ブロックを更新できませんでした。そのパスを確認し、`cmux hooks setup kimi` を再実行して更新を完了してください。"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការព្រមាន៖ cmux hooks ត្រូវបានដំឡើងនៅ %@ ប៉ុន្តែ cmux មិនអាចធ្វើបច្ចុប្បន្នភាពប្លុក hook ដែលមានស្រាប់នៅក្នុង %@ បានទេ។ សូមពិនិត្យផ្លូវនោះ រួចដំណើរការ `cmux hooks setup kimi` ម្ដងទៀត ដើម្បីបញ្ចប់ការធ្វើបច្ចុប្បន្នភាព។"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -43633,6 +43639,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "警告: hook ブロックを %@ から削除できませんでした。そのパスを確認し、`cmux hooks uninstall kimi` を再実行してクリーンアップを完了してください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការព្រមាន៖ cmux មិនអាចលុបប្លុក hook របស់ខ្លួនចេញពី %@ បានទេ។ សូមពិនិត្យផ្លូវនោះ រួចដំណើរការ `cmux hooks uninstall kimi` ម្ដងទៀត ដើម្បីបញ្ចប់ការសម្អាត។"
           }
         },
         "ko": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43462,10 +43462,52 @@
     "cli.hooks.kimi.secondaryRefreshWarning": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحذير: تم تثبيت خطافات cmux في %@، لكن تعذّر على cmux تحديث كتلة الخطافات الموجودة في %@. تحقّق من هذا المسار وأعد تشغيل `cmux hooks setup kimi` لإكمال التحديث."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upozorenje: cmux hookovi su instalirani u %@, ali cmux nije mogao osvježiti postojeći blok hookova u %@. Provjerite tu putanju i ponovo pokrenite `cmux hooks setup kimi` da dovršite ažuriranje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel: cmux-hooks er installeret i %@, men cmux kunne ikke opdatere sin eksisterende hook-blok i %@. Tjek den sti, og kør `cmux hooks setup kimi` igen for at fuldføre opdateringen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung: cmux-Hooks sind in %@ installiert, aber cmux konnte den vorhandenen Hook-Block in %@ nicht aktualisieren. Prüfe diesen Pfad und führe `cmux hooks setup kimi` erneut aus, um die Aktualisierung abzuschließen."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Warning: cmux hooks are installed at %@, but cmux could not refresh its existing hook block in %@. Check that path and re-run `cmux hooks setup kimi` to finish the update."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia: los hooks de cmux están instalados en %@, pero cmux no pudo actualizar su bloque de hooks existente en %@. Revisa esa ruta y vuelve a ejecutar `cmux hooks setup kimi` para completar la actualización."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement : les hooks cmux sont installés dans %@, mais cmux n'a pas pu actualiser son bloc de hooks existant dans %@. Vérifiez ce chemin et relancez `cmux hooks setup kimi` pour terminer la mise à jour."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avviso: gli hook di cmux sono installati in %@, ma cmux non è riuscito ad aggiornare il blocco di hook esistente in %@. Controlla quel percorso ed esegui di nuovo `cmux hooks setup kimi` per completare l'aggiornamento."
           }
         },
         "ja": {
@@ -43473,22 +43515,184 @@
             "state": "translated",
             "value": "警告: cmux hooks は %@ にインストールされましたが、%@ にある既存の hook ブロックを更新できませんでした。そのパスを確認し、`cmux hooks setup kimi` を再実行して更新を完了してください。"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경고: cmux hooks가 %@에 설치되었지만 %@에 있는 기존 hook 블록을 갱신하지 못했습니다. 해당 경로를 확인한 뒤 `cmux hooks setup kimi`를 다시 실행해 업데이트를 완료하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel: cmux-hooks er installert i %@, men cmux kunne ikke oppdatere den eksisterende hook-blokken i %@. Sjekk den banen og kjør `cmux hooks setup kimi` på nytt for å fullføre oppdateringen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ostrzeżenie: hooki cmux są zainstalowane w %@, ale cmux nie mógł odświeżyć istniejącego bloku hooków w %@. Sprawdź tę ścieżkę i uruchom ponownie `cmux hooks setup kimi`, aby dokończyć aktualizację."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso: os hooks do cmux estão instalados em %@, mas o cmux não conseguiu atualizar o bloco de hooks existente em %@. Verifique esse caminho e execute `cmux hooks setup kimi` novamente para concluir a atualização."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предупреждение: хуки cmux установлены в %@, но cmux не смог обновить существующий блок хуков в %@. Проверьте этот путь и запустите `cmux hooks setup kimi` ещё раз, чтобы завершить обновление."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คำเตือน: ติดตั้ง cmux hooks ไว้ที่ %@ แล้ว แต่ cmux ไม่สามารถอัปเดตบล็อก hook ที่มีอยู่ใน %@ ได้ ตรวจสอบพาธนั้นแล้วรัน `cmux hooks setup kimi` อีกครั้งเพื่อทำการอัปเดตให้เสร็จสมบูรณ์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarı: cmux hook'ları %@ konumuna kuruldu ancak cmux, %@ içindeki mevcut hook bloğunu güncelleyemedi. Bu yolu kontrol edin ve güncellemeyi tamamlamak için `cmux hooks setup kimi` komutunu yeniden çalıştırın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попередження: хуки cmux встановлено в %@, але cmux не зміг оновити наявний блок хуків у %@. Перевірте цей шлях і запустіть `cmux hooks setup kimi` ще раз, щоб завершити оновлення."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告：cmux hooks 已安装到 %@，但 cmux 无法刷新 %@ 中已有的 hook 块。请检查该路径，然后重新运行 `cmux hooks setup kimi` 以完成更新。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告：cmux hooks 已安裝到 %@，但 cmux 無法更新 %@ 中既有的 hook 區塊。請檢查該路徑，然後重新執行 `cmux hooks setup kimi` 以完成更新。"
+          }
         }
       }
     },
     "cli.hooks.kimi.secondaryUninstallWarning": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحذير: تعذّر على cmux إزالة كتلة الخطافات من %@. تحقّق من هذا المسار وأعد تشغيل `cmux hooks uninstall kimi` لإكمال التنظيف."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upozorenje: cmux nije mogao ukloniti svoj blok hookova iz %@. Provjerite tu putanju i ponovo pokrenite `cmux hooks uninstall kimi` da dovršite čišćenje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel: cmux kunne ikke fjerne sin hook-blok fra %@. Tjek den sti, og kør `cmux hooks uninstall kimi` igen for at fuldføre oprydningen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung: cmux konnte seinen Hook-Block nicht aus %@ entfernen. Prüfe diesen Pfad und führe `cmux hooks uninstall kimi` erneut aus, um die Bereinigung abzuschließen."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Warning: cmux could not remove its hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia: cmux no pudo eliminar su bloque de hooks de %@. Revisa esa ruta y vuelve a ejecutar `cmux hooks uninstall kimi` para completar la limpieza."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement : cmux n'a pas pu supprimer son bloc de hooks de %@. Vérifiez ce chemin et relancez `cmux hooks uninstall kimi` pour terminer le nettoyage."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avviso: cmux non è riuscito a rimuovere il proprio blocco di hook da %@. Controlla quel percorso ed esegui di nuovo `cmux hooks uninstall kimi` per completare la pulizia."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "警告: hook ブロックを %@ から削除できませんでした。そのパスを確認し、`cmux hooks uninstall kimi` を再実行してクリーンアップを完了してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경고: %@에서 hook 블록을 제거하지 못했습니다. 해당 경로를 확인한 뒤 `cmux hooks uninstall kimi`를 다시 실행해 정리를 완료하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel: cmux kunne ikke fjerne hook-blokken sin fra %@. Sjekk den banen og kjør `cmux hooks uninstall kimi` på nytt for å fullføre oppryddingen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ostrzeżenie: cmux nie mógł usunąć swojego bloku hooków z %@. Sprawdź tę ścieżkę i uruchom ponownie `cmux hooks uninstall kimi`, aby dokończyć czyszczenie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso: o cmux não conseguiu remover seu bloco de hooks de %@. Verifique esse caminho e execute `cmux hooks uninstall kimi` novamente para concluir a limpeza."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предупреждение: cmux не смог удалить свой блок хуков из %@. Проверьте этот путь и запустите `cmux hooks uninstall kimi` ещё раз, чтобы завершить очистку."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คำเตือน: cmux ไม่สามารถลบบล็อก hook ออกจาก %@ ได้ ตรวจสอบพาธนั้นแล้วรัน `cmux hooks uninstall kimi` อีกครั้งเพื่อทำความสะอาดให้เสร็จสมบูรณ์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyarı: cmux, hook bloğunu %@ konumundan kaldıramadı. Bu yolu kontrol edin ve temizliği tamamlamak için `cmux hooks uninstall kimi` komutunu yeniden çalıştırın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попередження: cmux не зміг видалити свій блок хуків із %@. Перевірте цей шлях і запустіть `cmux hooks uninstall kimi` ще раз, щоб завершити очищення."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告：cmux 无法从 %@ 中移除其 hook 块。请检查该路径，然后重新运行 `cmux hooks uninstall kimi` 以完成清理。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告：cmux 無法從 %@ 移除其 hook 區塊。請檢查該路徑，然後重新執行 `cmux hooks uninstall kimi` 以完成清理。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43102,40 +43102,6 @@
         }
       }
     },
-    "cli.hooks.kimi.legacyCleanupWarning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告: cmux hooks は %@ で有効ですが、従来の hook ブロックを %@ から削除できませんでした。そのパスを確認し、`cmux hooks setup kimi` を再実行してクリーンアップを完了してください。"
-          }
-        }
-      }
-    },
-    "cli.hooks.kimi.legacyUninstallWarning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warning: cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告: 従来の hook ブロックを %@ から削除できませんでした。そのパスを確認し、`cmux hooks uninstall kimi` を再実行してクリーンアップを完了してください。"
-          }
-        }
-      }
-    },
     "cli.hooks.kimi.noneFound": {
       "extractionState": "manual",
       "localizations": {
@@ -43489,6 +43455,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Removed 0 cmux hook(s) from %@"
+          }
+        }
+      }
+    },
+    "cli.hooks.kimi.secondaryRefreshWarning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning: cmux hooks are installed at %@, but cmux could not refresh its existing hook block in %@. Check that path and re-run `cmux hooks setup kimi` to finish the update."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告: cmux hooks は %@ にインストールされましたが、%@ にある既存の hook ブロックを更新できませんでした。そのパスを確認し、`cmux hooks setup kimi` を再実行して更新を完了してください。"
+          }
+        }
+      }
+    },
+    "cli.hooks.kimi.secondaryUninstallWarning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning: cmux could not remove its hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告: hook ブロックを %@ から削除できませんでした。そのパスを確認し、`cmux hooks uninstall kimi` を再実行してクリーンアップを完了してください。"
           }
         }
       }

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -13,129 +13,249 @@ struct KimiHookConfigLocationTests {
         let timedOut: Bool
     }
 
-    @Test("Setup writes the default Kimi config file")
-    func setupWritesDefaultKimiConfigFile() throws {
+    @Test("Setup targets the Kimi Code config when only it exists")
+    func setupTargetsKimiCodeConfigWhenOnlyItExists() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let currentConfig = fixture.home
-            .appendingPathComponent(".kimi", isDirectory: true)
-            .appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = fixture.home
-            .appendingPathComponent(".kimi-code", isDirectory: true)
-            .appendingPathComponent("config.toml", isDirectory: false)
-        try FileManager.default.createDirectory(
-            at: currentConfig.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+        let kimiCodeConfig = try fixture.seedConfig(
+            directory: ".kimi-code",
+            content: Self.userHookContent(command: "orca")
         )
-        let result = try runCLI(
-            arguments: ["hooks", "setup", "kimi", "--yes"],
-            fixture: fixture
-        )
+        let kimiCliConfig = fixture.configURL(directory: ".kimi")
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(FileManager.default.fileExists(atPath: currentConfig.path), Comment(rawValue: result.output))
-        #expect(!FileManager.default.fileExists(atPath: legacyConfig.path), Comment(rawValue: result.output))
-        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
-        #expect(installed.contains("hooks kimi stop"))
+        #expect(!FileManager.default.fileExists(atPath: kimiCliConfig.path), Comment(rawValue: result.output))
+        let installed = try String(contentsOf: kimiCodeConfig, encoding: .utf8)
+        #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(installed.contains(#"command = "orca""#), Comment(rawValue: result.output))
         #expect(installed.contains(#"event = "Notification""#))
         #expect(!installed.contains(#"event = "PermissionRequest""#))
         #expect(!installed.contains(#"event = "Interrupt""#))
     }
 
-    @Test("Setup honors KIMI_SHARE_DIR and cleans the legacy cmux block")
-    func setupHonorsShareDirectoryAndCleansLegacyBlock() throws {
+    @Test("Setup targets the Kimi CLI config when only it exists")
+    func setupTargetsKimiCliConfigWhenOnlyItExists() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentUserContent = Self.userHookContent(command: "vibe-island")
-        let legacyUserContent = Self.userHookContent(command: "orca")
-        let legacyWithCmuxBlock = Self.installingCmuxBlock(in: legacyUserContent)
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        try currentUserContent.write(to: currentConfig, atomically: true, encoding: .utf8)
-        try legacyWithCmuxBlock.write(to: legacyConfig, atomically: true, encoding: .utf8)
-
-        let result = try runCLI(
-            arguments: ["hooks", "setup", "kimi", "--yes"],
-            fixture: fixture,
-            environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
-            ]
+        let kimiCliConfig = try fixture.seedConfig(
+            directory: ".kimi",
+            content: Self.userHookContent(command: "vibe-island")
         )
+        let kimiCodeConfig = fixture.configURL(directory: ".kimi-code")
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
-        let migratedLegacy = try String(contentsOf: legacyConfig, encoding: .utf8)
-        #expect(installed.contains(#"command = "vibe-island""#))
-        #expect(installed.contains("hooks kimi stop"))
-        #expect(migratedLegacy == legacyUserContent)
-    }
-
-    @Test("Setup succeeds when the legacy Kimi config cannot be read")
-    func setupSucceedsWhenLegacyConfigCannotBeRead() throws {
-        let fixture = try makeFixture()
-        defer { try? FileManager.default.removeItem(at: fixture.root) }
-
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
-
-        let result = try runCLI(
-            arguments: ["hooks", "setup", "kimi", "--yes"],
-            fixture: fixture,
-            environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
-            ]
-        )
-
-        #expect(!result.timedOut, Comment(rawValue: result.output))
-        #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8).contains("hooks kimi stop"))
-        #expect(result.output.contains(legacyConfig.path))
-    }
-
-    @Test("Setup does not clean the active Kimi config through a legacy symlink")
-    func setupDoesNotCleanActiveConfigThroughLegacySymlink() throws {
-        let fixture = try makeFixture()
-        defer { try? FileManager.default.removeItem(at: fixture.root) }
-
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createSymbolicLink(
-            at: legacyDirectory,
-            withDestinationURL: currentDirectory
-        )
-
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let result = try runCLI(
-            arguments: ["hooks", "setup", "kimi", "--yes"],
-            fixture: fixture,
-            environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
-            ]
-        )
-
-        #expect(!result.timedOut, Comment(rawValue: result.output))
-        #expect(result.status == 0, Comment(rawValue: result.output))
-        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
+        #expect(!FileManager.default.fileExists(atPath: kimiCodeConfig.path), Comment(rawValue: result.output))
+        let installed = try String(contentsOf: kimiCliConfig, encoding: .utf8)
         #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(installed.contains(#"command = "vibe-island""#), Comment(rawValue: result.output))
+    }
+
+    @Test("Setup prefers the Kimi Code config and keeps the Kimi CLI block installed")
+    func setupPrefersKimiCodeAndRefreshesKimiCliBlock() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let kimiCodeConfig = try fixture.seedConfig(
+            directory: ".kimi-code",
+            content: Self.userHookContent(command: "orca")
+        )
+        let kimiCliConfig = try fixture.seedConfig(
+            directory: ".kimi",
+            content: Self.installingCmuxBlock(in: Self.userHookContent(command: "vibe-island"))
+        )
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        let installed = try String(contentsOf: kimiCodeConfig, encoding: .utf8)
+        let secondary = try String(contentsOf: kimiCliConfig, encoding: .utf8)
+        #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(installed.contains(#"command = "orca""#), Comment(rawValue: result.output))
+        #expect(secondary.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(secondary.contains(#"command = "vibe-island""#), Comment(rawValue: result.output))
+    }
+
+    @Test("Setup leaves a secondary config without a cmux block untouched")
+    func setupLeavesSecondaryConfigWithoutCmuxBlockUntouched() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let secondaryContent = Self.userHookContent(command: "vibe-island")
+        let kimiCodeConfig = try fixture.seedConfig(
+            directory: ".kimi-code",
+            content: Self.userHookContent(command: "orca")
+        )
+        let kimiCliConfig = try fixture.seedConfig(directory: ".kimi", content: secondaryContent)
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(
+            try String(contentsOf: kimiCodeConfig, encoding: .utf8).contains("hooks kimi stop"),
+            Comment(rawValue: result.output)
+        )
+        #expect(
+            try String(contentsOf: kimiCliConfig, encoding: .utf8) == secondaryContent,
+            Comment(rawValue: result.output)
+        )
+    }
+
+    @Test("Setup uses the config path the installed Kimi binary reports")
+    func setupUsesConfigPathReportedByKimiBinary() throws {
+        let probedDirectory = "probed-kimi"
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let probedConfig = fixture.root
+            .appendingPathComponent(probedDirectory, isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: probedConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fixture.setDoctorOutput(Self.doctorReport(configPath: probedConfig.path))
+
+        let kimiCodeContent = Self.userHookContent(command: "orca")
+        let kimiCodeConfig = try fixture.seedConfig(directory: ".kimi-code", content: kimiCodeContent)
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(
+            try String(contentsOf: probedConfig, encoding: .utf8).contains("hooks kimi stop"),
+            Comment(rawValue: result.output)
+        )
+        #expect(
+            try String(contentsOf: kimiCodeConfig, encoding: .utf8) == kimiCodeContent,
+            Comment(rawValue: result.output)
+        )
+    }
+
+    @Test("Setup falls back to a well-known config when the reported path is unusable")
+    func setupFallsBackWhenReportedPathIsUnusable() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let missingConfig = fixture.root
+            .appendingPathComponent("never-created", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        try fixture.setDoctorOutput(Self.doctorReport(configPath: missingConfig.path))
+        let kimiCodeConfig = try fixture.seedConfig(
+            directory: ".kimi-code",
+            content: Self.userHookContent(command: "orca")
+        )
+
+        let result = try runCLI(arguments: ["hooks", "setup", "kimi", "--yes"], fixture: fixture)
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(!FileManager.default.fileExists(atPath: missingConfig.path), Comment(rawValue: result.output))
+        #expect(
+            try String(contentsOf: kimiCodeConfig, encoding: .utf8).contains("hooks kimi stop"),
+            Comment(rawValue: result.output)
+        )
+    }
+
+    @Test("Setup honors KIMI_CODE_HOME and keeps the Kimi CLI block installed")
+    func setupHonorsKimiCodeHomeAndKeepsKimiCliBlock() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let kimiCodeDirectory = try fixture.makeDirectory(named: "kimi-code-home")
+        let kimiCliDirectory = try fixture.makeDirectory(named: "kimi-share-dir")
+        let kimiCodeConfig = kimiCodeDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let kimiCliConfig = kimiCliDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try Self.userHookContent(command: "orca")
+            .write(to: kimiCodeConfig, atomically: true, encoding: .utf8)
+        try Self.installingCmuxBlock(in: Self.userHookContent(command: "vibe-island"))
+            .write(to: kimiCliConfig, atomically: true, encoding: .utf8)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_CODE_HOME": kimiCodeDirectory.path,
+                "KIMI_SHARE_DIR": kimiCliDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        let installed = try String(contentsOf: kimiCodeConfig, encoding: .utf8)
+        let secondary = try String(contentsOf: kimiCliConfig, encoding: .utf8)
+        #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(installed.contains(#"command = "orca""#), Comment(rawValue: result.output))
+        #expect(secondary.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(secondary.contains(#"command = "vibe-island""#), Comment(rawValue: result.output))
+    }
+
+    @Test("Setup succeeds when a secondary Kimi config cannot be read")
+    func setupSucceedsWhenSecondaryConfigCannotBeRead() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let kimiCodeDirectory = try fixture.makeDirectory(named: "kimi-code-home")
+        let kimiCliDirectory = try fixture.makeDirectory(named: "kimi-share-dir")
+        let kimiCodeConfig = kimiCodeDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let kimiCliConfig = kimiCliDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(at: kimiCliConfig, withIntermediateDirectories: true)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_CODE_HOME": kimiCodeDirectory.path,
+                "KIMI_SHARE_DIR": kimiCliDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(
+            try String(contentsOf: kimiCodeConfig, encoding: .utf8).contains("hooks kimi stop"),
+            Comment(rawValue: result.output)
+        )
+        #expect(result.output.contains(kimiCliConfig.path), Comment(rawValue: result.output))
+    }
+
+    @Test("Setup writes one block when both Kimi paths resolve to the same directory")
+    func setupWritesOneBlockThroughSymlinkedConfigDirectory() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let kimiCodeDirectory = try fixture.makeDirectory(named: "kimi-code-home")
+        let kimiCliDirectory = fixture.root.appendingPathComponent("kimi-share-dir", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: kimiCliDirectory, withDestinationURL: kimiCodeDirectory)
+        let kimiCodeConfig = kimiCodeDirectory.appendingPathComponent("config.toml", isDirectory: false)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_CODE_HOME": kimiCodeDirectory.path,
+                "KIMI_SHARE_DIR": kimiCliDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        let installed = try String(contentsOf: kimiCodeConfig, encoding: .utf8)
+        #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(
+            installed.components(separatedBy: #"event = "Stop""#).count == 2,
+            Comment(rawValue: installed)
+        )
     }
 
     @Test("Declining setup previews and preserves both Kimi configs")
@@ -143,148 +263,114 @@ struct KimiHookConfigLocationTests {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentContent = Self.userHookContent(command: "vibe-island")
-        let legacyContent = Self.installingCmuxBlock(in: Self.userHookContent(command: "orca"))
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        try currentContent.write(to: currentConfig, atomically: true, encoding: .utf8)
-        try legacyContent.write(to: legacyConfig, atomically: true, encoding: .utf8)
+        let kimiCodeContent = Self.userHookContent(command: "orca")
+        let kimiCliContent = Self.installingCmuxBlock(in: Self.userHookContent(command: "vibe-island"))
+        let kimiCodeConfig = try fixture.seedConfig(directory: ".kimi-code", content: kimiCodeContent)
+        let kimiCliConfig = try fixture.seedConfig(directory: ".kimi", content: kimiCliContent)
 
         let result = try runCLI(
             arguments: ["hooks", "setup", "kimi"],
             fixture: fixture,
-            environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
-            ],
             standardInput: "n\n"
         )
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentContent)
-        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyContent)
-        #expect(result.output.contains(currentConfig.path))
-        #expect(result.output.contains(legacyConfig.path))
+        #expect(try String(contentsOf: kimiCodeConfig, encoding: .utf8) == kimiCodeContent)
+        #expect(try String(contentsOf: kimiCliConfig, encoding: .utf8) == kimiCliContent)
+        #expect(result.output.contains(kimiCodeConfig.path), Comment(rawValue: result.output))
     }
 
-    @Test("Declining legacy cleanup preserves an up-to-date active Kimi config")
-    func decliningLegacyCleanupPreservesCurrentConfigs() throws {
+    @Test("Uninstall removes cmux blocks from both Kimi configs")
+    func uninstallRemovesBlocksFromBothConfigs() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let environment = [
-            "KIMI_SHARE_DIR": currentDirectory.path,
-            "KIMI_CODE_HOME": legacyDirectory.path,
-        ]
-        let seedResult = try runCLI(
-            arguments: ["hooks", "setup", "kimi", "--yes"],
-            fixture: fixture,
-            environmentOverrides: environment
+        let kimiCodeContent = Self.userHookContent(command: "orca")
+        let kimiCliContent = Self.userHookContent(command: "vibe-island")
+        let kimiCodeConfig = try fixture.seedConfig(
+            directory: ".kimi-code",
+            content: Self.installingCmuxBlock(in: kimiCodeContent)
         )
-        #expect(seedResult.status == 0, Comment(rawValue: seedResult.output))
-        let currentContent = try String(contentsOf: currentConfig, encoding: .utf8)
-        let legacyContent = Self.installingCmuxBlock(in: Self.userHookContent(command: "orca"))
-        try legacyContent.write(to: legacyConfig, atomically: true, encoding: .utf8)
-
-        let result = try runCLI(
-            arguments: ["hooks", "setup", "kimi"],
-            fixture: fixture,
-            environmentOverrides: environment,
-            standardInput: "n\n"
+        let kimiCliConfig = try fixture.seedConfig(
+            directory: ".kimi",
+            content: Self.installingCmuxBlock(in: kimiCliContent)
         )
+
+        let result = try runCLI(arguments: ["hooks", "uninstall", "kimi", "--yes"], fixture: fixture)
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentContent)
-        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyContent)
-        #expect(result.output.contains(legacyConfig.path))
+        #expect(try String(contentsOf: kimiCodeConfig, encoding: .utf8) == kimiCodeContent)
+        #expect(try String(contentsOf: kimiCliConfig, encoding: .utf8) == kimiCliContent)
     }
 
-    @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
-    func uninstallRemovesCurrentAndLegacyBlocks() throws {
+    @Test("Uninstall succeeds when a secondary Kimi config cannot be read")
+    func uninstallSucceedsWhenSecondaryConfigCannotBeRead() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentUserContent = Self.userHookContent(command: "vibe-island")
-        let legacyUserContent = Self.userHookContent(command: "orca")
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        try Self.installingCmuxBlock(in: currentUserContent)
-            .write(to: currentConfig, atomically: true, encoding: .utf8)
-        try Self.installingCmuxBlock(in: legacyUserContent)
-            .write(to: legacyConfig, atomically: true, encoding: .utf8)
+        let kimiCodeDirectory = try fixture.makeDirectory(named: "kimi-code-home")
+        let kimiCliDirectory = try fixture.makeDirectory(named: "kimi-share-dir")
+        let kimiCodeContent = Self.userHookContent(command: "orca")
+        let kimiCodeConfig = kimiCodeDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let kimiCliConfig = kimiCliDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try Self.installingCmuxBlock(in: kimiCodeContent)
+            .write(to: kimiCodeConfig, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: kimiCliConfig, withIntermediateDirectories: true)
 
         let result = try runCLI(
             arguments: ["hooks", "uninstall", "kimi", "--yes"],
             fixture: fixture,
             environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
+                "KIMI_CODE_HOME": kimiCodeDirectory.path,
+                "KIMI_SHARE_DIR": kimiCliDirectory.path,
             ]
         )
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentUserContent)
-        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyUserContent)
-    }
-
-    @Test("Uninstall succeeds when the legacy Kimi config cannot be read")
-    func uninstallSucceedsWhenLegacyConfigCannotBeRead() throws {
-        let fixture = try makeFixture()
-        defer { try? FileManager.default.removeItem(at: fixture.root) }
-
-        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
-        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
-        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
-
-        let currentUserContent = Self.userHookContent(command: "vibe-island")
-        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
-        try Self.installingCmuxBlock(in: currentUserContent)
-            .write(to: currentConfig, atomically: true, encoding: .utf8)
-        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
-
-        let result = try runCLI(
-            arguments: ["hooks", "uninstall", "kimi", "--yes"],
-            fixture: fixture,
-            environmentOverrides: [
-                "KIMI_SHARE_DIR": currentDirectory.path,
-                "KIMI_CODE_HOME": legacyDirectory.path,
-            ]
-        )
-
-        #expect(!result.timedOut, Comment(rawValue: result.output))
-        #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentUserContent)
-        #expect(FileManager.default.fileExists(atPath: legacyConfig.path))
-        #expect(result.output.contains(legacyConfig.path))
-        #expect(result.output.contains("cmux hooks uninstall kimi"))
+        #expect(try String(contentsOf: kimiCodeConfig, encoding: .utf8) == kimiCodeContent)
+        #expect(FileManager.default.fileExists(atPath: kimiCliConfig.path))
+        #expect(result.output.contains(kimiCliConfig.path), Comment(rawValue: result.output))
+        #expect(result.output.contains("cmux hooks uninstall kimi"), Comment(rawValue: result.output))
     }
 
     private struct Fixture {
         let root: URL
         let home: URL
         let bin: URL
+
+        func configURL(directory: String) -> URL {
+            home
+                .appendingPathComponent(directory, isDirectory: true)
+                .appendingPathComponent("config.toml", isDirectory: false)
+        }
+
+        @discardableResult
+        func seedConfig(directory: String, content: String) throws -> URL {
+            let url = configURL(directory: directory)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        }
+
+        func makeDirectory(named name: String) throws -> URL {
+            let url = root.appendingPathComponent(name, isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            return url
+        }
+
+        func setDoctorOutput(_ output: String) throws {
+            try output.write(
+                to: bin.appendingPathComponent("doctor-output.txt", isDirectory: false),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
     }
 
     private func makeFixture() throws -> Fixture {
@@ -296,7 +382,14 @@ struct KimiHookConfigLocationTests {
         try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
 
         let kimi = bin.appendingPathComponent("kimi", isDirectory: false)
-        try "#!/bin/sh\nexit 0\n".write(to: kimi, atomically: true, encoding: .utf8)
+        let stub = """
+        #!/bin/sh
+        if [ "$1" = "doctor" ]; then
+            cat "$(dirname "$0")/doctor-output.txt" 2>/dev/null
+        fi
+        exit 0
+        """
+        try (stub + "\n").write(to: kimi, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: kimi.path)
         return Fixture(root: root, home: home, bin: bin)
     }
@@ -357,6 +450,14 @@ struct KimiHookConfigLocationTests {
             output: String(data: data, encoding: .utf8) ?? "",
             timedOut: timedOut
         )
+    }
+
+    private static func doctorReport(configPath: String) -> String {
+        """
+        Checking Kimi Code CLI configuration
+        config.toml: \(configPath) ok
+        tui.toml: skipped
+        """ + "\n"
     }
 
     private static func userHookContent(command: String) -> String {

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -33,7 +33,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | CodeBuddy | `codebuddy` | `~/.codebuddy/settings.json` | `codebuddy --resume <id>` | PreToolUse |
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
-| Kimi Code | `kimi` | `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
+| Kimi Code | `kimi` | `~/.kimi-code/config.toml` or `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
 
 OpenCode also supports project-local Feed installation:
 
@@ -149,7 +149,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Cursor CLI | none | `CMUX_CURSOR_HOOKS_DISABLED=1` |
 | Gemini | none | `CMUX_GEMINI_HOOKS_DISABLED=1` |
 | Kiro CLI | `KIRO_HOME` | `CMUX_KIRO_HOOKS_DISABLED=1` |
-| Kimi Code | `KIMI_SHARE_DIR` | `CMUX_KIMI_HOOKS_DISABLED=1` |
+| Kimi Code | `KIMI_CODE_HOME`, `KIMI_SHARE_DIR` | `CMUX_KIMI_HOOKS_DISABLED=1` |
 | Rovo Dev | none | `CMUX_ROVODEV_HOOKS_DISABLED=1` |
 | Copilot | `COPILOT_HOME` | `CMUX_COPILOT_HOOKS_DISABLED=1` |
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
@@ -166,7 +166,7 @@ Kiro stores hooks inside agent configuration files. The cmux installer creates o
 
 Kiro Feed verbosity follows **Settings > Automation > Kiro Notification Level** or `automation.kiroNotificationLevel` in `cmux.json`. `minimal` keeps actionable approval cards only, `standard` also keeps mutating tool events, and `verbose` keeps every Kiro tool event.
 
-Kimi Code reads its main config from `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. During setup and uninstall, cmux also removes its marker-delimited block from the obsolete `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` location while preserving all unrelated TOML and third-party hooks.
+Kimi ships under two config layouts: Kimi Code CLI reads `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`, and Kimi CLI 1.49 and earlier read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. cmux installs into the file the installed binary reports through `kimi doctor`; when the binary cannot answer, it installs into the first of those two locations that already exists, defaulting to the Kimi Code CLI path. The other location is never emptied by setup: an existing cmux block there is refreshed in place so a second Kimi install keeps working, and a config without a cmux block is left untouched. `cmux hooks uninstall kimi` removes the block from both. Unrelated TOML and third-party hooks are preserved everywhere.
 
 ## Troubleshooting
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -381,7 +381,7 @@ Hook subcommands:
 | `hooks feed --source <agent>` | Convert agent hook events into Feed context. |
 | `hooks <agent> <event>` | Generic hook surface for `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `kimi`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
 
-Kimi hook setup targets the config file `kimi doctor` reports, falling back to the first of `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` (Kimi Code CLI) and `${KIMI_SHARE_DIR:-~/.kimi}/config.toml` (Kimi CLI 1.49 and earlier) that already exists, and to the Kimi Code CLI path when neither does. Setup refreshes, but never removes, a cmux marker block already present in the other location; `hooks kimi uninstall` removes the block from both.
+Kimi hook setup targets the config file `kimi doctor` reports. Without a reported path, it takes the first of `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` (Kimi Code CLI) and `${KIMI_SHARE_DIR:-~/.kimi}/config.toml` (Kimi CLI 1.49 and earlier) that already exists as a file, then the first whose directory exists, and the Kimi Code CLI path when neither directory exists. Setup refreshes, but never removes, a cmux marker block already present in the other location; `hooks kimi uninstall` removes the block from both.
 
 Right sidebar commands:
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -381,7 +381,7 @@ Hook subcommands:
 | `hooks feed --source <agent>` | Convert agent hook events into Feed context. |
 | `hooks <agent> <event>` | Generic hook surface for `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `kimi`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
 
-Kimi hook setup targets `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. Setup and uninstall also remove only cmux's marker-delimited block from the legacy `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` path.
+Kimi hook setup targets the config file `kimi doctor` reports, falling back to the first of `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` (Kimi Code CLI) and `${KIMI_SHARE_DIR:-~/.kimi}/config.toml` (Kimi CLI 1.49 and earlier) that already exists, and to the Kimi Code CLI path when neither does. Setup refreshes, but never removes, a cmux marker block already present in the other location; `hooks kimi uninstall` removes the block from both.
 
 Right sidebar commands:
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -84,7 +84,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
-| Kimi Code    | `~/.kimi/config.toml`                     | PreToolUse / PostToolUse |
+| Kimi Code    | `~/.kimi-code/config.toml` or `~/.kimi/config.toml` | PreToolUse / PostToolUse |
 | Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | tool_execution_start / tool_execution_end telemetry |
 | OMP          | `~/.omp/agent/extensions/cmux-omp-session.ts` or `$PI_CODING_AGENT_DIR/extensions/cmux-omp-session.ts` | lifecycle only           |
 | Campfire     | `~/.campfire/agent/extensions/cmux-campfire-session.ts` or `$CAMPFIRE_CODING_AGENT_DIR/extensions/cmux-campfire-session.ts` | lifecycle + collaborative notifications |


### PR DESCRIPTION
## What broke

Kimi ships under two config layouts:

- **Kimi Code CLI** (current, e.g. 0.36.1) reads `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml`
- **Kimi CLI 1.49** and earlier read `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`

`CLI/CMUXCLI+AgentHookCatalog.swift:234` hardcoded the second one (`configDir: ".kimi", configDirEnvOverride: "KIMI_SHARE_DIR"`), and `CLI/CMUXCLI+KimiHooks.swift:7` treated `~/.kimi-code` as legacy, so `installKimiHooks` wrote the block to `~/.kimi/config.toml` and then ran `KimiCodeHookConfig.uninstalling` over `~/.kimi-code/config.toml` (old `CMUXCLI+KimiHooks.swift:66-85`). On Kimi Code CLI the hooks therefore landed in a file nothing reads, and the block in the file the running CLI *did* read was deleted — no running/idle state, no turn-complete notification.

#8278 moved the path to `~/.kimi` for Kimi CLI 1.49, which was correct at the time; the CLI has since become Kimi Code CLI and moved back.

## The rule

**cmux installs the Kimi hook block into the `config.toml` the installed binary reports via `kimi doctor`, falling back to the first well-known location that already exists — `${KIMI_CODE_HOME:-~/.kimi-code}` then `${KIMI_SHARE_DIR:-~/.kimi}` — and defaulting to the Kimi Code CLI path when neither does; setup refreshes, but never removes, a cmux block already present in the other location, and uninstall clears the block from all of them.**

Why this does not regress Kimi CLI 1.49:

- A 1.49-only user has `~/.kimi` and no `~/.kimi-code`, so the fallback order selects `~/.kimi` exactly as today (covered by "Setup targets the Kimi CLI config when only it exists", which is green before and after).
- A user with both installs gets the block in `~/.kimi-code` **and** keeps the refreshed block in `~/.kimi` — setup never deletes a block another CLI still reads. A config with no cmux block is left byte-identical, so cmux does not spray itself into a file nothing reads.
- The probe degrades gracefully: a missing binary, an unknown `doctor` subcommand, output with no absolute `config.toml` path, or a reported path whose parent directory does not exist all fall through to the well-known order. `kimi doctor` runs with stdin on `/dev/null`, output to a temp file, and a 3s timeout with `terminate()`/`SIGKILL` escalation.
- `KIMI_CODE_HOME` is also added back to the agent relaunch environment allowlist (`AgentLaunchEnvironmentPolicy`), so a resumed Kimi Code session keeps the config home its hooks were installed for. #8278 had retired it as unsupported.

Uninstall is symmetric with setup: it walks active + every well-known location, removes the marker block from each, throws on the active config and warns (exit 0) on a secondary one it cannot read.

## Red/green

The regression pair is the first two commits, test first; the later commits are review follow-ups listed below.

`d27ddc9` (test only) — 9 of 12 fail against the old resolver. Real output from `./scripts/test-unit.sh test -only-testing:cmuxTests/KimiHookConfigLocationTests`:

```
✘ Test "Setup targets the Kimi Code config when only it exists" recorded an issue at
  KimiHookConfigLocationTests.swift:31:9: Expectation failed:
  !((FileManager.default → <NSFileManager: 0x1097099d0>).fileExists(atPath: kimiCliConfig.path →
  ".../cmux-kimi-hooks-0CA0F482-.../home/.kimi/config.toml") → true)
✘ Test "Setup prefers the Kimi Code config and keeps the Kimi CLI block installed" recorded an issue at
  KimiHookConfigLocationTests.swift:81:9: Expectation failed: (installed → "default_model = "user-model"
✘ Test "Setup leaves a secondary config without a cmux block untouched" recorded an issue at
  KimiHookConfigLocationTests.swift:107:9: Expectation failed:
  try String(contentsOf: kimiCliConfig, encoding: .utf8) == secondaryContent
✘ Test "Setup uses the config path the installed Kimi binary reports" recorded an issue at
  KimiHookConfigLocationTests.swift:113:6: Caught error: ... "The file “config.toml” couldn’t be opened
  because there is no such file." ... NSFilePath=.../probed-kimi/config.toml
✘ Test "Uninstall succeeds when a secondary Kimi config cannot be read" recorded an issue at
  KimiHookConfigLocationTests.swift:332:9: Expectation failed: (result.status → 1) == 0
✘ Test run with 12 tests in 1 suite failed after 1.583 seconds with 15 issues.
```

The three that already pass are the no-regression guards (Kimi CLI 1.49 layout, symlinked config dirs, plain uninstall).

`d5cf2e1` (fix) — same command, `Test run with 12 tests in 1 suite passed after 4.551 seconds`, `** TEST SUCCEEDED **`.

The suite drives the real bundled CLI against a fake `HOME` and a stub `kimi` on `PATH`; no real `~/.kimi` or `~/.kimi-code` is touched.

## Validation

| Command | Result |
| --- | --- |
| `swift test --package-path Packages/macOS/CMUXAgentLaunch` | `Test run with 337 tests in 46 suites passed` |
| `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-kimi build` | `** BUILD SUCCEEDED **`, no new warnings |
| `./scripts/test-unit.sh test -only-testing:cmuxTests/KimiHookConfigLocationTests -derivedDataPath /tmp/cmux-kimi` | 12/12 passed |
| `./scripts/lint-pbxproj-test-wiring.sh` | `ok (checked 693 test files)` |

Manual end-to-end run of the built CLI against a temp `HOME` with a stub `kimi` reporting `.../Kimi Code/config.toml`: setup installed there, uninstall restored the file byte-for-byte, and neither `~/.kimi` nor `~/.kimi-code` was created.

`cmuxTests/KimiResumeReviewRegressionTests` (3 failures) and two `SessionPersistenceTests/testRemoteHermes*` cases fail identically on unmodified `upstream/main` on this machine — verified by stashing the change and re-running; they are unrelated to this diff.

## Review follow-ups

- `refactor: move Kimi config resolution into CMUXAgentLaunch` (56cd516) — path candidates, fallback order, `kimi doctor` parsing and canonical dedupe now live in `KimiConfigLocationResolver` with their own package tests. Writing the dedupe test surfaced a real bug the pre-existing CLI code shared: `resolvingSymlinksInPath()` leaves an intermediate symlink in place when the file does not exist yet, so a symlinked config directory looked like a second distinct config. Uninstall also carries an explicit active flag instead of inferring severity from array position.
- `fix: keep a reported Kimi config path that contains spaces` (0873fc3) — the report is scanned per line instead of tokenized on whitespace.
- `fix: bound Kimi doctor report parsing and translate the warnings for km` (7ff363e) — report capped at 8 KB, lines over 1 KB skipped, at most 32 path starts per line.
- `fix: correct fallback wording and tighten Kimi resolver test coverage` (978626f) — `docs/cli-contract.md` now describes the resolver's actual two-tier fallback (a directory holding `config.toml`, then a directory that merely exists) instead of a single existence check; the tilde-expansion test now asserts against the real process `HOME` instead of an expression identical to the code under test; added coverage for the resolver's three parsing bounds (8 KB report, 1 KB line, 32 path starts).

**Declined:** a suggestion to make `KimiCodeHookConfig`'s marker-block removal fail closed (or delete the malformed region) when a cmux begin marker has no matching end marker, so a hand-corrupted config can't leave stale hook entries behind after a refresh. Not applied — it would delete content it can't attribute to cmux, which two existing regression tests (`uninstallRemovesOrphanedBeginMarkerWithoutDroppingFollowingTOML` and its consecutive-marker sibling) deliberately forbid, because once the end marker is gone the code has no way to distinguish leftover cmux hook entries from real user TOML. Every write here is atomic and setup shows a diff with `[y/N]` confirmation before writing, so the scenario needs manual file corruption to occur at all; discussion on the PR thread.

- `fix: recognize cmux Kimi hook markers in CRLF-terminated configs` (9dc8329) — `tomlLines(from:)` stripped only LF, so a CRLF config.toml (TOML permits CRLF) never matched the cmux markers: reinstall duplicated the block, uninstall left it in place, secondary refresh skipped it. Fixing it surfaced a second bug in the same function — `content.hasSuffix("\n")` is false for CRLF-terminated content because Swift treats `\r\n` as one `Character` — also fixed. New test covers detection, refresh, and uninstall under CRLF, asserting parity with the plain-LF path.

**Declined:** a suggestion to move `runKimiDoctor`'s bounded external-process wait off `DispatchSemaphore` onto async cancellation. Not applied — the same shape (semaphore wait, `terminate()` then `SIGKILL` escalation, hard timeout) already exists in this file's own target for the identical problem (`codexTeamsLoginShellPath` in `CLI/cmux.swift`), and the review rule this cites scopes the concern to latency-sensitive paths (typing, rendering, socket telemetry) that a one-shot `cmux hooks setup kimi` invocation isn't; discussion on the PR thread.

**Declined:** a suggestion that `reportedConfigURL` could pick an inactive/previous config path mentioned in `kimi doctor` output ahead of the active one. Not applied — as of Kimi Code CLI 0.36.1 (the version this PR targets), a bare `kimi doctor` checks `config.toml`/`tui.toml` under exactly one directory (`KIMI_CODE_HOME`) per invocation, per the upstream docs (https://moonshotai.github.io/kimi-code/en/reference/kimi-command.html, checked 2026-08-19); there's no multi-location or previous-vs-active report to disambiguate today, so the premise doesn't match the tool being probed. This is the same upstream that already relocated once (`~/.kimi` → `~/.kimi-code`, the bug this PR fixes), so if `doctor` ever starts reporting more than one location, `usableConfigURL`'s directory-existence gate is not a full defense and this should be revisited; discussion on the PR thread.

Localization: two obsolete keys (`cli.hooks.kimi.legacyCleanupWarning`, `cli.hooks.kimi.legacyUninstallWarning`) are replaced by `cli.hooks.kimi.secondaryRefreshWarning` / `cli.hooks.kimi.secondaryUninstallWarning`, translated for all 20 locales in `Resources/Localizable.xcstrings`. `docs/agent-hooks.md`, `docs/cli-contract.md` and `docs/feed.md` now state both layouts and the resolution rule.

Fork-PR workflows sit in `action_required`, so GitHub CI has not run on this PR yet.

**Merge Risk block status:** CodeRabbit is rate-limited and its walkthrough is still calculated up to `978626f264`, three commits behind head. Its three listed items map to: CRLF marker detection — fixed (`9dc8329d9c`); probing-timeout shape and inactive-config selection — both declined with evidence (see the two "Declined" notes above and https://github.com/manaflow-ai/cmux/pull/10344#issuecomment-5339792461). All four review threads on this pass are resolved.

Fixes #10255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Kimi hook setup to detect configuration locations automatically, including paths reported by `kimi doctor`.
  - Added support for current Kimi Code and legacy Kimi CLI configuration layouts.
  - Setup and uninstall now manage cmux hooks across multiple configuration files while preserving unrelated settings.
  - Added support for `KIMI_CODE_HOME` environment configuration.

- **Bug Fixes**
  - Added clearer per-file warnings when hook updates or removal cannot be completed.

- **Documentation**
  - Updated Kimi integration and configuration guidance for supported layouts and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



