### PR TITLE
Fix terminal Copy Mode selection scope across split panes

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Hosting/TerminalSurfaceNativeViewing.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Hosting/TerminalSurfaceNativeViewing.swift
@@ -27,6 +27,9 @@ public protocol TerminalSurfaceNativeViewing: NSView, TerminalSurfaceHosting {
     @discardableResult
     func toggleKeyboardCopyMode() -> Bool
 
+    /// Ends keyboard copy mode and clears its selection when focus leaves the view.
+    func cancelKeyboardCopyMode()
+
     /// Re-applies the window background for the active surface.
     func applyWindowBackgroundIfActive()
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -15,9 +15,6 @@ extension TerminalSurface {
     /// calls `ghostty_surface_set_focus` directly (bypassing `setFocus`).
     /// Without this, `createSurface` would replay a stale state on recreation.
     public func recordExternalFocusState(_ focused: Bool) {
-        if !focused {
-            surfaceView.cancelKeyboardCopyMode()
-        }
         desiredFocusState = focused
     }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -15,12 +15,18 @@ extension TerminalSurface {
     /// calls `ghostty_surface_set_focus` directly (bypassing `setFocus`).
     /// Without this, `createSurface` would replay a stale state on recreation.
     public func recordExternalFocusState(_ focused: Bool) {
+        if !focused {
+            surfaceView.cancelKeyboardCopyMode()
+        }
         desiredFocusState = focused
     }
 
     /// Applies a focus state to the runtime surface (deduplicated).
     @MainActor
     public func setFocus(_ focused: Bool, force: Bool = false) {
+        if !focused {
+            surfaceView.cancelKeyboardCopyMode()
+        }
         // Only send focus events when the state changes to avoid redundant
         // prompt redraws with zsh themes like Powerlevel10k.
         guard force || focused != desiredFocusState else { return }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalSurfaceNativeView.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalSurfaceNativeView.swift
@@ -9,7 +9,8 @@ final class FakeTerminalSurfaceNativeView: NSView {
     weak var attachedController: (any TerminalSurfaceControlling)?
     var attachedSurfaceController: (any TerminalSurfaceControlling)? { attachedController }
     var currentKeyStateIndicatorText: String? { nil }
-    var isKeyboardCopyModeActive: Bool { false }
+    var isKeyboardCopyModeActive = false
+    private(set) var keyboardCopyModeCancellationCount = 0
     var shouldDeferRuntimeInput = false
     var runtimeInputDeferralResponses: [Bool] = []
     var runtimeInputDeferralCallCount = 0
@@ -18,6 +19,10 @@ final class FakeTerminalSurfaceNativeView: NSView {
     var mobileMouseButtonEvents: [String] = []
 
     func toggleKeyboardCopyMode() -> Bool { false }
+    func cancelKeyboardCopyMode() {
+        keyboardCopyModeCancellationCount += 1
+        isKeyboardCopyModeActive = false
+    }
     func applyWindowBackgroundIfActive() {}
     func forceRefreshSurface() -> Bool { true }
     func runtimeSurfaceDidBecomeReady() {}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceExplicitInputTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceExplicitInputTests.swift
@@ -184,6 +184,18 @@ struct TerminalSurfaceExplicitInputTests {
         #expect(fixture.paneHost.explicitInputCount == 1)
     }
 
+    @Test func losingFocusCancelsKeyboardCopyModeOnTheSurface() {
+        let fixture = makeFixture()
+        defer { fixture.surface.releaseSurfaceForTesting() }
+        fixture.nativeView.isKeyboardCopyModeActive = true
+
+        fixture.surface.setFocus(true)
+        fixture.surface.setFocus(false)
+
+        #expect(fixture.nativeView.keyboardCopyModeCancellationCount == 1)
+        #expect(!fixture.nativeView.isKeyboardCopyModeActive)
+    }
+
     @Test func mobileGesturesNotifyPaneHost() {
         let fixture = makeFixture()
         defer { fixture.surface.releaseSurfaceForTesting() }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4521,6 +4521,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return true
     }
 
+    func cancelKeyboardCopyMode() {
+        guard keyboardCopyModeActive else { return }
+        if let surface {
+            _ = GhosttyRuntimeCInterop.clearSelection(surface)
+        }
+        setKeyboardCopyModeActive(false)
+    }
+
     private func setKeyboardCopyModeActive(_ active: Bool) {
         keyboardCopyModeInputState.reset()
         keyboardCopyModeSelectionKind = nil

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5349,6 +5349,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             imeConsumedKeyUps.removeAll()
             manualNamedKeyConsumedKeyUps.removeAll()
             desiredFocus = false
+            cancelKeyboardCopyMode()
             terminalSurface?.hostedView.cancelSuppressedFirstResponderFocusReapply()
             terminalSurface?.recordExternalFocusState(false)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10104,6 +10104,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     func setActive(_ active: Bool) {
         let wasActive = isActive
+        if !active {
+            surfaceView.cancelKeyboardCopyMode()
+        }
         isActive = active
 #if DEBUG
         if wasActive != active {


### PR DESCRIPTION
Closes #10103

## Summary

Terminal Copy Mode state and its native selection could survive after a terminal pane stopped owning keyboard focus. During split-pane focus/reparent transitions, that stale selection remained visible/copyable outside the focused pane.

The fix adds an explicit cancellation seam for terminal Copy Mode and clears the Ghostty selection whenever the pane loses model focus, its native responder, or active-pane status. The regression test is in a separate first commit from the fix commits and verifies the focus-loss ownership contract.

## Verification

- Focused remote package test (shared Mac fleet): `swift test --package-path Packages/macOS/CmuxTerminal --filter TerminalSurfaceExplicitInputTests/losingFocusCancelsKeyboardCopyModeOnTheSurface` — passed (1 test).
- `git diff --check` — passed.
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (693 test files checked).
- `python3 scripts/check-package-resolved-policy.py` — passed.
- Hosted `test-depot.yml` run [32189853442](https://github.com/manaflow-ai/cmux/actions/runs/32189853442): checkout, Xcode selection, GhosttyKit download, toolchain setup, and package resolution passed; the full app-host unit suite reached its 20-minute workflow timeout while still running, without a reported test failure. This workflow does not execute SwiftPM package test targets.
- No local Xcode build/test, XCUITest, or app launch was run per repository instructions.

No user-facing strings changed; no localization entries were required.