### PR TITLE
Fix terminal file drops being ghosted after pane teardown

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+ImageMaterialization.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+ImageMaterialization.swift
@@ -1,6 +1,5 @@
 public import AppKit
 public import CmuxTerminalCore
-internal import UniformTypeIdentifiers
 #if DEBUG
 internal import CMUXDebugLog
 #endif
@@ -91,55 +90,6 @@ extension TerminalPasteboardService: TerminalImagePasteWriting {
         }
         registerOwnedTemporaryImageFile(fileURL)
         return fileURL.path.terminalShellEscaped
-    }
-
-    /// Copies a source-owned temporary image into this service's owned storage.
-    ///
-    /// File URLs supplied by image drag providers can outlive the drag only
-    /// briefly. Callers that need to hand the path to a terminal or agent use
-    /// this method to establish process-owned lifetime before inserting it.
-    /// Existing files already owned by this service are returned unchanged.
-    ///
-    /// - Parameter sourceURL: A local regular image file to retain.
-    /// - Returns: An owned copy, or `nil` when the source is unavailable,
-    ///   invalid, or exceeds the clipboard image-size limit.
-    public func copyTemporaryImageFile(_ sourceURL: URL) -> URL? {
-        let source = sourceURL.standardizedFileURL
-        guard source.isFileURL else { return nil }
-        if isOwnedTemporaryImageFile(source) {
-            return source
-        }
-
-        guard let values = try? source.resourceValues(
-            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
-        ),
-        values.isRegularFile == true,
-        values.isSymbolicLink != true,
-        let fileSize = values.fileSize,
-        fileSize > 0,
-        fileSize <= Self.maxClipboardImageSize,
-        let type = UTType(filenameExtension: source.pathExtension),
-        type.conforms(to: .image) else {
-            return nil
-        }
-
-        let destination = temporaryImageFileURL(
-            fileExtension: sanitizedImageFileExtension(
-                type.preferredFilenameExtension ?? source.pathExtension
-            )
-        ).standardizedFileURL
-        do {
-            try fileManager.copyItem(at: source, to: destination)
-            try fileManager.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: destination.path
-            )
-        } catch {
-            try? fileManager.removeItem(at: destination)
-            return nil
-        }
-        registerOwnedTemporaryImageFile(destination)
-        return destination
     }
 }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+ImageMaterialization.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+ImageMaterialization.swift
@@ -92,6 +92,55 @@ extension TerminalPasteboardService: TerminalImagePasteWriting {
         registerOwnedTemporaryImageFile(fileURL)
         return fileURL.path.terminalShellEscaped
     }
+
+    /// Copies a source-owned temporary image into this service's owned storage.
+    ///
+    /// File URLs supplied by image drag providers can outlive the drag only
+    /// briefly. Callers that need to hand the path to a terminal or agent use
+    /// this method to establish process-owned lifetime before inserting it.
+    /// Existing files already owned by this service are returned unchanged.
+    ///
+    /// - Parameter sourceURL: A local regular image file to retain.
+    /// - Returns: An owned copy, or `nil` when the source is unavailable,
+    ///   invalid, or exceeds the clipboard image-size limit.
+    public func copyTemporaryImageFile(_ sourceURL: URL) -> URL? {
+        let source = sourceURL.standardizedFileURL
+        guard source.isFileURL else { return nil }
+        if isOwnedTemporaryImageFile(source) {
+            return source
+        }
+
+        guard let values = try? source.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+        ),
+        values.isRegularFile == true,
+        values.isSymbolicLink != true,
+        let fileSize = values.fileSize,
+        fileSize > 0,
+        fileSize <= Self.maxClipboardImageSize,
+        let type = UTType(filenameExtension: source.pathExtension),
+        type.conforms(to: .image) else {
+            return nil
+        }
+
+        let destination = temporaryImageFileURL(
+            fileExtension: sanitizedImageFileExtension(
+                type.preferredFilenameExtension ?? source.pathExtension
+            )
+        ).standardizedFileURL
+        do {
+            try fileManager.copyItem(at: source, to: destination)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: destination.path
+            )
+        } catch {
+            try? fileManager.removeItem(at: destination)
+            return nil
+        }
+        registerOwnedTemporaryImageFile(destination)
+        return destination
+    }
 }
 
 extension TerminalPasteboardService {

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+TransientImageFiles.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService+TransientImageFiles.swift
@@ -1,0 +1,183 @@
+public import Foundation
+internal import Darwin
+internal import UniformTypeIdentifiers
+
+extension TerminalPasteboardService {
+    private enum TransientImageCopyError: Error {
+        case emptySource
+        case exceedsSizeLimit
+    }
+
+    private static let transientImageCopyChunkSize = 64 * 1024
+
+    /// Rehomes temporary image URLs before a terminal receives their path.
+    ///
+    /// Returns `nil` when a qualifying transient image cannot be copied. A
+    /// failed copy rejects the complete transfer so a multi-file drop cannot
+    /// silently omit one of the user's selected files.
+    ///
+    /// - Parameters:
+    ///   - fileURLs: URLs read from a pasteboard or drag provider.
+    ///   - sourceIsTransient: Whether the provider promised temporary files.
+    /// - Returns: The original URLs plus owned copies, or `nil` on failure.
+    public func durableDroppedFileURLs(
+        _ fileURLs: [URL],
+        sourceIsTransient: Bool = false
+    ) -> [URL]? {
+        var durableURLs: [URL] = []
+        durableURLs.reserveCapacity(fileURLs.count)
+        var newlyOwnedURLs: [URL] = []
+
+        for fileURL in fileURLs {
+            guard isTransientImageFileURL(
+                fileURL,
+                sourceIsTransient: sourceIsTransient
+            ) else {
+                durableURLs.append(fileURL)
+                continue
+            }
+
+            let wasAlreadyOwned = isOwnedTemporaryImageFile(fileURL)
+            guard let durableURL = copyTemporaryImageFile(fileURL) else {
+                cleanupTransferredTemporaryImageFiles(newlyOwnedURLs)
+                return nil
+            }
+            durableURLs.append(durableURL)
+            if !wasAlreadyOwned {
+                newlyOwnedURLs.append(durableURL)
+            }
+        }
+
+        return durableURLs
+    }
+
+    /// Copies a source-owned temporary image into this service's owned storage.
+    ///
+    /// The source is opened once with symlink-following disabled, validated via
+    /// its opened descriptor, and copied through a bounded read loop. This
+    /// keeps a drag provider from replacing or growing the path after a
+    /// path-based metadata check.
+    ///
+    /// - Parameter sourceURL: A local regular image file to retain.
+    /// - Returns: An owned copy, or `nil` when the source is unavailable,
+    ///   invalid, or exceeds the clipboard image-size limit.
+    public func copyTemporaryImageFile(_ sourceURL: URL) -> URL? {
+        let source = sourceURL.standardizedFileURL
+        guard source.isFileURL,
+              let type = UTType(filenameExtension: source.pathExtension),
+              type.conforms(to: .image),
+              isValidTemporaryDirectory else {
+            return nil
+        }
+        if isOwnedTemporaryImageFile(source) {
+            return fileManager.fileExists(atPath: source.path) ? source : nil
+        }
+
+        let sourceDescriptor = Darwin.open(
+            source.path,
+            O_RDONLY | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard sourceDescriptor >= 0 else { return nil }
+        let sourceHandle = FileHandle(
+            fileDescriptor: sourceDescriptor,
+            closeOnDealloc: true
+        )
+        defer { try? sourceHandle.close() }
+
+        var metadata = Darwin.stat()
+        guard Darwin.fstat(sourceDescriptor, &metadata) == 0,
+              metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+              metadata.st_size > 0,
+              metadata.st_size <= off_t(Self.maxClipboardImageSize) else {
+            return nil
+        }
+
+        let destination = temporaryImageFileURL(
+            fileExtension: sanitizedImageFileExtension(
+                type.preferredFilenameExtension ?? source.pathExtension
+            )
+        ).standardizedFileURL
+        let destinationDescriptor = Darwin.open(
+            destination.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+            mode_t(0o600)
+        )
+        guard destinationDescriptor >= 0 else { return nil }
+        let destinationHandle = FileHandle(
+            fileDescriptor: destinationDescriptor,
+            closeOnDealloc: true
+        )
+        defer { try? destinationHandle.close() }
+
+        do {
+            var copiedByteCount = 0
+            while let chunk = try sourceHandle.read(
+                upToCount: Self.transientImageCopyChunkSize
+            ), !chunk.isEmpty {
+                copiedByteCount += chunk.count
+                guard copiedByteCount <= Self.maxClipboardImageSize else {
+                    throw TransientImageCopyError.exceedsSizeLimit
+                }
+                try destinationHandle.write(contentsOf: chunk)
+            }
+            guard copiedByteCount > 0 else {
+                throw TransientImageCopyError.emptySource
+            }
+            try destinationHandle.close()
+        } catch {
+            try? destinationHandle.close()
+            try? fileManager.removeItem(at: destination)
+            return nil
+        }
+
+        registerOwnedTemporaryImageFile(destination)
+        return destination
+    }
+
+    private var isValidTemporaryDirectory: Bool {
+        guard let values = try? temporaryDirectory.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        ) else {
+            return false
+        }
+        return values.isDirectory == true && values.isSymbolicLink != true
+    }
+
+    private func isTransientImageFileURL(
+        _ fileURL: URL,
+        sourceIsTransient: Bool
+    ) -> Bool {
+        let normalizedURL = fileURL.standardizedFileURL
+        guard normalizedURL.isFileURL,
+              let type = UTType(filenameExtension: normalizedURL.pathExtension),
+              type.conforms(to: .image) else {
+            return false
+        }
+
+        let path = Self.normalizedTemporaryAlias(normalizedURL.path)
+        let temporaryRoots = [
+            temporaryDirectory.standardizedFileURL.path,
+            fileManager.temporaryDirectory.standardizedFileURL.path,
+            "/tmp",
+            "/private/tmp",
+        ].map(Self.normalizedTemporaryAlias)
+        guard temporaryRoots.contains(where: { root in
+            path == root || path.hasPrefix(root + "/")
+        }) else {
+            return false
+        }
+
+        let filename = normalizedURL.lastPathComponent.lowercased()
+        return sourceIsTransient || filename.hasPrefix("cmux-drop-")
+    }
+
+    private static func normalizedTemporaryAlias(_ path: String) -> String {
+        if path == "/tmp" || path.hasPrefix("/tmp/") {
+            return "/private" + path
+        }
+        if path == "/var" || path.hasPrefix("/var/") {
+            return "/private" + path
+        }
+        return path
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService.swift
@@ -69,7 +69,7 @@ public final class TerminalPasteboardService: Sendable {
     nonisolated(unsafe) let fileManager: FileManager
 
     /// The directory that owned temporary image files are written into.
-    let temporaryDirectory: URL
+    public let temporaryDirectory: URL
 
     private let temporaryImageOwnershipLock = NSLock()
     // SAFETY: guarded by `temporaryImageOwnershipLock`; mutated from

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/TerminalPasteboardService.swift
@@ -69,7 +69,7 @@ public final class TerminalPasteboardService: Sendable {
     nonisolated(unsafe) let fileManager: FileManager
 
     /// The directory that owned temporary image files are written into.
-    public let temporaryDirectory: URL
+    let temporaryDirectory: URL
 
     private let temporaryImageOwnershipLock = NSLock()
     // SAFETY: guarded by `temporaryImageOwnershipLock`; mutated from

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7856,9 +7856,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
+        let dragTypes = NSPasteboard(name: .drag).types ?? []
         let durableURLs = TerminalImageTransferPlanner.durableDroppedFileURLs(
             urls,
-            pasteboardService: GhosttyApp.terminalPasteboard
+            pasteboardService: GhosttyApp.terminalPasteboard,
+            sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
+                dragTypes
+            )
         )
         executePreparedImageTransfer(
             .fileURLs(durableURLs),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7856,8 +7856,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
+        let durableURLs = TerminalImageTransferPlanner.durableDroppedFileURLs(
+            urls,
+            pasteboardService: GhosttyApp.terminalPasteboard
+        )
         executePreparedImageTransfer(
-            .fileURLs(urls),
+            .fileURLs(durableURLs),
             onCancel: {}
         )
     }
@@ -9936,6 +9940,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func paneDropTargetForDrop(at localPoint: NSPoint) -> TerminalPaneDropTargetView? {
+        guard paneDropTargetView.dropContext != nil else { return nil }
         guard bounds.contains(localPoint) else { return nil }
         let pointInTarget = paneDropTargetView.convert(localPoint, from: self)
         guard paneDropTargetView.bounds.contains(pointInTarget) else { return nil }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7856,7 +7856,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
-        let dragTypes = NSPasteboard(name: .drag).types ?? []
+        let dragTypes = NSPasteboard(name: .drag).types
         let durableURLs = TerminalImageTransferPlanner.durableDroppedFileURLs(
             urls,
             pasteboardService: GhosttyApp.terminalPasteboard,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7856,7 +7856,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
-        let dragTypes = NSPasteboard(name: .drag).types
+        let dragTypes = NSPasteboard(name: .drag).types ?? []
         guard let durableURLs = GhosttyApp.terminalPasteboard.durableDroppedFileURLs(
             urls,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7865,7 +7865,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) else {
             return false
         }
-        executePreparedImageTransfer(
+        return executePreparedImageTransfer(
             .fileURLs(durableURLs),
             onCancel: {}
         )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7857,13 +7857,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
         let dragTypes = NSPasteboard(name: .drag).types
-        let durableURLs = TerminalImageTransferPlanner.durableDroppedFileURLs(
+        guard let durableURLs = GhosttyApp.terminalPasteboard.durableDroppedFileURLs(
             urls,
-            pasteboardService: GhosttyApp.terminalPasteboard,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
                 dragTypes
             )
-        )
+        ) else {
+            return false
+        }
         executePreparedImageTransfer(
             .fileURLs(durableURLs),
             onCancel: {}

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -34,13 +34,23 @@ enum TerminalImageTransferPreparedContent: Codable, Equatable, Sendable {
 
 enum PasteboardFileURLReader {
     static let legacyFilenamesPboardType = NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")
+    static let promisedFileURLPasteboardType = NSPasteboard.PasteboardType(
+        rawValue: "com.apple.pasteboard.promised-file-url"
+    )
     static let fileURLPasteboardTypes: Set<NSPasteboard.PasteboardType> = [
         .fileURL,
-        legacyFilenamesPboardType
+        legacyFilenamesPboardType,
+        promisedFileURLPasteboardType,
     ]
 
     static func hasFileURLType(_ pasteboardTypes: [NSPasteboard.PasteboardType]) -> Bool {
         return pasteboardTypes.contains { fileURLPasteboardTypes.contains($0) }
+    }
+
+    static func hasPromisedFileURLType(
+        _ pasteboardTypes: [NSPasteboard.PasteboardType]
+    ) -> Bool {
+        pasteboardTypes.contains(promisedFileURLPasteboardType)
     }
 
     static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
@@ -67,6 +77,14 @@ enum PasteboardFileURLReader {
         if let rawFileURL = pasteboard.string(forType: .fileURL),
            let url = URL(string: rawFileURL),
            url.isFileURL {
+            fileURLs.append(url.standardizedFileURL)
+        }
+
+        if let rawPromisedFileURL = pasteboard.string(
+            forType: promisedFileURLPasteboardType
+        ),
+        let url = URL(string: rawPromisedFileURL),
+        url.isFileURL {
             fileURLs.append(url.standardizedFileURL)
         }
 
@@ -415,7 +433,10 @@ enum TerminalImageTransferPlanner {
     ) -> TerminalImageTransferPreparedContent {
         let fileURLs = durableDroppedFileURLs(
             fileURLs(from: pasteboard),
-            pasteboardService: pasteboardService
+            pasteboardService: pasteboardService,
+            sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
+                pasteboard.types ?? []
+            )
         )
         if !fileURLs.isEmpty {
             return .fileURLs(fileURLs)
@@ -480,7 +501,10 @@ enum TerminalImageTransferPlanner {
     ) -> [URL] {
         let urls = durableDroppedFileURLs(
             fileURLs(from: pasteboard),
-            pasteboardService: pasteboardService
+            pasteboardService: pasteboardService,
+            sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
+                pasteboard.types ?? []
+            )
         )
         if !urls.isEmpty {
             return urls
@@ -500,12 +524,14 @@ enum TerminalImageTransferPlanner {
     /// by image providers need an owned copy to survive the drag/paste handoff.
     static func durableDroppedFileURLs(
         _ fileURLs: [URL],
-        pasteboardService: TerminalPasteboardService
+        pasteboardService: TerminalPasteboardService,
+        sourceIsTransient: Bool = false
     ) -> [URL] {
         fileURLs.compactMap { fileURL in
             guard isTransientImageFileURL(
                 fileURL,
-                pasteboardService: pasteboardService
+                pasteboardService: pasteboardService,
+                sourceIsTransient: sourceIsTransient
             ) else {
                 return fileURL
             }
@@ -515,7 +541,8 @@ enum TerminalImageTransferPlanner {
 
     private static func isTransientImageFileURL(
         _ fileURL: URL,
-        pasteboardService: TerminalPasteboardService
+        pasteboardService: TerminalPasteboardService,
+        sourceIsTransient: Bool
     ) -> Bool {
         let normalizedURL = fileURL.standardizedFileURL
         guard normalizedURL.isFileURL,
@@ -542,7 +569,7 @@ enum TerminalImageTransferPlanner {
         guard isTemporaryPath else { return false }
 
         let filename = normalizedURL.lastPathComponent.lowercased()
-        return filename.hasPrefix("cmux-drop-")
+        return sourceIsTransient || filename.hasPrefix("cmux-drop-")
     }
 
     private static func finishUpload(

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -529,10 +529,16 @@ enum TerminalImageTransferPlanner {
             .standardizedFileURL.path
         let systemTemporaryPath = FileManager.default.temporaryDirectory
             .standardizedFileURL.path
-        let isTemporaryPath = path == serviceTemporaryPath
-            || path.hasPrefix(serviceTemporaryPath + "/")
-            || path == systemTemporaryPath
-            || path.hasPrefix(systemTemporaryPath + "/")
+        let unixTemporaryPath = URL(fileURLWithPath: "/tmp")
+            .standardizedFileURL.path
+        let temporaryRoots = [
+            serviceTemporaryPath,
+            systemTemporaryPath,
+            unixTemporaryPath,
+        ]
+        let isTemporaryPath = temporaryRoots.contains { root in
+            path == root || path.hasPrefix(root + "/")
+        }
         guard isTemporaryPath else { return false }
 
         let filename = normalizedURL.lastPathComponent.lowercased()

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -431,13 +431,14 @@ enum TerminalImageTransferPlanner {
         pasteboard: NSPasteboard,
         pasteboardService: TerminalPasteboardService
     ) -> TerminalImageTransferPreparedContent {
-        let fileURLs = durableDroppedFileURLs(
+        guard let fileURLs = pasteboardService.durableDroppedFileURLs(
             fileURLs(from: pasteboard),
-            pasteboardService: pasteboardService,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
                 pasteboard.types
             )
-        )
+        ) else {
+            return .reject
+        }
         if !fileURLs.isEmpty {
             return .fileURLs(fileURLs)
         }
@@ -476,10 +477,12 @@ enum TerminalImageTransferPlanner {
         pasteboard: NSPasteboard,
         pasteboardService: TerminalPasteboardService
     ) -> TerminalImageTransferPreparedContent {
-        let fileURLs = materializedFileURLs(
+        guard let fileURLs = materializedFileURLs(
             from: pasteboard,
             pasteboardService: pasteboardService
-        )
+        ) else {
+            return .reject
+        }
         if !fileURLs.isEmpty {
             return .fileURLs(fileURLs)
         }
@@ -498,14 +501,15 @@ enum TerminalImageTransferPlanner {
     private static func materializedFileURLs(
         from pasteboard: NSPasteboard,
         pasteboardService: TerminalPasteboardService
-    ) -> [URL] {
-        let urls = durableDroppedFileURLs(
+    ) -> [URL]? {
+        guard let urls = pasteboardService.durableDroppedFileURLs(
             fileURLs(from: pasteboard),
-            pasteboardService: pasteboardService,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
                 pasteboard.types
             )
-        )
+        ) else {
+            return nil
+        }
         if !urls.isEmpty {
             return urls
         }
@@ -517,59 +521,6 @@ enum TerminalImageTransferPlanner {
 
     private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         PasteboardFileURLReader.fileURLs(from: pasteboard)
-    }
-
-    /// Rehomes transient image URLs before a terminal receives their path.
-    /// Finder-owned paths remain unchanged; only the temporary names emitted
-    /// by image providers need an owned copy to survive the drag/paste handoff.
-    static func durableDroppedFileURLs(
-        _ fileURLs: [URL],
-        pasteboardService: TerminalPasteboardService,
-        sourceIsTransient: Bool = false
-    ) -> [URL] {
-        fileURLs.compactMap { fileURL in
-            guard isTransientImageFileURL(
-                fileURL,
-                pasteboardService: pasteboardService,
-                sourceIsTransient: sourceIsTransient
-            ) else {
-                return fileURL
-            }
-            return pasteboardService.copyTemporaryImageFile(fileURL)
-        }
-    }
-
-    private static func isTransientImageFileURL(
-        _ fileURL: URL,
-        pasteboardService: TerminalPasteboardService,
-        sourceIsTransient: Bool
-    ) -> Bool {
-        let normalizedURL = fileURL.standardizedFileURL
-        guard normalizedURL.isFileURL,
-              let type = UTType(filenameExtension: normalizedURL.pathExtension),
-              type.conforms(to: .image) else {
-            return false
-        }
-
-        let path = normalizedURL.path
-        let serviceTemporaryPath = pasteboardService.temporaryDirectory
-            .standardizedFileURL.path
-        let systemTemporaryPath = FileManager.default.temporaryDirectory
-            .standardizedFileURL.path
-        let unixTemporaryPath = URL(fileURLWithPath: "/tmp")
-            .standardizedFileURL.path
-        let temporaryRoots = [
-            serviceTemporaryPath,
-            systemTemporaryPath,
-            unixTemporaryPath,
-        ]
-        let isTemporaryPath = temporaryRoots.contains { root in
-            path == root || path.hasPrefix(root + "/")
-        }
-        guard isTemporaryPath else { return false }
-
-        let filename = normalizedURL.lastPathComponent.lowercased()
-        return sourceIsTransient || filename.hasPrefix("cmux-drop-")
     }
 
     private static func finishUpload(

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -435,7 +435,7 @@ enum TerminalImageTransferPlanner {
             fileURLs(from: pasteboard),
             pasteboardService: pasteboardService,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
-                pasteboard.types ?? []
+                pasteboard.types
             )
         )
         if !fileURLs.isEmpty {
@@ -503,7 +503,7 @@ enum TerminalImageTransferPlanner {
             fileURLs(from: pasteboard),
             pasteboardService: pasteboardService,
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
-                pasteboard.types ?? []
+                pasteboard.types
             )
         )
         if !urls.isEmpty {

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -55,6 +55,7 @@ enum PasteboardFileURLReader {
 
     static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         var fileURLs: [URL] = []
+        var didReadPromisedFileURL = false
 
         let objects = pasteboard.readObjects(
             forClasses: [NSURL.self],
@@ -80,11 +81,27 @@ enum PasteboardFileURLReader {
             fileURLs.append(url.standardizedFileURL)
         }
 
-        if let rawPromisedFileURL = pasteboard.string(
-            forType: promisedFileURLPasteboardType
-        ),
-        let url = URL(string: rawPromisedFileURL),
-        url.isFileURL {
+        for item in pasteboard.pasteboardItems ?? [] {
+            guard let rawPromisedFileURL = item.string(
+                forType: promisedFileURLPasteboardType
+            ),
+            let url = URL(string: rawPromisedFileURL),
+            url.isFileURL else {
+                continue
+            }
+            fileURLs.append(url.standardizedFileURL)
+            didReadPromisedFileURL = true
+        }
+
+        // A few providers expose the promised value on the pasteboard rather
+        // than on an individual item. Preserve that legacy representation as
+        // a fallback after item-level extraction.
+        if !didReadPromisedFileURL,
+           let rawPromisedFileURL = pasteboard.string(
+               forType: promisedFileURLPasteboardType
+           ),
+           let url = URL(string: rawPromisedFileURL),
+           url.isFileURL {
             fileURLs.append(url.standardizedFileURL)
         }
 

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -434,7 +434,7 @@ enum TerminalImageTransferPlanner {
         guard let fileURLs = pasteboardService.durableDroppedFileURLs(
             fileURLs(from: pasteboard),
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
-                pasteboard.types
+                pasteboard.types ?? []
             )
         ) else {
             return .reject
@@ -505,7 +505,7 @@ enum TerminalImageTransferPlanner {
         guard let urls = pasteboardService.durableDroppedFileURLs(
             fileURLs(from: pasteboard),
             sourceIsTransient: PasteboardFileURLReader.hasPromisedFileURLType(
-                pasteboard.types
+                pasteboard.types ?? []
             )
         ) else {
             return nil

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -413,7 +413,10 @@ enum TerminalImageTransferPlanner {
         pasteboard: NSPasteboard,
         pasteboardService: TerminalPasteboardService
     ) -> TerminalImageTransferPreparedContent {
-        let fileURLs = fileURLs(from: pasteboard)
+        let fileURLs = durableDroppedFileURLs(
+            fileURLs(from: pasteboard),
+            pasteboardService: pasteboardService
+        )
         if !fileURLs.isEmpty {
             return .fileURLs(fileURLs)
         }
@@ -475,7 +478,10 @@ enum TerminalImageTransferPlanner {
         from pasteboard: NSPasteboard,
         pasteboardService: TerminalPasteboardService
     ) -> [URL] {
-        let urls = fileURLs(from: pasteboard)
+        let urls = durableDroppedFileURLs(
+            fileURLs(from: pasteboard),
+            pasteboardService: pasteboardService
+        )
         if !urls.isEmpty {
             return urls
         }
@@ -487,6 +493,50 @@ enum TerminalImageTransferPlanner {
 
     private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         PasteboardFileURLReader.fileURLs(from: pasteboard)
+    }
+
+    /// Rehomes transient image URLs before a terminal receives their path.
+    /// Finder-owned paths remain unchanged; only the temporary names emitted
+    /// by image providers need an owned copy to survive the drag/paste handoff.
+    static func durableDroppedFileURLs(
+        _ fileURLs: [URL],
+        pasteboardService: TerminalPasteboardService
+    ) -> [URL] {
+        fileURLs.compactMap { fileURL in
+            guard isTransientImageFileURL(
+                fileURL,
+                pasteboardService: pasteboardService
+            ) else {
+                return fileURL
+            }
+            return pasteboardService.copyTemporaryImageFile(fileURL)
+        }
+    }
+
+    private static func isTransientImageFileURL(
+        _ fileURL: URL,
+        pasteboardService: TerminalPasteboardService
+    ) -> Bool {
+        let normalizedURL = fileURL.standardizedFileURL
+        guard normalizedURL.isFileURL,
+              let type = UTType(filenameExtension: normalizedURL.pathExtension),
+              type.conforms(to: .image) else {
+            return false
+        }
+
+        let path = normalizedURL.path
+        let serviceTemporaryPath = pasteboardService.temporaryDirectory
+            .standardizedFileURL.path
+        let systemTemporaryPath = FileManager.default.temporaryDirectory
+            .standardizedFileURL.path
+        let isTemporaryPath = path == serviceTemporaryPath
+            || path.hasPrefix(serviceTemporaryPath + "/")
+            || path == systemTemporaryPath
+            || path.hasPrefix(systemTemporaryPath + "/")
+        guard isTemporaryPath else { return false }
+
+        let filename = normalizedURL.lastPathComponent.lowercased()
+        return filename.hasPrefix("cmux-drop-")
     }
 
     private static func finishUpload(

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -244,6 +244,52 @@ final class FinderFileDropRegressionTests: XCTestCase {
         XCTAssertFalse(text.contains("/clipboard-"))
     }
 
+    func testTransientImageFileURLDropGetsAnOwnedCopyBeforeInsertion() throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-drop-\(UUID().uuidString).png")
+        try make1x1PNG(color: .systemPurple).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let ownedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-owned-drop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: ownedDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: ownedDirectory) }
+
+        let pasteboard = NSPasteboard(
+            name: .init("cmux-test-transient-image-drop-\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([sourceURL as NSURL]))
+
+        let service = TerminalPasteboardService(
+            temporaryDirectory: ownedDirectory
+        )
+        let prepared = TerminalImageTransferPlanner.prepareSynchronously(
+            pasteboard: pasteboard,
+            mode: .drop,
+            pasteboardService: service
+        )
+
+        guard case .fileURLs(let fileURLs) = prepared,
+              let ownedURL = fileURLs.first else {
+            return XCTFail("expected a durable image file URL, got \(prepared)")
+        }
+        XCTAssertNotEqual(ownedURL.standardizedFileURL, sourceURL.standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: ownedURL.path))
+
+        try FileManager.default.removeItem(at: sourceURL)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: ownedURL.path),
+            "The terminal path must survive the source drag provider's cleanup"
+        )
+
+        service.cleanupTransferredTemporaryImageFiles([ownedURL])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ownedURL.path))
+    }
+
     func testImageFileURLDropUploadsOriginalFilesForRemoteTerminal() throws {
         let imageDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux remote image file drop \(UUID().uuidString)")

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -364,6 +364,28 @@ final class FinderFileDropRegressionTests: XCTestCase {
             PasteboardFileURLReader.fileURLs(from: pasteboard),
             [firstURL.standardizedFileURL, secondURL.standardizedFileURL]
         )
+
+        let ownedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-owned-multiple-promised-(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: ownedDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: ownedDirectory) }
+        let service = TerminalPasteboardService(temporaryDirectory: ownedDirectory)
+        let prepared = TerminalImageTransferPlanner.prepareSynchronously(
+            pasteboard: pasteboard,
+            mode: .drop,
+            pasteboardService: service
+        )
+        guard case .fileURLs(let durableURLs) = prepared else {
+            return XCTFail("expected both promised image items to be materialized")
+        }
+        XCTAssertEqual(durableURLs.count, 2)
+        XCTAssertTrue(
+            durableURLs.allSatisfy { FileManager.default.fileExists(atPath: $0.path) }
+        )
+        service.cleanupTransferredTemporaryImageFiles(durableURLs)
     }
 
     func testTransientImageURLsUnderTmpAliasesGetOwnedCopies() throws {

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -332,6 +332,73 @@ final class FinderFileDropRegressionTests: XCTestCase {
         service.cleanupTransferredTemporaryImageFiles([ownedURL])
     }
 
+    func testTransientImageURLsUnderTmpAliasesGetOwnedCopies() throws {
+        let ownedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-owned-alias-drop-(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: ownedDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: ownedDirectory) }
+
+        let service = TerminalPasteboardService(
+            temporaryDirectory: ownedDirectory
+        )
+        for root in ["/tmp", "/private/tmp"] {
+            let sourceURL = URL(fileURLWithPath: root)
+                .appendingPathComponent("cmux-drop-(UUID().uuidString).png")
+            try make1x1PNG(color: .systemTeal).write(to: sourceURL)
+            defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+            guard let durableURL = service.durableDroppedFileURLs([sourceURL])?.first else {
+                return XCTFail("expected a durable copy for (sourceURL.path)")
+            }
+            XCTAssertNotEqual(durableURL.standardizedFileURL, sourceURL.standardizedFileURL)
+            try FileManager.default.removeItem(at: sourceURL)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: durableURL.path))
+            service.cleanupTransferredTemporaryImageFiles([durableURL])
+            XCTAssertFalse(FileManager.default.fileExists(atPath: durableURL.path))
+        }
+    }
+
+    func testTransientCopyFailureRejectsMixedFileDrop() throws {
+        let regularURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-mixed-drop-(UUID().uuidString).txt")
+        try "plain text".write(to: regularURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: regularURL) }
+
+        let missingTransientURL = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("cmux-drop-(UUID().uuidString).png")
+        try? FileManager.default.removeItem(at: missingTransientURL)
+        let pasteboard = NSPasteboard(
+            name: .init("cmux-test-mixed-transient-failure-(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setPropertyList(
+            [regularURL.path, missingTransientURL.path],
+            forType: PasteboardFileURLReader.legacyFilenamesPboardType
+        )
+
+        let ownedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-owned-mixed-drop-(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: ownedDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: ownedDirectory) }
+
+        let prepared = TerminalImageTransferPlanner.prepareSynchronously(
+            pasteboard: pasteboard,
+            mode: .drop,
+            pasteboardService: TerminalPasteboardService(
+                temporaryDirectory: ownedDirectory
+            )
+        )
+        guard case .reject = prepared else {
+            return XCTFail("a mixed drop must be rejected when a transient image cannot be retained")
+        }
+    }
+
     func testImageFileURLDropUploadsOriginalFilesForRemoteTerminal() throws {
         let imageDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux remote image file drop \(UUID().uuidString)")

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -332,6 +332,40 @@ final class FinderFileDropRegressionTests: XCTestCase {
         service.cleanupTransferredTemporaryImageFiles([ownedURL])
     }
 
+    func testMultiplePromisedFileURLItemsAreReadIndividually() throws {
+        let firstURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("promised-first-(UUID().uuidString).png")
+        let secondURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("promised-second-(UUID().uuidString).png")
+        try make1x1PNG(color: .systemPink).write(to: firstURL)
+        try make1x1PNG(color: .systemYellow).write(to: secondURL)
+        defer {
+            try? FileManager.default.removeItem(at: firstURL)
+            try? FileManager.default.removeItem(at: secondURL)
+        }
+
+        let pasteboard = NSPasteboard(
+            name: .init("cmux-test-multiple-promised-file-urls-(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        let firstItem = NSPasteboardItem()
+        firstItem.setString(
+            firstURL.absoluteString,
+            forType: PasteboardFileURLReader.promisedFileURLPasteboardType
+        )
+        let secondItem = NSPasteboardItem()
+        secondItem.setString(
+            secondURL.absoluteString,
+            forType: PasteboardFileURLReader.promisedFileURLPasteboardType
+        )
+        XCTAssertTrue(pasteboard.writeObjects([firstItem, secondItem]))
+
+        XCTAssertEqual(
+            PasteboardFileURLReader.fileURLs(from: pasteboard),
+            [firstURL.standardizedFileURL, secondURL.standardizedFileURL]
+        )
+    }
+
     func testTransientImageURLsUnderTmpAliasesGetOwnedCopies() throws {
         let ownedDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-owned-alias-drop-(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -334,9 +334,9 @@ final class FinderFileDropRegressionTests: XCTestCase {
 
     func testMultiplePromisedFileURLItemsAreReadIndividually() throws {
         let firstURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("promised-first-(UUID().uuidString).png")
+            .appendingPathComponent("promised-first-" + UUID().uuidString + ".png")
         let secondURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("promised-second-(UUID().uuidString).png")
+            .appendingPathComponent("promised-second-" + UUID().uuidString + ".png")
         try make1x1PNG(color: .systemPink).write(to: firstURL)
         try make1x1PNG(color: .systemYellow).write(to: secondURL)
         defer {
@@ -345,7 +345,7 @@ final class FinderFileDropRegressionTests: XCTestCase {
         }
 
         let pasteboard = NSPasteboard(
-            name: .init("cmux-test-multiple-promised-file-urls-(UUID().uuidString)")
+            name: .init("cmux-test-multiple-promised-file-urls-" + UUID().uuidString)
         )
         pasteboard.clearContents()
         let firstItem = NSPasteboardItem()
@@ -366,7 +366,7 @@ final class FinderFileDropRegressionTests: XCTestCase {
         )
 
         let ownedDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-owned-multiple-promised-(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-owned-multiple-promised-" + UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: ownedDirectory,
             withIntermediateDirectories: false
@@ -390,7 +390,7 @@ final class FinderFileDropRegressionTests: XCTestCase {
 
     func testTransientImageURLsUnderTmpAliasesGetOwnedCopies() throws {
         let ownedDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-owned-alias-drop-(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-owned-alias-drop-" + UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: ownedDirectory,
             withIntermediateDirectories: false
@@ -402,12 +402,12 @@ final class FinderFileDropRegressionTests: XCTestCase {
         )
         for root in ["/tmp", "/private/tmp"] {
             let sourceURL = URL(fileURLWithPath: root)
-                .appendingPathComponent("cmux-drop-(UUID().uuidString).png")
+                .appendingPathComponent("cmux-drop-" + UUID().uuidString + ".png")
             try make1x1PNG(color: .systemTeal).write(to: sourceURL)
             defer { try? FileManager.default.removeItem(at: sourceURL) }
 
             guard let durableURL = service.durableDroppedFileURLs([sourceURL])?.first else {
-                return XCTFail("expected a durable copy for (sourceURL.path)")
+                return XCTFail("expected a durable copy for " + sourceURL.path)
             }
             XCTAssertNotEqual(durableURL.standardizedFileURL, sourceURL.standardizedFileURL)
             try FileManager.default.removeItem(at: sourceURL)
@@ -419,15 +419,20 @@ final class FinderFileDropRegressionTests: XCTestCase {
 
     func testTransientCopyFailureRejectsMixedFileDrop() throws {
         let regularURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-mixed-drop-(UUID().uuidString).txt")
+            .appendingPathComponent("cmux-mixed-drop-" + UUID().uuidString + ".txt")
         try "plain text".write(to: regularURL, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: regularURL) }
 
+        let validTransientURL = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("cmux-drop-" + UUID().uuidString + ".png")
+        try make1x1PNG(color: .systemBlue).write(to: validTransientURL)
+        defer { try? FileManager.default.removeItem(at: validTransientURL) }
+
         let missingTransientURL = URL(fileURLWithPath: "/tmp")
-            .appendingPathComponent("cmux-drop-(UUID().uuidString).png")
+            .appendingPathComponent("cmux-drop-" + UUID().uuidString + ".png")
         try? FileManager.default.removeItem(at: missingTransientURL)
         let pasteboard = NSPasteboard(
-            name: .init("cmux-test-mixed-transient-failure-(UUID().uuidString)")
+            name: .init("cmux-test-mixed-transient-failure-" + UUID().uuidString)
         )
         pasteboard.clearContents()
         pasteboard.setPropertyList(
@@ -436,23 +441,30 @@ final class FinderFileDropRegressionTests: XCTestCase {
         )
 
         let ownedDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-owned-mixed-drop-(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-owned-mixed-drop-" + UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: ownedDirectory,
             withIntermediateDirectories: false
         )
         defer { try? FileManager.default.removeItem(at: ownedDirectory) }
 
+        let service = TerminalPasteboardService(
+            temporaryDirectory: ownedDirectory
+        )
         let prepared = TerminalImageTransferPlanner.prepareSynchronously(
             pasteboard: pasteboard,
             mode: .drop,
-            pasteboardService: TerminalPasteboardService(
-                temporaryDirectory: ownedDirectory
-            )
+            pasteboardService: service
         )
         guard case .reject = prepared else {
             return XCTFail("a mixed drop must be rejected when a transient image cannot be retained")
         }
+        XCTAssertTrue(
+            try FileManager.default
+                .contentsOfDirectory(at: ownedDirectory, includingPropertiesForKeys: nil)
+                .isEmpty,
+            "partially copied transient files must be rolled back when the drop is rejected"
+        )
     }
 
     func testImageFileURLDropUploadsOriginalFilesForRemoteTerminal() throws {

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -290,6 +290,48 @@ final class FinderFileDropRegressionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: ownedURL.path))
     }
 
+    func testPromisedTransientImageURLGetsCopiedEvenWithoutCmuxDropName() throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("provider-image-\(UUID().uuidString).png")
+        try make1x1PNG(color: .systemOrange).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let ownedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-owned-promised-drop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: ownedDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: ownedDirectory) }
+
+        let pasteboard = NSPasteboard(
+            name: .init("cmux-test-promised-image-drop-\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setString(
+            sourceURL.absoluteString,
+            forType: PasteboardFileURLReader.promisedFileURLPasteboardType
+        )
+
+        let service = TerminalPasteboardService(
+            temporaryDirectory: ownedDirectory
+        )
+        let prepared = TerminalImageTransferPlanner.prepareSynchronously(
+            pasteboard: pasteboard,
+            mode: .drop,
+            pasteboardService: service
+        )
+
+        guard case .fileURLs(let fileURLs) = prepared,
+              let ownedURL = fileURLs.first else {
+            return XCTFail("expected a durable promised image URL, got \(prepared)")
+        }
+        XCTAssertNotEqual(ownedURL.standardizedFileURL, sourceURL.standardizedFileURL)
+        try FileManager.default.removeItem(at: sourceURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: ownedURL.path))
+        service.cleanupTransferredTemporaryImageFiles([ownedURL])
+    }
+
     func testImageFileURLDropUploadsOriginalFilesForRemoteTerminal() throws {
         let imageDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux remote image file drop \(UUID().uuidString)")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3764,6 +3764,31 @@ final class WindowTerminalHostViewTests: XCTestCase {
         return hostedView
     }
 
+    func testTerminalPaneDropTargetLookupRequiresActiveDropContext() {
+        let frame = NSRect(x: 0, y: 0, width: 240, height: 160)
+        let hostedView = makeHostedTerminalView(frame: frame)
+        hostedView.layoutSubtreeIfNeeded()
+        hostedView.layout()
+        let dropPoint = NSPoint(x: frame.midX, y: frame.midY)
+
+        hostedView.setPaneDropContext(TerminalPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        XCTAssertNotNil(
+            hostedView.paneDropTargetForDrop(at: dropPoint),
+            "Active terminal pane drop targets should remain discoverable for pane drop routing"
+        )
+
+        hostedView.setPaneDropContext(nil)
+
+        XCTAssertNil(
+            hostedView.paneDropTargetForDrop(at: dropPoint),
+            "Inactive terminal pane drop targets must not shadow terminal file-path drop insertion"
+        )
+    }
+
     private func assertHitFallsInsideHostedTerminal(
         _ hitView: NSView?,
         hostedView: GhosttySurfaceScrollView,


### PR DESCRIPTION
Closes #10102

## Summary
- restore terminal file-path insertion when a portal-owned pane has no active drop context
- preserve transient and promised image files in pasteboard-service-owned storage before handing paths to a terminal or agent
- reject a complete mixed drop when a transient image cannot be retained, including `/tmp` and `/private/tmp` aliases

## Root cause
`GhosttySurfaceScrollView.paneDropTargetForDrop(at:)` returned its `PaneDropTargetView` after `dropContext` had been cleared during portal/sidebar churn. `FileDropOverlayView` delegated Finder drops to that inert target, which rejected them before the underlying terminal could insert the path. Image providers can also hand out short-lived promised files, so the path could be typed after the provider had already removed the source.

## Fix
The portal lookup now requires an active drop context. Promised file URLs are read per pasteboard item, and transient image sources are copied through a no-follow, byte-capped descriptor read into service-owned temporary storage before local insertion or remote upload. Ownership cleanup remains centralized in `TerminalPasteboardService`.

## Testing
- Red regression baseline: [run 32184949070](https://github.com/manaflow-ai/cmux/actions/runs/32184949070) failed on the test-only commit as expected; the inactive-target assertion reproduced the bug.
- Focused Finder-drop suite: [run 32198380048](https://github.com/manaflow-ai/cmux/actions/runs/32198380048) passed 25 tests on commit `485d627042`.
- Focused inactive-target regression: [run 32199051828](https://github.com/manaflow-ai/cmux/actions/runs/32199051828) passed 1 test on commit `485d627042`.
- Manual CI attempt: [run 32198382275](https://github.com/manaflow-ai/cmux/actions/runs/32198382275) compiled the changed terminal/package code successfully; its aggregate result was affected by a pre-existing `BrowserPanelView.swift` warning-budget mismatch and unrelated fleet test/time-out failures.
- Static checks passed locally: `git diff --check`, `lint-pbxproj-test-wiring.sh`, pbxproj/package/workspace policy checks, and Swift frontend parsing of changed files.
- Per task instructions, no local Xcode build, app launch, XCTest, or XCUITest was run.

## Demo Video
Not applicable: this fix is verified by hosted macOS tests, and local app launch is explicitly prohibited for this task.

## Review Trigger
Automatic review checks are enabled. CodeRabbit is green; its actionable threads were addressed or resolved with the AppKit promised-file lifetime rationale.

## Checklist
- [x] `Closes #10102` included
- [x] No user-facing strings changed; localization audit found no surfaces requiring catalog updates
- [x] Branch pushed to `origin`
- [x] No app launch or merge performed
