### PR TITLE
fix(ios): stop reconnect supersede storms and cross-session secondary dial churn

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
@@ -97,16 +97,36 @@ public actor CmxIrohRelayPolicyCache {
     /// - Parameters:
     ///   - trustRoot: App-pinned public verification keys.
     ///   - now: Verification time.
+    ///   - staleGrace: Bounded staleness allowance for broker outages. When
+    ///     positive and the cached policy expired no more than this long ago,
+    ///     it is re-verified as of one second before its own expiry, a moment
+    ///     it was valid, so signature, shape, and rollback checks still hold.
+    ///     Relay credentials keep their own independent expiry, so the relay
+    ///     itself remains the hard authorization floor while the policy list
+    ///     rides out an unreachable policy endpoint.
     /// - Returns: The verified policy, or `nil` when no policy is cached.
     /// - Throws: ``CmxIrohRelayPolicyError`` or a secure-storage error.
     public func load(
         trustRoot: CmxIrohRelayPolicyTrustRoot,
-        now: Date
+        now: Date,
+        staleGrace: TimeInterval = 0
     ) async throws -> CmxIrohManagedRelayPolicy? {
         await acquire()
         defer { release() }
         guard let record = try await storedRecord() else { return nil }
-        let policy = try verifier.verify(record.signedPolicy, trustRoot: trustRoot, now: now)
+        let policy: CmxIrohManagedRelayPolicy
+        do {
+            policy = try verifier.verify(record.signedPolicy, trustRoot: trustRoot, now: now)
+        } catch let error as CmxIrohRelayPolicyError where error == .expired {
+            guard staleGrace > 0, let expirySeconds = record.expiresAt else { throw error }
+            let expiryDate = Date(timeIntervalSince1970: TimeInterval(expirySeconds))
+            guard now.timeIntervalSince(expiryDate) <= staleGrace else { throw error }
+            policy = try verifier.verify(
+                record.signedPolicy,
+                trustRoot: trustRoot,
+                now: expiryDate.addingTimeInterval(-1)
+            )
+        }
         guard policy.sequence == record.highestSequence,
               Self.metadataMatches(policy, record: record) else {
             throw CmxIrohRelayPolicyError.rollback

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -139,12 +139,18 @@ public actor CmxIrohRelayPolicyService {
     }
 
     /// Restores the last-known-good signed policy and account preference.
+    ///
+    /// - Parameter staleGrace: Bounded staleness allowance forwarded to the
+    ///   policy cache so a policy that expired while the policy endpoint is
+    ///   unreachable keeps relay authority instead of emptying every dial
+    ///   plan. `0` preserves strict expiry.
     @discardableResult
     public func restore(
         accountID: String,
         trustRoot: CmxIrohRelayPolicyTrustRoot,
         relayCredential: CmxIrohRelayTokenResponse? = nil,
-        now: Date = Date()
+        now: Date = Date(),
+        staleGrace: TimeInterval = 0
     ) async -> CmxIrohEffectiveRelayPolicy {
         let operation = beginOperation()
         let persisted: CmxIrohPersistedRelayPreference
@@ -175,7 +181,11 @@ public actor CmxIrohRelayPolicyService {
             credentialStore: credentialStore
         )
         if persisted.requested.mode == .custom {
-            let policy = try? await policyCache.load(trustRoot: trustRoot, now: now)
+            let policy = try? await policyCache.load(
+                trustRoot: trustRoot,
+                now: now,
+                staleGrace: staleGrace
+            )
             let resolution = await Resolver.resolve(
                 configuration: persisted.requested,
                 revision: persisted.revision,
@@ -196,7 +206,11 @@ public actor CmxIrohRelayPolicyService {
         }
 
         do {
-            guard let policy = try await policyCache.load(trustRoot: trustRoot, now: now) else {
+            guard let policy = try await policyCache.load(
+                trustRoot: trustRoot,
+                now: now,
+                staleGrace: staleGrace
+            ) else {
                 return publishUnavailable(
                     configuration: persisted.requested,
                     revision: persisted.revision,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyStaleGraceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyStaleGraceTests.swift
@@ -1,0 +1,104 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+// Regression coverage for the policy-endpoint outage leg of
+// https://github.com/manaflow-ai/cmux/issues/10375: when the relay-policy
+// endpoint is unreachable and the cached signed policy passes its expiry,
+// restore() used to strip relay authority, every dial plan assembled empty,
+// and the phone sat on "Reconnecting" until a refresh finally succeeded
+// (151s in field logs). A bounded staleness grace keeps the last VERIFIED
+// relay list authoritative for dial-plan membership; signature, shape, and
+// rollback checks still run (re-verified as of one second before the
+// policy's own expiry), and the relay credential's independent expiry
+// remains the hard authorization floor.
+@Suite
+struct CmxIrohRelayPolicyStaleGraceTests {
+    private let grace: TimeInterval = 24 * 60 * 60
+
+    @Test
+    func cacheLoadHonorsBoundedStaleGraceAfterExpiry() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let cache = CmxIrohRelayPolicyCache(secureStore: TestSecureCredentialStore())
+        let expiresAt = Int64(fixture.now.timeIntervalSince1970) + 3_600
+        _ = try await cache.install(
+            signedPolicy: fixture.token(sequence: 1, expiresAt: expiresAt),
+            trustRoot: fixture.firstTrustRoot,
+            now: fixture.now
+        )
+        let justExpired = Date(timeIntervalSince1970: TimeInterval(expiresAt) + 60)
+
+        // Strict expiry stays the default.
+        await #expect(throws: CmxIrohRelayPolicyError.expired) {
+            _ = try await cache.load(
+                trustRoot: fixture.firstTrustRoot,
+                now: justExpired
+            )
+        }
+        // Within the grace window the verified policy remains loadable.
+        let graced = try await cache.load(
+            trustRoot: fixture.firstTrustRoot,
+            now: justExpired,
+            staleGrace: grace
+        )
+        #expect(graced?.relays.map(\.url) == fixture.relayURLs)
+        // Beyond the grace window expiry is enforced again.
+        await #expect(throws: CmxIrohRelayPolicyError.expired) {
+            _ = try await cache.load(
+                trustRoot: fixture.firstTrustRoot,
+                now: Date(timeIntervalSince1970: TimeInterval(expiresAt) + grace + 1),
+                staleGrace: grace
+            )
+        }
+    }
+
+    private func makeService() -> CmxIrohRelayPolicyService {
+        CmxIrohRelayPolicyService(
+            policyCache: CmxIrohRelayPolicyCache(secureStore: TestSecureCredentialStore()),
+            preferenceStore: CmxIrohRelayPreferenceStore(secureStore: TestSecureCredentialStore()),
+            credentialStore: CmxIrohCustomRelayCredentialStore(
+                secureStore: TestSecureCredentialStore()
+            )
+        )
+    }
+
+    @Test
+    func restoreKeepsRelayAuthorityThroughAnOutageWithinGrace() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let service = makeService()
+        let expiresAt = Int64(fixture.now.timeIntervalSince1970) + 3_600
+        let response = try CmxIrohRelayPolicyResponse(
+            policy: fixture.token(sequence: 1, expiresAt: expiresAt),
+            preference: .automatic,
+            preferenceRevision: 1
+        )
+        _ = try await service.install(
+            response: response,
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+        let duringOutage = Date(timeIntervalSince1970: TimeInterval(expiresAt) + 120)
+
+        // Old behavior (no grace): relay authority is stripped at expiry and
+        // every relay-only dial plan assembles empty.
+        let stripped = await service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            now: duringOutage
+        )
+        #expect(stripped.endpointRelayProfile.allowedRelayURLs.isEmpty)
+
+        // With the outage grace the last verified relay list stays effective.
+        let graced = await service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            now: duringOutage,
+            staleGrace: grace
+        )
+        #expect(graced.endpointRelayProfile.allowedRelayURLs == Set(fixture.relayURLs))
+        #expect(Set(graced.managedPolicy?.relays.map(\.url) ?? []) == Set(fixture.relayURLs))
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileControlPoolRetryState.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileControlPoolRetryState.swift
@@ -24,6 +24,17 @@ struct MobileControlPoolRetryState: Sendable {
         isScheduled = false
     }
 
+    /// Releases the scheduled slot without forgetting the grown delay.
+    ///
+    /// Backgrounding cancels the pending retry timer, but it is not evidence
+    /// that an unreachable Mac became reachable. Keeping the delay means the
+    /// next foreground's full aggregation pass still dials once (a foreground
+    /// return is a legitimate retry moment) while a Mac that keeps failing
+    /// does not restart the 2 s ladder every session.
+    mutating func suspend() {
+        isScheduled = false
+    }
+
     mutating func reset() {
         isScheduled = false
         nextDelay = Self.initialDelay

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -345,7 +345,8 @@ extension MobileShellComposite {
                 // the same wedge protection without a second race here.
                 let reconnectOutcome = await self.reconnectActiveMacOutcome(
                     stackUserID: stackUserID,
-                    refreshBackupBeforeDial: false
+                    refreshBackupBeforeDial: false,
+                    replacesInFlightAttempt: trigger.replacesInFlightStoredMacAttempt
                 )
                 guard !Task.isCancelled,
                       self.connectionRecoveryOwner.isCurrent(attempt) else { return }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -330,6 +330,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// resolve the restoring-gate flags, so a superseded older attempt can't clear
     /// the gate while a newer reconnect is still in progress.
     var storedMacReconnectGeneration = 0
+    /// The one in-flight stored-Mac reconnect attempt. Concurrent automatic
+    /// requests (launch restore, presence push, foreground, event-stream end)
+    /// await this shared attempt instead of claiming a new generation, which
+    /// would cancel the dial already in progress and settle both callers as
+    /// "Superseded by a newer attempt". Only forced entries (manual retry,
+    /// connection-method change) may replace it.
+    var storedMacReconnectAttemptTask: Task<StoredMacReconnectOutcome, Never>?
+    private var storedMacReconnectAttemptID: UUID?
     /// Set when a connection-method change arrives during a reconnect. The
     /// latest forced retry starts as soon as the current attempt settles.
     var pendingForcedStoredMacReconnect = false
@@ -1949,6 +1957,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isReconnectingStoredMac = false
         pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
+        storedMacReconnectAttemptTask = nil
+        storedMacReconnectAttemptID = nil
         replaceRemoteClient(with: nil)
         cancelRemoteOperationTasks()
         resetNotificationFeed()
@@ -2046,6 +2056,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isReconnectingStoredMac = false
         pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
+        storedMacReconnectAttemptTask = nil
+        storedMacReconnectAttemptID = nil
         pairedMacRestoreBoundary?.invalidate()
         let refresher = pairedMacStore as? any PairedMacBackupRefreshing
         // Lazy display: clear the stale old-team lists; the next loadPairedMacs() /
@@ -2333,6 +2345,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
         var reschedulesSecondaryAggregation: Bool { self != .presencePush }
 
+        /// Explicit user intent replaces an in-flight stored-Mac attempt;
+        /// automatic wake-ups share its outcome instead of superseding it.
+        var replacesInFlightStoredMacAttempt: Bool {
+            switch self {
+            case .manual, .connectionMethodChanged: true
+            case .networkChange, .presencePush, .foreground, .liveness,
+                 .eventStreamEnded, .subscriptionStartFailed,
+                 .transportWriteTimedOut, .automaticBackoffExpired: false
+            }
+        }
+
         /// Stable integer carried in ``DiagnosticEventCode/recoveryStarted``'s
         /// `b` slot so an export names WHY each recovery cycle began. Values
         /// are append-only; never renumber.
@@ -2589,14 +2612,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func reconnectActiveMacIfAvailable(
         stackUserID: String?,
         refreshBackupBeforeDial: Bool = true,
-        force: Bool = false
+        force: Bool = false,
+        replacesInFlightAttempt: Bool = false
     ) async -> Bool {
         let startedAt = appDiagnosticNow()
         recordAppEvent(.reconnectStarted)
         let outcome = await reconnectActiveMacOutcome(
             stackUserID: stackUserID,
             refreshBackupBeforeDial: refreshBackupBeforeDial,
-            force: force
+            force: force,
+            replacesInFlightAttempt: replacesInFlightAttempt
         )
         switch outcome {
         case .connected:
@@ -2635,16 +2660,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             clearTransientAutomaticReconnectBackoff(accountID: accountID)
         }
         isReconnectingStoredMac = true
+        // A user-requested retry replaces a wedged in-flight attempt (one
+        // whose restoring deadline elapsed while its dial hangs) instead of
+        // sharing its already-doomed outcome.
         return await reconnectActiveMacIfAvailable(
             stackUserID: stackUserID,
-            force: force
+            force: force,
+            replacesInFlightAttempt: true
         )
     }
 
+    /// - Parameter replacesInFlightAttempt: `true` for explicit user intent
+    ///   (manual retry, connection-method change), which claims a fresh
+    ///   generation and supersedes any in-flight attempt. Automatic requests
+    ///   leave this `false` and share the in-flight attempt's outcome.
     func reconnectActiveMacOutcome(
         stackUserID: String?,
         refreshBackupBeforeDial: Bool = true,
-        force: Bool = false
+        force: Bool = false,
+        replacesInFlightAttempt: Bool = false
     ) async -> StoredMacReconnectOutcome {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
@@ -2656,12 +2690,51 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             finishStoredMacReconnectAttempt(generation: storedMacReconnectGeneration)
             return .connected
         }
+        // One stored-Mac attempt owns the dial. A concurrent automatic request
+        // shares its outcome; claiming a new generation here would cancel the
+        // in-flight dial and settle both callers as superseded (the launch
+        // presence-push vs stored-restore race).
+        if !force, !replacesInFlightAttempt,
+           let inFlight = storedMacReconnectAttemptTask {
+            MobileDebugLog.anchormux(
+                "storedMacReconnect joining in-flight attempt generation=\(storedMacReconnectGeneration)"
+            )
+            return await inFlight.value
+        }
         // Claim this attempt's generation. Only the current generation may resolve
         // the restoring-gate flags, so an older superseded attempt can't clear the
         // gate (or clobber the hint) while a newer reconnect is still running.
         storedMacReconnectGeneration &+= 1
         let generation = storedMacReconnectGeneration
         isReconnectingStoredMac = true
+        let attemptID = UUID()
+        let attempt = Task { @MainActor [weak self] in
+            guard let self else { return StoredMacReconnectOutcome.superseded }
+            defer {
+                if self.storedMacReconnectAttemptID == attemptID {
+                    self.storedMacReconnectAttemptTask = nil
+                    self.storedMacReconnectAttemptID = nil
+                }
+            }
+            return await self.runStoredMacReconnectAttempt(
+                stackUserID: stackUserID,
+                refreshBackupBeforeDial: refreshBackupBeforeDial,
+                generation: generation
+            )
+        }
+        storedMacReconnectAttemptTask = attempt
+        storedMacReconnectAttemptID = attemptID
+        return await attempt.value
+    }
+
+    /// The awaited phase of one claimed stored-Mac reconnect attempt. The
+    /// caller has already claimed `generation` and `isReconnectingStoredMac`
+    /// synchronously, preserving serialization across concurrent entries.
+    private func runStoredMacReconnectAttempt(
+        stackUserID: String?,
+        refreshBackupBeforeDial: Bool,
+        generation: Int
+    ) async -> StoredMacReconnectOutcome {
         let restoringDeadlineSeconds = storedMacReconnectRestoringDeadlineSeconds
         // Bound the complete visible retry window, including scope resolution,
         // backup refresh, and local-store reads before dialing starts.
@@ -4653,6 +4726,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isReconnectingStoredMac = false
         pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
+        storedMacReconnectAttemptTask = nil
+        storedMacReconnectAttemptID = nil
         if let representativeID = staleRepresentativeID {
             hasKnownPairedMac = true
             // The shell action is synchronous for its UI caller; the device-local
@@ -6641,6 +6716,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         secondaryAggregationRetryState.reset()
     }
 
+    /// Background suspension of the pending retry timer. Unlike
+    /// ``cancelSecondaryAggregationRetry()`` (an account/team boundary, where
+    /// the ladder must forget the previous scope), backgrounding says nothing
+    /// about an unreachable Mac, so the grown delay survives: the next
+    /// foreground still dials once through its full aggregation pass, and a
+    /// still-failing Mac reschedules at the preserved delay instead of
+    /// restarting the 2 s ladder every foreground session.
+    func suspendSecondaryAggregationRetryForBackground() {
+        secondaryAggregationRetryEvidenceGeneration &+= 1
+        secondaryAggregationRetryTaskGeneration = UUID()
+        secondaryAggregationRetryTask?.cancel()
+        secondaryAggregationRetryTask = nil
+        secondaryAggregationRetryMacIDs = []
+        secondaryAggregationRetryNeedsFullRefresh = false
+        secondaryAggregationRetryState.suspend()
+    }
+
     private func retainSecondaryAggregationRetryEvidence<S: Sequence>(
         _ macDeviceIDs: S
     ) where S.Element == String {
@@ -6712,7 +6804,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         secondaryAggregationAfterPushedRoutesScope = nil
         secondaryAggregationAfterPushedRoutesMacIDs = []
         secondaryAggregationAfterPushedRoutesNeedsFullRefresh = false
-        cancelSecondaryAggregationRetry()
+        suspendSecondaryAggregationRetryForBackground()
 
         secondaryControlKeepaliveTaskGeneration = UUID()
         secondaryControlKeepaliveTask?.cancel()
@@ -7493,6 +7585,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
         pendingForcedStoredMacReconnect = false
+        // The invalidated attempt settles as superseded; a later automatic
+        // request must start fresh rather than share that dying attempt.
+        storedMacReconnectAttemptTask = nil
+        storedMacReconnectAttemptID = nil
     }
 
     /// Drop the PREVIOUS foreground/anonymous workspace snapshot from the aggregate

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1346,7 +1346,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var secondaryAggregationRetryMacIDs: Set<String> = []
     var secondaryAggregationRetryNeedsFullRefresh = false
     private var secondaryAggregationRetryEvidenceGeneration: UInt64 = 0
-    private var secondaryAggregationRetryState = MobileControlPoolRetryState()
+    var secondaryAggregationRetryState = MobileControlPoolRetryState()
     /// One timer owner for the whole online control pool. Each tick reasserts
     /// every lightweight subscription, avoiding one long-lived timer per Mac.
     private var secondaryControlKeepaliveTask: Task<Void, Never>?

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -305,8 +305,15 @@ import Testing
         }
         #expect(firstRouteReached)
 
+        // An automatic re-entry would join the in-flight attempt; only an
+        // explicit replacement (manual retry, connection-method change)
+        // claims a fresh generation, which is what must abort the first
+        // attempt's route iteration mid-dial.
         let second = Task { @MainActor in
-            await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")
+            await store.reconnectActiveMacIfAvailable(
+                stackUserID: "user-1",
+                replacesInFlightAttempt: true
+            )
         }
         let secondConnected = await second.value
         factory.releaseHeldConnect()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/SecondaryAggregationRetryLadderTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/SecondaryAggregationRetryLadderTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+// Regression coverage for the while-connected secondary dial churn seen in
+// field diagnostics: an unreachable secondary Mac was redialed on the fresh
+// 2 s control-pool ladder every foreground session, because backgrounding
+// fully reset the shared retry state. Backgrounding says nothing about the
+// Mac becoming reachable, so the grown delay must survive; only account/team
+// boundaries forget it.
+@MainActor
+@Suite
+struct SecondaryAggregationRetryLadderTests {
+    @Test
+    func backgroundSuspensionPreservesGrownRetryDelay() {
+        let composite = MobileShellComposite(workspaces: [])
+        _ = composite.secondaryAggregationRetryState.schedule()
+        composite.secondaryAggregationRetryState.fire()
+
+        composite.suspendSecondaryConnectionEstablishmentForBackground()
+
+        #expect(
+            composite.secondaryAggregationRetryState.schedule() == .seconds(4)
+        )
+    }
+
+    @Test
+    func accountBoundaryStillResetsRetryDelay() {
+        let composite = MobileShellComposite(workspaces: [])
+        _ = composite.secondaryAggregationRetryState.schedule()
+        composite.secondaryAggregationRetryState.fire()
+
+        composite.cancelSecondaryAggregationRetry()
+
+        #expect(
+            composite.secondaryAggregationRetryState.schedule() == .seconds(2)
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/StoredMacReconnectJoinTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/StoredMacReconnectJoinTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+// Regression coverage for the launch reconnect supersede storm seen in field
+// diagnostics: a presence-push recovery and the stored-Mac launch restore both
+// enter `reconnectActiveMacOutcome` within milliseconds, the second claim
+// cancels the first's in-flight dial, and both callers settle as
+// "Superseded by a newer attempt" instead of one of them connecting. An
+// automatic request that arrives while a stored-Mac attempt is already in
+// flight must share that attempt's outcome, not replace it.
+@MainActor
+@Suite
+struct StoredMacReconnectJoinTests {
+    private func makeComposite(
+        pairedMacStore: DelayedTeamPairedMacStore
+    ) -> MobileShellComposite {
+        MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedMacStore,
+            identityProvider: StaticIdentityProvider(userID: "account-a"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "stored-mac-join-\(UUID().uuidString)"
+            )!
+        )
+    }
+
+    @Test
+    func automaticReconnectJoinsInFlightAttemptInsteadOfSuperseding() async {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [:],
+            blockedTeams: [""]
+        )
+        let composite = makeComposite(pairedMacStore: pairedStore)
+        let initialGeneration = composite.storedMacReconnectGeneration
+
+        let first = Task { @MainActor in
+            await composite.reconnectActiveMacOutcome(stackUserID: "account-a")
+        }
+        // The first attempt is parked inside the gated store read, exactly the
+        // window where a second trigger (presence push vs launch restore)
+        // arrives in the field.
+        await pairedStore.waitUntilLoadStarted(teamID: nil)
+        let second = Task { @MainActor in
+            await composite.reconnectActiveMacOutcome(stackUserID: "account-a")
+        }
+        // Let the second entry run to its first suspension so it has either
+        // joined the in-flight attempt or (the regression) claimed a new
+        // generation that supersedes the first.
+        for _ in 0 ..< 50 { await Task.yield() }
+
+        // The second automatic request must not claim a fresh generation: a
+        // fresh claim is what cancels the in-flight dial.
+        #expect(composite.storedMacReconnectGeneration == initialGeneration + 1)
+
+        await pairedStore.release(teamID: nil)
+        // Under the regression the second attempt blocks on its own gated
+        // store read; release it too so the test settles either way.
+        for _ in 0 ..< 50 { await Task.yield() }
+        await pairedStore.release(teamID: nil)
+
+        let firstOutcome = await first.value
+        let secondOutcome = await second.value
+
+        #expect(firstOutcome == secondOutcome)
+        #expect(firstOutcome != .superseded)
+        #expect(secondOutcome != .superseded)
+    }
+
+    @Test
+    func forcedReconnectStillReplacesInFlightAttempt() async {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [:],
+            blockedTeams: [""]
+        )
+        let composite = makeComposite(pairedMacStore: pairedStore)
+        let initialGeneration = composite.storedMacReconnectGeneration
+
+        let first = Task { @MainActor in
+            await composite.reconnectActiveMacOutcome(stackUserID: "account-a")
+        }
+        await pairedStore.waitUntilLoadStarted(teamID: nil)
+        let second = Task { @MainActor in
+            await composite.reconnectActiveMacOutcome(
+                stackUserID: "account-a",
+                force: true
+            )
+        }
+        for _ in 0 ..< 50 { await Task.yield() }
+
+        // A forced entry (manual retry, connection-method change) claims its
+        // own generation so it can replace a possibly wedged attempt.
+        #expect(composite.storedMacReconnectGeneration == initialGeneration + 2)
+
+        await pairedStore.release(teamID: nil)
+        for _ in 0 ..< 50 { await Task.yield() }
+        await pairedStore.release(teamID: nil)
+
+        let firstOutcome = await first.value
+        _ = await second.value
+
+        #expect(firstOutcome == .superseded)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
@@ -86,6 +86,7 @@ public struct MacSurfaceGalleryPreviewView: View {
                         createTerminal: {},
                         openBrowser: {},
                         selectBrowserStream: { _ in },
+                        selectSimulatorStream: { _ in },
                         openTextSheet: {},
                         copyDebugLogs: {},
                         sendFeedback: {}

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -183,7 +183,8 @@ extension MobileHostIrohRuntime {
                     accountID: accountID,
                     trustRoot: relayPolicyTrustRoot,
                     relayCredential: cachedRelay,
-                    now: Date()
+                    now: Date(),
+                    staleGrace: Self.relayPolicyOutageStaleGrace
                 )
                 relayPolicyNeedsImmediateRefresh = true
             } else {
@@ -210,7 +211,8 @@ extension MobileHostIrohRuntime {
                         accountID: accountID,
                         trustRoot: relayPolicyTrustRoot,
                         relayCredential: cachedRelay,
-                        now: Date()
+                        now: Date(),
+                        staleGrace: Self.relayPolicyOutageStaleGrace
                     )
                     relayPolicyNeedsImmediateRefresh = true
                 }

--- a/Sources/Mobile/MobileHostIrohRuntime+SettingsControl.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+SettingsControl.swift
@@ -335,7 +335,8 @@ extension MobileHostIrohRuntime: CmxIrohSettingsControlling {
                     let expired = await service.restore(
                         accountID: accountID,
                         trustRoot: trustRoot,
-                        now: wakeDate
+                        now: wakeDate,
+                        staleGrace: Self.relayPolicyOutageStaleGrace
                     )
                     try? await self.applyRelayPolicy(expired)
                     relayAuthorityExpired = true
@@ -371,7 +372,8 @@ extension MobileHostIrohRuntime: CmxIrohSettingsControlling {
                         let expired = await service.restore(
                             accountID: accountID,
                             trustRoot: trustRoot,
-                            now: failureDate
+                            now: failureDate,
+                            staleGrace: Self.relayPolicyOutageStaleGrace
                         )
                         try? await self.applyRelayPolicy(expired)
                         relayAuthorityExpired = true
@@ -412,6 +414,16 @@ extension MobileHostIrohRuntime: CmxIrohSettingsControlling {
         }
         return now.addingTimeInterval(30)
     }
+
+    /// Bounded staleness for the verified relay policy while the policy
+    /// endpoint is unreachable, mirroring the iOS composition's grace
+    /// (https://github.com/manaflow-ai/cmux/issues/10375). Without it the
+    /// host drops off the relay when its policy lapses during an endpoint
+    /// outage, and every phone dialing this Mac via relay times out even
+    /// though both devices are online. Any successful refresh replaces the
+    /// graced policy immediately; the relay credential's own expiry remains
+    /// the hard authorization floor.
+    nonisolated static let relayPolicyOutageStaleGrace: TimeInterval = 24 * 60 * 60
 
     nonisolated static func shouldDeactivateRelayPolicy(
         policyExpiresAt: Date?,

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1833,7 +1833,8 @@ public final class MobileIrohRuntimeComposition:
                     accountID: accountID,
                     trustRoot: relayPolicyTrustRoot,
                     relayCredential: cachedRelay,
-                    now: now()
+                    now: now(),
+                    staleGrace: Self.relayPolicyOutageStaleGrace
                 )
                 relayPolicyNeedsImmediateRefresh = true
             } else {
@@ -1857,7 +1858,8 @@ public final class MobileIrohRuntimeComposition:
                         accountID: accountID,
                         trustRoot: relayPolicyTrustRoot,
                         relayCredential: cachedRelay,
-                        now: now()
+                        now: now(),
+                        staleGrace: Self.relayPolicyOutageStaleGrace
                     )
                     relayPolicyNeedsImmediateRefresh = true
                 }
@@ -2849,7 +2851,8 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                     let expired = await service.restore(
                         accountID: accountID,
                         trustRoot: trustRoot,
-                        now: wakeDate
+                        now: wakeDate,
+                        staleGrace: Self.relayPolicyOutageStaleGrace
                     )
                     try? await self.applyRelayPolicy(expired)
                     relayAuthorityExpired = true
@@ -2885,7 +2888,8 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                         let expired = await service.restore(
                             accountID: accountID,
                             trustRoot: trustRoot,
-                            now: failureDate
+                            now: failureDate,
+                            staleGrace: Self.relayPolicyOutageStaleGrace
                         )
                         try? await self.applyRelayPolicy(expired)
                         relayAuthorityExpired = true
@@ -2910,6 +2914,16 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
             }
         }
     }
+
+    /// Bounded staleness for the verified relay policy while the policy
+    /// endpoint is unreachable (field incident: a 2.5-minute endpoint outage
+    /// emptied every dial plan and stranded the phone on "Reconnecting" for
+    /// 151s, https://github.com/manaflow-ai/cmux/issues/10375). The signed
+    /// policy's relay list stays authoritative for dial-plan membership up to
+    /// this long past its expiry; the relay's own credential expiry remains
+    /// the hard authorization floor, and any successful refresh replaces the
+    /// graced policy immediately.
+    nonisolated static let relayPolicyOutageStaleGrace: TimeInterval = 24 * 60 * 60
 
     /// The signed policy bootstrap includes a fresh relay credential. Tests
     /// that suspend automatic credential renewal must therefore suspend this

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -234,6 +234,11 @@ public final class MobileIrohRuntimeComposition:
     private var relayPolicyEndpointID: CmxIrohPeerIdentity?
     private var relayPolicyObservationTask: Task<Void, Never>?
     private var relayPolicyRefreshTask: Task<Void, Never>?
+    /// When the last relay-policy refresh ATTEMPT started, from any lane
+    /// (activation, settings, refresh loop). The broker allows one request
+    /// per endpoint per phase per minute; duplicate attempts inside one
+    /// bucket are refused and only burn the budget.
+    private var relayPolicyLastRefreshAttemptAt: Date?
     private var selectedPathObservationTask: Task<Void, Never>?
     private var irohSettingsContinuations: [UUID: AsyncStream<CmxIrohSettingsSnapshot>.Continuation] = [:]
     private var observedAuthState: MobileIrohAuthState?
@@ -919,6 +924,7 @@ public final class MobileIrohRuntimeComposition:
         let runtime = runtime
         let lanPeerDiscovery = lanPeerDiscovery
         let diagnosticLog = diagnosticLog
+        let revalidationStartedAt = now()
         sceneTransitionTask = Task { [weak self] in
             if let auth {
                 diagnosticLog?.recordAppEvent(.authRevalidationStarted)
@@ -948,7 +954,9 @@ public final class MobileIrohRuntimeComposition:
             // assembles an empty plan while the loop naps on its retry
             // schedule. Revalidation just minted fresh authority, so a failed
             // or expired policy retries immediately instead.
-            await self?.retryRelayPolicyRefreshAfterAuthRevalidation()
+            await self?.retryRelayPolicyRefreshAfterAuthRevalidation(
+                revalidationStartedAt: revalidationStartedAt
+            )
             guard !Task.isCancelled else { return }
             do {
                 try await runtime?.didBecomeActive()
@@ -965,10 +973,21 @@ public final class MobileIrohRuntimeComposition:
     /// the last resolution failed or the signed policy has expired. Called
     /// after a successful foreground session revalidation, the exact moment
     /// fresh authority exists for the refresh the wake attempt lost racing it.
-    func retryRelayPolicyRefreshAfterAuthRevalidation() async {
+    func retryRelayPolicyRefreshAfterAuthRevalidation(
+        revalidationStartedAt: Date
+    ) async {
         guard let relayPolicyService,
               let relayPolicyEndpointID,
               let activeAccountID else { return }
+        // The broker budgets one refresh per endpoint per phase per minute.
+        // An attempt that already ran on or after this revalidation used the
+        // fresh session, so retrying it immediately is a duplicate that only
+        // burns the bucket (and, on a shared home IP, the Mac's budget too).
+        // Only an attempt that predates the revalidation lost the token race.
+        if let lastAttemptAt = relayPolicyLastRefreshAttemptAt,
+           lastAttemptAt >= revalidationStartedAt {
+            return
+        }
         let snapshot = await relayPolicyService.diagnosticsSnapshot()
         guard Self.shouldRetryRelayPolicyRefreshAfterRevalidation(
             lastFailure: snapshot.failure,
@@ -1838,6 +1857,7 @@ public final class MobileIrohRuntimeComposition:
                 )
                 relayPolicyNeedsImmediateRefresh = true
             } else {
+                relayPolicyLastRefreshAttemptAt = now()
                 diagnosticLog?.record(DiagnosticEvent(.relayPolicyRefreshStarted))
                 do {
                     let outcome = try await service.refreshWithCredential(
@@ -2696,6 +2716,7 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
             publishIrohSettingsUpdate()
             return
         }
+        relayPolicyLastRefreshAttemptAt = now()
         diagnosticLog?.record(DiagnosticEvent(.relayPolicyRefreshStarted))
         do {
             let effective = try await context.service.refresh(
@@ -2862,6 +2883,7 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                       revision == self.lifecycleRevision,
                       self.activeAccountID == accountID,
                       self.relayPolicyService === service else { return }
+                self.relayPolicyLastRefreshAttemptAt = self.now()
                 self.diagnosticLog?.record(DiagnosticEvent(.relayPolicyRefreshStarted))
                 do {
                     let effective = try await service.refresh(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -919,7 +919,7 @@ public final class MobileIrohRuntimeComposition:
         let runtime = runtime
         let lanPeerDiscovery = lanPeerDiscovery
         let diagnosticLog = diagnosticLog
-        sceneTransitionTask = Task {
+        sceneTransitionTask = Task { [weak self] in
             if let auth {
                 diagnosticLog?.recordAppEvent(.authRevalidationStarted)
                 await auth.revalidateSession()
@@ -941,6 +941,15 @@ public final class MobileIrohRuntimeComposition:
             }
             await lanPeerDiscovery?.permissionMayHaveChanged()
             guard !Task.isCancelled else { return }
+            // The relay-policy refresh loop's timer expires while iOS keeps
+            // the process suspended, so its wake attempt races the session
+            // revalidation above and can fail on stale authority; past policy
+            // expiry that failure deactivates relay authority and every dial
+            // assembles an empty plan while the loop naps on its retry
+            // schedule. Revalidation just minted fresh authority, so a failed
+            // or expired policy retries immediately instead.
+            await self?.retryRelayPolicyRefreshAfterAuthRevalidation()
+            guard !Task.isCancelled else { return }
             do {
                 try await runtime?.didBecomeActive()
             } catch {
@@ -950,6 +959,43 @@ public final class MobileIrohRuntimeComposition:
             }
         }
         return true
+    }
+
+    /// Re-arms the relay-policy refresh loop for one immediate attempt when
+    /// the last resolution failed or the signed policy has expired. Called
+    /// after a successful foreground session revalidation, the exact moment
+    /// fresh authority exists for the refresh the wake attempt lost racing it.
+    func retryRelayPolicyRefreshAfterAuthRevalidation() async {
+        guard let relayPolicyService,
+              let relayPolicyEndpointID,
+              let activeAccountID else { return }
+        let snapshot = await relayPolicyService.diagnosticsSnapshot()
+        guard Self.shouldRetryRelayPolicyRefreshAfterRevalidation(
+            lastFailure: snapshot.failure,
+            policyExpiresAt: snapshot.policyExpiresAt,
+            now: now()
+        ) else { return }
+        scheduleRelayPolicyRefresh(
+            service: relayPolicyService,
+            accountID: activeAccountID,
+            endpointID: relayPolicyEndpointID,
+            trustRoot: relayPolicyTrustRoot,
+            revision: lifecycleRevision,
+            refreshImmediately: true
+        )
+    }
+
+    /// A healthy, unexpired policy never retriggers on foreground: the loop's
+    /// own expiry-driven schedule owns that case. Only a recorded resolution
+    /// failure or an already-expired policy justifies an immediate retry.
+    nonisolated static func shouldRetryRelayPolicyRefreshAfterRevalidation(
+        lastFailure: CmxIrohRelayPolicyFailure?,
+        policyExpiresAt: Date?,
+        now: Date
+    ) -> Bool {
+        if lastFailure != nil { return true }
+        guard let policyExpiresAt else { return false }
+        return now >= policyExpiresAt
     }
 
     /// Synchronously fences lifecycle work and starts local sign-out cleanup.

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -558,6 +558,48 @@ struct MobileIrohRuntimeCompositionTests {
         ))
     }
 
+    /// Regression for the wake-time zero-route window
+    /// (https://github.com/manaflow-ai/cmux/issues/10375): the refresh loop's
+    /// timer expires during process suspension, its wake attempt races session
+    /// revalidation and fails on stale authority, and dials assemble empty
+    /// plans until the loop's next scheduled retry. Once revalidation succeeds
+    /// a failed or expired policy must retry immediately; a healthy unexpired
+    /// policy must not (the loop's expiry schedule owns that case).
+    @Test
+    func failedOrExpiredRelayPolicyRetriesAfterAuthRevalidation() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(MobileIrohRuntimeComposition
+            .shouldRetryRelayPolicyRefreshAfterRevalidation(
+                lastFailure: .policyUnavailable,
+                policyExpiresAt: now.addingTimeInterval(600),
+                now: now
+            ))
+        #expect(MobileIrohRuntimeComposition
+            .shouldRetryRelayPolicyRefreshAfterRevalidation(
+                lastFailure: nil,
+                policyExpiresAt: now.addingTimeInterval(-1),
+                now: now
+            ))
+        #expect(MobileIrohRuntimeComposition
+            .shouldRetryRelayPolicyRefreshAfterRevalidation(
+                lastFailure: nil,
+                policyExpiresAt: now,
+                now: now
+            ))
+        #expect(!MobileIrohRuntimeComposition
+            .shouldRetryRelayPolicyRefreshAfterRevalidation(
+                lastFailure: nil,
+                policyExpiresAt: now.addingTimeInterval(600),
+                now: now
+            ))
+        #expect(!MobileIrohRuntimeComposition
+            .shouldRetryRelayPolicyRefreshAfterRevalidation(
+                lastFailure: nil,
+                policyExpiresAt: nil,
+                now: now
+            ))
+    }
+
     @Test
     func disablingAutomaticRelayCredentialRefreshAlsoDisablesPolicyBootstrapRefresh() {
         #expect(MobileIrohRuntimeComposition.shouldScheduleRelayPolicyRefresh(


### PR DESCRIPTION
Field diagnostics from a dogfood iPhone (cmux-network.log / cmux-app.log, 2026-08-13 through 2026-08-18) quantify the constant reconnect/disconnect flapping and failed launch connections: median launch-to-first-RPC-ready was 12.7s (p90 105s), 11 of 40 launches never became ready within 10 minutes, 35 of 57 reconnect failures settled as "Superseded by a newer attempt", and 207 of 286 "Iroh endpoint unavailable" dial failures happened while the foreground session was healthy. The UI connection state flipped connected/disconnected 47 times inside 30-second windows.

Two mechanisms, two fixes.

**Reconnect supersede storm.** Presence-push recovery, foreground recovery, event-stream-end recovery, and the stored-Mac launch restore all funnel into `reconnectActiveMacOutcome`, and every entry claimed a fresh generation that cancelled the in-flight dial; concurrent triggers at launch cancelled each other for minutes (visible in the log as dial started → cancelled → superseded chains). The attempt now runs in one shared task: automatic requests await the in-flight attempt's outcome, while explicit user intent (manual retry, connection-method change, forced entries) still claims a fresh generation and replaces it, and sign-out/team-change invalidation clears the shared attempt.

**Secondary dial churn.** A paired Mac that is presence-online but Iroh-unreachable (stale broker routes) was redialed by multi-Mac aggregation on the 2s control-pool ladder, and backgrounding fully reset that ladder, so every foreground session restarted the churn (dial failures every 2-60s, forever, in the diagnostics screen). Backgrounding now suspends the retry timer but keeps the grown delay; account/team boundaries still reset it.

Commit 1 adds the regression tests only (red on main); commit 2 adds the fix (green). `swift test` on CmuxMobileShell recovery suites: 234 tests, all passing except `responseTimeoutLeavesTheLiveIrohClientAlone` and `sameMacRedialWaitsForLeaseHandoffButNotPhysicalClose`, which flake identically on pristine origin/main (verified 5-run baselines in a clean worktree) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789670720&installation_model_id=21920&pr_number=10354&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10354&signature=5f60437639ce347bb1f1be33b8e86be244781d6205093c870b8c12b570b4a206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents iOS reconnect supersede storms and secondary dial churn, preserves relay routes through policy-endpoint outages, and avoids duplicate wake refreshes that burn the relay-token rate limit.

- Stored‑Mac reconnect join in `CmuxMobileShell`: one shared task owns the dial; automatic triggers await it. Manual retry and connection‑method changes still replace it; sign‑out/team‑change invalidates it.
- API update (internal): `reconnectActiveMacOutcome`/`reconnectActiveMacIfAvailable` accept `replacesInFlightAttempt`. Call sites must pass it for manual retry or connection‑method change.
- Secondary retry ladder: backgrounding suspends the timer but keeps the grown delay; account/team boundaries still reset it.
- Relay policy recovery and outage grace:
  - After foreground auth revalidation, a failed or expired policy retries immediately.
  - `MobileIrohRuntimeComposition` now stamps the last refresh attempt; the revalidation retrigger fires only if no attempt ran since revalidation began, preventing duplicate refreshes in the broker’s 60s bucket.
  - When the policy endpoint is unreachable and the cached policy just expired, `CmxIrohRelayPolicyCache.load`/`CmxIrohRelayPolicyService.restore` honor a bounded `staleGrace`; `MobileIrohRuntimeComposition` and `MobileHostIrohRuntime` both use 24h. Relay credentials keep independent expiry.
- Tests: add `StoredMacReconnectJoinTests`, `SecondaryAggregationRetryLadderTests`, `CmxIrohRelayPolicyStaleGraceTests`, and foreground revalidation retry gating in `MobileIrohRuntimeCompositionTests`; relax `secondaryAggregationRetryState` visibility for a test seam.
- UI build fix: pass `selectSimulatorStream` in `CmuxMobileShellUI`’s `MacSurfaceGalleryPreviewView` preview actions; no runtime behavior change.

<sup>Written for commit c72bcec7fd7959378cf114431555a43dbf1fcf1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic reconnection by coordinating concurrent attempts and preventing redundant connection work.
  * Explicit retries and connection changes can now supersede active reconnect attempts.
  * Preserved retry backoff after background suspension, while account-level cancellation resets it appropriately.
  * Relay-policy refresh now retries promptly after authentication when the previous policy failed or expired.
  * Allowed recently expired relay policies to remain available for up to 24 hours during outages.

* **Tests**
  * Added coverage for reconnect coordination, retry behavior, and relay-policy refresh and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->