### PR TITLE
Fix stale persistent SSH bridge lease takeover

### DIFF
--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -62,6 +62,12 @@ Remote slot files:
 3. `~/.cmux/daemon/<version>/<slot>/daemon.lock` single-owner lock.
 4. `~/.cmux/daemon/<version>/<slot>/daemon.log` lifecycle and crash diagnostics.
 
+Each `serve --stdio --persistent` bridge includes a fresh `bridge_lease_id` in
+its authenticated socket handshake. The persistent server tracks authenticated
+bridge connections and lets the newest authenticated bridge take over the slot,
+closing older connections (including half-open SSH bridges) without touching
+the persistent PTY sessions.
+
 PTY lifecycle:
 1. A local attach creates or reuses a named `pty.*` session in the persistent daemon.
 2. If the local surface closes, the stdio proxy disconnects and its attachment detaches, but the PTY process and bounded scrollback remain in the daemon.

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -924,7 +924,12 @@ func runPersistentStdioProxy(stdin io.Reader, stdout, stderr io.Writer, slot str
 	}
 	bridgeLeaseID, err := newPersistentDaemonBridgeLeaseID()
 	if err != nil {
-		return fmt.Errorf("create persistent daemon bridge lease: %w", err)
+		logPersistentDaemonEvent(
+			stderr,
+			"bridge_lease_generation_failed",
+			"error_category", persistentDaemonErrorCategory(err),
+		)
+		return errors.New(persistentDaemonBridgeLeaseError)
 	}
 	conn, err := dialPersistentDaemonWithBridgeLease(paths.socket, token, bridgeLeaseID)
 	if err != nil {
@@ -1475,6 +1480,8 @@ func persistentDaemonAuthenticationFailureReason(err error) string {
 		"authentication method is invalid",
 		"authentication token is invalid":
 		return err.Error()
+	case "persistent daemon bridge lease rejected":
+		return "bridge_lease_rejected"
 	default:
 		return persistentDaemonErrorCategory(err)
 	}
@@ -1550,7 +1557,7 @@ func authenticatePersistentDaemonConnWithLease(
 				OK: false,
 				Error: &rpcError{
 					Code:    "unauthorized",
-					Message: "persistent daemon bridge lease rejected",
+					Message: persistentDaemonBridgeLeaseError,
 				},
 			}, errors.New("persistent daemon bridge lease rejected"))
 		}
@@ -1666,7 +1673,8 @@ func dialPersistentDaemon(socketPath string, token string) (net.Conn, error) {
 }
 
 func dialPersistentDaemonWithBridgeLease(socketPath string, token string, bridgeLeaseID string) (net.Conn, error) {
-	conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
+	dialer := net.Dialer{Timeout: 2 * time.Second}
+	conn, err := dialer.DialContext(context.Background(), "unix", socketPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1675,15 +1683,6 @@ func dialPersistentDaemonWithBridgeLease(socketPath string, token string, bridge
 		return nil, err
 	}
 	return conn, nil
-}
-
-func authenticatePersistentDaemonClient(conn net.Conn, token string) error {
-	return authenticatePersistentDaemonClientWithTimeoutAndBridgeLease(
-		conn,
-		token,
-		persistentDaemonAuthTimeout,
-		"",
-	)
 }
 
 func authenticatePersistentDaemonClientWithTimeout(conn net.Conn, token string, timeout time.Duration) error {
@@ -2054,10 +2053,11 @@ func (s *rpcServer) handleProxyOpen(req rpcRequest) rpcResponse {
 		timeoutMs = parsed
 	}
 
-	conn, err := net.DialTimeout(
+	dialer := net.Dialer{Timeout: time.Duration(timeoutMs) * time.Millisecond}
+	conn, err := dialer.DialContext(
+		context.Background(),
 		"tcp",
 		net.JoinHostPort(host, strconv.Itoa(port)),
-		time.Duration(timeoutMs)*time.Millisecond,
 	)
 	if err != nil {
 		return rpcResponse{

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -922,7 +922,11 @@ func runPersistentStdioProxy(stdin io.Reader, stdout, stderr io.Writer, slot str
 	if err := ensurePersistentDaemonRunning(paths, token, leasePort, stderr); err != nil {
 		return err
 	}
-	conn, err := dialPersistentDaemon(paths.socket, token)
+	bridgeLeaseID, err := newPersistentDaemonBridgeLeaseID()
+	if err != nil {
+		return fmt.Errorf("create persistent daemon bridge lease: %w", err)
+	}
+	conn, err := dialPersistentDaemonWithBridgeLease(paths.socket, token, bridgeLeaseID)
 	if err != nil {
 		return err
 	}
@@ -1228,6 +1232,7 @@ func servePersistentDaemonWithVerifierConfig(
 ) error {
 	hub := newWebSocketPTYHub(wsPTYServerConfig{}, stderr)
 	defer hub.closeAll()
+	bridgeLeases := newPersistentDaemonBridgeLeaseRegistry()
 	var activeConnections int64
 	var idleSince time.Time
 	var slotLeaseObserved bool
@@ -1313,7 +1318,7 @@ func servePersistentDaemonWithVerifierConfig(
 		atomic.AddInt64(&activeConnections, 1)
 		go func() {
 			defer atomic.AddInt64(&activeConnections, -1)
-			handlePersistentDaemonConn(conn, verifier, hub, stderr, requestShutdown)
+			handlePersistentDaemonConn(conn, verifier, hub, stderr, requestShutdown, bridgeLeases)
 		}()
 	}
 }
@@ -1363,6 +1368,7 @@ func handlePersistentDaemonConn(
 	hub *wsPTYHub,
 	stderr io.Writer,
 	requestShutdown func(),
+	bridgeLeases ...*persistentDaemonBridgeLeaseRegistry,
 ) {
 	handlePersistentDaemonConnWithAuthTimeout(
 		conn,
@@ -1371,6 +1377,7 @@ func handlePersistentDaemonConn(
 		stderr,
 		persistentDaemonAuthTimeout,
 		requestShutdown,
+		bridgeLeases...,
 	)
 }
 
@@ -1381,9 +1388,16 @@ func handlePersistentDaemonConnWithAuthTimeout(
 	stderr io.Writer,
 	timeout time.Duration,
 	requestShutdown func(),
+	bridgeLeases ...*persistentDaemonBridgeLeaseRegistry,
 ) {
+	var bridgeLeaseRegistry *persistentDaemonBridgeLeaseRegistry
+	if len(bridgeLeases) > 0 {
+		bridgeLeaseRegistry = bridgeLeases[0]
+	}
 	defer conn.Close()
+	defer bridgeLeaseRegistry.release(conn)
 	defer logPersistentDaemonEvent(stderr, "connection_closed")
+	bridgeLeaseRegistry.register(conn)
 	logPersistentDaemonEvent(stderr, "connection_accepted")
 	if timeout > 0 {
 		if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
@@ -1398,13 +1412,33 @@ func handlePersistentDaemonConnWithAuthTimeout(
 	}
 	reader := bufio.NewReaderSize(conn, 64*1024)
 	writer := &stdioFrameWriter{writer: bufio.NewWriter(conn)}
-	if err := authenticatePersistentDaemonConn(reader, writer, verifier); err != nil {
+	evictedBridgeConnections := 0
+	if err := authenticatePersistentDaemonConnWithLease(
+		reader,
+		writer,
+		verifier,
+		func(leaseID string) error {
+			if bridgeLeaseRegistry == nil {
+				return nil
+			}
+			evicted, claimErr := bridgeLeaseRegistry.claim(conn, leaseID)
+			evictedBridgeConnections = evicted
+			return claimErr
+		},
+	); err != nil {
 		logPersistentDaemonEvent(
 			stderr,
 			"connection_rejected",
 			"reason", persistentDaemonAuthenticationFailureReason(err),
 		)
 		return
+	}
+	if evictedBridgeConnections > 0 {
+		logPersistentDaemonEvent(
+			stderr,
+			"bridge_lease_takeover",
+			"evicted_connections", strconv.Itoa(evictedBridgeConnections),
+		)
 	}
 	logPersistentDaemonEvent(stderr, "connection_authenticated")
 	if timeout > 0 {
@@ -1447,6 +1481,15 @@ func persistentDaemonAuthenticationFailureReason(err error) string {
 }
 
 func authenticatePersistentDaemonConn(reader *bufio.Reader, writer *stdioFrameWriter, verifier persistentDaemonTokenVerifier) error {
+	return authenticatePersistentDaemonConnWithLease(reader, writer, verifier, nil)
+}
+
+func authenticatePersistentDaemonConnWithLease(
+	reader *bufio.Reader,
+	writer *stdioFrameWriter,
+	verifier persistentDaemonTokenVerifier,
+	onBridgeLease func(string) error,
+) error {
 	line, oversized, err := readRPCFrame(reader, maxRPCFrameBytes)
 	if err != nil || oversized {
 		rejection := fmt.Errorf("authentication frame read failed: %w", err)
@@ -1497,6 +1540,20 @@ func authenticatePersistentDaemonConn(reader *bufio.Reader, writer *stdioFrameWr
 				Message: "invalid persistent daemon token",
 			},
 		}, errors.New("authentication token is invalid"))
+	}
+	bridgeLeaseID, _ := getStringParam(req.Params, persistentDaemonBridgeLeaseParam)
+	bridgeLeaseID = strings.TrimSpace(bridgeLeaseID)
+	if bridgeLeaseID != "" && onBridgeLease != nil {
+		if err := onBridgeLease(bridgeLeaseID); err != nil {
+			return writePersistentDaemonAuthRejection(writer, rpcResponse{
+				ID: req.ID,
+				OK: false,
+				Error: &rpcError{
+					Code:    "unauthorized",
+					Message: "persistent daemon bridge lease rejected",
+				},
+			}, errors.New("persistent daemon bridge lease rejected"))
+		}
 	}
 	if err := writer.writeResponse(rpcResponse{
 		ID: req.ID,
@@ -1605,11 +1662,15 @@ func runRPCServerWithReader(
 }
 
 func dialPersistentDaemon(socketPath string, token string) (net.Conn, error) {
+	return dialPersistentDaemonWithBridgeLease(socketPath, token, "")
+}
+
+func dialPersistentDaemonWithBridgeLease(socketPath string, token string, bridgeLeaseID string) (net.Conn, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
 	if err != nil {
 		return nil, err
 	}
-	if err := authenticatePersistentDaemonClient(conn, token); err != nil {
+	if err := authenticatePersistentDaemonClientWithBridgeLease(conn, token, bridgeLeaseID); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
@@ -1617,10 +1678,33 @@ func dialPersistentDaemon(socketPath string, token string) (net.Conn, error) {
 }
 
 func authenticatePersistentDaemonClient(conn net.Conn, token string) error {
-	return authenticatePersistentDaemonClientWithTimeout(conn, token, persistentDaemonAuthTimeout)
+	return authenticatePersistentDaemonClientWithTimeoutAndBridgeLease(
+		conn,
+		token,
+		persistentDaemonAuthTimeout,
+		"",
+	)
 }
 
 func authenticatePersistentDaemonClientWithTimeout(conn net.Conn, token string, timeout time.Duration) error {
+	return authenticatePersistentDaemonClientWithTimeoutAndBridgeLease(conn, token, timeout, "")
+}
+
+func authenticatePersistentDaemonClientWithBridgeLease(conn net.Conn, token string, bridgeLeaseID string) error {
+	return authenticatePersistentDaemonClientWithTimeoutAndBridgeLease(
+		conn,
+		token,
+		persistentDaemonAuthTimeout,
+		bridgeLeaseID,
+	)
+}
+
+func authenticatePersistentDaemonClientWithTimeoutAndBridgeLease(
+	conn net.Conn,
+	token string,
+	timeout time.Duration,
+	bridgeLeaseID string,
+) error {
 	if timeout > 0 {
 		if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 			return err
@@ -1629,12 +1713,16 @@ func authenticatePersistentDaemonClientWithTimeout(conn net.Conn, token string, 
 	}
 
 	writer := bufio.NewWriter(conn)
+	params := map[string]any{
+		"token": token,
+	}
+	if normalizedLeaseID := strings.TrimSpace(bridgeLeaseID); normalizedLeaseID != "" {
+		params[persistentDaemonBridgeLeaseParam] = normalizedLeaseID
+	}
 	request := rpcRequest{
 		ID:     "auth",
 		Method: persistentDaemonAuthMethod,
-		Params: map[string]any{
-			"token": token,
-		},
+		Params: params,
 	}
 	data, err := json.Marshal(request)
 	if err != nil {

--- a/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease.go
+++ b/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease.go
@@ -12,6 +12,7 @@ import (
 const (
 	persistentDaemonBridgeLeaseParam = "bridge_lease_id"
 	persistentDaemonBridgeLeaseMax   = 128
+	persistentDaemonBridgeLeaseError = "persistent daemon connection could not be established; reconnect and try again"
 )
 
 func newPersistentDaemonBridgeLeaseID() (string, error) {

--- a/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease.go
+++ b/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+)
+
+const (
+	persistentDaemonBridgeLeaseParam = "bridge_lease_id"
+	persistentDaemonBridgeLeaseMax   = 128
+)
+
+func newPersistentDaemonBridgeLeaseID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+// persistentDaemonBridgeLeaseRegistry tracks every accepted stdio connection
+// and the one connection that most recently claimed the slot. A new claimed
+// bridge is authoritative: it closes all older connections, which makes
+// takeover work even when an older binary did not send a lease id.
+type persistentDaemonBridgeLeaseRegistry struct {
+	mu          sync.Mutex
+	connections map[net.Conn]struct{}
+	holder      net.Conn
+}
+
+func newPersistentDaemonBridgeLeaseRegistry() *persistentDaemonBridgeLeaseRegistry {
+	return &persistentDaemonBridgeLeaseRegistry{
+		connections: make(map[net.Conn]struct{}),
+	}
+}
+
+func (r *persistentDaemonBridgeLeaseRegistry) register(conn net.Conn) {
+	if r == nil || conn == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.connections == nil {
+		r.connections = make(map[net.Conn]struct{})
+	}
+	r.connections[conn] = struct{}{}
+	r.mu.Unlock()
+}
+
+func (r *persistentDaemonBridgeLeaseRegistry) claim(conn net.Conn, leaseID string) (int, error) {
+	if r == nil || conn == nil {
+		return 0, errors.New("persistent daemon bridge lease registry is unavailable")
+	}
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return 0, errors.New("persistent daemon bridge lease id is required")
+	}
+	if len(leaseID) > persistentDaemonBridgeLeaseMax {
+		return 0, errors.New("persistent daemon bridge lease id is too long")
+	}
+
+	r.mu.Lock()
+	if r.connections == nil {
+		r.connections = make(map[net.Conn]struct{})
+	}
+	r.connections[conn] = struct{}{}
+	evicted := make([]net.Conn, 0, len(r.connections)-1)
+	for candidate := range r.connections {
+		if candidate == conn {
+			continue
+		}
+		evicted = append(evicted, candidate)
+		delete(r.connections, candidate)
+	}
+	r.holder = conn
+	r.mu.Unlock()
+
+	for _, candidate := range evicted {
+		_ = candidate.Close()
+	}
+	return len(evicted), nil
+}
+
+func (r *persistentDaemonBridgeLeaseRegistry) release(conn net.Conn) {
+	if r == nil || conn == nil {
+		return
+	}
+	r.mu.Lock()
+	delete(r.connections, conn)
+	if r.holder == conn {
+		r.holder = nil
+	}
+	r.mu.Unlock()
+}

--- a/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"bufio"
+	"encoding/base64"
 	"errors"
-	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -16,13 +17,38 @@ func TestPersistentDaemonAuthenticatedBridgeLeaseTakeoverEvictsStaleHolder(t *te
 	socketPath, stop := startPersistentDaemonForTest(t, "bridge-lease-token")
 	defer stop()
 
-	stale, staleReader, _ := openPersistentTestClientWithBridgeLease(
+	stale, staleReader, staleWriter := openPersistentTestClientWithBridgeLease(
 		t,
 		socketPath,
 		"bridge-lease-token",
 		"stale-bridge",
 	)
 	defer stale.Close()
+	staleAttach := persistentTestRPCCall(t, stale, staleReader, staleWriter, rpcRequest{
+		ID:     "stale-attach",
+		Method: "pty.attach",
+		Params: map[string]any{
+			"session_id":              "lease-preserved-session",
+			"attachment_id":           "stale-attachment",
+			"client_attachment_token": "stale-attachment-token",
+			"cols":                    80,
+			"rows":                    24,
+			"command":                 "printf 'lease-preserved-data\\n'; sleep 60",
+		},
+	})
+	if staleAttach["ok"] != true {
+		t.Fatalf("stale bridge PTY attach failed: %v", staleAttach)
+	}
+	readPersistentTestEvent(t, stale, staleReader, func(frame map[string]any) bool {
+		return frame["event"] == "pty.ready" && frame["attachment_id"] == "stale-attachment"
+	})
+	readPersistentTestEvent(t, stale, staleReader, func(frame map[string]any) bool {
+		if frame["event"] != "pty.data" || frame["attachment_id"] != "stale-attachment" {
+			return false
+		}
+		payload, decodeErr := base64.StdEncoding.DecodeString(frame["data_base64"].(string))
+		return decodeErr == nil && strings.Contains(string(payload), "lease-preserved-data")
+	})
 
 	current, currentReader, currentWriter := openPersistentTestClientWithBridgeLease(
 		t,
@@ -32,14 +58,6 @@ func TestPersistentDaemonAuthenticatedBridgeLeaseTakeoverEvictsStaleHolder(t *te
 	)
 	defer current.Close()
 
-	if response := persistentTestRPCCall(t, current, currentReader, currentWriter, rpcRequest{
-		ID:     "hello",
-		Method: "hello",
-		Params: map[string]any{},
-	}); response["ok"] != true {
-		t.Fatalf("replacement bridge hello failed: %v", response)
-	}
-
 	if err := stale.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
 		t.Fatalf("set stale bridge read deadline: %v", err)
 	}
@@ -47,15 +65,68 @@ func TestPersistentDaemonAuthenticatedBridgeLeaseTakeoverEvictsStaleHolder(t *te
 	if err == nil {
 		t.Fatal("stale bridge remained connected after authenticated lease takeover")
 	}
-	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
-		return
-	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		t.Fatalf("stale bridge was not evicted before read deadline: %v", err)
 	}
 	// A Unix socket may report ECONNRESET instead of EOF when the server closes
 	// the connection; any non-timeout read failure is still an eviction.
+	reattach := persistentTestRPCCall(t, current, currentReader, currentWriter, rpcRequest{
+		ID:     "replacement-attach",
+		Method: "pty.attach",
+		Params: map[string]any{
+			"session_id":              "lease-preserved-session",
+			"attachment_id":           "replacement-attachment",
+			"client_attachment_token": "replacement-attachment-token",
+			"cols":                    100,
+			"rows":                    30,
+			"require_existing":        true,
+		},
+	})
+	if reattach["ok"] != true {
+		t.Fatalf("replacement bridge PTY reattach failed: %v", reattach)
+	}
+	result, _ := reattach["result"].(map[string]any)
+	if replayBytes, _ := result["replay_bytes"].(float64); replayBytes <= 0 {
+		t.Fatalf("replacement bridge replay_bytes = %v, want preserved output", result["replay_bytes"])
+	}
+	readPersistentTestEvent(t, current, currentReader, func(frame map[string]any) bool {
+		return frame["event"] == "pty.ready" && frame["attachment_id"] == "replacement-attachment"
+	})
+	readPersistentTestEvent(t, current, currentReader, func(frame map[string]any) bool {
+		if frame["event"] != "pty.data" || frame["attachment_id"] != "replacement-attachment" {
+			return false
+		}
+		payload, decodeErr := base64.StdEncoding.DecodeString(frame["data_base64"].(string))
+		return decodeErr == nil && strings.Contains(string(payload), "lease-preserved-data")
+	})
+}
+
+func TestPersistentDaemonBridgeLeaseTakeoverEvictsLegacyAuthenticatedConnection(t *testing.T) {
+	socketPath, stop := startPersistentDaemonForTest(t, "legacy-bridge-token")
+	defer stop()
+
+	legacy, legacyReader, _ := openPersistentTestClient(t, socketPath, "legacy-bridge-token")
+	defer legacy.Close()
+	replacement, _, _ := openPersistentTestClientWithBridgeLease(
+		t,
+		socketPath,
+		"legacy-bridge-token",
+		"replacement-bridge",
+	)
+	defer replacement.Close()
+
+	if err := legacy.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set legacy bridge read deadline: %v", err)
+	}
+	_, err := legacyReader.ReadByte()
+	if err == nil {
+		t.Fatal("legacy bridge remained connected after lease takeover")
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatalf("legacy bridge was not evicted before read deadline: %v", err)
+	}
 }
 
 func openPersistentTestClientWithBridgeLease(
@@ -69,20 +140,11 @@ func openPersistentTestClientWithBridgeLease(
 	if err != nil {
 		t.Fatalf("dial persistent daemon: %v", err)
 	}
+	if err := authenticatePersistentDaemonClientWithBridgeLease(conn, token, leaseID); err != nil {
+		_ = conn.Close()
+		t.Fatalf("persistent daemon bridge lease auth failed: %v", err)
+	}
 	reader := bufio.NewReader(conn)
 	writer := bufio.NewWriter(conn)
-	writePersistentTestFrame(t, writer, rpcRequest{
-		ID:     "auth-" + leaseID,
-		Method: persistentDaemonAuthMethod,
-		Params: map[string]any{
-			"token":           token,
-			"bridge_lease_id": leaseID,
-		},
-	})
-	frame := readPersistentTestFrame(t, conn, reader)
-	if ok, _ := frame["ok"].(bool); !ok {
-		_ = conn.Close()
-		t.Fatalf("persistent daemon bridge lease auth failed: %v", frame)
-	}
 	return conn, reader, writer
 }

--- a/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/persistent_bridge_lease_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// A bridge whose SSH channel went half-open can remain authenticated on the
+// remote Unix socket forever. The next authenticated bridge must be able to
+// claim the slot and evict that stale connection before it starts forwarding.
+func TestPersistentDaemonAuthenticatedBridgeLeaseTakeoverEvictsStaleHolder(t *testing.T) {
+	socketPath, stop := startPersistentDaemonForTest(t, "bridge-lease-token")
+	defer stop()
+
+	stale, staleReader, _ := openPersistentTestClientWithBridgeLease(
+		t,
+		socketPath,
+		"bridge-lease-token",
+		"stale-bridge",
+	)
+	defer stale.Close()
+
+	current, currentReader, currentWriter := openPersistentTestClientWithBridgeLease(
+		t,
+		socketPath,
+		"bridge-lease-token",
+		"replacement-bridge",
+	)
+	defer current.Close()
+
+	if response := persistentTestRPCCall(t, current, currentReader, currentWriter, rpcRequest{
+		ID:     "hello",
+		Method: "hello",
+		Params: map[string]any{},
+	}); response["ok"] != true {
+		t.Fatalf("replacement bridge hello failed: %v", response)
+	}
+
+	if err := stale.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set stale bridge read deadline: %v", err)
+	}
+	_, err := staleReader.ReadByte()
+	if err == nil {
+		t.Fatal("stale bridge remained connected after authenticated lease takeover")
+	}
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+		return
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatalf("stale bridge was not evicted before read deadline: %v", err)
+	}
+	// A Unix socket may report ECONNRESET instead of EOF when the server closes
+	// the connection; any non-timeout read failure is still an eviction.
+}
+
+func openPersistentTestClientWithBridgeLease(
+	t *testing.T,
+	socketPath string,
+	token string,
+	leaseID string,
+) (net.Conn, *bufio.Reader, *bufio.Writer) {
+	t.Helper()
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial persistent daemon: %v", err)
+	}
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	writePersistentTestFrame(t, writer, rpcRequest{
+		ID:     "auth-" + leaseID,
+		Method: persistentDaemonAuthMethod,
+		Params: map[string]any{
+			"token":           token,
+			"bridge_lease_id": leaseID,
+		},
+	})
+	frame := readPersistentTestFrame(t, conn, reader)
+	if ok, _ := frame["ok"].(bool); !ok {
+		_ = conn.Close()
+		t.Fatalf("persistent daemon bridge lease auth failed: %v", frame)
+	}
+	return conn, reader, writer
+}

--- a/docs/remote-daemon-spec.md
+++ b/docs/remote-daemon-spec.md
@@ -50,6 +50,7 @@ This is a **living implementation spec** (also called an **execution spec**): a 
 - `DONE` bootstrap/probe failures surface actionable details.
 - `DONE` bootstrap installs `~/.cmux/bin/cmux` wrapper (also tries `/usr/local/bin/cmux`) so `cmux` is available in PATH on the remote.
 - `DONE` normal `cmux ssh` launches `cmuxd-remote serve --stdio --persistent --slot <slot> --persistent-lease-port <port>`, where the stdio process proxies to a long-lived authenticated daemon with slot credentials under `~/.cmux/daemon/<version>/<slot>/`, a short per-user socket path under `/tmp/cmuxd-remote-<uid>/`, and an exact relay-slot lease path.
+- `DONE` each persistent stdio bridge claims its slot with a fresh authenticated `bridge_lease_id`; a newer bridge evicts older authenticated connections, including half-open SSH bridges, while the persistent PTY hub remains intact.
 - `DONE` persistent daemon slots advertise `pty.session.persistent_daemon`; cmux requires that capability before preserving a saved remote PTY session ID across app relaunch.
 - `DONE` clean workspace teardown verifies the relay's slot matches the workspace, sends an authenticated per-slot shutdown, waits a bounded interval for daemon ownership to release, removes relay shell state, and passively reaps disconnected, session-empty daemons whose exact previously observed relay slot lease disappears.
 


### PR DESCRIPTION
Closes #10367

## Root cause

Persistent `serve --stdio --persistent` processes authenticated to the per-slot Unix socket but had no bridge ownership protocol. A half-open SSH bridge therefore remained an active connection indefinitely; a replacement bridge could authenticate but could not evict the stale holder, leaving reconnects wedged while the persistent PTY daemon stayed alive.

## Fix

- Generate a fresh `bridge_lease_id` for every persistent stdio bridge.
- Track accepted persistent-daemon connections and make the newest authenticated lease claim authoritative.
- Close older (including legacy no-lease) connections on takeover while leaving the shared persistent PTY hub and sessions intact.
- Keep the existing token authentication and compatibility paths for probes/stop commands.
- Document the wire/lifecycle contract.

The orphaned-slot listing/adoption observation is separate bookkeeping work and is left as follow-up.

## Verification

- Red regression commit: `6d93ddf55` (`test: cover persistent bridge lease takeover`) — the stale connection remained open and timed out before the fix.
- Green fix commit: `f74554bdfa` (`fix: evict stale persistent SSH bridge leases`).
- `go test ./...` in `daemon/remote` — pass.
- `go test -race ./cmd/cmuxd-remote -run "TestPersistentDaemon.*BridgeLease|TestPersistentDaemonPTYReattachSurvivesClientDisconnect" -count=1` — pass.
- `go vet ./...` in `daemon/remote` — pass.
- Manual SIGSTOP harness: a stopped old stdio bridge was taken over by a new bridge, and the new bridge completed `hello`.

No local Xcode build, app launch, or UI test was run; this change is confined to the Go remote daemon and its documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789689902&installation_model_id=21920&pr_number=10368&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10368&signature=612e159c6f5e3dffd817b5d8bf59cba7c9cdff89bca2ec79678b643adf1f73a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evicts stale persistent SSH bridges by introducing an authenticated bridge lease. Previously a half-open `serve --stdio --persistent` bridge could monopolize the per-slot Unix socket; now the newest authenticated bridge with a `bridge_lease_id` claims the slot, older connections close, and the persistent PTY hub/sessions remain intact.

- Clients generate and send `bridge_lease_id` during auth; the daemon claims the newest lease, evicts older (including legacy no-lease) connections, and logs `bridge_lease_takeover` with an eviction count.
- Lease rejection and client-visible errors are sanitized; failed lease ID generation logs `bridge_lease_generation_failed` and returns a generic retryable error.
- All connection dials use context-aware `Dialer` with timeouts for both the Unix socket and TCP proxy opens.
- Compatibility: token-only probes/stop are unchanged; legacy bridges can still connect but will be evicted on takeover. No migration required—persistent bridges include the lease automatically.

<sup>Written for commit 8f3869f53ddf942acca23bc4a4ab52560559eb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent remote daemon bridges now support authenticated lease IDs.
  * Newer bridge connections can replace stale or older connections without interrupting active PTY sessions or replayable output.
  * Legacy connections without lease IDs are also safely replaced.

* **Documentation**
  * Updated remote daemon documentation to describe persistent bridge lease handling and takeover behavior.

* **Tests**
  * Added coverage for bridge takeover while preserving existing sessions and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->