### PR TITLE
fix: keep spinner titles animating without waking the app on every frame

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
@@ -1,8 +1,15 @@
 /// Normalizes animated terminal titles before title-update deduplication.
 ///
-/// Command-line spinners commonly prefix a stable label with one of ten
-/// Braille Pattern frames. Collapsing that standalone animation token makes
-/// successive frames equal while preserving ordinary titles byte-for-byte.
+/// Command-line spinners animate one glyph next to a stable label. Removing
+/// that standalone animation token makes successive frames equal while
+/// preserving ordinary titles byte-for-byte.
+///
+/// The token is removed wherever it sits, not only in leading position, because
+/// agents brand their titles: OMP writes `π ⠋ label`, so a leading-only rule
+/// leaves its frames churning. A glyph is only removed when whitespace or a
+/// string edge bounds it on both sides, and a title containing a run of two or
+/// more spinner glyphs is treated as text and returned untouched, which is what
+/// keeps Braille words such as `⠋ ⠑⠇⠇⠕` intact.
 public struct TerminalTitleChurnFilter: Sendable {
     /// Creates a stateless terminal-title normalizer.
     public init() {}
@@ -13,27 +20,48 @@ public struct TerminalTitleChurnFilter: Sendable {
     /// - Returns: The unchanged ordinary title, its spinner-free label, or `nil`
     ///   when no label remains after normalization.
     public func stableTitle(for rawTitle: String) -> String? {
-        var remainder = rawTitle[...]
-        while remainder.first?.isWhitespace == true {
-            remainder = remainder.dropFirst()
+        let characters = Array(rawTitle)
+        guard !characters.isEmpty else { return rawTitle }
+        guard !containsGlyphRun(characters) else { return rawTitle }
+
+        var kept: [Character] = []
+        var removedFrame = false
+        for (index, character) in characters.enumerated() {
+            if isKnownSpinnerFrame(character), isStandaloneToken(at: index, in: characters) {
+                removedFrame = true
+                continue
+            }
+            kept.append(character)
         }
-        guard let first = remainder.first, isKnownSpinnerFrame(first) else {
-            return rawTitle
+        guard removedFrame else { return rawTitle }
+
+        let label = String(kept)
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        return label.isEmpty ? nil : label
+    }
+
+    /// True when whitespace or a string edge bounds the glyph on both sides, so
+    /// it stands alone rather than belonging to a surrounding word.
+    private func isStandaloneToken(at index: Int, in characters: [Character]) -> Bool {
+        let precedingIsBoundary = index == 0 || characters[index - 1].isWhitespace
+        let followingIsBoundary = index == characters.count - 1 || characters[index + 1].isWhitespace
+        return precedingIsBoundary && followingIsBoundary
+    }
+
+    /// True when two or more spinner-range glyphs sit next to each other, which
+    /// reads as text or art rather than a single animation frame.
+    private func containsGlyphRun(_ characters: [Character]) -> Bool {
+        var runLength = 0
+        for character in characters {
+            if brailleScalarValue(for: character) != nil || isKnownSpinnerFrame(character) {
+                runLength += 1
+                if runLength >= 2 { return true }
+            } else {
+                runLength = 0
+            }
         }
-        remainder = remainder.dropFirst()
-        guard remainder.isEmpty || remainder.first?.isWhitespace == true else {
-            return rawTitle
-        }
-        while remainder.first?.isWhitespace == true {
-            remainder = remainder.dropFirst()
-        }
-        guard !remainder.isEmpty else { return nil }
-        guard let labelStart = remainder.first,
-              brailleScalarValue(for: labelStart) == nil,
-              !isKnownSpinnerFrame(labelStart) else {
-            return rawTitle
-        }
-        return String(remainder)
+        return false
     }
 
     private func isKnownSpinnerFrame(_ character: Character) -> Bool {
@@ -46,8 +74,7 @@ public struct TerminalTitleChurnFilter: Sendable {
         case 0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
              0x2834, 0x2826, 0x2827, 0x2807, 0x280F:
             return true
-        // Asterisk frames. Claude Code animates these, so on an agent-heavy
-        // window they are the frames that actually churn.
+        // Asterisk frames, which is what Claude Code animates.
         case 0x2731...0x273D:
             return true
         // Half-filled and quadrant circle frames.

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
@@ -29,17 +29,29 @@ public struct TerminalTitleChurnFilter: Sendable {
         }
         guard !remainder.isEmpty else { return nil }
         guard let labelStart = remainder.first,
-              brailleScalarValue(for: labelStart) == nil else {
+              brailleScalarValue(for: labelStart) == nil,
+              !isKnownSpinnerFrame(labelStart) else {
             return rawTitle
         }
         return String(remainder)
     }
 
     private func isKnownSpinnerFrame(_ character: Character) -> Bool {
-        guard let value = brailleScalarValue(for: character) else { return false }
+        guard character.unicodeScalars.count == 1,
+              let value = character.unicodeScalars.first?.value else {
+            return false
+        }
         switch value {
+        // Braille "dots" frames.
         case 0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
              0x2834, 0x2826, 0x2827, 0x2807, 0x280F:
+            return true
+        // Asterisk frames. Claude Code animates these, so on an agent-heavy
+        // window they are the frames that actually churn.
+        case 0x2731...0x273D:
+            return true
+        // Half-filled and quadrant circle frames.
+        case 0x25D0...0x25D3, 0x25F4...0x25F7:
             return true
         default:
             return false

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
@@ -36,4 +36,37 @@ struct TerminalTitleChurnFilterTests {
         #expect(filter.stableTitle(for: "") == "")
         #expect(filter.stableTitle(for: "   ") == "   ")
     }
+
+    /// Claude Code animates an asterisk, not a Braille glyph, so the Braille-only
+    /// frame set never collapsed the titles this filter exists to collapse.
+    /// https://github.com/manaflow-ai/cmux/issues/10348
+    @Test func collapsesAsteriskSpinnerFramesToOneLabel() {
+        let frames = ["✻", "✽", "✳", "✶", "✷", "✵"]
+
+        let stableTitles = Set(frames.compactMap {
+            filter.stableTitle(for: "\($0) Remove third floor back window")
+        })
+
+        #expect(stableTitles == ["Remove third floor back window"])
+    }
+
+    @Test func collapsesCircleSpinnerFramesToOneLabel() {
+        let halves = Set(["◐", "◑", "◒", "◓"].compactMap {
+            filter.stableTitle(for: "\($0) Cmux CPU usage")
+        })
+        #expect(halves == ["Cmux CPU usage"])
+
+        let quadrants = Set(["◴", "◵", "◶", "◷"].compactMap {
+            filter.stableTitle(for: "\($0) Cmux CPU usage")
+        })
+        #expect(quadrants == ["Cmux CPU usage"])
+    }
+
+    @Test func preservesOrdinaryNonBrailleTitlesExactly() {
+        #expect(filter.stableTitle(for: "✳") == nil)
+        #expect(filter.stableTitle(for: "✳-project") == "✳-project")
+        #expect(filter.stableTitle(for: "Build ✳ step") == "Build ✳ step")
+        #expect(filter.stableTitle(for: "✳ ✳✳✳") == "✳ ✳✳✳")
+        #expect(filter.stableTitle(for: "★ Starred build") == "★ Starred build")
+    }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
@@ -22,7 +22,6 @@ struct TerminalTitleChurnFilterTests {
     @Test func preservesOrdinaryTitlesExactly() {
         #expect(filter.stableTitle(for: "npm install") == "npm install")
         #expect(filter.stableTitle(for: "  zsh - ~/project  ") == "  zsh - ~/project  ")
-        #expect(filter.stableTitle(for: "Build ⠋ step") == "Build ⠋ step")
         #expect(filter.stableTitle(for: "⟿ not a Braille spinner") == "⟿ not a Braille spinner")
         #expect(filter.stableTitle(for: "⠋-project") == "⠋-project")
         #expect(filter.stableTitle(for: "⠋⠑⠇⠇⠕") == "⠋⠑⠇⠇⠕")
@@ -65,8 +64,32 @@ struct TerminalTitleChurnFilterTests {
     @Test func preservesOrdinaryNonBrailleTitlesExactly() {
         #expect(filter.stableTitle(for: "✳") == nil)
         #expect(filter.stableTitle(for: "✳-project") == "✳-project")
-        #expect(filter.stableTitle(for: "Build ✳ step") == "Build ✳ step")
         #expect(filter.stableTitle(for: "✳ ✳✳✳") == "✳ ✳✳✳")
         #expect(filter.stableTitle(for: "★ Starred build") == "★ Starred build")
+    }
+
+    /// OMP brands its title, so the frame is never in leading position and a
+    /// leading-only rule left all ten of its frames churning.
+    @Test func collapsesSpinnerFramesBehindABrandPrefix() {
+        let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+        let stableTitles = Set(frames.compactMap {
+            filter.stableTitle(for: "π \($0) safety-rating")
+        })
+
+        #expect(stableTitles == ["π safety-rating"])
+        #expect(
+            filter.stableTitle(for: "π > Continue after corruption")
+                == "π > Continue after corruption"
+        )
+    }
+
+    /// A lone frame bounded by whitespace is an animation, wherever it sits.
+    /// A run of two or more spinner glyphs is text, and stays untouched.
+    @Test func removesStandaloneFramesAnywhereButLeavesRunsAlone() {
+        #expect(filter.stableTitle(for: "Build ⠋ step") == "Build step")
+        #expect(filter.stableTitle(for: "deploy ✳ staging") == "deploy staging")
+        #expect(filter.stableTitle(for: "⠋⠑⠇⠇⠕") == "⠋⠑⠇⠇⠕")
+        #expect(filter.stableTitle(for: "⠋ ⠑⠇⠇⠕") == "⠋ ⠑⠇⠇⠕")
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2847,7 +2847,10 @@ struct ContentView: View {
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidSetTitle)) { notification in
-            guard tabManager.shouldScheduleRawTitleRefresh(forWorkspaceId: GhosttyTitleChange(notification: notification)?.tabId) else { return }
+            let change = GhosttyTitleChange(notification: notification)
+            // An advancing spinner cannot change the titlebar text.
+            guard change?.isSpinnerFrameOnly != true else { return }
+            guard tabManager.shouldScheduleRawTitleRefresh(forWorkspaceId: change?.tabId) else { return }
             scheduleTitlebarTextRefresh()
         })
 

--- a/Sources/GhosttyTerminalAppearance.swift
+++ b/Sources/GhosttyTerminalAppearance.swift
@@ -96,6 +96,7 @@ enum GhosttyNotificationKey {
     static let explicitFocusIntent = "ghostty.explicitFocusIntent"
     static let focusTransactionId = "ghostty.focusTransactionId"
     static let title = "ghostty.title"
+    static let stableTitle = "ghostty.stableTitle"
     static let sourceSurfaceIdentifier = "ghostty.sourceSurfaceIdentifier"
     static let terminalLifecycleID = "ghostty.terminalLifecycleId"
     static let backgroundColor = "ghostty.backgroundColor"

--- a/Sources/GhosttyTitleChange.swift
+++ b/Sources/GhosttyTitleChange.swift
@@ -4,20 +4,33 @@ import Foundation
 struct GhosttyTitleChange: Equatable, Sendable {
     let tabId: UUID
     let surfaceId: UUID
+    /// The title exactly as the terminal emitted it, spinner frame included.
+    /// Only the tab label renders this; it changes on every animation tick.
     let title: String
+    /// `title` with any standalone spinner frame removed, so successive
+    /// animation ticks compare equal. Everything that costs more than an AppKit
+    /// label redraw keys off this: a consumer that reacts to `title` reacts once
+    /// per frame, and a consumer that reacts to `stableTitle` reacts once per
+    /// real change.
+    let stableTitle: String
     let sourceSurfaceIdentifier: ObjectIdentifier?
     let terminalLifecycleID: UUID?
+
+    /// True when this event carries a new animation frame and nothing else.
+    var isSpinnerFrameOnly: Bool { title != stableTitle }
 
     init(
         tabId: UUID,
         surfaceId: UUID,
         title: String,
+        stableTitle: String? = nil,
         sourceSurfaceIdentifier: ObjectIdentifier? = nil,
         terminalLifecycleID: UUID? = nil
     ) {
         self.tabId = tabId
         self.surfaceId = surfaceId
         self.title = title
+        self.stableTitle = stableTitle ?? title
         self.sourceSurfaceIdentifier = sourceSurfaceIdentifier
         self.terminalLifecycleID = terminalLifecycleID
     }
@@ -32,6 +45,9 @@ struct GhosttyTitleChange: Equatable, Sendable {
             tabId: tabId,
             surfaceId: surfaceId,
             title: title,
+            // Absent on legacy in-process posts; falling back to `title` makes
+            // those look like a real change, which is the safe direction.
+            stableTitle: notification.userInfo?[GhosttyNotificationKey.stableTitle] as? String,
             sourceSurfaceIdentifier: notification.userInfo?[GhosttyNotificationKey.sourceSurfaceIdentifier]
                 as? ObjectIdentifier ?? (notification.object as AnyObject?).map(ObjectIdentifier.init),
             terminalLifecycleID: notification.userInfo?[GhosttyNotificationKey.terminalLifecycleID]
@@ -44,6 +60,7 @@ struct GhosttyTitleChange: Equatable, Sendable {
             GhosttyNotificationKey.tabId: tabId,
             GhosttyNotificationKey.surfaceId: surfaceId,
             GhosttyNotificationKey.title: title,
+            GhosttyNotificationKey.stableTitle: stableTitle,
         ]
         if let sourceSurfaceIdentifier {
             info[GhosttyNotificationKey.sourceSurfaceIdentifier] = sourceSurfaceIdentifier

--- a/Sources/GhosttyTitleUpdate.swift
+++ b/Sources/GhosttyTitleUpdate.swift
@@ -4,15 +4,24 @@ import Foundation
 struct GhosttyTitleUpdate: Equatable, Sendable {
     let tabId: UUID
     let surfaceId: UUID
+    /// The title exactly as the terminal emitted it, spinner frame included.
     let title: String
+    /// `title` with any standalone spinner frame removed. Successive animation
+    /// ticks share a `stableTitle`, which is what lets the expensive consumers
+    /// tell "the label changed" from "the spinner advanced".
+    let stableTitle: String
     let sourceSurfaceIdentifier: ObjectIdentifier
     let terminalLifecycleID: UUID
     let attachmentGeneration: UInt64
+
+    /// True when this update carries a new animation frame and nothing else.
+    var isSpinnerFrameOnly: Bool { title != stableTitle }
 
     init(
         tabId: UUID,
         surfaceId: UUID,
         title: String,
+        stableTitle: String? = nil,
         sourceSurfaceIdentifier: ObjectIdentifier,
         terminalLifecycleID: UUID,
         attachmentGeneration: UInt64 = 0
@@ -20,6 +29,7 @@ struct GhosttyTitleUpdate: Equatable, Sendable {
         self.tabId = tabId
         self.surfaceId = surfaceId
         self.title = title
+        self.stableTitle = stableTitle ?? title
         self.sourceSurfaceIdentifier = sourceSurfaceIdentifier
         self.terminalLifecycleID = terminalLifecycleID
         self.attachmentGeneration = attachmentGeneration

--- a/Sources/GhosttyTitleUpdateIngress.swift
+++ b/Sources/GhosttyTitleUpdateIngress.swift
@@ -33,6 +33,7 @@ final class GhosttyTitleUpdateIngress {
                     tabId: update.tabId,
                     surfaceId: update.surfaceId,
                     title: update.title,
+                    stableTitle: update.stableTitle,
                     sourceSurfaceIdentifier: update.sourceSurfaceIdentifier,
                     terminalLifecycleID: update.terminalLifecycleID
                 )
@@ -68,6 +69,11 @@ final class GhosttyTitleUpdateIngress {
     /// Returns false when normalization removes a label-less spinner frame,
     /// when the update duplicates the callback-local snapshot, or when the
     /// ingress has already terminated.
+    ///
+    /// Animation frames are forwarded rather than collapsed, so the tab label
+    /// still animates. What they carry is a `stableTitle` equal to the previous
+    /// frame's, which is how a consumer distinguishes "the label changed" from
+    /// "the spinner advanced" and skips the expensive path for the latter.
     @discardableResult
     func submit(
         tabId: UUID,
@@ -77,18 +83,24 @@ final class GhosttyTitleUpdateIngress {
         title: String,
         titleOverride: String? = nil
     ) -> Bool {
+        let displayTitle: String
         let stableTitle: String
         if let titleOverride {
+            // An override is already the resolved label; there is no frame in it.
+            displayTitle = titleOverride
             stableTitle = titleOverride
         } else if let churnStableTitle = titleChurnFilter.stableTitle(for: title) {
+            displayTitle = title
             stableTitle = churnStableTitle
         } else {
+            // Nothing but spinner glyphs: no label to show, so drop it entirely.
             return false
         }
         let update = GhosttyTitleUpdate(
             tabId: tabId,
             surfaceId: surfaceId,
-            title: stableTitle,
+            title: displayTitle,
+            stableTitle: stableTitle,
             sourceSurfaceIdentifier: sourceSurfaceIdentifier,
             terminalLifecycleID: terminalLifecycleID,
             attachmentGeneration: attachmentGeneration.loadRelaxed()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -406,6 +406,9 @@ class TabManager: ObservableObject {
     }
     private struct PendingPanelTitleUpdate {
         let title: String
+        /// `title` with any spinner frame removed. Carried alongside so the
+        /// flush can tell an advancing spinner from a changed label.
+        let stableTitle: String
         weak var sourceSurface: TerminalSurface?
         let sourceTerminalLifecycleId: UUID
     }
@@ -3732,9 +3735,11 @@ class TabManager: ObservableObject {
             )
         }
 #endif
+        let trimmedStable = change.stableTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let key = PanelTitleUpdateKey(tabId: change.tabId, panelId: change.surfaceId)
         pendingPanelTitleUpdates[key] = PendingPanelTitleUpdate(
             title: trimmed,
+            stableTitle: trimmedStable.isEmpty ? trimmed : trimmedStable,
             sourceSurface: sourceSurface,
             sourceTerminalLifecycleId: sourceSurface.terminalLifecycleId
         )
@@ -3758,19 +3763,35 @@ class TabManager: ObservableObject {
                   sourceSurface.terminalLifecycleId == update.sourceTerminalLifecycleId else {
                 continue
             }
-            updatePanelTitle(tabId: key.tabId, panelId: key.panelId, title: update.title, sourceSurface: sourceSurface)
+            updatePanelTitle(
+                tabId: key.tabId,
+                panelId: key.panelId,
+                title: update.title,
+                stableTitle: update.stableTitle,
+                sourceSurface: sourceSurface
+            )
         }
     }
     func flushPendingPanelTitleUpdatesForWorkspaceSnapshot() {
         panelTitleUpdateCoalescer.flushNow()
     }
-    private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String, sourceSurface: TerminalSurface) {
+    private func updatePanelTitle(
+        tabId: UUID,
+        panelId: UUID,
+        title: String,
+        stableTitle: String,
+        sourceSurface: TerminalSurface
+    ) {
         guard let tab = workspacesById[tabId],
               let terminalPanel = tab.terminalPanel(for: panelId),
               terminalPanel.surface === sourceSurface else { return }
         let previousDisplayTitle = resolvedWorkspaceDisplayTitle(for: tab).trimmingCharacters(in: .whitespacesAndNewlines)
-        _ = tab.updatePanelTitle(panelId: panelId, title: title)
+        let didMutate = tab.updatePanelTitle(panelId: panelId, title: title, stableTitle: stableTitle)
         guard !tab.isRemoteTmuxMirror else { return }
+        // A spinner-only frame has already refreshed the AppKit tab label inside
+        // `updatePanelTitle`. Nothing below it can produce a different result, so
+        // stop before the window title and the display-title comparison.
+        guard didMutate else { return }
         if tab.focusedPanelId == panelId {
             if selectedTabId == tabId {
                 updateWindowTitle(for: tab)

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -40,7 +40,10 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            let changedWorkspaceId = GhosttyTitleChange(notification: notification)?.tabId
+            let change = GhosttyTitleChange(notification: notification)
+            // An advancing spinner cannot change the focused command text.
+            guard change?.isSpinnerFrameOnly != true else { return }
+            let changedWorkspaceId = change?.tabId
             MainActor.assumeIsolated { [weak self] in
                 guard let self,
                       self.tabManager?.shouldScheduleRawTitleRefresh(forWorkspaceId: changedWorkspaceId) == true else { return }

--- a/Sources/Workspace+TitleOwnership.swift
+++ b/Sources/Workspace+TitleOwnership.swift
@@ -103,8 +103,8 @@ extension Workspace {
     /// frame with any spinner glyph removed, so consecutive animation ticks
     /// share one. The tab label always takes `title`, which keeps the spinner
     /// animating. Everything else keys off `stableTitle`, so an advancing
-    /// spinner never writes `@Published` state and never reaches the sidebar's
-    /// observation stream.
+    /// spinner never writes `@Published` state, never reaches the sidebar's
+    /// observation stream, and never refreshes the titlebar.
     ///
     /// Returns whether anything beyond the tab label changed.
     @discardableResult
@@ -117,9 +117,9 @@ extension Workspace {
         let trimmedStable = stableTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
         let stable = (trimmedStable?.isEmpty == false) ? trimmedStable! : trimmed
 
-        // Bonsplit is a plain class driving an AppKit tab bar, so this is a
-        // label redraw rather than a SwiftUI invalidation. Cheap enough to run
-        // on every frame, which is what keeps the animation.
+        // Runs on every frame, which is what keeps the animation. It still
+        // invalidates the tab bar's own SwiftUI subtree; what it avoids is the
+        // app-wide cascade below.
         refreshTabLabel(panelId: panelId, displayTitle: trimmed)
 
         // Only the spinner advanced. Everything below either writes @Published
@@ -146,9 +146,13 @@ extension Workspace {
         return true
     }
 
-    /// Pushes a title straight to the AppKit tab label without touching
-    /// `panelTitles` or the workspace title, so an animation frame can render
-    /// without waking any SwiftUI observer.
+    /// Pushes a title straight to the Bonsplit tab model without touching
+    /// `panelTitles` or the workspace title, so an animation frame reaches the
+    /// tab label without waking the sidebar, the titlebar, or the App body.
+    ///
+    /// This is not free: `PaneState` is `@Observable` with `var tabs:
+    /// [TabItem]`, so writing one tab's title writes the whole `tabs` property
+    /// and re-renders the entire tab bar. Narrowing that is separate work.
     private func refreshTabLabel(panelId: UUID, displayTitle: String) {
         guard !isRemoteTmuxMirror,
               let tabId = surfaceIdFromPanelId(panelId),

--- a/Sources/Workspace+TitleOwnership.swift
+++ b/Sources/Workspace+TitleOwnership.swift
@@ -97,57 +97,71 @@ extension Workspace {
         sidebarProcessTitleObservation.processTitleDidChange()
     }
 
+    /// Applies a terminal title.
+    ///
+    /// `title` is the frame the terminal just emitted; `stableTitle` is that
+    /// frame with any spinner glyph removed, so consecutive animation ticks
+    /// share one. The tab label always takes `title`, which keeps the spinner
+    /// animating. Everything else keys off `stableTitle`, so an advancing
+    /// spinner never writes `@Published` state and never reaches the sidebar's
+    /// observation stream.
+    ///
+    /// Returns whether anything beyond the tab label changed.
     @discardableResult
-    func updatePanelTitle(panelId: UUID, title: String) -> Bool {
+    func updatePanelTitle(panelId: UUID, title: String, stableTitle: String? = nil) -> Bool {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, panels[panelId] != nil else { return false }
         guard shouldApplyRestoredPanelTitle(panelId: panelId, rawTitle: trimmed) else {
             return false
         }
-        var didMutate = false
-        var didMutatePanelTitle = false
+        let trimmedStable = stableTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stable = (trimmedStable?.isEmpty == false) ? trimmedStable! : trimmed
+
+        // Bonsplit is a plain class driving an AppKit tab bar, so this is a
+        // label redraw rather than a SwiftUI invalidation. Cheap enough to run
+        // on every frame, which is what keeps the animation.
+        refreshTabLabel(panelId: panelId, displayTitle: trimmed)
+
+        // Only the spinner advanced. Everything below either writes @Published
+        // state or signals the sidebar chokepoint, and all of it would land on
+        // the same values it already holds.
+        guard !isRemoteTmuxMirror, panelTitles[panelId] != stable else { return false }
+
         var didMutateWorkspaceTitle = false
-
-        if !isRemoteTmuxMirror, panelTitles[panelId] != trimmed {
-            panelTitles[panelId] = trimmed
-            didMutate = true
-            didMutatePanelTitle = true
-        }
-
-        if didMutatePanelTitle,
-           let tabId = surfaceIdFromPanelId(panelId),
-           let panel = panels[panelId],
-           let existing = bonsplitController.tab(tabId) {
-            let baseTitle = panelTitles[panelId] ?? panel.displayTitle
-            let resolvedTitle = resolvedPanelTitle(panelId: panelId, fallback: baseTitle)
-            let titleUpdate: String? = existing.title == resolvedTitle ? nil : resolvedTitle
-            let hasCustomTitle = panelCustomTitles[panelId] != nil
-            if titleUpdate != nil || existing.hasCustomTitle != hasCustomTitle {
-                bonsplitController.updateTab(
-                    tabId,
-                    title: titleUpdate,
-                    hasCustomTitle: hasCustomTitle
-                )
-            }
-        }
+        panelTitles[panelId] = stable
 
         let previousWorkspaceTitle = self.title
         if applyFocusedPanelTitle(panelId: panelId) {
-            didMutate = true
             didMutateWorkspaceTitle = self.title != previousWorkspaceTitle
         }
 
 #if DEBUG
-        if didMutate {
-            cmuxDebugLog(
-                "workspace.title.updatePanel workspace=\(id.uuidString.prefix(5)) " +
-                "panel=\(panelId.uuidString.prefix(5)) panels=\(panels.count) custom=\(customTitle == nil ? 0 : 1) " +
-                "panelChanged=\(didMutatePanelTitle ? 1 : 0) workspaceChanged=\(didMutateWorkspaceTitle ? 1 : 0) " +
-                "title=\"\(debugWorkspaceDescriptionPreview(trimmed, limit: 80))\""
-            )
-        }
+        cmuxDebugLog(
+            "workspace.title.updatePanel workspace=\(id.uuidString.prefix(5)) " +
+            "panel=\(panelId.uuidString.prefix(5)) panels=\(panels.count) custom=\(customTitle == nil ? 0 : 1) " +
+            "panelChanged=1 workspaceChanged=\(didMutateWorkspaceTitle ? 1 : 0) " +
+            "title=\"\(debugWorkspaceDescriptionPreview(stable, limit: 80))\""
+        )
 #endif
-        return didMutate
+        return true
+    }
+
+    /// Pushes a title straight to the AppKit tab label without touching
+    /// `panelTitles` or the workspace title, so an animation frame can render
+    /// without waking any SwiftUI observer.
+    private func refreshTabLabel(panelId: UUID, displayTitle: String) {
+        guard !isRemoteTmuxMirror,
+              let tabId = surfaceIdFromPanelId(panelId),
+              let existing = bonsplitController.tab(tabId) else { return }
+        let resolvedTitle = resolvedPanelTitle(panelId: panelId, fallback: displayTitle)
+        let titleUpdate: String? = existing.title == resolvedTitle ? nil : resolvedTitle
+        let hasCustomTitle = panelCustomTitles[panelId] != nil
+        guard titleUpdate != nil || existing.hasCustomTitle != hasCustomTitle else { return }
+        bonsplitController.updateTab(
+            tabId,
+            title: titleUpdate,
+            hasCustomTitle: hasCustomTitle
+        )
     }
 
     private static func normalizedCustomDescription(_ description: String?) -> String? {

--- a/cmuxTests/GhosttyTitleUpdateIngressTests.swift
+++ b/cmuxTests/GhosttyTitleUpdateIngressTests.swift
@@ -40,7 +40,10 @@ struct GhosttyTitleUpdateIngressTests {
         ))
     }
 
-    @Test func spinnerFramesCollapseBeforeAsyncStreamEnqueue() {
+    /// Frames are forwarded, not collapsed, so the tab label keeps animating.
+    /// The saving comes from what they carry, not from dropping them.
+    /// https://github.com/manaflow-ai/cmux/issues/10348
+    @Test func spinnerFramesAreForwardedSoTheTabLabelKeepsAnimating() {
         let ingress = GhosttyTitleUpdateIngress()
         let tabId = UUID()
         let surfaceId = UUID()
@@ -48,15 +51,14 @@ struct GhosttyTitleUpdateIngressTests {
         let terminalLifecycleID = UUID()
         let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
-        for (index, frame) in frames.enumerated() {
-            let submitted = ingress.submit(
+        for frame in frames {
+            #expect(ingress.submit(
                 tabId: tabId,
                 surfaceId: surfaceId,
                 sourceSurfaceIdentifier: sourceIdentifier,
                 terminalLifecycleID: terminalLifecycleID,
                 title: "\(frame) pnpm install"
-            )
-            #expect(submitted == (index == 0))
+            ))
         }
 
         #expect(ingress.submit(
@@ -66,6 +68,71 @@ struct GhosttyTitleUpdateIngressTests {
             terminalLifecycleID: terminalLifecycleID,
             title: "⠋ pnpm run build"
         ))
+    }
+
+    /// A repeated identical frame still dedups; only genuinely new frames pass.
+    @Test func repeatedIdenticalFrameIsStillRejected() {
+        let ingress = GhosttyTitleUpdateIngress()
+        let tabId = UUID()
+        let surfaceId = UUID()
+        let sourceIdentifier = ObjectIdentifier(NSObject())
+        let terminalLifecycleID = UUID()
+
+        #expect(ingress.submit(
+            tabId: tabId,
+            surfaceId: surfaceId,
+            sourceSurfaceIdentifier: sourceIdentifier,
+            terminalLifecycleID: terminalLifecycleID,
+            title: "⠋ pnpm install"
+        ))
+        #expect(!ingress.submit(
+            tabId: tabId,
+            surfaceId: surfaceId,
+            sourceSurfaceIdentifier: sourceIdentifier,
+            terminalLifecycleID: terminalLifecycleID,
+            title: "⠋ pnpm install"
+        ))
+    }
+
+    /// The whole point: consecutive frames differ in `title` so the tab redraws,
+    /// and agree on `stableTitle` so every expensive consumer can skip them.
+    @Test func consecutiveFramesShareOneStableTitle() {
+        let frames = ["⠋", "⠙", "⠹"].map { frame in
+            GhosttyTitleChange(
+                tabId: UUID(),
+                surfaceId: UUID(),
+                title: "\(frame) pnpm install",
+                stableTitle: "pnpm install"
+            )
+        }
+
+        #expect(Set(frames.map(\.title)).count == 3)
+        #expect(Set(frames.map(\.stableTitle)) == ["pnpm install"])
+        #expect(frames.allSatisfy(\.isSpinnerFrameOnly))
+    }
+
+    @Test func aRealLabelChangeIsNotMarkedSpinnerOnly() {
+        let change = GhosttyTitleChange(
+            tabId: UUID(),
+            surfaceId: UUID(),
+            title: "pnpm run build",
+            stableTitle: "pnpm run build"
+        )
+
+        #expect(!change.isSpinnerFrameOnly)
+    }
+
+    /// A payload from a legacy in-process post carries no stable title. Treating
+    /// it as a real change is the safe direction: stale chrome beats churn.
+    @Test func missingStableTitleFallsBackToTheRawTitle() {
+        let change = GhosttyTitleChange(
+            tabId: UUID(),
+            surfaceId: UUID(),
+            title: "⠋ pnpm install"
+        )
+
+        #expect(change.stableTitle == "⠋ pnpm install")
+        #expect(!change.isSpinnerFrameOnly)
     }
 
     @Test func retiringAttachmentAllowsItsFirstRepeatedTitleAfterReattach() {

--- a/cmuxTests/GhosttyTitleUpdateIngressTests.swift
+++ b/cmuxTests/GhosttyTitleUpdateIngressTests.swift
@@ -7,6 +7,31 @@ import Testing
 @testable import cmux
 #endif
 
+/// Collects the title changes posted to a test-owned notification center. The
+/// ingress posts from its consumer task, so the reads are locked.
+final class GhosttyTitleChangeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [GhosttyTitleChange] = []
+
+    var values: [GhosttyTitleChange] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func append(_ change: GhosttyTitleChange) {
+        lock.lock()
+        recorded.append(change)
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        recorded.removeAll()
+        lock.unlock()
+    }
+}
+
 @Suite("Ghostty title update ingress")
 @MainActor
 struct GhosttyTitleUpdateIngressTests {
@@ -42,9 +67,32 @@ struct GhosttyTitleUpdateIngressTests {
 
     /// Frames are forwarded, not collapsed, so the tab label keeps animating.
     /// The saving comes from what they carry, not from dropping them.
+    ///
+    /// The assertions read the changes that actually reach `.ghosttyDidSetTitle`
+    /// rather than `submit`'s return value, so a later stage that dropped a
+    /// frame's `stableTitle` or its spinner-only marking would fail here. The
+    /// ingress stream buffers the newest update, so the number of posted changes
+    /// is not fixed; what every posted frame carries is.
     /// https://github.com/manaflow-ai/cmux/issues/10348
-    @Test func spinnerFramesAreForwardedSoTheTabLabelKeepsAnimating() {
-        let ingress = GhosttyTitleUpdateIngress()
+    @Test func spinnerFramesAreForwardedSoTheTabLabelKeepsAnimating() async {
+        let center = NotificationCenter()
+        let scheduler = TitleScheduleRecorder()
+        let observed = GhosttyTitleChangeRecorder()
+        let token = center.addObserver(
+            forName: .ghosttyDidSetTitle,
+            object: nil,
+            queue: nil
+        ) { notification in
+            if let change = GhosttyTitleChange(notification: notification) {
+                observed.append(change)
+            }
+        }
+        defer { center.removeObserver(token) }
+
+        let ingress = GhosttyTitleUpdateIngress(
+            center: center,
+            schedule: { interval, action in scheduler.schedule(interval, action: action) }
+        )
         let tabId = UUID()
         let surfaceId = UUID()
         let sourceIdentifier = ObjectIdentifier(NSObject())
@@ -60,14 +108,41 @@ struct GhosttyTitleUpdateIngressTests {
                 title: "\(frame) pnpm install"
             ))
         }
+        await scheduler.awaitFirstSchedule()
+        await scheduler.fire()
 
+        let spinnerChanges = observed.values
+        let everySpinnerChangeSharesTheStableTitle = spinnerChanges
+            .allSatisfy { $0.stableTitle == "pnpm install" }
+        let everySpinnerChangeIsMarkedSpinnerOnly = spinnerChanges.allSatisfy(\.isSpinnerFrameOnly)
+        let everySpinnerChangeKeepsItsFrame = spinnerChanges
+            .allSatisfy { $0.title.hasSuffix(" pnpm install") }
+        #expect(!spinnerChanges.isEmpty)
+        #expect(everySpinnerChangeSharesTheStableTitle)
+        #expect(everySpinnerChangeIsMarkedSpinnerOnly)
+        #expect(everySpinnerChangeKeepsItsFrame)
+
+        observed.reset()
         #expect(ingress.submit(
             tabId: tabId,
             surfaceId: surfaceId,
             sourceSurfaceIdentifier: sourceIdentifier,
             terminalLifecycleID: terminalLifecycleID,
-            title: "⠋ pnpm run build"
+            title: "pnpm run build"
         ))
+        await scheduler.awaitFirstSchedule()
+        await scheduler.fire()
+
+        // A frame-free title: `isSpinnerFrameOnly` is `title != stableTitle`, so a
+        // real label change only reads as one when the raw title has no frame in
+        // it. That is the case a consumer must not skip.
+        let labelChanges = observed.values
+        let everyLabelChangeCarriesTheNewTitle = labelChanges
+            .allSatisfy { $0.stableTitle == "pnpm run build" }
+        let noLabelChangeIsMarkedSpinnerOnly = labelChanges.allSatisfy { !$0.isSpinnerFrameOnly }
+        #expect(!labelChanges.isEmpty)
+        #expect(everyLabelChangeCarriesTheNewTitle)
+        #expect(noLabelChangeIsMarkedSpinnerOnly)
     }
 
     /// A repeated identical frame still dedups; only genuinely new frames pass.
@@ -106,9 +181,10 @@ struct GhosttyTitleUpdateIngressTests {
             )
         }
 
+        let everyFrameIsMarkedSpinnerOnly = frames.allSatisfy(\.isSpinnerFrameOnly)
         #expect(Set(frames.map(\.title)).count == 3)
         #expect(Set(frames.map(\.stableTitle)) == ["pnpm install"])
-        #expect(frames.allSatisfy(\.isSpinnerFrameOnly))
+        #expect(everyFrameIsMarkedSpinnerOnly)
     }
 
     @Test func aRealLabelChangeIsNotMarkedSpinnerOnly() {
@@ -123,7 +199,8 @@ struct GhosttyTitleUpdateIngressTests {
     }
 
     /// A payload from a legacy in-process post carries no stable title. Treating
-    /// it as a real change is the safe direction: stale chrome beats churn.
+    /// it as a real change is the safe direction: it permits a refresh, and
+    /// churn beats stale chrome.
     @Test func missingStableTitleFallsBackToTheRawTitle() {
         let change = GhosttyTitleChange(
             tabId: UUID(),


### PR DESCRIPTION
**Status:** updated onto `main` (`78f4c82504`) as merge commit `1e34d3640a`. Two conflicts, both resolved keeping the upstream side too:

- `Sources/Workspace+TitleOwnership.swift`: `main` now projects a cloud title (`cloudProjectedResource(forPanel:).cloudProcessDisplayTitle`) into the trim step. That projection is preserved, and the stable-title mechanism sits on top of it. The tab label still takes the animating frame through `refreshTabLabel`; `panelTitles` takes the stable title.
- `Sources/TabManager.swift`: `main` added a `Bool`-returning `updatePanelTitle(tabId:panelId:title:)` that the cloud rename paths call (`TabManager+CloudAgentTitle`, `TerminalController+AgentTitle`). Both entry points now exist: that one unchanged, plus the spinner-aware `stableTitle` variant the coalescer calls.

**Reviewer's guide**
- Read `TerminalTitleChurnFilter` (frame classification) first, then `GhosttyTitleUpdateIngress` and `Workspace+TitleOwnership.updatePanelTitle`.
- Tests: `TerminalTitleChurnFilterTests.swift`, `cmuxTests/GhosttyTitleUpdateIngressTests.swift`.
- The point of the change: a frame that only advances a spinner refreshes the tab label and stops. Everything else keys off the stable title, so it never writes `@Published` state and never reaches the sidebar or titlebar.

---

A spinner frame is cheap to draw and expensive to announce. cmux currently announces it: every tick of `✳ Working` or `π ⠋ safety-rating` is a new title string, so it flows through the workspace title, the sidebar's observation stream, the titlebar, and the toolbar. On a window running several agents that is the app re-laying itself out to move one glyph.

This keeps the animation and cuts the announcement.

## Why the earlier approach was wrong

The first version of this PR removed the frame from the title, which is what `TerminalTitleChurnFilter` already did for Braille spinners on main. It works, and dogfooding showed why it should not ship: the tab stops animating. Widening the frame set to the glyphs agents actually use just made the existing behavior visible. Losing the animation to save CPU is paying with the feature.

## Change

`GhosttyTitleUpdate` and `GhosttyTitleChange` carry two strings:

- `title` stays the frame the terminal emitted, spinner included.
- `stableTitle` is that frame with a standalone spinner glyph removed, so consecutive ticks share one.
- `isSpinnerFrameOnly` is `title != stableTitle`.

The ingress forwards every frame again instead of collapsing them, so the label still has something to animate with. The saving comes from what each consumer does with it:

| consumer | on a spinner-only frame |
|---|---|
| `Workspace.updatePanelTitle` | refreshes the AppKit tab label, then returns before touching `@Published panelTitles` or `applyFocusedPanelTitle` |
| `TabManager.updatePanelTitle` | skips the window title and the display-title comparison |
| `ContentView.onReceive` | skips `scheduleTitlebarTextRefresh` |
| `WindowToolbarController` | skips `scheduleFocusedCommandTextUpdate` |

`panelTitles` doubles as the memo, since it already holds the last stable label, so the change adds no new state.

The tab label path is `bonsplitController.updateTab`. `BonsplitController` is a plain `final class` with no `@Published` and no `ObservableObject` conformance, so that call is an AppKit label redraw rather than a SwiftUI invalidation. That is what makes it safe to run on every frame.

Also extends the frame set past Braille to `U+2731...U+273D` (asterisks, which is what Claude Code animates) and `U+25D0...U+25D3` / `U+25F4...U+25F7` (circles), and drops the leading-position requirement so a branded title like `π ⠋ label` is recognized. Sampling a live 20-surface window, every animated title used a glyph or a position the old filter missed, so it collapsed nothing there.

## Deleted test, deliberately

`spinnerFramesCollapseBeforeAsyncStreamEnqueue` asserted `submitted == (index == 0)`, i.e. that frames are dropped at the ingress. That assertion is the animation bug, so it is replaced by:

- `spinnerFramesAreForwardedSoTheTabLabelKeepsAnimating`
- `repeatedIdenticalFrameIsStillRejected`, so the plain duplicate guard is still covered
- three tests over the `stableTitle` / `isSpinnerFrameOnly` contract, including the legacy-payload fallback

## Verification

`xcodebuild -scheme cmux -configuration Debug`: **BUILD SUCCEEDED**.

I cannot run `cmuxTests` locally, so CI is the gate there. The churn filter itself I exercised through a standalone harness compiling the real source file alongside every pre-existing assertion plus the new ones: 23 pass, and against unmodified `main` the new cases fail.

Both new fields default to `nil` and fall back to the raw title, so the other `GhosttyTitleChange(...)` and `updatePanelTitle(...)` call sites compile unchanged and treat their input as a real change, which is the safe direction.

Running it: the tab animates as before, and the sidebar's own `✦ Running` indicator is unaffected since it comes from agent status rather than the title.

## Not in this PR

The per-frame `NotificationCenter` post stays. Removing it needs a display-only sink from the ingress to the tab bar, which is a bigger change; this cuts the cascade behind the post, which is the expensive half.

Related: #10348, #6599. Supersedes #9094.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal titles now remain stable while spinner animations update, reducing unnecessary tab, sidebar, and workspace refreshes.
  * Spinner-only titles are ignored, while meaningful title changes continue to appear immediately.
  * Title normalization now supports additional spinner styles without altering ordinary symbols or branded titles.

* **Tests**
  * Expanded coverage for spinner frames, embedded titles, stable-title handling, deduplication, and legacy notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
