### PR TITLE
fix(focus-history): resolve each history entry once per menu snapshot

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Navigation/FocusHistoryModel.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Navigation/FocusHistoryModel.swift
@@ -262,20 +262,32 @@ public final class FocusHistoryModel: FocusHistoryNavigating {
         )
     }
 
-    private func focusHistoryEntryResolvesToCurrent(_ entry: FocusHistoryEntry, currentEntry: FocusHistoryEntry?) -> Bool {
-        guard let currentEntry,
-              let resolvedEntry = resolvedFocusHistoryEntry(for: entry) else { return false }
-        return resolvedEntry == currentEntry
-    }
-
-    private func focusHistoryEntryIsNavigable(_ entry: FocusHistoryEntry, currentEntry: FocusHistoryEntry?) -> Bool {
-        guard resolvedFocusHistoryEntry(for: entry) != nil else { return false }
-        if navigationScope() == .workspacesOnly,
+    /// Navigability given an already-resolved entry. Callers that have just
+    /// resolved `entry` pass the result here instead of resolving it again;
+    /// `resolvedFocusHistoryEntry` reaches the host for every panel lookup, and
+    /// the menu path runs this once per history entry per rebuild.
+    private func focusHistoryEntryIsNavigable(
+        _ entry: FocusHistoryEntry,
+        resolvedEntry: FocusHistoryEntry,
+        scope: FocusHistoryNavigationScope,
+        currentEntry: FocusHistoryEntry?
+    ) -> Bool {
+        if scope == .workspacesOnly,
            entry.workspaceId == currentEntry?.workspaceId {
             return false
         }
-        if focusHistoryEntryResolvesToCurrent(entry, currentEntry: currentEntry) { return false }
+        if let currentEntry, resolvedEntry == currentEntry { return false }
         return true
+    }
+
+    private func focusHistoryEntryIsNavigable(_ entry: FocusHistoryEntry, currentEntry: FocusHistoryEntry?) -> Bool {
+        guard let resolvedEntry = resolvedFocusHistoryEntry(for: entry) else { return false }
+        return focusHistoryEntryIsNavigable(
+            entry,
+            resolvedEntry: resolvedEntry,
+            scope: navigationScope(),
+            currentEntry: currentEntry
+        )
     }
 
     private func navigationEntry(for entry: FocusHistoryEntry) -> FocusHistoryEntry {
@@ -311,7 +323,12 @@ public final class FocusHistoryModel: FocusHistoryNavigating {
             let scopedEntry = navigationEntry(for: entry)
             guard let resolvedEntry = resolvedFocusHistoryEntry(for: scopedEntry),
                   let rawWorkspaceTitle = host?.workspaceTitle(resolvedEntry.workspaceId),
-                  focusHistoryEntryIsNavigable(scopedEntry, currentEntry: currentEntry) else {
+                  focusHistoryEntryIsNavigable(
+                      scopedEntry,
+                      resolvedEntry: resolvedEntry,
+                      scope: scope,
+                      currentEntry: currentEntry
+                  ) else {
                 return nil
             }
             if scope == .workspacesOnly, previousWorkspaceId == entry.workspaceId {

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Navigation/FocusHistoryModelTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Navigation/FocusHistoryModelTests.swift
@@ -20,9 +20,11 @@ private final class FakeFocusHistoryHost: FocusHistoryHosting {
     var focusedPanels: [(workspaceId: UUID, panelId: UUID)] = []
     var flashedPanels: [(workspaceId: UUID, panelId: UUID)] = []
     var focusSelectedWorkspacePanelCalls = 0
+    var workspaceExistsCalls = 0
 
     func workspaceExists(_ workspaceId: UUID) -> Bool {
-        workspaces[workspaceId] != nil
+        workspaceExistsCalls += 1
+        return workspaces[workspaceId] != nil
     }
 
     func panelExists(workspaceId: UUID, panelId: UUID) -> Bool {
@@ -367,6 +369,27 @@ struct FocusHistoryModelTests {
         #expect(limited.totalItemCount == 3)
         #expect(limited.isLimited)
         #expect(limited.items.allSatisfy { $0.position == .older })
+    }
+
+    /// The History menu is rebuilt on every App body evaluation, so the cost of
+    /// one snapshot is paid constantly. Each entry must be resolved once, not
+    /// once per navigability check.
+    /// https://github.com/manaflow-ai/cmux/issues/10348
+    @Test func menuSnapshotResolvesEachEntryOnce() {
+        let (model, host) = makeModel()
+        for index in 0..<10 {
+            let panel = UUID()
+            let ws = host.addWorkspace(title: "ws\(index)", panels: [panel: "panel\(index)"])
+            host.selectedWorkspaceId = ws
+            host.workspaces[ws]?.rememberedFocusedPanelId = panel
+            model.recordFocusInHistory(workspaceId: ws, panelId: panel, preservingForwardBranch: false)
+        }
+
+        host.workspaceExistsCalls = 0
+        let snapshot = model.focusHistoryMenuSnapshot(direction: .back)
+
+        #expect(snapshot.items.count == 9)
+        #expect(host.workspaceExistsCalls == 9)
     }
 
     @Test func menuSnapshotResolvesClosedPanelToWorkspaceLevelEntry() {


### PR DESCRIPTION
`focusHistoryMenuSnapshot` resolves every history entry three times. The `compactMap` calls `resolvedFocusHistoryEntry(for:)`, then `focusHistoryEntryIsNavigable` resolves the same entry again, and that calls `focusHistoryEntryResolvesToCurrent`, which resolves it a third time. Each resolution runs a `workspaceExists` check plus `resolvedFocusHistoryPanelId`, which reaches `PaneTreeModel.panelId(forSurfaceId:)` through the host.

Against the 50-entry cap across both directions, one History menu build costs up to 300 host resolutions to render 10 rows. The History `CommandMenu` rebuilds on every App body evaluation rather than on open (`Sources/cmuxApp+HistoryMenu.swift:9-11`), so this is paid continuously, not per-open.

Found while profiling an idle app holding 48-56% of one core: #10348.

## Change

Add an overload of `focusHistoryEntryIsNavigable` that takes the already-resolved entry plus the hoisted `scope`, and call it from the menu `compactMap`. The existing single-argument version delegates to it, which also drops one redundant resolution for its five other callers.

`focusHistoryEntryResolvesToCurrent` had no other caller, so its two lines are folded into the overload.

The snapshot output is unchanged. Only the number of host lookups moves.

Equivalence, since the overload skips two guards the old path ran:

- The `resolvedFocusHistoryEntry(for:) != nil` guard is subsumed by the caller already holding a non-nil `resolvedEntry`.
- `focusHistoryEntryResolvesToCurrent` reduced to `resolvedEntry == currentEntry` when `currentEntry` is non-nil, which is what the overload does inline.
- `navigationScope()` is a closure property read once per snapshot; it cannot change mid-`compactMap`, so hoisting it is safe.

## Verification

Two commits, red then green, per the regression policy in CLAUDE.md.

The test counts `workspaceExists` calls on the fake host across one snapshot of 9 navigable entries:

```
before:  Expectation failed: (host.workspaceExistsCalls → 27) == 9
after:   ✔ Test menuSnapshotResolvesEachEntryOnce() passed
```

`swift test` in `Packages/macOS/CmuxWorkspaces`: 209 tests in 30 suites pass.

I verified at package level only. I did not run a tagged Xcode app build; the change is confined to two private methods inside `CmuxWorkspaces` and adds no new user-facing strings, so there is no localization surface.

## What this does not fix

This trims one hot path, not the loop in #10348. The App body still re-evaluates continuously and still rebuilds the whole History menu each time, and `AppDelegate.makeMainMenu` still calls `ViewGraphRootValueUpdater.invalidateProperties` inside the same update. Those need someone who knows which publisher is driving the App body; I could not name it from a stripped release build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657090&installation_model_id=21920&pr_number=10349&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10349&signature=aaa9c3a521799dde03ebab4e52b2439ff12a12d24691199ebe172373c8dd79d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve each focus history entry once per History menu snapshot to remove redundant host lookups while keeping the snapshot identical. Previously the menu resolved each entry up to three times; now it resolves once, reducing continuous CPU cost because the History `CommandMenu` rebuilds on every App body evaluation.

- Add an overload of `focusHistoryEntryIsNavigable` that takes `resolvedEntry` and hoisted `scope`, and call it from the menu `compactMap`; the existing method delegates to it.
- Inline and remove the unused `focusHistoryEntryResolvesToCurrent`; compare against `currentEntry` directly.
- Hoist `navigationScope()` to one read per snapshot.
- Add a regression test that counts host `workspaceExists` calls: for 9 navigable entries, 27 → 9.
- No public API or menu output changes; changes are confined to private code in `CmuxWorkspaces`.

<sup>Written for commit 52617ff4317becf573e853791ff4d865a822b221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back-navigation menu generation to reduce redundant workspace lookups and keep entries consistent.
  * Ensured history menu building uses pre-resolved context to prevent repeated resolution during snapshot creation.

* **Tests**
  * Added a regression test verifying that a back-navigation menu with ten history entries displays nine entries.
  * Confirmed each workspace is checked exactly once during menu snapshot generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->