### PR TITLE
fix: record why a launch capture was rejected, not just that it was

### DIFF
--- a/CLI/CMUXCLI+SessionsList.swift
+++ b/CLI/CMUXCLI+SessionsList.swift
@@ -181,6 +181,9 @@ extension CMUXCLI {
                 payload["active_prompt_turn_id"] = record.activePromptTurnId ?? NSNull()
                 payload["launch_working_directory"] = record.launchCommand?.workingDirectory ?? NSNull()
                 payload["launch_arguments"] = record.launchCommand?.arguments ?? []
+                // Why `launch_arguments` is empty, when the capture recorded a
+                // ground for it. Null on a capture that produced a usable argv.
+                payload["launch_rejection_reason"] = record.launchCommand?.rejectionReason?.rawValue ?? NSNull()
                 payload.merge(
                     sessionsListForkDiagnostics(
                         agent: spec.name,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28734,24 +28734,31 @@ struct CMUXCLI {
             envLauncher,
             kind: fallbackKind
         )
+        // The first ground on which an argv was discarded, kept so a record that
+        // ends up storing no argv says why instead of only that it has none.
+        var argvRejectionReason: AgentLaunchCaptureRejectionReason?
         let envArguments = envCaptureIsTrusted
             ? decodeNULSeparatedBase64(env["CMUX_AGENT_LAUNCH_ARGV_B64"])
             : nil
-        var processArguments = fallbackPID.flatMap { fallbackPID -> [String]? in
-            let pid = pid_t(fallbackPID)
-            let candidate = self.processArguments(for: pid)
-            guard AgentLaunchCaptureTrust.nativeProcessDescribesKind(
-                processName: processName(for: pid),
-                arguments: candidate,
-                kind: fallbackKind
-            ) else { return nil }
-            return candidate
+        if !envCaptureIsTrusted, normalizedHookValue(env["CMUX_AGENT_LAUNCH_ARGV_B64"]) != nil {
+            argvRejectionReason = .launcherDoesNotDescribeKind
         }
-        if let candidate = processArguments,
-           AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(candidate) {
-            // The PID fallback resolved to a shell dispatcher (e.g. the hook's own
-            // `sh -c …` wrapper), not the agent. That argv is not a launch.
-            processArguments = nil
+        var processArguments: [String]?
+        if let fallbackPID {
+            let pid = pid_t(fallbackPID)
+            switch AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+                processName: processName(for: pid),
+                arguments: self.processArguments(for: pid),
+                kind: fallbackKind
+            ) {
+            case .trusted(let candidate):
+                processArguments = candidate
+            case .rejected(let reason):
+                // The PID fallback resolved to something that is not this
+                // agent's launch: an unrelated process, or a shell dispatcher
+                // (e.g. the hook's own `sh -c …` wrapper).
+                argvRejectionReason = argvRejectionReason ?? reason
+            }
         }
         let arguments = envArguments ?? processArguments
         let launcher = envCaptureIsTrusted ? (envLauncher ?? fallbackKind) : fallbackKind
@@ -28777,9 +28784,11 @@ struct CMUXCLI {
         // resume command is produced (omx/omc and unknown kinds stay non-resumable). Empty selected env
         // keeps the historical nil. This deliberately does NOT cover a captured-but-rejected argv (see
         // the sanitizer guard below), so non-restorable invocations stay non-resumable.
-        func environmentOnlyRecord() -> AgentHookLaunchCommandRecord? {
+        func environmentOnlyRecord(
+            rejectionReason: AgentLaunchCaptureRejectionReason
+        ) -> AgentHookLaunchCommandRecord? {
             guard !environment.isEmpty else {
-                return fallbackKind == "codex" ? AgentHookLaunchCommandRecord(launcher: launcher, executablePath: nil, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "default") : nil
+                return fallbackKind == "codex" ? AgentHookLaunchCommandRecord(launcher: launcher, executablePath: nil, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "default", rejectionReason: rejectionReason) : nil
             }
             return AgentHookLaunchCommandRecord(
                 launcher: launcher,
@@ -28789,12 +28798,13 @@ struct CMUXCLI {
                 environment: environment,
                 verificationHome: verificationHome,
                 capturedAt: Date().timeIntervalSince1970,
-                source: "environment"
+                source: "environment",
+                rejectionReason: rejectionReason
             )
         }
 
         guard let arguments, !arguments.isEmpty else {
-            return environmentOnlyRecord()
+            return environmentOnlyRecord(rejectionReason: argvRejectionReason ?? .argvUnavailable)
         }
 
         let executablePath = (envCaptureIsTrusted ? normalizedHookValue(env["CMUX_AGENT_LAUNCH_EXECUTABLE"]) : nil)
@@ -28806,7 +28816,7 @@ struct CMUXCLI {
         ) else {
             // Sanitized-away argv means a non-restorable invocation. Do not
             // replace it with an env-only fallback.
-            return AgentHookLaunchCommandRecord(launcher: launcher, executablePath: executablePath, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "rejected")
+            return AgentHookLaunchCommandRecord(launcher: launcher, executablePath: executablePath, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "rejected", rejectionReason: .sanitizerRejectedArgv)
         }
         let source = envArguments == nil ? "process" : "environment"
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28734,18 +28734,18 @@ struct CMUXCLI {
             envLauncher,
             kind: fallbackKind
         )
-        // The ground an argv was discarded on, kept so a record that ends up storing no argv says
-        // why instead of only that it has none. The env capture and the PID fallback are two
-        // different candidates rather than two grounds for one, so the env capture — the one cmux
-        // itself recorded at launch — names the record when both were discarded; the fallback only
-        // speaks when there was no cmux capture to reject. Grounds competing over the SAME argv are
-        // ordered inside AgentLaunchCaptureArgvVerdict.
-        var argvRejectionReason: AgentLaunchCaptureRejectionReason?
+        // The ground each argv candidate was discarded on, kept so a record that ends up storing no
+        // argv says why instead of only that it has none. The two are tracked apart because they
+        // are different candidates rather than two grounds for one argv; which of them names the
+        // record is AgentLaunchCaptureRejectionReason.recorded's rule, and grounds competing over
+        // the SAME argv are ordered inside AgentLaunchCaptureArgvVerdict.
+        var cmuxCaptureRejectionReason: AgentLaunchCaptureRejectionReason?
+        var processFallbackRejectionReason: AgentLaunchCaptureRejectionReason?
         let envArguments = envCaptureIsTrusted
             ? decodeNULSeparatedBase64(env["CMUX_AGENT_LAUNCH_ARGV_B64"])
             : nil
         if !envCaptureIsTrusted, normalizedHookValue(env["CMUX_AGENT_LAUNCH_ARGV_B64"]) != nil {
-            argvRejectionReason = .launcherDoesNotDescribeKind
+            cmuxCaptureRejectionReason = .launcherDoesNotDescribeKind
         }
         var processArguments: [String]?
         if let fallbackPID {
@@ -28761,7 +28761,7 @@ struct CMUXCLI {
                 // The PID fallback resolved to something that is not this
                 // agent's launch: an unrelated process, or a shell dispatcher
                 // (e.g. the hook's own `sh -c …` wrapper).
-                argvRejectionReason = argvRejectionReason ?? reason
+                processFallbackRejectionReason = reason
             }
         }
         let arguments = envArguments ?? processArguments
@@ -28829,7 +28829,12 @@ struct CMUXCLI {
         }
 
         guard let arguments, !arguments.isEmpty else {
-            return environmentOnlyRecord(rejectionReason: argvRejectionReason ?? .argvUnavailable)
+            return environmentOnlyRecord(
+                rejectionReason: AgentLaunchCaptureRejectionReason.recorded(
+                    cmuxCapture: cmuxCaptureRejectionReason,
+                    processFallback: processFallbackRejectionReason
+                )
+            )
         }
 
         let executablePath = (envCaptureIsTrusted ? normalizedHookValue(env["CMUX_AGENT_LAUNCH_EXECUTABLE"]) : nil)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28734,8 +28734,12 @@ struct CMUXCLI {
             envLauncher,
             kind: fallbackKind
         )
-        // The first ground on which an argv was discarded, kept so a record that
-        // ends up storing no argv says why instead of only that it has none.
+        // The ground an argv was discarded on, kept so a record that ends up storing no argv says
+        // why instead of only that it has none. The env capture and the PID fallback are two
+        // different candidates rather than two grounds for one, so the env capture — the one cmux
+        // itself recorded at launch — names the record when both were discarded; the fallback only
+        // speaks when there was no cmux capture to reject. Grounds competing over the SAME argv are
+        // ordered inside AgentLaunchCaptureArgvVerdict.
         var argvRejectionReason: AgentLaunchCaptureRejectionReason?
         let envArguments = envCaptureIsTrusted
             ? decodeNULSeparatedBase64(env["CMUX_AGENT_LAUNCH_ARGV_B64"])
@@ -28783,15 +28787,14 @@ struct CMUXCLI {
             rejectionReason: AgentLaunchCaptureRejectionReason
         ) -> AgentHookLaunchCommandRecord {
             AgentHookLaunchCommandRecord(
+                rejectedOn: rejectionReason,
                 launcher: launcher,
                 executablePath: executablePath,
-                arguments: [],
                 workingDirectory: workingDirectory,
                 environment: environment,
                 verificationHome: verificationHome,
                 capturedAt: Date().timeIntervalSince1970,
-                source: source,
-                rejectionReason: rejectionReason
+                source: source
             )
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28746,7 +28746,7 @@ struct CMUXCLI {
         var processArguments: [String]?
         if let fallbackPID {
             let pid = pid_t(fallbackPID)
-            switch AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+            switch AgentLaunchCaptureArgvVerdict(
                 processName: processName(for: pid),
                 arguments: self.processArguments(for: pid),
                 kind: fallbackKind
@@ -28774,6 +28774,27 @@ struct CMUXCLI {
             ? normalizedHookValue(env["HOME"])
             : nil
 
+        // A record that carries no argv. The three branches that build one differ only in what they
+        // can still salvage (an executable path, a replay environment) and in the ground they name.
+        func argvLessRecord(
+            executablePath: String?,
+            environment: [String: String]?,
+            source: String,
+            rejectionReason: AgentLaunchCaptureRejectionReason
+        ) -> AgentHookLaunchCommandRecord {
+            AgentHookLaunchCommandRecord(
+                launcher: launcher,
+                executablePath: executablePath,
+                arguments: [],
+                workingDirectory: workingDirectory,
+                environment: environment,
+                verificationHome: verificationHome,
+                capturedAt: Date().timeIntervalSince1970,
+                source: source,
+                rejectionReason: rejectionReason
+            )
+        }
+
         // Fallback when the launch argv is genuinely UNAVAILABLE: plain `codex` with no cmux launcher
         // (no CMUX_AGENT_LAUNCH_ARGV_B64) and an unresolved/exited PID, so processArguments returns nil.
         // The argv is gone, but the agent's launch env may still carry a non-default home that
@@ -28788,16 +28809,17 @@ struct CMUXCLI {
             rejectionReason: AgentLaunchCaptureRejectionReason
         ) -> AgentHookLaunchCommandRecord? {
             guard !environment.isEmpty else {
-                return fallbackKind == "codex" ? AgentHookLaunchCommandRecord(launcher: launcher, executablePath: nil, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "default", rejectionReason: rejectionReason) : nil
+                guard fallbackKind == "codex" else { return nil }
+                return argvLessRecord(
+                    executablePath: nil,
+                    environment: nil,
+                    source: "default",
+                    rejectionReason: rejectionReason
+                )
             }
-            return AgentHookLaunchCommandRecord(
-                launcher: launcher,
+            return argvLessRecord(
                 executablePath: nil,
-                arguments: [],
-                workingDirectory: workingDirectory,
                 environment: environment,
-                verificationHome: verificationHome,
-                capturedAt: Date().timeIntervalSince1970,
                 source: "environment",
                 rejectionReason: rejectionReason
             )
@@ -28816,7 +28838,12 @@ struct CMUXCLI {
         ) else {
             // Sanitized-away argv means a non-restorable invocation. Do not
             // replace it with an env-only fallback.
-            return AgentHookLaunchCommandRecord(launcher: launcher, executablePath: executablePath, arguments: [], workingDirectory: workingDirectory, environment: nil, verificationHome: verificationHome, capturedAt: Date().timeIntervalSince1970, source: "rejected", rejectionReason: .sanitizerRejectedArgv)
+            return argvLessRecord(
+                executablePath: executablePath,
+                environment: nil,
+                source: "rejected",
+                rejectionReason: .sanitizerRejectedArgv
+            )
         }
         let source = envArguments == nil ? "process" : "environment"
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureArgvVerdict.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureArgvVerdict.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The outcome of judging one captured argv for an agent kind.
+public enum AgentLaunchCaptureArgvVerdict: Equatable, Sendable {
+    /// The argv describes a launch of the kind it was captured for.
+    case trusted([String])
+    /// The argv is not this agent's launch, on the named ground.
+    case rejected(AgentLaunchCaptureRejectionReason)
+
+    /// Judges a PID-derived argv candidate for `kind`, naming the ground when it
+    /// cannot be trusted so a capture that stores no argv can record why.
+    ///
+    /// The grounds are checked most specific first, not in the order the hook
+    /// happened to run them: a shell dispatcher (`sh -c …`) is not an agent
+    /// launch whatever its process name resolves to, so it names itself instead
+    /// of coming back as a kind mismatch. Trust is unaffected either way — an
+    /// argv is `.trusted` only when both checks pass.
+    public init(processName: String?, arguments: [String]?, kind: String) {
+        guard let arguments, !arguments.isEmpty else {
+            self = .rejected(.argvUnavailable)
+            return
+        }
+        guard !AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(arguments) else {
+            self = .rejected(.argvLooksLikeShellWrapper)
+            return
+        }
+        guard AgentLaunchCaptureTrust.nativeProcessDescribesKind(
+            processName: processName,
+            arguments: arguments,
+            kind: kind
+        ) else {
+            self = .rejected(.nativeProcessDoesNotDescribeKind)
+            return
+        }
+        self = .trusted(arguments)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureArgvVerdict.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureArgvVerdict.swift
@@ -10,11 +10,17 @@ public enum AgentLaunchCaptureArgvVerdict: Equatable, Sendable {
     /// Judges a PID-derived argv candidate for `kind`, naming the ground when it
     /// cannot be trusted so a capture that stores no argv can record why.
     ///
-    /// The grounds are checked most specific first, not in the order the hook
-    /// happened to run them: a shell dispatcher (`sh -c …`) is not an agent
-    /// launch whatever its process name resolves to, so it names itself instead
-    /// of coming back as a kind mismatch. Trust is unaffected either way — an
-    /// argv is `.trusted` only when both checks pass.
+    /// More than one ground can hold for the same argv — `zsh -lc "claude …"`
+    /// read by the codex hook is both a shell dispatcher and another agent — so
+    /// the order is a rule, not an accident of how the checks were written:
+    /// **the record names the ground that stands on its own.** A `-c`
+    /// invocation is not an agent launch for any kind, and would still be
+    /// rejected if the descriptors matched; a kind mismatch is only a statement
+    /// about this hook, and would disappear under another one. The unconditional
+    /// ground is the one worth storing, so it is checked first.
+    ///
+    /// Trust does not depend on the order — an argv is `.trusted` only when
+    /// every check passes, which `trustDecisionMatchesTheChecksItWraps` pins.
     public init(processName: String?, arguments: [String]?, kind: String) {
         guard let arguments, !arguments.isEmpty else {
             self = .rejected(.argvUnavailable)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Why a captured agent launch carries no trustworthy argv.
+///
+/// Stored next to the capture verdict on `AgentLaunchCommand`, so a record that
+/// says "rejected" also says what it was rejected on. The values are stable
+/// tokens meant to be grepped, diffed and compared across records, never a
+/// human sentence that changes shape per call site.
+///
+/// This is a `RawRepresentable` string rather than an `enum` because hook
+/// stores are read and rewritten by whichever cmux build runs next. A token
+/// written by a newer build has to decode in an older one and survive being
+/// written back: an `enum` would either throw on the unknown token, taking the
+/// whole session record down with it, or coerce it to a fallback case the way
+/// `AgentHibernationLifecycleState` does and silently rewrite the store with
+/// the wrong reason.
+public struct AgentLaunchCaptureRejectionReason: RawRepresentable, Codable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    /// The `CMUX_AGENT_LAUNCH_*` capture describes a different agent than the
+    /// hook it reached. That environment leaks into every descendant process,
+    /// so an agent started inside another agent's session inherits the
+    /// ancestor's launch capture; replaying it would run the wrong binary.
+    public static let launcherDoesNotDescribeKind = Self(rawValue: "launcherDoesNotDescribeKind")
+
+    /// The PID fallback resolved to a process that does not describe this agent
+    /// kind (an unrelated parent, a test host, the cmux app executable).
+    public static let nativeProcessDoesNotDescribeKind = Self(rawValue: "nativeProcessDoesNotDescribeKind")
+
+    /// The PID fallback resolved to a shell dispatcher (`sh -c …`, `zsh -lc …`),
+    /// typically the hook's own dispatch shell rather than the agent.
+    public static let argvLooksLikeShellWrapper = Self(rawValue: "argvLooksLikeShellWrapper")
+
+    /// No argv was available to judge: no cmux launch capture in the
+    /// environment, and no readable argv for the hook's PID (unresolved, or
+    /// already exited).
+    public static let argvUnavailable = Self(rawValue: "argvUnavailable")
+
+    /// An argv was captured and trusted, but `AgentLaunchSanitizer` judged the
+    /// invocation non-restorable (a one-shot subcommand such as `codex exec`, a
+    /// rejected option, a wrapper launcher that cannot be replayed). This is
+    /// the ground behind a stored `source: "rejected"`.
+    public static let sanitizerRejectedArgv = Self(rawValue: "sanitizerRejectedArgv")
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
@@ -46,4 +46,28 @@ public struct AgentLaunchCaptureRejectionReason: RawRepresentable, Codable, Hash
     /// rejected option, a wrapper launcher that cannot be replayed). This is
     /// the ground behind a stored `source: "rejected"`.
     public static let sanitizerRejectedArgv = Self(rawValue: "sanitizerRejectedArgv")
+
+    /// The ground a record names when a hook had two argv candidates and
+    /// discarded both: the `CMUX_AGENT_LAUNCH_*` capture cmux wrote at launch,
+    /// and the argv read back from the hook's PID.
+    ///
+    /// The cmux capture wins. Not because it comes first, but because the
+    /// fallback's ground is frequently an artefact of how the hook itself was
+    /// dispatched — hooks run under `sh -c …`, so its argv reads as a shell
+    /// wrapper for reasons that have nothing to do with the agent. Letting that
+    /// override the capture verdict would systematically hide
+    /// `launcherDoesNotDescribeKind`, the ancestor-leak case this field exists
+    /// to expose, behind a detail of cmux's own plumbing. The fallback speaks
+    /// only when there was no cmux capture to reject.
+    ///
+    /// - Parameters:
+    ///   - cmuxCapture: The ground the `CMUX_AGENT_LAUNCH_*` capture was discarded on, if it was.
+    ///   - processFallback: The ground the PID-derived argv was discarded on, if it was.
+    /// - Returns: The ground to store, defaulting to `argvUnavailable` when neither candidate existed.
+    public static func recorded(
+        cmuxCapture: Self?,
+        processFallback: Self?
+    ) -> Self {
+        cmuxCapture ?? processFallback ?? .argvUnavailable
+    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureRejectionReason.swift
@@ -17,6 +17,7 @@ import Foundation
 public struct AgentLaunchCaptureRejectionReason: RawRepresentable, Codable, Hashable, Sendable {
     public let rawValue: String
 
+    /// Wraps a stored token, including one this build does not know.
     public init(rawValue: String) {
         self.rawValue = rawValue
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// The outcome of judging one captured argv for an agent kind.
+public enum AgentLaunchCaptureArgvVerdict: Equatable, Sendable {
+    /// The argv describes a launch of the kind it was captured for.
+    case trusted([String])
+    /// The argv is not this agent's launch, on the named ground.
+    case rejected(AgentLaunchCaptureRejectionReason)
+}
+
 /// Decides whether a captured agent launch command can be trusted for the agent
 /// kind it is stored under.
 ///
@@ -95,6 +103,35 @@ public enum AgentLaunchCaptureTrust {
                 || nativeProcessAliasesByKind[expectedKind]?.contains(descriptor) == true
                 || descriptor == "\(expectedKind)-cli"
         }
+    }
+
+    /// Judges a PID-derived argv candidate for `kind`, naming the ground when
+    /// it cannot be trusted so a capture that stores no argv can record why.
+    ///
+    /// The order mirrors what the hook applied before this returned a reason:
+    /// process descriptors first, because an argv that does not describe the
+    /// kind is not this agent's at all, then the shell-dispatcher check for an
+    /// argv that does describe it (`codex` resolved by process name, `sh -c …`
+    /// in argv).
+    public static func nativeProcessArgvVerdict(
+        processName: String?,
+        arguments: [String]?,
+        kind: String
+    ) -> AgentLaunchCaptureArgvVerdict {
+        guard let arguments, !arguments.isEmpty else {
+            return .rejected(.argvUnavailable)
+        }
+        guard nativeProcessDescribesKind(
+            processName: processName,
+            arguments: arguments,
+            kind: kind
+        ) else {
+            return .rejected(.nativeProcessDoesNotDescribeKind)
+        }
+        guard !argvLooksLikeShellWrapper(arguments) else {
+            return .rejected(.argvLooksLikeShellWrapper)
+        }
+        return .trusted(arguments)
     }
 
     public static func nativeProcessDescribesKnownAgent(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-/// The outcome of judging one captured argv for an agent kind.
-public enum AgentLaunchCaptureArgvVerdict: Equatable, Sendable {
-    /// The argv describes a launch of the kind it was captured for.
-    case trusted([String])
-    /// The argv is not this agent's launch, on the named ground.
-    case rejected(AgentLaunchCaptureRejectionReason)
-}
-
 /// Decides whether a captured agent launch command can be trusted for the agent
 /// kind it is stored under.
 ///
@@ -103,35 +95,6 @@ public enum AgentLaunchCaptureTrust {
                 || nativeProcessAliasesByKind[expectedKind]?.contains(descriptor) == true
                 || descriptor == "\(expectedKind)-cli"
         }
-    }
-
-    /// Judges a PID-derived argv candidate for `kind`, naming the ground when
-    /// it cannot be trusted so a capture that stores no argv can record why.
-    ///
-    /// The order mirrors what the hook applied before this returned a reason:
-    /// process descriptors first, because an argv that does not describe the
-    /// kind is not this agent's at all, then the shell-dispatcher check for an
-    /// argv that does describe it (`codex` resolved by process name, `sh -c …`
-    /// in argv).
-    public static func nativeProcessArgvVerdict(
-        processName: String?,
-        arguments: [String]?,
-        kind: String
-    ) -> AgentLaunchCaptureArgvVerdict {
-        guard let arguments, !arguments.isEmpty else {
-            return .rejected(.argvUnavailable)
-        }
-        guard nativeProcessDescribesKind(
-            processName: processName,
-            arguments: arguments,
-            kind: kind
-        ) else {
-            return .rejected(.nativeProcessDoesNotDescribeKind)
-        }
-        guard !argvLooksLikeShellWrapper(arguments) else {
-            return .rejected(.argvLooksLikeShellWrapper)
-        }
-        return .trusted(arguments)
     }
 
     public static func nativeProcessDescribesKnownAgent(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCommand.swift
@@ -19,6 +19,10 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
     public var capturedAt: TimeInterval?
     /// The capture source.
     public var source: String?
+    /// Why this capture carries no trustworthy argv, for a capture that carries
+    /// none. Optional so records written before the field existed keep
+    /// decoding, and omitted entirely when `arguments` is a usable launch.
+    public var rejectionReason: AgentLaunchCaptureRejectionReason?
 
     /// Creates a structured captured launch.
     ///
@@ -31,6 +35,7 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
     ///   - verificationHome: The launch home used only for provider-state verification.
     ///   - capturedAt: The capture timestamp.
     ///   - source: The capture source.
+    ///   - rejectionReason: Why the capture carries no trustworthy argv.
     public init(
         launcher: String? = nil,
         executablePath: String? = nil,
@@ -39,7 +44,8 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
         environment: [String: String]? = nil,
         verificationHome: String? = nil,
         capturedAt: TimeInterval? = nil,
-        source: String? = nil
+        source: String? = nil,
+        rejectionReason: AgentLaunchCaptureRejectionReason? = nil
     ) {
         self.launcher = launcher
         self.executablePath = executablePath
@@ -49,5 +55,6 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
         self.verificationHome = verificationHome
         self.capturedAt = capturedAt
         self.source = source
+        self.rejectionReason = rejectionReason
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCommand.swift
@@ -1,13 +1,34 @@
 import Foundation
 
 /// A captured agent launch kept as structured values for later resume planning.
+///
+/// A capture either produced a trustworthy argv or it did not, and the record
+/// says which: `arguments` carries the launch, or it is empty and
+/// `rejectionReason` names the ground it was rejected on. The two never appear
+/// together, on any path — `rejectionReason` is only reachable through
+/// `init(rejectedOn:…)`, which fixes `arguments` to empty; decoding resolves the
+/// one contradictory record cmux never writes in favour of the argv; and a later
+/// mutation that gives a record a usable argv drops the ground with it.
 public struct AgentLaunchCommand: Codable, Equatable, Sendable {
     /// The cmux launcher classification, when one was captured.
     public var launcher: String?
     /// The captured executable path.
     public var executablePath: String?
-    /// The captured process arguments, including `argv[0]`.
-    public var arguments: [String]
+    /// The captured process arguments, including `argv[0]`. Empty on a capture
+    /// that produced no trustworthy argv, where `rejectionReason` says why.
+    ///
+    /// Callers repair a usable launch in place (`replaySafeCodexLaunchCommand`
+    /// rewrites `argv[0]`, `repairedCodexLaunchCommand` appends recovered
+    /// permission flags), so a record can gain an argv after it was built. It
+    /// drops the ground when it does: a launch a reader can replay is not a
+    /// rejected capture, whatever it used to be.
+    public var arguments: [String] {
+        didSet {
+            if !arguments.isEmpty {
+                rejectionReason = nil
+            }
+        }
+    }
     /// The working directory at initial launch.
     public var workingDirectory: String?
     /// Replay-safe environment captured with the launch.
@@ -19,10 +40,10 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
     public var capturedAt: TimeInterval?
     /// The capture source.
     public var source: String?
-    /// Why this capture carries no trustworthy argv, for a capture that carries
-    /// none. Optional so records written before the field existed keep
-    /// decoding, and omitted entirely when `arguments` is a usable launch.
-    public var rejectionReason: AgentLaunchCaptureRejectionReason?
+    /// Why this capture carries no trustworthy argv. Optional so records written
+    /// before the field existed keep decoding, absent on a capture that produced
+    /// a usable argv, and never set alongside one.
+    public private(set) var rejectionReason: AgentLaunchCaptureRejectionReason?
 
     /// Creates a structured captured launch.
     ///
@@ -35,7 +56,6 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
     ///   - verificationHome: The launch home used only for provider-state verification.
     ///   - capturedAt: The capture timestamp.
     ///   - source: The capture source.
-    ///   - rejectionReason: Why the capture carries no trustworthy argv.
     public init(
         launcher: String? = nil,
         executablePath: String? = nil,
@@ -44,8 +64,7 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
         environment: [String: String]? = nil,
         verificationHome: String? = nil,
         capturedAt: TimeInterval? = nil,
-        source: String? = nil,
-        rejectionReason: AgentLaunchCaptureRejectionReason? = nil
+        source: String? = nil
     ) {
         self.launcher = launcher
         self.executablePath = executablePath
@@ -55,6 +74,70 @@ public struct AgentLaunchCommand: Codable, Equatable, Sendable {
         self.verificationHome = verificationHome
         self.capturedAt = capturedAt
         self.source = source
+        self.rejectionReason = nil
+    }
+
+    /// Creates a capture that produced no trustworthy argv, naming the ground it
+    /// was rejected on. `arguments` is empty by construction: this is the only
+    /// way to set a rejection reason, so no producer can pair one with a launch
+    /// that a reader could still replay.
+    ///
+    /// - Parameters:
+    ///   - rejectionReason: The ground the captured argv was rejected on.
+    ///   - launcher: The cmux launcher classification, when one was captured.
+    ///   - executablePath: The captured executable path, when one survived.
+    ///   - workingDirectory: The working directory at initial launch.
+    ///   - environment: Replay-safe environment captured with the launch.
+    ///   - verificationHome: The launch home used only for provider-state verification.
+    ///   - capturedAt: The capture timestamp.
+    ///   - source: The capture source.
+    public init(
+        rejectedOn rejectionReason: AgentLaunchCaptureRejectionReason,
+        launcher: String? = nil,
+        executablePath: String? = nil,
+        workingDirectory: String? = nil,
+        environment: [String: String]? = nil,
+        verificationHome: String? = nil,
+        capturedAt: TimeInterval? = nil,
+        source: String? = nil
+    ) {
+        self.launcher = launcher
+        self.executablePath = executablePath
+        self.arguments = []
+        self.workingDirectory = workingDirectory
+        self.environment = environment
+        self.verificationHome = verificationHome
+        self.capturedAt = capturedAt
+        self.source = source
         self.rejectionReason = rejectionReason
+    }
+
+    /// Decodes a stored record, keeping it as written except for the one
+    /// combination cmux never writes.
+    ///
+    /// A record that carries both a usable argv and a rejection ground is
+    /// self-contradictory: the argv is the actionable half, so the ground is
+    /// dropped rather than surfaced through `sessions --json` next to a launch
+    /// it does not describe. Every other record round-trips byte for byte,
+    /// including a ground this build does not know — the store is rewritten in
+    /// full on each mutation, so a token from a newer build has to survive an
+    /// older one reading and writing it back.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        launcher = try container.decodeIfPresent(String.self, forKey: .launcher)
+        executablePath = try container.decodeIfPresent(String.self, forKey: .executablePath)
+        // Required, as the synthesized decoder had it: a launch command without
+        // an `arguments` key is a malformed record, not an empty capture.
+        arguments = try container.decode([String].self, forKey: .arguments)
+        workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+        environment = try container.decodeIfPresent([String: String].self, forKey: .environment)
+        verificationHome = try container.decodeIfPresent(String.self, forKey: .verificationHome)
+        capturedAt = try container.decodeIfPresent(TimeInterval.self, forKey: .capturedAt)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        let storedRejectionReason = try container.decodeIfPresent(
+            AgentLaunchCaptureRejectionReason.self,
+            forKey: .rejectionReason
+        )
+        rejectionReason = arguments.isEmpty ? storedRejectionReason : nil
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
@@ -4,8 +4,9 @@ import Testing
 
 @Suite("Agent launch capture argv verdict")
 struct AgentLaunchCaptureArgvVerdictTests {
+    /// The ordinary case: the PID resolved to the agent the hook belongs to.
     @Test func trustsAnArgvThatDescribesTheKind() {
-        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+        let verdict = AgentLaunchCaptureArgvVerdict(
             processName: "codex",
             arguments: ["/usr/local/bin/codex", "resume", "abc"],
             kind: "codex"
@@ -17,7 +18,7 @@ struct AgentLaunchCaptureArgvVerdictTests {
     /// test host, the cmux app itself). The record must say so rather than only
     /// that it holds no argv.
     @Test func namesTheGroundWhenTheProcessDescribesAnotherAgent() {
-        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+        let verdict = AgentLaunchCaptureArgvVerdict(
             processName: "claude",
             arguments: ["/usr/local/bin/claude", "--resume", "abc"],
             kind: "codex"
@@ -25,20 +26,23 @@ struct AgentLaunchCaptureArgvVerdictTests {
         #expect(verdict == .rejected(.nativeProcessDoesNotDescribeKind))
     }
 
-    /// The PID resolved to the hook's own dispatch shell. The process name still
-    /// describes the kind, so only the argv gives it away.
-    @Test func namesTheGroundWhenTheArgvIsAShellDispatcher() {
-        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
-            processName: "codex",
+    /// The PID resolved to a shell dispatcher, typically the hook's own. The
+    /// ground holds whether the process name still points at the agent or has
+    /// already become the shell: a `-c` invocation is not a launch either way.
+    @Test(arguments: ["codex", "zsh", nil] as [String?])
+    func namesTheGroundWhenTheArgvIsAShellDispatcher(processName: String?) {
+        let verdict = AgentLaunchCaptureArgvVerdict(
+            processName: processName,
             arguments: ["/bin/zsh", "-lc", "codex resume abc"],
             kind: "codex"
         )
         #expect(verdict == .rejected(.argvLooksLikeShellWrapper))
     }
 
+    /// The PID was unresolved or the process had already exited.
     @Test(arguments: [nil, []] as [[String]?])
     func namesTheGroundWhenThereIsNoArgvToJudge(arguments: [String]?) {
-        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+        let verdict = AgentLaunchCaptureArgvVerdict(
             processName: nil,
             arguments: arguments,
             kind: "codex"
@@ -63,7 +67,7 @@ struct AgentLaunchCaptureArgvVerdictTests {
                     arguments: arguments,
                     kind: kind
                 ) && !AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(arguments)
-                let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+                let verdict = AgentLaunchCaptureArgvVerdict(
                     processName: processName,
                     arguments: arguments,
                     kind: kind

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
@@ -92,6 +92,47 @@ struct AgentLaunchCaptureArgvVerdictTests {
         #expect(verdict == .rejected(.argvUnavailable))
     }
 
+    /// Two candidates, both discarded: the cmux launch capture names the record.
+    /// The fallback's ground is often an artefact of the hook's own dispatch —
+    /// hooks run under `sh -c …`, so a PID fallback reads as a shell wrapper for
+    /// reasons unrelated to the agent — and letting it win would bury the
+    /// ancestor-leak case the field exists to expose.
+    @Test func theCmuxCaptureNamesTheRecordWhenBothCandidatesWereDiscarded() {
+        #expect(
+            AgentLaunchCaptureRejectionReason.recorded(
+                cmuxCapture: .launcherDoesNotDescribeKind,
+                processFallback: .argvLooksLikeShellWrapper
+            ) == .launcherDoesNotDescribeKind
+        )
+    }
+
+    /// With no cmux capture to reject, the fallback is the only candidate there
+    /// was, so its ground is the record's.
+    @Test func theFallbackNamesTheRecordWhenThereWasNoCmuxCapture() {
+        #expect(
+            AgentLaunchCaptureRejectionReason.recorded(
+                cmuxCapture: nil,
+                processFallback: .argvLooksLikeShellWrapper
+            ) == .argvLooksLikeShellWrapper
+        )
+        #expect(
+            AgentLaunchCaptureRejectionReason.recorded(
+                cmuxCapture: nil,
+                processFallback: .nativeProcessDoesNotDescribeKind
+            ) == .nativeProcessDoesNotDescribeKind
+        )
+    }
+
+    /// Neither candidate existed: nothing was rejected, there was nothing to read.
+    @Test func noCandidateAtAllIsItsOwnGround() {
+        #expect(
+            AgentLaunchCaptureRejectionReason.recorded(
+                cmuxCapture: nil,
+                processFallback: nil
+            ) == .argvUnavailable
+        )
+    }
+
     /// The verdict only names grounds; it must not widen or narrow which argv
     /// the hook was already willing to trust.
     @Test func trustDecisionMatchesTheChecksItWraps() {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
@@ -39,6 +39,48 @@ struct AgentLaunchCaptureArgvVerdictTests {
         #expect(verdict == .rejected(.argvLooksLikeShellWrapper))
     }
 
+    /// An argv that trips both grounds at once: `zsh -lc "claude …"` read by the
+    /// codex hook is a shell dispatcher AND another agent. The record must name
+    /// the ground that stands on its own — the `-c` invocation is not a launch
+    /// for any kind, while the kind mismatch is only true of this hook — rather
+    /// than whichever check the implementation happens to run first.
+    @Test func namesTheGroundThatHoldsWhenTwoGroundsApply() {
+        let arguments = ["/bin/zsh", "-lc", "claude --resume abc"]
+        // Both grounds really do hold for this capture, not just the one asserted.
+        #expect(AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(arguments))
+        #expect(!AgentLaunchCaptureTrust.nativeProcessDescribesKind(
+            processName: "claude",
+            arguments: arguments,
+            kind: "codex"
+        ))
+
+        let verdict = AgentLaunchCaptureArgvVerdict(
+            processName: "claude",
+            arguments: arguments,
+            kind: "codex"
+        )
+        #expect(verdict == .rejected(.argvLooksLikeShellWrapper))
+    }
+
+    /// The same argv under the kind it does describe still names the shell
+    /// ground, which is what makes it the unconditional one: removing the
+    /// mismatch does not change the answer.
+    @Test func theShellGroundSurvivesRemovingTheOtherGround() {
+        let arguments = ["/bin/zsh", "-lc", "claude --resume abc"]
+        #expect(AgentLaunchCaptureTrust.nativeProcessDescribesKind(
+            processName: "claude",
+            arguments: arguments,
+            kind: "claude"
+        ))
+
+        let verdict = AgentLaunchCaptureArgvVerdict(
+            processName: "claude",
+            arguments: arguments,
+            kind: "claude"
+        )
+        #expect(verdict == .rejected(.argvLooksLikeShellWrapper))
+    }
+
     /// The PID was unresolved or the process had already exited.
     @Test(arguments: [nil, []] as [[String]?])
     func namesTheGroundWhenThereIsNoArgvToJudge(arguments: [String]?) {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCaptureArgvVerdictTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite("Agent launch capture argv verdict")
+struct AgentLaunchCaptureArgvVerdictTests {
+    @Test func trustsAnArgvThatDescribesTheKind() {
+        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+            processName: "codex",
+            arguments: ["/usr/local/bin/codex", "resume", "abc"],
+            kind: "codex"
+        )
+        #expect(verdict == .trusted(["/usr/local/bin/codex", "resume", "abc"]))
+    }
+
+    /// The hook's PID fallback landed on an unrelated process (another agent, a
+    /// test host, the cmux app itself). The record must say so rather than only
+    /// that it holds no argv.
+    @Test func namesTheGroundWhenTheProcessDescribesAnotherAgent() {
+        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+            processName: "claude",
+            arguments: ["/usr/local/bin/claude", "--resume", "abc"],
+            kind: "codex"
+        )
+        #expect(verdict == .rejected(.nativeProcessDoesNotDescribeKind))
+    }
+
+    /// The PID resolved to the hook's own dispatch shell. The process name still
+    /// describes the kind, so only the argv gives it away.
+    @Test func namesTheGroundWhenTheArgvIsAShellDispatcher() {
+        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+            processName: "codex",
+            arguments: ["/bin/zsh", "-lc", "codex resume abc"],
+            kind: "codex"
+        )
+        #expect(verdict == .rejected(.argvLooksLikeShellWrapper))
+    }
+
+    @Test(arguments: [nil, []] as [[String]?])
+    func namesTheGroundWhenThereIsNoArgvToJudge(arguments: [String]?) {
+        let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+            processName: nil,
+            arguments: arguments,
+            kind: "codex"
+        )
+        #expect(verdict == .rejected(.argvUnavailable))
+    }
+
+    /// The verdict only names grounds; it must not widen or narrow which argv
+    /// the hook was already willing to trust.
+    @Test func trustDecisionMatchesTheChecksItWraps() {
+        let cases: [(String?, [String])] = [
+            ("codex", ["/usr/local/bin/codex"]),
+            ("claude", ["/usr/local/bin/claude", "--resume"]),
+            ("codex", ["/bin/sh", "-c", "codex"]),
+            ("node", ["/usr/bin/node", "/home/u/.claude/versions/1.0/cli.js"]),
+            (nil, ["/opt/homebrew/bin/codex", "exec", "run"]),
+        ]
+        for (processName, arguments) in cases {
+            for kind in ["codex", "claude"] {
+                let trusted = AgentLaunchCaptureTrust.nativeProcessDescribesKind(
+                    processName: processName,
+                    arguments: arguments,
+                    kind: kind
+                ) && !AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(arguments)
+                let verdict = AgentLaunchCaptureTrust.nativeProcessArgvVerdict(
+                    processName: processName,
+                    arguments: arguments,
+                    kind: kind
+                )
+                #expect(
+                    (verdict == .trusted(arguments)) == trusted,
+                    "kind=\(kind) processName=\(processName ?? "nil") argv=\(arguments)"
+                )
+            }
+        }
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
@@ -13,7 +13,7 @@ struct AgentLaunchCommandRejectionReasonTests {
           "arguments": [],
           "launcher": "codex",
           "source": "rejected",
-          "rejectionReason": "sanitizer_rejected_argv",
+          "rejectionReason": "sanitizerRejectedArgv",
           "capturedAt": 1
         }
         """
@@ -23,10 +23,27 @@ struct AgentLaunchCommandRejectionReasonTests {
             try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
         )
         #expect(object["source"] as? String == "rejected")
-        #expect(object["rejectionReason"] as? String == "sanitizer_rejected_argv")
+        #expect(object["rejectionReason"] as? String == "sanitizerRejectedArgv")
     }
 
-    /// Records written before the field existed must still decode.
+    /// A ground written by a newer cmux build has to survive an older build
+    /// reading the store and writing it back: the store is rewritten in full on
+    /// every mutation, so a token that decodes to a fallback is a token this
+    /// build silently replaces with the wrong reason.
+    @Test func groundFromANewerBuildRoundTripsUnchanged() throws {
+        let stored = """
+        {"arguments": [], "source": "rejected", "rejectionReason": "groundThisBuildDoesNotKnow"}
+        """
+        let command = try JSONDecoder().decode(AgentLaunchCommand.self, from: Data(stored.utf8))
+        let rewritten = try JSONEncoder().encode(command)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+        )
+        #expect(object["rejectionReason"] as? String == "groundThisBuildDoesNotKnow")
+    }
+
+    /// Records written before the field existed must still decode, and must not
+    /// grow the key when the capture produced a usable argv.
     @Test func recordWithoutARejectionGroundStillDecodes() throws {
         let stored = """
         {"arguments": ["/usr/local/bin/codex"], "source": "process"}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
@@ -42,6 +42,56 @@ struct AgentLaunchCommandRejectionReasonTests {
         #expect(object["rejectionReason"] as? String == "groundThisBuildDoesNotKnow")
     }
 
+    /// A record cannot say "rejected, here is why" and still hand a reader a
+    /// launch it could replay. The reason is only reachable through the rejected
+    /// initializer, which fixes `arguments` to empty, and neither property can
+    /// be reassigned afterwards.
+    @Test func aRejectionGroundNeverSitsBesideAUsableArgv() {
+        let rejected = AgentLaunchCommand(
+            rejectedOn: .sanitizerRejectedArgv,
+            launcher: "codex",
+            executablePath: "/usr/local/bin/codex",
+            source: "rejected"
+        )
+        #expect(rejected.arguments.isEmpty)
+        #expect(rejected.rejectionReason == .sanitizerRejectedArgv)
+
+        let captured = AgentLaunchCommand(
+            launcher: "codex",
+            arguments: ["/usr/local/bin/codex", "--yolo"],
+            source: "process"
+        )
+        #expect(captured.rejectionReason == nil)
+
+        // Repair paths mutate a record's argv in place, so the invariant has to
+        // hold after construction too.
+        var repaired = rejected
+        repaired.arguments = ["/usr/local/bin/codex", "resume"]
+        #expect(repaired.rejectionReason == nil)
+    }
+
+    /// The one combination cmux never writes, if a hand-edited or foreign record
+    /// carries it: the argv is the actionable half, so it survives and the
+    /// ground that contradicts it does not reach `sessions --json`.
+    @Test func aGroundBesideAUsableArgvDoesNotSurviveDecoding() throws {
+        let stored = """
+        {
+          "arguments": ["/usr/local/bin/codex", "--yolo"],
+          "source": "rejected",
+          "rejectionReason": "sanitizerRejectedArgv"
+        }
+        """
+        let command = try JSONDecoder().decode(AgentLaunchCommand.self, from: Data(stored.utf8))
+        #expect(command.arguments == ["/usr/local/bin/codex", "--yolo"])
+        #expect(command.rejectionReason == nil)
+
+        let rewritten = try JSONEncoder().encode(command)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+        )
+        #expect(object["rejectionReason"] == nil)
+    }
+
     /// Records written before the field existed must still decode, and must not
     /// grow the key when the capture produced a usable argv.
     @Test func recordWithoutARejectionGroundStillDecodes() throws {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
@@ -89,6 +89,9 @@ struct AgentLaunchCommandRejectionReasonTests {
         let object = try #require(
             try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
         )
+        // The argv is what the rewrite must not lose: dropping the contradicting
+        // ground is the point, dropping the launch would be a new defect.
+        #expect(object["arguments"] as? [String] == ["/usr/local/bin/codex", "--yolo"])
         #expect(object["rejectionReason"] == nil)
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchCommandRejectionReasonTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite("Agent launch command rejection reason")
+struct AgentLaunchCommandRejectionReasonTests {
+    /// A rejected capture must keep the ground it was rejected on. Storing only
+    /// `source: "rejected"` records a verdict nobody can act on: the CLI treats
+    /// it as no evidence at all and silently downgrades restore.
+    @Test func rejectionGroundSurvivesAStoreRoundTrip() throws {
+        let stored = """
+        {
+          "arguments": [],
+          "launcher": "codex",
+          "source": "rejected",
+          "rejectionReason": "sanitizer_rejected_argv",
+          "capturedAt": 1
+        }
+        """
+        let command = try JSONDecoder().decode(AgentLaunchCommand.self, from: Data(stored.utf8))
+        let rewritten = try JSONEncoder().encode(command)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+        )
+        #expect(object["source"] as? String == "rejected")
+        #expect(object["rejectionReason"] as? String == "sanitizer_rejected_argv")
+    }
+
+    /// Records written before the field existed must still decode.
+    @Test func recordWithoutARejectionGroundStillDecodes() throws {
+        let stored = """
+        {"arguments": ["/usr/local/bin/codex"], "source": "process"}
+        """
+        let command = try JSONDecoder().decode(AgentLaunchCommand.self, from: Data(stored.utf8))
+        #expect(command.arguments == ["/usr/local/bin/codex"])
+        #expect(command.source == "process")
+
+        let rewritten = try JSONEncoder().encode(command)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+        )
+        #expect(object["rejectionReason"] == nil)
+    }
+}

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3987,6 +3987,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
            let sessions = storeJSON["sessions"] as? [String: Any],
            let persisted = sessions[sessionId] as? [String: Any] {
             let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any]); XCTAssertEqual(launchCommand["source"] as? String, "rejected")
+            XCTAssertEqual(
+                launchCommand["rejectionReason"] as? String,
+                "sanitizer_rejected_argv",
+                "a rejected capture must record the ground it was rejected on; launchCommand=\(launchCommand)"
+            )
             let env = launchCommand["environment"] as? [String: String]
             XCTAssertNil(
                 env?["CODEX_HOME"],

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3989,7 +3989,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any]); XCTAssertEqual(launchCommand["source"] as? String, "rejected")
             XCTAssertEqual(
                 launchCommand["rejectionReason"] as? String,
-                "sanitizer_rejected_argv",
+                "sanitizerRejectedArgv",
                 "a rejected capture must record the ground it was rejected on; launchCommand=\(launchCommand)"
             )
             let env = launchCommand["environment"] as? [String: String]

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3982,22 +3982,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(result.status, 0, result.stderr)
 
         // Persist the rejection marker so reload cannot treat it as a plain default Codex hook.
-        if let data = try? Data(contentsOf: root.appendingPathComponent("codex-hook-sessions.json")),
-           let storeJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let sessions = storeJSON["sessions"] as? [String: Any],
-           let persisted = sessions[sessionId] as? [String: Any] {
-            let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any]); XCTAssertEqual(launchCommand["source"] as? String, "rejected")
-            XCTAssertEqual(
-                launchCommand["rejectionReason"] as? String,
-                "sanitizerRejectedArgv",
-                "a rejected capture must record the ground it was rejected on; launchCommand=\(launchCommand)"
-            )
-            let env = launchCommand["environment"] as? [String: String]
-            XCTAssertNil(
-                env?["CODEX_HOME"],
-                "non-restorable codex exec must not persist an env-only CODEX_HOME record; launchCommand=\(persisted["launchCommand"] ?? "nil")"
-            )
-        }
+        // Unwrapped rather than pattern-matched: a store the hook never wrote is a failure of
+        // this test's subject, not a reason to skip its assertions.
+        let data = try Data(contentsOf: root.appendingPathComponent("codex-hook-sessions.json"))
+        let storeJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let sessions = try XCTUnwrap(storeJSON["sessions"] as? [String: Any])
+        let persisted = try XCTUnwrap(sessions[sessionId] as? [String: Any])
+        let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any])
+        XCTAssertEqual(launchCommand["source"] as? String, "rejected")
+        XCTAssertEqual(
+            launchCommand["rejectionReason"] as? String,
+            "sanitizerRejectedArgv",
+            "a rejected capture must record the ground it was rejected on; launchCommand=\(launchCommand)"
+        )
+        let env = launchCommand["environment"] as? [String: String]
+        XCTAssertNil(
+            env?["CODEX_HOME"],
+            "non-restorable codex exec must not persist an env-only CODEX_HOME record; launchCommand=\(persisted["launchCommand"] ?? "nil")"
+        )
     }
 
     private func writeHermesStateDatabase(

--- a/cmuxTests/CMUXCLISessionsListTests.swift
+++ b/cmuxTests/CMUXCLISessionsListTests.swift
@@ -209,4 +209,88 @@ extension CMUXCLIErrorOutputRegressionTests {
         #expect(session["session_home"] as? String == codexHome.path)
     }
 
+    /// A capture that stored no argv has to say why in `sessions --json`, or the
+    /// only self-service answer for an empty `launch_arguments` is guesswork.
+    @Test func testSessionsListReportsWhyALaunchCaptureWasRejected() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-sessions-list-\(UUID().uuidString)", isDirectory: true)
+        let stateDir = root.appendingPathComponent("state", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let rejectedSessionId = "019efab1-1f2c-7a41-9f3e-6d1c0a2b4e77"
+        let capturedSessionId = "019efab2-24d8-7c05-b1a6-3f9e77c1d208"
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                rejectedSessionId: [
+                    "sessionId": rejectedSessionId,
+                    "workspaceId": "workspace-rejected",
+                    "surfaceId": "surface-rejected",
+                    "cwd": "/tmp/cmux/rejected",
+                    "startedAt": 1_782_254_900.0,
+                    "updatedAt": 1_782_255_000.0,
+                    "launchCommand": [
+                        "launcher": "codex",
+                        "executablePath": "/usr/local/bin/codex",
+                        "arguments": [],
+                        "capturedAt": 1_782_254_900.0,
+                        "source": "rejected",
+                        "rejectionReason": "sanitizerRejectedArgv",
+                    ],
+                ],
+                capturedSessionId: [
+                    "sessionId": capturedSessionId,
+                    "workspaceId": "workspace-captured",
+                    "surfaceId": "surface-captured",
+                    "cwd": "/tmp/cmux/captured",
+                    "startedAt": 1_782_254_910.0,
+                    "updatedAt": 1_782_255_010.0,
+                    "launchCommand": [
+                        "launcher": "codex",
+                        "executablePath": "/usr/local/bin/codex",
+                        "arguments": ["/usr/local/bin/codex", "--yolo"],
+                        "capturedAt": 1_782_254_910.0,
+                        "source": "process",
+                    ],
+                ],
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: stateDir.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = stateDir.path
+        environment["CODEX_HOME"] = codexHome.path
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["sessions", "list", "--agent", "codex", "--all", "--json"],
+            environment: environment,
+            timeout: 5
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.stdout))
+        #expect(result.status == 0, Comment(rawValue: result.stdout))
+        let outputData = try #require(result.stdout.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: outputData) as? [String: Any])
+        let sessions = try #require(object["sessions"] as? [[String: Any]])
+
+        let rejected = try #require(sessions.first { $0["session_id"] as? String == rejectedSessionId })
+        #expect(rejected["launch_arguments"] as? [String] == [])
+        #expect(rejected["launch_rejection_reason"] as? String == "sanitizerRejectedArgv")
+
+        // A capture that produced a usable argv has no ground to report.
+        let captured = try #require(sessions.first { $0["session_id"] as? String == capturedSessionId })
+        #expect(captured["launch_arguments"] as? [String] == ["/usr/local/bin/codex", "--yolo"])
+        #expect(captured["launch_rejection_reason"] is NSNull)
+    }
+
 }


### PR DESCRIPTION
A rejected launch capture stored `launchCommand.source == "rejected"` and nothing else, so the record held a verdict with no ground. On the reporter's machine all 11 Codex captures are rejected and 43/44 Claude captures are not, and neither the user nor a maintainer can tell from the data whether that is correct.

It is not cosmetic. `CLI/CMUXCLI+AgentHookRestoreEvidence.swift` treats `"rejected"` as no evidence and returns early at `:57`, `:84`, `:135` and `:157`, and `Sources/RestorableAgentSession.swift:1678` does the same, so a rejected capture silently downgrades restore for that session with the word "rejected" as its only artifact.

## What the record now carries

`AgentLaunchCommand` gains an optional `rejectionReason`, written whenever the stored record ends up with an empty `arguments`:

```json
"launchCommand": {
  "source": "rejected",
  "rejectionReason": "sanitizerRejectedArgv",
  "launcher": "codex",
  "capturedAt": 1771000000
}
```

Five stable tokens, one per ground the capture path can reach (`AgentLaunchCaptureRejectionReason`):

| token | ground |
|---|---|
| `launcherDoesNotDescribeKind` | `CMUX_AGENT_LAUNCH_*` described another agent — the ancestor-leak case `AgentLaunchCaptureTrust` exists for |
| `nativeProcessDoesNotDescribeKind` | the PID fallback resolved to a process that is not this agent |
| `argvLooksLikeShellWrapper` | the PID fallback resolved to a shell dispatcher (`sh -c …`), typically the hook's own |
| `argvUnavailable` | no launch capture in the environment and no readable argv for the PID |
| `sanitizerRejectedArgv` | argv captured and trusted, then judged non-restorable by `AgentLaunchSanitizer` — this is the ground behind every stored `source: "rejected"` |

Shape notes:

- **camelCase tokens**, not the kebab-case the issue sketched, because the store's other stable tokens are camelCase raw values (`AgentHookRuntimeStatus.needsInput`) and the key sits next to `capturedAt` and `verificationHome`.
- **`RawRepresentable` over `String`, not an `enum`.** Hook stores are rewritten in full by whichever cmux build runs next, so an unknown token must survive an older build reading and writing it back. An `enum` would either throw and take the whole session record down or coerce to a fallback the way `AgentHibernationLifecycleState` does — and then rewrite the store with the wrong reason.
- **Backward compatible both ways.** The property is optional, so records written before the field decode unchanged; it is omitted entirely when the capture produced a usable argv, so a green record does not grow a key.
- **A ground and a usable argv are mutually exclusive, by the type.** `rejectionReason` is `private(set)` and reachable only through `init(rejectedOn:)`, which has no `arguments` parameter; decoding resolves the one contradictory record cmux never writes in favour of the argv, leaving every other record — unknown grounds included — to round-trip as written; and a repair that hands a record an argv drops the ground with it, which is what `replaySafeCodexLaunchCommand` and `repairedCodexLaunchCommand` do.
- **When several grounds hold, the record names the one that stands on its own.** `zsh -lc "claude …"` read by the codex hook is both a shell dispatcher and another agent; the shell ground would reject it under any kind, while the kind mismatch describes only the hook that read it. Pinned by a test that asserts both grounds hold before asserting the verdict, and a second showing the answer does not move when the other ground is removed. The env capture and the PID fallback are two candidates rather than two grounds for one, so their order is a separate rule, written down where it is applied.
- The reason branches moved into `AgentLaunchCaptureArgvVerdict.init(processName:arguments:kind:)`, which wraps the two checks the hook already ran, so the ground is unit-testable without booting a hook. Its rejection grounds are ordered most specific first — a shell dispatcher names itself rather than coming back as a kind mismatch — which changes no trust decision, since an argv is trusted only when both checks pass.
- **When both argv candidates are discarded, the cmux capture names the record** (`AgentLaunchCaptureRejectionReason.recorded`). Hooks are dispatched under `sh -c …`, so a PID fallback reads as a shell wrapper for reasons unrelated to the agent; letting that override the capture verdict would systematically hide `launcherDoesNotDescribeKind` behind cmux's own plumbing. The fallback speaks when there was no cmux capture to reject.
- `cmux sessions --json` gains `launch_rejection_reason`, which is what makes this self-service: empty `launch_arguments` now comes with the reason next to it.

## Behavior is unchanged, deliberately

Nothing reads the new field to decide anything. `"rejected"` still means no restore evidence in all five call sites above, restore still takes the same path, and no capture is trusted that was not trusted before — the verdict returns `.trusted` on exactly the inputs the previous two-step check accepted, pinned by `trustDecisionMatchesTheChecksItWraps`.

That is the right split: the issue asks for observability first, and any change to how a ground is treated (e.g. deciding `argvLooksLikeShellWrapper` is recoverable) is a separate judgement that should be made on the evidence this PR starts collecting, not on the same commit that starts collecting it. The reason is also not added to the control-socket `launch_command` payload (`CLI/CMUXCLI+Restore.swift:13`); that payload is the restore transport, and a rejected record has empty `arguments` and never reaches it.

## Red then green

Commit 1 and 2 add the test, commit 3 the fix. Without the fix (`swift test --package-path Packages/macOS/CMUXAgentLaunch --filter RejectionReason`):

```
✘ Test rejectionGroundSurvivesAStoreRoundTrip() recorded an issue at AgentLaunchCommandRejectionReasonTests.swift:26:9:
  Expectation failed: (object["rejectionReason"] as? String → nil) == "sanitizerRejectedArgv"
✘ Test groundFromANewerBuildRoundTripsUnchanged() recorded an issue at AgentLaunchCommandRejectionReasonTests.swift:42:9:
  Expectation failed: (object["rejectionReason"] as? String → nil) == "groundThisBuildDoesNotKnow"
✘ Test run with 3 tests in 1 suite failed after 0.001 seconds with 2 issues.
```

`cmuxTests/CLIGenericHookPersistenceTests.swift` asserts the same end to end: the `codex exec` hook run that already stored `source: "rejected"` must now also store `rejectionReason: "sanitizerRejectedArgv"`.

## Validation

- `swift test --package-path Packages/macOS/CMUXAgentLaunch` — 345 tests in 47 suites passed (was 2 failures before the fix).
- `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -derivedDataPath /tmp/cmux-capture-reason build` — BUILD SUCCEEDED.
- `xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/CMUXCLIErrorOutputRegressionTests/testSessionsListReportsWhyALaunchCaptureWasRejected -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookDoesNotPersistEnvOnlyRecordForNonRestorableExec` — both passed.

Fork-PR workflows sit in `action_required`, so GitHub CI has not run on this branch.

Fixes #10307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session listings now explain why launch details could not be captured.
  - Launch records preserve rejection reasons for unavailable, mismatched, shell-wrapped, or sanitized arguments.
  - Unknown rejection reasons remain compatible across versions.

- **Bug Fixes**
  - Improved validation prevents untrusted launch arguments from being recorded or persisted.

- **Tests**
  - Added coverage for rejection reporting, validation, persistence, precedence, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
