### PR TITLE
Let the iOS toolbar title use all remaining bar width

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -105,6 +105,8 @@ struct AgentChatDemoScreen: View {
                 hasBackButton: true,
                 hasTrailingCluster: true,
                 hasChatToggle: true,
+                measuredTrailingItemsWidth: 0,
+                trailingItemCount: 0,
                 isEnabled: true,
                 workspaceName: inlineWorkspaceTitle ?? "",
                 hasUnread: false,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -106,6 +106,7 @@ struct AgentChatDemoScreen: View {
                 hasTrailingCluster: true,
                 hasChatToggle: true,
                 measuredTrailingItemsWidth: 0,
+                measuredTrailingItemCount: 0,
                 trailingItemCount: 0,
                 isEnabled: true,
                 workspaceName: inlineWorkspaceTitle ?? "",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceGalleryPreviewView.swift
@@ -86,6 +86,7 @@ public struct MacSurfaceGalleryPreviewView: View {
                         createTerminal: {},
                         openBrowser: {},
                         selectBrowserStream: { _ in },
+                        selectSimulatorStream: { _ in },
                         openTextSheet: {},
                         copyDebugLogs: {},
                         sendFeedback: {}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -4,7 +4,8 @@ import CoreGraphics
 ///
 /// The workspace title belongs beside the back button, not in the centered
 /// principal slot. Reserve the trailing toolbar cluster and the leading back
-/// control so the title truncates before it can underlap native toolbar items.
+/// control so the title truncates before it can underlap native toolbar items;
+/// beyond those reserves the title may use all remaining bar width.
 struct MobileLeadingToolbarTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
@@ -16,7 +17,6 @@ struct MobileLeadingToolbarTitleWidth {
     static let chatToggleReserve: CGFloat = 60
     static let barMarginsAndSpacing: CGFloat = 84
     static let unmeasuredFallback: CGFloat = 140
-    static let maximumMeasuredCap: CGFloat = unmeasuredFallback
     static let floor: CGFloat = 96
 
     var cap: CGFloat {
@@ -25,7 +25,6 @@ struct MobileLeadingToolbarTitleWidth {
         let trailing = hasTrailingCluster
             ? Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
             : 0
-        let measuredCap = max(0, contentWidth - leading - trailing - Self.barMarginsAndSpacing)
-        return min(Self.maximumMeasuredCap, measuredCap)
+        return max(0, contentWidth - leading - trailing - Self.barMarginsAndSpacing)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -18,11 +18,16 @@ struct MobileLeadingToolbarTitleWidth {
     let hasBackButton: Bool
     let hasTrailingCluster: Bool
     let hasChatToggle: Bool
-    /// Sum of the measured content widths of every visible trailing toolbar
-    /// item, 0 until the first layout pass reports them.
+    /// Sum of the measured content widths of the structurally visible trailing
+    /// toolbar items, 0 until the first layout pass reports them.
     let measuredTrailingItemsWidth: CGFloat
-    /// How many trailing toolbar items are visible; each carries its own glass
-    /// capsule chrome around the measured content.
+    /// How many of the structurally visible trailing items have reported a
+    /// measurement. A structural item without one (it just appeared and its
+    /// geometry callback has not fired yet) must still reserve fallback space,
+    /// or the title claims the new item's room and bounces it into More.
+    let measuredTrailingItemCount: Int
+    /// How many trailing toolbar items are structurally visible right now;
+    /// each carries its own glass capsule chrome around the measured content.
     let trailingItemCount: Int
 
     static let backButtonReserve: CGFloat = 44
@@ -31,6 +36,9 @@ struct MobileLeadingToolbarTitleWidth {
     static let barMarginsAndSpacing: CGFloat = 84
     /// Horizontal glass-capsule chrome around one trailing item's content.
     static let trailingItemChrome: CGFloat = 24
+    /// Safe content-width reserve for a structural item that has not reported
+    /// geometry yet.
+    static let unmeasuredTrailingItemReserve: CGFloat = 64
     static let unmeasuredFallback: CGFloat = 140
     static let floor: CGFloat = 96
 
@@ -40,6 +48,7 @@ struct MobileLeadingToolbarTitleWidth {
         hasTrailingCluster: Bool,
         hasChatToggle: Bool,
         measuredTrailingItemsWidth: CGFloat = 0,
+        measuredTrailingItemCount: Int = 0,
         trailingItemCount: Int = 0
     ) {
         self.contentWidth = contentWidth
@@ -47,6 +56,7 @@ struct MobileLeadingToolbarTitleWidth {
         self.hasTrailingCluster = hasTrailingCluster
         self.hasChatToggle = hasChatToggle
         self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
+        self.measuredTrailingItemCount = measuredTrailingItemCount
         self.trailingItemCount = trailingItemCount
     }
 
@@ -57,9 +67,11 @@ struct MobileLeadingToolbarTitleWidth {
     }
 
     private var trailingReserve: CGFloat {
-        if measuredTrailingItemsWidth > 0 {
+        if measuredTrailingItemCount > 0 {
+            let unmeasured = CGFloat(max(trailingItemCount - measuredTrailingItemCount, 0))
             return measuredTrailingItemsWidth
                 + CGFloat(max(trailingItemCount, 1)) * Self.trailingItemChrome
+                + unmeasured * Self.unmeasuredTrailingItemReserve
         }
         guard hasTrailingCluster else { return 0 }
         return Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -6,25 +6,62 @@ import CoreGraphics
 /// principal slot. Reserve the trailing toolbar cluster and the leading back
 /// control so the title truncates before it can underlap native toolbar items;
 /// beyond those reserves the title may use all remaining bar width.
+///
+/// iOS overflows toolbar items into a trailing More menu whenever the bar's
+/// contents do not fit, and below iOS 27 there is no public priority to keep
+/// specific items in the bar. The title therefore must never claim space the
+/// trailing items actually render with. Callers report the measured content
+/// widths of the trailing toolbar items; the estimate constants only cover the
+/// frames before the first measurement arrives.
 struct MobileLeadingToolbarTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
     let hasTrailingCluster: Bool
     let hasChatToggle: Bool
+    /// Sum of the measured content widths of every visible trailing toolbar
+    /// item, 0 until the first layout pass reports them.
+    let measuredTrailingItemsWidth: CGFloat
+    /// How many trailing toolbar items are visible; each carries its own glass
+    /// capsule chrome around the measured content.
+    let trailingItemCount: Int
 
     static let backButtonReserve: CGFloat = 44
     static let trailingReserveBase: CGFloat = 64
     static let chatToggleReserve: CGFloat = 60
     static let barMarginsAndSpacing: CGFloat = 84
+    /// Horizontal glass-capsule chrome around one trailing item's content.
+    static let trailingItemChrome: CGFloat = 24
     static let unmeasuredFallback: CGFloat = 140
     static let floor: CGFloat = 96
+
+    init(
+        contentWidth: CGFloat,
+        hasBackButton: Bool,
+        hasTrailingCluster: Bool,
+        hasChatToggle: Bool,
+        measuredTrailingItemsWidth: CGFloat = 0,
+        trailingItemCount: Int = 0
+    ) {
+        self.contentWidth = contentWidth
+        self.hasBackButton = hasBackButton
+        self.hasTrailingCluster = hasTrailingCluster
+        self.hasChatToggle = hasChatToggle
+        self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
+        self.trailingItemCount = trailingItemCount
+    }
 
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
         let leading = hasBackButton ? Self.backButtonReserve : 0
-        let trailing = hasTrailingCluster
-            ? Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
-            : 0
-        return max(0, contentWidth - leading - trailing - Self.barMarginsAndSpacing)
+        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing)
+    }
+
+    private var trailingReserve: CGFloat {
+        if measuredTrailingItemsWidth > 0 {
+            return measuredTrailingItemsWidth
+                + CGFloat(max(trailingItemCount, 1)) * Self.trailingItemChrome
+        }
+        guard hasTrailingCluster else { return 0 }
+        return Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+extension View {
+    /// Reports this trailing toolbar item's rendered content width into the
+    /// shared measurement dictionary.
+    ///
+    /// The leading title menu caps its width to the bar's remaining space so
+    /// the trailing items are never squeezed into the overflow More menu.
+    /// Deliberately no `onDisappear` cleanup: overflowing into More also
+    /// removes the bar content, so clearing on disappear would release the
+    /// reservation and make the collapse sticky. Callers that structurally
+    /// remove an item clear its key from the condition that removed it.
+    func measureTrailingToolbarItem(
+        _ key: String,
+        into widths: Binding<[String: CGFloat]>
+    ) -> some View {
+        onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            widths.wrappedValue[key] = width
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -74,6 +74,11 @@ struct WorkspaceDetailView: View {
     @State var isCustomizationPresented = false
     /// Live pane width for capping the leading glass title pill.
     @State private var contentWidth: CGFloat = 0
+    // Rendered content width per visible trailing toolbar item. The title's
+    // width cap subtracts these so the trailing items always fit and iOS never
+    // folds them into the overflow More menu (no per-item priority exists
+    // below iOS 27).
+    @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
     /// Identity of the in-flight New Browser creation. A late RPC result must
@@ -191,6 +196,16 @@ struct WorkspaceDetailView: View {
             }
             .onChange(of: workspace.simulators) { _, _ in syncSimulatorStreamPanels() }
             .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
+            // Structural removal of a conditional trailing item releases its
+            // width reservation. Layout-driven disappearance (overflow into
+            // the More menu) must NOT release it, or the collapse turns
+            // sticky; see measureTrailingToolbarItem.
+            .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
+                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
+            }
+            .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
+                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
+            }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
                 refreshWorkspaceChangesHint()
@@ -263,6 +278,12 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
+    private var altScreenNoticeIsVisible: Bool {
+        guard let selectedTerminalID else { return false }
+        return store.isAlternateScreen(surfaceID: selectedTerminalID)
+            && displaySettings.showAltScreenNotice
+    }
+
     @ToolbarContentBuilder
     private var workspaceDetailToolbar: some ToolbarContent {
         if backButtonConfiguration != nil {
@@ -276,13 +297,12 @@ struct WorkspaceDetailView: View {
         ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
         }
-        if let selectedTerminalID,
-           store.isAlternateScreen(surfaceID: selectedTerminalID),
-           displaySettings.showAltScreenNotice {
+        if altScreenNoticeIsVisible {
             ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
                 AltScreenNoticeButton {
                     displaySettings.showAltScreenNotice = false
                 }
+                .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
             }
         }
         if workspaceChangesAreAvailable {
@@ -295,10 +315,12 @@ struct WorkspaceDetailView: View {
                 // The chrome sits on the terminal theme's background, not the
                 // system scheme; resolve the counts' green/red for that.
                 .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+                .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
             }
         }
         ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
             toolbarTrailingCluster
+                .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemWidths)
         }
     }
 
@@ -308,6 +330,8 @@ struct WorkspaceDetailView: View {
             hasBackButton: backButtonConfiguration != nil,
             hasTrailingCluster: true,
             hasChatToggle: shouldShowChatToggle,
+            measuredTrailingItemsWidth: trailingToolbarItemWidths.values.reduce(0, +),
+            trailingItemCount: trailingToolbarItemWidths.count,
             isEnabled: hasTitleMenuActions,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -297,31 +297,85 @@ struct WorkspaceDetailView: View {
         ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
         }
+        // iOS 27's visibilityPriority(.high) natively keeps the trailing items
+        // out of the overflow More menu. The symbols are absent from SDK 26.x,
+        // so the branch is compiler-gated until an Xcode 27 toolchain builds
+        // this target; the measured title cap below stays the sizing mechanism
+        // on every OS (the native priority only decides who overflows, it does
+        // not grant the title the remaining space).
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, *) {
+            highPriorityTrailingToolbarItems
+        } else {
+            trailingToolbarItems
+        }
+        #else
+        trailingToolbarItems
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var trailingToolbarItems: some ToolbarContent {
         if altScreenNoticeIsVisible {
             ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
-                AltScreenNoticeButton {
-                    displaySettings.showAltScreenNotice = false
-                }
-                .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
+                altScreenNoticeToolbarContent
             }
         }
         if workspaceChangesAreAvailable {
             ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
-                WorkspaceChangesToolbarButton(
-                    chip: workspaceChangesChip,
-                    workspaceID: workspace.rpcWorkspaceID.rawValue,
-                    action: openWorkspaceChanges
-                )
-                // The chrome sits on the terminal theme's background, not the
-                // system scheme; resolve the counts' green/red for that.
-                .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
-                .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
+                workspaceChangesToolbarContent
             }
         }
         ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
-            toolbarTrailingCluster
-                .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemWidths)
+            trailingClusterToolbarContent
         }
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, *)
+    @ToolbarContentBuilder
+    private var highPriorityTrailingToolbarItems: some ToolbarContent {
+        if altScreenNoticeIsVisible {
+            ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
+                altScreenNoticeToolbarContent
+            }
+            .visibilityPriority(.high)
+        }
+        if workspaceChangesAreAvailable {
+            ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
+                workspaceChangesToolbarContent
+            }
+            .visibilityPriority(.high)
+        }
+        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
+            trailingClusterToolbarContent
+        }
+        .visibilityPriority(.high)
+    }
+    #endif
+
+    private var altScreenNoticeToolbarContent: some View {
+        AltScreenNoticeButton {
+            displaySettings.showAltScreenNotice = false
+        }
+        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
+    }
+
+    private var workspaceChangesToolbarContent: some View {
+        WorkspaceChangesToolbarButton(
+            chip: workspaceChangesChip,
+            workspaceID: workspace.rpcWorkspaceID.rawValue,
+            action: openWorkspaceChanges
+        )
+        // The chrome sits on the terminal theme's background, not the
+        // system scheme; resolve the counts' green/red for that.
+        .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
+    }
+
+    private var trailingClusterToolbarContent: some View {
+        toolbarTrailingCluster
+            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemWidths)
     }
 
     private var workspaceTitleToolbarMenu: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -77,11 +77,10 @@ struct WorkspaceDetailView: View {
     // Rendered content width per trailing toolbar item, keyed by item. The
     // title's width cap subtracts the structurally visible items' widths so
     // they always fit and iOS never folds them into the overflow More menu
-    // (no per-item priority exists below iOS 27). Entries are never deleted:
-    // summation filters by the structural key set, so an entry for a removed
-    // item is simply ignored (and still warm if the item returns), and a
-    // layout-driven disappearance (overflow into More) cannot release the
-    // reservation and make the collapse sticky.
+    // (no per-item priority exists below iOS 27). Only structural removal
+    // deletes an entry (see the onChange handlers); a layout-driven
+    // disappearance (overflow into More) cannot release a reservation and
+    // make the collapse sticky.
     @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
@@ -200,6 +199,17 @@ struct WorkspaceDetailView: View {
             }
             .onChange(of: workspace.simulators) { _, _ in syncSimulatorStreamPanels() }
             .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
+            // Structural removal drops the item's retained measurement so a
+            // returning item takes the fail-safe unmeasured reserve instead of
+            // a stale width for its first layout pass. Layout-driven
+            // disappearance (overflow into More) never flips these conditions,
+            // so it cannot release a reservation and make the collapse sticky.
+            .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
+                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
+            }
+            .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
+                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
+            }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
                 refreshWorkspaceChangesHint()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -74,10 +74,14 @@ struct WorkspaceDetailView: View {
     @State var isCustomizationPresented = false
     /// Live pane width for capping the leading glass title pill.
     @State private var contentWidth: CGFloat = 0
-    // Rendered content width per visible trailing toolbar item. The title's
-    // width cap subtracts these so the trailing items always fit and iOS never
-    // folds them into the overflow More menu (no per-item priority exists
-    // below iOS 27).
+    // Rendered content width per trailing toolbar item, keyed by item. The
+    // title's width cap subtracts the structurally visible items' widths so
+    // they always fit and iOS never folds them into the overflow More menu
+    // (no per-item priority exists below iOS 27). Entries are never deleted:
+    // summation filters by the structural key set, so an entry for a removed
+    // item is simply ignored (and still warm if the item returns), and a
+    // layout-driven disappearance (overflow into More) cannot release the
+    // reservation and make the collapse sticky.
     @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
@@ -196,16 +200,6 @@ struct WorkspaceDetailView: View {
             }
             .onChange(of: workspace.simulators) { _, _ in syncSimulatorStreamPanels() }
             .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
-            // Structural removal of a conditional trailing item releases its
-            // width reservation. Layout-driven disappearance (overflow into
-            // the More menu) must NOT release it, or the collapse turns
-            // sticky; see measureTrailingToolbarItem.
-            .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
-                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
-            }
-            .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
-                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
-            }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
                 refreshWorkspaceChangesHint()
@@ -378,14 +372,25 @@ struct WorkspaceDetailView: View {
             .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemWidths)
     }
 
+    // Which trailing toolbar items are structurally in the bar right now.
+    // Must mirror the conditions in trailingToolbarItems.
+    private var structuralTrailingItemKeys: [String] {
+        var keys = ["trailing-cluster"]
+        if altScreenNoticeIsVisible { keys.append("altscreen-notice") }
+        if workspaceChangesAreAvailable { keys.append("changes") }
+        return keys
+    }
+
     private var workspaceTitleToolbarMenu: some View {
+        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
             hasTrailingCluster: true,
             hasChatToggle: shouldShowChatToggle,
-            measuredTrailingItemsWidth: trailingToolbarItemWidths.values.reduce(0, +),
-            trailingItemCount: trailingToolbarItemWidths.count,
+            measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
+            measuredTrailingItemCount: measuredWidths.count,
+            trailingItemCount: structuralTrailingItemKeys.count,
             isEnabled: hasTitleMenuActions,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -33,7 +33,9 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             contentWidth: value.contentWidth,
             hasBackButton: value.hasBackButton,
             hasTrailingCluster: value.hasTrailingCluster,
-            hasChatToggle: value.hasChatToggle
+            hasChatToggle: value.hasChatToggle,
+            measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
+            trailingItemCount: value.trailingItemCount
         ).cap
 
         return label()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -35,6 +35,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             hasTrailingCluster: value.hasTrailingCluster,
             hasChatToggle: value.hasChatToggle,
             measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
+            measuredTrailingItemCount: value.measuredTrailingItemCount,
             trailingItemCount: value.trailingItemCount
         ).cap
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -6,6 +6,8 @@ struct WorkspaceTitleMenuValue: Equatable {
     let hasBackButton: Bool
     let hasTrailingCluster: Bool
     let hasChatToggle: Bool
+    let measuredTrailingItemsWidth: CGFloat
+    let trailingItemCount: Int
     let isEnabled: Bool
     let workspaceName: String
     let hasUnread: Bool

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -7,6 +7,7 @@ struct WorkspaceTitleMenuValue: Equatable {
     let hasTrailingCluster: Bool
     let hasChatToggle: Bool
     let measuredTrailingItemsWidth: CGFloat
+    let measuredTrailingItemCount: Int
     let trailingItemCount: Int
     let isEnabled: Bool
     let workspaceName: String

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -79,7 +79,10 @@ struct MobileInjectedAttachStartupTests {
             of: MobilePairingURLConnectionResult.self
         )
 
-        #expect(coordinator.startInjectedAttach(
+        // Hoisted out of #expect: the macro captures call arguments in
+        // @Sendable closures, which rejects these non-Sendable closure
+        // parameters on current toolchains.
+        let startedInitialAttach = coordinator.startInjectedAttach(
             attachURL: attachURL,
             prepare: {},
             connect: { rawURL in
@@ -91,14 +94,15 @@ struct MobileInjectedAttachStartupTests {
             onCompletion: { completion in
                 connectionFinished.continuation.yield(completion.result)
             }
-        ))
+        )
+        #expect(startedInitialAttach)
 
         for await _ in connectionStarted.stream.prefix(1) {}
 
         // A reconstructed root asks startup to run again. The app-lifetime
         // coordinator must retain the original task and consume this duplicate
         // request without starting a replacement connection.
-        #expect(coordinator.startInjectedAttach(
+        let startedDuplicateAttach = coordinator.startInjectedAttach(
             attachURL: attachURL,
             prepare: {},
             connect: { rawURL in
@@ -108,7 +112,8 @@ struct MobileInjectedAttachStartupTests {
             onCompletion: { completion in
                 connectionFinished.continuation.yield(completion.result)
             }
-        ))
+        )
+        #expect(startedDuplicateAttach)
 
         allowConnectionToFinish.continuation.yield()
         var results: [MobilePairingURLConnectionResult] = []

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -22,25 +22,17 @@ import Testing
     }
 
     @Test func leadingTitleReservesBackAndTrailingControls() {
-        let expected = min(
-            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
-            393
+        let expected = 393
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.trailingReserveBase
             - MobileLeadingToolbarTitleWidth.chatToggleReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
-        )
 
         #expect(cap(393) == expected)
     }
 
     @Test func titleGainsRoomWithoutChatToggle() {
         #expect(cap(260, hasChatToggle: false) > cap(260, hasChatToggle: true))
-    }
-
-    @Test func iPhoneWidthCapsTitleBeforeTrailingControlsOverflow() {
-        #expect(cap(393, hasChatToggle: true) <= 140)
-        #expect(cap(393, hasChatToggle: false) == 140)
     }
 
     @Test func titleGainsRoomWithoutBackButton() {
@@ -50,17 +42,19 @@ import Testing
     @Test func noTrailingClusterDoesNotReserveChatToggle() {
         let contentWidth: CGFloat = 220
         let withoutTrailing = cap(contentWidth, hasTrailingCluster: false)
-        let expected = min(
-            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
-            contentWidth
+        let expected = contentWidth
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
-        )
 
         #expect(withoutTrailing == expected)
     }
 
-    @Test func measuredWidthDoesNotExpandPastInitialFallback() {
-        #expect(cap(800, hasChatToggle: false) == MobileLeadingToolbarTitleWidth.unmeasuredFallback)
+    @Test func measuredWidthUsesAllRemainingSpace() {
+        let expected: CGFloat = 800
+            - MobileLeadingToolbarTitleWidth.backButtonReserve
+            - MobileLeadingToolbarTitleWidth.trailingReserveBase
+            - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+
+        #expect(cap(800, hasChatToggle: false) == expected)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -57,4 +57,50 @@ import Testing
 
         #expect(cap(800, hasChatToggle: false) == expected)
     }
+
+    @Test func measuredTrailingItemsReplaceTheConstantEstimate() {
+        let measured = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 150,
+            trailingItemCount: 2
+        )
+        let expected: CGFloat = 393
+            - MobileLeadingToolbarTitleWidth.backButtonReserve
+            - (150 + 2 * MobileLeadingToolbarTitleWidth.trailingItemChrome)
+            - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+
+        #expect(measured.cap == max(0, expected))
+    }
+
+    @Test func wideMeasuredTrailingItemsShrinkTheTitleInsteadOfOverflowing() {
+        // A changes chip plus picker plus chat toggle wider than the constant
+        // estimate must shrink the title cap, not push items into More.
+        let constantOnly = cap(393)
+        let measured = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 200,
+            trailingItemCount: 3
+        )
+
+        #expect(measured.cap < constantOnly)
+    }
+
+    @Test func zeroMeasurementFallsBackToConstants() {
+        let unmeasured = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 0,
+            trailingItemCount: 0
+        )
+
+        #expect(unmeasured.cap == cap(393))
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -65,6 +65,7 @@ import Testing
             hasTrailingCluster: true,
             hasChatToggle: true,
             measuredTrailingItemsWidth: 150,
+            measuredTrailingItemCount: 2,
             trailingItemCount: 2
         )
         let expected: CGFloat = 393
@@ -85,6 +86,7 @@ import Testing
             hasTrailingCluster: true,
             hasChatToggle: true,
             measuredTrailingItemsWidth: 200,
+            measuredTrailingItemCount: 3,
             trailingItemCount: 3
         )
 
@@ -98,9 +100,38 @@ import Testing
             hasTrailingCluster: true,
             hasChatToggle: true,
             measuredTrailingItemsWidth: 0,
-            trailingItemCount: 0
+            measuredTrailingItemCount: 0,
+            trailingItemCount: 1
         )
 
         #expect(unmeasured.cap == cap(393))
+    }
+
+    @Test func structuralItemWithoutMeasurementStillReservesSpace() {
+        // The changes chip just appeared: the cluster has measured, the chip
+        // has not. The cap must not expand into the chip's space, or the
+        // system bounces it into the More menu.
+        let clusterOnly = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 90,
+            measuredTrailingItemCount: 1,
+            trailingItemCount: 1
+        )
+        let clusterPlusUnmeasuredChip = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 90,
+            measuredTrailingItemCount: 1,
+            trailingItemCount: 2
+        )
+
+        let reserveDelta = clusterOnly.cap - clusterPlusUnmeasuredChip.cap
+        #expect(reserveDelta
+            >= MobileLeadingToolbarTitleWidth.unmeasuredTrailingItemReserve)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -54,6 +54,8 @@ import Testing
             hasBackButton: true,
             hasTrailingCluster: true,
             hasChatToggle: true,
+            measuredTrailingItemsWidth: 0,
+            trailingItemCount: 0,
             isEnabled: true,
             workspaceName: "Workspace",
             hasUnread: false,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -55,6 +55,7 @@ import Testing
             hasTrailingCluster: true,
             hasChatToggle: true,
             measuredTrailingItemsWidth: 0,
+            measuredTrailingItemCount: 0,
             trailingItemCount: 0,
             isEnabled: true,
             workspaceName: "Workspace",


### PR DESCRIPTION
The leading workspace title menu on iOS was clamped to a flat 140pt (`MobileLeadingToolbarTitleWidth.maximumMeasuredCap`) even when the toolbar had far more room, so long workspace names truncated next to empty space. This drops the flat clamp: the cap is now the measured content width minus the back-button and trailing reserves, so the title/subtitle pill flexes with the remaining horizontal space while still truncating before it can underlap toolbar controls (the guarantee from https://github.com/manaflow-ai/cmux/commit/664a54dd13b75cc5aabebbd5695ed015427e51de).

Dogfood round 2 found that a long title plus the conditional Changes chip could exceed the bar width, and iOS folded the trailing items into the overflow More menu. Two mechanisms address it:

- Sizing (all OS versions): each trailing toolbar item reports its rendered content width via `onGeometryChange`, and the title cap subtracts the measured sum plus per-item capsule chrome, falling back to the old constants until the first measurement. Overflow into More must not release the reservation (that would make the collapse sticky), so there is deliberately no `onDisappear` cleanup; conditional items clear their entry from the condition that structurally removes them.
- Native (iOS 27, staged): `visibilityPriority(.high)` on the trailing items so the system itself keeps them out of More. The symbols are absent from SDK 26.x (zero occurrences in the 26.5 swiftinterface), so the branch is `#if compiler(>=6.4)`-gated and activates with the first Xcode 27 toolchain; the measurement stays the sizing mechanism since the native priority only decides who overflows.

Verified on isolated simulators on BOTH iOS 26.5 and iOS 27.0 runtimes: long title fills the bar and the Changes chip plus trailing cluster stay visible, no More menu.

Two commits fix pre-existing main breakage this PR needs in order to build and test, both hidden from Release/TestFlight lanes: https://github.com/manaflow-ai/cmux/pull/9401 added the required `selectSimulatorStream` action without updating the `MacSurfaceGalleryPreviewView` fixture (`canImport(UIKit) && DEBUG`), breaking every iOS Debug build; and `MobileInjectedAttachStartupTests` passed non-Sendable closures inside `#expect(...)`, breaking the `CmuxMobileShellUITests` target build in the test-ios simulator lane.

Tests: `MobileLeadingToolbarTitleWidthTests` updated; cap-at-140 assertions became expand-with-space assertions, plus measured-trailing cases (measured widths replace the constant estimate, wide measured items shrink the title, zero measurement falls back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)