### PR TITLE
fix: converge cmux hook --settings when the claude wrapper re-enters itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1169,6 +1169,7 @@ jobs:
           python3 tests/test_claude_wrapper_hooks.py
           python3 tests/test_hermes_wrapper_hooks.py
           python3 tests/test_claude_wrapper_mutual_shim_loop.py
+          python3 tests/test_claude_wrapper_settings_reentry.py
           python3 tests/test_claude_wrapper_shim_root_survives_tmpdir_change.py
           python3 tests/test_claude_wrapper_user_binary_resolution.py
           python3 tests/test_claude_teams_test_utils.py

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -145,6 +145,16 @@ EOF
 # (a launcher that spawns instead of exec'ing); a file named after this pid
 # carries it when a launcher rebuilds the environment but stays in the same
 # process, which is exactly how the bounce happens. Whichever is higher wins.
+#
+# What the file checks below defend, and what they deliberately do not: a hostile
+# path planted before cmux gets there -- another user's symlink or leftover in a
+# shared /tmp -- is refused, which is why every path proves the directory and the
+# file before touching either. A process running as THIS user is inside the trust
+# boundary and is not defended against: bash cannot validate and use one
+# descriptor, so any check here is racy, and winning that race yields cmux's own
+# counter (1..16, whose only effect is stopping a launch with the message below)
+# or removes a path that process could remove directly. The tag is a cooperation
+# marker for that user's own tools, not authentication.
 cmux_claude_wrapper_hook_reentry_state_dir() {
     local dir="${TMPDIR:-/tmp}"
     # Scoped per user: with TMPDIR unset this lands in a shared /tmp, where an

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -68,6 +68,11 @@ EOF
 # https://github.com/manaflow-ai/cmux/issues/10230
 cmux_claude_wrapper_hook_reentry_limit=16
 
+# First word of every re-entry state file this wrapper writes. A same-user
+# process can create a pid-shaped name in the state directory too, so the tag,
+# not the name, is what makes a file cmux's to read or to sweep.
+cmux_claude_hook_state_tag='cmux-claude-hook-reentry-v1'
+
 # The pin cmux writes at the head of every hook command it injects: a `:` shell
 # no-op carrying a fixed token, the same shape HermesAgentHookCommandOwnership
 # uses to recognize cmux-owned Hermes hooks. Identity is this pin and nothing
@@ -180,8 +185,10 @@ cmux_claude_wrapper_read_hook_reentry_state() {
         rm -f "$file" 2>/dev/null
         return 1
     fi
-    local value
-    IFS= read -r value < "$file" 2>/dev/null || return 1
+    local line
+    IFS= read -r line < "$file" 2>/dev/null || return 1
+    [[ "$line" == "$cmux_claude_hook_state_tag "* ]] || return 1
+    local value="${line#"$cmux_claude_hook_state_tag "}"
     cmux_claude_wrapper_is_nonnegative_integer "$value" || return 1
     printf '%s' "$value"
 }
@@ -193,7 +200,7 @@ cmux_claude_wrapper_write_hook_reentry_state() {
     cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 0
     file="$dir/$$"
     cmux_claude_wrapper_hook_reentry_state_file_is_ours "$file" || return 0
-    printf '%s\n' "$1" > "$file" 2>/dev/null || true
+    printf '%s %s\n' "$cmux_claude_hook_state_tag" "$1" > "$file" 2>/dev/null || true
     cmux_claude_wrapper_prune_hook_reentry_state "$dir"
 }
 
@@ -209,10 +216,15 @@ cmux_claude_wrapper_prune_hook_reentry_state() {
     local -a entries=("$dir"/*)
     [[ -e "${entries[0]}" || -L "${entries[0]}" ]] || return 0
     (( ${#entries[@]} > cmux_claude_wrapper_hook_reentry_state_sweep_threshold )) || return 0
-    # Only all-digit names, which is what this wrapper writes ($$), and only
-    # yesterday's: those cannot belong to a live pid it cares about. Anything
-    # else in the directory was not written here and is left alone.
-    find "$dir" -maxdepth 1 -type f -name '[0-9]*' ! -name '*[!0-9]*' -mtime +1 -delete 2>/dev/null || true
+    # Candidates are yesterday's all-digit names -- what this wrapper writes
+    # ($$) -- and each one is removed only if it carries the state tag, so a file
+    # another process of this user left here is never swept.
+    local entry line
+    while IFS= read -r -d '' entry; do
+        IFS= read -r line < "$entry" 2>/dev/null || continue
+        [[ "$line" == "$cmux_claude_hook_state_tag "* ]] || continue
+        rm -f "$entry" 2>/dev/null || true
+    done < <(find "$dir" -maxdepth 1 -type f -name '[0-9]*' ! -name '*[!0-9]*' -mtime +1 -print0 2>/dev/null)
 }
 
 cmux_claude_wrapper_clear_hook_reentry_state() {

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -73,7 +73,7 @@ cmux_claude_wrapper_hook_reentry_limit=16
 # uses to recognize cmux-owned Hermes hooks. Identity is this pin and nothing
 # else -- never what a command happens to look like -- so a hook cmux did not
 # write is always the user's, even when it runs the very same cmux command.
-# HOOKS_JSON below writes it; keep the two in step.
+# HOOKS_JSON below is templated from this one definition, so the two cannot drift.
 cmux_claude_hook_pin=': cmux-claude-hook-v1;'
 
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
@@ -1112,7 +1112,10 @@ install_cmux_node_options
 #   timeout because it may run a summarization subprocess; it gates itself
 #   on the workspaceAutoNaming setting via a socket probe, so it is a
 #   no-op when the feature is disabled.
-HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude auto-name","timeout":120,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PostToolUse":[{"matcher":"PushNotification","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude push-notification","timeout":10,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
+HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]},{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude auto-name","timeout":120,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PostToolUse":[{"matcher":"PushNotification","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude push-notification","timeout":10,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"__CMUX_HOOK_PIN__ \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
+# The single definition of the pin lives in cmux_claude_hook_pin; the template
+# above only marks where it goes, so the two cannot drift apart.
+HOOKS_JSON="${HOOKS_JSON//__CMUX_HOOK_PIN__/$cmux_claude_hook_pin}"
 
 # Fold any user-provided --settings into HOOKS_JSON before launching.
 #
@@ -1184,9 +1187,11 @@ if (( ${#CMUX_USER_SETTINGS[@]} > 0 )) && command -v node >/dev/null 2>&1; then
         node -e '
 const fs=require("fs"),os=require("os"),path=require("path");
 const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
-// Same literal as cmux_claude_hook_pin above; the fallback keeps identity working
-// if this helper is ever invoked without that variable in its environment.
-const CMUX_HOOK_PIN=process.env.CMUX_HOOK_PIN||": cmux-claude-hook-v1;";
+// The wrapper passes its one definition of the pin in; without it ownership
+// cannot be decided, and guessing would either strip user hooks or grow the
+// block, so fail into the caller-visible merge fallback instead.
+const CMUX_HOOK_PIN=process.env.CMUX_HOOK_PIN;
+if(!CMUX_HOOK_PIN){process.stderr.write("cmux: --settings merge error: hook pin unavailable\n");process.exit(1);}
 // An incoming --settings that already carries cmux-pinned hooks is cmux output
 // from an earlier wrapper pass (re-entry through a custom Claude Binary Path that
 // resolves `claude` by name, https://github.com/manaflow-ai/cmux/issues/10230).

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -169,7 +169,16 @@ cmux_claude_wrapper_hook_reentry_state_dir_is_ours() {
 cmux_claude_wrapper_hook_reentry_state_file_is_ours() {
     [[ ! -L "$1" ]] || return 1
     [[ -e "$1" ]] || return 0
-    [[ -f "$1" && -O "$1" ]]
+    [[ -f "$1" && -O "$1" ]] || return 1
+    # Present and ours by mode, but only cmux's to overwrite or remove if cmux
+    # stamped it: another process of this user can create this name too.
+    cmux_claude_wrapper_hook_reentry_state_file_is_tagged "$1"
+}
+
+cmux_claude_wrapper_hook_reentry_state_file_is_tagged() {
+    local line
+    IFS= read -r line < "$1" 2>/dev/null || return 1
+    [[ "$line" == "$cmux_claude_hook_state_tag "* ]]
 }
 
 cmux_claude_wrapper_read_hook_reentry_state() {
@@ -219,10 +228,9 @@ cmux_claude_wrapper_prune_hook_reentry_state() {
     # Candidates are yesterday's all-digit names -- what this wrapper writes
     # ($$) -- and each one is removed only if it carries the state tag, so a file
     # another process of this user left here is never swept.
-    local entry line
+    local entry
     while IFS= read -r -d '' entry; do
-        IFS= read -r line < "$entry" 2>/dev/null || continue
-        [[ "$line" == "$cmux_claude_hook_state_tag "* ]] || continue
+        cmux_claude_wrapper_hook_reentry_state_file_is_tagged "$entry" || continue
         rm -f "$entry" 2>/dev/null || true
     done < <(find "$dir" -maxdepth 1 -type f -name '[0-9]*' ! -name '*[!0-9]*' -mtime +1 -print0 2>/dev/null)
 }

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -119,12 +119,12 @@ cmux_claude_wrapper_argv_has_injected_settings() {
 cmux_claude_wrapper_fail_hook_reentry_guard() {
     cat >&2 <<'EOF'
 cmux: stopped a claude launch loop before it could spin.
-cmux already injected its hook --settings for this launch, and control returned
-to cmux's per-surface claude shim instead of starting Claude.
-This usually means Settings > Automation > Claude Binary Path points at a script
-that resolves `claude` through PATH and finds that shim. Point it at the real
-claude binary, or drop */cmux-cli-shims/* entries from PATH inside that script
-before it hands off.
+cmux prepared this launch, then control came back to cmux instead of Claude
+starting. This usually means Settings > Automation > Claude Binary Path points at
+a script that starts Claude by name rather than by its full path, so the launch
+returns to cmux each time.
+Point that setting at the real claude executable, or make the script start Claude
+by full path, then open a new terminal.
 EOF
     exit 126
 }

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -68,15 +68,22 @@ EOF
 # https://github.com/manaflow-ai/cmux/issues/10230
 cmux_claude_wrapper_hook_reentry_limit=16
 
+# The pin cmux writes at the head of every hook command it injects: a `:` shell
+# no-op carrying a fixed token, the same shape HermesAgentHookCommandOwnership
+# uses to recognize cmux-owned Hermes hooks. Identity is this pin and nothing
+# else -- never what a command happens to look like -- so a hook cmux did not
+# write is always the user's, even when it runs the very same cmux command.
+# HOOKS_JSON below writes it; keep the two in step.
+cmux_claude_hook_pin=': cmux-claude-hook-v1;'
+
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
-    # Match the whole first hook object of HOOKS_JSON below, verbatim, so a hook
-    # the user wrote around the same command cannot read as cmux's own block.
-    # Only the head of the value is inspected, because the injected block always
-    # carries its SessionStart entry there, and pattern-matching an unbounded
-    # argument is exactly the cost this guard exists to avoid. Keep this literal
-    # in step with HOOKS_JSON; a mismatch only costs the early no-op below, since
-    # the merge is idempotent on its own.
-    [[ "${1:0:4096}" == *'{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}'* ]]
+    # A --settings value whose hook commands carry the pin was produced by an
+    # earlier pass of this wrapper. Only the head of the value is inspected,
+    # because the injected block always carries its first pinned command there,
+    # and pattern-matching an unbounded argument is exactly the cost this guard
+    # exists to avoid. A miss only costs the early no-op below, since the merge
+    # is idempotent on its own.
+    [[ "${1:0:4096}" == *"\"command\":\"$cmux_claude_hook_pin"* ]]
 }
 
 cmux_claude_wrapper_argv_has_injected_settings() {
@@ -1059,7 +1066,7 @@ install_cmux_node_options
 #   timeout because it may run a summarization subprocess; it gates itself
 #   on the workspaceAutoNaming setting via a socket probe, so it is a
 #   no-op when the feature is disabled.
-HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude auto-name","timeout":120,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PostToolUse":[{"matcher":"PushNotification","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude push-notification","timeout":10,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
+HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude auto-name","timeout":120,"async":true}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PostToolUse":[{"matcher":"PushNotification","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude push-notification","timeout":10,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":": cmux-claude-hook-v1; \"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
 
 # Fold any user-provided --settings into HOOKS_JSON before launching.
 #
@@ -1126,40 +1133,27 @@ fi
 if (( ${#CMUX_USER_SETTINGS[@]} > 0 )) && command -v node >/dev/null 2>&1; then
     CMUX_MERGED_SETTINGS="$(
         CMUX_BASE_SETTINGS="$HOOKS_JSON" \
+        CMUX_HOOK_PIN="$cmux_claude_hook_pin" \
         CMUX_USER_SETTINGS_B64="$(printf '%s\0' "${CMUX_USER_SETTINGS[@]}" | base64 | tr -d '\n')" \
         node -e '
 const fs=require("fs"),os=require("os"),path=require("path");
 const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
-// An incoming --settings that already carries the cmux hook commands is cmux
-// output from an earlier wrapper pass (re-entry through a custom Claude Binary
-// Path that resolves `claude` by name, https://github.com/manaflow-ai/cmux/issues/10230).
-// Drop those commands before merging so the current block REPLACES the previous
-// one instead of concatenating onto it: injecting the same block twice converges
-// to one copy, while every user-authored hook and key is merged untouched.
+// Same literal as cmux_claude_hook_pin above; the fallback keeps identity working
+// if this helper is ever invoked without that variable in its environment.
+const CMUX_HOOK_PIN=process.env.CMUX_HOOK_PIN||": cmux-claude-hook-v1;";
+// An incoming --settings that already carries cmux-pinned hooks is cmux output
+// from an earlier wrapper pass (re-entry through a custom Claude Binary Path that
+// resolves `claude` by name, https://github.com/manaflow-ai/cmux/issues/10230).
+// Drop those hooks before merging so the current block REPLACES the previous one
+// instead of concatenating onto it: injecting the same block twice converges to
+// one copy, while every user-authored hook and key is merged untouched.
 //
-// Identity is the whole hook object this launch is about to inject, canonicalized
-// and collected from the base block below. Matching the command alone would take
-// a user hook that runs the same command with their own timeout/async and replace
-// their configuration with cmux defaults; matching the whole object means a hook
-// that differs in any field is theirs and is merged verbatim.
-const cmuxInjectedHooks=new Set();
-const canonicalHook=h=>{
-  if(!isObj(h))return null;
-  const o={};
-  for(const k of Object.keys(h).sort())o[k]=h[k];
-  return JSON.stringify(o);
-};
-const forEachHook=(s,fn)=>{
-  if(!isObj(s)||!isObj(s.hooks))return;
-  for(const entries of Object.values(s.hooks)){
-    if(!Array.isArray(entries))continue;
-    for(const entry of entries){
-      if(!isObj(entry)||!Array.isArray(entry.hooks))continue;
-      for(const h of entry.hooks)fn(h);
-    }
-  }
-};
-const isCmuxHook=h=>{const c=canonicalHook(h);return c!==null&&cmuxInjectedHooks.has(c);};
+// Identity is the pin cmux itself writes at the head of every command it injects
+// (a `:` no-op, the same shape HermesAgentHookCommandOwnership pins with), never
+// what a command looks like. A hook that does not start with the pin belongs to
+// the user, even when it runs the very same cmux command with the very same
+// timeout, and is merged verbatim.
+const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&h.command.trimStart().startsWith(CMUX_HOOK_PIN);
 const stripCmuxHooks=s=>{
   if(!isObj(s)||!isObj(s.hooks))return s;
   const hooks={};
@@ -1194,7 +1188,6 @@ const merge=(a,b)=>{
 const expand=p=>p.indexOf("~/")===0?path.join(os.homedir(),p.slice(2)):p;
 const load=v=>{const t=String(v).trim();return (t[0]==="{"||t[0]==="[")?JSON.parse(t):JSON.parse(fs.readFileSync(expand(t),"utf8"));};
 let acc=JSON.parse(process.env.CMUX_BASE_SETTINGS);
-forEachHook(acc,h=>{const c=canonicalHook(h);if(c!==null)cmuxInjectedHooks.add(c);});
 const raw=Buffer.from(process.env.CMUX_USER_SETTINGS_B64||"","base64").toString("utf8");
 // split() leaves one trailing "" from printf terminating NUL; slice it off
 // rather than filtering all empties, so an explicit empty --settings= reaches

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -78,12 +78,14 @@ cmux_claude_hook_pin=': cmux-claude-hook-v1;'
 
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
     # A --settings value whose hook commands carry the pin was produced by an
-    # earlier pass of this wrapper. Only the head of the value is inspected,
-    # because the injected block always carries its first pinned command there,
-    # and pattern-matching an unbounded argument is exactly the cost this guard
-    # exists to avoid. A miss only costs the early no-op below, since the merge
-    # is idempotent on its own.
-    [[ "${1:0:4096}" == *"\"command\":\"$cmux_claude_hook_pin"* ]]
+    # earlier pass of this wrapper. The whole value is scanned: a launcher that
+    # re-serializes the settings JSON can move the pinned hook past any fixed
+    # window, and missing it there would leave the bounce unbounded. Matching a
+    # literal against a bash string is linear (~22ms/MB on bash 3.2/5.2), so the
+    # scan costs microseconds on a normal settings value. The pin is matched on
+    # its own, without surrounding JSON punctuation, so re-indenting or reordering
+    # the value cannot hide it.
+    [[ "$1" == *"$cmux_claude_hook_pin"* ]]
 }
 
 cmux_claude_wrapper_argv_has_injected_settings() {

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -69,17 +69,14 @@ EOF
 cmux_claude_wrapper_hook_reentry_limit=16
 
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
-    # cmux is the only writer of CMUX_CLAUDE_HOOK_CMUX_BIN, and every command in
-    # the injected block both references it and invokes a cmux hook subcommand,
-    # so a --settings value carrying both was produced by an earlier pass of this
-    # wrapper. Requiring the command shape as well keeps a hook the user wrote
-    # against the same variable from reading as cmux's own block. Only the head
-    # of the value is inspected: the injected block always carries its first hook
-    # entry there, and pattern-matching an unbounded argument is exactly the cost
-    # this guard exists to avoid.
-    local head="${1:0:4096}"
-    [[ "$head" == *"CMUX_CLAUDE_HOOK_CMUX_BIN"* ]] || return 1
-    [[ "$head" == *"hooks claude "* || "$head" == *"hooks feed --source claude"* ]]
+    # Match the whole first command of HOOKS_JSON below, not just the cmux hook
+    # binary variable: a hook the user wrote against that same variable must not
+    # read as cmux's own block. Only the head of the value is inspected, because
+    # the injected block always carries its SessionStart entry there, and
+    # pattern-matching an unbounded argument is exactly the cost this guard
+    # exists to avoid. A false negative here is harmless: the merge below is
+    # idempotent on its own.
+    [[ "${1:0:4096}" == *'${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start'* ]]
 }
 
 cmux_claude_wrapper_argv_has_injected_settings() {
@@ -1133,20 +1130,28 @@ if (( ${#CMUX_USER_SETTINGS[@]} > 0 )) && command -v node >/dev/null 2>&1; then
         node -e '
 const fs=require("fs"),os=require("os"),path=require("path");
 const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
-// Every command in HOOKS_JSON references CMUX_CLAUDE_HOOK_CMUX_BIN, and cmux is
-// the only writer of that variable, so it doubles as the marker identifying
-// cmux-injected hooks. An incoming --settings that carries them is cmux output
-// from an earlier wrapper pass (re-entry through a PATH-resolving custom Claude
-// Binary Path, https://github.com/manaflow-ai/cmux/issues/10230). Drop them
-// before merging so the current block REPLACES the previous one instead of
-// concatenating onto it: injecting the same block twice converges to one copy,
-// while every user-authored hook and key is merged untouched.
-// Marker AND the injected command shape, so a hook the user wrote themselves
-// against the same variable (`"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify ...`)
-// is left alone instead of being deleted on every merge.
-const CMUX_HOOK_MARKER="CMUX_CLAUDE_HOOK_CMUX_BIN";
-const CMUX_HOOK_COMMAND=/\bhooks\s+(claude\b|feed\s+--source\s+claude\b)/;
-const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&h.command.includes(CMUX_HOOK_MARKER)&&CMUX_HOOK_COMMAND.test(h.command);
+// An incoming --settings that already carries the cmux hook commands is cmux
+// output from an earlier wrapper pass (re-entry through a custom Claude Binary
+// Path that resolves `claude` by name, https://github.com/manaflow-ai/cmux/issues/10230).
+// Drop those commands before merging so the current block REPLACES the previous
+// one instead of concatenating onto it: injecting the same block twice converges
+// to one copy, while every user-authored hook and key is merged untouched.
+//
+// Identity is the exact command string this launch is about to inject, collected
+// from the base block below. Nothing else is touched, so a user hook that runs
+// the same cmux binary with a command of their own survives verbatim.
+const cmuxInjectedCommands=new Set();
+const forEachHookCommand=(s,fn)=>{
+  if(!isObj(s)||!isObj(s.hooks))return;
+  for(const entries of Object.values(s.hooks)){
+    if(!Array.isArray(entries))continue;
+    for(const entry of entries){
+      if(!isObj(entry)||!Array.isArray(entry.hooks))continue;
+      for(const h of entry.hooks)if(isObj(h)&&typeof h.command==="string")fn(h.command);
+    }
+  }
+};
+const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&cmuxInjectedCommands.has(h.command);
 const stripCmuxHooks=s=>{
   if(!isObj(s)||!isObj(s.hooks))return s;
   const hooks={};
@@ -1181,6 +1186,7 @@ const merge=(a,b)=>{
 const expand=p=>p.indexOf("~/")===0?path.join(os.homedir(),p.slice(2)):p;
 const load=v=>{const t=String(v).trim();return (t[0]==="{"||t[0]==="[")?JSON.parse(t):JSON.parse(fs.readFileSync(expand(t),"utf8"));};
 let acc=JSON.parse(process.env.CMUX_BASE_SETTINGS);
+forEachHookCommand(acc,c=>cmuxInjectedCommands.add(c));
 const raw=Buffer.from(process.env.CMUX_USER_SETTINGS_B64||"","base64").toString("utf8");
 // split() leaves one trailing "" from printf terminating NUL; slice it off
 // rather than filtering all empties, so an explicit empty --settings= reaches

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -70,12 +70,16 @@ cmux_claude_wrapper_hook_reentry_limit=16
 
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
     # cmux is the only writer of CMUX_CLAUDE_HOOK_CMUX_BIN, and every command in
-    # the injected block references it, so a --settings value carrying it was
-    # produced by an earlier pass of this wrapper. Only the head of the value is
-    # inspected: the injected block always carries the marker in its first hook
-    # entry, and pattern-matching an unbounded argument is exactly the cost this
-    # guard exists to avoid.
-    [[ "${1:0:4096}" == *"CMUX_CLAUDE_HOOK_CMUX_BIN"* ]]
+    # the injected block both references it and invokes a cmux hook subcommand,
+    # so a --settings value carrying both was produced by an earlier pass of this
+    # wrapper. Requiring the command shape as well keeps a hook the user wrote
+    # against the same variable from reading as cmux's own block. Only the head
+    # of the value is inspected: the injected block always carries its first hook
+    # entry there, and pattern-matching an unbounded argument is exactly the cost
+    # this guard exists to avoid.
+    local head="${1:0:4096}"
+    [[ "$head" == *"CMUX_CLAUDE_HOOK_CMUX_BIN"* ]] || return 1
+    [[ "$head" == *"hooks claude "* || "$head" == *"hooks feed --source claude"* ]]
 }
 
 cmux_claude_wrapper_argv_has_injected_settings() {
@@ -1137,8 +1141,12 @@ const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
 // before merging so the current block REPLACES the previous one instead of
 // concatenating onto it: injecting the same block twice converges to one copy,
 // while every user-authored hook and key is merged untouched.
+// Marker AND the injected command shape, so a hook the user wrote themselves
+// against the same variable (`"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify ...`)
+// is left alone instead of being deleted on every merge.
 const CMUX_HOOK_MARKER="CMUX_CLAUDE_HOOK_CMUX_BIN";
-const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&h.command.includes(CMUX_HOOK_MARKER);
+const CMUX_HOOK_COMMAND=/\bhooks\s+(claude\b|feed\s+--source\s+claude\b)/;
+const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&h.command.includes(CMUX_HOOK_MARKER)&&CMUX_HOOK_COMMAND.test(h.command);
 const stripCmuxHooks=s=>{
   if(!isObj(s)||!isObj(s.hooks))return s;
   const hooks={};

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -194,9 +194,23 @@ cmux_claude_wrapper_write_hook_reentry_state() {
     file="$dir/$$"
     cmux_claude_wrapper_hook_reentry_state_file_is_ours "$file" || return 0
     printf '%s\n' "$1" > "$file" 2>/dev/null || true
-    # Housekeeping, since a launch that reaches Claude leaves its file behind:
-    # yesterday's entries cannot belong to a live pid this wrapper cares about.
-    find "$dir" -type f -mtime +1 -delete 2>/dev/null || true
+    cmux_claude_wrapper_prune_hook_reentry_state "$dir"
+}
+
+# A launch that reaches Claude leaves its state file behind, so the directory
+# needs an occasional sweep -- but not one per launch. Counting with a glob is
+# in-process and cheap; the sweep itself only forks once the directory has more
+# entries than any single bounce can produce, which caps both the directory and
+# the work a launch pays for it.
+cmux_claude_wrapper_hook_reentry_state_sweep_threshold=256
+
+cmux_claude_wrapper_prune_hook_reentry_state() {
+    local dir="$1"
+    local -a entries=("$dir"/*)
+    [[ -e "${entries[0]}" || -L "${entries[0]}" ]] || return 0
+    (( ${#entries[@]} > cmux_claude_wrapper_hook_reentry_state_sweep_threshold )) || return 0
+    # Yesterday's entries cannot belong to a live pid this wrapper cares about.
+    find "$dir" -maxdepth 1 -type f -mtime +1 -delete 2>/dev/null || true
 }
 
 cmux_claude_wrapper_clear_hook_reentry_state() {

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -209,8 +209,10 @@ cmux_claude_wrapper_prune_hook_reentry_state() {
     local -a entries=("$dir"/*)
     [[ -e "${entries[0]}" || -L "${entries[0]}" ]] || return 0
     (( ${#entries[@]} > cmux_claude_wrapper_hook_reentry_state_sweep_threshold )) || return 0
-    # Yesterday's entries cannot belong to a live pid this wrapper cares about.
-    find "$dir" -maxdepth 1 -type f -mtime +1 -delete 2>/dev/null || true
+    # Only all-digit names, which is what this wrapper writes ($$), and only
+    # yesterday's: those cannot belong to a live pid it cares about. Anything
+    # else in the directory was not written here and is left alone.
+    find "$dir" -maxdepth 1 -type f -name '[0-9]*' ! -name '*[!0-9]*' -mtime +1 -delete 2>/dev/null || true
 }
 
 cmux_claude_wrapper_clear_hook_reentry_state() {

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -69,14 +69,14 @@ EOF
 cmux_claude_wrapper_hook_reentry_limit=16
 
 cmux_claude_wrapper_settings_value_is_cmux_injected() {
-    # Match the whole first command of HOOKS_JSON below, not just the cmux hook
-    # binary variable: a hook the user wrote against that same variable must not
-    # read as cmux's own block. Only the head of the value is inspected, because
-    # the injected block always carries its SessionStart entry there, and
-    # pattern-matching an unbounded argument is exactly the cost this guard
-    # exists to avoid. A false negative here is harmless: the merge below is
-    # idempotent on its own.
-    [[ "${1:0:4096}" == *'${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start'* ]]
+    # Match the whole first hook object of HOOKS_JSON below, verbatim, so a hook
+    # the user wrote around the same command cannot read as cmux's own block.
+    # Only the head of the value is inspected, because the injected block always
+    # carries its SessionStart entry there, and pattern-matching an unbounded
+    # argument is exactly the cost this guard exists to avoid. Keep this literal
+    # in step with HOOKS_JSON; a mismatch only costs the early no-op below, since
+    # the merge is idempotent on its own.
+    [[ "${1:0:4096}" == *'{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}'* ]]
 }
 
 cmux_claude_wrapper_argv_has_injected_settings() {
@@ -1137,21 +1137,29 @@ const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
 // one instead of concatenating onto it: injecting the same block twice converges
 // to one copy, while every user-authored hook and key is merged untouched.
 //
-// Identity is the exact command string this launch is about to inject, collected
-// from the base block below. Nothing else is touched, so a user hook that runs
-// the same cmux binary with a command of their own survives verbatim.
-const cmuxInjectedCommands=new Set();
-const forEachHookCommand=(s,fn)=>{
+// Identity is the whole hook object this launch is about to inject, canonicalized
+// and collected from the base block below. Matching the command alone would take
+// a user hook that runs the same command with their own timeout/async and replace
+// their configuration with cmux defaults; matching the whole object means a hook
+// that differs in any field is theirs and is merged verbatim.
+const cmuxInjectedHooks=new Set();
+const canonicalHook=h=>{
+  if(!isObj(h))return null;
+  const o={};
+  for(const k of Object.keys(h).sort())o[k]=h[k];
+  return JSON.stringify(o);
+};
+const forEachHook=(s,fn)=>{
   if(!isObj(s)||!isObj(s.hooks))return;
   for(const entries of Object.values(s.hooks)){
     if(!Array.isArray(entries))continue;
     for(const entry of entries){
       if(!isObj(entry)||!Array.isArray(entry.hooks))continue;
-      for(const h of entry.hooks)if(isObj(h)&&typeof h.command==="string")fn(h.command);
+      for(const h of entry.hooks)fn(h);
     }
   }
 };
-const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&cmuxInjectedCommands.has(h.command);
+const isCmuxHook=h=>{const c=canonicalHook(h);return c!==null&&cmuxInjectedHooks.has(c);};
 const stripCmuxHooks=s=>{
   if(!isObj(s)||!isObj(s.hooks))return s;
   const hooks={};
@@ -1186,7 +1194,7 @@ const merge=(a,b)=>{
 const expand=p=>p.indexOf("~/")===0?path.join(os.homedir(),p.slice(2)):p;
 const load=v=>{const t=String(v).trim();return (t[0]==="{"||t[0]==="[")?JSON.parse(t):JSON.parse(fs.readFileSync(expand(t),"utf8"));};
 let acc=JSON.parse(process.env.CMUX_BASE_SETTINGS);
-forEachHookCommand(acc,c=>cmuxInjectedCommands.add(c));
+forEachHook(acc,h=>{const c=canonicalHook(h);if(c!==null)cmuxInjectedHooks.add(c);});
 const raw=Buffer.from(process.env.CMUX_USER_SETTINGS_B64||"","base64").toString("utf8");
 // split() leaves one trailing "" from printf terminating NUL; slice it off
 // rather than filtering all empties, so an explicit empty --settings= reaches

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -135,17 +135,61 @@ EOF
     exit 126
 }
 
-# Count one re-entry pass. The counter rides in the environment, so it bounds the
-# bounce whenever the environment is inherited (the normal exec chain); when a
-# launcher scrubs the environment the argv-side marker still makes each pass a
-# no-op, so the injected --settings stays a fixed size instead of growing.
+# Re-entry is counted in two places, because either one alone has a blind spot.
+# The environment carries it across an `exec` chain even when the pid changes
+# (a launcher that spawns instead of exec'ing); a file named after this pid
+# carries it when a launcher rebuilds the environment but stays in the same
+# process, which is exactly how the bounce happens. Whichever is higher wins.
+cmux_claude_wrapper_hook_reentry_state_file() {
+    local dir="${TMPDIR:-/tmp}"
+    printf '%s/cmux-claude-hook-reentry/%s' "${dir%/}" "$$"
+}
+
+cmux_claude_wrapper_read_hook_reentry_state() {
+    local file
+    file="$(cmux_claude_wrapper_hook_reentry_state_file)"
+    [[ -f "$file" ]] || return 1
+    # The bounce spins in milliseconds, so anything older belongs to a dead
+    # process whose pid was recycled. Drop it rather than counting it.
+    if [[ -n "$(find "$file" -mmin +5 2>/dev/null)" ]]; then
+        rm -f "$file" 2>/dev/null
+        return 1
+    fi
+    local value
+    IFS= read -r value < "$file" 2>/dev/null || return 1
+    cmux_claude_wrapper_is_nonnegative_integer "$value" || return 1
+    printf '%s' "$value"
+}
+
+cmux_claude_wrapper_write_hook_reentry_state() {
+    local file
+    file="$(cmux_claude_wrapper_hook_reentry_state_file)"
+    mkdir -p "${file%/*}" 2>/dev/null || return 0
+    printf '%s\n' "$1" > "$file" 2>/dev/null || true
+}
+
+cmux_claude_wrapper_clear_hook_reentry_state() {
+    rm -f "$(cmux_claude_wrapper_hook_reentry_state_file)" 2>/dev/null || true
+}
+
+cmux_claude_wrapper_hook_reentry_recorded() {
+    [[ -n "${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-}" ]] && return 0
+    cmux_claude_wrapper_read_hook_reentry_state >/dev/null
+}
+
 cmux_claude_wrapper_note_hook_reentry() {
-    local seen="${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-1}"
-    cmux_claude_wrapper_is_nonnegative_integer "$seen" || seen=1
+    local seen="${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-}"
+    cmux_claude_wrapper_is_nonnegative_integer "$seen" || seen=0
+    local recorded
+    recorded="$(cmux_claude_wrapper_read_hook_reentry_state)" || recorded=0
+    (( recorded > seen )) && seen="$recorded"
+    (( seen < 1 )) && seen=1
     if (( seen >= cmux_claude_wrapper_hook_reentry_limit )); then
+        cmux_claude_wrapper_clear_hook_reentry_state
         cmux_claude_wrapper_fail_hook_reentry_guard
     fi
     export CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED=$((seen + 1))
+    cmux_claude_wrapper_write_hook_reentry_state "$((seen + 1))"
 }
 
 cmux_claude_wrapper_init_reexec_guard() {
@@ -969,8 +1013,8 @@ should_inject_claude_hooks() {
 # marker alone would also be present in an ordinary `claude` started BY Claude
 # Code, which must still get its own fresh injection.
 cmux_claude_wrapper_hook_reentry=0
-if [[ -n "${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-}" ]] &&
-   cmux_claude_wrapper_argv_has_injected_settings "$@"; then
+if cmux_claude_wrapper_argv_has_injected_settings "$@" &&
+   cmux_claude_wrapper_hook_reentry_recorded; then
     cmux_claude_wrapper_hook_reentry=1
 fi
 
@@ -1218,10 +1262,12 @@ process.stdout.write(JSON.stringify(acc));
     unset CMUX_MERGED_SETTINGS cmux_merge_status
 fi
 
-# Mark this launch as carrying cmux-injected hooks. A wrapper pass that sees the
-# marker AND finds the injected block on argv knows it is a re-entry and forwards
-# argv untouched; a fresh injection resets the count to 1.
+# Mark this launch as carrying cmux-injected hooks, in the environment and in
+# this process's own state file. A wrapper pass that finds either mark AND the
+# pinned block on argv knows it is a re-entry, forwards argv untouched and counts
+# the bounce; a fresh injection resets the count to 1.
 export CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED=1
+cmux_claude_wrapper_write_hook_reentry_state 1
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -59,6 +59,85 @@ EOF
     exit 126
 }
 
+# Hook-injection re-entry, which the re-exec guard above cannot see: the wrapper
+# hands off with `exec`, so a custom Claude Binary Path script that resolves
+# `claude` through PATH re-enters this wrapper through cmux's own per-surface
+# shim inside the SAME pid. That script is not a recognizable shim, so
+# cmux_claude_wrapper_exec_resolved_claude treats it as the real-binary boundary
+# and clears the hop counter before every re-entry, leaving the bounce unbounded.
+# https://github.com/manaflow-ai/cmux/issues/10230
+cmux_claude_wrapper_hook_reentry_limit=16
+
+cmux_claude_wrapper_settings_value_is_cmux_injected() {
+    # cmux is the only writer of CMUX_CLAUDE_HOOK_CMUX_BIN, and every command in
+    # the injected block references it, so a --settings value carrying it was
+    # produced by an earlier pass of this wrapper. Only the head of the value is
+    # inspected: the injected block always carries the marker in its first hook
+    # entry, and pattern-matching an unbounded argument is exactly the cost this
+    # guard exists to avoid.
+    [[ "${1:0:4096}" == *"CMUX_CLAUDE_HOOK_CMUX_BIN"* ]]
+}
+
+cmux_claude_wrapper_argv_has_injected_settings() {
+    local arg
+    local want_settings_value=false
+    local skip_option_value=false
+    for arg in "$@"; do
+        if [[ "$want_settings_value" == true ]]; then
+            want_settings_value=false
+            cmux_claude_wrapper_settings_value_is_cmux_injected "$arg" && return 0
+            continue
+        fi
+        if [[ "$skip_option_value" == true ]]; then
+            skip_option_value=false
+            continue
+        fi
+        if [[ "$arg" == "--" ]]; then
+            return 1
+        fi
+        if [[ "$arg" == "--settings" ]]; then
+            want_settings_value=true
+            continue
+        fi
+        if [[ "${arg:0:11}" == "--settings=" ]]; then
+            cmux_claude_wrapper_settings_value_is_cmux_injected "${arg:11}" && return 0
+            continue
+        fi
+        # Value-taking options only ever match their bare form here, so a value
+        # that happens to read like `--settings` is never mistaken for the flag.
+        if claude_option_consumes_value "$arg"; then
+            skip_option_value=true
+        fi
+    done
+    return 1
+}
+
+cmux_claude_wrapper_fail_hook_reentry_guard() {
+    cat >&2 <<'EOF'
+cmux: stopped a claude launch loop before it could spin.
+cmux already injected its hook --settings for this launch, and control returned
+to cmux's per-surface claude shim instead of starting Claude.
+This usually means Settings > Automation > Claude Binary Path points at a script
+that resolves `claude` through PATH and finds that shim. Point it at the real
+claude binary, or drop */cmux-cli-shims/* entries from PATH inside that script
+before it hands off.
+EOF
+    exit 126
+}
+
+# Count one re-entry pass. The counter rides in the environment, so it bounds the
+# bounce whenever the environment is inherited (the normal exec chain); when a
+# launcher scrubs the environment the argv-side marker still makes each pass a
+# no-op, so the injected --settings stays a fixed size instead of growing.
+cmux_claude_wrapper_note_hook_reentry() {
+    local seen="${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-1}"
+    cmux_claude_wrapper_is_nonnegative_integer "$seen" || seen=1
+    if (( seen >= cmux_claude_wrapper_hook_reentry_limit )); then
+        cmux_claude_wrapper_fail_hook_reentry_guard
+    fi
+    export CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED=$((seen + 1))
+}
+
 cmux_claude_wrapper_init_reexec_guard() {
     local guard="${cmux_claude_wrapper_reexec_guard:-}"
     local hops
@@ -874,11 +953,25 @@ should_inject_claude_hooks() {
     return 0
 }
 
-if (( cmux_claude_wrapper_reexec_hops > 0 )); then
+# Hooks this wrapper already injected, coming back in on argv, mean control
+# re-entered after the hand-off (a custom Claude Binary Path resolving `claude`
+# through PATH into cmux's shim). Both markers are required: the environment
+# marker alone would also be present in an ordinary `claude` started BY Claude
+# Code, which must still get its own fresh injection.
+cmux_claude_wrapper_hook_reentry=0
+if [[ -n "${CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED:-}" ]] &&
+   cmux_claude_wrapper_argv_has_injected_settings "$@"; then
+    cmux_claude_wrapper_hook_reentry=1
+fi
+
+if (( cmux_claude_wrapper_reexec_hops > 0 || cmux_claude_wrapper_hook_reentry == 1 )); then
     # A previous wrapper pass already made the cmux launch decision and may have
     # injected --session-id/--settings. While resolving a finite shim chain,
     # refresh per-process hook metadata, then forward argv unchanged so hooks are
     # not merged again on re-entry.
+    if (( cmux_claude_wrapper_hook_reentry == 1 )); then
+        cmux_claude_wrapper_note_hook_reentry
+    fi
     unset CLAUDECODE
     clear_inherited_claude_auth_selection_env
     export CMUX_CLAUDE_PID=$$
@@ -1036,6 +1129,38 @@ if (( ${#CMUX_USER_SETTINGS[@]} > 0 )) && command -v node >/dev/null 2>&1; then
         node -e '
 const fs=require("fs"),os=require("os"),path=require("path");
 const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
+// Every command in HOOKS_JSON references CMUX_CLAUDE_HOOK_CMUX_BIN, and cmux is
+// the only writer of that variable, so it doubles as the marker identifying
+// cmux-injected hooks. An incoming --settings that carries them is cmux output
+// from an earlier wrapper pass (re-entry through a PATH-resolving custom Claude
+// Binary Path, https://github.com/manaflow-ai/cmux/issues/10230). Drop them
+// before merging so the current block REPLACES the previous one instead of
+// concatenating onto it: injecting the same block twice converges to one copy,
+// while every user-authored hook and key is merged untouched.
+const CMUX_HOOK_MARKER="CMUX_CLAUDE_HOOK_CMUX_BIN";
+const isCmuxHook=h=>isObj(h)&&typeof h.command==="string"&&h.command.includes(CMUX_HOOK_MARKER);
+const stripCmuxHooks=s=>{
+  if(!isObj(s)||!isObj(s.hooks))return s;
+  const hooks={};
+  let changed=false;
+  for(const event of Object.keys(s.hooks)){
+    const entries=s.hooks[event];
+    if(!Array.isArray(entries)){hooks[event]=entries;continue;}
+    const kept=[];
+    for(const entry of entries){
+      if(!isObj(entry)||!Array.isArray(entry.hooks)){kept.push(entry);continue;}
+      const userHooks=entry.hooks.filter(h=>!isCmuxHook(h));
+      if(userHooks.length===entry.hooks.length){kept.push(entry);continue;}
+      changed=true;
+      // Keep a mixed entry, minus the cmux commands; drop a purely cmux one.
+      if(userHooks.length>0)kept.push(Object.assign({},entry,{hooks:userHooks}));
+    }
+    if(kept.length>0)hooks[event]=kept;
+    else if(entries.length>0)changed=true;
+    else hooks[event]=entries;
+  }
+  return changed?Object.assign({},s,{hooks}):s;
+};
 const merge=(a,b)=>{
   if(Array.isArray(a)&&Array.isArray(b))return a.concat(b);
   if(isObj(a)&&isObj(b)){const o=Object.assign({},a);for(const k of Object.keys(b))o[k]=(k in a)?merge(a[k],b[k]):b[k];return o;}
@@ -1057,7 +1182,7 @@ const raw=Buffer.from(process.env.CMUX_USER_SETTINGS_B64||"","base64").toString(
 // <=2.1.168, last-wins >=2.1.169, undocumented) is irrelevant here. Among
 // repeated USER --settings, reverse() makes the earliest-listed value win the
 // scalar conflict (issue #2816).
-try{for(const it of raw.split("\0").slice(0,-1).reverse())acc=merge(acc,load(it));}
+try{for(const it of raw.split("\0").slice(0,-1).reverse())acc=merge(acc,stripCmuxHooks(load(it)));}
 catch(e){process.stderr.write("cmux: --settings merge error: "+((e&&e.message)||e)+"\n");process.exit(1);}
 process.stdout.write(JSON.stringify(acc));
 '
@@ -1075,6 +1200,11 @@ process.stdout.write(JSON.stringify(acc));
     fi
     unset CMUX_MERGED_SETTINGS cmux_merge_status
 fi
+
+# Mark this launch as carrying cmux-injected hooks. A wrapper pass that sees the
+# marker AND finds the injected block on argv knows it is a re-entry and forwards
+# argv untouched; a fresh injection resets the count to 1.
+export CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED=1
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -158,12 +158,22 @@ cmux_claude_wrapper_hook_reentry_state_dir_is_ours() {
     [[ -d "$1" && ! -L "$1" && -O "$1" ]]
 }
 
+# Absent is fine for the write path; present must mean a regular file this user
+# owns, so a link, a fifo or a directory planted at the path is never written
+# through, read from, or deleted.
+cmux_claude_wrapper_hook_reentry_state_file_is_ours() {
+    [[ ! -L "$1" ]] || return 1
+    [[ -e "$1" ]] || return 0
+    [[ -f "$1" && -O "$1" ]]
+}
+
 cmux_claude_wrapper_read_hook_reentry_state() {
     local dir file
     dir="$(cmux_claude_wrapper_hook_reentry_state_dir)"
     cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 1
     file="$dir/$$"
-    [[ -f "$file" && ! -L "$file" && -O "$file" ]] || return 1
+    [[ -e "$file" ]] || return 1
+    cmux_claude_wrapper_hook_reentry_state_file_is_ours "$file" || return 1
     # The bounce spins in milliseconds, so anything older belongs to a dead
     # process whose pid was recycled. Drop it rather than counting it.
     if [[ -n "$(find "$file" -mmin +5 2>/dev/null)" ]]; then
@@ -182,7 +192,7 @@ cmux_claude_wrapper_write_hook_reentry_state() {
     [[ -e "$dir" ]] || mkdir -m 0700 -p "$dir" 2>/dev/null || return 0
     cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 0
     file="$dir/$$"
-    [[ ! -L "$file" ]] || return 0
+    cmux_claude_wrapper_hook_reentry_state_file_is_ours "$file" || return 0
     printf '%s\n' "$1" > "$file" 2>/dev/null || true
     # Housekeeping, since a launch that reaches Claude leaves its file behind:
     # yesterday's entries cannot belong to a live pid this wrapper cares about.
@@ -196,7 +206,8 @@ cmux_claude_wrapper_clear_hook_reentry_state() {
     # else's link is their file removed, not ours.
     cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 0
     file="$dir/$$"
-    [[ ! -L "$file" ]] || return 0
+    [[ -e "$file" ]] || return 0
+    cmux_claude_wrapper_hook_reentry_state_file_is_ours "$file" || return 0
     rm -f "$file" 2>/dev/null || true
 }
 

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -190,7 +190,14 @@ cmux_claude_wrapper_write_hook_reentry_state() {
 }
 
 cmux_claude_wrapper_clear_hook_reentry_state() {
-    rm -f "$(cmux_claude_wrapper_hook_reentry_state_file)" 2>/dev/null || true
+    local dir file
+    dir="$(cmux_claude_wrapper_hook_reentry_state_dir)"
+    # Same ownership gate as the read and write paths: deleting through someone
+    # else's link is their file removed, not ours.
+    cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 0
+    file="$dir/$$"
+    [[ ! -L "$file" ]] || return 0
+    rm -f "$file" 2>/dev/null || true
 }
 
 cmux_claude_wrapper_hook_reentry_recorded() {

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -140,15 +140,30 @@ EOF
 # (a launcher that spawns instead of exec'ing); a file named after this pid
 # carries it when a launcher rebuilds the environment but stays in the same
 # process, which is exactly how the bounce happens. Whichever is higher wins.
-cmux_claude_wrapper_hook_reentry_state_file() {
+cmux_claude_wrapper_hook_reentry_state_dir() {
     local dir="${TMPDIR:-/tmp}"
-    printf '%s/cmux-claude-hook-reentry/%s' "${dir%/}" "$$"
+    # Scoped per user: with TMPDIR unset this lands in a shared /tmp, where an
+    # unscoped name is another user's to squat on.
+    printf '%s/cmux-claude-hook-reentry-%s' "${dir%/}" "${UID:-$(id -u)}"
+}
+
+cmux_claude_wrapper_hook_reentry_state_file() {
+    printf '%s/%s' "$(cmux_claude_wrapper_hook_reentry_state_dir)" "$$"
+}
+
+# Anything at these paths that cmux does not own, or that is a symlink, was not
+# written by an earlier pass of this wrapper. Do without the state rather than
+# reading through it or writing through it into someone else's file.
+cmux_claude_wrapper_hook_reentry_state_dir_is_ours() {
+    [[ -d "$1" && ! -L "$1" && -O "$1" ]]
 }
 
 cmux_claude_wrapper_read_hook_reentry_state() {
-    local file
-    file="$(cmux_claude_wrapper_hook_reentry_state_file)"
-    [[ -f "$file" ]] || return 1
+    local dir file
+    dir="$(cmux_claude_wrapper_hook_reentry_state_dir)"
+    cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 1
+    file="$dir/$$"
+    [[ -f "$file" && ! -L "$file" && -O "$file" ]] || return 1
     # The bounce spins in milliseconds, so anything older belongs to a dead
     # process whose pid was recycled. Drop it rather than counting it.
     if [[ -n "$(find "$file" -mmin +5 2>/dev/null)" ]]; then
@@ -162,10 +177,16 @@ cmux_claude_wrapper_read_hook_reentry_state() {
 }
 
 cmux_claude_wrapper_write_hook_reentry_state() {
-    local file
-    file="$(cmux_claude_wrapper_hook_reentry_state_file)"
-    mkdir -p "${file%/*}" 2>/dev/null || return 0
+    local dir file
+    dir="$(cmux_claude_wrapper_hook_reentry_state_dir)"
+    [[ -e "$dir" ]] || mkdir -m 0700 -p "$dir" 2>/dev/null || return 0
+    cmux_claude_wrapper_hook_reentry_state_dir_is_ours "$dir" || return 0
+    file="$dir/$$"
+    [[ ! -L "$file" ]] || return 0
     printf '%s\n' "$1" > "$file" 2>/dev/null || true
+    # Housekeeping, since a launch that reaches Claude leaves its file behind:
+    # yesterday's entries cannot belong to a live pid this wrapper cares about.
+    find "$dir" -type f -mtime +1 -delete 2>/dev/null || true
 }
 
 cmux_claude_wrapper_clear_hook_reentry_state() {

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import os
 import shutil
 import socket
@@ -20,11 +21,21 @@ from node_runtime import ensure_node_on_path
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
 
-# cmux pins every hook command it injects with a `:` shell no-op carrying this
-# token, so a later wrapper pass can tell its own hooks from the user's without
-# guessing from the command text. Keep in step with cmux_claude_hook_pin in the
-# wrapper.
-CMUX_HOOK_PIN = ": cmux-claude-hook-v1; "
+
+def read_hook_pin() -> str:
+    """The pin cmux marks its own hook commands with, read from the wrapper.
+
+    Kept out of the tests as a literal so the two cannot drift: a wrapper that
+    stops pinning, or pins with a different token, fails these tests instead of
+    silently disabling hook ownership.
+    """
+    match = re.search(r"^cmux_claude_hook_pin='([^']+)'", SOURCE_WRAPPER.read_text(encoding="utf-8"), re.M)
+    if match is None:
+        raise AssertionError("cmux_claude_hook_pin is not defined in the wrapper")
+    return match.group(1)
+
+
+CMUX_HOOK_PIN = f"{read_hook_pin()} "
 
 
 def make_executable(path: Path, content: str) -> None:

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -20,6 +20,12 @@ from node_runtime import ensure_node_on_path
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
 
+# cmux pins every hook command it injects with a `:` shell no-op carrying this
+# token, so a later wrapper pass can tell its own hooks from the user's without
+# guessing from the command text. Keep in step with cmux_claude_hook_pin in the
+# wrapper.
+CMUX_HOOK_PIN = ": cmux-claude-hook-v1; "
+
 
 def make_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
@@ -540,7 +546,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
     }.items():
         hook_command = hooks.get(hook_name, [{}])[0].get("hooks", [{}])[0].get("command", "")
         expect(
-            hook_command == f'"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks claude {expected_subcommand}',
+            hook_command == f'{CMUX_HOOK_PIN}"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks claude {expected_subcommand}',
             f"{hook_name} hook should pin bundled cmux, got {hook_command!r}",
             failures,
         )
@@ -551,7 +557,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
         cron_guard_hooks = cron_guard_groups[0].get("hooks", [])
         expect(
             any(
-                h.get("command") == '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude cron-create-guard'
+                h.get("command") == f'{CMUX_HOOK_PIN}"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks claude cron-create-guard'
                 and h.get("async") is not True
                 for h in cron_guard_hooks
             ),
@@ -573,7 +579,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
         push_hooks = push_notification_groups[0].get("hooks", [])
         expect(
             any(
-                h.get("command") == '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude push-notification'
+                h.get("command") == f'{CMUX_HOOK_PIN}"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks claude push-notification'
                 and h.get("async") is True
                 for h in push_hooks
             ),
@@ -595,14 +601,17 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
     )
     permission_request_hooks = hooks.get("PermissionRequest", [{}])[0].get("hooks", [{}])
     expect(
-        any(h.get("command") == '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks feed --source claude' for h in permission_request_hooks),
+        any(
+            h.get("command") == f'{CMUX_HOOK_PIN}"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks feed --source claude'
+            for h in permission_request_hooks
+        ),
         f"PermissionRequest hook should call hooks feed, got {permission_request_hooks}",
         failures,
     )
     subagent_stop_hooks = hooks.get("SubagentStop", [{}])[0].get("hooks", [{}])
     expect(
         any(
-            h.get("command") == '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks feed --source claude'
+            h.get("command") == f'{CMUX_HOOK_PIN}"${{CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}}" hooks feed --source claude'
             and h.get("async") is True
             for h in subagent_stop_hooks
         ),

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -157,6 +157,7 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # Resolves `claude` through PATH the way `shutil.which` / `command -v` /
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
+        victim_literal = "None" if hostile_state_dir is None else repr(str(hostile_state_dir))
         scrub_literal = "True" if scrub_env_marker else "False"
         scrub_state_literal = "True" if scrub_state_file else "False"
         reserialize_literal = "True" if reserialize_settings else "False"
@@ -166,11 +167,19 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
 import glob, json, os, shutil, sys
 
 pass_dir = {str(pass_dir)!r}
+victim_dir = {victim_literal}
 break_after = {break_after_literal}
 scrub_env_marker = {scrub_literal}
 scrub_state_file = {scrub_state_literal}
 reserialize_settings = {reserialize_literal}
 argv = sys.argv[2:]
+if victim_dir is not None:
+    # Named after this pid, which is the pid the wrapper composes its state path
+    # from: an unguarded write or delete through the planted symlink lands here.
+    decoy = os.path.join(victim_dir, str(os.getpid()))
+    if not os.path.exists(decoy):
+        with open(decoy, "w") as handle:
+            handle.write("decoy")
 if scrub_env_marker:
     for key in ("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", "cmux_claude_wrapper_reexec_guard", "cmux_claude_wrapper_reexec_targets"):
         os.environ.pop(key, None)
@@ -449,13 +458,43 @@ def test_hostile_state_directory_is_not_written_through(failures: list[str]) -> 
         victim = Path(victim_dir)
         run = run_reentry(argv=[], break_after=3, hostile_state_dir=victim, timeout=30.0)
 
-        planted = sorted(path.name for path in victim.iterdir())
-        if planted:
-            failures.append(f"wrapper wrote through the planted symlink: {planted!r}")
+        # The launcher plants one decoy, named after the pid the wrapper composes
+        # its state path from; nothing else may appear, and it must be untouched.
+        planted = sorted(victim.iterdir())
+        if len(planted) != 1 or planted[0].read_text(encoding="utf-8") != "decoy":
+            failures.append(
+                f"wrapper wrote through the planted symlink: {[(p.name, p.read_text(encoding='utf-8')) for p in planted]!r}"
+            )
         if not run.real_argv:
             failures.append(f"real claude never started with a hostile state directory: {run.stderr!r}")
         if run.returncode != 0:
             failures.append(f"expected a clean launch with a hostile state directory, got {run.returncode}: {run.stderr!r}")
+
+
+def test_hostile_state_directory_survives_the_guard_trip(failures: list[str]) -> None:
+    """The cleanup path must refuse the planted link too, not just read and write.
+
+    The guard deletes its state file when it trips, so this run lets the loop
+    run to the limit. The launcher plants a decoy named after the pid the
+    wrapper composes its state path from, which is exactly the file an
+    unguarded write would overwrite or an unguarded delete would remove.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-victim-") as victim_dir:
+        victim = Path(victim_dir)
+        run = run_reentry(argv=[], break_after=None, hostile_state_dir=victim, timeout=30.0)
+
+        if run.returncode == -1:
+            failures.append(f"loop did not stop with a hostile state directory: {run.stderr!r}")
+            return
+        if run.returncode == 0:
+            failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+        decoys = sorted(path for path in victim.iterdir())
+        if len(decoys) != 1:
+            failures.append(f"victim directory changed through the planted symlink: {[p.name for p in decoys]!r}")
+            return
+        if decoys[0].read_text(encoding="utf-8") != "decoy":
+            failures.append(f"wrapper wrote through the planted symlink: {decoys[0].read_text(encoding='utf-8')!r}")
 
 
 def test_env_scrubbed_reentry_loop_is_stopped(failures: list[str]) -> None:
@@ -548,6 +587,7 @@ def main() -> int:
     test_unbounded_reentry_loop_is_stopped(failures)
     test_env_scrubbed_reentry_loop_is_stopped(failures)
     test_hostile_state_directory_is_not_written_through(failures)
+    test_hostile_state_directory_survives_the_guard_trip(failures)
     test_reentry_guard_survives_a_reserializing_launcher(failures)
     if failures:
         print("FAIL: claude wrapper --settings re-entry checks failed")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import socket
 import subprocess
 import tempfile
@@ -85,11 +86,21 @@ def collect_hook_commands(settings: dict) -> list[str]:
 
 
 class ReentryRun:
-    def __init__(self, returncode: int, stderr: str, passes: list[list[str]], real_argv: list[str]) -> None:
+    def __init__(
+        self,
+        returncode: int,
+        stderr: str,
+        passes: list[list[str]],
+        real_argv: list[str],
+        state_entries: list[tuple[str, str]],
+    ) -> None:
         self.returncode = returncode
         self.stderr = stderr
         self.passes = passes
         self.real_argv = real_argv
+        # (name, kind) of what is left in the wrapper's state directory, sampled
+        # before the fixture's temporary tree goes away.
+        self.state_entries = state_entries
 
 
 def run_reentry(
@@ -100,6 +111,7 @@ def run_reentry(
     scrub_state_file: bool = False,
     reserialize_settings: bool = False,
     hostile_state_dir: Path | None = None,
+    occupy_state_path: bool = False,
     timeout: float = 30.0,
 ) -> ReentryRun:
     """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
@@ -117,7 +129,9 @@ def run_reentry(
     hooks object behind any large user-owned key that sorts before it.
     `hostile_state_dir` plants a symlink where the re-entry state directory
     belongs, pointing at that directory, the way a squatter in a shared /tmp
-    would.
+    would. `occupy_state_path` puts a fifo where the state file belongs, inside
+    the wrapper's own verified directory, so the paths that write, read and
+    delete it meet something that is not a regular file.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -158,16 +172,18 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
         victim_literal = "None" if hostile_state_dir is None else repr(str(hostile_state_dir))
+        occupy_literal = "True" if occupy_state_path else "False"
         scrub_literal = "True" if scrub_env_marker else "False"
         scrub_state_literal = "True" if scrub_state_file else "False"
         reserialize_literal = "True" if reserialize_settings else "False"
         make_executable(
             launcher_dir / "claude-launcher",
             f"""#!/usr/bin/env python3
-import glob, json, os, shutil, sys
+import glob, json, os, shutil, stat, sys
 
 pass_dir = {str(pass_dir)!r}
 victim_dir = {victim_literal}
+occupy_state_path = {occupy_literal}
 break_after = {break_after_literal}
 scrub_env_marker = {scrub_literal}
 scrub_state_file = {scrub_state_literal}
@@ -180,6 +196,14 @@ if victim_dir is not None:
     if not os.path.exists(decoy):
         with open(decoy, "w") as handle:
             handle.write("decoy")
+if occupy_state_path:
+    state_dir = os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry-%d" % os.getuid())
+    os.makedirs(state_dir, mode=0o700, exist_ok=True)
+    state_path = os.path.join(state_dir, str(os.getpid()))
+    if not os.path.exists(state_path) or not stat.S_ISFIFO(os.stat(state_path).st_mode):
+        if os.path.exists(state_path):
+            os.unlink(state_path)
+        os.mkfifo(state_path)
 if scrub_env_marker:
     for key in ("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", "cmux_claude_wrapper_reexec_guard", "cmux_claude_wrapper_reexec_targets"):
         os.environ.pop(key, None)
@@ -258,7 +282,21 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
 
         passes = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(pass_dir.iterdir())]
         real_argv = json.loads(real_argv_log.read_text(encoding="utf-8")) if real_argv_log.exists() else []
-        return ReentryRun(returncode, stderr, passes, real_argv)
+        state_dir = wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}"
+        state_entries: list[tuple[str, str]] = []
+        if state_dir.is_dir():
+            for entry in sorted(state_dir.iterdir()):
+                mode = entry.lstat().st_mode
+                if stat.S_ISLNK(mode):
+                    kind = "link"
+                elif stat.S_ISFIFO(mode):
+                    kind = "fifo"
+                elif stat.S_ISDIR(mode):
+                    kind = "dir"
+                else:
+                    kind = "file"
+                state_entries.append((entry.name, kind))
+        return ReentryRun(returncode, stderr, passes, real_argv, state_entries)
 
 
 def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
@@ -497,6 +535,29 @@ def test_hostile_state_directory_survives_the_guard_trip(failures: list[str]) ->
             failures.append(f"wrapper wrote through the planted symlink: {decoys[0].read_text(encoding='utf-8')!r}")
 
 
+def test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures: list[str]) -> None:
+    """Only a regular file cmux owns is written, read or deleted at that path.
+
+    The launcher replaces the wrapper's state file with a fifo inside the
+    wrapper's own verified directory. Writing to it would block the launch
+    forever and deleting it would destroy something cmux did not create, so the
+    wrapper has to leave it alone and still stop the loop on the env-side count.
+    """
+
+    run = run_reentry(argv=[], break_after=None, occupy_state_path=True, timeout=30.0)
+
+    if run.returncode == -1:
+        failures.append(f"a fifo at the state path stalled or unbounded the launch: {run.stderr!r}")
+        return
+    if run.returncode == 0:
+        failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+    if "Claude Binary Path" not in run.stderr:
+        failures.append(f"expected the error to name Claude Binary Path, got: {run.stderr!r}")
+    kinds = [kind for _, kind in run.state_entries]
+    if kinds != ["fifo"]:
+        failures.append(f"wrapper did not leave the fifo at its state path alone: {run.state_entries!r}")
+
+
 def test_env_scrubbed_reentry_loop_is_stopped(failures: list[str]) -> None:
     """A launcher that rebuilds the environment must not unbound the loop.
 
@@ -586,6 +647,7 @@ def main() -> int:
     test_merge_converges_without_the_env_marker(failures)
     test_unbounded_reentry_loop_is_stopped(failures)
     test_env_scrubbed_reentry_loop_is_stopped(failures)
+    test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures)
     test_hostile_state_directory_is_not_written_through(failures)
     test_hostile_state_directory_survives_the_guard_trip(failures)
     test_reentry_guard_survives_a_reserializing_launcher(failures)

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -644,7 +644,9 @@ def test_state_directory_sweep_only_removes_its_own_entries(failures: list[str])
             failures.append(
                 f"sweep removed {decoy_name}, which cmux did not write: {names[:8]!r} ({len(names)} entries)"
             )
-    seeded_left = [name for name in names if name.isdigit() and name.startswith("9")]
+    # Only the seeded range: the live launch writes its own state file, whose pid
+    # can start with any digit, and that one is expected to still be there.
+    seeded_left = [name for name in names if name.isdigit() and 900000 <= int(name) < 900000 + 300]
     if seeded_left:
         failures.append(f"sweep left {len(seeded_left)} of its own day-old entries behind: {seeded_left[:8]!r}")
 

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -81,6 +81,7 @@ def run_reentry(
     argv: list[str],
     break_after: int | None,
     scrub_env_marker: bool = False,
+    scrub_state_file: bool = False,
     reserialize_settings: bool = False,
     timeout: float = 30.0,
 ) -> ReentryRun:
@@ -91,8 +92,9 @@ def run_reentry(
     cmux's shim directory first, so every hand-off lands back in the wrapper.
     `break_after` passes lets the launcher escape the loop and reach the real
     binary; `None` keeps the loop running so the wrapper's guard has to stop it.
-    `scrub_env_marker` drops every cmux env marker the way a launcher that
-    rebuilds the environment would, leaving argv as the only re-entry signal.
+    `scrub_env_marker` drops the cmux re-entry env marker the way a launcher that
+    rebuilds the environment would; `scrub_state_file` additionally deletes the
+    per-process state file, leaving argv as the only re-entry signal.
     `reserialize_settings` re-encodes the --settings JSON with sorted keys, the
     way a launcher that parses and re-emits its arguments would, which moves the
     hooks object behind any large user-owned key that sorts before it.
@@ -136,19 +138,24 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
         scrub_literal = "True" if scrub_env_marker else "False"
+        scrub_state_literal = "True" if scrub_state_file else "False"
         reserialize_literal = "True" if reserialize_settings else "False"
         make_executable(
             launcher_dir / "claude-launcher",
             f"""#!/usr/bin/env python3
-import json, os, shutil, sys
+import glob, json, os, shutil, sys
 
 pass_dir = {str(pass_dir)!r}
 break_after = {break_after_literal}
 scrub_env_marker = {scrub_literal}
+scrub_state_file = {scrub_state_literal}
 reserialize_settings = {reserialize_literal}
 argv = sys.argv[2:]
 if scrub_env_marker:
     os.environ.pop("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", None)
+if scrub_state_file:
+    for name in glob.glob(os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry", "*")):
+        os.unlink(name)
 if reserialize_settings and "--settings" in argv:
     at = argv.index("--settings")
     if at + 1 < len(argv):
@@ -368,6 +375,7 @@ def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
         argv=["--settings", json.dumps(user_settings)],
         break_after=3,
         scrub_env_marker=True,
+        scrub_state_file=True,
     )
 
     if len(run.passes) < 3:
@@ -401,6 +409,28 @@ def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
             failures.append(
                 f"pass {index} carried {pass_argv.count('--session-id')} --session-id arguments without the env marker"
             )
+
+
+def test_env_scrubbed_reentry_loop_is_stopped(failures: list[str]) -> None:
+    """A launcher that rebuilds the environment must not unbound the loop.
+
+    The env marker is gone on every pass, so the bound has to come from the
+    state file this process wrote before handing off.
+    """
+
+    run = run_reentry(argv=[], break_after=None, scrub_env_marker=True, timeout=30.0)
+
+    if run.returncode == -1:
+        failures.append(
+            f"a scrubbed environment defeated the loop guard: {run.stderr!r} after {len(run.passes)} passes"
+        )
+        return
+    if run.returncode == 0:
+        failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+    if "Claude Binary Path" not in run.stderr:
+        failures.append(f"expected the error to name Claude Binary Path, got: {run.stderr!r}")
+    if len(run.passes) > 32:
+        failures.append(f"re-entry guard allowed {len(run.passes)} passes without the env marker")
 
 
 def test_reentry_guard_survives_a_reserializing_launcher(failures: list[str]) -> None:
@@ -469,6 +499,7 @@ def main() -> int:
     test_reentry_preserves_user_settings(failures)
     test_merge_converges_without_the_env_marker(failures)
     test_unbounded_reentry_loop_is_stopped(failures)
+    test_env_scrubbed_reentry_loop_is_stopped(failures)
     test_reentry_guard_survives_a_reserializing_launcher(failures)
     if failures:
         print("FAIL: claude wrapper --settings re-entry checks failed")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -11,6 +11,7 @@ per pass, and a user's own `--settings` must survive unchanged.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import socket
@@ -98,6 +99,7 @@ def run_reentry(
     scrub_env_marker: bool = False,
     scrub_state_file: bool = False,
     reserialize_settings: bool = False,
+    hostile_state_dir: Path | None = None,
     timeout: float = 30.0,
 ) -> ReentryRun:
     """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
@@ -113,6 +115,9 @@ def run_reentry(
     `reserialize_settings` re-encodes the --settings JSON with sorted keys, the
     way a launcher that parses and re-emits its arguments would, which moves the
     hooks object behind any large user-owned key that sorts before it.
+    `hostile_state_dir` plants a symlink where the re-entry state directory
+    belongs, pointing at that directory, the way a squatter in a shared /tmp
+    would.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -170,7 +175,7 @@ if scrub_env_marker:
     for key in ("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", "cmux_claude_wrapper_reexec_guard", "cmux_claude_wrapper_reexec_targets"):
         os.environ.pop(key, None)
 if scrub_state_file:
-    for name in glob.glob(os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry", "*")):
+    for name in glob.glob(os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry-*", "*")):
         os.unlink(name)
 if reserialize_settings and "--settings" in argv:
     at = argv.index("--settings")
@@ -197,6 +202,11 @@ os.execv(target, ["claude"] + argv)
 exec {launcher_dir / "claude-launcher"} claude "$@"
 """,
         )
+
+        wrapper_tmpdir = tmp / "tmp"
+        wrapper_tmpdir.mkdir(parents=True, exist_ok=True)
+        if hostile_state_dir is not None:
+            (wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}").symlink_to(hostile_state_dir)
 
         socket_path = str(tmp / "cmux.sock")
         test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -427,6 +437,27 @@ def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
             )
 
 
+def test_hostile_state_directory_is_not_written_through(failures: list[str]) -> None:
+    """With TMPDIR unset the state directory lands in a shared /tmp.
+
+    A symlink planted at that path must not be followed: the wrapper has to do
+    without its state file rather than write through someone else's link, and
+    the launch has to proceed normally.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-victim-") as victim_dir:
+        victim = Path(victim_dir)
+        run = run_reentry(argv=[], break_after=3, hostile_state_dir=victim, timeout=30.0)
+
+        planted = sorted(path.name for path in victim.iterdir())
+        if planted:
+            failures.append(f"wrapper wrote through the planted symlink: {planted!r}")
+        if not run.real_argv:
+            failures.append(f"real claude never started with a hostile state directory: {run.stderr!r}")
+        if run.returncode != 0:
+            failures.append(f"expected a clean launch with a hostile state directory, got {run.returncode}: {run.stderr!r}")
+
+
 def test_env_scrubbed_reentry_loop_is_stopped(failures: list[str]) -> None:
     """A launcher that rebuilds the environment must not unbound the loop.
 
@@ -516,6 +547,7 @@ def main() -> int:
     test_merge_converges_without_the_env_marker(failures)
     test_unbounded_reentry_loop_is_stopped(failures)
     test_env_scrubbed_reentry_loop_is_stopped(failures)
+    test_hostile_state_directory_is_not_written_through(failures)
     test_reentry_guard_survives_a_reserializing_launcher(failures)
     if failures:
         print("FAIL: claude wrapper --settings re-entry checks failed")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -71,7 +71,13 @@ class ReentryRun:
         self.real_argv = real_argv
 
 
-def run_reentry(*, argv: list[str], break_after: int | None, timeout: float = 30.0) -> ReentryRun:
+def run_reentry(
+    *,
+    argv: list[str],
+    break_after: int | None,
+    scrub_env_marker: bool = False,
+    timeout: float = 30.0,
+) -> ReentryRun:
     """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
 
     The custom binary path is a script that hands off to a launcher which
@@ -79,6 +85,8 @@ def run_reentry(*, argv: list[str], break_after: int | None, timeout: float = 30
     cmux's shim directory first, so every hand-off lands back in the wrapper.
     `break_after` passes lets the launcher escape the loop and reach the real
     binary; `None` keeps the loop running so the wrapper's guard has to stop it.
+    `scrub_env_marker` drops every cmux env marker the way a launcher that
+    rebuilds the environment would, leaving argv as the only re-entry signal.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -118,6 +126,7 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # Resolves `claude` through PATH the way `shutil.which` / `command -v` /
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
+        scrub_literal = "True" if scrub_env_marker else "False"
         make_executable(
             launcher_dir / "claude-launcher",
             f"""#!/usr/bin/env python3
@@ -125,7 +134,10 @@ import json, os, shutil, sys
 
 pass_dir = {str(pass_dir)!r}
 break_after = {break_after_literal}
+scrub_env_marker = {scrub_literal}
 argv = sys.argv[2:]
+if scrub_env_marker:
+    os.environ.pop("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", None)
 index = len(os.listdir(pass_dir)) + 1
 with open(os.path.join(pass_dir, "pass-%03d.json" % index), "w") as handle:
     json.dump(argv, handle)
@@ -278,6 +290,40 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
             failures.append(f"pass {index} settings diverged from the first pass")
 
 
+def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
+    """The merge alone must converge, so a launcher that rebuilds the
+    environment still cannot grow the injected block one copy per pass."""
+
+    user_settings = {"model": "user-selected-model"}
+    run = run_reentry(
+        argv=["--settings", json.dumps(user_settings)],
+        break_after=3,
+        scrub_env_marker=True,
+    )
+
+    if len(run.passes) < 3:
+        failures.append(f"expected at least 3 wrapper passes without the env marker, got {len(run.passes)}: stderr={run.stderr!r}")
+        return
+
+    baseline = settings_from_argv(run.passes[0])
+    if baseline is None:
+        failures.append(f"first pass carried no --settings: {run.passes[0]!r}")
+        return
+
+    for index, pass_argv in enumerate(run.passes[1:], start=2):
+        settings = settings_from_argv(pass_argv)
+        if settings is None:
+            failures.append(f"pass {index} carried no --settings without the env marker")
+            continue
+        hook_count = count_cmux_hook_commands(settings)
+        if hook_count != 3:
+            failures.append(f"pass {index} carried {hook_count} cmux hook-feed commands without the env marker, expected 3")
+        if settings.get("model") != "user-selected-model":
+            failures.append(f"pass {index} lost the user's model setting without the env marker")
+        if settings != baseline:
+            failures.append(f"pass {index} settings diverged from the first pass without the env marker")
+
+
 def test_unbounded_reentry_loop_is_stopped(failures: list[str]) -> None:
     run = run_reentry(argv=[], break_after=None, timeout=30.0)
 
@@ -301,6 +347,7 @@ def main() -> int:
     failures: list[str] = []
     test_reentry_does_not_duplicate_injected_hooks(failures)
     test_reentry_preserves_user_settings(failures)
+    test_merge_converges_without_the_env_marker(failures)
     test_unbounded_reentry_loop_is_stopped(failures)
     if failures:
         print("FAIL: claude wrapper --settings re-entry checks failed")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -45,6 +45,17 @@ def read_hook_pin() -> str:
 CMUX_HOOK_PIN = f"{read_hook_pin()} "
 
 
+def read_state_tag() -> str:
+    """The tag cmux stamps its re-entry state files with, read from the wrapper."""
+    match = re.search(r"^cmux_claude_hook_state_tag='([^']+)'", SOURCE_WRAPPER.read_text(encoding="utf-8"), re.M)
+    if match is None:
+        raise AssertionError("cmux_claude_hook_state_tag is not defined in the wrapper")
+    return match.group(1)
+
+
+CMUX_STATE_TAG = read_state_tag()
+
+
 def make_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(0o755)
@@ -248,11 +259,12 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
             stale = time.time() - 2 * 24 * 3600
             for index in range(seed_state_dir):
                 entry = state_dir / str(900000 + index)
-                entry.write_text("1\n", encoding="utf-8")
+                entry.write_text(f"{CMUX_STATE_TAG} 1\n", encoding="utf-8")
                 os.utime(entry, (stale, stale))
-            decoy = state_dir / "not-a-pid.txt"
-            decoy.write_text("keep me", encoding="utf-8")
-            os.utime(decoy, (stale, stale))
+            for decoy_name, decoy_body in (("not-a-pid.txt", "keep me"), ("800001", "someone else's pid-shaped file")):
+                decoy = state_dir / decoy_name
+                decoy.write_text(decoy_body, encoding="utf-8")
+                os.utime(decoy, (stale, stale))
         if hostile_state_dir is not None:
             (wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}").symlink_to(hostile_state_dir)
 
@@ -576,9 +588,10 @@ def test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures: list[
 def test_state_directory_sweep_only_removes_its_own_entries(failures: list[str]) -> None:
     """The sweep clears cmux's own stale entries and nothing else.
 
-    Seeded past the sweep threshold with day-old pid-shaped entries plus one
-    day-old file that is not named after a pid, a launch has to collect its own
-    litter and leave the stranger's file exactly where it is.
+    Seeded past the sweep threshold with day-old tagged entries plus two day-old
+    files another process of the same user could have left there -- one of them
+    pid-shaped, so the name alone cannot tell them apart -- a launch has to
+    collect its own litter and leave both strangers exactly where they are.
     """
 
     run = run_reentry(argv=[], break_after=3, seed_state_dir=300, timeout=30.0)
@@ -586,8 +599,11 @@ def test_state_directory_sweep_only_removes_its_own_entries(failures: list[str])
     if not run.real_argv:
         failures.append(f"real claude never started with a seeded state directory: {run.stderr!r}")
     names = [name for name, _ in run.state_entries]
-    if "not-a-pid.txt" not in names:
-        failures.append(f"sweep removed a file cmux did not write: {names[:8]!r} ({len(names)} entries)")
+    for decoy_name in ("not-a-pid.txt", "800001"):
+        if decoy_name not in names:
+            failures.append(
+                f"sweep removed {decoy_name}, which cmux did not write: {names[:8]!r} ({len(names)} entries)"
+            )
     seeded_left = [name for name in names if name.isdigit() and name.startswith("9")]
     if seeded_left:
         failures.append(f"sweep left {len(seeded_left)} of its own day-old entries behind: {seeded_left[:8]!r}")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -251,10 +251,12 @@ def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
 
 
 def test_reentry_preserves_user_settings(failures: list[str]) -> None:
-    # The second hook references cmux's own hook binary variable with a command
-    # cmux never injects: the wrapper must recognise its own block by shape, not
-    # by the variable alone, or it deletes a user hook on every merge.
+    # These two run cmux's own hook binary with commands cmux never injects, the
+    # second one right next to an injected command shape. The wrapper must
+    # recognise its own block by the exact commands it is injecting, or it
+    # deletes a user hook on every merge.
     user_bin_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify --title mine'
+    user_hooks_claude_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude audit'
     user_settings = {
         "model": "user-selected-model",
         "hooks": {
@@ -264,6 +266,7 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
                     "hooks": [
                         {"type": "command", "command": "user-stop-hook", "timeout": 7},
                         {"type": "command", "command": user_bin_hook, "timeout": 7},
+                        {"type": "command", "command": user_hooks_claude_hook, "timeout": 7},
                     ],
                 }
             ]
@@ -291,11 +294,10 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
         user_hook_count = hook_commands.count("user-stop-hook")
         if user_hook_count != 1:
             failures.append(f"pass {index} carried {user_hook_count} copies of the user's hook, expected 1")
-        user_bin_hook_count = hook_commands.count(user_bin_hook)
-        if user_bin_hook_count != 1:
-            failures.append(
-                f"pass {index} carried {user_bin_hook_count} copies of the user's cmux-bin hook, expected 1"
-            )
+        for label, command in (("cmux-bin", user_bin_hook), ("hooks-claude", user_hooks_claude_hook)):
+            count = hook_commands.count(command)
+            if count != 1:
+                failures.append(f"pass {index} carried {count} copies of the user's {label} hook, expected 1")
         cmux_hook_count = count_cmux_hook_commands(settings)
         if cmux_hook_count != 3:
             failures.append(f"pass {index} carried {cmux_hook_count} cmux hook-feed commands, expected 3")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -54,13 +54,16 @@ def count_cmux_hook_commands(settings: dict) -> int:
     return total
 
 
-def collect_hook_commands(settings: dict) -> list[str]:
-    commands: list[str] = []
+def collect_hooks(settings: dict) -> list[dict]:
+    hooks: list[dict] = []
     for entries in (settings.get("hooks") or {}).values():
         for entry in entries:
-            for hook in entry.get("hooks", []):
-                commands.append(hook.get("command", ""))
-    return commands
+            hooks.extend(entry.get("hooks", []))
+    return hooks
+
+
+def collect_hook_commands(settings: dict) -> list[str]:
+    return [hook.get("command", "") for hook in collect_hooks(settings)]
 
 
 class ReentryRun:
@@ -257,6 +260,9 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
     # deletes a user hook on every merge.
     user_bin_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify --title mine'
     user_hooks_claude_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude audit'
+    # Same command cmux injects, but the user's own timeout: their configuration
+    # must survive rather than be replaced by cmux's copy of that command.
+    cmux_stop_command = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude stop'
     user_settings = {
         "model": "user-selected-model",
         "hooks": {
@@ -267,6 +273,7 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
                         {"type": "command", "command": "user-stop-hook", "timeout": 7},
                         {"type": "command", "command": user_bin_hook, "timeout": 7},
                         {"type": "command", "command": user_hooks_claude_hook, "timeout": 7},
+                        {"type": "command", "command": cmux_stop_command, "timeout": 90},
                     ],
                 }
             ]
@@ -298,6 +305,15 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
             count = hook_commands.count(command)
             if count != 1:
                 failures.append(f"pass {index} carried {count} copies of the user's {label} hook, expected 1")
+        user_timeouts = [
+            hook.get("timeout")
+            for hook in collect_hooks(settings)
+            if hook.get("command") == cmux_stop_command and hook.get("timeout") == 90
+        ]
+        if len(user_timeouts) != 1:
+            failures.append(
+                f"pass {index} kept {len(user_timeouts)} copies of the user's own timeout on cmux's stop command, expected 1"
+            )
         cmux_hook_count = count_cmux_hook_commands(settings)
         if cmux_hook_count != 3:
             failures.append(f"pass {index} carried {cmux_hook_count} cmux hook-feed commands, expected 3")

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -81,6 +81,7 @@ def run_reentry(
     argv: list[str],
     break_after: int | None,
     scrub_env_marker: bool = False,
+    reserialize_settings: bool = False,
     timeout: float = 30.0,
 ) -> ReentryRun:
     """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
@@ -92,6 +93,9 @@ def run_reentry(
     binary; `None` keeps the loop running so the wrapper's guard has to stop it.
     `scrub_env_marker` drops every cmux env marker the way a launcher that
     rebuilds the environment would, leaving argv as the only re-entry signal.
+    `reserialize_settings` re-encodes the --settings JSON with sorted keys, the
+    way a launcher that parses and re-emits its arguments would, which moves the
+    hooks object behind any large user-owned key that sorts before it.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -132,6 +136,7 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
         scrub_literal = "True" if scrub_env_marker else "False"
+        reserialize_literal = "True" if reserialize_settings else "False"
         make_executable(
             launcher_dir / "claude-launcher",
             f"""#!/usr/bin/env python3
@@ -140,9 +145,14 @@ import json, os, shutil, sys
 pass_dir = {str(pass_dir)!r}
 break_after = {break_after_literal}
 scrub_env_marker = {scrub_literal}
+reserialize_settings = {reserialize_literal}
 argv = sys.argv[2:]
 if scrub_env_marker:
     os.environ.pop("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", None)
+if reserialize_settings and "--settings" in argv:
+    at = argv.index("--settings")
+    if at + 1 < len(argv):
+        argv[at + 1] = json.dumps(json.loads(argv[at + 1]), sort_keys=True)
 index = len(os.listdir(pass_dir)) + 1
 with open(os.path.join(pass_dir, "pass-%03d.json" % index), "w") as handle:
     json.dump(argv, handle)
@@ -393,6 +403,47 @@ def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
             )
 
 
+def test_reentry_guard_survives_a_reserializing_launcher(failures: list[str]) -> None:
+    """The loop guard must not depend on where the pin lands in the payload.
+
+    A launcher that parses and re-emits its arguments re-encodes the settings
+    JSON; with a large user key that sorts before "hooks", cmux's pinned hook
+    moves kilobytes into the value. A guard that only inspected the head of the
+    value would stop recognising the re-entry and never bound the loop.
+    """
+
+    user_settings = {"aaa_large_user_key": "x" * 8192, "model": "user-selected-model"}
+    run = run_reentry(
+        argv=["--settings", json.dumps(user_settings)],
+        break_after=None,
+        reserialize_settings=True,
+        timeout=30.0,
+    )
+
+    if run.returncode == -1:
+        failures.append(
+            f"re-serialized settings defeated the loop guard: {run.stderr!r} after {len(run.passes)} passes"
+        )
+        return
+    if run.returncode == 0:
+        failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+    if "Claude Binary Path" not in run.stderr:
+        failures.append(f"expected the error to name Claude Binary Path, got: {run.stderr!r}")
+    if len(run.passes) > 32:
+        failures.append(f"re-entry guard allowed {len(run.passes)} passes before stopping")
+    if run.passes:
+        settings = settings_from_argv(run.passes[-1])
+        if settings is None:
+            failures.append(f"last pass carried no --settings: {run.passes[-1]!r}")
+        else:
+            if settings.get("aaa_large_user_key") != "x" * 8192:
+                failures.append("the user's large setting did not survive re-serialized re-entry")
+            if count_cmux_hook_commands(settings) != 3:
+                failures.append(
+                    f"last pass carried {count_cmux_hook_commands(settings)} cmux hook-feed commands, expected 3"
+                )
+
+
 def test_unbounded_reentry_loop_is_stopped(failures: list[str]) -> None:
     run = run_reentry(argv=[], break_after=None, timeout=30.0)
 
@@ -418,6 +469,7 @@ def main() -> int:
     test_reentry_preserves_user_settings(failures)
     test_merge_converges_without_the_env_marker(failures)
     test_unbounded_reentry_loop_is_stopped(failures)
+    test_reentry_guard_survives_a_reserializing_launcher(failures)
     if failures:
         print("FAIL: claude wrapper --settings re-entry checks failed")
         for failure in failures:

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import stat
+import time
 import socket
 import subprocess
 import tempfile
@@ -112,6 +113,7 @@ def run_reentry(
     reserialize_settings: bool = False,
     hostile_state_dir: Path | None = None,
     occupy_state_path: bool = False,
+    seed_state_dir: int = 0,
     timeout: float = 30.0,
 ) -> ReentryRun:
     """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
@@ -131,7 +133,9 @@ def run_reentry(
     belongs, pointing at that directory, the way a squatter in a shared /tmp
     would. `occupy_state_path` puts a fifo where the state file belongs, inside
     the wrapper's own verified directory, so the paths that write, read and
-    delete it meet something that is not a regular file.
+    delete it meet something that is not a regular file. `seed_state_dir` fills
+    that directory with that many day-old pid-shaped entries plus one day-old
+    file nobody named after a pid, to exercise the sweep.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -238,6 +242,17 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
 
         wrapper_tmpdir = tmp / "tmp"
         wrapper_tmpdir.mkdir(parents=True, exist_ok=True)
+        if seed_state_dir:
+            state_dir = wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}"
+            state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            stale = time.time() - 2 * 24 * 3600
+            for index in range(seed_state_dir):
+                entry = state_dir / str(900000 + index)
+                entry.write_text("1\n", encoding="utf-8")
+                os.utime(entry, (stale, stale))
+            decoy = state_dir / "not-a-pid.txt"
+            decoy.write_text("keep me", encoding="utf-8")
+            os.utime(decoy, (stale, stale))
         if hostile_state_dir is not None:
             (wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}").symlink_to(hostile_state_dir)
 
@@ -558,6 +573,26 @@ def test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures: list[
         failures.append(f"wrapper did not leave the fifo at its state path alone: {run.state_entries!r}")
 
 
+def test_state_directory_sweep_only_removes_its_own_entries(failures: list[str]) -> None:
+    """The sweep clears cmux's own stale entries and nothing else.
+
+    Seeded past the sweep threshold with day-old pid-shaped entries plus one
+    day-old file that is not named after a pid, a launch has to collect its own
+    litter and leave the stranger's file exactly where it is.
+    """
+
+    run = run_reentry(argv=[], break_after=3, seed_state_dir=300, timeout=30.0)
+
+    if not run.real_argv:
+        failures.append(f"real claude never started with a seeded state directory: {run.stderr!r}")
+    names = [name for name, _ in run.state_entries]
+    if "not-a-pid.txt" not in names:
+        failures.append(f"sweep removed a file cmux did not write: {names[:8]!r} ({len(names)} entries)")
+    seeded_left = [name for name in names if name.isdigit() and name.startswith("9")]
+    if seeded_left:
+        failures.append(f"sweep left {len(seeded_left)} of its own day-old entries behind: {seeded_left[:8]!r}")
+
+
 def test_env_scrubbed_reentry_loop_is_stopped(failures: list[str]) -> None:
     """A launcher that rebuilds the environment must not unbound the loop.
 
@@ -648,6 +683,7 @@ def main() -> int:
     test_unbounded_reentry_loop_is_stopped(failures)
     test_env_scrubbed_reentry_loop_is_stopped(failures)
     test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures)
+    test_state_directory_sweep_only_removes_its_own_entries(failures)
     test_hostile_state_directory_is_not_written_through(failures)
     test_hostile_state_directory_survives_the_guard_trip(failures)
     test_reentry_guard_survives_a_reserializing_launcher(failures)

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -11,6 +11,7 @@ per pass, and a user's own `--settings` must survive unchanged.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import socket
 import subprocess
@@ -23,8 +24,22 @@ from node_runtime import ensure_node_on_path
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
 CMUX_HOOK_FEED_COMMAND = "hooks feed --source claude"
-# cmux pins the hook commands it injects; anything without the pin is the user's.
-CMUX_HOOK_PIN = ": cmux-claude-hook-v1; "
+
+
+def read_hook_pin() -> str:
+    """The pin cmux marks its own hook commands with, read from the wrapper.
+
+    Kept out of the tests as a literal so the two cannot drift: a wrapper that
+    stops pinning, or pins with a different token, fails these tests instead of
+    silently disabling hook ownership.
+    """
+    match = re.search(r"^cmux_claude_hook_pin='([^']+)'", SOURCE_WRAPPER.read_text(encoding="utf-8"), re.M)
+    if match is None:
+        raise AssertionError("cmux_claude_hook_pin is not defined in the wrapper")
+    return match.group(1)
+
+
+CMUX_HOOK_PIN = f"{read_hook_pin()} "
 
 
 def make_executable(path: Path, content: str) -> None:
@@ -152,7 +167,8 @@ scrub_state_file = {scrub_state_literal}
 reserialize_settings = {reserialize_literal}
 argv = sys.argv[2:]
 if scrub_env_marker:
-    os.environ.pop("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", None)
+    for key in ("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", "cmux_claude_wrapper_reexec_guard", "cmux_claude_wrapper_reexec_targets"):
+        os.environ.pop(key, None)
 if scrub_state_file:
     for name in glob.glob(os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry", "*")):
         os.unlink(name)

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -251,13 +251,20 @@ def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
 
 
 def test_reentry_preserves_user_settings(failures: list[str]) -> None:
+    # The second hook references cmux's own hook binary variable with a command
+    # cmux never injects: the wrapper must recognise its own block by shape, not
+    # by the variable alone, or it deletes a user hook on every merge.
+    user_bin_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify --title mine'
     user_settings = {
         "model": "user-selected-model",
         "hooks": {
             "Stop": [
                 {
                     "matcher": "",
-                    "hooks": [{"type": "command", "command": "user-stop-hook", "timeout": 7}],
+                    "hooks": [
+                        {"type": "command", "command": "user-stop-hook", "timeout": 7},
+                        {"type": "command", "command": user_bin_hook, "timeout": 7},
+                    ],
                 }
             ]
         },
@@ -280,9 +287,15 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
             continue
         if settings.get("model") != "user-selected-model":
             failures.append(f"pass {index} lost the user's model setting: {settings.get('model')!r}")
-        user_hook_count = collect_hook_commands(settings).count("user-stop-hook")
+        hook_commands = collect_hook_commands(settings)
+        user_hook_count = hook_commands.count("user-stop-hook")
         if user_hook_count != 1:
             failures.append(f"pass {index} carried {user_hook_count} copies of the user's hook, expected 1")
+        user_bin_hook_count = hook_commands.count(user_bin_hook)
+        if user_bin_hook_count != 1:
+            failures.append(
+                f"pass {index} carried {user_bin_hook_count} copies of the user's cmux-bin hook, expected 1"
+            )
         cmux_hook_count = count_cmux_hook_commands(settings)
         if cmux_hook_count != 3:
             failures.append(f"pass {index} carried {cmux_hook_count} cmux hook-feed commands, expected 3")
@@ -322,6 +335,16 @@ def test_merge_converges_without_the_env_marker(failures: list[str]) -> None:
             failures.append(f"pass {index} lost the user's model setting without the env marker")
         if settings != baseline:
             failures.append(f"pass {index} settings diverged from the first pass without the env marker")
+        # settings_from_argv reads the first match, so argv growth has to be
+        # asserted separately from payload convergence.
+        if pass_argv.count("--settings") != 1:
+            failures.append(
+                f"pass {index} carried {pass_argv.count('--settings')} --settings arguments without the env marker, expected 1"
+            )
+        if pass_argv.count("--session-id") > 1:
+            failures.append(
+                f"pass {index} carried {pass_argv.count('--session-id')} --session-id arguments without the env marker"
+            )
 
 
 def test_unbounded_reentry_loop_is_stopped(failures: list[str]) -> None:

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -14,9 +14,8 @@ import json
 import os
 import re
 import shutil
-import stat
-import time
 import socket
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
@@ -105,6 +104,7 @@ class ReentryRun:
         passes: list[list[str]],
         real_argv: list[str],
         state_entries: list[tuple[str, str]],
+        state_contents: list[tuple[str, str]],
     ) -> None:
         self.returncode = returncode
         self.stderr = stderr
@@ -113,6 +113,8 @@ class ReentryRun:
         # (name, kind) of what is left in the wrapper's state directory, sampled
         # before the fixture's temporary tree goes away.
         self.state_entries = state_entries
+        # (name, contents) for the regular files among them.
+        self.state_contents = state_contents
 
 
 def run_reentry(
@@ -123,7 +125,7 @@ def run_reentry(
     scrub_state_file: bool = False,
     reserialize_settings: bool = False,
     hostile_state_dir: Path | None = None,
-    occupy_state_path: bool = False,
+    occupy_state_path: str = "",
     seed_state_dir: int = 0,
     timeout: float = 30.0,
 ) -> ReentryRun:
@@ -142,11 +144,12 @@ def run_reentry(
     hooks object behind any large user-owned key that sorts before it.
     `hostile_state_dir` plants a symlink where the re-entry state directory
     belongs, pointing at that directory, the way a squatter in a shared /tmp
-    would. `occupy_state_path` puts a fifo where the state file belongs, inside
-    the wrapper's own verified directory, so the paths that write, read and
-    delete it meet something that is not a regular file. `seed_state_dir` fills
-    that directory with that many day-old pid-shaped entries plus one day-old
-    file nobody named after a pid, to exercise the sweep.
+    would. `occupy_state_path` puts a fifo ("fifo") or an untagged regular file
+    ("file") where the state file belongs, inside the wrapper's own verified
+    directory, so the paths that write, read and delete it meet something cmux
+    did not stamp. `seed_state_dir` fills that directory with that many day-old
+    tagged entries plus two day-old files cmux did not write -- one named after
+    a pid, one not -- to exercise the sweep.
     """
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
@@ -187,7 +190,7 @@ open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
         # `execvp` do in a user launcher, which is what finds cmux's shim.
         break_after_literal = "None" if break_after is None else str(break_after)
         victim_literal = "None" if hostile_state_dir is None else repr(str(hostile_state_dir))
-        occupy_literal = "True" if occupy_state_path else "False"
+        occupy_literal = repr(occupy_state_path)
         scrub_literal = "True" if scrub_env_marker else "False"
         scrub_state_literal = "True" if scrub_state_file else "False"
         reserialize_literal = "True" if reserialize_settings else "False"
@@ -215,10 +218,17 @@ if occupy_state_path:
     state_dir = os.path.join(os.environ.get("TMPDIR", "/tmp"), "cmux-claude-hook-reentry-%d" % os.getuid())
     os.makedirs(state_dir, mode=0o700, exist_ok=True)
     state_path = os.path.join(state_dir, str(os.getpid()))
-    if not os.path.exists(state_path) or not stat.S_ISFIFO(os.stat(state_path).st_mode):
-        if os.path.exists(state_path):
-            os.unlink(state_path)
-        os.mkfifo(state_path)
+    if occupy_state_path == "fifo":
+        occupied = os.path.exists(state_path) and stat.S_ISFIFO(os.stat(state_path).st_mode)
+        if not occupied:
+            if os.path.lexists(state_path):
+                os.unlink(state_path)
+            os.mkfifo(state_path)
+    else:
+        occupied = os.path.isfile(state_path) and open(state_path).read() == "not cmux state"
+        if not occupied:
+            with open(state_path, "w") as handle:
+                handle.write("not cmux state")
 if scrub_env_marker:
     for key in ("CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED", "cmux_claude_wrapper_reexec_guard", "cmux_claude_wrapper_reexec_targets"):
         os.environ.pop(key, None)
@@ -256,7 +266,10 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
         if seed_state_dir:
             state_dir = wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}"
             state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-            stale = time.time() - 2 * 24 * 3600
+            # A fixed historical timestamp: the sweep only cares that the entry
+            # is older than a day, and a fixed value keeps the fixture off the
+            # wall clock.
+            stale = 1600000000.0
             for index in range(seed_state_dir):
                 entry = state_dir / str(900000 + index)
                 entry.write_text(f"{CMUX_STATE_TAG} 1\n", encoding="utf-8")
@@ -311,6 +324,7 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
         real_argv = json.loads(real_argv_log.read_text(encoding="utf-8")) if real_argv_log.exists() else []
         state_dir = wrapper_tmpdir / f"cmux-claude-hook-reentry-{os.getuid()}"
         state_entries: list[tuple[str, str]] = []
+        state_contents: list[tuple[str, str]] = []
         if state_dir.is_dir():
             for entry in sorted(state_dir.iterdir()):
                 mode = entry.lstat().st_mode
@@ -323,7 +337,9 @@ exec {launcher_dir / "claude-launcher"} claude "$@"
                 else:
                     kind = "file"
                 state_entries.append((entry.name, kind))
-        return ReentryRun(returncode, stderr, passes, real_argv, state_entries)
+                if kind == "file":
+                    state_contents.append((entry.name, entry.read_text(encoding="utf-8", errors="replace")))
+        return ReentryRun(returncode, stderr, passes, real_argv, state_entries, state_contents)
 
 
 def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
@@ -571,7 +587,7 @@ def test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures: list[
     wrapper has to leave it alone and still stop the loop on the env-side count.
     """
 
-    run = run_reentry(argv=[], break_after=None, occupy_state_path=True, timeout=30.0)
+    run = run_reentry(argv=[], break_after=None, occupy_state_path="fifo", timeout=30.0)
 
     if run.returncode == -1:
         failures.append(f"a fifo at the state path stalled or unbounded the launch: {run.stderr!r}")
@@ -583,6 +599,30 @@ def test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures: list[
     kinds = [kind for _, kind in run.state_entries]
     if kinds != ["fifo"]:
         failures.append(f"wrapper did not leave the fifo at its state path alone: {run.state_entries!r}")
+
+
+def test_untagged_file_at_the_state_path_is_left_alone(failures: list[str]) -> None:
+    """A regular file cmux did not stamp is neither overwritten nor deleted.
+
+    The mode checks pass here -- it is a regular file owned by this user, at the
+    pid-scoped path cmux composes -- so only the tag tells the two apart. The
+    launcher writes it on every pass; if the wrapper overwrote it, the content
+    would come back as cmux state, and if it deleted it at the guard, it would
+    be gone.
+    """
+
+    run = run_reentry(argv=[], break_after=None, occupy_state_path="file", timeout=30.0)
+
+    if run.returncode == -1:
+        failures.append(f"an untagged file at the state path unbounded the launch: {run.stderr!r}")
+        return
+    if run.returncode == 0:
+        failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+    if [name for name, _ in run.state_entries] == []:
+        failures.append("wrapper deleted the untagged file at its state path")
+    for name, contents in run.state_contents:
+        if contents != "not cmux state":
+            failures.append(f"wrapper overwrote the untagged file at its state path: {name} -> {contents!r}")
 
 
 def test_state_directory_sweep_only_removes_its_own_entries(failures: list[str]) -> None:
@@ -699,6 +739,7 @@ def main() -> int:
     test_unbounded_reentry_loop_is_stopped(failures)
     test_env_scrubbed_reentry_loop_is_stopped(failures)
     test_state_path_occupied_by_a_non_regular_file_is_left_alone(failures)
+    test_untagged_file_at_the_state_path_is_left_alone(failures)
     test_state_directory_sweep_only_removes_its_own_entries(failures)
     test_hostile_state_directory_is_not_written_through(failures)
     test_hostile_state_directory_survives_the_guard_trip(failures)

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -23,6 +23,8 @@ from node_runtime import ensure_node_on_path
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
 CMUX_HOOK_FEED_COMMAND = "hooks feed --source claude"
+# cmux pins the hook commands it injects; anything without the pin is the user's.
+CMUX_HOOK_PIN = ": cmux-claude-hook-v1; "
 
 
 def make_executable(path: Path, content: str) -> None:
@@ -254,15 +256,15 @@ def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
 
 
 def test_reentry_preserves_user_settings(failures: list[str]) -> None:
-    # These two run cmux's own hook binary with commands cmux never injects, the
-    # second one right next to an injected command shape. The wrapper must
-    # recognise its own block by the exact commands it is injecting, or it
-    # deletes a user hook on every merge.
+    # Hooks the user authored that resemble cmux's own to increasing degrees:
+    # same binary variable, then the same `hooks claude` shape, then the exact
+    # command cmux injects with a different timeout, then a byte-identical copy
+    # of an injected hook. None of them carries cmux's pin, so all four are the
+    # user's and must survive every pass untouched.
     user_bin_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" notify --title mine'
     user_hooks_claude_hook = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude audit'
-    # Same command cmux injects, but the user's own timeout: their configuration
-    # must survive rather than be replaced by cmux's copy of that command.
     cmux_stop_command = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude stop'
+    cmux_session_start_command = '"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude session-start'
     user_settings = {
         "model": "user-selected-model",
         "hooks": {
@@ -276,7 +278,16 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
                         {"type": "command", "command": cmux_stop_command, "timeout": 90},
                     ],
                 }
-            ]
+            ],
+            # Byte-identical to cmux's own SessionStart hook, pin excluded.
+            "SessionStart": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": cmux_session_start_command, "timeout": 10},
+                    ],
+                }
+            ],
         },
     }
     run = run_reentry(argv=["--settings", json.dumps(user_settings)], break_after=3)
@@ -313,6 +324,23 @@ def test_reentry_preserves_user_settings(failures: list[str]) -> None:
         if len(user_timeouts) != 1:
             failures.append(
                 f"pass {index} kept {len(user_timeouts)} copies of the user's own timeout on cmux's stop command, expected 1"
+            )
+        # The user's unpinned twin of an injected hook survives alongside cmux's
+        # pinned one, exactly as it was written: two hooks run that command, one
+        # pinned by cmux and one the user's, and the user's is byte-identical to
+        # what they passed in.
+        session_start_hooks = [
+            hook for hook in collect_hooks(settings) if hook.get("command", "").endswith("hooks claude session-start")
+        ]
+        pinned = [hook for hook in session_start_hooks if hook.get("command", "").startswith(CMUX_HOOK_PIN)]
+        unpinned = [hook for hook in session_start_hooks if not hook.get("command", "").startswith(CMUX_HOOK_PIN)]
+        if unpinned != [{"type": "command", "command": cmux_session_start_command, "timeout": 10}]:
+            failures.append(
+                f"pass {index} did not keep the user's copy of cmux's session-start hook verbatim: {unpinned!r}"
+            )
+        if len(pinned) != 1:
+            failures.append(
+                f"pass {index} carried {len(pinned)} pinned session-start hooks alongside the user's copy, expected 1"
             )
         cmux_hook_count = count_cmux_hook_commands(settings)
         if cmux_hook_count != 3:

--- a/tests/test_claude_wrapper_settings_reentry.py
+++ b/tests/test_claude_wrapper_settings_reentry.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Regression tests for https://github.com/manaflow-ai/cmux/issues/10230.
+
+A custom `Claude Binary Path` script that resolves `claude` through PATH finds
+cmux's own per-surface shim, so control re-enters `cmux-claude-wrapper` after it
+has already injected its hook `--settings`. The wrapper must treat that re-entry
+as a no-op: the injected settings must converge instead of growing one hook copy
+per pass, and a user's own `--settings` must survive unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+from node_runtime import ensure_node_on_path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+CMUX_HOOK_FEED_COMMAND = "hooks feed --source claude"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def settings_from_argv(argv: list[str]) -> dict | None:
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            return None
+        if arg == "--settings" and index + 1 < len(argv):
+            return json.loads(argv[index + 1])
+        if arg.startswith("--settings="):
+            return json.loads(arg[len("--settings=") :])
+        index += 1
+    return None
+
+
+def count_cmux_hook_commands(settings: dict) -> int:
+    total = 0
+    for entries in (settings.get("hooks") or {}).values():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                if CMUX_HOOK_FEED_COMMAND in hook.get("command", ""):
+                    total += 1
+    return total
+
+
+def collect_hook_commands(settings: dict) -> list[str]:
+    commands: list[str] = []
+    for entries in (settings.get("hooks") or {}).values():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                commands.append(hook.get("command", ""))
+    return commands
+
+
+class ReentryRun:
+    def __init__(self, returncode: int, stderr: str, passes: list[list[str]], real_argv: list[str]) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.passes = passes
+        self.real_argv = real_argv
+
+
+def run_reentry(*, argv: list[str], break_after: int | None, timeout: float = 30.0) -> ReentryRun:
+    """Launch cmux's shim `claude` with a re-entrant custom Claude Binary Path.
+
+    The custom binary path is a script that hands off to a launcher which
+    resolves `claude` through PATH, exactly like the reporter's setup. PATH puts
+    cmux's shim directory first, so every hand-off lands back in the wrapper.
+    `break_after` passes lets the launcher escape the loop and reach the real
+    binary; `None` keeps the loop running so the wrapper's guard has to stop it.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-reentry-") as td:
+        tmp = Path(td)
+        shim_dir = tmp / "tmp" / "cmux-cli-shims" / "surface-reentry"
+        launcher_dir = tmp / "launcher-bin"
+        custom_dir = tmp / "custom-bin"
+        real_dir = tmp / "real-bin"
+        pass_dir = tmp / "passes"
+        for directory in (shim_dir, launcher_dir, custom_dir, real_dir, pass_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        shim_claude = shim_dir / "claude"
+        shutil.copy2(SOURCE_WRAPPER, shim_claude)
+        shim_claude.chmod(0o755)
+
+        fake_cmux = """#!/usr/bin/env bash
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+"""
+        make_executable(shim_dir / "cmux", fake_cmux)
+
+        real_argv_log = tmp / "real-argv.json"
+        make_executable(
+            real_dir / "claude",
+            f"""#!/usr/bin/env python3
+import json, sys
+open({str(real_argv_log)!r}, "w").write(json.dumps(sys.argv[1:]))
+""",
+        )
+
+        # Resolves `claude` through PATH the way `shutil.which` / `command -v` /
+        # `execvp` do in a user launcher, which is what finds cmux's shim.
+        break_after_literal = "None" if break_after is None else str(break_after)
+        make_executable(
+            launcher_dir / "claude-launcher",
+            f"""#!/usr/bin/env python3
+import json, os, shutil, sys
+
+pass_dir = {str(pass_dir)!r}
+break_after = {break_after_literal}
+argv = sys.argv[2:]
+index = len(os.listdir(pass_dir)) + 1
+with open(os.path.join(pass_dir, "pass-%03d.json" % index), "w") as handle:
+    json.dump(argv, handle)
+if break_after is not None and index >= break_after:
+    entries = [e for e in os.environ["PATH"].split(os.pathsep) if "cmux-cli-shims" not in e]
+    os.environ["PATH"] = os.pathsep.join(entries)
+target = shutil.which("claude")
+if target is None:
+    sys.stderr.write("launcher: claude not found\\n")
+    raise SystemExit(127)
+os.execv(target, ["claude"] + argv)
+""",
+        )
+
+        custom_claude = custom_dir / "claude-custom"
+        make_executable(
+            custom_claude,
+            f"""#!/bin/sh
+exec {launcher_dir / "claude-launcher"} claude "$@"
+""",
+        )
+
+        socket_path = str(tmp / "cmux.sock")
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket.bind(socket_path)
+
+        # The wrapper folds a user's --settings into its own with node; without
+        # node on PATH it falls back to emitting two --settings flags and the
+        # merge under test never runs.
+        node_dir = str(Path(ensure_node_on_path() or "/usr/bin/node").parent)
+        env = {
+            "HOME": str(tmp / "home"),
+            "PATH": f"{shim_dir}:{launcher_dir}:{real_dir}:{node_dir}:/usr/bin:/bin",
+            "TMPDIR": str(tmp / "tmp") + "/",
+            "CMUX_SURFACE_ID": "surface:reentry",
+            "CMUX_SOCKET_PATH": socket_path,
+            "CMUX_CLAUDE_WRAPPER_SHIM": str(shim_claude),
+            "CMUX_CLAUDE_WRAPPER_SHIM_ROOT": str(shim_dir),
+            "CMUX_CUSTOM_CLAUDE_PATH": str(custom_claude),
+        }
+        (tmp / "home").mkdir(parents=True, exist_ok=True)
+
+        try:
+            proc = subprocess.run(
+                [str(shim_claude), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            returncode = proc.returncode
+            stderr = proc.stderr
+        except subprocess.TimeoutExpired as expired:
+            returncode = -1
+            stderr = (expired.stderr or b"").decode("utf-8", "replace") if isinstance(expired.stderr, bytes) else (expired.stderr or "")
+            stderr = f"TIMEOUT after {timeout}s\n{stderr}"
+        finally:
+            test_socket.close()
+
+        passes = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(pass_dir.iterdir())]
+        real_argv = json.loads(real_argv_log.read_text(encoding="utf-8")) if real_argv_log.exists() else []
+        return ReentryRun(returncode, stderr, passes, real_argv)
+
+
+def test_reentry_does_not_duplicate_injected_hooks(failures: list[str]) -> None:
+    run = run_reentry(argv=[], break_after=3)
+
+    if len(run.passes) < 3:
+        failures.append(f"expected at least 3 wrapper passes, got {len(run.passes)}: stderr={run.stderr!r}")
+        return
+    if not run.real_argv:
+        failures.append(f"real claude never started: stderr={run.stderr!r}")
+        return
+
+    baseline = settings_from_argv(run.passes[0])
+    if baseline is None:
+        failures.append(f"first pass carried no --settings: {run.passes[0]!r}")
+        return
+
+    baseline_hook_count = count_cmux_hook_commands(baseline)
+    if baseline_hook_count != 3:
+        failures.append(f"expected 3 cmux hook-feed commands on first pass, got {baseline_hook_count}")
+
+    for index, pass_argv in enumerate(run.passes[1:], start=2):
+        settings = settings_from_argv(pass_argv)
+        if settings is None:
+            failures.append(f"pass {index} carried no --settings: {pass_argv!r}")
+            continue
+        hook_count = count_cmux_hook_commands(settings)
+        if hook_count != baseline_hook_count:
+            failures.append(
+                f"pass {index} duplicated cmux hooks: {hook_count} hook-feed commands, expected {baseline_hook_count}"
+            )
+        if settings != baseline:
+            failures.append(f"pass {index} settings diverged from the first pass")
+        if pass_argv.count("--settings") != 1:
+            failures.append(f"pass {index} carried {pass_argv.count('--settings')} --settings arguments, expected 1")
+        if pass_argv.count("--session-id") > 1:
+            failures.append(f"pass {index} carried {pass_argv.count('--session-id')} --session-id arguments")
+
+    final_settings = settings_from_argv(run.real_argv)
+    if final_settings is None:
+        failures.append(f"real claude received no --settings: {run.real_argv!r}")
+    elif count_cmux_hook_commands(final_settings) != baseline_hook_count:
+        failures.append(
+            "real claude received "
+            f"{count_cmux_hook_commands(final_settings)} cmux hook-feed commands, expected {baseline_hook_count}"
+        )
+
+
+def test_reentry_preserves_user_settings(failures: list[str]) -> None:
+    user_settings = {
+        "model": "user-selected-model",
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "",
+                    "hooks": [{"type": "command", "command": "user-stop-hook", "timeout": 7}],
+                }
+            ]
+        },
+    }
+    run = run_reentry(argv=["--settings", json.dumps(user_settings)], break_after=3)
+
+    if len(run.passes) < 3:
+        failures.append(f"expected at least 3 wrapper passes with user settings, got {len(run.passes)}: stderr={run.stderr!r}")
+        return
+
+    baseline = settings_from_argv(run.passes[0])
+    if baseline is None:
+        failures.append(f"first pass carried no --settings: {run.passes[0]!r}")
+        return
+
+    for index, pass_argv in enumerate(run.passes, start=1):
+        settings = settings_from_argv(pass_argv)
+        if settings is None:
+            failures.append(f"pass {index} carried no --settings")
+            continue
+        if settings.get("model") != "user-selected-model":
+            failures.append(f"pass {index} lost the user's model setting: {settings.get('model')!r}")
+        user_hook_count = collect_hook_commands(settings).count("user-stop-hook")
+        if user_hook_count != 1:
+            failures.append(f"pass {index} carried {user_hook_count} copies of the user's hook, expected 1")
+        cmux_hook_count = count_cmux_hook_commands(settings)
+        if cmux_hook_count != 3:
+            failures.append(f"pass {index} carried {cmux_hook_count} cmux hook-feed commands, expected 3")
+        if settings != baseline:
+            failures.append(f"pass {index} settings diverged from the first pass")
+
+
+def test_unbounded_reentry_loop_is_stopped(failures: list[str]) -> None:
+    run = run_reentry(argv=[], break_after=None, timeout=30.0)
+
+    if run.returncode == -1:
+        failures.append(f"wrapper never stopped the re-entry loop: {run.stderr!r} after {len(run.passes)} passes")
+        return
+    if run.returncode == 0:
+        failures.append(f"expected a non-zero exit from the re-entry guard, got 0: {run.stderr!r}")
+    if "cmux:" not in run.stderr:
+        failures.append(f"expected an actionable cmux error on stderr, got: {run.stderr!r}")
+    if "Claude Binary Path" not in run.stderr:
+        failures.append(f"expected the error to name Claude Binary Path, got: {run.stderr!r}")
+    if len(run.passes) > 32:
+        failures.append(f"re-entry guard allowed {len(run.passes)} passes before stopping")
+
+
+def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; the wrapper's --settings merge needs node")
+        return 0
+    failures: list[str] = []
+    test_reentry_does_not_duplicate_injected_hooks(failures)
+    test_reentry_preserves_user_settings(failures)
+    test_unbounded_reentry_loop_is_stopped(failures)
+    if failures:
+        print("FAIL: claude wrapper --settings re-entry checks failed")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: claude wrapper --settings injection converges across re-entry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #10230.

## Mechanism

`cmux-claude-wrapper` injects its hook block as an inline `--settings <json>` and `exec`s the configured Claude binary. When `Automation > Claude Binary Path` is a script that resolves `claude` through `PATH`, the lookup finds cmux's own per-surface shim (`$TMPDIR/cmux-cli-shims/<uuid>/claude`) and control re-enters the wrapper inside the same pid.

Two things then compound:

- `Resources/bin/cmux-claude-wrapper:1032-1077` (pre-fix line numbers) folds any incoming `--settings` into `HOOKS_JSON` with a deep merge whose array rule is `a.concat(b)`. The wrapper's own output from the previous pass is indistinguishable from a user's settings, so every pass appends another full copy of the hook block.
- `Resources/bin/cmux-claude-wrapper:159-162` clears `cmux_claude_wrapper_reexec_guard` at what it believes is the real-binary boundary. The custom script is not a recognizable shim (`cmux_claude_wrapper_target_looks_like_reexec_shim` does not match `exec some-launcher claude "$@"`), so the hop counter is reset before *every* re-entry and never reaches its limit of 16. That is why the report shows 492 copies rather than at most 16.

Reproduced locally: 3 -> 6 -> 9 `hooks feed --source claude` commands over three passes, and 141 passes in 30s with no termination.

## Fix

**1. cmux marks its own hooks, and the merge replaces them instead of appending.** Every injected command now starts with a pin — a `:` shell no-op carrying a fixed token, the same shape `HermesAgentHookCommandOwnership` uses for cmux-owned Hermes hooks:

```
: cmux-claude-hook-v1; "${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}" hooks claude session-start
```

Before merging an incoming `--settings`, the wrapper strips the hooks carrying that pin and re-adds its current block, so injecting the same block twice converges to one copy for any number of passes. Ownership is the pin cmux writes and nothing else — never what a command looks like — so a user hook survives verbatim even when it runs the very same cmux command with the very same timeout. The pin has a single definition (`cmux_claude_hook_pin`); `HOOKS_JSON` is templated from it, the node helper takes it from the environment, and both test files derive it from the wrapper source.

This half is argv-only, so it holds even when a launcher rebuilds the environment.

**2. Re-entry is a no-op, and bounded.** Yes, the shim-on-PATH re-entry deserves its own guard — without one the wrapper still ping-pongs forever, just at a constant argument size. A pass that finds cmux's pinned block on argv *and* a record of an earlier injection takes the existing "already decided" branch: refresh per-process hook metadata, forward argv unchanged, no second merge and no second `--session-id`. Each such pass counts, and the guard trips at 16 with a message pointing at Claude Binary Path.

The record lives in two places because each covers the other's blind spot: `CMUX_CLAUDE_WRAPPER_HOOKS_INJECTED` in the environment survives a launcher that *spawns* (new pid, inherited env), and `${TMPDIR}/cmux-claude-hook-reentry-<uid>/<pid>` survives a launcher that *rebuilds the environment* in the same pid, which is how this bounce actually happens. Both marks are required together with the pinned argv, so an ordinary `claude` started by Claude Code — env inherited, argv clean — still gets its own fresh injection.

The state file is scoped per user in a `0700` directory, and every path (read, write, delete, sweep) requires a non-symlink regular file owned by this user that carries `cmux-claude-hook-reentry-v1` as its first word. Entries older than five minutes are ignored and dropped, so a recycled pid cannot inherit a count. Cleanup costs a fork-free glob per launch and only sweeps — `find -maxdepth 1`, tagged pid-shaped entries older than a day — once the directory passes 256 entries.

**Deliberately not done here.** Passing the hook block as a temp-file path (issue suggestion 1) is a coordinated wrapper+restore change, not a bugfix: `AgentLaunchSanitizer.claudeHookSettingsReplacement` (`Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift:299-340`) recognises cmux's block by parsing the inline JSON on argv when it rebuilds a resume argv, so a path would slip past it and a stale settings file would ride into every restore. Keeping the shim directory out of `PATH` (suggestion 4) would stop `claude` routing through the wrapper at all, which is the mechanism, not a bug. No hard size cap was added: it would hide the loop rather than close it. Item 5 of the issue (glob matching on unbounded arguments) is left out — with the growth closed, cmux can no longer manufacture the 243 KB argument, and the `*=*` tests in the option loops would need a bounded-prefix heuristic that changes option-parsing semantics; worth its own issue. Incidentally, measuring for this PR showed bash matches a literal pattern linearly here (~22 ms/MB, and `*=*` costs the same as a literal), so that item may be smaller than the report assumed.

## Accepted residual risk: same-UID tampering

The re-entry state is an ordinary file, so a process running as **the same user** can race the wrapper between a check and its use, or write a file carrying the tag. Both are accepted rather than fixed:

- Bash has no `openat`/`O_NOFOLLOW` and no way to validate and use one descriptor, so a check-then-use here is racy by construction.
- The blast radius under a shared UID is empty. Winning the race yields cmux's own counter (an integer 1..16, whose only effect is stopping a launch with an actionable message) or deletes a path that process could already delete. The same process can `rm -rf` the state directory, kill the wrapper, or rewrite `~/.claude/settings.json` directly.
- The tag is a cooperation marker, not authentication; authenticating against the same UID would need a secret that same UID can also read.

The static checks remain, because they defend the case that *is* real: a hostile path planted in a shared `/tmp` — by another user or left behind — before cmux gets there. That case is covered end to end by tests.

## Red/green evidence

`42f04e857` + `b4d585b4c` add `tests/test_claude_wrapper_settings_reentry.py` (wired into the CI wrapper-test block), test-only, CI red. `586660f2e` is the fix, CI green. The fixture is the reporter's setup: a custom Claude Binary Path script that hands off to a launcher resolving `claude` via `shutil.which`, with cmux's shim directory first on `PATH`.

Before `586660f2e`:

```
FAIL: claude wrapper --settings re-entry checks failed
- pass 2 duplicated cmux hooks: 6 hook-feed commands, expected 3
- pass 3 duplicated cmux hooks: 9 hook-feed commands, expected 3
- real claude received 9 cmux hook-feed commands, expected 3
- pass 2 carried 6 cmux hook-feed commands without the env marker, expected 3
- wrapper never stopped the re-entry loop: 'TIMEOUT after 30.0s\n' after 141 passes
```

After: `PASS: claude wrapper --settings injection converges across re-entry`.

The suite is now 11 cases, and every later commit ships the case that fails without it:

| Commit | Case that is red without it |
|---|---|
| `fbe74cb35` pin-based ownership | `pass 1/2/3 carried 0 pinned session-start hooks alongside the user's copy, expected 1` |
| `5922cf071` scan the whole settings value | `re-serialized settings defeated the loop guard: TIMEOUT after 30.0s after 313 passes` |
| `947ebcbb5` bound without the env marker | `a scrubbed environment defeated the loop guard: TIMEOUT after 30.0s after 358 passes` |
| `ba9bfa0f3` per-user state path | `wrapper wrote through the planted symlink: ['62693']` |
| `369dac62d` gate the cleanup path | `victim directory changed through the planted symlink: []` |
| `8684d4b36` regular-file gate | `a fifo at the state path stalled or unbounded the launch: TIMEOUT after 30.0s` |
| `63bd893eb` sweep only pid-shaped names | `sweep removed a file cmux did not write: ['23905']` |
| `625cc0271` tag the state files | `sweep removed 800001, which cmux did not write` |
| `51eaca7c5` never touch an untagged file | `wrapper deleted the untagged file at its state path` |

## Validation

Each suite run with a scrubbed environment (`env -i PATH=… HOME=… python3 tests/<suite>.py`), on `51eaca7c51`:

```
tests/test_claude_wrapper_settings_reentry.py                 PASS (11 cases)
tests/test_claude_wrapper_hooks.py                            PASS
tests/test_claude_wrapper_mutual_shim_loop.py                 PASS
tests/test_claude_wrapper_shim_root_survives_tmpdir_change.py PASS
tests/test_claude_wrapper_user_binary_resolution.py           PASS
tests/test_codex_wrapper_resume_hooks.py                      PASS
tests/test_hermes_wrapper_hooks.py                            PASS
tests/test_claude_hook_push_notification.py                   PASS
tests/test_issue_2448_shell_claude_wrapper_dispatch.py        PASS (fish leg skipped, fish not installed)
tests/test_issue_8743_path_directory_shadowing.py             PASS
bash -n Resources/bin/cmux-claude-wrapper                     OK
```

`env -i` matters: `test_claude_wrapper_hooks.py` copies the ambient environment, so on any machine with cmux installed it picks up the real `/Applications/cmux.app/.../bin/cmux` and fails — on `main` too, unrelated to this PR.

No app build was needed: the change is confined to the shipped wrapper script and its Python tests.

Workflows sit in `action_required` on this fork PR, so GitHub CI has not run.
