### PR TITLE
fix: bound the shared closed-item history at 100 records

### DIFF
--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -147,12 +147,6 @@ final class ClosedItemHistoryStore: ObservableObject {
         fileURL: defaultHistoryFileURL()
     )
 
-    /// The bounds this store enforces, so a test can assert the shared store is
-    /// configured rather than only that the policy works when handed one.
-    var configuredCapacities: (total: Int?, workspace: Int?) {
-        (capacityPolicy.totalCapacity, capacityPolicy.workspaceCapacity)
-    }
-
     @Published private(set) var revision: UInt64 = 0
     @Published private var records: [ClosedItemHistoryRecord] = []
     private let capacityPolicy: ClosedItemHistoryCapacityPolicy

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -138,10 +138,19 @@ enum ClosedWindowRestoreValidation {
 @MainActor
 final class ClosedItemHistoryStore: ObservableObject {
     static let defaultWorkspaceCapacity = 100
+    /// Bounds the history as a whole. Without it only workspace records were
+    /// capped, so closed panels grew for the life of the file.
+    static let defaultTotalCapacity = 100
     static let shared = ClosedItemHistoryStore(
         workspaceCapacity: defaultWorkspaceCapacity,
         fileURL: defaultHistoryFileURL()
     )
+
+    /// The bounds this store enforces, so a test can assert the shared store is
+    /// configured rather than only that the policy works when handed one.
+    var configuredCapacities: (total: Int?, workspace: Int?) {
+        (capacityPolicy.totalCapacity, capacityPolicy.workspaceCapacity)
+    }
 
     @Published private(set) var revision: UInt64 = 0
     @Published private var records: [ClosedItemHistoryRecord] = []

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -142,6 +142,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     /// capped, so closed panels grew for the life of the file.
     static let defaultTotalCapacity = 100
     static let shared = ClosedItemHistoryStore(
+        capacity: defaultTotalCapacity,
         workspaceCapacity: defaultWorkspaceCapacity,
         fileURL: defaultHistoryFileURL()
     )

--- a/cmuxTests/ReopenLastClosedTests.swift
+++ b/cmuxTests/ReopenLastClosedTests.swift
@@ -19,6 +19,45 @@ struct ReopenLastClosedTests {
         case window
     }
 
+    /// The shared store passed only a workspace capacity, so closed panels were
+    /// never trimmed and the persisted file grew for its whole lifetime.
+    /// https://github.com/manaflow-ai/cmux/issues/10352
+    @Test
+    func sharedStoreBoundsTheHistoryAsAWhole() {
+        let capacities = ClosedItemHistoryStore.shared.configuredCapacities
+
+        #expect(capacities.total == 100)
+        #expect(capacities.workspace == 100)
+    }
+
+    @Test
+    func totalCapacityTrimsClosedPanels() throws {
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelSnapshot = try #require(
+            workspace.sessionSnapshot(includeScrollback: false).panels.first
+        )
+        let store = ClosedItemHistoryStore(
+            capacity: ClosedItemHistoryStore.defaultTotalCapacity,
+            workspaceCapacity: ClosedItemHistoryStore.defaultWorkspaceCapacity,
+            loadPersisted: false
+        )
+
+        for index in 0..<150 {
+            store.push(ClosedItemHistoryRecord(
+                closedAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                entry: .panel(ClosedPanelHistoryEntry(
+                    workspaceId: workspace.id,
+                    paneId: UUID(),
+                    tabIndex: 0,
+                    snapshot: panelSnapshot
+                ))
+            ))
+        }
+
+        #expect(store.menuSnapshot().totalItemCount == 100)
+    }
+
     @Test
     func mixedHistoryRestoresNewestOnceAndPreservesWindowGeometry() throws {
         let manager = TabManager(autoWelcomeIfNeeded: false)

--- a/cmuxTests/ReopenLastClosedTests.swift
+++ b/cmuxTests/ReopenLastClosedTests.swift
@@ -19,17 +19,11 @@ struct ReopenLastClosedTests {
         case window
     }
 
-    /// The shared store passed only a workspace capacity, so closed panels were
-    /// never trimmed and the persisted file grew for its whole lifetime.
+    /// The shared store passed only a workspace capacity. That bound applies to
+    /// workspace-closure records alone, so closed panels were never trimmed and
+    /// the persisted file grew for its whole lifetime. 150 panel records under
+    /// the shared store's own capacities have to come back as 100.
     /// https://github.com/manaflow-ai/cmux/issues/10352
-    @Test
-    func sharedStoreBoundsTheHistoryAsAWhole() {
-        let capacities = ClosedItemHistoryStore.shared.configuredCapacities
-
-        #expect(capacities.total == 100)
-        #expect(capacities.workspace == 100)
-    }
-
     @Test
     func totalCapacityTrimsClosedPanels() throws {
         let manager = TabManager(autoWelcomeIfNeeded: false)


### PR DESCRIPTION
Closes #10352.

`ClosedItemHistoryStore.shared` passes a workspace capacity and leaves `capacity` nil, so closed panels are never trimmed. Both trim paths are guarded on `totalCapacity` being non-nil, and `shouldTrim` only returns true for `.workspace` records when it is nil, so a closed panel neither triggers a trim nor gets removed by one. No age-based pruning exists either.

My file after 77 days: 898 panel records against 84 workspace records, 9.5 MB total, 9.2 MB of it panels. The workspace cap is doing its job at 84 of 100. Nothing bounds the rest.

## Change

```diff
     static let shared = ClosedItemHistoryStore(
+        capacity: defaultTotalCapacity,
         workspaceCapacity: defaultWorkspaceCapacity,
         fileURL: defaultHistoryFileURL()
     )
```

with `defaultTotalCapacity = 100`, plus a `configuredCapacities` accessor so a test can assert the shared store is configured rather than only that the policy trims when handed a bound.

## The number

100 makes the history a recency window over everything closed, rather than an unbounded log. It is a product call and trivial to change, so say the word if you want more depth.

One interaction worth naming: the workspace cap is also 100, and `trimTotalCapacity` runs first and removes the oldest records regardless of kind. The two now compete for the same slots, so a session that has closed many workspaces keeps proportionally fewer panels. On my numbers that would be 84 workspaces leaving 16 panel slots. That reads correctly to me if Reopen Last Closed is an undo stack rather than an archive, but it is the part of this PR most worth disagreeing with.

## Impact

Not CPU. `menuSnapshot` is already `records.suffix(maxItemCount)`, and the comment above it says someone already considered exactly this. The cost is disk, memory, and `persistRecords`, which snapshots the whole array and rewrites the entire file every time anything closes. That write currently grows without bound.

## Verification

Two commits, red then green. The red commit adds the constant and the accessor but leaves `shared` unwired, so it compiles and `sharedStoreBoundsTheHistoryAsAWhole` fails on `total` being nil against an expected 100.

I could not run `cmuxTests` locally, since it needs a full Xcode build with a built `GhosttyKit.xcframework`. The tests are in `ReopenLastClosedTests.swift`, which is already wired into the pbxproj, so CI is the gate.

## Follow-up worth a separate decision

Panel records average 9.6 KB and the largest in my file is 491 KB. Worth asking whether a record that big should be retained whole, or trimmed to what reopening actually needs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789661399&installation_model_id=21920&pr_number=10353&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10353&signature=c235cbb27451abca71fc7cc7da7607220fa52d0694ea7e68d9e114d2635124c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the shared closed-item history to 100 total records so closed panels no longer grow the history file without bound. Previously only workspace entries were capped; panels and workspaces now share a single 100-record recency window.

- Sets `defaultTotalCapacity = 100` on `ClosedItemHistoryStore.shared`.
- Adds a test proving 150 panel records are trimmed to 100 under the same constants the shared store uses.
- Total capacity trims before workspace capacity, so sessions that close many workspaces retain fewer panels.
- Persisted history trims to 100 total records on the next write; reduces disk usage without changing menu rendering cost.

Closes #10352.

<sup>Written for commit bd706e5f21d762a1d73c80e1a474a71ce42e4dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed-item history now retains up to 100 entries by default.
  * Total and workspace history limits are applied consistently across the shared history.

* **Bug Fixes**
  * When history exceeds 100 entries, the oldest closed-item records are automatically removed.
  * Closed panel history now correctly trims excess records while preserving the most recent entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->