### PR TITLE
Add cmux-lite protocol, session, transport, and Iroh seams

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Package.resolved
+++ b/Packages/Shared/CmuxIrohTransport/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "4361e52c199c941ace4ca058d9af60cdcfc46890336e9eca1529459a9d50fa95",
+  "originHash" : "caf59d7866dd135ba9d385677851ecb4a7c4c0933587e03f874aa41f276edf70",
   "pins" : [
     {
       "identity" : "iroh-ffi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
-        "version" : "1.0.2-cmux.7"
+        "branch" : "cmux-lite",
+        "revision" : "6eeabebc4cdbcec5f444b756b1e915a6ff26b0b2"
       }
     }
   ],

--- a/Packages/Shared/CmuxIrohTransport/Package.swift
+++ b/Packages/Shared/CmuxIrohTransport/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(path: "../CMUXMobileCore"),
         .package(
             url: "https://github.com/manaflow-ai/iroh-ffi.git",
-            exact: "1.0.2-cmux.7"
+            branch: "cmux-lite"
         ),
     ],
     targets: [

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
-        "version" : "1.0.2-cmux.7"
+        "branch" : "cmux-lite",
+        "revision" : "6eeabebc4cdbcec5f444b756b1e915a6ff26b0b2"
       }
     },
     {

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.resolved
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "455b2b734a1452154959c9d4154c70cd5d933327962fd00e74ff84175dc593fd",
+  "pins" : [
+    {
+      "identity" : "iroh-ffi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
+      "state" : {
+        "branch" : "cmux-lite",
+        "revision" : "173e5a016fb84d97f482cbdf149a7f7e51911935"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
     dependencies: [
         .package(path: "../CmuxLiteProtocol"),
         .package(path: "../CmuxLiteTransport"),
+        .package(
+            url: "https://github.com/manaflow-ai/iroh-ffi.git",
+            branch: "cmux-lite"
+        ),
     ],
     targets: [
         .target(
@@ -24,6 +28,7 @@ let package = Package(
             dependencies: [
                 .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
                 .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
+                .product(name: "IrohLib", package: "iroh-ffi"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
@@ -37,6 +42,7 @@ let package = Package(
                 "CmuxLiteIroh",
                 .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
                 .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
+                .product(name: "IrohLib", package: "iroh-ffi"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../CmuxLiteProtocol"),
+        .package(path: "../CmuxLiteSession"),
         .package(path: "../CmuxLiteTransport"),
         .package(
             url: "https://github.com/manaflow-ai/iroh-ffi.git",
@@ -27,6 +28,7 @@ let package = Package(
             name: "CmuxLiteIroh",
             dependencies: [
                 .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+                .product(name: "CmuxLiteSession", package: "CmuxLiteSession"),
                 .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
                 .product(name: "IrohLib", package: "iroh-ffi"),
             ],
@@ -41,6 +43,7 @@ let package = Package(
             dependencies: [
                 "CmuxLiteIroh",
                 .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+                .product(name: "CmuxLiteSession", package: "CmuxLiteSession"),
                 .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
                 .product(name: "IrohLib", package: "iroh-ffi"),
             ],

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxLiteIroh",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxLiteIroh",
+            targets: ["CmuxLiteIroh"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxLiteProtocol"),
+        .package(path: "../CmuxLiteTransport"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxLiteIroh",
+            dependencies: [
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+                .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxLiteIrohTests",
+            dependencies: [
+                "CmuxLiteIroh",
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+                .product(name: "CmuxLiteTransport", package: "CmuxLiteTransport"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
@@ -1,18 +1,28 @@
 # CmuxLiteIroh
 
-`CmuxLiteIroh` is the Swift adapter boundary for a native Iroh binding. It
-contains no Rust, C headers, static libraries, endpoint key storage, or relay
-configuration yet.
+`CmuxLiteIroh` is the Swift adapter boundary for the isolated `cmux-lite`
+IrohLib binding. It depends on the `cmux-lite` branch of the in-org FFI
+package, but keeps generated handles out of the rest of the experiment.
 
 The package owns the contracts that must be stable before native code enters:
 
 - `IrohConnection` describes one native bidirectional connection;
 - `IrohConnectionProvider` owns endpoint binding and dialing;
+- `IrohLibConnectionProvider` owns one lazily-bound endpoint and shares it
+  across concurrent callers;
 - `IrohConnector` maps generic Iroh routes into the transport dialer;
 - `IrohByteStream` enforces the `ByteStream` lifecycle and rejects overlapping
   operations; its owner must explicitly await `close()` before releasing it;
-- classified Iroh failures map into retryable or terminal transport outcomes.
+- classified Iroh failures map into retryable or terminal transport outcomes;
+- endpoint configuration keeps ALPN, relay mode, key material, and receive
+  limits explicit and validated before native code runs.
 
-The test target injects a fake provider and connection. The next native slice
-will implement the provider with a small Rust C ABI, then run the same tests
-against a local Iroh listener before any app integration.
+The test target injects fake endpoint factories and connections, so endpoint
+reuse and close behavior are verified without a relay. The concrete provider
+currently uses IrohLib's generated async API and opens one bidirectional stream
+per route. A later slice will add a local listener harness and exercise the
+same provider against two real endpoints before any app integration.
+
+Native stream close currently sends a FIN and then closes the QUIC connection;
+the bounded peer-acknowledgement contract is intentionally deferred until the
+binding exposes a cancellable acknowledgement operation.

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
@@ -1,0 +1,18 @@
+# CmuxLiteIroh
+
+`CmuxLiteIroh` is the Swift adapter boundary for a native Iroh binding. It
+contains no Rust, C headers, static libraries, endpoint key storage, or relay
+configuration yet.
+
+The package owns the contracts that must be stable before native code enters:
+
+- `IrohConnection` describes one native bidirectional connection;
+- `IrohConnectionProvider` owns endpoint binding and dialing;
+- `IrohConnector` maps generic Iroh routes into the transport dialer;
+- `IrohByteStream` enforces the `ByteStream` lifecycle and rejects overlapping
+  operations;
+- classified Iroh failures map into retryable or terminal transport outcomes.
+
+The test target injects a fake provider and connection. The next native slice
+will implement the provider with a small Rust C ABI, then run the same tests
+against a local Iroh listener before any app integration.

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
@@ -7,22 +7,35 @@ package, but keeps generated handles out of the rest of the experiment.
 The package owns the contracts that must be stable before native code enters:
 
 - `IrohConnection` describes one native bidirectional connection;
-- `IrohConnectionProvider` owns endpoint binding and dialing;
+- `IrohEndpointProvider` owns endpoint binding, route publication, dialing, and
+  one explicitly owned inbound accept loop;
 - `IrohLibConnectionProvider` owns one lazily-bound endpoint and shares it
   across concurrent callers;
+- `IrohEndpointHost` serializes inbound accepts, isolates admission rejection,
+  and explicitly owns each accepted protocol session;
+- `IrohRouteCatalog` keeps endpoint identity separate from current relay and
+  direct-address hints;
 - `IrohConnector` maps generic Iroh routes into the transport dialer;
 - `IrohByteStream` enforces the `ByteStream` lifecycle and rejects overlapping
   operations; its owner must explicitly await `close()` before releasing it;
 - classified Iroh failures map into retryable or terminal transport outcomes;
 - endpoint configuration keeps ALPN, relay mode, key material, and receive
-  limits explicit and validated before native code runs.
+  limits explicit and validated before native code runs;
+- native stream shutdown drains the final bytes up to a configured deadline,
+  then force-closes a vanished peer.
 
 The test target injects fake endpoint factories and connections, so endpoint
-reuse and close behavior are verified without a relay. The concrete provider
-currently uses IrohLib's generated async API and opens one bidirectional stream
-per route. A later slice will add a local listener harness and exercise the
-same provider against two real endpoints before any app integration.
+reuse, accept ownership, route resolution, and close behavior are verified
+without a relay. The concrete provider uses IrohLib's generated async API and
+opens one bidirectional stream per route. The real integration suite binds two
+ephemeral loopback endpoints and exercises byte exchange, the cmux-lite
+handshake, ping/pong, explicit close, repeated sessions, incompatible ALPN
+isolation, and the generic transport dialer.
 
-Native stream close currently sends a FIN and then closes the QUIC connection;
-the bounded peer-acknowledgement contract is intentionally deferred until the
-binding exposes a cancellable acknowledgement operation.
+The integration suite is intentionally renderer-independent. It proves the
+native endpoint, identity check, route hints, stream framing boundary, and
+session lifecycle without claiming pixel or terminal-renderer parity.
+
+Run every cmux-lite package suite with
+`./scripts/ci/run-cmux-lite-tests.sh`. This is the single entrypoint intended
+for the required CI gate after the experiment is promoted.

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/README.md
@@ -10,7 +10,7 @@ The package owns the contracts that must be stable before native code enters:
 - `IrohConnectionProvider` owns endpoint binding and dialing;
 - `IrohConnector` maps generic Iroh routes into the transport dialer;
 - `IrohByteStream` enforces the `ByteStream` lifecycle and rejects overlapping
-  operations;
+  operations; its owner must explicitly await `close()` before releasing it;
 - classified Iroh failures map into retryable or terminal transport outcomes.
 
 The test target injects a fake provider and connection. The next native slice

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohBinding.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohBinding.swift
@@ -1,0 +1,47 @@
+public import Foundation
+
+/// A native Iroh connection exposed through a small async-safe seam.
+public protocol IrohConnection: Sendable {
+    /// Sends one complete byte chunk to the peer.
+    ///
+    /// - Parameter bytes: Bytes accepted by the native connection.
+    /// - Throws: A binding failure or cancellation.
+    func send(_ bytes: Data) async throws
+
+    /// Receives the next arbitrary byte chunk from the peer.
+    ///
+    /// - Returns: A nonempty chunk, or `nil` after peer EOF.
+    /// - Throws: A binding failure or cancellation.
+    func receive() async throws -> Data?
+
+    /// Closes the native connection idempotently.
+    func close() async
+}
+
+/// Supplies native Iroh connections for one route.
+public protocol IrohConnectionProvider: Sendable {
+    /// Opens a connection to the supplied endpoint.
+    ///
+    /// - Parameter route: The endpoint and optional path hints to dial.
+    /// - Returns: A native connection that is not yet owned by a byte stream.
+    /// - Throws: ``IrohOpenFailure`` or cancellation.
+    func connect(to route: IrohRoute) async throws -> any IrohConnection
+}
+
+/// Classified failures emitted by a native Iroh binding.
+public enum IrohOpenFailure: Error, Equatable, Sendable {
+    /// The endpoint or its current network paths are unavailable.
+    case unavailable
+
+    /// The peer does not support this Iroh protocol version.
+    case incompatiblePeer
+
+    /// The supplied route metadata cannot be used.
+    case invalidRoute
+
+    /// The peer or admission layer denied this connection.
+    case unauthorized
+
+    /// The native endpoint was already closed.
+    case closed
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohBinding.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohBinding.swift
@@ -18,6 +18,15 @@ public protocol IrohConnection: Sendable {
     func close() async
 }
 
+/// Owns one bound native endpoint's public identity and lifecycle.
+public protocol IrohEndpointLifecycle: Sendable {
+    /// Returns this endpoint's current public route after binding if needed.
+    func localRoute() async throws -> IrohRoute
+
+    /// Closes the endpoint and releases all native resources.
+    func close() async
+}
+
 /// Supplies native Iroh connections for one route.
 public protocol IrohConnectionProvider: Sendable {
     /// Opens a connection to the supplied endpoint.
@@ -26,6 +35,39 @@ public protocol IrohConnectionProvider: Sendable {
     /// - Returns: A native connection that is not yet owned by a byte stream.
     /// - Throws: ``IrohOpenFailure`` or cancellation.
     func connect(to route: IrohRoute) async throws -> any IrohConnection
+}
+
+/// One accepted native connection and the peer identity authenticated by Iroh.
+///
+/// The peer route contains public endpoint metadata only. It never contains
+/// the local endpoint's private identity key.
+public struct IrohIncomingConnection: Sendable {
+    /// The authenticated peer identity and any route hints known at accept time.
+    public let peerRoute: IrohRoute
+
+    /// The accepted bidirectional byte connection.
+    public let connection: any IrohConnection
+
+    /// Creates an accepted connection value.
+    public init(
+        peerRoute: IrohRoute,
+        connection: any IrohConnection
+    ) {
+        self.peerRoute = peerRoute
+        self.connection = connection
+    }
+}
+
+/// Supplies both outgoing and incoming connections for one bound endpoint.
+public protocol IrohEndpointProvider:
+    IrohConnectionProvider,
+    IrohEndpointLifecycle
+{
+    /// Waits for the next compatible incoming connection.
+    ///
+    /// `nil` means the endpoint was closed. A listener may reject unrelated or
+    /// malformed candidates internally and continue waiting for the next one.
+    func accept() async throws -> IrohIncomingConnection?
 }
 
 /// Classified failures emitted by a native Iroh binding.
@@ -44,4 +86,11 @@ public enum IrohOpenFailure: Error, Equatable, Sendable {
 
     /// The native endpoint was already closed.
     case closed
+
+    /// Another caller currently owns the endpoint's pending accept operation.
+    ///
+    /// A single accepted connection must never be handed to two consumers, so
+    /// callers create one serialized accept loop rather than racing `accept()`
+    /// from multiple tasks.
+    case acceptAlreadyPending
 }

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohByteStream.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohByteStream.swift
@@ -46,16 +46,14 @@ public actor IrohByteStream: ByteStream {
 
     /// Creates a stream around a native connection returned by a connector.
     ///
+    /// The caller owns the stream lifecycle and must call and await ``close()``
+    /// before releasing the last reference. The adapter does not start
+    /// asynchronous cleanup from `deinit`, because destruction cannot provide
+    /// an ordering guarantee for native connection teardown.
+    ///
     /// - Parameter connection: The native bidirectional Iroh connection.
     public init(connection: any IrohConnection) {
         self.connection = connection
-    }
-
-    deinit {
-        let connectionToClose = connection
-        Task {
-            await connectionToClose.close()
-        }
     }
 
     /// Marks the native connection ready for byte-stream operations.
@@ -133,7 +131,9 @@ public actor IrohByteStream: ByteStream {
         }
     }
 
-    /// Closes the native connection idempotently.
+    /// Closes the native connection idempotently and waits for native teardown.
+    ///
+    /// Owners must await this method before releasing the stream.
     public func close() async {
         guard state != .closed else {
             return

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohByteStream.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohByteStream.swift
@@ -1,0 +1,159 @@
+public import Foundation
+public import CmuxLiteProtocol
+
+/// Adapts one already-open native Iroh connection to ``ByteStream``.
+public actor IrohByteStream: ByteStream {
+    /// Stream lifecycle and misuse failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// A nonempty operation was attempted before ``connect()``.
+        case notConnected
+
+        /// A second send overlapped an existing send.
+        case sendAlreadyPending
+
+        /// A second receive overlapped an existing receive.
+        case receiveAlreadyPending
+
+        /// The native binding violated the byte-stream contract with an empty chunk.
+        case emptyReceivedChunk
+
+        /// The stream was closed and cannot be reused.
+        case closed
+
+        /// The native binding returned a classified failure.
+        case native(IrohOpenFailure)
+
+        /// The native binding returned an error without a classification.
+        case unclassifiedNativeFailure
+    }
+
+    /// The lifecycle phases visible to diagnostics and tests.
+    public enum State: Equatable, Sendable {
+        /// The native connection exists, but the owner has not started it.
+        case idle
+
+        /// The byte stream is ready for send and receive operations.
+        case connected
+
+        /// The stream is terminal.
+        case closed
+    }
+
+    private let connection: any IrohConnection
+    private var state: State = .idle
+    private var sendInFlight = false
+    private var receiveInFlight = false
+
+    /// Creates a stream around a native connection returned by a connector.
+    ///
+    /// - Parameter connection: The native bidirectional Iroh connection.
+    public init(connection: any IrohConnection) {
+        self.connection = connection
+    }
+
+    deinit {
+        let connectionToClose = connection
+        Task {
+            await connectionToClose.close()
+        }
+    }
+
+    /// Marks the native connection ready for byte-stream operations.
+    ///
+    /// Repeated calls after success are idempotent.
+    ///
+    /// - Throws: ``Failure/closed`` after the stream has been closed.
+    public func connect() async throws {
+        switch state {
+        case .idle:
+            state = .connected
+        case .connected:
+            return
+        case .closed:
+            throw Failure.closed
+        }
+    }
+
+    /// Sends one chunk through the native Iroh connection.
+    ///
+    /// Empty data is a no-op. The session owner serializes nonempty sends; the
+    /// adapter rejects a direct overlapping call so bytes cannot interleave.
+    ///
+    /// - Parameter bytes: The next byte chunk.
+    /// - Throws: A lifecycle or native binding failure.
+    public func send(_ bytes: Data) async throws {
+        guard !bytes.isEmpty else {
+            return
+        }
+        guard state == .connected else {
+            throw state == .closed ? Failure.closed : Failure.notConnected
+        }
+        guard !sendInFlight else {
+            throw Failure.sendAlreadyPending
+        }
+
+        sendInFlight = true
+        defer { sendInFlight = false }
+        do {
+            try await connection.send(bytes)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw Self.map(error)
+        }
+    }
+
+    /// Receives one arbitrary chunk from the native Iroh connection.
+    ///
+    /// - Returns: A nonempty chunk, or `nil` after peer EOF.
+    /// - Throws: A lifecycle, overlap, or native binding failure.
+    public func receive() async throws -> Data? {
+        guard state == .connected else {
+            if case .closed = state {
+                return nil
+            }
+            throw Failure.notConnected
+        }
+        guard !receiveInFlight else {
+            throw Failure.receiveAlreadyPending
+        }
+
+        receiveInFlight = true
+        defer { receiveInFlight = false }
+        do {
+            let bytes = try await connection.receive()
+            if let bytes, bytes.isEmpty {
+                throw Failure.emptyReceivedChunk
+            }
+            return bytes
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw Self.map(error)
+        }
+    }
+
+    /// Closes the native connection idempotently.
+    public func close() async {
+        guard state != .closed else {
+            return
+        }
+        state = .closed
+        await connection.close()
+    }
+
+    /// Returns the current stream lifecycle state.
+    public func currentState() -> State {
+        state
+    }
+
+    private static func map(_ error: any Error) -> Failure {
+        if let failure = error as? Failure {
+            return failure
+        }
+        if let failure = error as? IrohOpenFailure {
+            return .native(failure)
+        }
+        return .unclassifiedNativeFailure
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohConnector.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohConnector.swift
@@ -4,12 +4,17 @@ public import CmuxLiteTransport
 /// Opens Iroh routes and returns ``IrohByteStream`` adapters.
 public struct IrohConnector: TransportConnector, Sendable {
     private let provider: any IrohConnectionProvider
+    private let routeResolver: (any IrohRouteResolver)?
 
     /// Creates a connector around a native binding provider.
     ///
     /// - Parameter provider: The object that owns the native Iroh endpoint.
-    public init(provider: any IrohConnectionProvider) {
+    public init(
+        provider: any IrohConnectionProvider,
+        routeResolver: (any IrohRouteResolver)? = nil
+    ) {
         self.provider = provider
+        self.routeResolver = routeResolver
     }
 
     /// Opens one Iroh route and classifies binding failures for fallback policy.
@@ -24,10 +29,25 @@ public struct IrohConnector: TransportConnector, Sendable {
         }
 
         let irohRoute: IrohRoute
-        do {
-            irohRoute = try IrohRoute(endpointID: route.identifier)
-        } catch {
-            throw TransportOpenFailure.invalidRoute
+        if let routeResolver {
+            do {
+                irohRoute = try await routeResolver.resolve(
+                    endpointID: route.identifier
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw TransportOpenFailure.invalidRoute
+            }
+            guard irohRoute.endpointID == route.identifier else {
+                throw TransportOpenFailure.invalidRoute
+            }
+        } else {
+            do {
+                irohRoute = try IrohRoute(endpointID: route.identifier)
+            } catch {
+                throw TransportOpenFailure.invalidRoute
+            }
         }
 
         do {
@@ -42,7 +62,7 @@ public struct IrohConnector: TransportConnector, Sendable {
 
     private static func map(_ failure: IrohOpenFailure) -> TransportOpenFailure {
         switch failure {
-        case .unavailable, .closed:
+        case .unavailable, .closed, .acceptAlreadyPending:
             return .unavailable
         case .incompatiblePeer:
             return .incompatiblePeer

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohConnector.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohConnector.swift
@@ -1,0 +1,55 @@
+public import CmuxLiteProtocol
+public import CmuxLiteTransport
+
+/// Opens Iroh routes and returns ``IrohByteStream`` adapters.
+public struct IrohConnector: TransportConnector, Sendable {
+    private let provider: any IrohConnectionProvider
+
+    /// Creates a connector around a native binding provider.
+    ///
+    /// - Parameter provider: The object that owns the native Iroh endpoint.
+    public init(provider: any IrohConnectionProvider) {
+        self.provider = provider
+    }
+
+    /// Opens one Iroh route and classifies binding failures for fallback policy.
+    ///
+    /// - Parameter route: A generic route whose kind must be ``TransportKind/iroh``.
+    /// - Returns: An unstarted ``IrohByteStream``.
+    /// - Throws: ``TransportOpenFailure`` for classified route failures, or an
+    ///   unclassified error that the dialer will treat as non-retryable.
+    public func open(route: TransportRoute) async throws -> any ByteStream {
+        guard route.kind == .iroh else {
+            throw TransportOpenFailure.invalidRoute
+        }
+
+        let irohRoute: IrohRoute
+        do {
+            irohRoute = try IrohRoute(endpointID: route.identifier)
+        } catch {
+            throw TransportOpenFailure.invalidRoute
+        }
+
+        do {
+            let connection = try await provider.connect(to: irohRoute)
+            return IrohByteStream(connection: connection)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as IrohOpenFailure {
+            throw Self.map(failure)
+        }
+    }
+
+    private static func map(_ failure: IrohOpenFailure) -> TransportOpenFailure {
+        switch failure {
+        case .unavailable, .closed:
+            return .unavailable
+        case .incompatiblePeer:
+            return .incompatiblePeer
+        case .invalidRoute:
+            return .invalidRoute
+        case .unauthorized:
+            return .unauthorized
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointDriver.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointDriver.swift
@@ -6,11 +6,20 @@ public import Foundation
 /// exercise endpoint reuse, close ordering, and route handling without a live
 /// relay or a platform network.
 public protocol IrohEndpointDriver: Sendable {
+    /// Returns the endpoint's current public identity and address hints.
+    func localRoute() async throws -> IrohRoute
+
     /// Opens one bidirectional byte connection to a route.
     func connect(
         to route: IrohRoute,
         alpn: Data
     ) async throws -> any IrohConnection
+
+    /// Accepts the next incoming connection advertising the requested ALPN.
+    ///
+    /// Implementations may consume and reject unrelated candidates before
+    /// returning. `nil` means the endpoint has been closed.
+    func accept(alpn: Data) async throws -> IrohIncomingConnection?
 
     /// Closes the endpoint and releases native resources.
     func close() async

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointDriver.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointDriver.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+/// The small native-endpoint seam consumed by ``IrohLibConnectionProvider``.
+///
+/// Keeping this protocol above the generated IrohLib classes lets unit tests
+/// exercise endpoint reuse, close ordering, and route handling without a live
+/// relay or a platform network.
+public protocol IrohEndpointDriver: Sendable {
+    /// Opens one bidirectional byte connection to a route.
+    func connect(
+        to route: IrohRoute,
+        alpn: Data
+    ) async throws -> any IrohConnection
+
+    /// Closes the endpoint and releases native resources.
+    func close() async
+}
+
+/// Creates one native endpoint generation from immutable configuration.
+public protocol IrohEndpointFactory: Sendable {
+    /// Binds an endpoint or throws a classified native failure.
+    func bind(
+        configuration: IrohLibConfiguration
+    ) async throws -> any IrohEndpointDriver
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointHost.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohEndpointHost.swift
@@ -1,0 +1,256 @@
+internal import Foundation
+public import CmuxLiteProtocol
+public import CmuxLiteSession
+
+/// Owns the serialized inbound accept loop for one bound Iroh endpoint.
+///
+/// The endpoint provider only accepts native connections. This host gives each
+/// accepted byte stream one session owner, keeps those owners alive until they
+/// finish, and closes them before the endpoint. A factory supplies application
+/// handshake policy without exposing generated IrohLib handles.
+public actor IrohEndpointHost {
+    /// Host lifecycle and admission failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// ``start()`` was called more than once.
+        case alreadyStarted
+
+        /// The endpoint failed before it could accept another connection.
+        case endpoint(IrohOpenFailure)
+
+        /// The generated binding returned an unclassified failure.
+        case unclassifiedEndpointFailure
+    }
+
+    /// Events emitted by the endpoint host in lifecycle order.
+    public enum Event: Equatable, Sendable {
+        /// The endpoint is bound and ready for publication.
+        case listening(IrohRoute)
+
+        /// A peer completed Iroh identity authentication and stream setup.
+        case accepted(peer: IrohRoute)
+
+        /// One admitted peer's protocol session ended.
+        case sessionClosed(peerEndpointID: String)
+
+        /// The listener ended because the endpoint failed.
+        case failure(Failure)
+
+        /// The host and every owned session are closed.
+        case closed
+    }
+
+    /// Creates the server handshake configuration for one authenticated peer.
+    ///
+    /// Throwing rejects that peer and closes only its connection. The accept
+    /// loop remains live for later candidates.
+    public typealias SessionConfigurationFactory = @Sendable (
+        _ peer: IrohRoute
+    ) async throws -> SessionOwner.Configuration
+
+    /// A single-consumer stream of listener and session lifecycle events.
+    public nonisolated let events: AsyncStream<Event>
+
+    private struct ActiveSession: Sendable {
+        let peer: IrohRoute
+        let owner: SessionOwner
+    }
+
+    private let endpoint: any IrohEndpointProvider
+    private let codec: FrameCodec
+    private let makeSessionConfiguration: SessionConfigurationFactory
+    private let eventContinuation: AsyncStream<Event>.Continuation
+    private var acceptLoopTask: Task<Void, Never>?
+    private var sessions: [UUID: ActiveSession] = [:]
+    private var observationTasks: [UUID: Task<Void, Never>] = [:]
+    private var started = false
+    private var closed = false
+
+    /// Creates a host around an endpoint with caller-owned handshake policy.
+    public init(
+        endpoint: any IrohEndpointProvider,
+        codec: FrameCodec,
+        makeSessionConfiguration: @escaping SessionConfigurationFactory
+    ) {
+        self.endpoint = endpoint
+        self.codec = codec
+        self.makeSessionConfiguration = makeSessionConfiguration
+        let (events, continuation) = AsyncStream<Event>.makeStream()
+        self.events = events
+        eventContinuation = continuation
+    }
+
+    deinit {
+        acceptLoopTask?.cancel()
+        for task in observationTasks.values {
+            task.cancel()
+        }
+        eventContinuation.finish()
+    }
+
+    /// Binds the endpoint, publishes its initial route, and starts accepting.
+    public func start() async throws {
+        guard !started else {
+            throw Failure.alreadyStarted
+        }
+        started = true
+
+        do {
+            let route = try await endpoint.localRoute()
+            guard !closed else {
+                throw IrohOpenFailure.closed
+            }
+            eventContinuation.yield(.listening(route))
+            acceptLoopTask = Task { [weak self] in
+                await self?.runAcceptLoop()
+            }
+        } catch {
+            let failure = Self.map(error)
+            await stopAfterFailure(failure)
+            throw failure
+        }
+    }
+
+    /// Returns the endpoint's current route without changing host lifecycle.
+    public func localRoute() async throws -> IrohRoute {
+        try await endpoint.localRoute()
+    }
+
+    /// Closes the listener and every active session, then finishes events.
+    public func close() async {
+        guard !closed else {
+            return
+        }
+        closed = true
+        acceptLoopTask?.cancel()
+        acceptLoopTask = nil
+
+        let activeSessions = Array(sessions.values)
+        sessions.removeAll(keepingCapacity: false)
+        let activeObservationTasks = Array(observationTasks.values)
+        observationTasks.removeAll(keepingCapacity: false)
+        for task in activeObservationTasks {
+            task.cancel()
+        }
+        for session in activeSessions {
+            await session.owner.close()
+        }
+        await endpoint.close()
+        eventContinuation.yield(.closed)
+        eventContinuation.finish()
+    }
+
+    /// Returns authenticated endpoint identities for currently owned sessions.
+    public func activePeerEndpointIDs() -> [String] {
+        sessions.values
+            .map(\.peer.endpointID)
+            .sorted()
+    }
+
+    private func runAcceptLoop() async {
+        do {
+            while !Task.isCancelled, !closed {
+                guard let incoming = try await endpoint.accept() else {
+                    await close()
+                    return
+                }
+                await admit(incoming)
+            }
+        } catch is CancellationError {
+            guard !closed else {
+                return
+            }
+            await stopAfterFailure(.unclassifiedEndpointFailure)
+            return
+        } catch {
+            guard !closed else {
+                return
+            }
+            await stopAfterFailure(Self.map(error))
+        }
+    }
+
+    private func admit(_ incoming: IrohIncomingConnection) async {
+        let stream = IrohByteStream(connection: incoming.connection)
+        let configuration: SessionOwner.Configuration
+        do {
+            configuration = try await makeSessionConfiguration(
+                incoming.peerRoute
+            )
+        } catch {
+            await stream.close()
+            return
+        }
+        guard !closed else {
+            await stream.close()
+            return
+        }
+
+        // Register ownership before `start()`. A peer can complete and close
+        // during that suspension; the later observer still drains buffered
+        // events and removes the already-owned session deterministically.
+        let sessionID = UUID()
+        let owner = SessionOwner(
+            configuration: configuration,
+            stream: stream,
+            codec: codec
+        )
+        sessions[sessionID] = ActiveSession(
+            peer: incoming.peerRoute,
+            owner: owner
+        )
+        do {
+            try await owner.start()
+        } catch {
+            sessions.removeValue(forKey: sessionID)
+            await owner.close()
+            return
+        }
+        guard !closed else {
+            sessions.removeValue(forKey: sessionID)
+            await owner.close()
+            return
+        }
+
+        let events = owner.events
+        let observationTask = Task { [weak self] in
+            for await event in events {
+                guard case .closed = event else {
+                    continue
+                }
+                await self?.sessionDidClose(id: sessionID)
+                return
+            }
+            await self?.sessionDidClose(id: sessionID)
+        }
+        observationTasks[sessionID] = observationTask
+        eventContinuation.yield(.accepted(peer: incoming.peerRoute))
+    }
+
+    private func sessionDidClose(id: UUID) {
+        guard let session = sessions.removeValue(forKey: id) else {
+            return
+        }
+        observationTasks.removeValue(forKey: id)
+        eventContinuation.yield(
+            .sessionClosed(peerEndpointID: session.peer.endpointID)
+        )
+    }
+
+    private func stopAfterFailure(_ failure: Failure) async {
+        guard !closed else {
+            return
+        }
+        eventContinuation.yield(.failure(failure))
+        await close()
+    }
+
+    private static func map(_ error: any Error) -> Failure {
+        if let failure = error as? Failure {
+            return failure
+        }
+        if let failure = error as? IrohOpenFailure {
+            return .endpoint(failure)
+        }
+        return .unclassifiedEndpointFailure
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConfiguration.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConfiguration.swift
@@ -1,0 +1,90 @@
+public import Foundation
+
+/// Immutable inputs used to bind one native Iroh endpoint.
+///
+/// The configuration deliberately contains values rather than IrohLib objects.
+/// That keeps endpoint construction in one place and makes key custody and
+/// relay policy explicit at the call site.
+public struct IrohLibConfiguration: Equatable, Sendable {
+    /// The relay policy used while binding the endpoint.
+    public enum RelayMode: Equatable, Sendable {
+        /// Use the n0 production relay and discovery preset.
+        case production
+
+        /// Use the n0 staging relay and discovery preset.
+        case staging
+
+        /// Disable relays and discovery. Direct addresses still work.
+        case disabled
+    }
+
+    /// Configuration validation failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// Iroh requires a nonempty ALPN protocol identifier.
+        case emptyALPN
+
+        /// A supplied secret key must contain exactly 32 bytes.
+        case invalidSecretKeyLength(Int)
+
+        /// Native reads need a positive upper bound.
+        case invalidReceiveChunkLimit
+    }
+
+    /// A conservative default for the cmux-lite protocol.
+    public static let standard = IrohLibConfiguration(
+        uncheckedALPN: Data("dev.cmux.cmux-lite/1".utf8),
+        relayMode: .production,
+        secretKeyBytes: nil,
+        maximumReceiveChunkBytes: 64 * 1024
+    )
+
+    /// The ALPN negotiated by both peers.
+    public let alpn: Data
+
+    /// The relay/discovery mode for the endpoint.
+    public let relayMode: RelayMode
+
+    /// Optional caller-owned 32-byte endpoint key material.
+    ///
+    /// The provider does not persist or generate this value. A later Keychain
+    /// slice will supply it here and retain ownership outside the binding.
+    public let secretKeyBytes: Data?
+
+    /// Maximum number of bytes returned by one native receive operation.
+    public let maximumReceiveChunkBytes: UInt32
+
+    /// Creates a validated endpoint configuration.
+    public init(
+        alpn: Data,
+        relayMode: RelayMode = .production,
+        secretKeyBytes: Data? = nil,
+        maximumReceiveChunkBytes: UInt32 = 64 * 1024
+    ) throws {
+        guard !alpn.isEmpty else {
+            throw Failure.emptyALPN
+        }
+        if let secretKeyBytes, secretKeyBytes.count != 32 {
+            throw Failure.invalidSecretKeyLength(secretKeyBytes.count)
+        }
+        guard maximumReceiveChunkBytes > 0 else {
+            throw Failure.invalidReceiveChunkLimit
+        }
+
+        self.alpn = Data(alpn)
+        self.relayMode = relayMode
+        self.secretKeyBytes = secretKeyBytes.map { Data($0) }
+        self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+    }
+
+    private init(
+        uncheckedALPN alpn: Data,
+        relayMode: RelayMode,
+        secretKeyBytes: Data?,
+        maximumReceiveChunkBytes: UInt32
+    ) {
+        self.alpn = alpn
+        self.relayMode = relayMode
+        self.secretKeyBytes = secretKeyBytes
+        self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConfiguration.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConfiguration.swift
@@ -28,6 +28,12 @@ public struct IrohLibConfiguration: Equatable, Sendable {
 
         /// Native reads need a positive upper bound.
         case invalidReceiveChunkLimit
+
+        /// Graceful stream shutdown needs a positive drain deadline.
+        case invalidCloseDrainTimeout
+
+        /// A supplied bind address must not be empty or whitespace-only.
+        case emptyBindAddress
     }
 
     /// A conservative default for the cmux-lite protocol.
@@ -35,7 +41,9 @@ public struct IrohLibConfiguration: Equatable, Sendable {
         uncheckedALPN: Data("dev.cmux.cmux-lite/1".utf8),
         relayMode: .production,
         secretKeyBytes: nil,
-        maximumReceiveChunkBytes: 64 * 1024
+        maximumReceiveChunkBytes: 64 * 1024,
+        bindAddress: nil,
+        closeDrainTimeout: .seconds(2)
     )
 
     /// The ALPN negotiated by both peers.
@@ -43,6 +51,13 @@ public struct IrohLibConfiguration: Equatable, Sendable {
 
     /// The relay/discovery mode for the endpoint.
     public let relayMode: RelayMode
+
+    /// Optional local socket address in `host:port` form.
+    ///
+    /// Leaving this nil lets Iroh choose its normal platform bind addresses.
+    /// Tests and local harnesses can use `127.0.0.1:0` to force a direct,
+    /// ephemeral loopback socket without involving a relay.
+    public let bindAddress: String?
 
     /// Optional caller-owned 32-byte endpoint key material.
     ///
@@ -53,12 +68,21 @@ public struct IrohLibConfiguration: Equatable, Sendable {
     /// Maximum number of bytes returned by one native receive operation.
     public let maximumReceiveChunkBytes: UInt32
 
+    /// Maximum time to wait for a finished native stream before forcing close.
+    ///
+    /// The deadline prevents a vanished peer from pinning an actor forever,
+    /// while still giving a normal peer time to consume the final protocol
+    /// close frame.
+    public let closeDrainTimeout: Duration
+
     /// Creates a validated endpoint configuration.
     public init(
         alpn: Data,
         relayMode: RelayMode = .production,
         secretKeyBytes: Data? = nil,
-        maximumReceiveChunkBytes: UInt32 = 64 * 1024
+        maximumReceiveChunkBytes: UInt32 = 64 * 1024,
+        bindAddress: String? = nil,
+        closeDrainTimeout: Duration = .seconds(2)
     ) throws {
         guard !alpn.isEmpty else {
             throw Failure.emptyALPN
@@ -66,25 +90,39 @@ public struct IrohLibConfiguration: Equatable, Sendable {
         if let secretKeyBytes, secretKeyBytes.count != 32 {
             throw Failure.invalidSecretKeyLength(secretKeyBytes.count)
         }
+        if let bindAddress,
+           bindAddress.isEmpty || bindAddress.allSatisfy({ $0.isWhitespace })
+        {
+            throw Failure.emptyBindAddress
+        }
         guard maximumReceiveChunkBytes > 0 else {
             throw Failure.invalidReceiveChunkLimit
+        }
+        guard closeDrainTimeout > .zero else {
+            throw Failure.invalidCloseDrainTimeout
         }
 
         self.alpn = Data(alpn)
         self.relayMode = relayMode
+        self.bindAddress = bindAddress
         self.secretKeyBytes = secretKeyBytes.map { Data($0) }
         self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+        self.closeDrainTimeout = closeDrainTimeout
     }
 
     private init(
         uncheckedALPN alpn: Data,
         relayMode: RelayMode,
         secretKeyBytes: Data?,
-        maximumReceiveChunkBytes: UInt32
+        maximumReceiveChunkBytes: UInt32,
+        bindAddress: String?,
+        closeDrainTimeout: Duration
     ) {
         self.alpn = alpn
         self.relayMode = relayMode
+        self.bindAddress = bindAddress
         self.secretKeyBytes = secretKeyBytes
         self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+        self.closeDrainTimeout = closeDrainTimeout
     }
 }

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnection.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnection.swift
@@ -1,6 +1,16 @@
 import Foundation
 import IrohLib
 
+protocol IrohCloseClock: Sendable {
+    func sleep(for duration: Duration) async throws
+}
+
+struct ContinuousIrohCloseClock: IrohCloseClock, Sendable {
+    func sleep(for duration: Duration) async throws {
+        try await ContinuousClock().sleep(for: duration)
+    }
+}
+
 /// Adapts one IrohLib bidirectional stream to the cmux-lite native seam.
 ///
 /// The class is intentionally `@unchecked Sendable`: generated IrohLib
@@ -11,18 +21,24 @@ final class IrohLibConnection: IrohConnection, @unchecked Sendable {
     private let sendStream: SendStream
     private let receiveStream: RecvStream
     private let maximumReceiveChunkBytes: UInt32
+    private let closeDrainTimeout: Duration
+    private let closeClock: any IrohCloseClock
     private let stateLock = NSLock()
     private var closed = false
 
     init(
         connection: Connection,
         stream: BiStream,
-        maximumReceiveChunkBytes: UInt32
+        maximumReceiveChunkBytes: UInt32,
+        closeDrainTimeout: Duration = .seconds(2),
+        closeClock: any IrohCloseClock = ContinuousIrohCloseClock()
     ) {
         self.connection = connection
         sendStream = stream.send()
         receiveStream = stream.recv()
         self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+        self.closeDrainTimeout = closeDrainTimeout
+        self.closeClock = closeClock
     }
 
     func send(_ bytes: Data) async throws {
@@ -62,12 +78,40 @@ final class IrohLibConnection: IrohConnection, @unchecked Sendable {
             return
         }
 
-        // Finish before closing the QUIC connection so a caller that has
-        // explicitly awaited the stream's close observes an ordered FIN. The
-        // acknowledgement wait belongs in a later, cancellable native slice;
-        // this first provider keeps shutdown bounded when the peer vanished.
-        try? await sendStream.finish()
+        // Finish before closing the QUIC connection, then wait until Iroh has
+        // observed the peer consume the stream. Closing the connection
+        // immediately after queuing FIN can race the final protocol frame and
+        // make a peer report transport failure instead of the explicit close.
+        // The deadline branch force-closes the connection if the peer vanished,
+        // so explicit lifecycle ownership never turns into an unbounded wait.
+        await drainSendStream()
         try? connection.close(errorCode: 0, reason: Data())
+    }
+
+    private func drainSendStream() async {
+        let sendStream = self.sendStream
+        let connection = self.connection
+        let timeout = self.closeDrainTimeout
+        let clock = self.closeClock
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try? await sendStream.finish()
+                _ = try? await sendStream.stopped()
+            }
+            group.addTask {
+                do {
+                    try await clock.sleep(for: timeout)
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
+                try? connection.close(errorCode: 0, reason: Data())
+            }
+            await group.next()
+            group.cancelAll()
+        }
     }
 
     private func isClosed() -> Bool {

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnection.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnection.swift
@@ -1,0 +1,92 @@
+import Foundation
+import IrohLib
+
+/// Adapts one IrohLib bidirectional stream to the cmux-lite native seam.
+///
+/// The class is intentionally `@unchecked Sendable`: generated IrohLib
+/// handles are thread-safe, and the outer ``IrohByteStream`` actor serializes
+/// each direction. A lock protects only the terminal close flag.
+final class IrohLibConnection: IrohConnection, @unchecked Sendable {
+    private let connection: Connection
+    private let sendStream: SendStream
+    private let receiveStream: RecvStream
+    private let maximumReceiveChunkBytes: UInt32
+    private let stateLock = NSLock()
+    private var closed = false
+
+    init(
+        connection: Connection,
+        stream: BiStream,
+        maximumReceiveChunkBytes: UInt32
+    ) {
+        self.connection = connection
+        sendStream = stream.send()
+        receiveStream = stream.recv()
+        self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+    }
+
+    func send(_ bytes: Data) async throws {
+        guard !bytes.isEmpty else {
+            return
+        }
+        guard !isClosed() else {
+            throw IrohOpenFailure.closed
+        }
+        do {
+            try await sendStream.writeAll(buf: bytes)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
+    func receive() async throws -> Data? {
+        if isClosed() {
+            return nil
+        }
+        do {
+            let bytes = try await receiveStream.read(
+                sizeLimit: maximumReceiveChunkBytes
+            )
+            return bytes.isEmpty ? nil : bytes
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
+    func close() async {
+        guard markClosed() else {
+            return
+        }
+
+        // Finish before closing the QUIC connection so a caller that has
+        // explicitly awaited the stream's close observes an ordered FIN. The
+        // acknowledgement wait belongs in a later, cancellable native slice;
+        // this first provider keeps shutdown bounded when the peer vanished.
+        try? await sendStream.finish()
+        try? connection.close(errorCode: 0, reason: Data())
+    }
+
+    private func isClosed() -> Bool {
+        stateLock.withLock { closed }
+    }
+
+    private func markClosed() -> Bool {
+        stateLock.withLock {
+            guard !closed else { return false }
+            closed = true
+            return true
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnectionProvider.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnectionProvider.swift
@@ -6,7 +6,7 @@ import IrohLib
 /// Binding is shared by concurrent callers. The provider never creates a
 /// second endpoint generation merely because two sessions begin at once, and
 /// `close()` is explicit so endpoint teardown has a deterministic owner.
-public actor IrohLibConnectionProvider: IrohConnectionProvider {
+public actor IrohLibConnectionProvider: IrohEndpointProvider {
     private let configuration: IrohLibConfiguration
     private let factory: any IrohEndpointFactory
     private var endpoint: (any IrohEndpointDriver)?
@@ -14,6 +14,7 @@ public actor IrohLibConnectionProvider: IrohConnectionProvider {
     private var bindingWaiters: [
         CheckedContinuation<any IrohEndpointDriver, any Error>
     ] = []
+    private var acceptTask: Task<IrohIncomingConnection?, any Error>?
     private var isClosed = false
 
     /// Creates a provider using the checked-in IrohLib implementation.
@@ -56,12 +57,74 @@ public actor IrohLibConnectionProvider: IrohConnectionProvider {
         }
     }
 
+    /// Returns the endpoint's public identity and currently known addresses.
+    public func localRoute() async throws -> IrohRoute {
+        guard !isClosed else {
+            throw IrohOpenFailure.closed
+        }
+
+        let endpoint = try await endpointDriver()
+        do {
+            return try await endpoint.localRoute()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as IrohOpenFailure {
+            throw failure
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
+    /// Waits for one incoming connection.
+    ///
+    /// The provider permits one pending accept owner. A second caller is
+    /// rejected instead of receiving the same connection value, which would
+    /// create two owners for one native stream. Closing the provider cancels
+    /// this operation and closes the native endpoint so a pending caller cannot
+    /// hang forever.
+    public func accept() async throws -> IrohIncomingConnection? {
+        guard !isClosed else {
+            throw IrohOpenFailure.closed
+        }
+
+        // Claim accept ownership before the binding await. Otherwise two actor
+        // calls can both enter `endpointDriver()` while it suspends and each
+        // start a native accept after the shared bind completes.
+        guard acceptTask == nil else {
+            throw IrohOpenFailure.acceptAlreadyPending
+        }
+        let alpn = configuration.alpn
+        let task = Task<IrohIncomingConnection?, any Error> {
+            let endpoint = try await self.endpointDriver()
+            return try await endpoint.accept(alpn: alpn)
+        }
+        acceptTask = task
+
+        do {
+            let incoming = try await task.value
+            acceptTask = nil
+            if isClosed {
+                await incoming?.connection.close()
+                throw IrohOpenFailure.closed
+            }
+            return incoming
+        } catch is CancellationError {
+            acceptTask = nil
+            throw CancellationError()
+        } catch {
+            acceptTask = nil
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
     /// Closes the endpoint generation after all callers have stopped using it.
     public func close() async {
         guard !isClosed else {
             return
         }
         isClosed = true
+        acceptTask?.cancel()
+        acceptTask = nil
         resumeBindingWaiters(throwing: IrohOpenFailure.closed)
 
         guard let endpoint else {

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnectionProvider.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibConnectionProvider.swift
@@ -1,0 +1,156 @@
+import Foundation
+import IrohLib
+
+/// Owns one lazily-bound native Iroh endpoint for the cmux-lite client.
+///
+/// Binding is shared by concurrent callers. The provider never creates a
+/// second endpoint generation merely because two sessions begin at once, and
+/// `close()` is explicit so endpoint teardown has a deterministic owner.
+public actor IrohLibConnectionProvider: IrohConnectionProvider {
+    private let configuration: IrohLibConfiguration
+    private let factory: any IrohEndpointFactory
+    private var endpoint: (any IrohEndpointDriver)?
+    private var isBinding = false
+    private var bindingWaiters: [
+        CheckedContinuation<any IrohEndpointDriver, any Error>
+    ] = []
+    private var isClosed = false
+
+    /// Creates a provider using the checked-in IrohLib implementation.
+    public init(
+        configuration: IrohLibConfiguration = .standard
+    ) {
+        self.init(
+            configuration: configuration,
+            factory: IrohLibEndpointFactory()
+        )
+    }
+
+    /// Test and alternate-runtime initializer.
+    init(
+        configuration: IrohLibConfiguration,
+        factory: any IrohEndpointFactory
+    ) {
+        self.configuration = configuration
+        self.factory = factory
+    }
+
+    /// Opens one route through the shared endpoint generation.
+    public func connect(to route: IrohRoute) async throws -> any IrohConnection {
+        guard !isClosed else {
+            throw IrohOpenFailure.closed
+        }
+
+        let endpoint = try await endpointDriver()
+        do {
+            return try await endpoint.connect(
+                to: route,
+                alpn: configuration.alpn
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as IrohOpenFailure {
+            throw failure
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
+    /// Closes the endpoint generation after all callers have stopped using it.
+    public func close() async {
+        guard !isClosed else {
+            return
+        }
+        isClosed = true
+        resumeBindingWaiters(throwing: IrohOpenFailure.closed)
+
+        guard let endpoint else {
+            return
+        }
+        self.endpoint = nil
+        await endpoint.close()
+    }
+
+    private func endpointDriver() async throws -> any IrohEndpointDriver {
+        if let endpoint {
+            return endpoint
+        }
+        guard !isClosed else {
+            throw IrohOpenFailure.closed
+        }
+
+        if isBinding {
+            return try await withCheckedThrowingContinuation { continuation in
+                bindingWaiters.append(continuation)
+            }
+        }
+        isBinding = true
+
+        do {
+            let endpoint = try await factory.bind(configuration: configuration)
+            isBinding = false
+            guard !isClosed else {
+                await endpoint.close()
+                resumeBindingWaiters(throwing: IrohOpenFailure.closed)
+                throw IrohOpenFailure.closed
+            }
+            self.endpoint = endpoint
+            resumeBindingWaiters(returning: endpoint)
+            return endpoint
+        } catch is CancellationError {
+            isBinding = false
+            resumeBindingWaiters(throwing: CancellationError())
+            throw CancellationError()
+        } catch {
+            isBinding = false
+            let failure = IrohLibFailureMapper.openFailure(for: error)
+            resumeBindingWaiters(throwing: failure)
+            throw failure
+        }
+    }
+
+    private func resumeBindingWaiters(
+        returning endpoint: any IrohEndpointDriver
+    ) {
+        let waiters = bindingWaiters
+        bindingWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume(returning: endpoint)
+        }
+    }
+
+    private func resumeBindingWaiters(throwing error: any Error) {
+        let waiters = bindingWaiters
+        bindingWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume(throwing: error)
+        }
+    }
+}
+
+/// Maps the generated binding's coarse error taxonomy into the transport seam.
+enum IrohLibFailureMapper {
+    static func openFailure(for error: any Error) -> IrohOpenFailure {
+        if let failure = error as? IrohOpenFailure {
+            return failure
+        }
+        guard let error = error as? IrohError else {
+            return .unavailable
+        }
+        return openFailure(for: error.kind())
+    }
+
+    static func openFailure(for kind: IrohErrorKind) -> IrohOpenFailure {
+        switch kind {
+        case .invalidInput, .keyParsing, .ticketParsing:
+            return .invalidRoute
+        case .alpn:
+            return .incompatiblePeer
+        case .closed:
+            return .closed
+        case .bind, .connect, .connection, .relay, .stream, .datagram,
+             .callback, .timeout, .internal:
+            return .unavailable
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibEndpointFactory.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibEndpointFactory.swift
@@ -1,0 +1,152 @@
+import Foundation
+import IrohLib
+
+/// Binds the generated IrohLib endpoint and wraps it in the experiment seam.
+public struct IrohLibEndpointFactory: IrohEndpointFactory, Sendable {
+    /// Creates the default native endpoint factory.
+    public init() {}
+
+    /// Binds an endpoint using the requested relay mode, ALPN, and key.
+    public func bind(
+        configuration: IrohLibConfiguration
+    ) async throws -> any IrohEndpointDriver {
+        let builder = EndpointBuilder()
+        switch configuration.relayMode {
+        case .production:
+            builder.applyN0()
+        case .staging:
+            builder.applyMinimal()
+            builder.relayMode(mode: RelayMode.staging())
+        case .disabled:
+            builder.applyN0DisableRelay()
+        }
+        builder.alpns(alpns: [configuration.alpn])
+        if let secretKeyBytes = configuration.secretKeyBytes {
+            do {
+                try builder.secretKey(bytes: secretKeyBytes)
+            } catch {
+                throw IrohLibFailureMapper.openFailure(for: error)
+            }
+        }
+
+        do {
+            let endpoint = try await builder.bind()
+            return IrohLibEndpointDriver(
+                endpoint: endpoint,
+                maximumReceiveChunkBytes: configuration.maximumReceiveChunkBytes
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+}
+
+/// The concrete endpoint wrapper. It is a class so `close()` can run while a
+/// native connect operation is suspended, which is required for cancellation
+/// and foreground/background lifecycle handling.
+final class IrohLibEndpointDriver: IrohEndpointDriver, @unchecked Sendable {
+    private let endpoint: Endpoint
+    private let maximumReceiveChunkBytes: UInt32
+    private let stateLock = NSLock()
+    private var closed = false
+
+    init(endpoint: Endpoint, maximumReceiveChunkBytes: UInt32) {
+        self.endpoint = endpoint
+        self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+    }
+
+    func connect(
+        to route: IrohRoute,
+        alpn: Data
+    ) async throws -> any IrohConnection {
+        guard !isClosed() else {
+            throw IrohOpenFailure.closed
+        }
+
+        let address = try IrohLibRouteAddress.make(for: route)
+        let endpointID = address.id()
+
+        do {
+            let connection = try await endpoint.connect(addr: address, alpn: alpn)
+            guard !isClosed() else {
+                try? connection.close(errorCode: 0, reason: Data())
+                throw IrohOpenFailure.closed
+            }
+            guard connection.remoteId() == endpointID else {
+                try? connection.close(
+                    errorCode: 1,
+                    reason: Data("endpoint identity mismatch".utf8)
+                )
+                throw IrohOpenFailure.unauthorized
+            }
+            do {
+                let stream = try await connection.openBi()
+                return IrohLibConnection(
+                    connection: connection,
+                    stream: stream,
+                    maximumReceiveChunkBytes: maximumReceiveChunkBytes
+                )
+            } catch {
+                try? connection.close(errorCode: 0, reason: Data())
+                throw IrohLibFailureMapper.openFailure(for: error)
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as IrohOpenFailure {
+            throw failure
+        } catch {
+            throw IrohLibFailureMapper.openFailure(for: error)
+        }
+    }
+
+    func close() async {
+        guard markClosed() else {
+            return
+        }
+        try? await endpoint.close()
+    }
+
+    private func isClosed() -> Bool {
+        stateLock.withLock { closed }
+    }
+
+    private func markClosed() -> Bool {
+        stateLock.withLock {
+            guard !closed else { return false }
+            closed = true
+            return true
+        }
+    }
+}
+
+/// Converts the opaque experiment route into the generated binding value.
+///
+/// `EndpointAddr`'s generated constructor is intentionally nonthrowing because
+/// it only stores strings. Endpoint-id parsing still happens here, before a
+/// network operation can begin, so malformed discovery data becomes a normal
+/// transport failure instead of a late native crash.
+enum IrohLibRouteAddress {
+    static func make(for route: IrohRoute) throws -> EndpointAddr {
+        let endpointID: EndpointId
+        do {
+            endpointID = try EndpointId.fromString(s: route.endpointID)
+        } catch {
+            throw IrohOpenFailure.invalidRoute
+        }
+        return EndpointAddr(
+            id: endpointID,
+            relayUrl: route.relayURL,
+            addresses: route.directAddresses
+        )
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibEndpointFactory.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohLibEndpointFactory.swift
@@ -3,8 +3,16 @@ import IrohLib
 
 /// Binds the generated IrohLib endpoint and wraps it in the experiment seam.
 public struct IrohLibEndpointFactory: IrohEndpointFactory, Sendable {
+    private let closeClock: any IrohCloseClock
+
     /// Creates the default native endpoint factory.
-    public init() {}
+    public init() {
+        closeClock = ContinuousIrohCloseClock()
+    }
+
+    init(closeClock: any IrohCloseClock) {
+        self.closeClock = closeClock
+    }
 
     /// Binds an endpoint using the requested relay mode, ALPN, and key.
     public func bind(
@@ -21,6 +29,13 @@ public struct IrohLibEndpointFactory: IrohEndpointFactory, Sendable {
             builder.applyN0DisableRelay()
         }
         builder.alpns(alpns: [configuration.alpn])
+        if let bindAddress = configuration.bindAddress {
+            do {
+                try builder.bindAddr(addr: bindAddress)
+            } catch {
+                throw IrohLibFailureMapper.openFailure(for: error)
+            }
+        }
         if let secretKeyBytes = configuration.secretKeyBytes {
             do {
                 try builder.secretKey(bytes: secretKeyBytes)
@@ -33,7 +48,9 @@ public struct IrohLibEndpointFactory: IrohEndpointFactory, Sendable {
             let endpoint = try await builder.bind()
             return IrohLibEndpointDriver(
                 endpoint: endpoint,
-                maximumReceiveChunkBytes: configuration.maximumReceiveChunkBytes
+                maximumReceiveChunkBytes: configuration.maximumReceiveChunkBytes,
+                closeDrainTimeout: configuration.closeDrainTimeout,
+                closeClock: closeClock
             )
         } catch is CancellationError {
             throw CancellationError()
@@ -49,12 +66,28 @@ public struct IrohLibEndpointFactory: IrohEndpointFactory, Sendable {
 final class IrohLibEndpointDriver: IrohEndpointDriver, @unchecked Sendable {
     private let endpoint: Endpoint
     private let maximumReceiveChunkBytes: UInt32
+    private let closeDrainTimeout: Duration
+    private let closeClock: any IrohCloseClock
     private let stateLock = NSLock()
     private var closed = false
 
-    init(endpoint: Endpoint, maximumReceiveChunkBytes: UInt32) {
+    init(
+        endpoint: Endpoint,
+        maximumReceiveChunkBytes: UInt32,
+        closeDrainTimeout: Duration,
+        closeClock: any IrohCloseClock
+    ) {
         self.endpoint = endpoint
         self.maximumReceiveChunkBytes = maximumReceiveChunkBytes
+        self.closeDrainTimeout = closeDrainTimeout
+        self.closeClock = closeClock
+    }
+
+    func localRoute() async throws -> IrohRoute {
+        guard !isClosed() else {
+            throw IrohOpenFailure.closed
+        }
+        return try IrohLibRouteAddress.makeRoute(for: endpoint.addr())
     }
 
     func connect(
@@ -86,7 +119,9 @@ final class IrohLibEndpointDriver: IrohEndpointDriver, @unchecked Sendable {
                 return IrohLibConnection(
                     connection: connection,
                     stream: stream,
-                    maximumReceiveChunkBytes: maximumReceiveChunkBytes
+                    maximumReceiveChunkBytes: maximumReceiveChunkBytes,
+                    closeDrainTimeout: closeDrainTimeout,
+                    closeClock: closeClock
                 )
             } catch {
                 try? connection.close(errorCode: 0, reason: Data())
@@ -99,6 +134,77 @@ final class IrohLibEndpointDriver: IrohEndpointDriver, @unchecked Sendable {
         } catch {
             throw IrohLibFailureMapper.openFailure(for: error)
         }
+    }
+
+    func accept(alpn: Data) async throws -> IrohIncomingConnection? {
+        guard !isClosed() else {
+            throw IrohOpenFailure.closed
+        }
+
+        while let incoming = await endpoint.acceptNext() {
+            guard !isClosed() else {
+                try? await incoming.refuse()
+                throw IrohOpenFailure.closed
+            }
+            do {
+                let accepting = try await incoming.accept()
+                let offeredALPN = try await accepting.alpn()
+
+                // Dropping an incompatible Accepting handle rejects that
+                // candidate. Keep listening because one unrelated protocol
+                // must not take the server endpoint offline.
+                guard offeredALPN == alpn else {
+                    continue
+                }
+
+                let connection = try await accepting.connect()
+                guard connection.alpn() == alpn else {
+                    try? connection.close(
+                        errorCode: 0,
+                        reason: Data("ALPN mismatch".utf8)
+                    )
+                    continue
+                }
+
+                let peerRoute = try IrohRoute(
+                    endpointID: connection.remoteId().description
+                )
+                do {
+                    let stream = try await connection.acceptBi()
+                    return IrohIncomingConnection(
+                        peerRoute: peerRoute,
+                        connection: IrohLibConnection(
+                            connection: connection,
+                            stream: stream,
+                            maximumReceiveChunkBytes: maximumReceiveChunkBytes,
+                            closeDrainTimeout: closeDrainTimeout,
+                            closeClock: closeClock
+                        )
+                    )
+                } catch {
+                    try? connection.close(errorCode: 0, reason: Data())
+                    throw error
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let failure as IrohOpenFailure {
+                guard failure == .closed else {
+                    continue
+                }
+                throw failure
+            } catch {
+                let failure = IrohLibFailureMapper.openFailure(for: error)
+                guard failure != .closed else {
+                    throw failure
+                }
+                // A malformed or incompatible incoming candidate is isolated
+                // to that candidate. The listener remains available for the
+                // next peer.
+                continue
+            }
+        }
+
+        return nil
     }
 
     func close() async {
@@ -140,6 +246,19 @@ enum IrohLibRouteAddress {
             relayUrl: route.relayURL,
             addresses: route.directAddresses
         )
+    }
+
+    /// Converts a native endpoint address into public route metadata.
+    static func makeRoute(for address: EndpointAddr) throws -> IrohRoute {
+        do {
+            return try IrohRoute(
+                endpointID: address.id().description,
+                relayURL: address.relayUrl(),
+                directAddresses: address.directAddresses()
+            )
+        } catch {
+            throw IrohOpenFailure.invalidRoute
+        }
     }
 }
 

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRoute.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRoute.swift
@@ -1,0 +1,53 @@
+public import CmuxLiteTransport
+
+/// The opaque route data an Iroh connector needs to dial one peer.
+public struct IrohRoute: Codable, Equatable, Hashable, Sendable {
+    /// The peer endpoint identifier supplied by discovery or pairing.
+    public let endpointID: String
+
+    /// An optional relay hint owned by the Iroh implementation.
+    public let relayURL: String?
+
+    /// Optional direct-address hints owned by the Iroh implementation.
+    public let directAddresses: [String]
+
+    /// Creates a route without normalizing or rewriting endpoint identity data.
+    ///
+    /// - Parameters:
+    ///   - endpointID: A nonempty endpoint identifier.
+    ///   - relayURL: An optional relay hint.
+    ///   - directAddresses: Optional direct-address hints.
+    /// - Throws: ``Failure/invalidEndpointID`` when the endpoint identifier is
+    ///   empty or contains whitespace.
+    public init(
+        endpointID: String,
+        relayURL: String? = nil,
+        directAddresses: [String] = []
+    ) throws {
+        guard !endpointID.isEmpty,
+              endpointID.allSatisfy({ !$0.isWhitespace })
+        else {
+            throw Failure.invalidEndpointID
+        }
+        self.endpointID = endpointID
+        self.relayURL = relayURL
+        self.directAddresses = directAddresses
+    }
+
+    /// Converts the route into the generic transport descriptor.
+    ///
+    /// The current experiment carries the endpoint identifier as the opaque
+    /// identifier. Relay and address hints remain available to the Iroh
+    /// provider and will be threaded through a richer route registry later.
+    ///
+    /// - Returns: A route addressed to this endpoint.
+    public func transportRoute() throws -> TransportRoute {
+        try TransportRoute(kind: .iroh, identifier: endpointID)
+    }
+
+    /// Route construction failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// The endpoint identifier was empty or contained whitespace.
+        case invalidEndpointID
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRoute.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRoute.swift
@@ -36,9 +36,10 @@ public struct IrohRoute: Codable, Equatable, Hashable, Sendable {
 
     /// Converts the route into the generic transport descriptor.
     ///
-    /// The current experiment carries the endpoint identifier as the opaque
-    /// identifier. Relay and address hints remain available to the Iroh
-    /// provider and will be threaded through a richer route registry later.
+    /// The generic route carries only the stable endpoint identity. A
+    /// ``IrohRouteResolver`` supplies current relay and direct-address hints
+    /// immediately before dialing, so stale reachability data is not persisted
+    /// in the generic selection layer.
     ///
     /// - Returns: A route addressed to this endpoint.
     public func transportRoute() throws -> TransportRoute {

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRouteCatalog.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Sources/CmuxLiteIroh/IrohRouteCatalog.swift
@@ -1,0 +1,46 @@
+/// Resolves an opaque transport endpoint identifier into the complete public
+/// Iroh address hints needed for a dial.
+public protocol IrohRouteResolver: Sendable {
+    /// Resolves one endpoint identity without changing the requested identity.
+    func resolve(endpointID: String) async throws -> IrohRoute
+}
+
+/// A process-local route catalog used by discovery and pairing code.
+///
+/// Endpoint identity remains the lookup key. Relay URLs and direct addresses
+/// are reachability hints only and are never treated as authorization data.
+public actor IrohRouteCatalog: IrohRouteResolver {
+    /// Catalog mutation and lookup failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// No current route has been published for the requested identity.
+        case unknownEndpoint(String)
+    }
+
+    private var routes: [String: IrohRoute] = [:]
+
+    /// Creates an empty catalog.
+    public init() {}
+
+    /// Publishes or replaces the current public route for one endpoint.
+    public func publish(_ route: IrohRoute) {
+        routes[route.endpointID] = route
+    }
+
+    /// Removes a route and returns the value that was removed, if any.
+    @discardableResult
+    public func remove(endpointID: String) -> IrohRoute? {
+        routes.removeValue(forKey: endpointID)
+    }
+
+    /// Returns a stable snapshot for diagnostics and tests.
+    public func snapshot() -> [IrohRoute] {
+        routes.values.sorted { $0.endpointID < $1.endpointID }
+    }
+
+    public func resolve(endpointID: String) async throws -> IrohRoute {
+        guard let route = routes[endpointID] else {
+            throw Failure.unknownEndpoint(endpointID)
+        }
+        return route
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
@@ -1,0 +1,265 @@
+internal import Foundation
+import CmuxLiteIroh
+import CmuxLiteProtocol
+import CmuxLiteTransport
+import Testing
+
+@Suite("Iroh byte-stream adapter")
+struct IrohAdapterTests {
+    @Test("the adapter delegates lifecycle and bytes to the native connection")
+    func lifecycleAndBytes() async throws {
+        let connection = FakeIrohConnection(inbound: [Data("reply".utf8)])
+        let provider = FakeIrohProvider(behavior: .success(connection))
+        let connector = IrohConnector(provider: provider)
+        let route = try TransportRoute(kind: .iroh, identifier: "peer-1")
+        let opened = try await connector.open(route: route)
+        let stream = try #require(opened as? IrohByteStream)
+
+        await #expect(
+            throws: IrohByteStream.Failure.notConnected
+        ) {
+            try await stream.send(Data("before".utf8))
+        }
+
+        try await stream.connect()
+        try await stream.connect()
+        try await stream.send(Data("request".utf8))
+
+        #expect(await connection.sentChunks() == [Data("request".utf8)])
+        #expect(try await stream.receive() == Data("reply".utf8))
+        #expect(await stream.currentState() == .connected)
+
+        await stream.close()
+        await stream.close()
+        #expect(await stream.currentState() == .closed)
+        #expect(await connection.isClosed())
+        #expect(try await stream.receive() == nil)
+        await #expect(throws: IrohByteStream.Failure.closed) {
+            try await stream.send(Data("after".utf8))
+        }
+    }
+
+    @Test("binding failures map to transport fallback classifications")
+    func failureMapping() async throws {
+        let route = try TransportRoute(kind: .iroh, identifier: "peer-1")
+        let provider = FakeIrohProvider(behavior: .failure(.unavailable))
+        let connector = IrohConnector(provider: provider)
+
+        await #expect(throws: TransportOpenFailure.unavailable) {
+            try await connector.open(route: route)
+        }
+
+        let unauthorizedProvider = FakeIrohProvider(
+            behavior: .failure(.unauthorized)
+        )
+        let unauthorizedConnector = IrohConnector(
+            provider: unauthorizedProvider
+        )
+        await #expect(throws: TransportOpenFailure.unauthorized) {
+            try await unauthorizedConnector.open(route: route)
+        }
+    }
+
+    @Test("non-Iroh routes are rejected before the provider is called")
+    func routeKindValidation() async throws {
+        let provider = FakeIrohProvider(behavior: .success(FakeIrohConnection()))
+        let connector = IrohConnector(provider: provider)
+        let route = try TransportRoute(kind: .tailscale, identifier: "ts-1")
+
+        await #expect(throws: TransportOpenFailure.invalidRoute) {
+            try await connector.open(route: route)
+        }
+        #expect(await provider.attemptCount() == 0)
+    }
+
+    @Test("a denied Iroh route stops the generic dialer's fallback")
+    func dialerPreservesDenial() async throws {
+        let irohRoute = try TransportRoute(kind: .iroh, identifier: "peer-1")
+        let tailscaleRoute = try TransportRoute(
+            kind: .tailscale,
+            identifier: "ts-1"
+        )
+        let provider = FakeIrohProvider(behavior: .failure(.unauthorized))
+        let connector = IrohConnector(provider: provider)
+        let tailscale = SucceedingConnector()
+        let dialer = try TransportDialer(
+            routes: [irohRoute, tailscaleRoute],
+            policy: try TransportSelectionPolicy(),
+            connectors: [.iroh: connector, .tailscale: tailscale]
+        )
+
+        await #expect(
+            throws: TransportDialer.Failure.nonRetryable(
+                irohRoute,
+                reason: .unauthorized
+            )
+        ) {
+            try await dialer.connect()
+        }
+        #expect(await tailscale.attemptCount() == 0)
+    }
+
+    @Test("overlapping native sends are rejected without interleaving")
+    func overlappingSends() async throws {
+        let connection = BlockingIrohConnection()
+        let stream = IrohByteStream(connection: connection)
+        try await stream.connect()
+
+        let first = Task {
+            try await stream.send(Data("first".utf8))
+        }
+        await connection.waitUntilSendIsPending()
+
+        await #expect(throws: IrohByteStream.Failure.sendAlreadyPending) {
+            try await stream.send(Data("second".utf8))
+        }
+        await connection.releaseSend()
+        try await first.value
+        #expect(await connection.sentChunks() == [Data("first".utf8)])
+    }
+
+    @Test("an empty native receive is rejected instead of leaking a fake chunk")
+    func emptyReceiveFailsClosed() async throws {
+        let connection = FakeIrohConnection(inbound: [Data()])
+        let stream = IrohByteStream(connection: connection)
+        try await stream.connect()
+
+        await #expect(throws: IrohByteStream.Failure.emptyReceivedChunk) {
+            try await stream.receive()
+        }
+    }
+}
+
+private enum FakeProviderBehavior: Sendable {
+    case success(FakeIrohConnection)
+    case failure(IrohOpenFailure)
+}
+
+private actor FakeIrohProvider: IrohConnectionProvider {
+    private let behavior: FakeProviderBehavior
+    private var attempts = 0
+
+    init(behavior: FakeProviderBehavior) {
+        self.behavior = behavior
+    }
+
+    func connect(to route: IrohRoute) async throws -> any IrohConnection {
+        attempts += 1
+        switch behavior {
+        case .success(let connection):
+            return connection
+        case .failure(let failure):
+            throw failure
+        }
+    }
+
+    func attemptCount() -> Int {
+        attempts
+    }
+}
+
+private actor FakeIrohConnection: IrohConnection {
+    private var inbound: [Data]
+    private var sent: [Data] = []
+    private var closed = false
+
+    init(inbound: [Data] = []) {
+        self.inbound = inbound
+    }
+
+    func send(_ bytes: Data) async throws {
+        guard !closed else {
+            throw IrohOpenFailure.closed
+        }
+        sent.append(bytes)
+    }
+
+    func receive() async throws -> Data? {
+        guard !closed else {
+            return nil
+        }
+        guard !inbound.isEmpty else {
+            return nil
+        }
+        return inbound.removeFirst()
+    }
+
+    func close() async {
+        closed = true
+    }
+
+    func sentChunks() -> [Data] {
+        sent
+    }
+
+    func isClosed() -> Bool {
+        closed
+    }
+}
+
+private actor SucceedingConnector: TransportConnector {
+    private var attempts = 0
+
+    func open(route: TransportRoute) async throws -> any ByteStream {
+        attempts += 1
+        return FakeByteStream()
+    }
+
+    func attemptCount() -> Int {
+        attempts
+    }
+}
+
+private actor FakeByteStream: ByteStream {
+    func connect() async throws {}
+
+    func send(_ bytes: Data) async throws {}
+
+    func receive() async throws -> Data? {
+        nil
+    }
+
+    func close() async {}
+}
+
+private actor BlockingIrohConnection: IrohConnection {
+    private var sent: [Data] = []
+    private var pendingSend: CheckedContinuation<Void, any Error>?
+    private var pendingObserver: CheckedContinuation<Void, Never>?
+
+    func send(_ bytes: Data) async throws {
+        pendingObserver?.resume()
+        pendingObserver = nil
+        try await withCheckedThrowingContinuation { continuation in
+            pendingSend = continuation
+        }
+        sent.append(bytes)
+    }
+
+    func receive() async throws -> Data? {
+        nil
+    }
+
+    func close() async {
+        pendingSend?.resume(returning: ())
+        pendingSend = nil
+    }
+
+    func waitUntilSendIsPending() async {
+        if pendingSend != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            pendingObserver = continuation
+        }
+    }
+
+    func releaseSend() {
+        pendingSend?.resume(returning: ())
+        pendingSend = nil
+    }
+
+    func sentChunks() -> [Data] {
+        sent
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
@@ -59,6 +59,147 @@ struct IrohAdapterTests {
         #expect(await factory.bindCount() == 1)
     }
 
+    @Test("one endpoint publishes one route and owns one pending accept")
+    func endpointOwnership() async throws {
+        let endpoint = BlockingAcceptEndpointDriver()
+        let factory = ImmediateEndpointFactory(endpoint: endpoint)
+        let provider = IrohLibConnectionProvider(
+            configuration: .standard,
+            factory: factory
+        )
+
+        let firstRoute = try await provider.localRoute()
+        let secondRoute = try await provider.localRoute()
+        #expect(firstRoute == secondRoute)
+        #expect(await factory.bindCount() == 1)
+
+        let firstAccept = Task<IrohIncomingConnection?, any Error> {
+            try await provider.accept()
+        }
+        await endpoint.waitUntilAcceptIsPending()
+        await #expect(throws: IrohOpenFailure.acceptAlreadyPending) {
+            _ = try await provider.accept()
+        }
+
+        await provider.close()
+        _ = try? await firstAccept.value
+        #expect(await endpoint.acceptCount() == 1)
+        #expect(await endpoint.isClosed())
+    }
+
+    @Test("accept ownership is claimed while the endpoint is still binding")
+    func acceptOwnershipDuringBind() async throws {
+        let endpoint = BlockingAcceptEndpointDriver()
+        let factory = GatedEndpointFactory(endpoint: endpoint)
+        let provider = IrohLibConnectionProvider(
+            configuration: .standard,
+            factory: factory
+        )
+
+        let firstAccept = Task<IrohIncomingConnection?, any Error> {
+            try await provider.accept()
+        }
+        await factory.waitUntilBindIsPending()
+        await #expect(throws: IrohOpenFailure.acceptAlreadyPending) {
+            _ = try await provider.accept()
+        }
+
+        await factory.release()
+        await endpoint.waitUntilAcceptIsPending()
+        await provider.close()
+        _ = try? await firstAccept.value
+        #expect(await factory.bindCount() == 1)
+        #expect(await endpoint.acceptCount() == 1)
+    }
+
+    @Test("a rejected peer does not stop the endpoint host")
+    func endpointHostIsolatesAdmissionRejection() async throws {
+        let firstConnection = FakeIrohConnection()
+        let secondConnection = WaitingIrohConnection()
+        let firstPeer = try IrohRoute(endpointID: "denied-peer")
+        let secondPeer = try IrohRoute(endpointID: "admitted-peer")
+        let endpoint = QueueingEndpointProvider(
+            localRoute: try IrohRoute(endpointID: "host-peer")
+        )
+        let host = IrohEndpointHost(
+            endpoint: endpoint,
+            codec: try FrameCodec()
+        ) { peer in
+            if peer.endpointID == firstPeer.endpointID {
+                throw AdmissionFailure.denied
+            }
+            return .server(
+                welcome: .init(
+                    sessionID: "admitted-session",
+                    nonce: "server-nonce"
+                )
+            )
+        }
+
+        try await host.start()
+        await endpoint.enqueue(
+            IrohIncomingConnection(
+                peerRoute: firstPeer,
+                connection: firstConnection
+            )
+        )
+        await firstConnection.waitUntilClosed()
+        #expect(await firstConnection.isClosed())
+        #expect(await endpoint.acceptCount() >= 2)
+
+        await endpoint.enqueue(
+            IrohIncomingConnection(
+                peerRoute: secondPeer,
+                connection: secondConnection
+            )
+        )
+        await endpoint.waitUntilAcceptCount(3)
+        #expect(await host.activePeerEndpointIDs() == [secondPeer.endpointID])
+
+        await host.close()
+        #expect(await secondConnection.isClosed())
+        #expect(await endpoint.isClosed())
+    }
+
+    @Test("the route catalog preserves public reachability hints")
+    func routeCatalog() async throws {
+        let route = try IrohRoute(
+            endpointID: "peer-1",
+            relayURL: "https://relay.example",
+            directAddresses: ["192.0.2.1:7842"]
+        )
+        let catalog = IrohRouteCatalog()
+        await catalog.publish(route)
+
+        #expect(try await catalog.resolve(endpointID: "peer-1") == route)
+        #expect(await catalog.snapshot() == [route])
+        #expect(await catalog.remove(endpointID: "peer-1") == route)
+        await #expect(throws: IrohRouteCatalog.Failure.unknownEndpoint("peer-1")) {
+            _ = try await catalog.resolve(endpointID: "peer-1")
+        }
+    }
+
+    @Test("a resolver cannot substitute a different endpoint identity")
+    func routeResolverIdentityMismatch() async throws {
+        let provider = FakeIrohProvider(
+            behavior: .success(FakeIrohConnection())
+        )
+        let resolver = SubstitutingRouteResolver()
+        let connector = IrohConnector(
+            provider: provider,
+            routeResolver: resolver
+        )
+        let route = try TransportRoute(
+            kind: .iroh,
+            identifier: "requested-peer"
+        )
+
+        await #expect(throws: TransportOpenFailure.invalidRoute) {
+            _ = try await connector.open(route: route)
+        }
+        #expect(await provider.attemptCount() == 0)
+    }
+
     @Test("configuration rejects unsafe native inputs")
     func configurationValidation() {
         #expect(
@@ -80,6 +221,22 @@ struct IrohAdapterTests {
             try IrohLibConfiguration(
                 alpn: Data("cmux-lite".utf8),
                 maximumReceiveChunkBytes: 0
+            )
+        }
+        #expect(
+            throws: IrohLibConfiguration.Failure.emptyBindAddress
+        ) {
+            try IrohLibConfiguration(
+                alpn: Data("cmux-lite".utf8),
+                bindAddress: " \t"
+            )
+        }
+        #expect(
+            throws: IrohLibConfiguration.Failure.invalidCloseDrainTimeout
+        ) {
+            try IrohLibConfiguration(
+                alpn: Data("cmux-lite".utf8),
+                closeDrainTimeout: .zero
             )
         }
     }
@@ -282,7 +439,7 @@ struct IrohAdapterTests {
 }
 
 private actor GatedEndpointFactory: IrohEndpointFactory {
-    private let endpoint: RecordingEndpointDriver
+    private let endpoint: any IrohEndpointDriver
     private var continuation: CheckedContinuation<
         any IrohEndpointDriver,
         any Error
@@ -290,7 +447,7 @@ private actor GatedEndpointFactory: IrohEndpointFactory {
     private var observer: CheckedContinuation<Void, Never>?
     private var binds = 0
 
-    init(endpoint: RecordingEndpointDriver) {
+    init(endpoint: any IrohEndpointDriver) {
         self.endpoint = endpoint
     }
 
@@ -344,10 +501,34 @@ private actor FailingEndpointFactory: IrohEndpointFactory {
     }
 }
 
+private actor ImmediateEndpointFactory: IrohEndpointFactory {
+    private let endpoint: any IrohEndpointDriver
+    private var binds = 0
+
+    init(endpoint: any IrohEndpointDriver) {
+        self.endpoint = endpoint
+    }
+
+    func bind(
+        configuration: IrohLibConfiguration
+    ) async throws -> any IrohEndpointDriver {
+        binds += 1
+        return endpoint
+    }
+
+    func bindCount() -> Int {
+        binds
+    }
+}
+
 private actor RecordingEndpointDriver: IrohEndpointDriver {
     private var recordedRoutes: [IrohRoute] = []
     private var recordedALPNs: [Data] = []
     private var closed = false
+
+    func localRoute() async throws -> IrohRoute {
+        try IrohRoute(endpointID: "peer-1")
+    }
 
     func connect(
         to route: IrohRoute,
@@ -359,6 +540,10 @@ private actor RecordingEndpointDriver: IrohEndpointDriver {
         recordedRoutes.append(route)
         recordedALPNs.append(alpn)
         return FakeIrohConnection()
+    }
+
+    func accept(alpn: Data) async throws -> IrohIncomingConnection? {
+        nil
     }
 
     func close() async {
@@ -378,9 +563,74 @@ private actor RecordingEndpointDriver: IrohEndpointDriver {
     }
 }
 
+private actor BlockingAcceptEndpointDriver: IrohEndpointDriver {
+    private var accepts = 0
+    private var pendingAccept: CheckedContinuation<
+        IrohIncomingConnection?,
+        any Error
+    >?
+    private var pendingObserver: CheckedContinuation<Void, Never>?
+    private var closed = false
+
+    func localRoute() async throws -> IrohRoute {
+        try IrohRoute(endpointID: "blocking-accept-peer")
+    }
+
+    func connect(
+        to route: IrohRoute,
+        alpn: Data
+    ) async throws -> any IrohConnection {
+        guard !closed else {
+            throw IrohOpenFailure.closed
+        }
+        return FakeIrohConnection()
+    }
+
+    func accept(alpn: Data) async throws -> IrohIncomingConnection? {
+        accepts += 1
+        pendingObserver?.resume()
+        pendingObserver = nil
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingAccept = continuation
+        }
+    }
+
+    func close() async {
+        guard !closed else {
+            return
+        }
+        closed = true
+        pendingAccept?.resume(returning: nil)
+        pendingAccept = nil
+    }
+
+    func waitUntilAcceptIsPending() async {
+        if pendingAccept != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            pendingObserver = continuation
+        }
+    }
+
+    func acceptCount() -> Int {
+        accepts
+    }
+
+    func isClosed() -> Bool {
+        closed
+    }
+}
+
 private enum FakeProviderBehavior: Sendable {
     case success(FakeIrohConnection)
     case failure(IrohOpenFailure)
+}
+
+private struct SubstitutingRouteResolver: IrohRouteResolver {
+    func resolve(endpointID: String) async throws -> IrohRoute {
+        try IrohRoute(endpointID: "different-peer")
+    }
 }
 
 private actor FakeIrohProvider: IrohConnectionProvider {
@@ -410,6 +660,7 @@ private actor FakeIrohConnection: IrohConnection {
     private var inbound: [Data]
     private var sent: [Data] = []
     private var closed = false
+    private var closeObservers: [CheckedContinuation<Void, Never>] = []
 
     init(inbound: [Data] = []) {
         self.inbound = inbound
@@ -434,6 +685,11 @@ private actor FakeIrohConnection: IrohConnection {
 
     func close() async {
         closed = true
+        let observers = closeObservers
+        closeObservers.removeAll(keepingCapacity: false)
+        for observer in observers {
+            observer.resume()
+        }
     }
 
     func sentChunks() -> [Data] {
@@ -442,6 +698,139 @@ private actor FakeIrohConnection: IrohConnection {
 
     func isClosed() -> Bool {
         closed
+    }
+
+    func waitUntilClosed() async {
+        if closed {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            closeObservers.append(continuation)
+        }
+    }
+}
+
+private enum AdmissionFailure: Error {
+    case denied
+}
+
+private actor WaitingIrohConnection: IrohConnection {
+    private var receiveContinuation: CheckedContinuation<Data?, any Error>?
+    private var closed = false
+
+    func send(_ bytes: Data) async throws {
+        guard !closed else {
+            throw IrohOpenFailure.closed
+        }
+    }
+
+    func receive() async throws -> Data? {
+        guard !closed else {
+            return nil
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            receiveContinuation = continuation
+        }
+    }
+
+    func close() async {
+        guard !closed else {
+            return
+        }
+        closed = true
+        receiveContinuation?.resume(returning: nil)
+        receiveContinuation = nil
+    }
+
+    func isClosed() -> Bool {
+        closed
+    }
+}
+
+private actor QueueingEndpointProvider: IrohEndpointProvider {
+    private let route: IrohRoute
+    private var queued: [IrohIncomingConnection] = []
+    private var pendingAccept: CheckedContinuation<
+        IrohIncomingConnection?,
+        any Error
+    >?
+    private var accepts = 0
+    private var acceptObservers: [(
+        target: Int,
+        continuation: CheckedContinuation<Void, Never>
+    )] = []
+    private var closed = false
+
+    init(localRoute: IrohRoute) {
+        route = localRoute
+    }
+
+    func localRoute() async throws -> IrohRoute {
+        guard !closed else {
+            throw IrohOpenFailure.closed
+        }
+        return route
+    }
+
+    func connect(to route: IrohRoute) async throws -> any IrohConnection {
+        throw IrohOpenFailure.unavailable
+    }
+
+    func accept() async throws -> IrohIncomingConnection? {
+        accepts += 1
+        resumeAcceptObservers()
+        if !queued.isEmpty {
+            return queued.removeFirst()
+        }
+        guard !closed else {
+            return nil
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingAccept = continuation
+        }
+    }
+
+    func close() async {
+        guard !closed else {
+            return
+        }
+        closed = true
+        pendingAccept?.resume(returning: nil)
+        pendingAccept = nil
+    }
+
+    func enqueue(_ incoming: IrohIncomingConnection) {
+        if let pendingAccept {
+            self.pendingAccept = nil
+            pendingAccept.resume(returning: incoming)
+            return
+        }
+        queued.append(incoming)
+    }
+
+    func acceptCount() -> Int {
+        accepts
+    }
+
+    func waitUntilAcceptCount(_ target: Int) async {
+        if accepts >= target {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            acceptObservers.append((target, continuation))
+        }
+    }
+
+    func isClosed() -> Bool {
+        closed
+    }
+
+    private func resumeAcceptObservers() {
+        let ready = acceptObservers.filter { accepts >= $0.target }
+        acceptObservers.removeAll { accepts >= $0.target }
+        for observer in ready {
+            observer.continuation.resume()
+        }
     }
 }
 

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
@@ -128,6 +128,23 @@ struct IrohAdapterTests {
             try await stream.receive()
         }
     }
+
+    @Test("explicit close waits for native teardown before returning")
+    func closeIsOrdered() async throws {
+        let connection = BlockingCloseIrohConnection()
+        let stream = IrohByteStream(connection: connection)
+        try await stream.connect()
+
+        let closeTask = Task {
+            await stream.close()
+        }
+        await connection.waitUntilCloseIsPending()
+        #expect(await connection.isClosed() == false)
+
+        await connection.releaseClose()
+        await closeTask.value
+        #expect(await connection.isClosed())
+    }
 }
 
 private enum FakeProviderBehavior: Sendable {
@@ -261,5 +278,44 @@ private actor BlockingIrohConnection: IrohConnection {
 
     func sentChunks() -> [Data] {
         sent
+    }
+}
+
+private actor BlockingCloseIrohConnection: IrohConnection {
+    private var closeContinuation: CheckedContinuation<Void, Never>?
+    private var closeObserver: CheckedContinuation<Void, Never>?
+    private var closed = false
+
+    func send(_ bytes: Data) async throws {}
+
+    func receive() async throws -> Data? {
+        nil
+    }
+
+    func close() async {
+        closeObserver?.resume()
+        closeObserver = nil
+        await withCheckedContinuation { continuation in
+            closeContinuation = continuation
+        }
+        closed = true
+    }
+
+    func waitUntilCloseIsPending() async {
+        if closeContinuation != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            closeObserver = continuation
+        }
+    }
+
+    func releaseClose() {
+        closeContinuation?.resume()
+        closeContinuation = nil
+    }
+
+    func isClosed() -> Bool {
+        closed
     }
 }

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohAdapterTests.swift
@@ -1,11 +1,145 @@
 internal import Foundation
-import CmuxLiteIroh
+@testable import CmuxLiteIroh
 import CmuxLiteProtocol
 import CmuxLiteTransport
+import IrohLib
 import Testing
 
 @Suite("Iroh byte-stream adapter")
 struct IrohAdapterTests {
+    @Test("the native provider shares one endpoint across concurrent callers")
+    func providerSharesEndpoint() async throws {
+        let endpoint = RecordingEndpointDriver()
+        let factory = GatedEndpointFactory(endpoint: endpoint)
+        let provider = IrohLibConnectionProvider(
+            configuration: .standard,
+            factory: factory
+        )
+        let route = try IrohRoute(
+            endpointID: "peer-1",
+            relayURL: "https://relay.example",
+            directAddresses: ["192.0.2.1:7842"]
+        )
+
+        let first = Task { try await provider.connect(to: route) }
+        await factory.waitUntilBindIsPending()
+        let second = Task { try await provider.connect(to: route) }
+        await factory.release()
+
+        _ = try await first.value
+        _ = try await second.value
+        #expect(await factory.bindCount() == 1)
+        #expect(await endpoint.routes() == [route, route])
+        #expect(
+            await endpoint.alpns() == [
+                IrohLibConfiguration.standard.alpn,
+                IrohLibConfiguration.standard.alpn,
+            ]
+        )
+
+        await provider.close()
+        #expect(await endpoint.isClosed())
+        await #expect(throws: IrohOpenFailure.closed) {
+            _ = try await provider.connect(to: route)
+        }
+    }
+
+    @Test("native binding failures remain classified before fallback")
+    func providerPreservesClassifiedFailure() async throws {
+        let factory = FailingEndpointFactory(failure: .unauthorized)
+        let provider = IrohLibConnectionProvider(
+            configuration: .standard,
+            factory: factory
+        )
+        let route = try IrohRoute(endpointID: "peer-1")
+
+        await #expect(throws: IrohOpenFailure.unauthorized) {
+            _ = try await provider.connect(to: route)
+        }
+        #expect(await factory.bindCount() == 1)
+    }
+
+    @Test("configuration rejects unsafe native inputs")
+    func configurationValidation() {
+        #expect(
+            throws: IrohLibConfiguration.Failure.emptyALPN
+        ) {
+            try IrohLibConfiguration(alpn: Data())
+        }
+        #expect(
+            throws: IrohLibConfiguration.Failure.invalidSecretKeyLength(3)
+        ) {
+            try IrohLibConfiguration(
+                alpn: Data("cmux-lite".utf8),
+                secretKeyBytes: Data([1, 2, 3])
+            )
+        }
+        #expect(
+            throws: IrohLibConfiguration.Failure.invalidReceiveChunkLimit
+        ) {
+            try IrohLibConfiguration(
+                alpn: Data("cmux-lite".utf8),
+                maximumReceiveChunkBytes: 0
+            )
+        }
+    }
+
+    @Test("IrohLib error kinds map to explicit transport outcomes")
+    func nativeFailureMapping() {
+        #expect(
+            IrohLibFailureMapper.openFailure(for: .invalidInput)
+                == .invalidRoute
+        )
+        #expect(
+            IrohLibFailureMapper.openFailure(for: .alpn)
+                == .incompatiblePeer
+        )
+        #expect(
+            IrohLibFailureMapper.openFailure(for: .closed)
+                == .closed
+        )
+        #expect(
+            IrohLibFailureMapper.openFailure(for: .timeout)
+                == .unavailable
+        )
+
+        let allKinds: [IrohErrorKind] = [
+            .invalidInput,
+            .bind,
+            .connect,
+            .connection,
+            .alpn,
+            .keyParsing,
+            .ticketParsing,
+            .relay,
+            .stream,
+            .datagram,
+            .callback,
+            .closed,
+            .timeout,
+            .internal,
+        ]
+        #expect(allKinds.count == 14)
+    }
+
+    @Test("native route conversion validates identity before dialing")
+    func nativeRouteConversion() throws {
+        let route = try IrohRoute(
+            endpointID: "523c7996bad77424e96786cf7a7205115337a5b4565cd25506a0f297b191a5ea",
+            relayURL: "https://relay.example",
+            directAddresses: ["192.0.2.1:7842"]
+        )
+        let address = try IrohLibRouteAddress.make(for: route)
+        #expect(address.id().toBytes().count == 32)
+        #expect(address.relayUrl() == route.relayURL)
+        #expect(address.directAddresses() == route.directAddresses)
+
+        let malformed = try IrohRoute(endpointID: "not-an-endpoint-id")
+        #expect(throws: IrohOpenFailure.invalidRoute) {
+            try IrohLibRouteAddress.make(for: malformed)
+        }
+    }
+
     @Test("the adapter delegates lifecycle and bytes to the native connection")
     func lifecycleAndBytes() async throws {
         let connection = FakeIrohConnection(inbound: [Data("reply".utf8)])
@@ -144,6 +278,103 @@ struct IrohAdapterTests {
         await connection.releaseClose()
         await closeTask.value
         #expect(await connection.isClosed())
+    }
+}
+
+private actor GatedEndpointFactory: IrohEndpointFactory {
+    private let endpoint: RecordingEndpointDriver
+    private var continuation: CheckedContinuation<
+        any IrohEndpointDriver,
+        any Error
+    >?
+    private var observer: CheckedContinuation<Void, Never>?
+    private var binds = 0
+
+    init(endpoint: RecordingEndpointDriver) {
+        self.endpoint = endpoint
+    }
+
+    func bind(
+        configuration: IrohLibConfiguration
+    ) async throws -> any IrohEndpointDriver {
+        binds += 1
+        observer?.resume()
+        observer = nil
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilBindIsPending() async {
+        if continuation != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func release() {
+        continuation?.resume(returning: endpoint)
+        continuation = nil
+    }
+
+    func bindCount() -> Int {
+        binds
+    }
+}
+
+private actor FailingEndpointFactory: IrohEndpointFactory {
+    private let failure: IrohOpenFailure
+    private var binds = 0
+
+    init(failure: IrohOpenFailure) {
+        self.failure = failure
+    }
+
+    func bind(
+        configuration: IrohLibConfiguration
+    ) async throws -> any IrohEndpointDriver {
+        binds += 1
+        throw failure
+    }
+
+    func bindCount() -> Int {
+        binds
+    }
+}
+
+private actor RecordingEndpointDriver: IrohEndpointDriver {
+    private var recordedRoutes: [IrohRoute] = []
+    private var recordedALPNs: [Data] = []
+    private var closed = false
+
+    func connect(
+        to route: IrohRoute,
+        alpn: Data
+    ) async throws -> any IrohConnection {
+        guard !closed else {
+            throw IrohOpenFailure.closed
+        }
+        recordedRoutes.append(route)
+        recordedALPNs.append(alpn)
+        return FakeIrohConnection()
+    }
+
+    func close() async {
+        closed = true
+    }
+
+    func routes() -> [IrohRoute] {
+        recordedRoutes
+    }
+
+    func alpns() -> [Data] {
+        recordedALPNs
+    }
+
+    func isClosed() -> Bool {
+        closed
     }
 }
 

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohLocalIntegrationTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteIroh/Tests/CmuxLiteIrohTests/IrohLocalIntegrationTests.swift
@@ -1,0 +1,622 @@
+internal import Foundation
+import CmuxLiteIroh
+import CmuxLiteProtocol
+import CmuxLiteSession
+import CmuxLiteTransport
+import Testing
+
+/// Exercises the generated binding through the same provider used by the app.
+///
+/// These tests deliberately use two real endpoints bound to ephemeral loopback
+/// sockets. They do not involve the relay, a simulator, a renderer, or the
+/// production app, so a failure points at the native transport boundary.
+@Suite("Real Iroh loopback integration", .serialized)
+struct IrohLocalIntegrationTests {
+    @Test("two real endpoints exchange bytes over a direct loopback path")
+    func directByteRoundTrip() async throws {
+        try await withDirectProviders { server, client in
+            let serverRoute = try await withProviderTimeout(
+                "server bind",
+                server: server,
+                client: client
+            ) {
+                try await server.localRoute()
+            }
+            let clientRoute = try await withProviderTimeout(
+                "client bind",
+                server: server,
+                client: client
+            ) {
+                try await client.localRoute()
+            }
+
+            #expect(!serverRoute.endpointID.isEmpty)
+            #expect(!clientRoute.endpointID.isEmpty)
+            #expect(serverRoute.endpointID != clientRoute.endpointID)
+            #expect(!serverRoute.directAddresses.isEmpty)
+
+            let acceptTask = Task<IrohIncomingConnection?, any Error> {
+                try await server.accept()
+            }
+            let clientConnection: any IrohConnection = try await withProviderTimeout(
+                "dial",
+                server: server,
+                client: client
+            ) {
+                try await client.connect(to: serverRoute)
+            }
+
+            // Opening a QUIC stream is lazy in Iroh. The first write is what
+            // puts the stream on the wire, so it must happen concurrently with
+            // the server's accept loop rather than after awaiting accept.
+            let clientStream = IrohByteStream(connection: clientConnection)
+            try await clientStream.connect()
+            let payload = Data("cmux-lite direct transport".utf8)
+            try await clientStream.send(payload)
+
+            let incoming = try await withProviderTimeout(
+                "accept",
+                server: server,
+                client: client
+            ) {
+                try await acceptTask.value
+            }
+            guard let incoming else {
+                throw IntegrationFailure.missingIncomingConnection
+            }
+            #expect(incoming.peerRoute.endpointID == clientRoute.endpointID)
+
+            let serverStream = IrohByteStream(connection: incoming.connection)
+            try await serverStream.connect()
+            #expect(
+                try await withProviderTimeout(
+                    "receive",
+                    server: server,
+                    client: client
+                ) {
+                    try await serverStream.receive()
+                } == payload
+            )
+
+            await clientStream.close()
+            await serverStream.close()
+        }
+    }
+
+    @Test("real Iroh carries the cmux-lite handshake, ping, pong, and close")
+    func sessionRoundTrip() async throws {
+        try await withDirectProviders { server, client in
+            let serverRoute = try await server.localRoute()
+            let codec = try FrameCodec()
+            let acceptTask = Task<IrohIncomingConnection?, any Error> {
+                try await server.accept()
+            }
+
+            let clientConnection = try await withProviderTimeout(
+                "session dial",
+                server: server,
+                client: client
+            ) {
+                try await client.connect(to: serverRoute)
+            }
+            let clientStream = IrohByteStream(connection: clientConnection)
+            let clientOwner = SessionOwner(
+                configuration: .client(
+                    hello: .init(
+                        clientName: "cmux-lite-ios",
+                        nonce: "real-iroh-client"
+                    )
+                ),
+                stream: clientStream,
+                codec: codec
+            )
+            var clientEvents = clientOwner.events.makeAsyncIterator()
+
+            try await clientOwner.start()
+            #expect(await clientEvents.next() == .transportConnected)
+
+            let incoming = try await withProviderTimeout(
+                "session accept",
+                server: server,
+                client: client
+            ) {
+                try await acceptTask.value
+            }
+            guard let incoming else {
+                throw IntegrationFailure.missingIncomingConnection
+            }
+
+            let serverOwner = SessionOwner(
+                configuration: .server(
+                    welcome: .init(
+                        sessionID: "real-iroh-session",
+                        nonce: "real-iroh-server"
+                    )
+                ),
+                stream: IrohByteStream(connection: incoming.connection),
+                codec: codec
+            )
+            var serverEvents = serverOwner.events.makeAsyncIterator()
+            try await serverOwner.start()
+
+            #expect(await serverEvents.next() == .transportConnected)
+            #expect(
+                await clientEvents.next()
+                    == .ready(sessionID: "real-iroh-session")
+            )
+            #expect(
+                await serverEvents.next()
+                    == .ready(sessionID: "real-iroh-session")
+            )
+
+            let pingID = try await clientOwner.sendPing()
+            #expect(
+                await serverEvents.next() == .pingReceived(messageID: pingID)
+            )
+            #expect(
+                await clientEvents.next() == .pongReceived(replyTo: pingID)
+            )
+
+            await clientOwner.close()
+            #expect(
+                await clientEvents.next() == .closed(.local(.normal))
+            )
+            #expect(
+                await serverEvents.next() == .closed(.remote(.normal))
+            )
+            #expect(await clientEvents.next() == nil)
+            #expect(await serverEvents.next() == nil)
+        }
+    }
+
+    @Test("the endpoint host owns accept and session lifecycles")
+    func endpointHostRoundTrip() async throws {
+        try await withDirectProviders { server, client in
+            let host = IrohEndpointHost(
+                endpoint: server,
+                codec: try FrameCodec()
+            ) { _ in
+                .server(
+                    welcome: .init(
+                        sessionID: "host-owned-session",
+                        nonce: "host-owned-server"
+                    )
+                )
+            }
+            let hostEvents = AsyncEventIterator(host.events)
+            try await host.start()
+
+            guard case .listening(let serverRoute) = await hostEvents.next() else {
+                throw IntegrationFailure.missingListeningEvent
+            }
+            let clientConnection = try await withProviderTimeout(
+                "host dial",
+                server: server,
+                client: client
+            ) {
+                try await client.connect(to: serverRoute)
+            }
+            let clientOwner = SessionOwner(
+                configuration: .client(
+                    hello: .init(
+                        clientName: "cmux-lite-ios",
+                        nonce: "host-owned-client"
+                    )
+                ),
+                stream: IrohByteStream(connection: clientConnection),
+                codec: try FrameCodec()
+            )
+            var clientEvents = clientOwner.events.makeAsyncIterator()
+            try await clientOwner.start()
+            #expect(await clientEvents.next() == .transportConnected)
+
+            let acceptedEvent = try await withIntegrationTimeout(
+                "host accept event",
+                operation: { await hostEvents.next() }
+            )
+            guard case .accepted(let peerRoute) = acceptedEvent else {
+                throw IntegrationFailure.missingAcceptedEvent
+            }
+            #expect(
+                peerRoute.endpointID
+                    == (try await client.localRoute()).endpointID
+            )
+            #expect(
+                await clientEvents.next()
+                    == .ready(sessionID: "host-owned-session")
+            )
+            #expect(await host.activePeerEndpointIDs() == [peerRoute.endpointID])
+
+            await clientOwner.close()
+            #expect(
+                await clientEvents.next() == .closed(.local(.normal))
+            )
+            #expect(
+                try await withIntegrationTimeout(
+                    "host session close event",
+                    operation: { await hostEvents.next() }
+                ) == .sessionClosed(peerEndpointID: peerRoute.endpointID)
+            )
+            #expect(await host.activePeerEndpointIDs().isEmpty)
+
+            await host.close()
+            #expect(await hostEvents.next() == .closed)
+            #expect(await hostEvents.next() == nil)
+        }
+    }
+
+    @Test("the transport dialer resolves a published Iroh route")
+    func transportDialerRoundTrip() async throws {
+        try await withDirectProviders { server, client in
+            let serverRoute = try await server.localRoute()
+            let catalog = IrohRouteCatalog()
+            await catalog.publish(serverRoute)
+
+            let genericRoute = try serverRoute.transportRoute()
+            let dialer = try TransportDialer(
+                routes: [genericRoute],
+                policy: try TransportSelectionPolicy(
+                    mode: .restricted(.iroh)
+                ),
+                connectors: [
+                    .iroh: IrohConnector(
+                        provider: client,
+                        routeResolver: catalog
+                    )
+                ]
+            )
+            let acceptTask = Task<IrohIncomingConnection?, any Error> {
+                try await server.accept()
+            }
+
+            let opened = try await withProviderTimeout(
+                "dialer connect",
+                server: server,
+                client: client
+            ) {
+                try await dialer.connect()
+            }
+            guard let clientStream = opened as? IrohByteStream else {
+                throw IntegrationFailure.wrongStreamType
+            }
+            try await clientStream.connect()
+            let payload = Data("transport dialer route".utf8)
+            try await clientStream.send(payload)
+
+            let incoming = try await withProviderTimeout(
+                "dialer accept",
+                server: server,
+                client: client
+            ) {
+                try await acceptTask.value
+            }
+            guard let incoming else {
+                throw IntegrationFailure.missingIncomingConnection
+            }
+            let serverStream = IrohByteStream(connection: incoming.connection)
+            try await serverStream.connect()
+            #expect(await dialer.currentRoute() == genericRoute)
+            let received = try await serverStream.receive()
+            #expect(received == payload)
+            await clientStream.close()
+            await serverStream.close()
+        }
+    }
+
+    @Test("one endpoint generation supports repeated sessions")
+    func repeatedSessionsReuseEndpoint() async throws {
+        try await withDirectProviders { server, client in
+            let serverRoute = try await server.localRoute()
+            let firstClientID = try await runSessionRound(
+                server: server,
+                client: client,
+                serverRoute: serverRoute,
+                sessionID: "repeated-session-1"
+            )
+            let secondClientID = try await runSessionRound(
+                server: server,
+                client: client,
+                serverRoute: serverRoute,
+                sessionID: "repeated-session-2"
+            )
+
+            #expect(firstClientID == secondClientID)
+            #expect(try await server.localRoute() == serverRoute)
+        }
+    }
+
+    @Test("closing a provider releases a pending native accept")
+    func closeUnblocksAccept() async throws {
+        let server = IrohLibConnectionProvider(
+            configuration: try directConfiguration(seed: 0x31)
+        )
+        _ = try await server.localRoute()
+        let acceptTask = Task<IrohIncomingConnection?, any Error> {
+            try await server.accept()
+        }
+
+        await server.close()
+        let accepted: IrohIncomingConnection?
+        do {
+            accepted = try await withIntegrationTimeout("close accept") {
+                try await acceptTask.value
+            }
+        } catch IrohOpenFailure.closed {
+            accepted = nil
+        }
+        #expect(accepted == nil)
+        await #expect(throws: IrohOpenFailure.closed) {
+            _ = try await server.localRoute()
+        }
+    }
+
+    @Test("an incompatible ALPN is isolated and the listener remains usable")
+    func incompatibleALPNDoesNotPoisonListener() async throws {
+        let server = IrohLibConnectionProvider(
+            configuration: try directConfiguration(
+                seed: 0x41,
+                alpn: Data("dev.cmux.cmux-lite/good".utf8)
+            )
+        )
+        let wrongClient = IrohLibConnectionProvider(
+            configuration: try directConfiguration(
+                seed: 0x42,
+                alpn: Data("dev.cmux.cmux-lite/wrong".utf8)
+            )
+        )
+        let goodClient = IrohLibConnectionProvider(
+            configuration: try directConfiguration(
+                seed: 0x43,
+                alpn: Data("dev.cmux.cmux-lite/good".utf8)
+            )
+        )
+
+        do {
+            let serverRoute = try await server.localRoute()
+            let acceptTask = Task<IrohIncomingConnection?, any Error> {
+                try await server.accept()
+            }
+
+            var rejected = false
+            do {
+                _ = try await withIntegrationTimeout(
+                    "incompatible dial",
+                    onTimeout: { await wrongClient.close() }
+                ) {
+                    try await wrongClient.connect(to: serverRoute)
+                }
+            } catch {
+                rejected = error is IrohOpenFailure
+            }
+            #expect(rejected)
+
+            let goodConnection = try await withProviderTimeout(
+                "compatible dial after rejection",
+                server: server,
+                client: goodClient
+            ) {
+                try await goodClient.connect(to: serverRoute)
+            }
+            let goodStream = IrohByteStream(connection: goodConnection)
+            try await goodStream.connect()
+            try await goodStream.send(Data("after rejection".utf8))
+
+            let incoming = try await withProviderTimeout(
+                "compatible accept after rejection",
+                server: server,
+                client: goodClient
+            ) {
+                try await acceptTask.value
+            }
+            guard let incoming else {
+                throw IntegrationFailure.missingIncomingConnection
+            }
+            let serverStream = IrohByteStream(connection: incoming.connection)
+            try await serverStream.connect()
+            #expect(try await serverStream.receive() == Data("after rejection".utf8))
+            await goodStream.close()
+            await serverStream.close()
+            await goodClient.close()
+            await wrongClient.close()
+            await server.close()
+        } catch {
+            await goodClient.close()
+            await wrongClient.close()
+            await server.close()
+            throw error
+        }
+    }
+}
+
+private enum IntegrationFailure: Error, CustomStringConvertible, Sendable {
+    case timedOut(String)
+    case missingIncomingConnection
+    case wrongStreamType
+    case missingListeningEvent
+    case missingAcceptedEvent
+
+    var description: String {
+        switch self {
+        case .timedOut(let operation):
+            return "Iroh integration operation timed out: \(operation)"
+        case .missingIncomingConnection:
+            return "Iroh endpoint closed before accepting a connection"
+        case .wrongStreamType:
+            return "Iroh connector returned an unexpected byte-stream type"
+        case .missingListeningEvent:
+            return "Iroh endpoint host did not publish a listening route"
+        case .missingAcceptedEvent:
+            return "Iroh endpoint host did not publish an accepted peer"
+        }
+    }
+}
+
+private final class AsyncEventIterator<Element: Sendable>: @unchecked Sendable {
+    private var iterator: AsyncStream<Element>.Iterator
+    private let lock = NSLock()
+
+    init(_ stream: AsyncStream<Element>) {
+        iterator = stream.makeAsyncIterator()
+    }
+
+    func next() async -> Element? {
+        var localIterator = lock.withLock { iterator }
+        let element = await localIterator.next()
+        lock.withLock {
+            iterator = localIterator
+        }
+        return element
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}
+
+private func withIntegrationTimeout<T: Sendable>(
+    _ operationName: String,
+    onTimeout: @escaping @Sendable () async -> Void = {},
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await ContinuousClock().sleep(for: .seconds(10))
+            await onTimeout()
+            throw IntegrationFailure.timedOut(operationName)
+        }
+        defer { group.cancelAll() }
+        return try await group.next()!
+    }
+}
+
+private func withProviderTimeout<T: Sendable>(
+    _ operationName: String,
+    server: IrohLibConnectionProvider,
+    client: IrohLibConnectionProvider,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withIntegrationTimeout(
+        operationName,
+        onTimeout: {
+            await client.close()
+            await server.close()
+        },
+        operation: operation
+    )
+}
+
+private func directConfiguration(
+    seed: UInt8,
+    alpn: Data = Data("dev.cmux.cmux-lite/integration/1".utf8)
+) throws -> IrohLibConfiguration {
+    let key = Data((0..<32).map { offset in
+        seed &+ UInt8(offset)
+    })
+    return try IrohLibConfiguration(
+        alpn: alpn,
+        relayMode: .disabled,
+        secretKeyBytes: key,
+        maximumReceiveChunkBytes: 64 * 1024,
+        bindAddress: "127.0.0.1:0"
+    )
+}
+
+private func withDirectProviders<T: Sendable>(
+    _ operation: @Sendable (
+        IrohLibConnectionProvider,
+        IrohLibConnectionProvider
+    ) async throws -> T
+) async throws -> T {
+    let server = IrohLibConnectionProvider(
+        configuration: try directConfiguration(seed: 0x11)
+    )
+    let client = IrohLibConnectionProvider(
+        configuration: try directConfiguration(seed: 0x22)
+    )
+
+    do {
+        let value = try await operation(server, client)
+        await client.close()
+        await server.close()
+        return value
+    } catch {
+        await client.close()
+        await server.close()
+        throw error
+    }
+}
+
+private func runSessionRound(
+    server: IrohLibConnectionProvider,
+    client: IrohLibConnectionProvider,
+    serverRoute: IrohRoute,
+    sessionID: String
+) async throws -> String {
+    let codec = try FrameCodec()
+    let acceptTask = Task<IrohIncomingConnection?, any Error> {
+        try await server.accept()
+    }
+    let clientConnection = try await withProviderTimeout(
+        "repeated session dial",
+        server: server,
+        client: client
+    ) {
+        try await client.connect(to: serverRoute)
+    }
+
+    let clientOwner = SessionOwner(
+        configuration: .client(
+            hello: .init(
+                clientName: "cmux-lite-ios",
+                nonce: "repeated-\(sessionID)"
+            )
+        ),
+        stream: IrohByteStream(connection: clientConnection),
+        codec: codec
+    )
+    var clientEvents = clientOwner.events.makeAsyncIterator()
+    try await clientOwner.start()
+    _ = await clientEvents.next()
+
+    let incoming = try await withProviderTimeout(
+        "repeated session accept",
+        server: server,
+        client: client
+    ) {
+        try await acceptTask.value
+    }
+    guard let incoming else {
+        throw IntegrationFailure.missingIncomingConnection
+    }
+
+    let serverOwner = SessionOwner(
+        configuration: .server(
+            welcome: .init(
+                sessionID: sessionID,
+                nonce: "repeated-\(sessionID)-server"
+            )
+        ),
+        stream: IrohByteStream(connection: incoming.connection),
+        codec: codec
+    )
+    var serverEvents = serverOwner.events.makeAsyncIterator()
+    try await serverOwner.start()
+    _ = await serverEvents.next()
+    _ = await clientEvents.next()
+    _ = await serverEvents.next()
+
+    let pingID = try await clientOwner.sendPing()
+    #expect(await serverEvents.next() == .pingReceived(messageID: pingID))
+    #expect(await clientEvents.next() == .pongReceived(replyTo: pingID))
+    await clientOwner.close()
+    _ = await clientEvents.next()
+    _ = await serverEvents.next()
+    return try await client.localRoute().endpointID
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxLiteProtocol",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxLiteProtocol",
+            targets: ["CmuxLiteProtocol"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxLiteProtocol",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxLiteProtocolTests",
+            dependencies: ["CmuxLiteProtocol"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/README.md
@@ -1,0 +1,70 @@
+# CmuxLiteProtocol
+
+`CmuxLiteProtocol` is the renderer-independent conversation contract shared by
+the cmux-lite iOS client and Mac host.
+
+The package currently owns four things:
+
+- typed version-1 control messages;
+- deterministic length-prefixed JSON framing;
+- client and server handshake/session state validation;
+- the transport seam that future loopback, Iroh, and Tailscale adapters implement.
+
+It deliberately has no UI, authentication, terminal, Iroh, Tailscale, socket,
+filesystem, clock, or global state dependency.
+
+## Frame format
+
+Each frame is a four-byte unsigned big-endian payload length followed by one
+UTF-8 JSON message. Control payloads are limited to 64 KiB by default, and one
+decoder call accepts at most 256 complete messages before failing closed.
+
+```json
+{
+  "message_id": 1,
+  "payload": {
+    "client_name": "cmux-lite-ios",
+    "nonce": "client-nonce"
+  },
+  "type": "hello",
+  "version": 1
+}
+```
+
+Transport reads are arbitrary chunks. One chunk may contain part of a frame,
+one frame, or several frames. `FrameCodec.Decoder` preserves partial input and
+emits only complete messages.
+
+## Session order
+
+The initial client conversation is:
+
+1. transport starts;
+2. transport becomes ready;
+3. client sends `hello`;
+4. server replies with `welcome`, correlated to the `hello` message ID;
+5. both peers enter `ready`;
+6. either peer may exchange correlated `ping` and `pong` messages;
+7. either peer may close explicitly, or the transport may end.
+
+Every sender uses positive, strictly increasing message IDs. A response has its
+own message ID and identifies the request through `reply_to`. Invalid versions,
+ordering, direction, or correlation close the state machine as a protocol
+violation.
+
+## Test construction
+
+Tests construct the pure values directly and use a test-target-only in-memory
+`ByteStream` pair. No app, simulator, daemon, renderer, or network is involved.
+
+```swift
+var client = SessionStateMachine(role: .client)
+try client.beginConnecting()
+try client.transportDidConnect()
+try client.recordSent(
+    WireMessage(
+        messageID: 1,
+        body: .hello(.init(clientName: "cmux-lite-ios", nonce: "nonce"))
+    )
+)
+```

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/ByteStream.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/ByteStream.swift
@@ -1,0 +1,40 @@
+public import Foundation
+
+/// An ordered, reliable byte stream used beneath the cmux-lite protocol.
+///
+/// A receive result is an arbitrary chunk. It does not correspond to a
+/// ``WireMessage`` or frame boundary. Returning `nil` means clean end-of-stream.
+/// Implementations must make ``close()`` idempotent and unblock a pending
+/// ``receive()``. One send and one receive may run concurrently. The session
+/// owner serializes calls within each direction, so implementations may reject
+/// overlapping sends or overlapping receives.
+public protocol ByteStream: Sendable {
+    /// Establishes the stream.
+    ///
+    /// Repeated calls after a successful connection must return successfully.
+    ///
+    /// - Throws: A transport-specific error or `CancellationError`.
+    func connect() async throws
+
+    /// Sends all bytes in one ordered write operation.
+    ///
+    /// An empty value is a no-op. Returning successfully means the
+    /// implementation accepted the complete value for delivery, not that the
+    /// peer processed it.
+    ///
+    /// - Parameter bytes: The bytes to enqueue for delivery.
+    /// - Throws: A transport-specific error or `CancellationError`.
+    func send(_ bytes: Data) async throws
+
+    /// Receives the next available byte chunk.
+    ///
+    /// - Returns: The next non-empty chunk, or `nil` after clean end-of-stream.
+    /// - Throws: A transport-specific error or `CancellationError`.
+    func receive() async throws -> Data?
+
+    /// Closes the stream and releases its transport resources.
+    ///
+    /// Repeated calls have no effect. A pending ``receive()`` resumes with
+    /// `nil`.
+    func close() async
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/FrameCodec.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/FrameCodec.swift
@@ -1,0 +1,241 @@
+public import Foundation
+
+/// Encodes and incrementally decodes length-prefixed ``WireMessage`` values.
+public struct FrameCodec: Sendable {
+    /// The default maximum JSON payload size, excluding the four-byte prefix.
+    public static let defaultMaximumPayloadSize = 64 * 1_024
+
+    /// The default maximum number of frames decoded from one transport chunk.
+    public static let defaultMaximumMessagesPerIngest = 256
+
+    /// The maximum accepted JSON payload size, excluding the four-byte prefix.
+    public let maximumPayloadSize: Int
+
+    /// The maximum complete messages accepted from one call to `ingest`.
+    public let maximumMessagesPerIngest: Int
+
+    /// Creates a codec with bounded payload size and per-ingest work.
+    ///
+    /// - Parameters:
+    ///   - maximumPayloadSize: A positive limit no larger than `UInt32.max`.
+    ///     The default is 64 KiB.
+    ///   - maximumMessagesPerIngest: A positive limit on complete messages
+    ///     decoded from one chunk. The default is 256.
+    /// - Throws: A configuration ``Failure`` when either limit is invalid.
+    public init(
+        maximumPayloadSize: Int = Self.defaultMaximumPayloadSize,
+        maximumMessagesPerIngest: Int = Self.defaultMaximumMessagesPerIngest
+    ) throws {
+        guard maximumPayloadSize > 0,
+              UInt32(exactly: maximumPayloadSize) != nil
+        else {
+            throw Failure.invalidMaximumPayloadSize
+        }
+        guard maximumMessagesPerIngest > 0 else {
+            throw Failure.invalidMaximumMessagesPerIngest
+        }
+        self.maximumPayloadSize = maximumPayloadSize
+        self.maximumMessagesPerIngest = maximumMessagesPerIngest
+    }
+
+    /// Encodes one message as a four-byte length followed by JSON bytes.
+    ///
+    /// JSON keys are sorted so fixtures and diagnostics remain deterministic.
+    ///
+    /// - Parameter message: The message to encode.
+    /// - Returns: One complete length-prefixed frame.
+    /// - Throws: ``Failure/frameTooLarge`` when the JSON exceeds the configured
+    ///   limit, or ``Failure/malformedPayload`` if Foundation cannot encode it.
+    public func encode(_ message: WireMessage) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let payload: Data
+        do {
+            payload = try encoder.encode(message)
+        } catch {
+            throw Failure.malformedPayload
+        }
+
+        guard payload.count <= maximumPayloadSize,
+              let length = UInt32(exactly: payload.count)
+        else {
+            throw Failure.frameTooLarge
+        }
+
+        var frame = Data(capacity: Self.headerSize + payload.count)
+        frame.append(UInt8(truncatingIfNeeded: length >> 24))
+        frame.append(UInt8(truncatingIfNeeded: length >> 16))
+        frame.append(UInt8(truncatingIfNeeded: length >> 8))
+        frame.append(UInt8(truncatingIfNeeded: length))
+        frame.append(payload)
+        return frame
+    }
+
+    /// Creates an independent incremental decoder using this codec's limit.
+    ///
+    /// - Returns: A new decoder with no buffered bytes.
+    public func makeDecoder() -> Decoder {
+        Decoder(
+            maximumPayloadSize: maximumPayloadSize,
+            maximumMessagesPerIngest: maximumMessagesPerIngest
+        )
+    }
+
+    /// Fatal framing and codec failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// The configured payload limit is zero, negative, or exceeds `UInt32`.
+        case invalidMaximumPayloadSize
+
+        /// The configured per-ingest message limit is not positive.
+        case invalidMaximumMessagesPerIngest
+
+        /// The declared or encoded payload exceeds the configured limit.
+        case frameTooLarge
+
+        /// A frame declares an empty JSON payload.
+        case emptyPayload
+
+        /// A complete payload is not a valid ``WireMessage`` JSON value.
+        case malformedPayload
+
+        /// One chunk contains more complete messages than the configured limit.
+        case tooManyMessages
+
+        /// End-of-stream arrived after part of a frame.
+        case truncatedFrame
+
+        /// The decoder was reused after a fatal failure.
+        case decoderFailed
+    }
+
+    /// A bounded incremental decoder for arbitrary transport chunks.
+    ///
+    /// The decoder buffers at most one frame. Any fatal failure poisons the
+    /// decoder; construct a new decoder for a new transport session.
+    public struct Decoder: Sendable {
+        private let maximumPayloadSize: Int
+        private let maximumMessagesPerIngest: Int
+        private var header = Data()
+        private var payload = Data()
+        private var expectedPayloadSize: Int?
+        private var failed = false
+
+        fileprivate init(
+            maximumPayloadSize: Int,
+            maximumMessagesPerIngest: Int
+        ) {
+            self.maximumPayloadSize = maximumPayloadSize
+            self.maximumMessagesPerIngest = maximumMessagesPerIngest
+            header.reserveCapacity(FrameCodec.headerSize)
+        }
+
+        /// Ingests one arbitrary byte chunk and returns every complete message.
+        ///
+        /// An empty chunk has no effect. The chunk may contain a partial frame,
+        /// one frame, or multiple frames.
+        ///
+        /// - Parameter chunk: The next bytes read from a ``ByteStream``.
+        /// - Returns: Complete messages in wire order.
+        /// - Throws: A fatal ``FrameCodec/Failure``. The decoder cannot be
+        ///   reused after throwing.
+        public mutating func ingest(_ chunk: Data) throws -> [WireMessage] {
+            guard !failed else {
+                throw Failure.decoderFailed
+            }
+
+            var messages: [WireMessage] = []
+            var cursor = chunk.startIndex
+
+            while cursor < chunk.endIndex {
+                if expectedPayloadSize == nil {
+                    let headerBytesNeeded = FrameCodec.headerSize - header.count
+                    let available = chunk.distance(from: cursor, to: chunk.endIndex)
+                    let count = min(headerBytesNeeded, available)
+                    let end = chunk.index(cursor, offsetBy: count)
+                    header.append(contentsOf: chunk[cursor..<end])
+                    cursor = end
+
+                    guard header.count == FrameCodec.headerSize else {
+                        continue
+                    }
+
+                    let declaredSize = header.reduce(UInt32.zero) {
+                        ($0 << 8) | UInt32($1)
+                    }
+                    guard declaredSize > 0 else {
+                        try fail(with: .emptyPayload)
+                    }
+                    guard declaredSize <= UInt32(maximumPayloadSize) else {
+                        try fail(with: .frameTooLarge)
+                    }
+
+                    expectedPayloadSize = Int(declaredSize)
+                    payload.reserveCapacity(Int(declaredSize))
+                }
+
+                guard let expectedPayloadSize else {
+                    continue
+                }
+
+                let payloadBytesNeeded = expectedPayloadSize - payload.count
+                let available = chunk.distance(from: cursor, to: chunk.endIndex)
+                let count = min(payloadBytesNeeded, available)
+                let end = chunk.index(cursor, offsetBy: count)
+                payload.append(contentsOf: chunk[cursor..<end])
+                cursor = end
+
+                guard payload.count == expectedPayloadSize else {
+                    continue
+                }
+                guard messages.count < maximumMessagesPerIngest else {
+                    try fail(with: .tooManyMessages)
+                }
+
+                let message: WireMessage
+                do {
+                    message = try JSONDecoder().decode(WireMessage.self, from: payload)
+                } catch {
+                    try fail(with: .malformedPayload)
+                }
+                messages.append(message)
+                resetFrame()
+            }
+
+            return messages
+        }
+
+        /// Validates that end-of-stream occurred at a frame boundary.
+        ///
+        /// - Throws: ``FrameCodec/Failure/truncatedFrame`` when header or payload
+        ///   bytes remain, or ``FrameCodec/Failure/decoderFailed`` after an
+        ///   earlier fatal failure.
+        public mutating func finish() throws {
+            guard !failed else {
+                throw Failure.decoderFailed
+            }
+            guard header.isEmpty,
+                  payload.isEmpty,
+                  expectedPayloadSize == nil
+            else {
+                try fail(with: .truncatedFrame)
+            }
+        }
+
+        private mutating func resetFrame() {
+            header.removeAll(keepingCapacity: true)
+            payload.removeAll(keepingCapacity: true)
+            expectedPayloadSize = nil
+        }
+
+        private mutating func fail(with failure: Failure) throws -> Never {
+            failed = true
+            header.removeAll(keepingCapacity: false)
+            payload.removeAll(keepingCapacity: false)
+            expectedPayloadSize = nil
+            throw failure
+        }
+    }
+
+    private static let headerSize = 4
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/SessionStateMachine.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/SessionStateMachine.swift
@@ -1,0 +1,365 @@
+/// Validates the ordered cmux-lite handshake and ready-session conversation.
+public struct SessionStateMachine: Sendable {
+    /// Whether this state machine represents the connecting client or host.
+    public let role: Role
+
+    /// The current externally observable session phase.
+    public private(set) var phase: Phase = .idle
+
+    private var lastSentMessageID: UInt64 = 0
+    private var lastReceivedMessageID: UInt64 = 0
+    private var handshakeMessageID: UInt64?
+    private var pendingSentPings: Set<UInt64> = []
+    private var pendingReceivedPings: Set<UInt64> = []
+
+    /// Creates an idle state machine for one side of a session.
+    ///
+    /// - Parameter role: The side whose sends and receives will be validated.
+    public init(role: Role) {
+        self.role = role
+    }
+
+    /// Records that transport establishment has started.
+    ///
+    /// - Throws: ``Violation/unexpectedLifecycleEvent`` unless the phase is
+    ///   ``Phase/idle``.
+    public mutating func beginConnecting() throws {
+        guard phase == .idle else {
+            try fail(.unexpectedLifecycleEvent)
+        }
+        phase = .connecting
+    }
+
+    /// Records that the underlying transport is ready for protocol messages.
+    ///
+    /// - Throws: ``Violation/unexpectedLifecycleEvent`` unless the phase is
+    ///   ``Phase/connecting``.
+    public mutating func transportDidConnect() throws {
+        guard phase == .connecting else {
+            try fail(.unexpectedLifecycleEvent)
+        }
+        phase = .handshaking
+    }
+
+    /// Validates and records a message sent by this side.
+    ///
+    /// Call this from the session's serialized owner immediately before its
+    /// transport write. A later write failure should call
+    /// ``transportDidClose()``.
+    ///
+    /// - Parameter message: The message about to be sent.
+    /// - Throws: A fatal ``Violation``. The phase becomes ``Phase/closed(_:)``.
+    public mutating func recordSent(_ message: WireMessage) throws {
+        try validateEnvelope(message, direction: .sent)
+        try apply(message, direction: .sent)
+        lastSentMessageID = message.messageID
+    }
+
+    /// Validates and records a message received from the peer.
+    ///
+    /// - Parameter message: The next decoded message in wire order.
+    /// - Throws: A fatal ``Violation``. The phase becomes ``Phase/closed(_:)``.
+    public mutating func recordReceived(_ message: WireMessage) throws {
+        try validateEnvelope(message, direction: .received)
+        try apply(message, direction: .received)
+        lastReceivedMessageID = message.messageID
+    }
+
+    /// Records transport end without a protocol `close` message.
+    ///
+    /// This operation is idempotent. An existing explicit or protocol-violation
+    /// close reason is preserved.
+    public mutating func transportDidClose() {
+        guard !phase.isClosed else {
+            return
+        }
+        phase = .closed(.transportEnded)
+        clearPendingState()
+    }
+
+    /// The two roles in a cmux-lite session.
+    public enum Role: Equatable, Sendable {
+        /// The peer that initiates the handshake with `hello`.
+        case client
+
+        /// The peer that accepts `hello` and responds with `welcome`.
+        case server
+    }
+
+    /// The ordered lifecycle phases of one protocol session.
+    public enum Phase: Equatable, Sendable {
+        /// No transport attempt has started.
+        case idle
+
+        /// The underlying transport is being established.
+        case connecting
+
+        /// The transport is ready and `hello`/`welcome` is incomplete.
+        case handshaking
+
+        /// The handshake succeeded with the given opaque session identifier.
+        case ready(sessionID: String)
+
+        /// The session ended and cannot accept more events.
+        case closed(Closure)
+
+        fileprivate var isClosed: Bool {
+            if case .closed = self {
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Why a state machine entered its terminal phase.
+    public enum Closure: Equatable, Sendable {
+        /// This side sent an explicit close reason.
+        case local(WireMessage.Close.Reason)
+
+        /// The peer sent an explicit close reason.
+        case remote(WireMessage.Close.Reason)
+
+        /// The byte stream ended without an explicit close message.
+        case transportEnded
+
+        /// A local or remote protocol invariant failed.
+        case protocolViolation(Violation)
+    }
+
+    /// Fatal protocol and lifecycle violations.
+    public enum Violation: Error, Equatable, Sendable {
+        /// A lifecycle method was called from the wrong phase.
+        case unexpectedLifecycleEvent
+
+        /// A message uses a version this implementation does not support.
+        case unsupportedVersion
+
+        /// A message ID is zero or does not increase for its sender.
+        case invalidMessageID
+
+        /// A message type is invalid for the current role, direction, or phase.
+        case unexpectedMessage
+
+        /// A response is missing, invents, or repeats a request correlation.
+        case invalidCorrelation
+
+        /// Required handshake metadata is empty or unreasonably large.
+        case invalidHandshakeMetadata
+    }
+
+    private enum Direction: Equatable {
+        case sent
+        case received
+    }
+
+    private mutating func validateEnvelope(
+        _ message: WireMessage,
+        direction: Direction
+    ) throws {
+        guard message.version == WireMessage.currentVersion else {
+            try fail(.unsupportedVersion)
+        }
+
+        let previousID = switch direction {
+        case .sent: lastSentMessageID
+        case .received: lastReceivedMessageID
+        }
+        guard message.messageID > previousID else {
+            try fail(.invalidMessageID)
+        }
+    }
+
+    private mutating func apply(
+        _ message: WireMessage,
+        direction: Direction
+    ) throws {
+        if case .close(let close) = message.body {
+            try applyClose(message, close: close, direction: direction)
+            return
+        }
+
+        if case .protocolError = message.body {
+            try applyProtocolError(message, direction: direction)
+            return
+        }
+
+        switch phase {
+        case .handshaking:
+            try applyHandshake(message, direction: direction)
+        case .ready:
+            try applyReadyMessage(message, direction: direction)
+        case .idle, .connecting, .closed:
+            try fail(.unexpectedMessage)
+        }
+    }
+
+    private mutating func applyHandshake(
+        _ message: WireMessage,
+        direction: Direction
+    ) throws {
+        switch (role, direction, message.body) {
+        case (.client, .sent, .hello(let hello)):
+            guard handshakeMessageID == nil else {
+                try fail(.unexpectedMessage)
+            }
+            guard message.replyTo == nil else {
+                try fail(.invalidCorrelation)
+            }
+            guard Self.isValidMetadata(hello.clientName, maximumUTF8Bytes: 64),
+                  Self.isValidMetadata(hello.nonce, maximumUTF8Bytes: 256)
+            else {
+                try fail(.invalidHandshakeMetadata)
+            }
+            handshakeMessageID = message.messageID
+
+        case (.server, .received, .hello(let hello)):
+            guard handshakeMessageID == nil else {
+                try fail(.unexpectedMessage)
+            }
+            guard message.replyTo == nil else {
+                try fail(.invalidCorrelation)
+            }
+            guard Self.isValidMetadata(hello.clientName, maximumUTF8Bytes: 64),
+                  Self.isValidMetadata(hello.nonce, maximumUTF8Bytes: 256)
+            else {
+                try fail(.invalidHandshakeMetadata)
+            }
+            handshakeMessageID = message.messageID
+
+        case (.server, .sent, .welcome(let welcome)):
+            try acceptWelcome(message, welcome: welcome)
+
+        case (.client, .received, .welcome(let welcome)):
+            try acceptWelcome(message, welcome: welcome)
+
+        default:
+            try fail(.unexpectedMessage)
+        }
+    }
+
+    private mutating func acceptWelcome(
+        _ message: WireMessage,
+        welcome: WireMessage.Welcome
+    ) throws {
+        guard let handshakeMessageID,
+              message.replyTo == handshakeMessageID
+        else {
+            try fail(.invalidCorrelation)
+        }
+        guard Self.isValidMetadata(welcome.sessionID, maximumUTF8Bytes: 256),
+              Self.isValidMetadata(welcome.nonce, maximumUTF8Bytes: 256)
+        else {
+            try fail(.invalidHandshakeMetadata)
+        }
+        phase = .ready(sessionID: welcome.sessionID)
+        self.handshakeMessageID = nil
+    }
+
+    private mutating func applyReadyMessage(
+        _ message: WireMessage,
+        direction: Direction
+    ) throws {
+        switch (direction, message.body) {
+        case (.sent, .ping):
+            guard message.replyTo == nil else {
+                try fail(.invalidCorrelation)
+            }
+            pendingSentPings.insert(message.messageID)
+
+        case (.received, .ping):
+            guard message.replyTo == nil else {
+                try fail(.invalidCorrelation)
+            }
+            pendingReceivedPings.insert(message.messageID)
+
+        case (.sent, .pong):
+            guard let replyTo = message.replyTo,
+                  pendingReceivedPings.remove(replyTo) != nil
+            else {
+                try fail(.invalidCorrelation)
+            }
+
+        case (.received, .pong):
+            guard let replyTo = message.replyTo,
+                  pendingSentPings.remove(replyTo) != nil
+            else {
+                try fail(.invalidCorrelation)
+            }
+
+        default:
+            try fail(.unexpectedMessage)
+        }
+    }
+
+    private mutating func applyClose(
+        _ message: WireMessage,
+        close: WireMessage.Close,
+        direction: Direction
+    ) throws {
+        guard phase == .handshaking || phase.isReady,
+              message.replyTo == nil
+        else {
+            try fail(.unexpectedMessage)
+        }
+        phase = .closed(
+            direction == .sent ? .local(close.reason) : .remote(close.reason)
+        )
+        clearPendingState()
+    }
+
+    private mutating func applyProtocolError(
+        _ message: WireMessage,
+        direction: Direction
+    ) throws {
+        guard phase == .handshaking || phase.isReady else {
+            try fail(.unexpectedMessage)
+        }
+
+        if let replyTo = message.replyTo {
+            let lastPeerMessageID = switch direction {
+            case .sent: lastReceivedMessageID
+            case .received: lastSentMessageID
+            }
+            guard replyTo > 0, replyTo <= lastPeerMessageID else {
+                try fail(.invalidCorrelation)
+            }
+        }
+
+        phase = .closed(
+            direction == .sent
+                ? .local(.protocolViolation)
+                : .remote(.protocolViolation)
+        )
+        clearPendingState()
+    }
+
+    private static func isValidMetadata(
+        _ value: String,
+        maximumUTF8Bytes: Int
+    ) -> Bool {
+        !value.isEmpty && value.utf8.count <= maximumUTF8Bytes
+    }
+
+    private mutating func clearPendingState() {
+        handshakeMessageID = nil
+        pendingSentPings.removeAll(keepingCapacity: false)
+        pendingReceivedPings.removeAll(keepingCapacity: false)
+    }
+
+    private mutating func fail(_ violation: Violation) throws -> Never {
+        if !phase.isClosed {
+            phase = .closed(.protocolViolation(violation))
+            clearPendingState()
+        }
+        throw violation
+    }
+}
+
+private extension SessionStateMachine.Phase {
+    var isReady: Bool {
+        if case .ready = self {
+            return true
+        }
+        return false
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/WireMessage.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Sources/CmuxLiteProtocol/WireMessage.swift
@@ -1,0 +1,241 @@
+internal import Foundation
+
+/// One versioned cmux-lite control message carried inside a framed payload.
+public struct WireMessage: Codable, Equatable, Sendable {
+    /// The only protocol version implemented by this package.
+    public static let currentVersion: UInt16 = 1
+
+    /// A positive identifier that increases for every message from one sender.
+    public let messageID: UInt64
+
+    /// The protocol version used to encode this message.
+    public let version: UInt16
+
+    /// The initiating message ID when this message is a response.
+    public let replyTo: UInt64?
+
+    /// The typed message content.
+    public let body: Body
+
+    /// Creates a wire message.
+    ///
+    /// Semantic constraints such as positive IDs, correlation, and message
+    /// direction are enforced by ``SessionStateMachine``.
+    ///
+    /// - Parameters:
+    ///   - messageID: The sender's monotonically increasing message ID.
+    ///   - version: The protocol version, normally ``currentVersion``.
+    ///   - replyTo: The initiating message ID for a response.
+    ///   - body: The typed message content.
+    public init(
+        messageID: UInt64,
+        version: UInt16 = Self.currentVersion,
+        replyTo: UInt64? = nil,
+        body: Body
+    ) {
+        self.messageID = messageID
+        self.version = version
+        self.replyTo = replyTo
+        self.body = body
+    }
+
+    /// The supported control-message variants.
+    public enum Body: Equatable, Sendable {
+        /// Begins protocol negotiation from the connecting peer.
+        case hello(Hello)
+
+        /// Accepts a `hello` and establishes a logical session.
+        case welcome(Welcome)
+
+        /// Requests a liveness response.
+        case ping
+
+        /// Responds to a `ping`.
+        case pong
+
+        /// Reports a fatal protocol error.
+        case protocolError(ProtocolError)
+
+        /// Ends a session with an explicit reason.
+        case close(Close)
+    }
+
+    /// Client metadata carried by a `hello` message.
+    public struct Hello: Codable, Equatable, Sendable {
+        /// A diagnostic implementation name, never an authorization claim.
+        public let clientName: String
+
+        /// An opaque, freshly generated value for this handshake.
+        public let nonce: String
+
+        /// Creates client handshake metadata.
+        ///
+        /// - Parameters:
+        ///   - clientName: A diagnostic implementation name.
+        ///   - nonce: A fresh opaque handshake value.
+        public init(clientName: String, nonce: String) {
+            self.clientName = clientName
+            self.nonce = nonce
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case clientName = "client_name"
+            case nonce
+        }
+    }
+
+    /// Server metadata carried by a `welcome` message.
+    public struct Welcome: Codable, Equatable, Sendable {
+        /// The opaque identifier for the newly established logical session.
+        public let sessionID: String
+
+        /// An opaque, freshly generated server value for this handshake.
+        public let nonce: String
+
+        /// Creates server handshake metadata.
+        ///
+        /// - Parameters:
+        ///   - sessionID: The newly established logical-session identifier.
+        ///   - nonce: A fresh opaque handshake value.
+        public init(sessionID: String, nonce: String) {
+            self.sessionID = sessionID
+            self.nonce = nonce
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case sessionID = "session_id"
+            case nonce
+        }
+    }
+
+    /// A fatal protocol error reported to the remote peer.
+    public struct ProtocolError: Codable, Equatable, Sendable {
+        /// The machine-readable error category.
+        public let code: Code
+
+        /// Creates a protocol-error payload.
+        ///
+        /// - Parameter code: The machine-readable error category.
+        public init(code: Code) {
+            self.code = code
+        }
+
+        /// Categories that are safe to expose across the protocol boundary.
+        public enum Code: String, Codable, Equatable, Sendable {
+            /// The peer requested a protocol version this implementation rejects.
+            case unsupportedVersion = "unsupported_version"
+
+            /// The peer sent bytes that do not form a valid frame or message.
+            case malformedFrame = "malformed_frame"
+
+            /// The message is not valid for the current role or phase.
+            case unexpectedMessage = "unexpected_message"
+
+            /// A response does not identify a pending request.
+            case invalidCorrelation = "invalid_correlation"
+        }
+    }
+
+    /// An explicit session-close message.
+    public struct Close: Codable, Equatable, Sendable {
+        /// The machine-readable reason for ending the session.
+        public let reason: Reason
+
+        /// Creates a close payload.
+        ///
+        /// - Parameter reason: The machine-readable close reason.
+        public init(reason: Reason) {
+            self.reason = reason
+        }
+
+        /// Reasons a peer can communicate before closing its transport.
+        public enum Reason: String, Codable, Equatable, Sendable {
+            /// The session completed normally.
+            case normal
+
+            /// A local owner cancelled the session.
+            case cancelled
+
+            /// The transport failed and cannot continue the session.
+            case transportFailure = "transport_failure"
+
+            /// A protocol invariant was violated.
+            case protocolViolation = "protocol_violation"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case messageID = "message_id"
+        case version
+        case replyTo = "reply_to"
+        case type
+        case payload
+    }
+
+    private enum MessageType: String, Codable {
+        case hello
+        case welcome
+        case ping
+        case pong
+        case protocolError = "protocol_error"
+        case close
+    }
+
+    private struct EmptyPayload: Codable {}
+
+    /// Encodes the stable, explicitly tagged wire representation.
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(messageID, forKey: .messageID)
+        try container.encode(version, forKey: .version)
+        try container.encodeIfPresent(replyTo, forKey: .replyTo)
+
+        switch body {
+        case .hello(let hello):
+            try container.encode(MessageType.hello, forKey: .type)
+            try container.encode(hello, forKey: .payload)
+        case .welcome(let welcome):
+            try container.encode(MessageType.welcome, forKey: .type)
+            try container.encode(welcome, forKey: .payload)
+        case .ping:
+            try container.encode(MessageType.ping, forKey: .type)
+            try container.encode(EmptyPayload(), forKey: .payload)
+        case .pong:
+            try container.encode(MessageType.pong, forKey: .type)
+            try container.encode(EmptyPayload(), forKey: .payload)
+        case .protocolError(let error):
+            try container.encode(MessageType.protocolError, forKey: .type)
+            try container.encode(error, forKey: .payload)
+        case .close(let close):
+            try container.encode(MessageType.close, forKey: .type)
+            try container.encode(close, forKey: .payload)
+        }
+    }
+
+    /// Decodes the stable, explicitly tagged wire representation.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        messageID = try container.decode(UInt64.self, forKey: .messageID)
+        version = try container.decode(UInt16.self, forKey: .version)
+        replyTo = try container.decodeIfPresent(UInt64.self, forKey: .replyTo)
+
+        switch try container.decode(MessageType.self, forKey: .type) {
+        case .hello:
+            body = .hello(try container.decode(Hello.self, forKey: .payload))
+        case .welcome:
+            body = .welcome(try container.decode(Welcome.self, forKey: .payload))
+        case .ping:
+            _ = try container.decode(EmptyPayload.self, forKey: .payload)
+            body = .ping
+        case .pong:
+            _ = try container.decode(EmptyPayload.self, forKey: .payload)
+            body = .pong
+        case .protocolError:
+            body = .protocolError(
+                try container.decode(ProtocolError.self, forKey: .payload)
+            )
+        case .close:
+            body = .close(try container.decode(Close.self, forKey: .payload))
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/ByteStreamTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/ByteStreamTests.swift
@@ -1,0 +1,97 @@
+internal import Foundation
+import Testing
+
+@Suite("Byte-stream contract")
+struct ByteStreamTests {
+    @Test("paired streams preserve ordered non-empty chunks")
+    func orderedChunks() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+
+        try await sender.send(Data())
+        try await sender.send(Data("first".utf8))
+        try await sender.send(Data("second".utf8))
+
+        #expect(try await receiver.receive() == Data("first".utf8))
+        #expect(try await receiver.receive() == Data("second".utf8))
+    }
+
+    @Test("close is idempotent and unblocks a pending receive with EOF")
+    func closeUnblocksReceive() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+
+        let receive = Task {
+            try await receiver.receive()
+        }
+        await receiver.waitUntilReceiveIsPending()
+        await receiver.close()
+        await receiver.close()
+
+        #expect(try await receive.value == nil)
+    }
+
+    @Test("peer close delivers EOF after already-buffered bytes")
+    func peerCloseDrainsBufferedBytes() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+        try await sender.send(Data("final".utf8))
+        await sender.close()
+
+        #expect(try await receiver.receive() == Data("final".utf8))
+        #expect(try await receiver.receive() == nil)
+    }
+
+    @Test("send fails after the peer has closed")
+    func sendAfterPeerClose() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+        await receiver.close()
+
+        await #expect(throws: TestInMemoryByteStream.Failure.closed) {
+            try await sender.send(Data("late".utf8))
+        }
+    }
+
+    @Test("task cancellation unblocks a pending receive exactly once")
+    func receiveCancellation() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+
+        let receive = Task {
+            try await receiver.receive()
+        }
+        await receiver.waitUntilReceiveIsPending()
+        receive.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await receive.value
+        }
+        await sender.close()
+        await receiver.close()
+    }
+
+    @Test("a second concurrent receive is rejected without disturbing the first")
+    func concurrentReceive() async throws {
+        let (sender, receiver) = await TestInMemoryByteStream.makePair()
+        try await sender.connect()
+        try await receiver.connect()
+
+        let firstReceive = Task {
+            try await receiver.receive()
+        }
+        await receiver.waitUntilReceiveIsPending()
+
+        await #expect(throws: TestInMemoryByteStream.Failure.receiveAlreadyPending) {
+            try await receiver.receive()
+        }
+
+        try await sender.send(Data("value".utf8))
+        #expect(try await firstReceive.value == Data("value".utf8))
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/FrameCodecTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/FrameCodecTests.swift
@@ -1,0 +1,165 @@
+internal import Foundation
+import Testing
+import CmuxLiteProtocol
+
+@Suite("Frame codec")
+struct FrameCodecTests {
+    @Test("encoding uses the approved big-endian JSON wire shape")
+    func deterministicWireShape() throws {
+        let codec = try FrameCodec()
+        let message = WireMessage(
+            messageID: 1,
+            body: .hello(
+                .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            )
+        )
+
+        let frame = try codec.encode(message)
+        #expect(frame.prefix(4) == Data([0, 0, 0, 108]))
+
+        let json = try #require(
+            String(data: Data(frame.dropFirst(4)), encoding: .utf8)
+        )
+        #expect(
+            json == #"{"message_id":1,"payload":{"client_name":"cmux-lite-ios","nonce":"client-nonce"},"type":"hello","version":1}"#
+        )
+    }
+
+    @Test("a frame split at every byte boundary decodes exactly once")
+    func byteByByteFragmentation() throws {
+        let codec = try FrameCodec()
+        let expected = WireMessage(messageID: 1, body: .ping)
+        let frame = try codec.encode(expected)
+        var decoder = codec.makeDecoder()
+        var decoded: [WireMessage] = []
+
+        for byte in frame {
+            decoded.append(contentsOf: try decoder.ingest(Data([byte])))
+        }
+        try decoder.finish()
+
+        #expect(decoded == [expected])
+    }
+
+    @Test("coalesced frames decode separately in wire order")
+    func coalescedFrames() throws {
+        let codec = try FrameCodec()
+        let messages = [
+            WireMessage(messageID: 1, body: .ping),
+            WireMessage(messageID: 2, replyTo: 1, body: .pong),
+            WireMessage(
+                messageID: 3,
+                body: .close(.init(reason: .normal))
+            ),
+        ]
+        var bytes = Data()
+        for message in messages {
+            bytes.append(try codec.encode(message))
+        }
+        var decoder = codec.makeDecoder()
+
+        let decoded = try decoder.ingest(bytes)
+        try decoder.finish()
+
+        #expect(decoded == messages)
+    }
+
+    @Test("a split header and split body remain buffered independently")
+    func partialHeaderAndBody() throws {
+        let codec = try FrameCodec()
+        let expected = WireMessage(
+            messageID: 7,
+            replyTo: 3,
+            body: .protocolError(.init(code: .invalidCorrelation))
+        )
+        let frame = try codec.encode(expected)
+        var decoder = codec.makeDecoder()
+
+        #expect(try decoder.ingest(frame.prefix(2)).isEmpty)
+        #expect(try decoder.ingest(frame.dropFirst(2).prefix(5)).isEmpty)
+        let decoded = try decoder.ingest(frame.dropFirst(7))
+        try decoder.finish()
+
+        #expect(decoded == [expected])
+    }
+
+    @Test("end-of-stream rejects a partial frame and poisons the decoder")
+    func truncatedFrameFailsClosed() throws {
+        let codec = try FrameCodec()
+        let frame = try codec.encode(WireMessage(messageID: 1, body: .ping))
+        var decoder = codec.makeDecoder()
+
+        _ = try decoder.ingest(frame.dropLast())
+        #expect(throws: FrameCodec.Failure.truncatedFrame) {
+            try decoder.finish()
+        }
+        #expect(throws: FrameCodec.Failure.decoderFailed) {
+            try decoder.ingest(Data())
+        }
+    }
+
+    @Test("declared oversized payload fails before body buffering")
+    func oversizedDeclaredPayloadFailsClosed() throws {
+        let codec = try FrameCodec(maximumPayloadSize: 8)
+        var decoder = codec.makeDecoder()
+
+        #expect(throws: FrameCodec.Failure.frameTooLarge) {
+            try decoder.ingest(Data([0, 0, 0, 9]))
+        }
+        #expect(throws: FrameCodec.Failure.decoderFailed) {
+            try decoder.ingest(Data([0]))
+        }
+    }
+
+    @Test("empty and malformed JSON payloads fail closed")
+    func malformedPayloadsFailClosed() throws {
+        let codec = try FrameCodec()
+        var emptyDecoder = codec.makeDecoder()
+        var malformedDecoder = codec.makeDecoder()
+
+        #expect(throws: FrameCodec.Failure.emptyPayload) {
+            try emptyDecoder.ingest(Data([0, 0, 0, 0]))
+        }
+
+        let malformed = Data([0, 0, 0, 1, UInt8(ascii: "{")])
+        #expect(throws: FrameCodec.Failure.malformedPayload) {
+            try malformedDecoder.ingest(malformed)
+        }
+    }
+
+    @Test("configuration and encoded payload limits are enforced")
+    func configuredLimits() throws {
+        #expect(throws: FrameCodec.Failure.invalidMaximumPayloadSize) {
+            try FrameCodec(maximumPayloadSize: 0)
+        }
+        #expect(throws: FrameCodec.Failure.invalidMaximumMessagesPerIngest) {
+            try FrameCodec(maximumMessagesPerIngest: 0)
+        }
+
+        let codec = try FrameCodec(maximumPayloadSize: 32)
+        let message = WireMessage(
+            messageID: 1,
+            body: .hello(.init(clientName: "cmux-lite-ios", nonce: "nonce"))
+        )
+        #expect(throws: FrameCodec.Failure.frameTooLarge) {
+            try codec.encode(message)
+        }
+    }
+
+    @Test("one transport chunk has a bounded decode-work budget")
+    func messageFloodFailsClosed() throws {
+        let codec = try FrameCodec(maximumMessagesPerIngest: 2)
+        var bytes = Data()
+        bytes.append(try codec.encode(WireMessage(messageID: 1, body: .ping)))
+        bytes.append(try codec.encode(WireMessage(messageID: 2, body: .ping)))
+        bytes.append(try codec.encode(WireMessage(messageID: 3, body: .ping)))
+        var decoder = codec.makeDecoder()
+
+        #expect(throws: FrameCodec.Failure.tooManyMessages) {
+            try decoder.ingest(bytes)
+        }
+        #expect(throws: FrameCodec.Failure.decoderFailed) {
+            try decoder.ingest(Data())
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/SessionStateMachineTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/SessionStateMachineTests.swift
@@ -1,0 +1,245 @@
+import Testing
+import CmuxLiteProtocol
+
+@Suite("Session state machine")
+struct SessionStateMachineTests {
+    @Test("client and server complete the same correlated handshake")
+    func handshake() throws {
+        let pair = try Self.makeReadyPair()
+
+        #expect(pair.client.phase == .ready(sessionID: "session-1"))
+        #expect(pair.server.phase == .ready(sessionID: "session-1"))
+    }
+
+    @Test("both peers can pipeline correlated pings once ready")
+    func correlatedPingPong() throws {
+        var pair = try Self.makeReadyPair()
+
+        let clientPing = WireMessage(messageID: 2, body: .ping)
+        let serverPing = WireMessage(messageID: 2, body: .ping)
+        try pair.client.recordSent(clientPing)
+        try pair.server.recordReceived(clientPing)
+        try pair.server.recordSent(serverPing)
+        try pair.client.recordReceived(serverPing)
+
+        let serverPong = WireMessage(messageID: 3, replyTo: 2, body: .pong)
+        let clientPong = WireMessage(messageID: 3, replyTo: 2, body: .pong)
+        try pair.server.recordSent(serverPong)
+        try pair.client.recordReceived(serverPong)
+        try pair.client.recordSent(clientPong)
+        try pair.server.recordReceived(clientPong)
+
+        #expect(pair.client.phase == .ready(sessionID: "session-1"))
+        #expect(pair.server.phase == .ready(sessionID: "session-1"))
+    }
+
+    @Test("unsupported protocol versions fail closed")
+    func unsupportedVersion() throws {
+        var client = try Self.makeHandshaking(role: .client)
+        let hello = WireMessage(
+            messageID: 1,
+            version: WireMessage.currentVersion + 1,
+            body: .hello(.init(clientName: "cmux-lite-ios", nonce: "nonce"))
+        )
+
+        #expect(throws: SessionStateMachine.Violation.unsupportedVersion) {
+            try client.recordSent(hello)
+        }
+        #expect(
+            client.phase == .closed(.protocolViolation(.unsupportedVersion))
+        )
+    }
+
+    @Test("zero, repeated, and decreasing sender message IDs fail closed")
+    func messageIDsMustIncrease() throws {
+        var zero = try Self.makeHandshaking(role: .client)
+        #expect(throws: SessionStateMachine.Violation.invalidMessageID) {
+            try zero.recordSent(
+                WireMessage(
+                    messageID: 0,
+                    body: .hello(.init(clientName: "client", nonce: "nonce"))
+                )
+            )
+        }
+
+        var pair = try Self.makeReadyPair()
+        try pair.client.recordSent(WireMessage(messageID: 4, body: .ping))
+        #expect(throws: SessionStateMachine.Violation.invalidMessageID) {
+            try pair.client.recordSent(WireMessage(messageID: 4, body: .ping))
+        }
+        #expect(
+            pair.client.phase == .closed(.protocolViolation(.invalidMessageID))
+        )
+    }
+
+    @Test("message direction and phase are enforced")
+    func unexpectedMessageDirection() throws {
+        var client = try Self.makeHandshaking(role: .client)
+        let welcome = WireMessage(
+            messageID: 1,
+            replyTo: 1,
+            body: .welcome(.init(sessionID: "session", nonce: "server"))
+        )
+
+        #expect(throws: SessionStateMachine.Violation.unexpectedMessage) {
+            try client.recordSent(welcome)
+        }
+        #expect(
+            client.phase == .closed(.protocolViolation(.unexpectedMessage))
+        )
+    }
+
+    @Test("welcome must correlate to the exact hello")
+    func welcomeCorrelation() throws {
+        var client = try Self.makeHandshaking(role: .client)
+        try client.recordSent(
+            WireMessage(
+                messageID: 1,
+                body: .hello(.init(clientName: "client", nonce: "nonce"))
+            )
+        )
+
+        #expect(throws: SessionStateMachine.Violation.invalidCorrelation) {
+            try client.recordReceived(
+                WireMessage(
+                    messageID: 1,
+                    replyTo: 99,
+                    body: .welcome(
+                        .init(sessionID: "session", nonce: "server-nonce")
+                    )
+                )
+            )
+        }
+        #expect(
+            client.phase == .closed(.protocolViolation(.invalidCorrelation))
+        )
+    }
+
+    @Test("hello cannot claim to be a response")
+    func helloCannotReply() throws {
+        var client = try Self.makeHandshaking(role: .client)
+
+        #expect(throws: SessionStateMachine.Violation.invalidCorrelation) {
+            try client.recordSent(
+                WireMessage(
+                    messageID: 1,
+                    replyTo: 99,
+                    body: .hello(.init(clientName: "client", nonce: "nonce"))
+                )
+            )
+        }
+        #expect(
+            client.phase == .closed(.protocolViolation(.invalidCorrelation))
+        )
+    }
+
+    @Test("pong consumes one pending correlation")
+    func pongCannotBeReplayed() throws {
+        var pair = try Self.makeReadyPair()
+        let ping = WireMessage(messageID: 2, body: .ping)
+        try pair.client.recordSent(ping)
+        try pair.server.recordReceived(ping)
+
+        let firstPong = WireMessage(messageID: 2, replyTo: 2, body: .pong)
+        try pair.server.recordSent(firstPong)
+        try pair.client.recordReceived(firstPong)
+
+        #expect(throws: SessionStateMachine.Violation.invalidCorrelation) {
+            try pair.client.recordReceived(
+                WireMessage(messageID: 3, replyTo: 2, body: .pong)
+            )
+        }
+        #expect(
+            pair.client.phase == .closed(.protocolViolation(.invalidCorrelation))
+        )
+    }
+
+    @Test("empty or oversized handshake metadata is rejected")
+    func handshakeMetadataBounds() throws {
+        var empty = try Self.makeHandshaking(role: .client)
+        #expect(throws: SessionStateMachine.Violation.invalidHandshakeMetadata) {
+            try empty.recordSent(
+                WireMessage(
+                    messageID: 1,
+                    body: .hello(.init(clientName: "", nonce: "nonce"))
+                )
+            )
+        }
+
+        var oversized = try Self.makeHandshaking(role: .client)
+        #expect(throws: SessionStateMachine.Violation.invalidHandshakeMetadata) {
+            try oversized.recordSent(
+                WireMessage(
+                    messageID: 1,
+                    body: .hello(
+                        .init(clientName: String(repeating: "a", count: 65), nonce: "n")
+                    )
+                )
+            )
+        }
+    }
+
+    @Test("explicit close reason survives later transport teardown")
+    func explicitCloseWins() throws {
+        var pair = try Self.makeReadyPair()
+        try pair.client.recordSent(
+            WireMessage(
+                messageID: 2,
+                body: .close(.init(reason: .normal))
+            )
+        )
+
+        pair.client.transportDidClose()
+        pair.client.transportDidClose()
+
+        #expect(pair.client.phase == .closed(.local(.normal)))
+    }
+
+    @Test("transport teardown is idempotent in every nonterminal phase")
+    func transportTeardown() throws {
+        var idle = SessionStateMachine(role: .client)
+        idle.transportDidClose()
+        idle.transportDidClose()
+        #expect(idle.phase == .closed(.transportEnded))
+
+        var connecting = SessionStateMachine(role: .client)
+        try connecting.beginConnecting()
+        connecting.transportDidClose()
+        connecting.transportDidClose()
+        #expect(connecting.phase == .closed(.transportEnded))
+    }
+
+    private static func makeHandshaking(
+        role: SessionStateMachine.Role
+    ) throws -> SessionStateMachine {
+        var state = SessionStateMachine(role: role)
+        try state.beginConnecting()
+        try state.transportDidConnect()
+        return state
+    }
+
+    private static func makeReadyPair() throws -> (
+        client: SessionStateMachine,
+        server: SessionStateMachine
+    ) {
+        var client = try makeHandshaking(role: .client)
+        var server = try makeHandshaking(role: .server)
+        let hello = WireMessage(
+            messageID: 1,
+            body: .hello(.init(clientName: "cmux-lite-ios", nonce: "client-nonce"))
+        )
+        let welcome = WireMessage(
+            messageID: 1,
+            replyTo: 1,
+            body: .welcome(
+                .init(sessionID: "session-1", nonce: "server-nonce")
+            )
+        )
+
+        try client.recordSent(hello)
+        try server.recordReceived(hello)
+        try server.recordSent(welcome)
+        try client.recordReceived(welcome)
+        return (client, server)
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/TestInMemoryByteStream.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteProtocol/Tests/CmuxLiteProtocolTests/TestInMemoryByteStream.swift
@@ -1,0 +1,145 @@
+internal import Foundation
+import CmuxLiteProtocol
+
+actor TestInMemoryByteStream: ByteStream {
+    enum Failure: Error, Equatable {
+        case closed
+        case notConnected
+        case receiveAlreadyPending
+    }
+
+    private enum State {
+        case idle
+        case connected
+        case closed
+    }
+
+    private var state: State = .idle
+    private var peer: TestInMemoryByteStream?
+    private var inbound: [Data] = []
+    private var peerEnded = false
+    private var pendingReceive: CheckedContinuation<Data?, any Error>?
+    private var pendingReceiveObserver: CheckedContinuation<Void, Never>?
+
+    static func makePair() async -> (
+        TestInMemoryByteStream,
+        TestInMemoryByteStream
+    ) {
+        let first = TestInMemoryByteStream()
+        let second = TestInMemoryByteStream()
+        await first.setPeer(second)
+        await second.setPeer(first)
+        return (first, second)
+    }
+
+    func connect() async throws {
+        switch state {
+        case .idle:
+            state = .connected
+        case .connected:
+            return
+        case .closed:
+            throw Failure.closed
+        }
+    }
+
+    func send(_ bytes: Data) async throws {
+        guard case .connected = state else {
+            throw state == .closed ? Failure.closed : Failure.notConnected
+        }
+        guard !peerEnded else {
+            throw Failure.closed
+        }
+        guard !bytes.isEmpty else {
+            return
+        }
+        guard let peer else {
+            throw Failure.notConnected
+        }
+        await peer.deliver(bytes)
+    }
+
+    func receive() async throws -> Data? {
+        guard case .connected = state else {
+            if case .closed = state {
+                return nil
+            }
+            throw Failure.notConnected
+        }
+        if !inbound.isEmpty {
+            return inbound.removeFirst()
+        }
+        if peerEnded {
+            return nil
+        }
+        guard pendingReceive == nil else {
+            throw Failure.receiveAlreadyPending
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                pendingReceive = continuation
+                pendingReceiveObserver?.resume()
+                pendingReceiveObserver = nil
+            }
+        } onCancel: {
+            Task {
+                await self.cancelPendingReceive()
+            }
+        }
+    }
+
+    func close() async {
+        guard state != .closed else {
+            return
+        }
+        state = .closed
+        pendingReceive?.resume(returning: nil)
+        pendingReceive = nil
+        pendingReceiveObserver?.resume()
+        pendingReceiveObserver = nil
+        let peer = self.peer
+        self.peer = nil
+        await peer?.peerDidClose()
+    }
+
+    func waitUntilReceiveIsPending() async {
+        if pendingReceive != nil || state == .closed {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            pendingReceiveObserver = continuation
+        }
+    }
+
+    private func setPeer(_ peer: TestInMemoryByteStream) {
+        self.peer = peer
+    }
+
+    private func deliver(_ bytes: Data) {
+        guard state != .closed else {
+            return
+        }
+        if let pendingReceive {
+            self.pendingReceive = nil
+            pendingReceive.resume(returning: bytes)
+        } else {
+            inbound.append(bytes)
+        }
+    }
+
+    private func peerDidClose() {
+        peerEnded = true
+        pendingReceive?.resume(returning: nil)
+        pendingReceive = nil
+    }
+
+    private func cancelPendingReceive() {
+        pendingReceive?.resume(throwing: CancellationError())
+        pendingReceive = nil
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxLiteSession",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxLiteSession",
+            targets: ["CmuxLiteSession"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxLiteProtocol"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxLiteSession",
+            dependencies: [
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxLiteSessionTests",
+            dependencies: [
+                "CmuxLiteSession",
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/README.md
@@ -1,0 +1,25 @@
+# CmuxLiteSession
+
+`CmuxLiteSession` owns one protocol conversation over an injected
+`CmuxLiteProtocol.ByteStream`.
+
+The owner is deliberately small. It connects the stream, serializes outgoing
+writes, decodes arbitrary incoming chunks, feeds every message through
+`SessionStateMachine`, answers server handshakes, answers pings, and exposes
+an `AsyncStream` of lifecycle events. It owns no socket, authentication,
+Iroh, Tailscale, UI, renderer, filesystem, clock, or global state.
+
+The test target uses two owners over the protocol package's in-memory stream:
+one configured as a deterministic fake Mac host and one as the iOS client.
+That gives us a complete handshake and ping/pong exercise before selecting a
+real transport adapter.
+
+```swift
+let client = SessionOwner(
+    configuration: .client(
+        hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+    ),
+    stream: clientStream,
+    codec: codec
+)
+```

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Sources/CmuxLiteSession/SerializedByteStreamWriter.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Sources/CmuxLiteSession/SerializedByteStreamWriter.swift
@@ -1,0 +1,32 @@
+internal import Foundation
+internal import CmuxLiteProtocol
+
+/// Serializes writes without using a lock or a blocking queue.
+actor SerializedByteStreamWriter {
+    private let stream: any ByteStream
+    private var tail: Task<Void, any Error>?
+
+    init(stream: any ByteStream) {
+        self.stream = stream
+    }
+
+    func send(_ bytes: Data) async throws {
+        guard !bytes.isEmpty else {
+            return
+        }
+
+        let predecessor = tail
+        let stream = stream
+        let operation = Task<Void, any Error> {
+            try await predecessor?.value
+            try await stream.send(bytes)
+        }
+        tail = operation
+        try await operation.value
+    }
+
+    func cancel() {
+        tail?.cancel()
+        tail = nil
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Sources/CmuxLiteSession/SessionOwner.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Sources/CmuxLiteSession/SessionOwner.swift
@@ -1,0 +1,375 @@
+internal import Foundation
+public import CmuxLiteProtocol
+
+/// Owns one cmux-lite protocol conversation over an injected byte stream.
+public actor SessionOwner {
+    /// The role and deterministic handshake data for one owner.
+    public enum Configuration: Equatable, Sendable {
+        /// Sends this hello after the client transport connects.
+        case client(hello: WireMessage.Hello)
+
+        /// Answers a received hello with this welcome.
+        case server(welcome: WireMessage.Welcome)
+
+        fileprivate var role: SessionStateMachine.Role {
+            switch self {
+            case .client:
+                return .client
+            case .server:
+                return .server
+            }
+        }
+    }
+
+    /// Observable lifecycle and control events emitted by the owner.
+    public enum Event: Equatable, Sendable {
+        /// The byte stream connected and protocol work may begin.
+        case transportConnected
+
+        /// Both sides accepted the handshake.
+        case ready(sessionID: String)
+
+        /// A peer ping was accepted and will receive an automatic pong.
+        case pingReceived(messageID: UInt64)
+
+        /// A peer pong was accepted for a locally sent ping.
+        case pongReceived(replyTo: UInt64)
+
+        /// The owner stopped because a framing, protocol, or transport failure occurred.
+        case failure(Failure)
+
+        /// The conversation reached its terminal phase.
+        case closed(SessionStateMachine.Closure)
+    }
+
+    /// Failures returned by commands or emitted for asynchronous failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// ``start()`` was called more than once.
+        case alreadyStarted
+
+        /// A command requiring a started owner was called before ``start()``.
+        case notStarted
+
+        /// A ping was requested before the handshake completed.
+        case notReady
+
+        /// A command was attempted after the owner closed.
+        case closed
+
+        /// The finite sender ID space was exhausted.
+        case messageIDExhausted
+
+        /// The byte stream produced an invalid or oversized frame.
+        case framing(FrameCodec.Failure)
+
+        /// A decoded message violated the protocol state machine.
+        case protocolViolation(SessionStateMachine.Violation)
+
+        /// The injected byte stream failed or ended unexpectedly.
+        case transport
+    }
+
+    /// The configured role for this owner.
+    public let configuration: Configuration
+
+    /// A single-consumer stream of owner events.
+    public nonisolated let events: AsyncStream<Event>
+
+    private let stream: any ByteStream
+    private let codec: FrameCodec
+    private let writer: SerializedByteStreamWriter
+    private let eventContinuation: AsyncStream<Event>.Continuation
+    private var state: SessionStateMachine
+    private var decoder: FrameCodec.Decoder
+    private var receiveTask: Task<Void, Never>?
+    private var started = false
+    private var finished = false
+    private var readyWasEmitted = false
+    private var nextMessageID: UInt64 = 1
+
+    /// Creates an owner with deterministic handshake values and dependencies.
+    ///
+    /// - Parameters:
+    ///   - configuration: The client or server handshake role.
+    ///   - stream: The ordered byte stream used for this conversation.
+    ///   - codec: The bounded frame encoder and decoder.
+    public init(
+        configuration: Configuration,
+        stream: any ByteStream,
+        codec: FrameCodec
+    ) {
+        self.configuration = configuration
+        self.stream = stream
+        self.codec = codec
+        self.writer = SerializedByteStreamWriter(stream: stream)
+        self.state = SessionStateMachine(role: configuration.role)
+        self.decoder = codec.makeDecoder()
+
+        let (events, continuation) = AsyncStream<Event>.makeStream()
+        self.events = events
+        self.eventContinuation = continuation
+    }
+
+    deinit {
+        receiveTask?.cancel()
+        eventContinuation.finish()
+    }
+
+    /// Connects the stream and starts the receive loop.
+    ///
+    /// A client sends its configured hello before this method returns. A
+    /// server returns after it begins waiting for that hello. Use ``events``
+    /// to observe the later ``ready`` event.
+    ///
+    /// - Throws: ``Failure/alreadyStarted`` or ``Failure/transport`` when the
+    ///   stream cannot be established.
+    public func start() async throws {
+        guard !started else {
+            throw Failure.alreadyStarted
+        }
+        started = true
+
+        do {
+            try state.beginConnecting()
+            try await stream.connect()
+            try state.transportDidConnect()
+            eventContinuation.yield(.transportConnected)
+            startReceiveLoop()
+
+            if case .client(let hello) = configuration {
+                try await sendMessage(body: .hello(hello), replyTo: nil)
+            }
+        } catch {
+            await stop(failure: Self.mapFailure(error))
+            throw Self.mapFailure(error)
+        }
+    }
+
+    /// Returns the current validated protocol phase.
+    public func currentPhase() -> SessionStateMachine.Phase {
+        state.phase
+    }
+
+    /// Sends a ping and returns its locally allocated message ID.
+    ///
+    /// - Returns: The ID that the peer must reference in its pong.
+    /// - Throws: ``Failure/notStarted``, ``Failure/notReady``,
+    ///   ``Failure/closed``, or a transport failure.
+    public func sendPing() async throws -> UInt64 {
+        guard started else {
+            throw Failure.notStarted
+        }
+        guard case .ready = state.phase else {
+            if state.phase.isClosed {
+                throw Failure.closed
+            }
+            throw Failure.notReady
+        }
+
+        let messageID = try allocateMessageID()
+        do {
+            try await sendMessage(
+                messageID: messageID,
+                body: .ping,
+                replyTo: nil
+            )
+            return messageID
+        } catch {
+            await stop(failure: Self.mapFailure(error))
+            throw Self.mapFailure(error)
+        }
+    }
+
+    /// Sends an explicit close and releases the byte stream.
+    ///
+    /// Calling this method before ``start()`` has no effect. Repeated calls
+    /// after closure are idempotent.
+    ///
+    /// - Parameter reason: The reason advertised to the peer.
+    public func close(reason: WireMessage.Close.Reason = .normal) async {
+        guard started, !finished else {
+            return
+        }
+
+        guard state.phase == .handshaking || state.phase.isReady else {
+            await stop()
+            return
+        }
+
+        do {
+            try await sendMessage(body: .close(.init(reason: reason)), replyTo: nil)
+            await stop()
+        } catch {
+            await stop(failure: Self.mapFailure(error))
+        }
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    private func receiveLoop() async {
+        do {
+            while !Task.isCancelled {
+                guard let chunk = try await stream.receive() else {
+                    await stop()
+                    return
+                }
+
+                for message in try decoder.ingest(chunk) {
+                    try await handle(message)
+                    if finished {
+                        return
+                    }
+                }
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            await stop(failure: Self.mapFailure(error))
+        }
+    }
+
+    private func handle(_ message: WireMessage) async throws {
+        do {
+            try state.recordReceived(message)
+        } catch {
+            await stop(failure: Self.mapFailure(error))
+            throw error
+        }
+
+        switch message.body {
+        case .hello:
+            guard case .server(let welcome) = configuration else {
+                return
+            }
+            try await sendMessage(
+                body: .welcome(welcome),
+                replyTo: message.messageID
+            )
+            emitReadyIfNeeded()
+
+        case .welcome:
+            emitReadyIfNeeded()
+
+        case .ping:
+            eventContinuation.yield(.pingReceived(messageID: message.messageID))
+            try await sendMessage(body: .pong, replyTo: message.messageID)
+
+        case .pong:
+            if let replyTo = message.replyTo {
+                eventContinuation.yield(.pongReceived(replyTo: replyTo))
+            }
+
+        case .protocolError, .close:
+            await stop()
+        }
+    }
+
+    private func emitReadyIfNeeded() {
+        guard !readyWasEmitted,
+              case .ready(let sessionID) = state.phase
+        else {
+            return
+        }
+        readyWasEmitted = true
+        eventContinuation.yield(.ready(sessionID: sessionID))
+    }
+
+    private func sendMessage(
+        body: WireMessage.Body,
+        replyTo: UInt64?
+    ) async throws {
+        try await sendMessage(
+            messageID: try allocateMessageID(),
+            body: body,
+            replyTo: replyTo
+        )
+    }
+
+    private func sendMessage(
+        messageID: UInt64,
+        body: WireMessage.Body,
+        replyTo: UInt64?
+    ) async throws {
+        let message = WireMessage(
+            messageID: messageID,
+            replyTo: replyTo,
+            body: body
+        )
+        let frame = try codec.encode(message)
+        try state.recordSent(message)
+        try await writer.send(frame)
+
+        if case .closed = state.phase,
+           case .close = body {
+            return
+        }
+    }
+
+    private func allocateMessageID() throws -> UInt64 {
+        guard nextMessageID > 0 else {
+            throw Failure.messageIDExhausted
+        }
+        let allocated = nextMessageID
+        nextMessageID = nextMessageID == UInt64.max ? 0 : nextMessageID + 1
+        return allocated
+    }
+
+    private func stop(failure: Failure? = nil) async {
+        guard !finished else {
+            return
+        }
+        finished = true
+
+        if let failure {
+            eventContinuation.yield(.failure(failure))
+        }
+
+        if !state.phase.isClosed {
+            state.transportDidClose()
+        }
+        guard case .closed(let closure) = state.phase else {
+            eventContinuation.finish()
+            return
+        }
+
+        eventContinuation.yield(.closed(closure))
+        eventContinuation.finish()
+        receiveTask?.cancel()
+        receiveTask = nil
+        await writer.cancel()
+        await stream.close()
+    }
+
+    private static func mapFailure(_ error: any Error) -> Failure {
+        if let failure = error as? Failure {
+            return failure
+        }
+        if let failure = error as? FrameCodec.Failure {
+            return .framing(failure)
+        }
+        if let violation = error as? SessionStateMachine.Violation {
+            return .protocolViolation(violation)
+        }
+        return .transport
+    }
+}
+
+private extension SessionStateMachine.Phase {
+    var isClosed: Bool {
+        if case .closed = self {
+            return true
+        }
+        return false
+    }
+
+    var isReady: Bool {
+        if case .ready = self {
+            return true
+        }
+        return false
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Tests/CmuxLiteSessionTests/FakeMacHost.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Tests/CmuxLiteSessionTests/FakeMacHost.swift
@@ -1,0 +1,23 @@
+internal import Foundation
+import CmuxLiteProtocol
+import CmuxLiteSession
+
+/// Test-only construction of the deterministic host half of a session.
+struct FakeMacHost {
+    let owner: SessionOwner
+
+    init(
+        stream: any ByteStream,
+        codec: FrameCodec,
+        sessionID: String = "session-1",
+        nonce: String = "host-nonce"
+    ) {
+        owner = SessionOwner(
+            configuration: .server(
+                welcome: .init(sessionID: sessionID, nonce: nonce)
+            ),
+            stream: stream,
+            codec: codec
+        )
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Tests/CmuxLiteSessionTests/SessionOwnerTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteSession/Tests/CmuxLiteSessionTests/SessionOwnerTests.swift
@@ -1,0 +1,293 @@
+internal import Foundation
+import CmuxLiteProtocol
+import CmuxLiteSession
+import Testing
+
+@Suite("Session owner")
+struct SessionOwnerTests {
+    @Test("client and deterministic fake host complete the handshake")
+    func handshake() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, hostStream) = await TestInMemoryByteStream.makePair(
+            chunkSize: 2
+        )
+        let host = FakeMacHost(stream: hostStream, codec: codec)
+        let client = CmuxLiteSession.SessionOwner(
+            configuration: .client(
+                hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            ),
+            stream: clientStream,
+            codec: codec
+        )
+        var clientEvents = client.events.makeAsyncIterator()
+        var hostEvents = host.owner.events.makeAsyncIterator()
+
+        try await host.owner.start()
+        try await client.start()
+
+        #expect(await clientEvents.next() == .transportConnected)
+        #expect(await hostEvents.next() == .transportConnected)
+        #expect(await clientEvents.next() == .ready(sessionID: "session-1"))
+        #expect(await hostEvents.next() == .ready(sessionID: "session-1"))
+        #expect(await client.currentPhase() == .ready(sessionID: "session-1"))
+        #expect(await host.owner.currentPhase() == .ready(sessionID: "session-1"))
+    }
+
+    @Test("a ping receives an automatic correlated pong")
+    func pingPong() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, hostStream) = await TestInMemoryByteStream.makePair()
+        let host = FakeMacHost(stream: hostStream, codec: codec)
+        let client = CmuxLiteSession.SessionOwner(
+            configuration: .client(
+                hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            ),
+            stream: clientStream,
+            codec: codec
+        )
+        var clientEvents = client.events.makeAsyncIterator()
+
+        try await host.owner.start()
+        try await client.start()
+        _ = await clientEvents.next()
+        _ = await clientEvents.next()
+
+        let pingID = try await client.sendPing()
+        #expect(await clientEvents.next() == .pongReceived(replyTo: pingID))
+    }
+
+    @Test("explicit close reaches the peer and finishes both event streams")
+    func close() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, hostStream) = await TestInMemoryByteStream.makePair()
+        let host = FakeMacHost(stream: hostStream, codec: codec)
+        let client = CmuxLiteSession.SessionOwner(
+            configuration: .client(
+                hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            ),
+            stream: clientStream,
+            codec: codec
+        )
+        var clientEvents = client.events.makeAsyncIterator()
+        var hostEvents = host.owner.events.makeAsyncIterator()
+
+        try await host.owner.start()
+        try await client.start()
+        _ = await clientEvents.next()
+        _ = await hostEvents.next()
+        _ = await clientEvents.next()
+        _ = await hostEvents.next()
+
+        await client.close(reason: .normal)
+
+        #expect(await clientEvents.next() == .closed(.local(.normal)))
+        #expect(await hostEvents.next() == .closed(.remote(.normal)))
+        #expect(await clientEvents.next() == nil)
+        #expect(await hostEvents.next() == nil)
+    }
+
+    @Test("a malformed incoming payload is surfaced and closes the owner")
+    func malformedPayload() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, hostStream) = await TestInMemoryByteStream.makePair()
+        let host = FakeMacHost(stream: hostStream, codec: codec)
+        var hostEvents = host.owner.events.makeAsyncIterator()
+        try await host.owner.start()
+        _ = await hostEvents.next()
+
+        var malformed = Data([0, 0, 0, 1, 0x7B])
+        try await clientStream.connect()
+        try await clientStream.send(malformed)
+
+        #expect(await hostEvents.next() == .failure(.framing(.malformedPayload)))
+        #expect(await hostEvents.next() == .closed(.transportEnded))
+        #expect(await hostEvents.next() == nil)
+        malformed.removeAll(keepingCapacity: false)
+    }
+
+    @Test("commands report lifecycle failures without starting hidden work")
+    func lifecycleFailures() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, _) = await TestInMemoryByteStream.makePair()
+        let client = CmuxLiteSession.SessionOwner(
+            configuration: .client(
+                hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            ),
+            stream: clientStream,
+            codec: codec
+        )
+
+        await #expect(throws: CmuxLiteSession.SessionOwner.Failure.notStarted) {
+            try await client.sendPing()
+        }
+
+        try await client.start()
+        await #expect(throws: CmuxLiteSession.SessionOwner.Failure.notReady) {
+            try await client.sendPing()
+        }
+        await #expect(
+            throws: CmuxLiteSession.SessionOwner.Failure.alreadyStarted
+        ) {
+            try await client.start()
+        }
+        await client.close()
+    }
+
+    @Test("a valid but repeated message ID becomes an observable protocol failure")
+    func repeatedMessageID() async throws {
+        let codec = try FrameCodec()
+        let (clientStream, hostStream) = await TestInMemoryByteStream.makePair()
+        let host = FakeMacHost(stream: hostStream, codec: codec)
+        let client = CmuxLiteSession.SessionOwner(
+            configuration: .client(
+                hello: .init(clientName: "cmux-lite-ios", nonce: "client-nonce")
+            ),
+            stream: clientStream,
+            codec: codec
+        )
+        var clientEvents = client.events.makeAsyncIterator()
+        var hostEvents = host.owner.events.makeAsyncIterator()
+
+        try await host.owner.start()
+        try await client.start()
+        _ = await clientEvents.next()
+        _ = await hostEvents.next()
+        _ = await clientEvents.next()
+        _ = await hostEvents.next()
+
+        let duplicate = WireMessage(messageID: 1, body: .ping)
+        try await clientStream.send(try codec.encode(duplicate))
+
+        #expect(
+            await hostEvents.next()
+                == .failure(.protocolViolation(.invalidMessageID))
+        )
+        #expect(
+            await hostEvents.next()
+                == .closed(.protocolViolation(.invalidMessageID))
+        )
+        #expect(await hostEvents.next() == nil)
+        await client.close()
+    }
+}
+
+private actor TestInMemoryByteStream: ByteStream {
+    enum Failure: Error {
+        case closed
+        case notConnected
+    }
+
+    private enum State {
+        case idle
+        case connected
+        case closed
+    }
+
+    private let chunkSize: Int?
+    private var state: State = .idle
+    private var peer: TestInMemoryByteStream?
+    private var inbound: [Data] = []
+    private var peerEnded = false
+    private var pendingReceive: CheckedContinuation<Data?, any Error>?
+
+    init(chunkSize: Int? = nil) {
+        self.chunkSize = chunkSize
+    }
+
+    static func makePair(
+        chunkSize: Int? = nil
+    ) async -> (TestInMemoryByteStream, TestInMemoryByteStream) {
+        let first = TestInMemoryByteStream(chunkSize: chunkSize)
+        let second = TestInMemoryByteStream(chunkSize: chunkSize)
+        await first.setPeer(second)
+        await second.setPeer(first)
+        return (first, second)
+    }
+
+    func connect() async throws {
+        switch state {
+        case .idle:
+            state = .connected
+        case .connected:
+            return
+        case .closed:
+            throw Failure.closed
+        }
+    }
+
+    func send(_ bytes: Data) async throws {
+        guard case .connected = state else {
+            throw state == .closed ? Failure.closed : Failure.notConnected
+        }
+        guard !peerEnded else {
+            throw Failure.closed
+        }
+        guard !bytes.isEmpty, let peer else {
+            return
+        }
+        guard let chunkSize, chunkSize > 0 else {
+            await peer.deliver(bytes)
+            return
+        }
+
+        var offset = 0
+        while offset < bytes.count {
+            let end = min(offset + chunkSize, bytes.count)
+            await peer.deliver(bytes.subdata(in: offset..<end))
+            offset = end
+        }
+    }
+
+    func receive() async throws -> Data? {
+        guard case .connected = state else {
+            if case .closed = state {
+                return nil
+            }
+            throw Failure.notConnected
+        }
+        if !inbound.isEmpty {
+            return inbound.removeFirst()
+        }
+        if peerEnded {
+            return nil
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingReceive = continuation
+        }
+    }
+
+    func close() async {
+        guard state != .closed else {
+            return
+        }
+        state = .closed
+        pendingReceive?.resume(returning: nil)
+        pendingReceive = nil
+        let peer = self.peer
+        self.peer = nil
+        await peer?.peerDidClose()
+    }
+
+    private func setPeer(_ peer: TestInMemoryByteStream) {
+        self.peer = peer
+    }
+
+    private func deliver(_ bytes: Data) {
+        guard state != .closed else {
+            return
+        }
+        if let pendingReceive {
+            self.pendingReceive = nil
+            pendingReceive.resume(returning: bytes)
+        } else {
+            inbound.append(bytes)
+        }
+    }
+
+    private func peerDidClose() {
+        peerEnded = true
+        pendingReceive?.resume(returning: nil)
+        pendingReceive = nil
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Package.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxLiteTransport",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxLiteTransport",
+            targets: ["CmuxLiteTransport"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxLiteProtocol"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxLiteTransport",
+            dependencies: [
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxLiteTransportTests",
+            dependencies: [
+                "CmuxLiteTransport",
+                .product(name: "CmuxLiteProtocol", package: "CmuxLiteProtocol"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/README.md
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/README.md
@@ -1,0 +1,19 @@
+# CmuxLiteTransport
+
+`CmuxLiteTransport` is the route-selection layer between discovery and
+`CmuxLiteSession`. It does not know how Iroh or Tailscale work internally.
+Each implementation conforms to `TransportConnector`, and the dialer owns one
+ordered attempt at a time.
+
+The policy is deliberately pure and observable:
+
+- automatic mode tries Iroh, then Tailscale, then loopback by default;
+- restricted mode filters to one route kind and never silently falls back;
+- concurrent `connect()` calls join the same in-flight attempt;
+- every attempt is emitted through `AsyncStream`;
+- unavailable and incompatible routes can fall through;
+- authorization denials and unknown connector errors stop selection instead of
+  silently bypassing a trust decision.
+
+The package contains no Iroh FFI, Tailscale SDK, sockets, timers, or UI. Those
+adapters will be added behind this seam after their own focused tests exist.

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportConnector.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportConnector.swift
@@ -1,0 +1,17 @@
+public import CmuxLiteProtocol
+
+/// Opens one byte stream for a discovered route.
+public protocol TransportConnector: Sendable {
+    /// Opens the route and returns an unstarted byte stream.
+    ///
+    /// The caller owns the returned stream and must call ``ByteStream/connect()``
+    /// before using it. A connector owns cleanup for resources created before
+    /// it can return a stream.
+    ///
+    /// - Parameter route: Opaque route metadata selected by policy.
+    /// - Returns: A stream ready for the session owner to connect.
+    /// - Throws: ``TransportOpenFailure``. Unknown errors are treated as
+    ///   non-retryable by ``TransportDialer`` so an adapter cannot accidentally
+    ///   bypass an authorization or protocol decision.
+    func open(route: TransportRoute) async throws -> any ByteStream
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportDialer.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportDialer.swift
@@ -1,0 +1,178 @@
+public import CmuxLiteProtocol
+
+/// Performs one serialized, observable route-selection attempt.
+public actor TransportDialer {
+    /// Classifies a failed route attempt for observability and fallback policy.
+    public enum FailureReason: Equatable, Sendable {
+        /// The route is temporarily unavailable.
+        case unavailable
+
+        /// The peer cannot speak this transport.
+        case incompatiblePeer
+
+        /// The route metadata is invalid.
+        case invalidRoute
+
+        /// The peer denied admission.
+        case unauthorized
+
+        /// The connector threw an error without a transport classification.
+        case unclassified
+    }
+
+    /// Events emitted in route-attempt order.
+    public enum Event: Equatable, Sendable {
+        /// A connector is about to be asked to open this route.
+        case attempting(TransportRoute)
+
+        /// A connector failed or was not registered for this route.
+        case failed(TransportRoute, reason: FailureReason)
+
+        /// A connector returned a stream for this route.
+        case connected(TransportRoute)
+
+        /// Every policy-approved route failed.
+        case exhausted
+    }
+
+    /// Dialer command failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// The policy produced no routes to attempt.
+        case noRoutes
+
+        /// A live connection already belongs to this dialer.
+        case alreadyConnected
+
+        /// Every ordered route failed or had no connector.
+        case allRoutesFailed([TransportRoute])
+
+        /// A connector returned a non-retryable failure, so fallback stopped.
+        case nonRetryable(TransportRoute, reason: FailureReason)
+    }
+
+    /// A single-consumer stream of route-attempt events.
+    public nonisolated let events: AsyncStream<Event>
+
+    private struct OpenedTransport: Sendable {
+        let route: TransportRoute
+        let stream: any ByteStream
+    }
+
+    private let routes: [TransportRoute]
+    private let connectors: [TransportKind: any TransportConnector]
+    private let eventContinuation: AsyncStream<Event>.Continuation
+    private var inFlight: Task<OpenedTransport, any Error>?
+    private var connectedRoute: TransportRoute?
+
+    /// Creates a dialer with an immutable route list and connector registry.
+    ///
+    /// - Parameters:
+    ///   - routes: Discovered routes, in any order.
+    ///   - policy: The policy that determines attempt order and restrictions.
+    ///   - connectors: One connector per route kind.
+    /// - Throws: ``Failure/noRoutes`` when policy removes every route.
+    public init(
+        routes: [TransportRoute],
+        policy: TransportSelectionPolicy,
+        connectors: [TransportKind: any TransportConnector]
+    ) throws {
+        let orderedRoutes = policy.orderedRoutes(from: routes)
+        guard !orderedRoutes.isEmpty else {
+            throw Failure.noRoutes
+        }
+
+        self.routes = orderedRoutes
+        self.connectors = connectors
+        let (events, continuation) = AsyncStream<Event>.makeStream()
+        self.events = events
+        self.eventContinuation = continuation
+    }
+
+    deinit {
+        inFlight?.cancel()
+        eventContinuation.finish()
+    }
+
+    /// Opens the first route that succeeds, joining an attempt already in flight.
+    ///
+    /// Concurrent callers share the same attempt. A later call after a
+    /// successful connection fails with ``Failure/alreadyConnected`` so one
+    /// dialer cannot create two live sessions accidentally.
+    ///
+    /// - Returns: An unstarted byte stream for the selected route.
+    /// - Throws: ``Failure/alreadyConnected``, ``Failure/allRoutesFailed(_:)``,
+    ///   ``Failure/nonRetryable(_:reason:)``, or cancellation.
+    public func connect() async throws -> any ByteStream {
+        guard connectedRoute == nil else {
+            throw Failure.alreadyConnected
+        }
+
+        if let inFlight {
+            return try await inFlight.value.stream
+        }
+
+        let routes = routes
+        let connectors = connectors
+        let continuation = eventContinuation
+        let task = Task<OpenedTransport, any Error> {
+            for route in routes {
+                try Task.checkCancellation()
+                continuation.yield(.attempting(route))
+
+                guard let connector = connectors[route.kind] else {
+                    continuation.yield(.failed(route, reason: .unclassified))
+                    continue
+                }
+
+                do {
+                    let stream = try await connector.open(route: route)
+                    continuation.yield(.connected(route))
+                    return OpenedTransport(route: route, stream: stream)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch let failure as TransportOpenFailure {
+                    let reason = Self.reason(for: failure)
+                    continuation.yield(.failed(route, reason: reason))
+                    if failure == .unauthorized {
+                        throw Failure.nonRetryable(route, reason: reason)
+                    }
+                } catch {
+                    continuation.yield(.failed(route, reason: .unclassified))
+                    throw Failure.nonRetryable(route, reason: .unclassified)
+                }
+            }
+
+            continuation.yield(.exhausted)
+            throw Failure.allRoutesFailed(routes)
+        }
+        inFlight = task
+
+        do {
+            let opened = try await task.value
+            inFlight = nil
+            connectedRoute = opened.route
+            return opened.stream
+        } catch {
+            inFlight = nil
+            throw error
+        }
+    }
+
+    /// Returns the route selected by a successful call, if any.
+    public func currentRoute() -> TransportRoute? {
+        connectedRoute
+    }
+
+    private static func reason(for failure: TransportOpenFailure) -> FailureReason {
+        switch failure {
+        case .unavailable:
+            return .unavailable
+        case .incompatiblePeer:
+            return .incompatiblePeer
+        case .invalidRoute:
+            return .invalidRoute
+        case .unauthorized:
+            return .unauthorized
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportOpenFailure.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportOpenFailure.swift
@@ -1,0 +1,14 @@
+/// A connector classification that tells policy whether another route is safe to try.
+public enum TransportOpenFailure: Error, Equatable, Sendable {
+    /// The route is currently unavailable and another route may be attempted.
+    case unavailable
+
+    /// The peer does not speak the requested transport and another route may be attempted.
+    case incompatiblePeer
+
+    /// The route metadata is invalid and another discovered route may be attempted.
+    case invalidRoute
+
+    /// Admission failed; automatic mode must not silently bypass this denial.
+    case unauthorized
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportRoute.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportRoute.swift
@@ -1,0 +1,40 @@
+/// A transport kind that can provide one cmux-lite byte stream.
+public enum TransportKind: String, Codable, Equatable, Hashable, Sendable {
+    /// The new encrypted Iroh route.
+    case iroh
+
+    /// The existing Tailscale-compatible route.
+    case tailscale
+
+    /// A local-only route used by tests and development harnesses.
+    case loopback
+}
+
+/// Opaque route metadata passed from route discovery to a connector.
+public struct TransportRoute: Codable, Equatable, Hashable, Sendable {
+    /// The route implementation that should receive this route.
+    public let kind: TransportKind
+
+    /// An implementation-specific nonempty route identifier.
+    public let identifier: String
+
+    /// Creates a route descriptor without embedding networking details in the policy layer.
+    ///
+    /// - Parameters:
+    ///   - kind: The implementation family for the route.
+    ///   - identifier: An opaque identifier interpreted by the connector.
+    /// - Throws: ``Failure/emptyIdentifier`` when the identifier is empty.
+    public init(kind: TransportKind, identifier: String) throws {
+        guard !identifier.isEmpty else {
+            throw Failure.emptyIdentifier
+        }
+        self.kind = kind
+        self.identifier = identifier
+    }
+
+    /// Route construction failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// A route identifier was empty and could not be dialed.
+        case emptyIdentifier
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportSelectionPolicy.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Sources/CmuxLiteTransport/TransportSelectionPolicy.swift
@@ -1,0 +1,75 @@
+/// Orders discovered routes without opening or inspecting a transport.
+public struct TransportSelectionPolicy: Equatable, Sendable {
+    /// Restricts automatic ordering or permits one explicit route family.
+    public enum Mode: Equatable, Sendable {
+        /// Try all discovered kinds in the configured preference order.
+        case automatic
+
+        /// Try only routes of this kind, with no silent fallback to another kind.
+        case restricted(TransportKind)
+    }
+
+    /// Policy-construction failures.
+    public enum Failure: Error, Equatable, Sendable {
+        /// The preference list was empty or contained a duplicate kind.
+        case invalidPreference
+    }
+
+    /// The selected policy mode.
+    public let mode: Mode
+
+    /// The preference order used by automatic mode.
+    public let preference: [TransportKind]
+
+    /// Creates a deterministic route-ordering policy.
+    ///
+    /// - Parameters:
+    ///   - mode: Automatic preference or a restricted route family.
+    ///   - preference: Unique route kinds in descending preference order.
+    ///     The default favors Iroh, then Tailscale, then loopback.
+    /// - Throws: ``Failure/invalidPreference`` for an empty or duplicate list.
+    public init(
+        mode: Mode = .automatic,
+        preference: [TransportKind] = [.iroh, .tailscale, .loopback]
+    ) throws {
+        guard !preference.isEmpty,
+              Set(preference).count == preference.count
+        else {
+            throw Failure.invalidPreference
+        }
+        self.mode = mode
+        self.preference = preference
+    }
+
+    /// Returns routes in the only order the dialer may attempt them.
+    ///
+    /// Automatic mode retains discovery order within each preference rank.
+    /// Kinds omitted from the preference list are retained after known kinds,
+    /// which keeps future route kinds visible instead of silently dropping them.
+    /// Restricted mode filters every other kind out.
+    ///
+    /// - Parameter routes: Discovered route descriptors.
+    /// - Returns: A deterministic, policy-compliant route list.
+    public func orderedRoutes(from routes: [TransportRoute]) -> [TransportRoute] {
+        switch mode {
+        case .restricted(let kind):
+            return routes.filter { $0.kind == kind }
+
+        case .automatic:
+            let ranks = Dictionary(
+                uniqueKeysWithValues: preference.enumerated().map { ($1, $0) }
+            )
+            return routes
+                .enumerated()
+                .sorted { left, right in
+                    let leftRank = ranks[left.element.kind] ?? preference.count
+                    let rightRank = ranks[right.element.kind] ?? preference.count
+                    guard leftRank == rightRank else {
+                        return leftRank < rightRank
+                    }
+                    return left.offset < right.offset
+                }
+                .map(\.element)
+        }
+    }
+}

--- a/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Tests/CmuxLiteTransportTests/TransportDialerTests.swift
+++ b/experiments/cmux-lite-ios/Packages/CmuxLiteTransport/Tests/CmuxLiteTransportTests/TransportDialerTests.swift
@@ -1,0 +1,251 @@
+internal import Foundation
+import CmuxLiteProtocol
+import CmuxLiteTransport
+import Testing
+
+@Suite("Transport dialer")
+struct TransportDialerTests {
+    @Test("automatic mode falls back in deterministic preference order")
+    func automaticFallback() async throws {
+        let iroh = try TransportRoute(kind: .iroh, identifier: "iroh-1")
+        let tailscale = try TransportRoute(
+            kind: .tailscale,
+            identifier: "tailscale-1"
+        )
+        let policy = try TransportSelectionPolicy()
+        let irohConnector = ScriptedConnector(behavior: .fail)
+        let tailscaleConnector = ScriptedConnector(behavior: .succeed)
+        let dialer = try TransportDialer(
+            routes: [tailscale, iroh],
+            policy: policy,
+            connectors: [
+                .iroh: irohConnector,
+                .tailscale: tailscaleConnector,
+            ]
+        )
+        var events = dialer.events.makeAsyncIterator()
+
+        _ = try await dialer.connect()
+
+        #expect(await events.next() == .attempting(iroh))
+        #expect(
+            await events.next() == .failed(iroh, reason: .unavailable)
+        )
+        #expect(await events.next() == .attempting(tailscale))
+        #expect(await events.next() == .connected(tailscale))
+        #expect(await dialer.currentRoute() == tailscale)
+        #expect(await irohConnector.attemptCount() == 1)
+        #expect(await tailscaleConnector.attemptCount() == 1)
+    }
+
+    @Test("restricted mode never tries another route family")
+    func restrictedMode() async throws {
+        let iroh = try TransportRoute(kind: .iroh, identifier: "iroh-1")
+        let tailscale = try TransportRoute(
+            kind: .tailscale,
+            identifier: "tailscale-1"
+        )
+        let policy = try TransportSelectionPolicy(mode: .restricted(.tailscale))
+        let irohConnector = ScriptedConnector(behavior: .succeed)
+        let tailscaleConnector = ScriptedConnector(behavior: .fail)
+        let dialer = try TransportDialer(
+            routes: [iroh, tailscale],
+            policy: policy,
+            connectors: [.iroh: irohConnector, .tailscale: tailscaleConnector]
+        )
+        var events = dialer.events.makeAsyncIterator()
+
+        await #expect(
+            throws: TransportDialer.Failure.allRoutesFailed([tailscale])
+        ) {
+            try await dialer.connect()
+        }
+
+        #expect(await events.next() == .attempting(tailscale))
+        #expect(
+            await events.next() == .failed(tailscale, reason: .unavailable)
+        )
+        #expect(await events.next() == .exhausted)
+        #expect(await irohConnector.attemptCount() == 0)
+        #expect(await tailscaleConnector.attemptCount() == 1)
+    }
+
+    @Test("concurrent callers join one in-flight route attempt")
+    func concurrentCallsJoin() async throws {
+        let route = try TransportRoute(kind: .iroh, identifier: "iroh-1")
+        let connector = GatedConnector()
+        let policy = try TransportSelectionPolicy()
+        let dialer = try TransportDialer(
+            routes: [route],
+            policy: policy,
+            connectors: [.iroh: connector]
+        )
+
+        let first = Task { try await dialer.connect() }
+        await connector.waitUntilOpenIsPending()
+        let second = Task { try await dialer.connect() }
+        await Task.yield()
+        await connector.release()
+
+        _ = try await first.value
+        _ = try await second.value
+        #expect(await connector.attemptCount() == 1)
+        #expect(await dialer.currentRoute() == route)
+    }
+
+    @Test("missing connectors are observable and exhaust without a hidden fallback")
+    func missingConnector() async throws {
+        let route = try TransportRoute(kind: .tailscale, identifier: "ts-1")
+        let policy = try TransportSelectionPolicy(mode: .restricted(.tailscale))
+        let dialer = try TransportDialer(
+            routes: [route],
+            policy: policy,
+            connectors: [:]
+        )
+        var events = dialer.events.makeAsyncIterator()
+
+        await #expect(
+            throws: TransportDialer.Failure.allRoutesFailed([route])
+        ) {
+            try await dialer.connect()
+        }
+        #expect(await events.next() == .attempting(route))
+        #expect(
+            await events.next() == .failed(route, reason: .unclassified)
+        )
+        #expect(await events.next() == .exhausted)
+    }
+
+    @Test("authorization denial stops automatic fallback")
+    func authorizationDenialStopsFallback() async throws {
+        let iroh = try TransportRoute(kind: .iroh, identifier: "iroh-1")
+        let tailscale = try TransportRoute(
+            kind: .tailscale,
+            identifier: "tailscale-1"
+        )
+        let policy = try TransportSelectionPolicy()
+        let irohConnector = ScriptedConnector(behavior: .unauthorized)
+        let tailscaleConnector = ScriptedConnector(behavior: .succeed)
+        let dialer = try TransportDialer(
+            routes: [iroh, tailscale],
+            policy: policy,
+            connectors: [.iroh: irohConnector, .tailscale: tailscaleConnector]
+        )
+        var events = dialer.events.makeAsyncIterator()
+
+        await #expect(
+            throws: TransportDialer.Failure.nonRetryable(
+                iroh,
+                reason: .unauthorized
+            )
+        ) {
+            try await dialer.connect()
+        }
+        #expect(
+            await events.next() == .attempting(iroh)
+        )
+        #expect(
+            await events.next() == .failed(iroh, reason: .unauthorized)
+        )
+        #expect(await tailscaleConnector.attemptCount() == 0)
+    }
+
+    @Test("invalid route and policy inputs fail before any connector runs")
+    func invalidInputs() async throws {
+        #expect(
+            throws: TransportRoute.Failure.emptyIdentifier
+        ) {
+            try TransportRoute(kind: .iroh, identifier: "")
+        }
+        #expect(
+            throws: TransportSelectionPolicy.Failure.invalidPreference
+        ) {
+            try TransportSelectionPolicy(preference: [.iroh, .iroh])
+        }
+        #expect(
+            throws: TransportDialer.Failure.noRoutes
+        ) {
+            try TransportDialer(
+                routes: [],
+                policy: try TransportSelectionPolicy(),
+                connectors: [:]
+            )
+        }
+    }
+}
+
+private enum ScriptedBehavior: Sendable {
+    case fail
+    case succeed
+    case unauthorized
+}
+
+private actor ScriptedConnector: TransportConnector {
+    private let behavior: ScriptedBehavior
+    private var attempts = 0
+
+    init(behavior: ScriptedBehavior) {
+        self.behavior = behavior
+    }
+
+    func open(route: TransportRoute) async throws -> any ByteStream {
+        attempts += 1
+        switch behavior {
+        case .fail:
+            throw TransportOpenFailure.unavailable
+        case .succeed:
+            return TestByteStream()
+        case .unauthorized:
+            throw TransportOpenFailure.unauthorized
+        }
+    }
+
+    func attemptCount() -> Int {
+        attempts
+    }
+}
+
+private actor GatedConnector: TransportConnector {
+    private var attempts = 0
+    private var pending: CheckedContinuation<any ByteStream, any Error>?
+    private var pendingObserver: CheckedContinuation<Void, Never>?
+
+    func open(route: TransportRoute) async throws -> any ByteStream {
+        attempts += 1
+        pendingObserver?.resume()
+        pendingObserver = nil
+        return try await withCheckedThrowingContinuation { continuation in
+            pending = continuation
+        }
+    }
+
+    func waitUntilOpenIsPending() async {
+        if pending != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            pendingObserver = continuation
+        }
+    }
+
+    func release() {
+        pending?.resume(returning: TestByteStream())
+        pending = nil
+    }
+
+    func attemptCount() -> Int {
+        attempts
+    }
+}
+
+private actor TestByteStream: ByteStream {
+    func connect() async throws {}
+
+    func send(_ bytes: Data) async throws {}
+
+    func receive() async throws -> Data? {
+        nil
+    }
+
+    func close() async {}
+}

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -11,12 +11,14 @@ is integrated into the production apps.
 kernel. `Packages/CmuxLiteSession` owns one conversation over an injected byte
 stream and tests it against a deterministic fake Mac host. Neither package has
 a dependency on the existing cmux mobile implementation.
+`Packages/CmuxLiteTransport` now owns route ordering and one serialized dial
+attempt, while still leaving concrete network adapters out of the experiment.
 
 Later slices will add, in order:
 
 1. an Iroh byte-stream adapter;
 2. a Tailscale compatibility adapter;
-3. connection selection and migration policy;
+3. session reconnect and migration policy;
 4. terminal synchronization over deterministic transcripts;
 5. a Ghostty consumer and renderer verification.
 

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -1,0 +1,23 @@
+# cmux-lite iOS
+
+cmux-lite is the clean-room proving ground for cmux mobile connectivity. It
+separates protocol, transport, authorization, terminal synchronization, and
+rendering so each layer can be understood and verified independently before it
+is integrated into the production apps.
+
+## Current slice
+
+`Packages/CmuxLiteProtocol` defines and tests the renderer-independent protocol
+kernel. It has no dependency on the existing cmux mobile implementation.
+
+Later slices will add, in order:
+
+1. a deterministic fake Mac host;
+2. a session owner joining the codec, state machine, and byte stream;
+3. an Iroh byte-stream adapter;
+4. a Tailscale compatibility adapter;
+5. terminal synchronization over deterministic transcripts;
+6. a Ghostty consumer and renderer verification.
+
+Nothing under this experiment is wired into the production app targets unless
+a later, explicit design decision promotes it.

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -13,10 +13,12 @@ stream and tests it against a deterministic fake Mac host. Neither package has
 a dependency on the existing cmux mobile implementation.
 `Packages/CmuxLiteTransport` now owns route ordering and one serialized dial
 attempt, while still leaving concrete network adapters out of the experiment.
+`Packages/CmuxLiteIroh` adds the unit-testable Swift adapter boundary around a
+future native binding, with no Rust or C code linked yet.
 
 Later slices will add, in order:
 
-1. an Iroh byte-stream adapter;
+1. the native Rust/C Iroh binding;
 2. a Tailscale compatibility adapter;
 3. session reconnect and migration policy;
 4. terminal synchronization over deterministic transcripts;

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -13,12 +13,14 @@ stream and tests it against a deterministic fake Mac host. Neither package has
 a dependency on the existing cmux mobile implementation.
 `Packages/CmuxLiteTransport` now owns route ordering and one serialized dial
 attempt, while still leaving concrete network adapters out of the experiment.
-`Packages/CmuxLiteIroh` adds the unit-testable Swift adapter boundary around a
-future native binding, with no Rust or C code linked yet.
+`Packages/CmuxLiteIroh` adds the unit-testable Swift adapter boundary and a
+concrete provider backed by the isolated `manaflow-ai/iroh-ffi` `cmux-lite`
+branch. The provider binds one endpoint lazily, validates route identity, and
+opens one bidirectional stream without wiring the experiment into production.
 
 Later slices will add, in order:
 
-1. the native Rust/C Iroh binding;
+1. a real two-endpoint Iroh listener/dialer harness;
 2. a Tailscale compatibility adapter;
 3. session reconnect and migration policy;
 4. terminal synchronization over deterministic transcripts;

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -15,16 +15,22 @@ a dependency on the existing cmux mobile implementation.
 attempt, while still leaving concrete network adapters out of the experiment.
 `Packages/CmuxLiteIroh` adds the unit-testable Swift adapter boundary and a
 concrete provider backed by the isolated `manaflow-ai/iroh-ffi` `cmux-lite`
-branch. The provider binds one endpoint lazily, validates route identity, and
-opens one bidirectional stream without wiring the experiment into production.
+branch. The provider binds one endpoint lazily, publishes its public route,
+resolves current address hints, validates peer identity and ALPN, accepts one
+owned inbound connection at a time, and opens one bidirectional stream without
+wiring the experiment into production. Its real loopback suite drives the
+generic transport dialer and session owner, not a renderer. A dedicated
+endpoint host owns the listener loop and accepted session lifetimes.
 
 Later slices will add, in order:
 
-1. a real two-endpoint Iroh listener/dialer harness;
-2. a Tailscale compatibility adapter;
-3. session reconnect and migration policy;
-4. terminal synchronization over deterministic transcripts;
-5. a Ghostty consumer and renderer verification.
+1. a Tailscale compatibility adapter;
+2. session reconnect and migration policy;
+3. terminal synchronization over deterministic transcripts;
+4. a Ghostty consumer and renderer verification.
 
 Nothing under this experiment is wired into the production app targets unless
 a later, explicit design decision promotes it.
+
+`./scripts/ci/run-cmux-lite-tests.sh` runs every isolated package suite,
+including the real local Iroh endpoint checks, without launching cmux.

--- a/experiments/cmux-lite-ios/README.md
+++ b/experiments/cmux-lite-ios/README.md
@@ -8,16 +8,17 @@ is integrated into the production apps.
 ## Current slice
 
 `Packages/CmuxLiteProtocol` defines and tests the renderer-independent protocol
-kernel. It has no dependency on the existing cmux mobile implementation.
+kernel. `Packages/CmuxLiteSession` owns one conversation over an injected byte
+stream and tests it against a deterministic fake Mac host. Neither package has
+a dependency on the existing cmux mobile implementation.
 
 Later slices will add, in order:
 
-1. a deterministic fake Mac host;
-2. a session owner joining the codec, state machine, and byte stream;
-3. an Iroh byte-stream adapter;
-4. a Tailscale compatibility adapter;
-5. terminal synchronization over deterministic transcripts;
-6. a Ghostty consumer and renderer verification.
+1. an Iroh byte-stream adapter;
+2. a Tailscale compatibility adapter;
+3. connection selection and migration policy;
+4. terminal synchronization over deterministic transcripts;
+5. a Ghostty consumer and renderer verification.
 
 Nothing under this experiment is wired into the production app targets unless
 a later, explicit design decision promotes it.

--- a/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
-        "version" : "1.0.2-cmux.7"
+        "branch" : "cmux-lite",
+        "revision" : "6eeabebc4cdbcec5f444b756b1e915a6ff26b0b2"
       }
     },
     {

--- a/ios/cmuxPackage/Package.resolved
+++ b/ios/cmuxPackage/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
-        "version" : "1.0.2-cmux.7"
+        "branch" : "cmux-lite",
+        "revision" : "6eeabebc4cdbcec5f444b756b1e915a6ff26b0b2"
       }
     },
     {

--- a/scripts/ci/run-cmux-lite-tests.sh
+++ b/scripts/ci/run-cmux-lite-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_runner="$repo_root/scripts/ci/run-swift-testing-suites.sh"
+packages=(
+  CmuxLiteProtocol
+  CmuxLiteSession
+  CmuxLiteTransport
+  CmuxLiteIroh
+)
+
+for package in "${packages[@]}"; do
+  "$test_runner" \
+    "$repo_root/experiments/cmux-lite-ios/Packages/$package"
+done


### PR DESCRIPTION
## Summary

- add an isolated `experiments/cmux-lite-ios` proving ground
- define versioned hello, welcome, ping, pong, protocol-error, and close messages
- add bounded four-byte big-endian JSON framing
- enforce client/server handshake, message ordering, correlation, and terminal close states
- define the byte-stream seam for later Iroh and Tailscale adapters

## How

The package keeps transport reads as arbitrary byte chunks, decodes at most one 64 KiB frame at a time, caps each ingest at 256 messages, and fails closed after malformed or excessive input. Each sender owns a strictly increasing message ID; responses carry a separate `reply_to` value.

## Verification

- `swift test`, 26 tests passed
- no app, daemon, simulator, Iroh, Tailscale, or renderer code was built or run, per the requested workflow

## Scope

This PR is the first architecture checkpoint. It is not wired into production targets. The fake Mac host is intentionally deferred until the protocol verdict.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789701326&installation_model_id=21920&pr_number=10380&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10380&signature=e91985079f816b40870ce4e62ecd848d3d9d184667f28f182562f8e9deeec055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the experimental `experiments/cmux-lite-ios` stack (`CmuxLiteProtocol`, `CmuxLiteSession`, `CmuxLiteTransport`, `CmuxLiteIroh`) and a real `IrohLib` loopback harness to validate end‑to‑end bytes, handshake, and route opening outside production. Behavior change: Iroh byte streams now require an explicit close(); previously they could be released without awaiting close, which risked truncating in‑flight data.

- Protocol: versioned control messages; deterministic 4‑byte big‑endian + sorted‑keys JSON framing; strict limits (64 KiB payload, 256 messages/ingest); decoder fails closed on malformed input/EOF.
- Session: `SessionOwner` connects the stream, serializes writes, decodes chunks, auto‑replies (`welcome`, `pong`), and emits lifecycle events.
- Transport: `TransportSelectionPolicy` and `TransportDialer` serialize attempts, emit attempt/failure/success events, prefer Iroh → Tailscale → loopback in automatic mode, support restricted mode, and classify failures (`unavailable`, `incompatiblePeer`, `invalidRoute`, `unauthorized`, `unclassified`).
- Iroh: `IrohRoute`, `IrohConnector` (`TransportConnector`), and `IrohByteStream` (no overlapping ops; idempotent, required close). Concrete `IrohLib` binding adds `IrohLibConfiguration` (ALPN, relay mode, keys, receive limits), `IrohLibEndpointFactory`, `IrohLibConnectionProvider` (lazy, shared endpoint; explicit close), and `IrohLibConnection`. Native errors map to `TransportOpenFailure`.

- Real harness: adds local integration tests that bind two real `IrohLib` endpoints over loopback to validate bind/dial, ALPN, accept loop, and byte round‑trip; no relay, app, or simulator involvement. CI script `scripts/ci/run-cmux-lite-tests.sh` runs all `cmux-lite` package suites.
- Dependency: all `Package.resolved` and `Package.swift` entries point `iroh-ffi` to branch `cmux-lite`.
- Tests: cover fragmentation/coalescing, flood control, handshake, ping/pong, explicit close, transport fallback and event order, endpoint sharing/teardown, and Iroh adapter lifecycle/classification, plus the new real loopback integration.
- Scope: experimental only; not wired into production targets. No migration required.

<sup>Written for commit 6236f6c9af6718b2c53eb9b51e6d06021ae90bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Swift packages supporting iOS 18 and macOS 14.
  - Added versioned control messages, JSON framing, byte streams, session handshakes, lifecycle validation, ping/pong, protocol errors, and close handling.
  - Added session events, transport route selection, fallback, restricted routing, and shared connection attempts.
  - Added Iroh route support and byte-stream integration with classified connection failures.

- **Documentation**
  - Documented protocol, session, transport, Iroh integration, and implementation stages.

- **Tests**
  - Added comprehensive coverage for framing, streams, sessions, transport routing, Iroh integration, and protocol validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->