### PR TITLE
fix(iroh): let pre-namespace legacy iOS bindings pair with default and nightly Macs

### DIFF
--- a/web/services/iroh/buildCompatibility.ts
+++ b/web/services/iroh/buildCompatibility.ts
@@ -17,21 +17,45 @@ export function canIOSBindingUseMac(
   caller: BuildBinding,
   target: BuildBinding,
 ): boolean {
+  return iosBindingMacLaneCompatible(caller, target, true);
+}
+
+/**
+ * Forgetting revokes the Mac's binding, so the legacy fallback that pairing
+ * gets does not extend here: a namespace-less caller keeps exact tag matching.
+ */
+export function canIOSBindingForgetMac(
+  caller: BuildBinding,
+  target: BuildBinding,
+): boolean {
+  return iosBindingMacLaneCompatible(caller, target, false);
+}
+
+function iosBindingMacLaneCompatible(
+  caller: BuildBinding,
+  target: BuildBinding,
+  legacyDefaultFallback: boolean,
+): boolean {
   if (caller.platform !== "ios" || target.platform !== "mac") return false;
   const targetHasCompatibleNamespace = target.clientNamespace === "legacy"
     || target.clientNamespace.startsWith("mac:");
   if (!targetHasCompatibleNamespace) return false;
 
-  if (
-    caller.tag === "default"
-    && OFFICIAL_IOS_NAMESPACES.has(caller.clientNamespace)
-  ) {
+  // iOS builds that predate the X-Cmux-App-Namespace header register as
+  // `legacy` and cannot send anything newer, so the missing namespace is the
+  // migration signal. The shipped pre-namespace population is the official
+  // Beta on the `default` lane; give it the same default->{default,nightly}
+  // reach as the official namespaced apps until those builds are sunset.
+  const callerHasDefaultLaneReach = caller.tag === "default"
+    && (
+      OFFICIAL_IOS_NAMESPACES.has(caller.clientNamespace)
+      || (legacyDefaultFallback && caller.clientNamespace === "legacy")
+    );
+  if (callerHasDefaultLaneReach) {
     return target.tag === "default" || target.tag === "nightly";
   }
   return caller.tag === target.tag;
 }
-
-export const canIOSBindingForgetMac = canIOSBindingUseMac;
 
 /**
  * Allows one active app bundle to clean up an older binding from the same

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -68,6 +68,75 @@ describe("Iroh build compatibility", () => {
     expect(canIOSBindingUseMac(ios, stableMac)).toBe(true);
     expect(canIOSBindingUseMac(ios, stagingMac)).toBe(true);
   });
+
+  test("a legacy default-lane iOS binding may use default and nightly Macs", () => {
+    const legacyIos = binding({
+      platform: "ios",
+      tag: "default",
+      clientNamespace: "legacy",
+    });
+    const defaultMac = binding({
+      platform: "mac",
+      tag: "default",
+      clientNamespace: "mac:com.cmuxterm.app",
+    });
+    const nightlyMac = binding({
+      platform: "mac",
+      tag: "nightly",
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+    });
+    const featureMac = binding({
+      platform: "mac",
+      tag: "feature-b",
+      clientNamespace: "mac:feature-b",
+    });
+
+    expect(canIOSBindingUseMac(legacyIos, defaultMac)).toBe(true);
+    expect(canIOSBindingUseMac(legacyIos, nightlyMac)).toBe(true);
+    expect(canIOSBindingUseMac(legacyIos, featureMac)).toBe(false);
+  });
+
+  test("the legacy fallback stays on the default lane", () => {
+    const taggedLegacyIos = binding({
+      platform: "ios",
+      tag: "feature-a",
+      clientNamespace: "legacy",
+    });
+    const nightlyMac = binding({
+      platform: "mac",
+      tag: "nightly",
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+    });
+    const sameLaneMac = binding({
+      platform: "mac",
+      tag: "feature-a",
+      clientNamespace: "mac:feature-a",
+    });
+
+    expect(canIOSBindingUseMac(taggedLegacyIos, nightlyMac)).toBe(false);
+    expect(canIOSBindingUseMac(taggedLegacyIos, sameLaneMac)).toBe(true);
+  });
+
+  test("the legacy fallback does not broaden Mac forgetting", () => {
+    const legacyIos = binding({
+      platform: "ios",
+      tag: "default",
+      clientNamespace: "legacy",
+    });
+    const defaultMac = binding({
+      platform: "mac",
+      tag: "default",
+      clientNamespace: "mac:com.cmuxterm.app",
+    });
+    const nightlyMac = binding({
+      platform: "mac",
+      tag: "nightly",
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+    });
+
+    expect(canIOSBindingForgetMac(legacyIos, defaultMac)).toBe(true);
+    expect(canIOSBindingForgetMac(legacyIos, nightlyMac)).toBe(false);
+  });
 });
 
 describe("Iroh trust broker registration", () => {
@@ -1376,6 +1445,101 @@ describe("Iroh discovery and grants", () => {
 
     expect(result.grant.split(".")).toHaveLength(3);
     expect(fixture.repository.pairGrantAudits).toHaveLength(1);
+  });
+
+  test("a pre-namespace legacy iOS binding can pair with a Nightly Mac", async () => {
+    const fixture = makeFixture();
+    const initiator = binding({
+      userId: USER_A,
+      clientNamespace: "legacy",
+      tag: "default",
+      platform: "ios",
+    });
+    const acceptor = binding({
+      userId: USER_A,
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+      tag: "nightly",
+      platform: "mac",
+      pairingEnabled: true,
+    });
+    fixture.repository.bindings.push(initiator, acceptor);
+
+    // Old Beta builds cannot send X-Cmux-App-Namespace or a binding request
+    // proof; the absence of both is the legacy migration signal.
+    const result = await Effect.runPromise(fixture.broker.issuePairGrant(USER_A, {
+      initiatorBindingId: initiator.id,
+      acceptorBindingId: acceptor.id,
+    }, NOW)) as { grant: string };
+
+    expect(result.grant.split(".")).toHaveLength(3);
+    expect(fixture.repository.pairGrantAudits).toHaveLength(1);
+  });
+
+  test("a legacy iOS binding outside the default lane keeps exact lane matching", async () => {
+    const fixture = makeFixture();
+    const initiator = binding({
+      userId: USER_A,
+      clientNamespace: "legacy",
+      tag: "feature-a",
+      platform: "ios",
+    });
+    const acceptor = binding({
+      userId: USER_A,
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+      tag: "nightly",
+      platform: "mac",
+      pairingEnabled: true,
+    });
+    fixture.repository.bindings.push(initiator, acceptor);
+
+    await expectEffectFailure(fixture.broker.issuePairGrant(USER_A, {
+      initiatorBindingId: initiator.id,
+      acceptorBindingId: acceptor.id,
+    }, NOW), "IrohForbiddenError");
+    expect(fixture.repository.pairGrantAudits).toHaveLength(0);
+  });
+
+  test("a proofed legacy iOS binding discovers nightly Macs but not feature lanes", async () => {
+    const fixture = makeFixture();
+    const ios = binding({
+      userId: USER_A,
+      deviceUuid: fixture.deviceId,
+      clientNamespace: "legacy",
+      tag: "default",
+      platform: "ios",
+      endpointId: fixture.endpointId,
+    });
+    const nightlyMac = binding({
+      userId: USER_A,
+      clientNamespace: "mac:com.cmuxterm.app.nightly",
+      tag: "nightly",
+      platform: "mac",
+    });
+    const featureMac = binding({
+      userId: USER_A,
+      clientNamespace: "mac:feature-b",
+      tag: "feature-b",
+      platform: "mac",
+    });
+    fixture.repository.bindings.push(ios, nightlyMac, featureMac);
+
+    const discovered = await Effect.runPromise(fixture.broker.discover(
+      USER_A,
+      NOW,
+      undefined,
+      "legacy",
+      fixture.bindingProof(
+        ios.id,
+        "GET",
+        "api/devices/iroh",
+        undefined,
+      ),
+    )) as { bindings: Array<{ binding_id: string }> };
+
+    const ids = discovered.bindings.map((row) => row.binding_id);
+    expect(ids).toContain(ios.id);
+    expect(ids).toContain(nightlyMac.id);
+    expect(ids).not.toContain(featureMac.id);
   });
 
   test("a namespaced app cannot discover or mutate a sibling app binding", async () => {


### PR DESCRIPTION
## Problem

Old Beta iOS builds predate the `X-Cmux-App-Namespace` header from the bundle-isolation rollout (https://github.com/manaflow-ai/cmux/pull/9183), so the trust broker records them as `legacy`/`default`. That classification loses the official-namespace `default -> {default, nightly}` exception: discovery still lists a Nightly Mac, but `issuePairGrant` denies it with `target_not_pairable`, which the phone shows as `Authorization failed` even though relay policy and reachability pass. Diagnosed from a user-supplied field incident (Aug 12 Beta client vs `cmux NIGHTLY 0.64.22` host).

## Fix

`web/services/iroh/buildCompatibility.ts`: a `legacy` caller on the `default` lane now gets the same `default`+`nightly` Mac reach as the official namespaced iOS apps. Old binaries cannot send a new field, so the missing namespace header is the migration signal. The rule lives in the single `canIOSBindingUseMac` choke point, so pair-grant issuance and proofed discovery filtering agree by construction.

Deliberately narrow:
- Non-default legacy lanes keep exact tag matching.
- `canIOSBindingForgetMac` is split off the alias: the destructive forget path keeps today's rules for legacy callers.
- Namespace isolation for Stable/Internal/experimental bundles is unchanged.

Sunsetting the fallback later is deleting the `legacyDefaultFallback` branch once pre-namespace Beta builds are retired.

## Tests

Two commits so CI proves the regression tests catch the bug: commit 1 adds failing tests (legacy pair grant against a Nightly Mac, proofed legacy discovery, unit compatibility matrix, forget-not-broadened guard), commit 2 adds the fix. `bun test tests/iroh-trust-broker.test.ts` 54 pass, adjacent iroh/relay/device route tests pass, `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789701439&installation_model_id=21920&pr_number=10381&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10381&signature=046b1b6c21a6fd15e96b7b7f176317443537ecc9a63e805001fae99d35470acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pairing for pre-namespace iOS Beta clients: legacy/default iOS bindings can now pair with `default` and `nightly` Macs. Previously, discovery listed Nightly Macs but pair grants failed with `target_not_pairable` (surface: “Authorization failed”); now discovery and grants align.

- Implemented via `iosBindingMacLaneCompatible`, used by `canIOSBindingUseMac`; split out `canIOSBindingForgetMac` so forgetting remains strict.
- Fallback applies only to legacy iOS on the `default` lane (missing `X-Cmux-App-Namespace` is the signal); other legacy lanes keep exact tag matching; namespace isolation is unchanged.
- Tests cover pair grant to Nightly, proofed discovery, non-default lane guard, and the strict forget path.

**Rollout**
- No client changes required; old Beta builds work automatically. To sunset later, remove the legacy default-lane fallback branch.

<sup>Written for commit 5bc3fee2c819899be9ad6eedaf67cec8253a93cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility between legacy iOS clients and macOS default or nightly builds.
  * Legacy default-lane iOS clients can now pair with and discover compatible nightly Macs.
* **Bug Fixes**
  * Restricted compatibility for non-default feature lanes.
  * Corrected Mac-forgetting behavior to require exact build matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->