### PR TITLE
GitHub PR poller User-Agent includes app version

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -16,6 +16,27 @@ public actor GitHubPullRequestRequestCoordinator {
     private static let maximumConcurrentTransportCount = 3
     private static let maximumRateLimitIdentityCount = 32
 
+    /// Product token identifying cmux's pull-request poller in GitHub requests.
+    private static let userAgentProductToken = "cmux-workspace-pr-poller"
+
+    /// User-Agent sent with every pull-request probe, formatted as Product/Version.
+    private static let userAgentHeaderValue = userAgentValue(
+        appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    )
+
+    /// Builds the pull-request poller's versioned User-Agent value.
+    ///
+    /// The product token remains the leading component so server-side matching
+    /// continues to work. Missing or blank versions use `unknown` to preserve
+    /// the conventional Product/Version shape.
+    static func userAgentValue(appVersion: String?) -> String {
+        let version = appVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let version, !version.isEmpty else {
+            return "\(userAgentProductToken)/unknown"
+        }
+        return "\(userAgentProductToken)/\(version)"
+    }
+
     internal struct RequestKey: Hashable, Sendable {
         let endpoint: String
         let authorizationFingerprint: Data
@@ -173,7 +194,7 @@ public actor GitHubPullRequestRequestCoordinator {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+        request.setValue(Self.userAgentHeaderValue, forHTTPHeaderField: "User-Agent")
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         let cachedResponse = cachedResponseByRequestKey[requestKey]
         if let cachedResponse {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -53,6 +53,31 @@ struct GitHubPullRequestRequestTests {
         )
     }
 
+    @Test func userAgentValueAppendsApplicationVersion() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "1.2.3")
+                == "cmux-workspace-pr-poller/1.2.3"
+        )
+    }
+
+    @Test func userAgentValueTrimsSurroundingWhitespace() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "  1.2.3  ")
+                == "cmux-workspace-pr-poller/1.2.3"
+        )
+    }
+
+    @Test func userAgentValueFallsBackWhenApplicationVersionIsUnavailable() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: nil)
+                == "cmux-workspace-pr-poller/unknown"
+        )
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "  ")
+                == "cmux-workspace-pr-poller/unknown"
+        )
+    }
+
     @Test func cachedETagRevalidatesAndReusesBodyAfterNotModified() async throws {
         let body = Data("[{\"number\":8175}]".utf8)
         GitHubPullRequestStubURLProtocol.reset(stubs: [

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -29,6 +29,30 @@ struct GitHubPullRequestRequestTests {
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().isEmpty)
     }
 
+    @Test func userAgentIdentifiesApplicationVersion() async throws {
+        let expectedVersion = (Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+            ?? "unknown"
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+
+        let request = try #require(GitHubPullRequestStubURLProtocol.capturedRequests().first)
+        #expect(
+            request.value(forHTTPHeaderField: "User-Agent")
+                == "cmux-workspace-pr-poller/\(expectedVersion)"
+        )
+    }
+
     @Test func cachedETagRevalidatesAndReusesBodyAfterNotModified() async throws {
         let body = Data("[{\"number\":8175}]".utf8)
         GitHubPullRequestStubURLProtocol.reset(stubs: [


### PR DESCRIPTION
Closes #10044

## Summary
- Root cause: the GitHub pull-request coordinator sent the fixed `cmux-workspace-pr-poller` User-Agent, so requests from different cmux releases were indistinguishable.
- Fix: build `cmux-workspace-pr-poller/<CFBundleShortVersionString>` once from the host bundle, trim surrounding whitespace, and use `unknown` when the version is missing or blank.
- The existing product token remains the prefix, and ETag/rate-limit request behavior is unchanged.

## Verification
- `swift test --package-path Packages/macOS/CmuxGit --filter GitHubPullRequestRequestTests` — 18 tests passed.
- Behavior coverage captures the outgoing `URLRequest` and asserts the complete User-Agent; pure formatter tests cover valid, trimmed, missing, and blank versions.
- PR check rollup is green; CodeRabbit reports no actionable comments.
- A manually dispatched full `cmux-unit` lane reached its existing 20-minute workflow cap while still in the unit-test step, with no compile or test failure emitted: https://github.com/manaflow-ai/cmux/actions/runs/32185269970

The first commit adds the regression test before the implementation so the PR history preserves the red/green ordering.