### PR TITLE
feat(tui): user commands bound to key chords

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7124,12 +7124,16 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
     if let Some(pipe) = stdout.as_ref() {
         use std::os::fd::AsRawFd;
         // SAFETY: fcntl flag update on a pipe fd this function owns.
-        unsafe {
+        let nonblocking = unsafe {
             let fd = pipe.as_raw_fd();
             let flags = libc::fcntl(fd, libc::F_GETFL);
-            if flags >= 0 {
-                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
-            }
+            flags >= 0 && libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) == 0
+        };
+        if !nonblocking {
+            // Fail closed: a blocking pipe would defeat the deadline and
+            // stop checks, so never enter the capture loop with one.
+            kill_status_command_group(&mut child);
+            return Vec::new();
         }
     }
     let group = child.id() as i32;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7015,8 +7015,23 @@ fn run_status_segment_loop(worker: StatusSegmentWorker) {
     let StatusSegmentWorker { index, argv, interval, outputs, generation, poke, events, stop } =
         worker;
     let mut pending_notify = false;
+    let mut unreaped: Option<std::process::Child> = None;
     while !stop.is_raised() {
-        let output = run_status_command(&argv, STATUS_COMMAND_TIMEOUT, &stop);
+        // A previous command stuck in uninterruptible kernel I/O survives
+        // SIGKILL; never stack another process behind it, and reap it once
+        // the kernel releases it, so stuck processes stay bounded at one
+        // per segment with no lasting zombie.
+        // A reaped predecessor is dropped by the reassignment below.
+        if let Some(child) = unreaped.as_mut()
+            && matches!(child.try_wait(), Ok(None))
+        {
+            if stop.wait_timeout(interval) {
+                return;
+            }
+            continue;
+        }
+        let (output, stuck_child) = run_status_command(&argv, STATUS_COMMAND_TIMEOUT, &stop);
+        unreaped = stuck_child;
         if stop.is_raised() {
             return;
         }
@@ -7093,22 +7108,33 @@ fn cached_status_user() -> &'static str {
     })
 }
 
-fn run_status_command(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> String {
+/// Returns the segment text plus the child when it could not be reaped
+/// (stuck in uninterruptible kernel I/O); the segment loop keeps at most
+/// one such child and never starts another command behind it.
+fn run_status_command(
+    argv: &[String],
+    timeout: Duration,
+    stop: &StatusWorkerStop,
+) -> (String, Option<std::process::Child>) {
     const MAX_STATUS_OUTPUT_CHARS: usize = 200;
-    let captured = capture_status_output(argv, timeout, stop);
+    let (captured, stuck_child) = capture_status_output(argv, timeout, stop);
     let text = String::from_utf8_lossy(&captured);
     let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
-    strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
+    (strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect(), stuck_child)
 }
 
 const MAX_STATUS_OUTPUT_BYTES: usize = 64 * 1024;
 const STATUS_POLL_TICK: Duration = Duration::from_millis(25);
 
 #[cfg(unix)]
-fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> Vec<u8> {
+fn capture_status_output(
+    argv: &[String],
+    timeout: Duration,
+    stop: &StatusWorkerStop,
+) -> (Vec<u8>, Option<std::process::Child>) {
     use std::io::Read;
 
-    let Some(program) = argv.first() else { return Vec::new() };
+    let Some(program) = argv.first() else { return (Vec::new(), None) };
     let mut command = std::process::Command::new(program);
     command
         .args(&argv[1..])
@@ -7119,18 +7145,16 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    let Ok(mut child) = ({
-        // Spawn under the raise lock: a raise that wins the lock happens
-        // strictly before this spawn, so a retired worker cannot start an
-        // obsolete command; a spawn that wins is killed by the next tick.
-        let _spawn_guard = stop.lock.lock().unwrap();
-        if stop.is_raised() {
-            return Vec::new();
-        }
-        command.spawn()
-    }) else {
-        return Vec::new();
-    };
+    // Final unlocked stop check directly before the spawn. Holding the
+    // raise lock across spawn would let a stalled filesystem block reload
+    // and shutdown on the UI thread, so the residual race is resolved the
+    // other way: a command that spawns against a concurrent raise is
+    // killed at the first poll tick below.
+    if stop.is_raised() {
+        return (Vec::new(), None);
+    }
+    let Ok(mut child) = command.spawn() else { return (Vec::new(), None) };
+    let mut child_reaped = false;
     let mut stdout = child.stdout.take();
     if let Some(pipe) = stdout.as_ref() {
         use std::os::fd::AsRawFd;
@@ -7143,8 +7167,8 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         if !nonblocking {
             // Fail closed: a blocking pipe would defeat the deadline and
             // stop checks, so never enter the capture loop with one.
-            kill_status_command_group(&mut child);
-            return Vec::new();
+            let reaped = kill_status_command_group(&mut child);
+            return (Vec::new(), (!reaped).then_some(child));
         }
     }
     let group = child.id() as i32;
@@ -7200,11 +7224,12 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         }
         if matches!(child.try_wait(), Ok(Some(_))) {
             // One more drain pass picks up bytes written before exit.
+            child_reaped = true;
             exited = true;
             continue;
         }
         if stop.is_raised() || Instant::now() >= deadline {
-            kill_status_command_group(&mut child);
+            child_reaped = kill_status_command_group(&mut child);
             exited = true;
             continue;
         }
@@ -7218,22 +7243,26 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
     unsafe {
         libc::kill(-group, libc::SIGKILL);
     }
-    captured
+    (captured, (!child_reaped).then_some(child))
 }
 
 #[cfg(windows)]
-fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> Vec<u8> {
+fn capture_status_output(
+    argv: &[String],
+    timeout: Duration,
+    stop: &StatusWorkerStop,
+) -> (Vec<u8>, Option<std::process::Child>) {
     use std::io::{Read, Seek, SeekFrom};
     use std::sync::atomic::AtomicU64;
 
     static CAPTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-    let Some(program) = argv.first() else { return Vec::new() };
+    let Some(program) = argv.first() else { return (Vec::new(), None) };
     let path = std::env::temp_dir().join(format!(
         "cmux-status-{}-{}.out",
         std::process::id(),
         CAPTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
     ));
-    let Ok(file) = std::fs::File::create(&path) else { return Vec::new() };
+    let Ok(file) = std::fs::File::create(&path) else { return (Vec::new(), None) };
     let mut command = std::process::Command::new(program);
     command
         .args(&argv[1..])
@@ -7247,18 +7276,14 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
         command.creation_flags(CREATE_SUSPENDED);
     }
-    let Ok(mut child) = ({
-        // Spawn under the raise lock; see the Unix path for the ordering
-        // argument.
-        let _spawn_guard = stop.lock.lock().unwrap();
-        if stop.is_raised() {
-            let _ = std::fs::remove_file(&path);
-            return Vec::new();
-        }
-        command.spawn()
-    }) else {
+    // Final unlocked stop check; see the Unix path for the trade-off.
+    if stop.is_raised() {
         let _ = std::fs::remove_file(&path);
-        return Vec::new();
+        return (Vec::new(), None);
+    }
+    let Ok(mut child) = command.spawn() else {
+        let _ = std::fs::remove_file(&path);
+        return (Vec::new(), None);
     };
     // The job's kill-on-close limit terminates the whole descendant tree
     // when this function returns, mirroring the Unix process-group kill.
@@ -7270,7 +7295,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
             let _ = child.kill();
             let _ = child.wait();
             let _ = std::fs::remove_file(&path);
-            return Vec::new();
+            return (Vec::new(), None);
         }
     };
     if resume_suspended_status_child(&child).is_err() {
@@ -7278,11 +7303,13 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         let _ = child.kill();
         let _ = child.wait();
         let _ = std::fs::remove_file(&path);
-        return Vec::new();
+        return (Vec::new(), None);
     }
+    let mut child_reaped = false;
     let deadline = Instant::now() + timeout;
     loop {
         if matches!(child.try_wait(), Ok(Some(_))) {
+            child_reaped = true;
             break;
         }
         // Bound the file while the command runs: a spewing command is
@@ -7295,7 +7322,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
             .is_ok_and(|metadata| metadata.len() > MAX_STATUS_OUTPUT_BYTES as u64);
         if oversized || stop.is_raised() || Instant::now() >= deadline {
             job.terminate();
-            kill_status_command_group(&mut child);
+            child_reaped = kill_status_command_group(&mut child);
             break;
         }
         std::thread::sleep(STATUS_POLL_TICK);
@@ -7316,7 +7343,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         let _ = file.take(MAX_STATUS_OUTPUT_BYTES as u64).read_to_end(&mut captured);
     }
     let _ = std::fs::remove_file(&path);
-    captured
+    (captured, (!child_reaped).then_some(child))
 }
 
 /// Windows job object with the kill-on-close limit, so every process a
@@ -7449,9 +7476,10 @@ fn resume_suspended_status_child(child: &std::process::Child) -> std::io::Result
 /// Kill a status command and, on Unix, its whole process group so every
 /// descendant exits with it. Reaping is bounded: a child stuck in
 /// uninterruptible kernel I/O survives SIGKILL until the kernel releases
-/// it, and blocking on it would transitively hang reload and shutdown, so
-/// after the bound the child is left for reaping at process exit.
-fn kill_status_command_group(child: &mut std::process::Child) {
+/// it, and blocking on it would transitively hang reload and shutdown.
+/// Returns whether the child was reaped; the caller keeps an unreaped
+/// child and refuses to start another command behind it.
+fn kill_status_command_group(child: &mut std::process::Child) -> bool {
     #[cfg(unix)]
     // SAFETY: plain syscall on the child's own process group id.
     unsafe {
@@ -7464,7 +7492,8 @@ fn kill_status_command_group(child: &mut std::process::Child) {
             Ok(None) if Instant::now() < deadline => {
                 std::thread::sleep(Duration::from_millis(10));
             }
-            _ => break,
+            Ok(None) => return false,
+            _ => return true,
         }
     }
 }
@@ -23686,13 +23715,13 @@ mod tests {
     #[test]
     fn status_command_runner_returns_last_clean_line() {
         let run = StatusWorkerStop::new();
-        let output = run_status_command(
+        let (output, _) = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "printf 'one\\ntwo\\n\\n'".to_string()],
             Duration::from_secs(5),
             &run,
         );
         assert_eq!(output, "two", "the last nonempty line wins");
-        let colored = run_status_command(
+        let (colored, _) = run_status_command(
             &[
                 "/bin/sh".to_string(),
                 "-c".to_string(),
@@ -23707,7 +23736,8 @@ mod tests {
                 &["/nonexistent-status-cmd".to_string()],
                 Duration::from_secs(1),
                 &run,
-            ),
+            )
+            .0,
             "",
             "spawn failures resolve to an empty segment"
         );
@@ -23718,12 +23748,13 @@ mod tests {
     fn status_command_timeout_kills_the_process_tree_and_keeps_partial_output() {
         let started = Instant::now();
         let run = StatusWorkerStop::new();
-        let output = run_status_command(
+        let (output, stuck) = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "echo early; sleep 60".to_string()],
             Duration::from_secs(1),
             &run,
         );
         assert_eq!(output, "early", "output before the timeout survives the group kill");
+        assert!(stuck.is_none(), "a killable command is reaped within the bound");
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "the runtime bound is real: {:?}",
@@ -23736,7 +23767,7 @@ mod tests {
         let stopped = StatusWorkerStop::new();
         stopped.raise();
         let started = Instant::now();
-        let output = run_status_command(
+        let (output, _) = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "sleep 60".to_string()],
             Duration::from_secs(60),
             &stopped,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5022,13 +5022,24 @@ pub struct ShortcutHelp {
 
 impl ShortcutHelp {
     fn resolved_rows(config: &Config, surface_only: bool) -> Vec<(Action, String)> {
-        config
+        let mut rows: Vec<(Action, String)> = config
             .keys
             .resolved_shortcuts()
             .into_iter()
             .filter(|(definition, _)| action_available_in_mode(definition.action, surface_only))
             .map(|(definition, shortcuts)| (definition.action, shortcuts.join(", ")))
-            .collect()
+            .collect();
+        for index in 0..config.commands.len() {
+            let Some(action) = Action::user_command(index) else { break };
+            if !action_available_in_mode(action, surface_only) {
+                continue;
+            }
+            let shortcuts = config.keys.shortcut_labels(action);
+            if !shortcuts.is_empty() {
+                rows.push((action, shortcuts.join(", ")));
+            }
+        }
+        rows
     }
 
     fn from_config(config: &Config, surface_only: bool) -> Self {
@@ -14805,6 +14816,22 @@ impl App {
         )
     }
 
+    /// Run one configured user command as a new PTY tab in the target pane.
+    /// The server defaults the working directory to the pane's current
+    /// directory when the command has no configured `cwd`.
+    fn run_user_command(&mut self, index: usize, pane: Option<PaneId>) -> anyhow::Result<()> {
+        let Some(command) = self.config.commands.get(index) else {
+            return Ok(());
+        };
+        let pane = pane.or_else(|| self.active_pane());
+        self.session.run_command(
+            command.run.clone(),
+            pane,
+            command.cwd.clone(),
+            self.terminal_tab_size_hint(pane),
+        )
+    }
+
     fn terminal_tab_size_hint(&self, pane: Option<PaneId>) -> Option<(u16, u16)> {
         match pane {
             Some(pane) => {
@@ -16955,6 +16982,11 @@ impl App {
                 // running server-side (detach).
                 self.quit = true;
                 return Ok(RenderAction::None);
+            }
+            Action::UserCommand(_) => {
+                if let Some(index) = action.user_command_index() {
+                    self.run_user_command(index, pane)?;
+                }
             }
         }
         if !self.status_message_hovered() {
@@ -20395,6 +20427,17 @@ impl App {
         action_available_in_mode(action, self.surface_only.is_some())
     }
 
+    /// The display label for an action: the localized catalog label, or the
+    /// user's configured command name for `Action::UserCommand`.
+    pub(crate) fn action_display_label(&self, action: Action) -> &str {
+        if let Some(index) = action.user_command_index()
+            && let Some(command) = self.config.commands.get(index)
+        {
+            return command.name.as_str();
+        }
+        localization::catalog().action_label(action)
+    }
+
     fn sidebar_menu_actions(&self) -> Vec<MenuAction> {
         vec![
             MenuAction::ToggleSidebar { visible: self.sidebar_visible },
@@ -22732,6 +22775,43 @@ mod tests {
         assert!(mux.surface(hidden.id).is_some());
         mux.close_surface(attached.id).unwrap();
         mux.close_surface(hidden.id).unwrap();
+    }
+
+    #[test]
+    fn user_command_action_runs_configured_argv_in_a_new_tab() {
+        let (mux, _surface) = test_mux("user-command-run-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        app.config.commands = vec![crate::config::UserCommandConfig {
+            id: "sleeper".to_string(),
+            name: "Sleeper".to_string(),
+            run: vec!["/bin/sh".to_string(), "-c".to_string(), "sleep 30".to_string()],
+            cwd: None,
+        }];
+        let pane = app.tree.active_screen().unwrap().active_pane;
+        let initial_surfaces = mux.with_state(|state| state.surfaces.len());
+
+        app.run_action_for_pane(Action::user_command(0).unwrap(), Some(pane)).unwrap();
+        while app.session.has_pending_mutations() {
+            let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
+            app.handle(event).unwrap();
+        }
+        assert_eq!(mux.with_state(|state| state.surfaces.len()), initial_surfaces + 1);
+
+        // An index without a configured command is a no-op.
+        app.run_action_for_pane(Action::user_command(1).unwrap(), Some(pane)).unwrap();
+        while app.session.has_pending_mutations() {
+            let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
+            app.handle(event).unwrap();
+        }
+        assert_eq!(mux.with_state(|state| state.surfaces.len()), initial_surfaces + 1);
+
+        // The shortcut modal shows the configured display name.
+        assert_eq!(app.action_display_label(Action::user_command(0).unwrap()), "Sleeper");
+
+        for surface in mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>()) {
+            mux.close_surface(surface).unwrap();
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7119,7 +7119,18 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    let Ok(mut child) = command.spawn() else { return Vec::new() };
+    let Ok(mut child) = ({
+        // Spawn under the raise lock: a raise that wins the lock happens
+        // strictly before this spawn, so a retired worker cannot start an
+        // obsolete command; a spawn that wins is killed by the next tick.
+        let _spawn_guard = stop.lock.lock().unwrap();
+        if stop.is_raised() {
+            return Vec::new();
+        }
+        command.spawn()
+    }) else {
+        return Vec::new();
+    };
     let mut stdout = child.stdout.take();
     if let Some(pipe) = stdout.as_ref() {
         use std::os::fd::AsRawFd;
@@ -7236,7 +7247,16 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
         command.creation_flags(CREATE_SUSPENDED);
     }
-    let Ok(mut child) = command.spawn() else {
+    let Ok(mut child) = ({
+        // Spawn under the raise lock; see the Unix path for the ordering
+        // argument.
+        let _spawn_guard = stop.lock.lock().unwrap();
+        if stop.is_raised() {
+            let _ = std::fs::remove_file(&path);
+            return Vec::new();
+        }
+        command.spawn()
+    }) else {
         let _ = std::fs::remove_file(&path);
         return Vec::new();
     };

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7427,7 +7427,10 @@ fn resume_suspended_status_child(child: &std::process::Child) -> std::io::Result
 }
 
 /// Kill a status command and, on Unix, its whole process group so every
-/// descendant exits with it.
+/// descendant exits with it. Reaping is bounded: a child stuck in
+/// uninterruptible kernel I/O survives SIGKILL until the kernel releases
+/// it, and blocking on it would transitively hang reload and shutdown, so
+/// after the bound the child is left for reaping at process exit.
 fn kill_status_command_group(child: &mut std::process::Child) {
     #[cfg(unix)]
     // SAFETY: plain syscall on the child's own process group id.
@@ -7435,7 +7438,15 @@ fn kill_status_command_group(child: &mut std::process::Child) {
         libc::kill(-(child.id() as i32), libc::SIGKILL);
     }
     let _ = child.kill();
-    let _ = child.wait();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match child.try_wait() {
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => break,
+        }
+    }
 }
 
 /// Drop ESC-introduced sequences (CSI/OSC and two-byte escapes) and other

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6798,7 +6798,7 @@ pub struct App {
     status_outputs_generation: Arc<AtomicU64>,
     /// Resolved status segments, rebuilt only when the fingerprint of their
     /// inputs changes, so drawing does not re-expand templates every frame.
-    status_segments_cache: Option<(u64, ResolvedStatusSegments)>,
+    status_segments_cache: Option<(u64, Arc<ResolvedStatusSegments>)>,
 }
 
 struct QueuedDurableNotice {
@@ -6925,6 +6925,7 @@ fn run_status_segment_loop(
     stop: Arc<AtomicBool>,
 ) {
     const STATUS_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut pending_notify = false;
     while !stop.load(Ordering::Acquire) {
         let output = run_status_command(&argv, STATUS_COMMAND_TIMEOUT, &stop);
         if stop.load(Ordering::Acquire) {
@@ -6941,13 +6942,20 @@ fn run_status_segment_loop(
         };
         if changed {
             generation.fetch_add(1, Ordering::Release);
-            // A full or closed queue drops one poke; the next tick retries.
-            let _ = events.try_send(AppEvent::StatusCommandsUpdated);
+            pending_notify = true;
+        }
+        // A full queue cannot lose the update: the poke stays pending and
+        // retries every sleep slice until the event loop accepts it.
+        if pending_notify && events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
+            pending_notify = false;
         }
         let deadline = Instant::now() + interval;
         while Instant::now() < deadline {
             if stop.load(Ordering::Acquire) {
                 return;
+            }
+            if pending_notify && events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
+                pending_notify = false;
             }
             std::thread::sleep(
                 deadline.saturating_duration_since(Instant::now()).min(Duration::from_millis(200)),
@@ -7009,26 +7017,27 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
             }
         }
     }
+    let group = child.id() as i32;
     let deadline = Instant::now() + timeout;
     let mut captured: Vec<u8> = Vec::new();
     let mut exited = false;
     loop {
-        // Drain what is available. Once the cap is reached, stop reading:
-        // the pipe fills and throttles the child until timeout handling.
+        // Drain what is available, keeping only the bounded tail so the
+        // final line survives even when a command writes more than the cap.
         if let Some(pipe) = stdout.as_mut() {
             let mut chunk = [0u8; 4096];
             loop {
-                if captured.len() >= MAX_STATUS_OUTPUT_BYTES {
-                    break;
-                }
                 match pipe.read(&mut chunk) {
                     Ok(0) => {
                         stdout = None;
                         break;
                     }
                     Ok(read) => {
-                        let room = MAX_STATUS_OUTPUT_BYTES - captured.len();
-                        captured.extend_from_slice(&chunk[..read.min(room)]);
+                        captured.extend_from_slice(&chunk[..read]);
+                        if captured.len() > MAX_STATUS_OUTPUT_BYTES {
+                            let excess = captured.len() - MAX_STATUS_OUTPUT_BYTES;
+                            captured.drain(..excess);
+                        }
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
                     Err(_) => {
@@ -7053,14 +7062,20 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         }
         std::thread::sleep(STATUS_POLL_TICK);
     }
-    // Dropping `stdout` closes this side of the pipe, so no resource stays
-    // behind even when a descendant of the command is still alive.
+    // A status command must not outlive its collection: descendants that
+    // detached from the exited command (for example `cmd &`) would
+    // otherwise accumulate one per interval. Idempotent when the group is
+    // already gone.
+    // SAFETY: plain syscall on the spawned child's own process group id.
+    unsafe {
+        libc::kill(-group, libc::SIGKILL);
+    }
     captured
 }
 
 #[cfg(windows)]
 fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) -> Vec<u8> {
-    use std::io::Read;
+    use std::io::{Read, Seek, SeekFrom};
     use std::sync::atomic::AtomicU64;
 
     static CAPTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -7081,25 +7096,116 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         let _ = std::fs::remove_file(&path);
         return Vec::new();
     };
+    // The job's kill-on-close limit terminates the whole descendant tree
+    // when this function returns, mirroring the Unix process-group kill.
+    let job = StatusCommandJob::assign(&child);
     let deadline = Instant::now() + timeout;
     loop {
         if matches!(child.try_wait(), Ok(Some(_))) {
             break;
         }
         if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+            if let Ok(job) = job.as_ref() {
+                job.terminate();
+            }
             kill_status_command_group(&mut child);
             break;
         }
         std::thread::sleep(STATUS_POLL_TICK);
     }
+    drop(job);
     // A file read never blocks on writers, so lingering descendants cannot
-    // pin this call open.
+    // pin this call open. Read the bounded tail so the final line survives
+    // a command that writes more than the cap.
     let mut captured = Vec::new();
-    if let Ok(file) = std::fs::File::open(&path) {
+    if let Ok(mut file) = std::fs::File::open(&path) {
+        if let Ok(metadata) = file.metadata() {
+            let length = metadata.len();
+            let cap = MAX_STATUS_OUTPUT_BYTES as u64;
+            if length > cap {
+                let _ = file.seek(SeekFrom::Start(length - cap));
+            }
+        }
         let _ = file.take(MAX_STATUS_OUTPUT_BYTES as u64).read_to_end(&mut captured);
     }
     let _ = std::fs::remove_file(&path);
     captured
+}
+
+/// Windows job object with the kill-on-close limit, so every process a
+/// status command started dies when the capture returns. Same pattern as
+/// the journal hook runner in cmux-tui-core.
+#[cfg(windows)]
+struct StatusCommandJob {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl StatusCommandJob {
+    fn assign(child: &std::process::Child) -> std::io::Result<Self> {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            SetInformationJobObject,
+        };
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+        };
+
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(std::io::Error::last_os_error());
+        }
+        let job = Self { handle };
+        let mut information = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        information.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let information_size =
+            u32::try_from(std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                .expect("Windows job information fits in u32");
+        if unsafe {
+            SetInformationJobObject(
+                job.handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&information).cast(),
+                information_size,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        let process = unsafe { OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, child.id()) };
+        if process.is_null() {
+            return Err(std::io::Error::last_os_error());
+        }
+        let assigned = unsafe { AssignProcessToJobObject(job.handle, process) };
+        let assign_error = (assigned == 0).then(std::io::Error::last_os_error);
+        unsafe {
+            CloseHandle(process);
+        }
+        if let Some(error) = assign_error {
+            return Err(error);
+        }
+        Ok(job)
+    }
+
+    fn terminate(&self) {
+        use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+        unsafe {
+            TerminateJobObject(self.handle, 1);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for StatusCommandJob {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        // Kill-on-close terminates any remaining descendants here.
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
 }
 
 /// Kill a status command and, on Unix, its whole process group so every
@@ -12471,19 +12577,20 @@ impl App {
     /// latest output. The resolved result is cached against a fingerprint
     /// of every expansion input, so an ordinary draw reuses the previous
     /// strings instead of re-expanding templates.
-    pub(crate) fn resolved_status_segments(&mut self) -> ResolvedStatusSegments {
+    pub(crate) fn resolved_status_segments(&mut self) -> Arc<ResolvedStatusSegments> {
+        static EMPTY: std::sync::OnceLock<Arc<ResolvedStatusSegments>> = std::sync::OnceLock::new();
         if self.config.status_bar.left.is_empty() && self.config.status_bar.right.is_empty() {
-            return (Vec::new(), Vec::new());
+            return EMPTY.get_or_init(|| Arc::new((Vec::new(), Vec::new()))).clone();
         }
         let fingerprint = self.status_segments_fingerprint();
         if self.status_segments_cache.as_ref().map(|(cached, _)| *cached) != Some(fingerprint) {
-            let resolved = self.resolve_status_segments_now();
+            let resolved = Arc::new(self.resolve_status_segments_now());
             self.status_segments_cache = Some((fingerprint, resolved));
         }
         self.status_segments_cache
             .as_ref()
-            .map(|(_, resolved)| resolved.clone())
-            .unwrap_or_default()
+            .map(|(_, resolved)| Arc::clone(resolved))
+            .unwrap_or_else(|| EMPTY.get_or_init(|| Arc::new((Vec::new(), Vec::new()))).clone())
     }
 
     /// Allocation-free hash of every input `resolve_status_segments_now`
@@ -23381,7 +23488,8 @@ mod tests {
         }];
         app.status_command_outputs.lock().unwrap().insert(1, "widget".to_string());
 
-        let (left, right) = app.resolved_status_segments();
+        let segments = app.resolved_status_segments();
+        let (left, right) = (&segments.0, &segments.1);
         assert_eq!(left.len(), 1);
         assert!(
             left[0].text.contains(" work 1 "),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -46,6 +46,8 @@ use ghostty_vt::{
 };
 use ratatui::Terminal as RatatuiTerminal;
 use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::style::Color;
+use wait_timeout::ChildExt;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -213,6 +215,8 @@ enum AppEvent {
     BrowserResizeFailed(BrowserResizeFailure),
     GraphicsWriterReady,
     PtyFailuresReady,
+    /// A status bar command segment produced new output; redraw the bar.
+    StatusCommandsUpdated,
     PtyOperationFailed(PtyOperationFailure),
     ClearHistorySucceeded {
         surface: SurfaceId,
@@ -6780,6 +6784,11 @@ pub struct App {
     encoder: KeyEncoder,
     encode_buf: Vec<u8>,
     quit: bool,
+    /// Latest output per status-bar command segment, keyed by the segment's
+    /// combined left-then-right index. Written by the status command worker.
+    status_command_outputs: Arc<Mutex<HashMap<usize, String>>>,
+    /// Stop flag for the running status command worker, if any.
+    status_command_worker_stop: Option<Arc<AtomicBool>>,
 }
 
 struct QueuedDurableNotice {
@@ -6879,6 +6888,113 @@ fn clamp_rail_width(desired: u16, configured_max: u16, available: u16) -> Option
     // `then_some` evaluates eagerly and would clamp with min > max while the
     // outer terminal is still publishing its initial zero-width geometry.
     (effective_max >= MIN_RAIL_WIDTH).then(|| desired.clamp(MIN_RAIL_WIDTH, effective_max))
+}
+
+/// One status segment resolved for drawing.
+pub(crate) struct StatusSegmentView {
+    pub(crate) text: String,
+    pub(crate) fg: Option<Color>,
+    pub(crate) bg: Option<Color>,
+}
+
+/// Background worker for status bar command segments: runs each command on
+/// its interval, stores the last nonempty stdout line, and pokes the event
+/// loop when any output changed. Exits when the stop flag is set.
+fn run_status_command_worker(
+    commands: Vec<(usize, Vec<String>, Duration)>,
+    outputs: Arc<Mutex<HashMap<usize, String>>>,
+    events: SyncSender<AppEvent>,
+    stop: Arc<AtomicBool>,
+) {
+    const STATUS_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut due: Vec<Instant> = vec![Instant::now(); commands.len()];
+    while !stop.load(Ordering::Acquire) {
+        let now = Instant::now();
+        let mut changed = false;
+        for (slot, (index, argv, interval)) in commands.iter().enumerate() {
+            if now < due[slot] {
+                continue;
+            }
+            due[slot] = now + *interval;
+            let output = run_status_command(argv, STATUS_COMMAND_TIMEOUT);
+            let mut map = outputs.lock().unwrap();
+            if map.get(index) != Some(&output) {
+                map.insert(*index, output);
+                changed = true;
+            }
+        }
+        if changed {
+            // A full or closed queue drops one poke; the next tick retries.
+            let _ = events.try_send(AppEvent::StatusCommandsUpdated);
+        }
+        let next = due.iter().min().copied().unwrap_or(now);
+        let wait = next
+            .saturating_duration_since(Instant::now())
+            .clamp(Duration::from_millis(200), Duration::from_secs(1));
+        std::thread::sleep(wait);
+    }
+}
+
+/// Run one status command with a bounded runtime and return its last
+/// nonempty stdout line, stripped of escape sequences and length-capped.
+fn run_status_command(argv: &[String], timeout: Duration) -> String {
+    const MAX_STATUS_OUTPUT_CHARS: usize = 200;
+    let Some(program) = argv.first() else { return String::new() };
+    let mut command = std::process::Command::new(program);
+    command
+        .args(&argv[1..])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+    let Ok(mut child) = command.spawn() else { return String::new() };
+    if !matches!(child.wait_timeout(timeout), Ok(Some(_))) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    let mut text = String::new();
+    if let Some(stdout) = child.stdout.take() {
+        use std::io::Read;
+        let _ = stdout.take(64 * 1024).read_to_string(&mut text);
+    }
+    let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
+    strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
+}
+
+/// Drop ESC-introduced sequences (CSI/OSC and two-byte escapes) and other
+/// control characters so colored tool output degrades to its plain text.
+fn strip_escape_sequences(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '\u{1b}' {
+            match chars.next() {
+                Some('[') => {
+                    for terminator in chars.by_ref() {
+                        if ('@'..='~').contains(&terminator) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    while let Some(next) = chars.next() {
+                        if next == '\u{7}' {
+                            break;
+                        }
+                        if next == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if !character.is_control() {
+            result.push(character);
+        }
+    }
+    result
 }
 
 fn sidebar_layout_for(
@@ -8253,7 +8369,10 @@ fn run_with_machine_updates_inner(
         encoder,
         encode_buf: Vec::with_capacity(64),
         quit: false,
+        status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
+        status_command_worker_stop: None,
     };
+    app.ensure_status_command_worker();
     if app.session_available() {
         app.session.refresh_clients_background();
     }
@@ -12120,6 +12239,95 @@ impl App {
             help.scroll_offset = help.scroll_offset.min(help.max_scroll(help.rows.len()));
         }
         self.sidebar_followed_surface = None;
+        self.ensure_status_command_worker();
+    }
+
+    /// Stop any running status command worker and start a new one when the
+    /// visible status bar has command segments. Called at startup and after
+    /// every config reload.
+    fn ensure_status_command_worker(&mut self) {
+        if let Some(stop) = self.status_command_worker_stop.take() {
+            stop.store(true, Ordering::Release);
+        }
+        self.status_command_outputs.lock().unwrap().clear();
+        if !self.config.status_bar.visible || self.is_surface_only() {
+            return;
+        }
+        let commands = self.config.status_bar.command_segments();
+        if commands.is_empty() {
+            return;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = stop.clone();
+        let outputs = self.status_command_outputs.clone();
+        let events = self.app_events.clone();
+        if std::thread::Builder::new()
+            .name("status-commands".into())
+            .spawn(move || run_status_command_worker(commands, outputs, events, worker_stop))
+            .is_ok()
+        {
+            self.status_command_worker_stop = Some(stop);
+        }
+    }
+
+    /// Resolve the configured status segments to displayable text: literal
+    /// segments expand `{variable}`s, command segments read the worker's
+    /// latest output.
+    pub(crate) fn resolved_status_segments(
+        &self,
+    ) -> (Vec<StatusSegmentView>, Vec<StatusSegmentView>) {
+        let outputs = self.status_command_outputs.lock().unwrap();
+        let mut index = 0usize;
+        let mut resolve = |segments: &[crate::config::StatusSegment]| {
+            segments
+                .iter()
+                .map(|segment| {
+                    let text = match &segment.content {
+                        crate::config::StatusSegmentContent::Text(template) => {
+                            self.expand_status_template(template)
+                        }
+                        crate::config::StatusSegmentContent::Command { .. } => {
+                            outputs.get(&index).cloned().unwrap_or_default()
+                        }
+                    };
+                    index += 1;
+                    StatusSegmentView { text, fg: segment.fg, bg: segment.bg }
+                })
+                .collect::<Vec<_>>()
+        };
+        let left = resolve(&self.config.status_bar.left);
+        let right = resolve(&self.config.status_bar.right);
+        (left, right)
+    }
+
+    /// `{session}`, `{workspace}`, `{screen}`, `{screens}`, `{title}`, and
+    /// `{user}`. Unknown braces stay literal.
+    fn expand_status_template(&self, template: &str) -> String {
+        if !template.contains('{') {
+            return template.to_string();
+        }
+        let workspace = self.tree.active_workspace();
+        let workspace_name = workspace.map(|ws| ws.name.clone()).unwrap_or_default();
+        let screens = workspace.map(|ws| ws.screens.len()).unwrap_or(0);
+        let screen_name = workspace
+            .and_then(|ws| {
+                ws.screens.get(ws.active_screen).map(|screen| screen.display_name(ws.active_screen))
+            })
+            .unwrap_or_default();
+        let title = self
+            .tree
+            .active_screen()
+            .and_then(|screen| screen.pane(screen.active_pane))
+            .and_then(|pane| pane.tabs.get(pane.active_tab))
+            .map(|tab| tab.name.clone().unwrap_or_else(|| tab.title.clone()))
+            .unwrap_or_default();
+        template
+            .replace("{session}", &self.session_label)
+            .replace("{workspace}", &workspace_name)
+            .replace("{screen}", &screen_name)
+            .replace("{screens}", &screens.to_string())
+            .replace("{title}", &title)
+            .replace("{user}", &std::env::var("USER").unwrap_or_default())
     }
 
     fn focused_surface_cwd(&self) -> Option<PathBuf> {
@@ -13032,6 +13240,13 @@ impl App {
             AppEvent::MuxTitlesReady => {
                 Ok(if self.apply_mux_titles() { RenderAction::Paint } else { RenderAction::None })
             }
+            AppEvent::StatusCommandsUpdated => Ok(
+                if self.config.status_bar.visible && !self.is_surface_only() {
+                    RenderAction::Draw
+                } else {
+                    RenderAction::None
+                },
+            ),
             AppEvent::MuxSubscriptionRecovered {
                 recovery_generation,
                 destination_generation,
@@ -22832,6 +23047,67 @@ mod tests {
         assert!(mux.surface(hidden.id).is_some());
         mux.close_surface(attached.id).unwrap();
         mux.close_surface(hidden.id).unwrap();
+    }
+
+    #[test]
+    fn status_command_runner_returns_last_clean_line() {
+        let output = run_status_command(
+            &["/bin/sh".to_string(), "-c".to_string(), "printf 'one\\ntwo\\n\\n'".to_string()],
+            Duration::from_secs(5),
+        );
+        assert_eq!(output, "two", "the last nonempty line wins");
+        let colored = run_status_command(
+            &[
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf '\\033[31mred\\033[0m done'".to_string(),
+            ],
+            Duration::from_secs(5),
+        );
+        assert_eq!(colored, "red done", "escape sequences are stripped");
+        assert_eq!(
+            run_status_command(&["/nonexistent-status-cmd".to_string()], Duration::from_secs(1)),
+            "",
+            "spawn failures resolve to an empty segment"
+        );
+    }
+
+    #[test]
+    fn status_segments_expand_variables_and_read_command_outputs() {
+        let (mux, _surface) = test_mux("status-segments-test", None);
+        let (mut app, _events) = test_app_with_events(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        app.config.status_bar.left = vec![crate::config::StatusSegment {
+            content: crate::config::StatusSegmentContent::Text(
+                " {session} {workspace} {screens} ".to_string(),
+            ),
+            fg: None,
+            bg: None,
+        }];
+        app.config.status_bar.right = vec![crate::config::StatusSegment {
+            content: crate::config::StatusSegmentContent::Command {
+                argv: vec!["true".to_string()],
+                interval: Duration::from_secs(5),
+            },
+            fg: Some(Color::Indexed(114)),
+            bg: None,
+        }];
+        app.status_command_outputs.lock().unwrap().insert(1, "widget".to_string());
+
+        let (left, right) = app.resolved_status_segments();
+        assert_eq!(left.len(), 1);
+        assert!(
+            left[0].text.contains(" work 1 "),
+            "workspace and screen count expand: {:?}",
+            left[0].text
+        );
+        assert!(!left[0].text.contains('{'), "no unexpanded braces: {:?}", left[0].text);
+        assert_eq!(right[0].text, "widget", "command segments read the worker output");
+        assert_eq!(right[0].fg, Some(Color::Indexed(114)));
+
+        for surface in mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>()) {
+            mux.close_surface(surface).unwrap();
+        }
     }
 
     #[test]
@@ -39835,6 +40111,8 @@ mod tests {
             encoder: KeyEncoder::new().unwrap(),
             encode_buf: Vec::new(),
             quit: false,
+            status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
+            status_command_worker_stop: None,
         };
         (app, receiver)
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6910,22 +6910,32 @@ fn run_status_command_worker(
     let mut due: Vec<Instant> = vec![Instant::now(); commands.len()];
     while !stop.load(Ordering::Acquire) {
         let now = Instant::now();
-        let mut changed = false;
         for (slot, (index, argv, interval)) in commands.iter().enumerate() {
+            // Re-check between commands so a config reload retires this
+            // worker within at most one command runtime, not one full pass.
+            if stop.load(Ordering::Acquire) {
+                return;
+            }
             if now < due[slot] {
                 continue;
             }
             due[slot] = now + *interval;
             let output = run_status_command(argv, STATUS_COMMAND_TIMEOUT);
-            let mut map = outputs.lock().unwrap();
-            if map.get(index) != Some(&output) {
-                map.insert(*index, output);
-                changed = true;
+            let changed = {
+                let mut map = outputs.lock().unwrap();
+                if map.get(index) != Some(&output) {
+                    map.insert(*index, output);
+                    true
+                } else {
+                    false
+                }
+            };
+            if changed {
+                // Publish per command so one slow segment cannot hold back
+                // the others. A full or closed queue drops one poke; the
+                // next tick retries.
+                let _ = events.try_send(AppEvent::StatusCommandsUpdated);
             }
-        }
-        if changed {
-            // A full or closed queue drops one poke; the next tick retries.
-            let _ = events.try_send(AppEvent::StatusCommandsUpdated);
         }
         let next = due.iter().min().copied().unwrap_or(now);
         let wait = next
@@ -6965,23 +6975,17 @@ fn run_status_command(argv: &[String], timeout: Duration) -> String {
         })
     });
     if !matches!(child.wait_timeout(timeout), Ok(Some(_))) {
-        #[cfg(unix)]
-        // SAFETY: plain syscall on the child's own process group id.
-        unsafe {
-            libc::kill(-(child.id() as i32), libc::SIGKILL);
-        }
-        let _ = child.kill();
-        let _ = child.wait();
+        kill_status_command_group(&mut child);
     }
-    // The reader finishes when the pipe closes; the group kill above forces
-    // that on timeout. A grandchild that detached into its own group can
-    // still hold the pipe, so give up after a bounded grace instead of
-    // blocking the worker forever.
+    // The reader finishes when the pipe closes. If a descendant still holds
+    // stdout open after the command itself exited (for example `cmd &`),
+    // kill the whole group so the pipe closes and the reader can finish,
+    // instead of detaching a blocked thread per interval.
     let mut text = String::new();
     if let Some(handle) = reader {
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !handle.is_finished() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(20));
+        if !wait_for_reader(&handle, Duration::from_secs(2)) {
+            kill_status_command_group(&mut child);
+            wait_for_reader(&handle, Duration::from_millis(500));
         }
         if handle.is_finished()
             && let Ok(captured) = handle.join()
@@ -6991,6 +6995,34 @@ fn run_status_command(argv: &[String], timeout: Duration) -> String {
     }
     let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
     strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
+}
+
+/// The `USER` environment value, read once: template expansion runs on the
+/// draw path and the value cannot change within one process.
+fn cached_status_user() -> &'static str {
+    static USER: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    USER.get_or_init(|| std::env::var("USER").unwrap_or_default())
+}
+
+/// Poll a status reader thread until it finishes or the grace expires.
+fn wait_for_reader(handle: &JoinHandle<String>, grace: Duration) -> bool {
+    let deadline = Instant::now() + grace;
+    while !handle.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    handle.is_finished()
+}
+
+/// Kill a status command and, on Unix, its whole process group so every
+/// descendant holding the stdout pipe exits with it.
+fn kill_status_command_group(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    // SAFETY: plain syscall on the child's own process group id.
+    unsafe {
+        libc::kill(-(child.id() as i32), libc::SIGKILL);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// Drop ESC-introduced sequences (CSI/OSC and two-byte escapes) and other
@@ -12370,7 +12402,7 @@ impl App {
             .replace("{screen}", &screen_name)
             .replace("{screens}", &screens.to_string())
             .replace("{title}", &title)
-            .replace("{user}", &std::env::var("USER").unwrap_or_default())
+            .replace("{user}", cached_status_user())
     }
 
     fn focused_surface_cwd(&self) -> Option<PathBuf> {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6172,7 +6172,12 @@ fn full_pane_parts_for_layout(
     } else if stacked_headers.contains(&pane.id) {
         stacked_header_parts_for_virtual_rect(full_rect)?
     } else {
-        pane_parts_for_virtual_rect(full_rect, scrollbar_position, pane_padding, has_browser_omnibar)?
+        pane_parts_for_virtual_rect(
+            full_rect,
+            scrollbar_position,
+            pane_padding,
+            has_browser_omnibar,
+        )?
     };
     Some((surface_id, parts))
 }
@@ -6916,8 +6921,7 @@ fn sidebar_layout_for_state(
     let (width, height) = size;
     // The bottom row belongs to the screens status bar unless the user
     // hides it; a hidden bar gives the row back to the panes.
-    let content_height =
-        if config.status_bar.visible { height.saturating_sub(1) } else { height };
+    let content_height = if config.status_bar.visible { height.saturating_sub(1) } else { height };
     if !visible {
         return SidebarLayout {
             content: Rect { x: 0, y: 0, width, height: content_height },
@@ -7892,7 +7896,8 @@ fn run_with_machine_updates_inner(
             SidebarWidthOverrides::default(),
         )
         .content;
-        content_size_for_rect(pane, config.scrollbar.position, config.pane.padding).unwrap_or((1, 1))
+        content_size_for_rect(pane, config.scrollbar.position, config.pane.padding)
+            .unwrap_or((1, 1))
     });
     ensure_managed_workspace_guard(&session, machine_ui.as_ref())?;
     let initial_workspace_error = recover_initial_workspace_failure(
@@ -17189,8 +17194,12 @@ impl App {
         let has_omnibar = if area.surface == surface {
             area.omnibar.is_some()
         } else {
-            let (_, omnibar, _, _) =
-                pane_parts_for_rect(area.rect, self.config.scrollbar.position, self.config.pane.padding, true);
+            let (_, omnibar, _, _) = pane_parts_for_rect(
+                area.rect,
+                self.config.scrollbar.position,
+                self.config.pane.padding,
+                true,
+            );
             omnibar.is_some()
         };
         if !has_omnibar {
@@ -21553,13 +21562,13 @@ mod tests {
         WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
         browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
         canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
-        client_menu_item, clip_horizontal_rect, disable_host_keyboard_protocol,
-        enable_host_keyboard_protocol, forward_host_input, forward_mux_event, forward_mux_events,
-        keyboard_protocol_accepts, layout_undo_error_completion,
-        negotiate_host_keyboard_protocol_with, outer_cursor_escape, outer_cursor_escape_if_changed,
-        pane_area_projection_work, pane_context_menu_groups, pane_parts_for_rect,
-        prepare_ordered_session, preserve_client_view, rail_drag_width, rebuild_pane_areas,
-        record_surface_resize_dispatch_result, report_after_unwind,
+        client_menu_item, clip_horizontal_rect, content_size_for_rect,
+        disable_host_keyboard_protocol, enable_host_keyboard_protocol, forward_host_input,
+        forward_mux_event, forward_mux_events, keyboard_protocol_accepts,
+        layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
+        outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
+        pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
+        rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
         reset_pane_area_projection_work, should_claim_clear_history_shortcut, sidebar_layout_for,
         sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
         start_ordered_session, swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
@@ -26460,7 +26469,8 @@ mod tests {
     #[test]
     fn pane_padding_insets_content_and_keeps_at_least_one_cell() {
         let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
-        let (bar, _, content, track) = pane_parts_for_rect(rect, ScrollbarPosition::Column, 2, false);
+        let (bar, _, content, track) =
+            pane_parts_for_rect(rect, ScrollbarPosition::Column, 2, false);
         // Bar and track keep the border geometry; only content is inset.
         assert_eq!(bar, Some(Rect { x: 10, y: 4, width: 80, height: 1 }));
         assert_eq!(track, Some(Rect { x: 88, y: 5, width: 1, height: 22 }));
@@ -26657,7 +26667,10 @@ mod tests {
     #[test]
     fn browser_tab_size_hint_uses_omnibar_reduced_content() {
         let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
-        assert_eq!(browser_content_size_for_rect(rect, ScrollbarPosition::Column, 0), Some((77, 21)));
+        assert_eq!(
+            browser_content_size_for_rect(rect, ScrollbarPosition::Column, 0),
+            Some((77, 21))
+        );
     }
 
     #[test]
@@ -29498,8 +29511,12 @@ mod tests {
         app.replace_tree(app.session.tree());
 
         let rect = Rect { x: 0, y: 0, width: 80, height: 23 };
-        let (bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, app.config.scrollbar.position, app.config.pane.padding, false);
+        let (bar, omnibar, content, track) = pane_parts_for_rect(
+            rect,
+            app.config.scrollbar.position,
+            app.config.pane.padding,
+            false,
+        );
         app.sidebar_visible = false;
         app.sidebar_width = 0;
         app.content_area = rect;
@@ -29566,8 +29583,12 @@ mod tests {
         app.replace_tree(app.session.tree());
 
         let rect = Rect { x: 0, y: 0, width: 80, height: 23 };
-        let (bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, app.config.scrollbar.position, app.config.pane.padding, false);
+        let (bar, omnibar, content, track) = pane_parts_for_rect(
+            rect,
+            app.config.scrollbar.position,
+            app.config.pane.padding,
+            false,
+        );
         app.sidebar_visible = false;
         app.sidebar_width = 0;
         app.content_area = rect;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6937,8 +6937,12 @@ fn run_status_command_worker(
 
 /// Run one status command with a bounded runtime and return its last
 /// nonempty stdout line, stripped of escape sequences and length-capped.
+/// Stdout is drained concurrently so a chatty command never deadlocks on
+/// the pipe buffer, and on Unix the command runs in its own process group
+/// so a timeout kills the whole tree, which also forces stdout to close.
 fn run_status_command(argv: &[String], timeout: Duration) -> String {
     const MAX_STATUS_OUTPUT_CHARS: usize = 200;
+    const MAX_STATUS_OUTPUT_BYTES: u64 = 64 * 1024;
     let Some(program) = argv.first() else { return String::new() };
     let mut command = std::process::Command::new(program);
     command
@@ -6946,15 +6950,44 @@ fn run_status_command(argv: &[String], timeout: Duration) -> String {
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
     let Ok(mut child) = command.spawn() else { return String::new() };
+    let reader = child.stdout.take().map(|stdout| {
+        std::thread::spawn(move || {
+            use std::io::Read;
+            let mut text = String::new();
+            let _ = stdout.take(MAX_STATUS_OUTPUT_BYTES).read_to_string(&mut text);
+            text
+        })
+    });
     if !matches!(child.wait_timeout(timeout), Ok(Some(_))) {
+        #[cfg(unix)]
+        // SAFETY: plain syscall on the child's own process group id.
+        unsafe {
+            libc::kill(-(child.id() as i32), libc::SIGKILL);
+        }
         let _ = child.kill();
         let _ = child.wait();
     }
+    // The reader finishes when the pipe closes; the group kill above forces
+    // that on timeout. A grandchild that detached into its own group can
+    // still hold the pipe, so give up after a bounded grace instead of
+    // blocking the worker forever.
     let mut text = String::new();
-    if let Some(stdout) = child.stdout.take() {
-        use std::io::Read;
-        let _ = stdout.take(64 * 1024).read_to_string(&mut text);
+    if let Some(handle) = reader {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        if handle.is_finished()
+            && let Ok(captured) = handle.join()
+        {
+            text = captured;
+        }
     }
     let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
     strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
@@ -6990,7 +7023,9 @@ fn strip_escape_sequences(text: &str) -> String {
             }
             continue;
         }
-        if !character.is_control() {
+        if character == '\t' {
+            result.push(' ');
+        } else if !character.is_control() {
             result.push(character);
         }
     }
@@ -9526,6 +9561,9 @@ impl App {
     }
 
     fn shutdown_background_workers(&mut self) {
+        if let Some(stop) = self.status_command_worker_stop.take() {
+            stop.store(true, Ordering::Release);
+        }
         self.frontend_journal.stop_and_join();
         if let Some(mut updates) = self.machine_update_pump.take() {
             updates.stop_and_join();
@@ -12249,7 +12287,10 @@ impl App {
         if let Some(stop) = self.status_command_worker_stop.take() {
             stop.store(true, Ordering::Release);
         }
-        self.status_command_outputs.lock().unwrap().clear();
+        // A fresh map per worker: a stopped worker mid-command can only
+        // write into its own orphaned map, never under an index that now
+        // belongs to a different segment.
+        self.status_command_outputs = Arc::new(Mutex::new(HashMap::new()));
         if !self.config.status_bar.visible || self.is_surface_only() {
             return;
         }
@@ -12261,12 +12302,14 @@ impl App {
         let worker_stop = stop.clone();
         let outputs = self.status_command_outputs.clone();
         let events = self.app_events.clone();
-        if std::thread::Builder::new()
+        match std::thread::Builder::new()
             .name("status-commands".into())
             .spawn(move || run_status_command_worker(commands, outputs, events, worker_stop))
-            .is_ok()
         {
-            self.status_command_worker_stop = Some(stop);
+            Ok(_) => self.status_command_worker_stop = Some(stop),
+            Err(error) => {
+                eprintln!("cmux-tui: could not start the status command worker: {error}");
+            }
         }
     }
 
@@ -23069,6 +23112,22 @@ mod tests {
             run_status_command(&["/nonexistent-status-cmd".to_string()], Duration::from_secs(1)),
             "",
             "spawn failures resolve to an empty segment"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn status_command_timeout_kills_the_process_tree_and_keeps_partial_output() {
+        let started = Instant::now();
+        let output = run_status_command(
+            &["/bin/sh".to_string(), "-c".to_string(), "echo early; sleep 60".to_string()],
+            Duration::from_secs(1),
+        );
+        assert_eq!(output, "early", "output before the timeout survives the group kill");
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the runtime bound is real: {:?}",
+            started.elapsed()
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -21784,9 +21784,8 @@ mod tests {
         outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
         pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
         rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
-        reset_pane_area_projection_work, run_status_command,
-        should_claim_clear_history_shortcut, sidebar_layout_for,
-        sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
+        reset_pane_area_projection_work, run_status_command, should_claim_clear_history_shortcut,
+        sidebar_layout_for, sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
         start_ordered_session, swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
     };
@@ -24224,7 +24223,7 @@ mod tests {
 
         assert!(rendered.contains("isolated attach error"), "{rendered}");
         assert!(!rendered.contains("screens"), "{rendered}");
-        assert_eq!(terminal.backend().buffer()[(0, 7)].fg, ratatui::style::Color::Red);
+        assert_eq!(terminal.backend().buffer()[(0, 7)].fg, Color::Red);
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7033,25 +7033,47 @@ fn run_status_segment_loop(worker: StatusSegmentWorker) {
             generation.fetch_add(1, Ordering::Release);
             pending_notify = true;
         }
-        if pending_notify {
-            if poke.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok() {
-                if events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
-                    pending_notify = false;
-                } else {
-                    // A full queue cannot lose the update: release the poke
-                    // and retry on the next wake; the fingerprint also picks
-                    // the change up on any draw in the meantime.
-                    poke.store(false, Ordering::Release);
-                }
-            } else {
-                // Another worker's poke is already in flight; the draw it
-                // triggers reads the shared outputs and covers this change.
-                pending_notify = false;
+        try_send_status_poke(&poke, &events, &mut pending_notify);
+        // Sleep out the interval, but wake on a short cadence while a poke
+        // is still pending so a transiently full event queue delays the
+        // update by moments, not by the configured interval. The command
+        // itself never re-runs before its interval elapses.
+        let deadline = Instant::now() + interval;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
             }
+            let wait =
+                if pending_notify { remaining.min(Duration::from_millis(500)) } else { remaining };
+            if stop.wait_timeout(wait) {
+                return;
+            }
+            try_send_status_poke(&poke, &events, &mut pending_notify);
         }
-        if stop.wait_timeout(interval) {
-            return;
+    }
+}
+
+/// Attempt to deliver one coalesced status redraw poke. Clears
+/// `pending_notify` when this worker's poke was delivered or another
+/// worker's poke is already in flight (that draw reads the same shared
+/// outputs); releases the poke on a full queue so the retry stays possible.
+fn try_send_status_poke(
+    poke: &AtomicBool,
+    events: &SyncSender<AppEvent>,
+    pending_notify: &mut bool,
+) {
+    if !*pending_notify {
+        return;
+    }
+    if poke.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok() {
+        if events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
+            *pending_notify = false;
+        } else {
+            poke.store(false, Ordering::Release);
         }
+    } else {
+        *pending_notify = false;
     }
 }
 
@@ -7135,10 +7157,6 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
                     Ok(read) => {
                         drained += read;
                         captured.extend_from_slice(&chunk[..read]);
-                        if captured.len() > MAX_STATUS_OUTPUT_BYTES {
-                            let excess = captured.len() - MAX_STATUS_OUTPUT_BYTES;
-                            captured.drain(..excess);
-                        }
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
                     Err(_) => {
@@ -7146,6 +7164,12 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
                         break;
                     }
                 }
+            }
+            // Compact to the tail once per pass, not per chunk, so a
+            // continuously writing command costs one bounded copy here.
+            if captured.len() > MAX_STATUS_OUTPUT_BYTES {
+                let excess = captured.len() - MAX_STATUS_OUTPUT_BYTES;
+                captured.drain(..excess);
             }
         }
         if exited {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6975,7 +6975,9 @@ fn run_status_segment_loop(
 /// draw path and the value cannot change within one process.
 fn cached_status_user() -> &'static str {
     static USER: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    USER.get_or_init(|| std::env::var("USER").unwrap_or_default())
+    USER.get_or_init(|| {
+        std::env::var("USER").or_else(|_| std::env::var("USERNAME")).unwrap_or_default()
+    })
 }
 
 fn run_status_command(argv: &[String], timeout: Duration, stop: &AtomicBool) -> String {
@@ -7104,7 +7106,12 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         if matches!(child.try_wait(), Ok(Some(_))) {
             break;
         }
-        if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+        // Bound the file while the command runs: a spewing command is
+        // killed once the file passes the cap, so it cannot fill the
+        // temporary volume for the rest of the timeout.
+        let oversized = std::fs::metadata(&path)
+            .is_ok_and(|metadata| metadata.len() > MAX_STATUS_OUTPUT_BYTES as u64);
+        if oversized || stop.load(Ordering::Acquire) || Instant::now() >= deadline {
             if let Ok(job) = job.as_ref() {
                 job.terminate();
             }
@@ -9795,6 +9802,14 @@ impl App {
     fn shutdown_background_workers(&mut self) {
         if let Some(stop) = self.status_command_worker_stop.take() {
             stop.store(true, Ordering::Release);
+        }
+        // Join, so a status command's process group is reaped before exit.
+        // The capture loop observes the flag every poll tick, so each join
+        // is bounded by that tick.
+        for handle in
+            self.status_command_workers.drain(..).chain(self.retiring_status_workers.drain(..))
+        {
+            let _ = handle.join();
         }
         self.frontend_journal.stop_and_join();
         if let Some(mut updates) = self.machine_update_pump.take() {
@@ -23401,6 +23416,7 @@ mod tests {
         mux.close_surface(hidden.id).unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     fn status_command_runner_returns_last_clean_line() {
         let run = AtomicBool::new(false);
@@ -23505,6 +23521,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn user_command_action_runs_configured_argv_in_a_new_tab() {
         let (mux, _surface) = test_mux("user-command-run-test", None);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6786,8 +6786,11 @@ pub struct App {
     /// Latest output per status-bar command segment, keyed by the segment's
     /// combined left-then-right index. Written by the status command worker.
     status_command_outputs: Arc<Mutex<HashMap<usize, String>>>,
-    /// Stop flag for the running status segment workers, if any.
-    status_command_worker_stop: Option<Arc<AtomicBool>>,
+    /// Stop signal for the running status segment workers, if any.
+    status_command_worker_stop: Option<Arc<StatusWorkerStop>>,
+    /// Coalesces status redraw pokes across workers: set when an event is
+    /// in flight, cleared when the event loop consumes it.
+    status_poke_pending: Arc<AtomicBool>,
     /// One worker thread per configured status command segment.
     status_command_workers: Vec<JoinHandle<()>>,
     /// Stopped worker generations that have not finished yet; bounded, so
@@ -6911,24 +6914,72 @@ pub(crate) struct StatusSegmentView {
     pub(crate) bg: Option<Color>,
 }
 
+/// Shared stop signal for status workers. `raise` wakes idle waiters
+/// immediately, so retiring a worker never waits out a sleep interval, and
+/// an idle worker wakes once per interval instead of polling.
+struct StatusWorkerStop {
+    raised: AtomicBool,
+    lock: Mutex<()>,
+    condvar: Condvar,
+}
+
+impl StatusWorkerStop {
+    fn new() -> Self {
+        Self { raised: AtomicBool::new(false), lock: Mutex::new(()), condvar: Condvar::new() }
+    }
+
+    fn raise(&self) {
+        self.raised.store(true, Ordering::Release);
+        let _guard = self.lock.lock().unwrap();
+        self.condvar.notify_all();
+    }
+
+    fn is_raised(&self) -> bool {
+        self.raised.load(Ordering::Acquire)
+    }
+
+    /// Wait until raised or the duration elapses; returns whether raised.
+    fn wait_timeout(&self, duration: Duration) -> bool {
+        let deadline = Instant::now() + duration;
+        let mut guard = self.lock.lock().unwrap();
+        while !self.is_raised() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let (next, _) = self.condvar.wait_timeout(guard, remaining).unwrap();
+            guard = next;
+        }
+        self.is_raised()
+    }
+}
+
 /// Per-segment status worker: runs one command on its own interval, so one
 /// slow command never delays another segment, and publishes on change.
-/// The capture path checks the stop flag every poll tick, so a stopped
-/// worker exits within milliseconds, never one full command runtime.
-fn run_status_segment_loop(
+/// The capture path checks the stop flag every poll tick and the idle wait
+/// is condvar-based, so a stopped worker exits within milliseconds and an
+/// idle worker never busy-polls. The shared `poke` flag coalesces redraw
+/// events: when several segments change together, only one event is sent
+/// until the event loop consumes it.
+struct StatusSegmentWorker {
     index: usize,
     argv: Vec<String>,
     interval: Duration,
     outputs: Arc<Mutex<HashMap<usize, String>>>,
     generation: Arc<AtomicU64>,
+    poke: Arc<AtomicBool>,
     events: SyncSender<AppEvent>,
-    stop: Arc<AtomicBool>,
-) {
+    stop: Arc<StatusWorkerStop>,
+}
+
+fn run_status_segment_loop(worker: StatusSegmentWorker) {
     const STATUS_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+    let StatusSegmentWorker { index, argv, interval, outputs, generation, poke, events, stop } =
+        worker;
     let mut pending_notify = false;
-    while !stop.load(Ordering::Acquire) {
+    while !stop.is_raised() {
         let output = run_status_command(&argv, STATUS_COMMAND_TIMEOUT, &stop);
-        if stop.load(Ordering::Acquire) {
+        if stop.is_raised() {
             return;
         }
         let changed = {
@@ -6944,22 +6995,24 @@ fn run_status_segment_loop(
             generation.fetch_add(1, Ordering::Release);
             pending_notify = true;
         }
-        // A full queue cannot lose the update: the poke stays pending and
-        // retries every sleep slice until the event loop accepts it.
-        if pending_notify && events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
-            pending_notify = false;
-        }
-        let deadline = Instant::now() + interval;
-        while Instant::now() < deadline {
-            if stop.load(Ordering::Acquire) {
-                return;
-            }
-            if pending_notify && events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
+        if pending_notify {
+            if poke.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok() {
+                if events.try_send(AppEvent::StatusCommandsUpdated).is_ok() {
+                    pending_notify = false;
+                } else {
+                    // A full queue cannot lose the update: release the poke
+                    // and retry on the next wake; the fingerprint also picks
+                    // the change up on any draw in the meantime.
+                    poke.store(false, Ordering::Release);
+                }
+            } else {
+                // Another worker's poke is already in flight; the draw it
+                // triggers reads the shared outputs and covers this change.
                 pending_notify = false;
             }
-            std::thread::sleep(
-                deadline.saturating_duration_since(Instant::now()).min(Duration::from_millis(200)),
-            );
+        }
+        if stop.wait_timeout(interval) {
+            return;
         }
     }
 }
@@ -6980,7 +7033,7 @@ fn cached_status_user() -> &'static str {
     })
 }
 
-fn run_status_command(argv: &[String], timeout: Duration, stop: &AtomicBool) -> String {
+fn run_status_command(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> String {
     const MAX_STATUS_OUTPUT_CHARS: usize = 200;
     let captured = capture_status_output(argv, timeout, stop);
     let text = String::from_utf8_lossy(&captured);
@@ -6992,7 +7045,7 @@ const MAX_STATUS_OUTPUT_BYTES: usize = 64 * 1024;
 const STATUS_POLL_TICK: Duration = Duration::from_millis(25);
 
 #[cfg(unix)]
-fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) -> Vec<u8> {
+fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> Vec<u8> {
     use std::io::Read;
 
     let Some(program) = argv.first() else { return Vec::new() };
@@ -7065,7 +7118,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
             exited = true;
             continue;
         }
-        if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+        if stop.is_raised() || Instant::now() >= deadline {
             kill_status_command_group(&mut child);
             exited = true;
             continue;
@@ -7084,7 +7137,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
 }
 
 #[cfg(windows)]
-fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) -> Vec<u8> {
+fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorkerStop) -> Vec<u8> {
     use std::io::{Read, Seek, SeekFrom};
     use std::sync::atomic::AtomicU64;
 
@@ -7140,10 +7193,13 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         }
         // Bound the file while the command runs: a spewing command is
         // killed once the file passes the cap, so it cannot fill the
-        // temporary volume for the rest of the timeout.
+        // temporary volume for the rest of the timeout. The bound is
+        // enforced per poll tick, so up to one tick of disk throughput can
+        // land past the cap before the kill; the file is removed below
+        // either way.
         let oversized = std::fs::metadata(&path)
             .is_ok_and(|metadata| metadata.len() > MAX_STATUS_OUTPUT_BYTES as u64);
-        if oversized || stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+        if oversized || stop.is_raised() || Instant::now() >= deadline {
             job.terminate();
             kill_status_command_group(&mut child);
             break;
@@ -8722,6 +8778,7 @@ fn run_with_machine_updates_inner(
         quit: false,
         status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
         status_command_worker_stop: None,
+        status_poke_pending: Arc::new(AtomicBool::new(false)),
         status_command_workers: Vec::new(),
         retiring_status_workers: Vec::new(),
         status_outputs_generation: Arc::new(AtomicU64::new(0)),
@@ -9882,7 +9939,7 @@ impl App {
 
     fn shutdown_background_workers(&mut self) {
         if let Some(stop) = self.status_command_worker_stop.take() {
-            stop.store(true, Ordering::Release);
+            stop.raise();
         }
         // Join, so a status command's process group is reaped before exit.
         // The capture loop observes the flag every poll tick, so each join
@@ -12613,7 +12670,7 @@ impl App {
     /// every config reload.
     fn ensure_status_command_worker(&mut self) {
         if let Some(stop) = self.status_command_worker_stop.take() {
-            stop.store(true, Ordering::Release);
+            stop.raise();
         }
         // Stopped workers observe the flag at every capture poll tick, so
         // they exit within milliseconds. Keep their handles and enforce a
@@ -12632,6 +12689,7 @@ impl App {
         // belongs to a different segment.
         self.status_command_outputs = Arc::new(Mutex::new(HashMap::new()));
         self.status_outputs_generation = Arc::new(AtomicU64::new(1));
+        self.status_poke_pending = Arc::new(AtomicBool::new(false));
         self.status_segments_cache = None;
         if !self.config.status_bar.visible || self.is_surface_only() {
             return;
@@ -12640,23 +12698,25 @@ impl App {
         if commands.is_empty() {
             return;
         }
-        let stop = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(StatusWorkerStop::new());
         for (index, argv, interval) in commands {
             let outputs = self.status_command_outputs.clone();
             let generation = self.status_outputs_generation.clone();
+            let poke = self.status_poke_pending.clone();
             let events = self.app_events.clone();
             let worker_stop = stop.clone();
             match std::thread::Builder::new().name(format!("status-segment-{index}")).spawn(
                 move || {
-                    run_status_segment_loop(
+                    run_status_segment_loop(StatusSegmentWorker {
                         index,
                         argv,
                         interval,
                         outputs,
                         generation,
+                        poke,
                         events,
-                        worker_stop,
-                    );
+                        stop: worker_stop,
+                    });
                 },
             ) {
                 Ok(handle) => self.status_command_workers.push(handle),
@@ -13683,6 +13743,7 @@ impl App {
                 Ok(if self.apply_mux_titles() { RenderAction::Paint } else { RenderAction::None })
             }
             AppEvent::StatusCommandsUpdated => {
+                self.status_poke_pending.store(false, Ordering::Release);
                 Ok(if self.config.status_bar.visible && !self.is_surface_only() {
                     RenderAction::Draw
                 } else {
@@ -22218,10 +22279,10 @@ mod tests {
         RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SessionCompletion,
         SessionCompletionAction, SessionEventSender, ShortcutHelp, SidebarActionTarget,
         SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides,
-        StdoutLock, SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
-        TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
-        TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput,
-        VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
+        StatusWorkerStop, StdoutLock, SurfaceAttachClaimState, SurfaceResizeDecision,
+        SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer,
+        TerminalPointerAdmission, TerminalPointerAdmissionResult, TerminalPointerEncoding,
+        TextInput, VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
         WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
         browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
         canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
@@ -23500,7 +23561,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn status_command_runner_returns_last_clean_line() {
-        let run = AtomicBool::new(false);
+        let run = StatusWorkerStop::new();
         let output = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "printf 'one\\ntwo\\n\\n'".to_string()],
             Duration::from_secs(5),
@@ -23532,7 +23593,7 @@ mod tests {
     #[test]
     fn status_command_timeout_kills_the_process_tree_and_keeps_partial_output() {
         let started = Instant::now();
-        let run = AtomicBool::new(false);
+        let run = StatusWorkerStop::new();
         let output = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "echo early; sleep 60".to_string()],
             Duration::from_secs(1),
@@ -23548,7 +23609,8 @@ mod tests {
         // A raised stop flag makes the capture return within one poll tick
         // instead of running out the timeout, so config reloads and app
         // shutdown never wait on a slow command.
-        let stopped = AtomicBool::new(true);
+        let stopped = StatusWorkerStop::new();
+        stopped.raise();
         let started = Instant::now();
         let output = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "sleep 60".to_string()],
@@ -40606,6 +40668,7 @@ mod tests {
             quit: false,
             status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
             status_command_worker_stop: None,
+            status_poke_pending: Arc::new(AtomicBool::new(false)),
             status_command_workers: Vec::new(),
             retiring_status_workers: Vec::new(),
             status_outputs_generation: Arc::new(AtomicU64::new(0)),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6095,12 +6095,13 @@ type PaneParts<T> = (Option<T>, Option<T>, T, Option<T>);
 fn pane_parts_for_virtual_rect(
     rect: VirtualRect,
     scrollbar_position: ScrollbarPosition,
+    pane_padding: u16,
     has_browser_omnibar: bool,
 ) -> Option<PaneParts<VirtualRect>> {
     let local =
         Rect { x: 0, y: rect.y, width: u16::try_from(rect.width).ok()?, height: rect.height };
     let (bar, omnibar, content, track) =
-        pane_parts_for_rect(local, scrollbar_position, has_browser_omnibar);
+        pane_parts_for_rect(local, scrollbar_position, pane_padding, has_browser_omnibar);
     Some((
         bar.map(|part| virtualize_local_rect(rect.x, part)),
         omnibar.map(|part| virtualize_local_rect(rect.x, part)),
@@ -6127,6 +6128,7 @@ struct PaneAreaProjection<'a> {
     stacked_headers: &'a HashSet<PaneId>,
     area: Rect,
     scrollbar_position: ScrollbarPosition,
+    pane_padding: u16,
     surface_only: Option<SurfaceId>,
     viewport_offset: Option<u64>,
 }
@@ -6159,6 +6161,7 @@ fn full_pane_parts_for_layout(
     full_rect: VirtualRect,
     stacked_headers: &HashSet<PaneId>,
     scrollbar_position: ScrollbarPosition,
+    pane_padding: u16,
     surface_only: Option<SurfaceId>,
 ) -> Option<(SurfaceId, PaneParts<VirtualRect>)> {
     let surface_id = pane.active_surface()?;
@@ -6169,7 +6172,7 @@ fn full_pane_parts_for_layout(
     } else if stacked_headers.contains(&pane.id) {
         stacked_header_parts_for_virtual_rect(full_rect)?
     } else {
-        pane_parts_for_virtual_rect(full_rect, scrollbar_position, has_browser_omnibar)?
+        pane_parts_for_virtual_rect(full_rect, scrollbar_position, pane_padding, has_browser_omnibar)?
     };
     Some((surface_id, parts))
 }
@@ -6180,6 +6183,7 @@ fn pane_area_source(
     full_rect: VirtualRect,
     stacked_headers: &HashSet<PaneId>,
     scrollbar_position: ScrollbarPosition,
+    pane_padding: u16,
     surface_only: Option<SurfaceId>,
 ) -> Option<PaneAreaSource> {
     let (surface, (full_bar, full_omnibar, full_content, full_track)) = full_pane_parts_for_layout(
@@ -6187,6 +6191,7 @@ fn pane_area_source(
         full_rect,
         stacked_headers,
         scrollbar_position,
+        pane_padding,
         surface_only,
     )?;
     Some(PaneAreaSource {
@@ -6285,6 +6290,7 @@ fn swept_viewport_size_leases(
         stacked_headers,
         area,
         scrollbar_position,
+        pane_padding,
         surface_only,
         viewport_offset,
     } = projection;
@@ -6303,6 +6309,7 @@ fn swept_viewport_size_leases(
             full_rect,
             stacked_headers,
             scrollbar_position,
+            pane_padding,
             surface_only,
         ) else {
             continue;
@@ -6407,6 +6414,7 @@ fn rebuild_pane_areas(pane_areas: &mut Vec<PaneArea>, projection: PaneAreaProjec
         stacked_headers,
         area,
         scrollbar_position,
+        pane_padding,
         surface_only,
         viewport_offset,
     } = projection;
@@ -6424,6 +6432,7 @@ fn rebuild_pane_areas(pane_areas: &mut Vec<PaneArea>, projection: PaneAreaProjec
             full_rect,
             stacked_headers,
             scrollbar_position,
+            pane_padding,
             surface_only,
         ) else {
             continue;
@@ -6903,7 +6912,10 @@ fn sidebar_layout_for_state(
     previous: Option<&SidebarLayout>,
 ) -> SidebarLayout {
     let (width, height) = size;
-    let content_height = height.saturating_sub(1);
+    // The bottom row belongs to the screens status bar unless the user
+    // hides it; a hidden bar gives the row back to the panes.
+    let content_height =
+        if config.status_bar.visible { height.saturating_sub(1) } else { height };
     if !visible {
         return SidebarLayout {
             content: Rect { x: 0, y: 0, width, height: content_height },
@@ -7050,13 +7062,21 @@ fn rail_drag_width(config: &Config, layout: &SidebarLayout, kind: RailKind, x: u
     clamp_rail_width(desired, configured_max, available)
 }
 
-fn content_size_for_rect(rect: Rect, scrollbar: ScrollbarPosition) -> Option<(u16, u16)> {
-    let (_, _, content, _) = pane_parts_for_rect(rect, scrollbar, false);
+fn content_size_for_rect(
+    rect: Rect,
+    scrollbar: ScrollbarPosition,
+    padding: u16,
+) -> Option<(u16, u16)> {
+    let (_, _, content, _) = pane_parts_for_rect(rect, scrollbar, padding, false);
     (content.width > 0 && content.height > 0).then_some((content.width, content.height))
 }
 
-fn browser_content_size_for_rect(rect: Rect, scrollbar: ScrollbarPosition) -> Option<(u16, u16)> {
-    let (_, _, content, _) = pane_parts_for_rect(rect, scrollbar, true);
+fn browser_content_size_for_rect(
+    rect: Rect,
+    scrollbar: ScrollbarPosition,
+    padding: u16,
+) -> Option<(u16, u16)> {
+    let (_, _, content, _) = pane_parts_for_rect(rect, scrollbar, padding, true);
     (content.width > 0 && content.height > 0).then_some((content.width, content.height))
 }
 
@@ -7170,6 +7190,7 @@ fn clamp_split_ratio_for_tab_bars(root: &Node, split: SplitId, height: u16, requ
 fn pane_parts_for_rect(
     rect: Rect,
     scrollbar: ScrollbarPosition,
+    padding: u16,
     browser_omnibar: bool,
 ) -> PaneParts<Rect> {
     let (bar, mut content, track) = if rect.width > 2 && rect.height > 2 {
@@ -7201,6 +7222,16 @@ fn pane_parts_for_rect(
     } else {
         (None, rect, None)
     };
+    // Configured padding: blank cells between border and content, applied
+    // only while at least one content cell survives on that axis.
+    if content.width > 0 && content.height > 0 {
+        let pad_x = padding.min(content.width.saturating_sub(1) / 2);
+        let pad_y = padding.min(content.height.saturating_sub(1) / 2);
+        content.x = content.x.saturating_add(pad_x);
+        content.width = content.width.saturating_sub(pad_x.saturating_mul(2)).max(1);
+        content.y = content.y.saturating_add(pad_y);
+        content.height = content.height.saturating_sub(pad_y.saturating_mul(2)).max(1);
+    }
     let omnibar = if browser_omnibar && content.height >= 2 {
         let row = Rect { height: 1, ..content };
         content.y = content.y.saturating_add(1);
@@ -7859,7 +7890,7 @@ fn run_with_machine_updates_inner(
             SidebarWidthOverrides::default(),
         )
         .content;
-        content_size_for_rect(pane, config.scrollbar.position).unwrap_or((1, 1))
+        content_size_for_rect(pane, config.scrollbar.position, config.pane.padding).unwrap_or((1, 1))
     });
     ensure_managed_workspace_guard(&session, machine_ui.as_ref())?;
     let initial_workspace_error = recover_initial_workspace_failure(
@@ -9418,7 +9449,11 @@ impl App {
             return RenderAction::None;
         };
         let preparation = MachineSessionPreparation {
-            initial_size: content_size_for_rect(self.content_area, self.config.scrollbar.position),
+            initial_size: content_size_for_rect(
+                self.content_area,
+                self.config.scrollbar.position,
+                self.config.pane.padding,
+            ),
             default_colors: self.default_colors,
             generation: self.session_generation.wrapping_add(1).max(1),
             pty_input: self.pty_input.sender(),
@@ -12182,6 +12217,7 @@ impl App {
                 stacked_headers: &self.viewport_stacked_headers,
                 area: self.content_area,
                 scrollbar_position: self.config.scrollbar.position,
+                pane_padding: self.config.pane.padding,
                 surface_only: self.surface_only,
                 viewport_offset: Some(self.viewport_offset),
             });
@@ -12366,6 +12402,7 @@ impl App {
             stacked_headers: &layout.stacked_headers,
             area,
             scrollbar_position: self.config.scrollbar.position,
+            pane_padding: self.config.pane.padding,
             surface_only: self.surface_only,
             viewport_offset: viewport_enabled.then_some(self.viewport_offset),
         };
@@ -12398,6 +12435,7 @@ impl App {
                     stacked_headers: &layout.stacked_headers,
                     area,
                     scrollbar_position: self.config.scrollbar.position,
+                    pane_padding: self.config.pane.padding,
                     surface_only: self.surface_only,
                     viewport_offset: Some(self.viewport_offset),
                 },
@@ -14750,7 +14788,7 @@ impl App {
 
     /// Content size for a pane filling `rect`.
     fn size_of_rect(&self, rect: Rect) -> Option<(u16, u16)> {
-        content_size_for_rect(rect, self.config.scrollbar.position)
+        content_size_for_rect(rect, self.config.scrollbar.position, self.config.pane.padding)
     }
 
     /// Size hint for splitting `pane`: the second side of its rect.
@@ -17082,13 +17120,21 @@ impl App {
     fn browser_tab_size_hint(&self, pane: Option<PaneId>) -> Option<(u16, u16)> {
         match pane {
             Some(pane) => self.pane_areas.iter().find(|area| area.pane == pane).and_then(|area| {
-                browser_content_size_for_rect(area.logical_rect(), self.config.scrollbar.position)
+                browser_content_size_for_rect(
+                    area.logical_rect(),
+                    self.config.scrollbar.position,
+                    self.config.pane.padding,
+                )
             }),
             None => self
                 .active_pane()
                 .and_then(|pane| self.browser_tab_size_hint(Some(pane)))
                 .or_else(|| {
-                    browser_content_size_for_rect(self.content_area, self.config.scrollbar.position)
+                    browser_content_size_for_rect(
+                        self.content_area,
+                        self.config.scrollbar.position,
+                        self.config.pane.padding,
+                    )
                 }),
         }
     }
@@ -17142,7 +17188,7 @@ impl App {
             area.omnibar.is_some()
         } else {
             let (_, omnibar, _, _) =
-                pane_parts_for_rect(area.rect, self.config.scrollbar.position, true);
+                pane_parts_for_rect(area.rect, self.config.scrollbar.position, self.config.pane.padding, true);
             omnibar.is_some()
         };
         if !has_omnibar {
@@ -24653,6 +24699,7 @@ mod tests {
                 stacked_headers: &HashSet::new(),
                 area: Rect { x: 0, y: 0, width: 80, height: 24 },
                 scrollbar_position: ScrollbarPosition::Column,
+                pane_padding: 0,
                 surface_only: None,
                 viewport_offset: Some(0),
             },
@@ -24711,6 +24758,7 @@ mod tests {
                 stacked_headers: &HashSet::new(),
                 area: Rect { x: 0, y: 0, width: 80, height: 24 },
                 scrollbar_position: ScrollbarPosition::Column,
+                pane_padding: 0,
                 surface_only: None,
                 viewport_offset: Some(0),
             },
@@ -24850,6 +24898,7 @@ mod tests {
             stacked_headers: &stacked_headers,
             area,
             scrollbar_position: ScrollbarPosition::Column,
+            pane_padding: 0,
             surface_only: None,
             viewport_offset: Some(0),
         });
@@ -24892,6 +24941,7 @@ mod tests {
                     stacked_headers: &stacked_headers,
                     area,
                     scrollbar_position: ScrollbarPosition::Column,
+                    pane_padding: 0,
                     surface_only: None,
                     viewport_offset: Some(offset),
                 },
@@ -26399,10 +26449,40 @@ mod tests {
     fn browser_omnibar_reduces_content_rect_for_graphics_and_input() {
         let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
         let (_bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, ScrollbarPosition::Column, true);
+            pane_parts_for_rect(rect, ScrollbarPosition::Column, 0, true);
         assert_eq!(omnibar, Some(Rect { x: 11, y: 5, width: 77, height: 1 }));
         assert_eq!(content, Rect { x: 11, y: 6, width: 77, height: 21 });
         assert_eq!(track, Some(Rect { x: 88, y: 5, width: 1, height: 22 }));
+    }
+
+    #[test]
+    fn pane_padding_insets_content_and_keeps_at_least_one_cell() {
+        let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
+        let (bar, _, content, track) = pane_parts_for_rect(rect, ScrollbarPosition::Column, 2, false);
+        // Bar and track keep the border geometry; only content is inset.
+        assert_eq!(bar, Some(Rect { x: 10, y: 4, width: 80, height: 1 }));
+        assert_eq!(track, Some(Rect { x: 88, y: 5, width: 1, height: 22 }));
+        assert_eq!(content, Rect { x: 13, y: 7, width: 73, height: 18 });
+
+        // A tiny pane never pads itself out of existence.
+        let tiny = Rect { x: 0, y: 0, width: 5, height: 4 };
+        let (_, _, content, _) = pane_parts_for_rect(tiny, ScrollbarPosition::Border, 4, false);
+        assert!(content.width >= 1 && content.height >= 1, "content survived: {content:?}");
+
+        // Padded content sizes drive PTY sizing through the same helper.
+        assert_eq!(content_size_for_rect(rect, ScrollbarPosition::Column, 0), Some((77, 22)));
+        assert_eq!(content_size_for_rect(rect, ScrollbarPosition::Column, 2), Some((73, 18)));
+    }
+
+    #[test]
+    fn hidden_status_bar_gives_the_bottom_row_to_panes() {
+        let mut config = Config::default();
+        let overrides = SidebarWidthOverrides::default();
+        let visible = sidebar_layout_for(&config, true, false, false, (100, 30), overrides);
+        assert_eq!(visible.content.height, 29);
+        config.status_bar.visible = false;
+        let hidden = sidebar_layout_for(&config, true, false, false, (100, 30), overrides);
+        assert_eq!(hidden.content.height, 30);
     }
 
     #[test]
@@ -26541,7 +26621,7 @@ mod tests {
     fn browser_omnibar_degrades_gracefully_with_one_content_row() {
         let rect = Rect { x: 0, y: 0, width: 20, height: 3 };
         let (_bar, omnibar, content, _track) =
-            pane_parts_for_rect(rect, ScrollbarPosition::Border, true);
+            pane_parts_for_rect(rect, ScrollbarPosition::Border, 0, true);
         assert_eq!(omnibar, None);
         assert_eq!(content, Rect { x: 1, y: 1, width: 18, height: 1 });
     }
@@ -26551,7 +26631,7 @@ mod tests {
         for height in [1, 2] {
             let rect = Rect { x: 4, y: 5, width: 20, height };
             let (bar, omnibar, content, track) =
-                pane_parts_for_rect(rect, ScrollbarPosition::Border, false);
+                pane_parts_for_rect(rect, ScrollbarPosition::Border, 0, false);
 
             assert_eq!(bar, Some(Rect { height: 1, ..rect }));
             assert_eq!(omnibar, None);
@@ -26564,7 +26644,7 @@ mod tests {
     fn narrow_tall_pane_keeps_unboxed_terminal_content() {
         let rect = Rect { x: 4, y: 5, width: 2, height: 20 };
         let (bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, ScrollbarPosition::Border, false);
+            pane_parts_for_rect(rect, ScrollbarPosition::Border, 0, false);
 
         assert_eq!(bar, None);
         assert_eq!(omnibar, None);
@@ -26575,7 +26655,7 @@ mod tests {
     #[test]
     fn browser_tab_size_hint_uses_omnibar_reduced_content() {
         let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
-        assert_eq!(browser_content_size_for_rect(rect, ScrollbarPosition::Column), Some((77, 21)));
+        assert_eq!(browser_content_size_for_rect(rect, ScrollbarPosition::Column, 0), Some((77, 21)));
     }
 
     #[test]
@@ -29417,7 +29497,7 @@ mod tests {
 
         let rect = Rect { x: 0, y: 0, width: 80, height: 23 };
         let (bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, app.config.scrollbar.position, false);
+            pane_parts_for_rect(rect, app.config.scrollbar.position, app.config.pane.padding, false);
         app.sidebar_visible = false;
         app.sidebar_width = 0;
         app.content_area = rect;
@@ -29485,7 +29565,7 @@ mod tests {
 
         let rect = Rect { x: 0, y: 0, width: 80, height: 23 };
         let (bar, omnibar, content, track) =
-            pane_parts_for_rect(rect, app.config.scrollbar.position, false);
+            pane_parts_for_rect(rect, app.config.scrollbar.position, app.config.pane.padding, false);
         app.sidebar_visible = false;
         app.sidebar_width = 0;
         app.content_area = rect;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7026,15 +7026,23 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
     loop {
         // Drain what is available, keeping only the bounded tail so the
         // final line survives even when a command writes more than the cap.
+        // Each poll pass reads a bounded amount, so a command that writes
+        // continuously cannot keep this loop away from the stop, timeout,
+        // and exit checks below.
         if let Some(pipe) = stdout.as_mut() {
             let mut chunk = [0u8; 4096];
+            let mut drained = 0usize;
             loop {
+                if drained >= MAX_STATUS_OUTPUT_BYTES {
+                    break;
+                }
                 match pipe.read(&mut chunk) {
                     Ok(0) => {
                         stdout = None;
                         break;
                     }
                     Ok(read) => {
+                        drained += read;
                         captured.extend_from_slice(&chunk[..read]);
                         if captured.len() > MAX_STATUS_OUTPUT_BYTES {
                             let excess = captured.len() - MAX_STATUS_OUTPUT_BYTES;
@@ -7094,13 +7102,37 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(file))
         .stderr(std::process::Stdio::null());
+    // Start suspended so the job assignment below covers the process
+    // before it can spawn any descendant; resume only after assignment.
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+        command.creation_flags(CREATE_SUSPENDED);
+    }
     let Ok(mut child) = command.spawn() else {
         let _ = std::fs::remove_file(&path);
         return Vec::new();
     };
     // The job's kill-on-close limit terminates the whole descendant tree
     // when this function returns, mirroring the Unix process-group kill.
-    let job = StatusCommandJob::assign(&child);
+    // Fail closed: without a job there is no tree-kill guarantee, so the
+    // suspended child is discarded before it ever runs.
+    let job = match StatusCommandJob::assign(&child) {
+        Ok(job) => job,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&path);
+            return Vec::new();
+        }
+    };
+    if resume_suspended_status_child(&child).is_err() {
+        job.terminate();
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&path);
+        return Vec::new();
+    }
     let deadline = Instant::now() + timeout;
     loop {
         if matches!(child.try_wait(), Ok(Some(_))) {
@@ -7112,9 +7144,7 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) 
         let oversized = std::fs::metadata(&path)
             .is_ok_and(|metadata| metadata.len() > MAX_STATUS_OUTPUT_BYTES as u64);
         if oversized || stop.load(Ordering::Acquire) || Instant::now() >= deadline {
-            if let Ok(job) = job.as_ref() {
-                job.terminate();
-            }
+            job.terminate();
             kill_status_command_group(&mut child);
             break;
         }
@@ -7213,6 +7243,57 @@ impl Drop for StatusCommandJob {
             CloseHandle(self.handle);
         }
     }
+}
+
+/// Resume the suspended status command after its job assignment, same
+/// pattern as the journal hook runner in cmux-tui-core.
+#[cfg(windows)]
+fn resume_suspended_status_child(child: &std::process::Child) -> std::io::Result<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let result = (|| {
+        let mut thread_entry = THREADENTRY32 {
+            dwSize: u32::try_from(std::mem::size_of::<THREADENTRY32>())
+                .expect("Windows thread entry size fits in u32"),
+            ..THREADENTRY32::default()
+        };
+        if unsafe { Thread32First(snapshot, &mut thread_entry) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        loop {
+            if thread_entry.th32OwnerProcessID == child.id() {
+                let thread =
+                    unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, thread_entry.th32ThreadID) };
+                if thread.is_null() {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let resume_result = unsafe { ResumeThread(thread) };
+                let resume_error = (resume_result == u32::MAX).then(std::io::Error::last_os_error);
+                unsafe {
+                    CloseHandle(thread);
+                }
+                return resume_error.map_or(Ok(()), Err);
+            }
+            if unsafe { Thread32Next(snapshot, &mut thread_entry) } == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "suspended status command has no thread to resume",
+                ));
+            }
+        }
+    })();
+    unsafe {
+        CloseHandle(snapshot);
+    }
+    result
 }
 
 /// Kill a status command and, on Unix, its whole process group so every

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6223,6 +6223,7 @@ impl ViewportPaneAreaProjection {
             layout,
             stacked_headers,
             scrollbar_position,
+            pane_padding,
             surface_only,
             ..
         } = projection;
@@ -6246,6 +6247,7 @@ impl ViewportPaneAreaProjection {
                     full_rect,
                     stacked_headers,
                     scrollbar_position,
+                    pane_padding,
                     surface_only,
                 )
             },

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6787,8 +6787,13 @@ pub struct App {
     /// Latest output per status-bar command segment, keyed by the segment's
     /// combined left-then-right index. Written by the status command worker.
     status_command_outputs: Arc<Mutex<HashMap<usize, String>>>,
-    /// Stop flag for the running status command worker, if any.
+    /// Stop flag for the running status segment workers, if any.
     status_command_worker_stop: Option<Arc<AtomicBool>>,
+    /// One worker thread per configured status command segment.
+    status_command_workers: Vec<JoinHandle<()>>,
+    /// Stopped worker generations that have not finished yet; bounded, so
+    /// reload storms cannot stack live workers.
+    retiring_status_workers: Vec<JoinHandle<()>>,
 }
 
 struct QueuedDurableNotice {
@@ -6897,63 +6902,73 @@ pub(crate) struct StatusSegmentView {
     pub(crate) bg: Option<Color>,
 }
 
-/// Background worker for status bar command segments: runs each command on
-/// its interval, stores the last nonempty stdout line, and pokes the event
-/// loop when any output changed. Exits when the stop flag is set.
-fn run_status_command_worker(
-    commands: Vec<(usize, Vec<String>, Duration)>,
+/// Per-segment status worker: runs one command on its own interval, so one
+/// slow command never delays another segment, publishes on change, and
+/// keeps at most one outstanding blocked reader instead of stacking new
+/// runs behind a wedged descendant. Exits when the stop flag is set.
+fn run_status_segment_loop(
+    index: usize,
+    argv: Vec<String>,
+    interval: Duration,
     outputs: Arc<Mutex<HashMap<usize, String>>>,
     events: SyncSender<AppEvent>,
     stop: Arc<AtomicBool>,
 ) {
     const STATUS_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut due: Vec<Instant> = vec![Instant::now(); commands.len()];
+    let mut blocked_reader: Option<JoinHandle<String>> = None;
     while !stop.load(Ordering::Acquire) {
-        let now = Instant::now();
-        for (slot, (index, argv, interval)) in commands.iter().enumerate() {
-            // Re-check between commands so a config reload retires this
-            // worker within at most one command runtime, not one full pass.
+        match blocked_reader.take() {
+            Some(handle) if !handle.is_finished() => {
+                // The previous reader is still pinned open by a detached
+                // descendant. Keep exactly one outstanding reader for this
+                // segment and retry after the interval.
+                blocked_reader = Some(handle);
+            }
+            finished => {
+                if let Some(handle) = finished {
+                    let _ = handle.join();
+                }
+                let (output, stuck) = run_status_command(&argv, STATUS_COMMAND_TIMEOUT);
+                blocked_reader = stuck;
+                let changed = {
+                    let mut map = outputs.lock().unwrap();
+                    if map.get(&index) != Some(&output) {
+                        map.insert(index, output);
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if changed {
+                    // A full or closed queue drops one poke; the next tick
+                    // retries.
+                    let _ = events.try_send(AppEvent::StatusCommandsUpdated);
+                }
+            }
+        }
+        let deadline = Instant::now() + interval;
+        while Instant::now() < deadline {
             if stop.load(Ordering::Acquire) {
                 return;
             }
-            if now < due[slot] {
-                continue;
-            }
-            due[slot] = now + *interval;
-            let output = run_status_command(argv, STATUS_COMMAND_TIMEOUT);
-            let changed = {
-                let mut map = outputs.lock().unwrap();
-                if map.get(index) != Some(&output) {
-                    map.insert(*index, output);
-                    true
-                } else {
-                    false
-                }
-            };
-            if changed {
-                // Publish per command so one slow segment cannot hold back
-                // the others. A full or closed queue drops one poke; the
-                // next tick retries.
-                let _ = events.try_send(AppEvent::StatusCommandsUpdated);
-            }
+            std::thread::sleep(
+                deadline.saturating_duration_since(Instant::now()).min(Duration::from_millis(200)),
+            );
         }
-        let next = due.iter().min().copied().unwrap_or(now);
-        let wait = next
-            .saturating_duration_since(Instant::now())
-            .clamp(Duration::from_millis(200), Duration::from_secs(1));
-        std::thread::sleep(wait);
     }
 }
 
-/// Run one status command with a bounded runtime and return its last
-/// nonempty stdout line, stripped of escape sequences and length-capped.
+/// Run one status command with a bounded runtime. Returns its last nonempty
+/// stdout line, stripped of escape sequences and length-capped, plus the
+/// reader handle when a descendant that survived the group kill still pins
+/// the pipe open; the caller keeps at most one such reader per segment.
 /// Stdout is drained concurrently so a chatty command never deadlocks on
 /// the pipe buffer, and on Unix the command runs in its own process group
 /// so a timeout kills the whole tree, which also forces stdout to close.
-fn run_status_command(argv: &[String], timeout: Duration) -> String {
+fn run_status_command(argv: &[String], timeout: Duration) -> (String, Option<JoinHandle<String>>) {
     const MAX_STATUS_OUTPUT_CHARS: usize = 200;
     const MAX_STATUS_OUTPUT_BYTES: u64 = 64 * 1024;
-    let Some(program) = argv.first() else { return String::new() };
+    let Some(program) = argv.first() else { return (String::new(), None) };
     let mut command = std::process::Command::new(program);
     command
         .args(&argv[1..])
@@ -6965,7 +6980,7 @@ fn run_status_command(argv: &[String], timeout: Duration) -> String {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    let Ok(mut child) = command.spawn() else { return String::new() };
+    let Ok(mut child) = command.spawn() else { return (String::new(), None) };
     let reader = child.stdout.take().map(|stdout| {
         std::thread::spawn(move || {
             use std::io::Read;
@@ -6979,22 +6994,27 @@ fn run_status_command(argv: &[String], timeout: Duration) -> String {
     }
     // The reader finishes when the pipe closes. If a descendant still holds
     // stdout open after the command itself exited (for example `cmd &`),
-    // kill the whole group so the pipe closes and the reader can finish,
-    // instead of detaching a blocked thread per interval.
+    // kill the whole group so the pipe closes and the reader can finish.
     let mut text = String::new();
+    let mut stuck = None;
     if let Some(handle) = reader {
         if !wait_for_reader(&handle, Duration::from_secs(2)) {
             kill_status_command_group(&mut child);
             wait_for_reader(&handle, Duration::from_millis(500));
         }
-        if handle.is_finished()
-            && let Ok(captured) = handle.join()
-        {
-            text = captured;
+        if handle.is_finished() {
+            if let Ok(captured) = handle.join() {
+                text = captured;
+            }
+        } else {
+            // Only a descendant that started its own session can reach
+            // this: it survived the group kill and owns the pipe. Hand the
+            // reader back instead of detaching it.
+            stuck = Some(handle);
         }
     }
     let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
-    strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
+    (strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect(), stuck)
 }
 
 /// The `USER` environment value, read once: template expansion runs on the
@@ -8438,6 +8458,8 @@ fn run_with_machine_updates_inner(
         quit: false,
         status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
         status_command_worker_stop: None,
+        status_command_workers: Vec::new(),
+        retiring_status_workers: Vec::new(),
     };
     app.ensure_status_command_worker();
     if app.session_available() {
@@ -12319,7 +12341,18 @@ impl App {
         if let Some(stop) = self.status_command_worker_stop.take() {
             stop.store(true, Ordering::Release);
         }
-        // A fresh map per worker: a stopped worker mid-command can only
+        // Stopped workers exit within at most one command runtime. Keep
+        // their handles and enforce a hard bound, so reload storms cannot
+        // stack live worker generations; joining here happens only past the
+        // bound and blocks at most that one runtime.
+        const MAX_RETIRING_STATUS_WORKERS: usize = 8;
+        self.retiring_status_workers.append(&mut self.status_command_workers);
+        self.retiring_status_workers.retain(|handle| !handle.is_finished());
+        while self.retiring_status_workers.len() > MAX_RETIRING_STATUS_WORKERS {
+            let handle = self.retiring_status_workers.remove(0);
+            let _ = handle.join();
+        }
+        // A fresh map per generation: a stopped worker mid-command can only
         // write into its own orphaned map, never under an index that now
         // belongs to a different segment.
         self.status_command_outputs = Arc::new(Mutex::new(HashMap::new()));
@@ -12331,18 +12364,22 @@ impl App {
             return;
         }
         let stop = Arc::new(AtomicBool::new(false));
-        let worker_stop = stop.clone();
-        let outputs = self.status_command_outputs.clone();
-        let events = self.app_events.clone();
-        match std::thread::Builder::new()
-            .name("status-commands".into())
-            .spawn(move || run_status_command_worker(commands, outputs, events, worker_stop))
-        {
-            Ok(_) => self.status_command_worker_stop = Some(stop),
-            Err(error) => {
-                eprintln!("cmux-tui: could not start the status command worker: {error}");
+        for (index, argv, interval) in commands {
+            let outputs = self.status_command_outputs.clone();
+            let events = self.app_events.clone();
+            let worker_stop = stop.clone();
+            match std::thread::Builder::new().name(format!("status-segment-{index}")).spawn(
+                move || {
+                    run_status_segment_loop(index, argv, interval, outputs, events, worker_stop);
+                },
+            ) {
+                Ok(handle) => self.status_command_workers.push(handle),
+                Err(error) => {
+                    eprintln!("cmux-tui: could not start a status segment worker: {error}");
+                }
             }
         }
+        self.status_command_worker_stop = Some(stop);
     }
 
     /// Resolve the configured status segments to displayable text: literal
@@ -15155,6 +15192,12 @@ impl App {
     /// The server defaults the working directory to the pane's current
     /// directory when the command has no configured `cwd`.
     fn run_user_command(&mut self, index: usize, pane: Option<PaneId>) -> anyhow::Result<()> {
+        // `action_available` already rejects user commands for single-surface
+        // clients; keep the invariant local so no future route can create a
+        // tab this mode cannot reach.
+        if self.is_surface_only() {
+            return Ok(());
+        }
         let Some(command) = self.config.commands.get(index) else {
             return Ok(());
         };
@@ -23126,12 +23169,13 @@ mod tests {
 
     #[test]
     fn status_command_runner_returns_last_clean_line() {
-        let output = run_status_command(
+        let (output, stuck) = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "printf 'one\\ntwo\\n\\n'".to_string()],
             Duration::from_secs(5),
         );
         assert_eq!(output, "two", "the last nonempty line wins");
-        let colored = run_status_command(
+        assert!(stuck.is_none(), "a finished command leaves no blocked reader");
+        let (colored, _) = run_status_command(
             &[
                 "/bin/sh".to_string(),
                 "-c".to_string(),
@@ -23141,7 +23185,7 @@ mod tests {
         );
         assert_eq!(colored, "red done", "escape sequences are stripped");
         assert_eq!(
-            run_status_command(&["/nonexistent-status-cmd".to_string()], Duration::from_secs(1)),
+            run_status_command(&["/nonexistent-status-cmd".to_string()], Duration::from_secs(1)).0,
             "",
             "spawn failures resolve to an empty segment"
         );
@@ -23151,11 +23195,12 @@ mod tests {
     #[test]
     fn status_command_timeout_kills_the_process_tree_and_keeps_partial_output() {
         let started = Instant::now();
-        let output = run_status_command(
+        let (output, stuck) = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "echo early; sleep 60".to_string()],
             Duration::from_secs(1),
         );
         assert_eq!(output, "early", "output before the timeout survives the group kill");
+        assert!(stuck.is_none(), "the group kill closes the pipe and frees the reader");
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "the runtime bound is real: {:?}",
@@ -40204,6 +40249,8 @@ mod tests {
             quit: false,
             status_command_outputs: Arc::new(Mutex::new(HashMap::new())),
             status_command_worker_stop: None,
+            status_command_workers: Vec::new(),
+            retiring_status_workers: Vec::new(),
         };
         (app, receiver)
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -47,9 +47,9 @@ use ghostty_vt::{
 use ratatui::Terminal as RatatuiTerminal;
 use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::style::Color;
-use wait_timeout::ChildExt;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
+use wait_timeout::ChildExt;
 
 use crate::browser_input::{
     BrowserInputDispatcher, BrowserInputEvent, BrowserInputKind, BrowserKey, BrowserResizeFailure,
@@ -13240,13 +13240,13 @@ impl App {
             AppEvent::MuxTitlesReady => {
                 Ok(if self.apply_mux_titles() { RenderAction::Paint } else { RenderAction::None })
             }
-            AppEvent::StatusCommandsUpdated => Ok(
-                if self.config.status_bar.visible && !self.is_surface_only() {
+            AppEvent::StatusCommandsUpdated => {
+                Ok(if self.config.status_bar.visible && !self.is_surface_only() {
                     RenderAction::Draw
                 } else {
                     RenderAction::None
-                },
-            ),
+                })
+            }
             AppEvent::MuxSubscriptionRecovered {
                 recovery_generation,
                 destination_generation,
@@ -21784,7 +21784,8 @@ mod tests {
         outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
         pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
         rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
-        reset_pane_area_projection_work, should_claim_clear_history_shortcut, sidebar_layout_for,
+        reset_pane_area_projection_work, run_status_command,
+        should_claim_clear_history_shortcut, sidebar_layout_for,
         sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
         start_ordered_session, swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
@@ -21814,7 +21815,7 @@ mod tests {
     };
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
-    use ratatui::style::Modifier;
+    use ratatui::style::{Color, Modifier};
     use unicode_width::UnicodeWidthStr;
 
     use crate::browser_input::{BrowserInputDispatcher, BrowserInputEvent, BrowserInputKind};

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7143,10 +7143,18 @@ fn capture_status_output(argv: &[String], timeout: Duration, stop: &StatusWorker
         // continuously cannot keep this loop away from the stop, timeout,
         // and exit checks below.
         if let Some(pipe) = stdout.as_mut() {
+            // While the command runs, each pass reads a bounded amount so a
+            // continuous writer cannot keep the loop away from the stop and
+            // timeout checks. The final pass after exit drains what the pipe
+            // buffered (kernels allow enlarged pipes) so the documented last
+            // line is the real one; it stays finite so a lingering
+            // descendant cannot pin this loop either.
+            const EXIT_DRAIN_CAP: usize = 4 * 1024 * 1024;
+            let pass_cap = if exited { EXIT_DRAIN_CAP } else { MAX_STATUS_OUTPUT_BYTES };
             let mut chunk = [0u8; 4096];
             let mut drained = 0usize;
             loop {
-                if drained >= MAX_STATUS_OUTPUT_BYTES {
+                if drained >= pass_cap {
                     break;
                 }
                 match pipe.read(&mut chunk) {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -49,7 +49,6 @@ use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::style::Color;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
-use wait_timeout::ChildExt;
 
 use crate::browser_input::{
     BrowserInputDispatcher, BrowserInputEvent, BrowserInputKind, BrowserKey, BrowserResizeFailure,
@@ -6794,6 +6793,12 @@ pub struct App {
     /// Stopped worker generations that have not finished yet; bounded, so
     /// reload storms cannot stack live workers.
     retiring_status_workers: Vec<JoinHandle<()>>,
+    /// Bumped by segment workers when any command output changes; part of
+    /// the resolved-segment cache fingerprint.
+    status_outputs_generation: Arc<AtomicU64>,
+    /// Resolved status segments, rebuilt only when the fingerprint of their
+    /// inputs changes, so drawing does not re-expand templates every frame.
+    status_segments_cache: Option<(u64, ResolvedStatusSegments)>,
 }
 
 struct QueuedDurableNotice {
@@ -6895,7 +6900,11 @@ fn clamp_rail_width(desired: u16, configured_max: u16, available: u16) -> Option
     (effective_max >= MIN_RAIL_WIDTH).then(|| desired.clamp(MIN_RAIL_WIDTH, effective_max))
 }
 
+/// Resolved left and right status segments, in draw order.
+type ResolvedStatusSegments = (Vec<StatusSegmentView>, Vec<StatusSegmentView>);
+
 /// One status segment resolved for drawing.
+#[derive(Clone)]
 pub(crate) struct StatusSegmentView {
     pub(crate) text: String,
     pub(crate) fg: Option<Color>,
@@ -6903,48 +6912,37 @@ pub(crate) struct StatusSegmentView {
 }
 
 /// Per-segment status worker: runs one command on its own interval, so one
-/// slow command never delays another segment, publishes on change, and
-/// keeps at most one outstanding blocked reader instead of stacking new
-/// runs behind a wedged descendant. Exits when the stop flag is set.
+/// slow command never delays another segment, and publishes on change.
+/// The capture path checks the stop flag every poll tick, so a stopped
+/// worker exits within milliseconds, never one full command runtime.
 fn run_status_segment_loop(
     index: usize,
     argv: Vec<String>,
     interval: Duration,
     outputs: Arc<Mutex<HashMap<usize, String>>>,
+    generation: Arc<AtomicU64>,
     events: SyncSender<AppEvent>,
     stop: Arc<AtomicBool>,
 ) {
     const STATUS_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut blocked_reader: Option<JoinHandle<String>> = None;
     while !stop.load(Ordering::Acquire) {
-        match blocked_reader.take() {
-            Some(handle) if !handle.is_finished() => {
-                // The previous reader is still pinned open by a detached
-                // descendant. Keep exactly one outstanding reader for this
-                // segment and retry after the interval.
-                blocked_reader = Some(handle);
+        let output = run_status_command(&argv, STATUS_COMMAND_TIMEOUT, &stop);
+        if stop.load(Ordering::Acquire) {
+            return;
+        }
+        let changed = {
+            let mut map = outputs.lock().unwrap();
+            if map.get(&index) != Some(&output) {
+                map.insert(index, output);
+                true
+            } else {
+                false
             }
-            finished => {
-                if let Some(handle) = finished {
-                    let _ = handle.join();
-                }
-                let (output, stuck) = run_status_command(&argv, STATUS_COMMAND_TIMEOUT);
-                blocked_reader = stuck;
-                let changed = {
-                    let mut map = outputs.lock().unwrap();
-                    if map.get(&index) != Some(&output) {
-                        map.insert(index, output);
-                        true
-                    } else {
-                        false
-                    }
-                };
-                if changed {
-                    // A full or closed queue drops one poke; the next tick
-                    // retries.
-                    let _ = events.try_send(AppEvent::StatusCommandsUpdated);
-                }
-            }
+        };
+        if changed {
+            generation.fetch_add(1, Ordering::Release);
+            // A full or closed queue drops one poke; the next tick retries.
+            let _ = events.try_send(AppEvent::StatusCommandsUpdated);
         }
         let deadline = Instant::now() + interval;
         while Instant::now() < deadline {
@@ -6958,65 +6956,13 @@ fn run_status_segment_loop(
     }
 }
 
-/// Run one status command with a bounded runtime. Returns its last nonempty
-/// stdout line, stripped of escape sequences and length-capped, plus the
-/// reader handle when a descendant that survived the group kill still pins
-/// the pipe open; the caller keeps at most one such reader per segment.
-/// Stdout is drained concurrently so a chatty command never deadlocks on
-/// the pipe buffer, and on Unix the command runs in its own process group
-/// so a timeout kills the whole tree, which also forces stdout to close.
-fn run_status_command(argv: &[String], timeout: Duration) -> (String, Option<JoinHandle<String>>) {
-    const MAX_STATUS_OUTPUT_CHARS: usize = 200;
-    const MAX_STATUS_OUTPUT_BYTES: u64 = 64 * 1024;
-    let Some(program) = argv.first() else { return (String::new(), None) };
-    let mut command = std::process::Command::new(program);
-    command
-        .args(&argv[1..])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null());
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
-    let Ok(mut child) = command.spawn() else { return (String::new(), None) };
-    let reader = child.stdout.take().map(|stdout| {
-        std::thread::spawn(move || {
-            use std::io::Read;
-            let mut text = String::new();
-            let _ = stdout.take(MAX_STATUS_OUTPUT_BYTES).read_to_string(&mut text);
-            text
-        })
-    });
-    if !matches!(child.wait_timeout(timeout), Ok(Some(_))) {
-        kill_status_command_group(&mut child);
-    }
-    // The reader finishes when the pipe closes. If a descendant still holds
-    // stdout open after the command itself exited (for example `cmd &`),
-    // kill the whole group so the pipe closes and the reader can finish.
-    let mut text = String::new();
-    let mut stuck = None;
-    if let Some(handle) = reader {
-        if !wait_for_reader(&handle, Duration::from_secs(2)) {
-            kill_status_command_group(&mut child);
-            wait_for_reader(&handle, Duration::from_millis(500));
-        }
-        if handle.is_finished() {
-            if let Ok(captured) = handle.join() {
-                text = captured;
-            }
-        } else {
-            // Only a descendant that started its own session can reach
-            // this: it survived the group kill and owns the pipe. Hand the
-            // reader back instead of detaching it.
-            stuck = Some(handle);
-        }
-    }
-    let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
-    (strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect(), stuck)
-}
-
+/// Run one status command with a bounded runtime and return its last
+/// nonempty stdout line, stripped of escape sequences and length-capped.
+/// The capture path uses no reader thread: on Unix the pipe is
+/// non-blocking and drained from this loop while the child runs in its own
+/// process group (a timeout or stop kills the whole tree), and on Windows
+/// stdout goes to a temporary file, which reads without blocking on
+/// writers. Setting `stop` makes the call return within one poll tick.
 /// The `USER` environment value, read once: template expansion runs on the
 /// draw path and the value cannot change within one process.
 fn cached_status_user() -> &'static str {
@@ -7024,17 +6970,140 @@ fn cached_status_user() -> &'static str {
     USER.get_or_init(|| std::env::var("USER").unwrap_or_default())
 }
 
-/// Poll a status reader thread until it finishes or the grace expires.
-fn wait_for_reader(handle: &JoinHandle<String>, grace: Duration) -> bool {
-    let deadline = Instant::now() + grace;
-    while !handle.is_finished() && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(20));
+fn run_status_command(argv: &[String], timeout: Duration, stop: &AtomicBool) -> String {
+    const MAX_STATUS_OUTPUT_CHARS: usize = 200;
+    let captured = capture_status_output(argv, timeout, stop);
+    let text = String::from_utf8_lossy(&captured);
+    let line = text.lines().rev().find(|line| !line.trim().is_empty()).unwrap_or("").trim();
+    strip_escape_sequences(line).chars().take(MAX_STATUS_OUTPUT_CHARS).collect()
+}
+
+const MAX_STATUS_OUTPUT_BYTES: usize = 64 * 1024;
+const STATUS_POLL_TICK: Duration = Duration::from_millis(25);
+
+#[cfg(unix)]
+fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) -> Vec<u8> {
+    use std::io::Read;
+
+    let Some(program) = argv.first() else { return Vec::new() };
+    let mut command = std::process::Command::new(program);
+    command
+        .args(&argv[1..])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
     }
-    handle.is_finished()
+    let Ok(mut child) = command.spawn() else { return Vec::new() };
+    let mut stdout = child.stdout.take();
+    if let Some(pipe) = stdout.as_ref() {
+        use std::os::fd::AsRawFd;
+        // SAFETY: fcntl flag update on a pipe fd this function owns.
+        unsafe {
+            let fd = pipe.as_raw_fd();
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            if flags >= 0 {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+    }
+    let deadline = Instant::now() + timeout;
+    let mut captured: Vec<u8> = Vec::new();
+    let mut exited = false;
+    loop {
+        // Drain what is available. Once the cap is reached, stop reading:
+        // the pipe fills and throttles the child until timeout handling.
+        if let Some(pipe) = stdout.as_mut() {
+            let mut chunk = [0u8; 4096];
+            loop {
+                if captured.len() >= MAX_STATUS_OUTPUT_BYTES {
+                    break;
+                }
+                match pipe.read(&mut chunk) {
+                    Ok(0) => {
+                        stdout = None;
+                        break;
+                    }
+                    Ok(read) => {
+                        let room = MAX_STATUS_OUTPUT_BYTES - captured.len();
+                        captured.extend_from_slice(&chunk[..read.min(room)]);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(_) => {
+                        stdout = None;
+                        break;
+                    }
+                }
+            }
+        }
+        if exited {
+            break;
+        }
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            // One more drain pass picks up bytes written before exit.
+            exited = true;
+            continue;
+        }
+        if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+            kill_status_command_group(&mut child);
+            exited = true;
+            continue;
+        }
+        std::thread::sleep(STATUS_POLL_TICK);
+    }
+    // Dropping `stdout` closes this side of the pipe, so no resource stays
+    // behind even when a descendant of the command is still alive.
+    captured
+}
+
+#[cfg(windows)]
+fn capture_status_output(argv: &[String], timeout: Duration, stop: &AtomicBool) -> Vec<u8> {
+    use std::io::Read;
+    use std::sync::atomic::AtomicU64;
+
+    static CAPTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let Some(program) = argv.first() else { return Vec::new() };
+    let path = std::env::temp_dir().join(format!(
+        "cmux-status-{}-{}.out",
+        std::process::id(),
+        CAPTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    let Ok(file) = std::fs::File::create(&path) else { return Vec::new() };
+    let mut command = std::process::Command::new(program);
+    command
+        .args(&argv[1..])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(file))
+        .stderr(std::process::Stdio::null());
+    let Ok(mut child) = command.spawn() else {
+        let _ = std::fs::remove_file(&path);
+        return Vec::new();
+    };
+    let deadline = Instant::now() + timeout;
+    loop {
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            break;
+        }
+        if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+            kill_status_command_group(&mut child);
+            break;
+        }
+        std::thread::sleep(STATUS_POLL_TICK);
+    }
+    // A file read never blocks on writers, so lingering descendants cannot
+    // pin this call open.
+    let mut captured = Vec::new();
+    if let Ok(file) = std::fs::File::open(&path) {
+        let _ = file.take(MAX_STATUS_OUTPUT_BYTES as u64).read_to_end(&mut captured);
+    }
+    let _ = std::fs::remove_file(&path);
+    captured
 }
 
 /// Kill a status command and, on Unix, its whole process group so every
-/// descendant holding the stdout pipe exits with it.
+/// descendant exits with it.
 fn kill_status_command_group(child: &mut std::process::Child) {
     #[cfg(unix)]
     // SAFETY: plain syscall on the child's own process group id.
@@ -7047,6 +7116,7 @@ fn kill_status_command_group(child: &mut std::process::Child) {
 
 /// Drop ESC-introduced sequences (CSI/OSC and two-byte escapes) and other
 /// control characters so colored tool output degrades to its plain text.
+/// Tabs become single spaces.
 fn strip_escape_sequences(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     let mut chars = text.chars().peekable();
@@ -8460,6 +8530,8 @@ fn run_with_machine_updates_inner(
         status_command_worker_stop: None,
         status_command_workers: Vec::new(),
         retiring_status_workers: Vec::new(),
+        status_outputs_generation: Arc::new(AtomicU64::new(0)),
+        status_segments_cache: None,
     };
     app.ensure_status_command_worker();
     if app.session_available() {
@@ -12341,11 +12413,12 @@ impl App {
         if let Some(stop) = self.status_command_worker_stop.take() {
             stop.store(true, Ordering::Release);
         }
-        // Stopped workers exit within at most one command runtime. Keep
-        // their handles and enforce a hard bound, so reload storms cannot
-        // stack live worker generations; joining here happens only past the
-        // bound and blocks at most that one runtime.
-        const MAX_RETIRING_STATUS_WORKERS: usize = 8;
+        // Stopped workers observe the flag at every capture poll tick, so
+        // they exit within milliseconds. Keep their handles and enforce a
+        // hard bound anyway, so even a reload storm cannot stack live
+        // worker generations; a join past the bound is bounded by that same
+        // poll tick.
+        const MAX_RETIRING_STATUS_WORKERS: usize = 32;
         self.retiring_status_workers.append(&mut self.status_command_workers);
         self.retiring_status_workers.retain(|handle| !handle.is_finished());
         while self.retiring_status_workers.len() > MAX_RETIRING_STATUS_WORKERS {
@@ -12356,6 +12429,8 @@ impl App {
         // write into its own orphaned map, never under an index that now
         // belongs to a different segment.
         self.status_command_outputs = Arc::new(Mutex::new(HashMap::new()));
+        self.status_outputs_generation = Arc::new(AtomicU64::new(1));
+        self.status_segments_cache = None;
         if !self.config.status_bar.visible || self.is_surface_only() {
             return;
         }
@@ -12366,11 +12441,20 @@ impl App {
         let stop = Arc::new(AtomicBool::new(false));
         for (index, argv, interval) in commands {
             let outputs = self.status_command_outputs.clone();
+            let generation = self.status_outputs_generation.clone();
             let events = self.app_events.clone();
             let worker_stop = stop.clone();
             match std::thread::Builder::new().name(format!("status-segment-{index}")).spawn(
                 move || {
-                    run_status_segment_loop(index, argv, interval, outputs, events, worker_stop);
+                    run_status_segment_loop(
+                        index,
+                        argv,
+                        interval,
+                        outputs,
+                        generation,
+                        events,
+                        worker_stop,
+                    );
                 },
             ) {
                 Ok(handle) => self.status_command_workers.push(handle),
@@ -12384,10 +12468,53 @@ impl App {
 
     /// Resolve the configured status segments to displayable text: literal
     /// segments expand `{variable}`s, command segments read the worker's
-    /// latest output.
-    pub(crate) fn resolved_status_segments(
-        &self,
-    ) -> (Vec<StatusSegmentView>, Vec<StatusSegmentView>) {
+    /// latest output. The resolved result is cached against a fingerprint
+    /// of every expansion input, so an ordinary draw reuses the previous
+    /// strings instead of re-expanding templates.
+    pub(crate) fn resolved_status_segments(&mut self) -> ResolvedStatusSegments {
+        if self.config.status_bar.left.is_empty() && self.config.status_bar.right.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+        let fingerprint = self.status_segments_fingerprint();
+        if self.status_segments_cache.as_ref().map(|(cached, _)| *cached) != Some(fingerprint) {
+            let resolved = self.resolve_status_segments_now();
+            self.status_segments_cache = Some((fingerprint, resolved));
+        }
+        self.status_segments_cache
+            .as_ref()
+            .map(|(_, resolved)| resolved.clone())
+            .unwrap_or_default()
+    }
+
+    /// Allocation-free hash of every input `resolve_status_segments_now`
+    /// reads: command outputs (via the workers' change counter) plus the
+    /// interpolated session, workspace, screen, and title values.
+    fn status_segments_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.status_outputs_generation.load(Ordering::Acquire).hash(&mut hasher);
+        self.session_label.hash(&mut hasher);
+        if let Some(workspace) = self.tree.active_workspace() {
+            workspace.name.hash(&mut hasher);
+            workspace.screens.len().hash(&mut hasher);
+            workspace.active_screen.hash(&mut hasher);
+            if let Some(screen) = workspace.screens.get(workspace.active_screen) {
+                screen.name.hash(&mut hasher);
+            }
+        }
+        if let Some(tab) = self
+            .tree
+            .active_screen()
+            .and_then(|screen| screen.pane(screen.active_pane))
+            .and_then(|pane| pane.tabs.get(pane.active_tab))
+        {
+            tab.name.hash(&mut hasher);
+            tab.title.hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
+    fn resolve_status_segments_now(&self) -> ResolvedStatusSegments {
         let outputs = self.status_command_outputs.lock().unwrap();
         let mut index = 0usize;
         let mut resolve = |segments: &[crate::config::StatusSegment]| {
@@ -23169,23 +23296,29 @@ mod tests {
 
     #[test]
     fn status_command_runner_returns_last_clean_line() {
-        let (output, stuck) = run_status_command(
+        let run = AtomicBool::new(false);
+        let output = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "printf 'one\\ntwo\\n\\n'".to_string()],
             Duration::from_secs(5),
+            &run,
         );
         assert_eq!(output, "two", "the last nonempty line wins");
-        assert!(stuck.is_none(), "a finished command leaves no blocked reader");
-        let (colored, _) = run_status_command(
+        let colored = run_status_command(
             &[
                 "/bin/sh".to_string(),
                 "-c".to_string(),
                 "printf '\\033[31mred\\033[0m done'".to_string(),
             ],
             Duration::from_secs(5),
+            &run,
         );
         assert_eq!(colored, "red done", "escape sequences are stripped");
         assert_eq!(
-            run_status_command(&["/nonexistent-status-cmd".to_string()], Duration::from_secs(1)).0,
+            run_status_command(
+                &["/nonexistent-status-cmd".to_string()],
+                Duration::from_secs(1),
+                &run,
+            ),
             "",
             "spawn failures resolve to an empty segment"
         );
@@ -23195,15 +23328,33 @@ mod tests {
     #[test]
     fn status_command_timeout_kills_the_process_tree_and_keeps_partial_output() {
         let started = Instant::now();
-        let (output, stuck) = run_status_command(
+        let run = AtomicBool::new(false);
+        let output = run_status_command(
             &["/bin/sh".to_string(), "-c".to_string(), "echo early; sleep 60".to_string()],
             Duration::from_secs(1),
+            &run,
         );
         assert_eq!(output, "early", "output before the timeout survives the group kill");
-        assert!(stuck.is_none(), "the group kill closes the pipe and frees the reader");
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "the runtime bound is real: {:?}",
+            started.elapsed()
+        );
+
+        // A raised stop flag makes the capture return within one poll tick
+        // instead of running out the timeout, so config reloads and app
+        // shutdown never wait on a slow command.
+        let stopped = AtomicBool::new(true);
+        let started = Instant::now();
+        let output = run_status_command(
+            &["/bin/sh".to_string(), "-c".to_string(), "sleep 60".to_string()],
+            Duration::from_secs(60),
+            &stopped,
+        );
+        assert_eq!(output, "");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "stop preempts the timeout: {:?}",
             started.elapsed()
         );
     }
@@ -40251,6 +40402,8 @@ mod tests {
             status_command_worker_stop: None,
             status_command_workers: Vec::new(),
             retiring_status_workers: Vec::new(),
+            status_outputs_generation: Arc::new(AtomicU64::new(0)),
+            status_segments_cache: None,
         };
         (app, receiver)
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6906,6 +6906,44 @@ fn clamp_rail_width(desired: u16, configured_max: u16, available: u16) -> Option
 /// Resolved left and right status segments, in draw order.
 type ResolvedStatusSegments = (Vec<StatusSegmentView>, Vec<StatusSegmentView>);
 
+/// The values one status template expansion can interpolate.
+struct StatusTemplateValues<'a> {
+    session: &'a str,
+    workspace: &'a str,
+    screen: &'a str,
+    screens: &'a str,
+    title: &'a str,
+    user: &'a str,
+}
+
+/// Expand `{variable}` tokens in one left-to-right pass, so an inserted
+/// value is never rescanned: a workspace literally named `{screens}` stays
+/// `{screens}` in the output. Unknown tokens stay literal.
+fn expand_status_tokens(template: &str, values: &StatusTemplateValues<'_>) -> String {
+    let mut result = String::with_capacity(template.len() + 16);
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        result.push_str(&rest[..start]);
+        let candidate = &rest[start..];
+        let Some(end) = candidate.find('}') else {
+            result.push_str(candidate);
+            return result;
+        };
+        match &candidate[1..end] {
+            "session" => result.push_str(values.session),
+            "workspace" => result.push_str(values.workspace),
+            "screen" => result.push_str(values.screen),
+            "screens" => result.push_str(values.screens),
+            "title" => result.push_str(values.title),
+            "user" => result.push_str(values.user),
+            _ => result.push_str(&candidate[..=end]),
+        }
+        rest = &candidate[end + 1..];
+    }
+    result.push_str(rest);
+    result
+}
+
 /// One status segment resolved for drawing.
 #[derive(Clone)]
 pub(crate) struct StatusSegmentView {
@@ -12751,7 +12789,10 @@ impl App {
 
     /// Allocation-free hash of every input `resolve_status_segments_now`
     /// reads: command outputs (via the workers' change counter) plus the
-    /// interpolated session, workspace, screen, and title values.
+    /// interpolated session, workspace, screen, and title values. The
+    /// frequently-changing tab title participates only when a configured
+    /// template actually uses `{title}`, so ordinary title churn does not
+    /// rebuild fixed segments.
     fn status_segments_fingerprint(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -12765,16 +12806,27 @@ impl App {
                 screen.name.hash(&mut hasher);
             }
         }
-        if let Some(tab) = self
-            .tree
-            .active_screen()
-            .and_then(|screen| screen.pane(screen.active_pane))
-            .and_then(|pane| pane.tabs.get(pane.active_tab))
+        if self.status_templates_use("{title}")
+            && let Some(tab) = self
+                .tree
+                .active_screen()
+                .and_then(|screen| screen.pane(screen.active_pane))
+                .and_then(|pane| pane.tabs.get(pane.active_tab))
         {
             tab.name.hash(&mut hasher);
             tab.title.hash(&mut hasher);
         }
         hasher.finish()
+    }
+
+    /// Whether any configured literal status segment contains `token`.
+    fn status_templates_use(&self, token: &str) -> bool {
+        self.config.status_bar.left.iter().chain(self.config.status_bar.right.iter()).any(
+            |segment| match &segment.content {
+                crate::config::StatusSegmentContent::Text(template) => template.contains(token),
+                crate::config::StatusSegmentContent::Command { .. } => false,
+            },
+        )
     }
 
     fn resolve_status_segments_now(&self) -> ResolvedStatusSegments {
@@ -12810,7 +12862,7 @@ impl App {
         }
         let workspace = self.tree.active_workspace();
         let workspace_name = workspace.map(|ws| ws.name.clone()).unwrap_or_default();
-        let screens = workspace.map(|ws| ws.screens.len()).unwrap_or(0);
+        let screens = workspace.map(|ws| ws.screens.len()).unwrap_or(0).to_string();
         let screen_name = workspace
             .and_then(|ws| {
                 ws.screens.get(ws.active_screen).map(|screen| screen.display_name(ws.active_screen))
@@ -12823,13 +12875,17 @@ impl App {
             .and_then(|pane| pane.tabs.get(pane.active_tab))
             .map(|tab| tab.name.clone().unwrap_or_else(|| tab.title.clone()))
             .unwrap_or_default();
-        template
-            .replace("{session}", &self.session_label)
-            .replace("{workspace}", &workspace_name)
-            .replace("{screen}", &screen_name)
-            .replace("{screens}", &screens.to_string())
-            .replace("{title}", &title)
-            .replace("{user}", cached_status_user())
+        expand_status_tokens(
+            template,
+            &StatusTemplateValues {
+                session: &self.session_label,
+                workspace: &workspace_name,
+                screen: &screen_name,
+                screens: &screens,
+                title: &title,
+                user: cached_status_user(),
+            },
+        )
     }
 
     fn focused_surface_cwd(&self) -> Option<PathBuf> {
@@ -22279,20 +22335,21 @@ mod tests {
         RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SessionCompletion,
         SessionCompletionAction, SessionEventSender, ShortcutHelp, SidebarActionTarget,
         SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides,
-        StatusWorkerStop, StdoutLock, SurfaceAttachClaimState, SurfaceResizeDecision,
-        SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer,
-        TerminalPointerAdmission, TerminalPointerAdmissionResult, TerminalPointerEncoding,
-        TextInput, VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
-        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
-        browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
-        canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
-        client_menu_item, clip_horizontal_rect, content_size_for_rect,
-        disable_host_keyboard_protocol, enable_host_keyboard_protocol, forward_host_input,
-        forward_mux_event, forward_mux_events, keyboard_protocol_accepts,
-        layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
-        outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
-        pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
-        rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
+        StatusTemplateValues, StatusWorkerStop, StdoutLock, SurfaceAttachClaimState,
+        SurfaceResizeDecision, SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput,
+        TerminalPaintPacer, TerminalPointerAdmission, TerminalPointerAdmissionResult,
+        TerminalPointerEncoding, TextInput, VIEWPORT_ANIMATION_DURATION, ViewportMotion,
+        ViewportPaneAreaProjection, WorkspaceRailSelection, action_available_in_mode,
+        browser_content_size_for_rect, browser_frame_source_crop, browser_hover_forward_allowed,
+        browser_source_crop, canonical_terminal_content, catch_renderer_panic,
+        clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
+        content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
+        expand_status_tokens, forward_host_input, forward_mux_event, forward_mux_events,
+        keyboard_protocol_accepts, layout_undo_error_completion,
+        negotiate_host_keyboard_protocol_with, outer_cursor_escape, outer_cursor_escape_if_changed,
+        pane_area_projection_work, pane_context_menu_groups, pane_parts_for_rect,
+        prepare_ordered_session, preserve_client_view, rail_drag_width, rebuild_pane_areas,
+        record_surface_resize_dispatch_result, report_after_unwind,
         reset_pane_area_projection_work, run_status_command, should_claim_clear_history_shortcut,
         sidebar_layout_for, sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
         start_ordered_session, swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
@@ -23623,6 +23680,29 @@ mod tests {
             "stop preempts the timeout: {:?}",
             started.elapsed()
         );
+    }
+
+    #[test]
+    fn status_token_expansion_never_rescans_inserted_values() {
+        let values = StatusTemplateValues {
+            session: "s",
+            workspace: "{screens}",
+            screen: "main",
+            screens: "3",
+            title: "{user}",
+            user: "lawrence",
+        };
+        assert_eq!(
+            expand_status_tokens("{workspace} of {screens} · {title}", &values),
+            "{screens} of 3 · {user}",
+            "inserted values stay literal"
+        );
+        assert_eq!(
+            expand_status_tokens("{unknown} {session", &values),
+            "{unknown} {session",
+            "unknown tokens and unterminated braces stay literal"
+        );
+        assert_eq!(expand_status_tokens("plain", &values), "plain");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2580,15 +2580,17 @@ impl Keys {
 
     /// Bind one user-command chord, stealing the chord from any action or
     /// earlier command that held it. The prefix chord stays reserved.
-    fn bind_user_command_chord(&mut self, id: &str, action: Action, chord: Chord) {
+    /// Returns whether the chord was bound.
+    fn bind_user_command_chord(&mut self, id: &str, action: Action, chord: Chord) -> bool {
         if chord == self.prefix {
             eprintln!(
                 "cmux-tui: ignoring command binding {id:?} because it conflicts with the prefix"
             );
-            return;
+            return false;
         }
         self.bindings.retain(|(existing, _)| existing != &chord);
         self.bindings.push((chord, action));
+        true
     }
 
     /// Apply config overrides: `"prefix"` rebinds the prefix; any action
@@ -3414,8 +3416,11 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
                     );
                     continue;
                 };
-                keys.bind_user_command_chord(&id, action, chord);
-                bound += 1;
+                // Only a successful bind consumes the limit; rejected
+                // chords leave room for the valid ones after them.
+                if keys.bind_user_command_chord(&id, action, chord) {
+                    bound += 1;
+                }
             }
         }
         let name = command

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2796,7 +2796,7 @@ impl Default for StatusBarOptions {
 
 impl StatusBarOptions {
     /// Command segments in draw order: left side first, then right.
-    pub fn command_segments(&self) -> Vec<(usize, Vec<String>, std::time::Duration)> {
+    pub fn command_segments(&self) -> Vec<(usize, Vec<String>, Duration)> {
         self.left
             .iter()
             .chain(self.right.iter())
@@ -2826,7 +2826,7 @@ pub struct StatusSegment {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StatusSegmentContent {
     Text(String),
-    Command { argv: Vec<String>, interval: std::time::Duration },
+    Command { argv: Vec<String>, interval: Duration },
 }
 
 fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<StatusSegment> {
@@ -2856,7 +2856,7 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
                 let interval = segment.interval.unwrap_or(5).clamp(1, 3600);
                 StatusSegmentContent::Command {
                     argv,
-                    interval: std::time::Duration::from_secs(interval),
+                    interval: Duration::from_secs(interval),
                 }
             }
         };
@@ -7674,7 +7674,7 @@ mod tests {
             right[0].content,
             StatusSegmentContent::Command {
                 argv: vec!["date".to_string(), "+%H:%M".to_string()],
-                interval: std::time::Duration::from_secs(1),
+                interval: Duration::from_secs(1),
             },
             "interval clamps to at least one second"
         );

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -187,6 +187,10 @@ struct RawConfig {
     #[serde(default)]
     scrollbar: RawScrollbar,
     #[serde(default)]
+    pane: RawPane,
+    #[serde(default)]
+    status_bar: RawStatusBar,
+    #[serde(default)]
     viewport: RawViewport,
     #[serde(default)]
     server: RawServer,
@@ -203,6 +207,19 @@ struct RawConfig {
 struct RawServer {
     ws: Option<String>,
     ws_token: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPane {
+    /// Blank cells between the pane border and the terminal content.
+    padding: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawStatusBar {
+    visible: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -257,6 +274,7 @@ struct RawTheme {
     notification_info: Option<ColorValue>,
     notification_warning: Option<ColorValue>,
     notification_error: Option<ColorValue>,
+    border_style: Option<BorderStyle>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
@@ -705,6 +723,77 @@ impl ColorValue {
     }
 }
 
+/// Pane border line style. `None` keeps the border cells blank so panes
+/// separate by empty space; geometry is unchanged in every style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BorderStyle {
+    #[default]
+    Single,
+    Rounded,
+    Thick,
+    Double,
+    None,
+}
+
+/// The six glyphs a pane box is drawn with.
+#[derive(Debug, Clone, Copy)]
+pub struct BorderGlyphs {
+    pub horizontal: &'static str,
+    pub vertical: &'static str,
+    pub top_left: &'static str,
+    pub top_right: &'static str,
+    pub bottom_left: &'static str,
+    pub bottom_right: &'static str,
+}
+
+impl BorderStyle {
+    pub fn glyphs(self) -> BorderGlyphs {
+        match self {
+            BorderStyle::Single => BorderGlyphs {
+                horizontal: "─",
+                vertical: "│",
+                top_left: "┌",
+                top_right: "┐",
+                bottom_left: "└",
+                bottom_right: "┘",
+            },
+            BorderStyle::Rounded => BorderGlyphs {
+                horizontal: "─",
+                vertical: "│",
+                top_left: "╭",
+                top_right: "╮",
+                bottom_left: "╰",
+                bottom_right: "╯",
+            },
+            BorderStyle::Thick => BorderGlyphs {
+                horizontal: "━",
+                vertical: "┃",
+                top_left: "┏",
+                top_right: "┓",
+                bottom_left: "┗",
+                bottom_right: "┛",
+            },
+            BorderStyle::Double => BorderGlyphs {
+                horizontal: "═",
+                vertical: "║",
+                top_left: "╔",
+                top_right: "╗",
+                bottom_left: "╚",
+                bottom_right: "╝",
+            },
+            BorderStyle::None => BorderGlyphs {
+                horizontal: " ",
+                vertical: " ",
+                top_left: " ",
+                top_right: " ",
+                bottom_left: " ",
+                bottom_right: " ",
+            },
+        }
+    }
+}
+
 /// Resolved presentation colors used by the renderers.
 #[derive(Debug, Clone, Copy)]
 pub struct Theme {
@@ -722,6 +811,7 @@ pub struct Theme {
     pub notification_info: Color,
     pub notification_warning: Color,
     pub notification_error: Color,
+    pub border_style: BorderStyle,
 }
 
 impl Default for Theme {
@@ -740,6 +830,7 @@ impl Default for Theme {
             notification_info: Color::Indexed(110),
             notification_warning: Color::Indexed(179),
             notification_error: Color::Indexed(167),
+            border_style: BorderStyle::Single,
         }
     }
 }
@@ -2629,10 +2720,36 @@ pub struct Config {
     pub machines: Vec<MachineConfig>,
     pub browser: Browser,
     pub scrollbar: Scrollbar,
+    pub pane: PaneOptions,
+    pub status_bar: StatusBarOptions,
     pub viewport: Viewport,
     pub server: Server,
     pub keys: Keys,
     pub commands: Vec<UserCommandConfig>,
+}
+
+/// The maximum configurable pane padding, in cells per side.
+pub const MAX_PANE_PADDING: u16 = 4;
+
+/// Pane presentation options.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PaneOptions {
+    /// Blank cells between the pane border and the terminal content,
+    /// applied on every side, clamped to `MAX_PANE_PADDING`.
+    pub padding: u16,
+}
+
+/// Bottom screens-bar options. A hidden bar gives its row back to the
+/// panes; transient status messages still overlay the last row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusBarOptions {
+    pub visible: bool,
+}
+
+impl Default for StatusBarOptions {
+    fn default() -> Self {
+        Self { visible: true }
+    }
 }
 
 /// One resolved user command from the top-level `commands` section.
@@ -3084,6 +3201,15 @@ pub fn load() -> Config {
     }
     if let Some(position) = raw.scrollbar.position {
         config.scrollbar.position = position;
+    }
+    if let Some(style) = raw.theme.border_style {
+        config.theme.border_style = style;
+    }
+    if let Some(padding) = raw.pane.padding {
+        config.pane.padding = padding.min(MAX_PANE_PADDING);
+    }
+    if let Some(visible) = raw.status_bar.visible {
+        config.status_bar.visible = visible;
     }
     if let Some(animation) = raw.viewport.animation {
         config.viewport.animation = animation;
@@ -6590,7 +6716,8 @@ mod tests {
                     "selection_background": "#101010",
                     "sidebar_rail": 42,
                     "sidebar_active_bg": "#202020",
-                    "tab_bg": 44
+                    "tab_bg": 44,
+                    "border_style": "rounded"
                 },
                 "tabs": {"min_width": 9, "solid_background": false},
                 "sidebar": {
@@ -6638,6 +6765,8 @@ mod tests {
                     }
                 ],
                 "scrollbar": {"position": "border"},
+                "pane": {"padding": 9},
+                "status_bar": {"visible": false},
                 "viewport": {"animation": false},
                 "keys": {
                     "alt_shortcuts": false,
@@ -6733,6 +6862,9 @@ mod tests {
         assert_eq!(plugin.command, vec!["/tmp/sidebar-plugin", "--mode", "test"]);
         assert_eq!(plugin.cwd.as_deref(), Some("/tmp"));
         assert_eq!(config.scrollbar.position, ScrollbarPosition::Border);
+        assert_eq!(config.theme.border_style, BorderStyle::Rounded);
+        assert_eq!(config.pane.padding, MAX_PANE_PADDING, "padding clamps to the maximum");
+        assert!(!config.status_bar.visible);
         assert!(!config.viewport.animation);
         assert_eq!(
             config.keys.action_for(&KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
@@ -7345,6 +7477,34 @@ mod tests {
             "the prefix chord must not remain advertised as a modeless action"
         );
         assert_eq!(collision.shortcut_label(Action::SendPrefix).as_deref(), Some("Alt-n Alt-n"));
+    }
+
+    #[test]
+    fn border_style_parses_every_name_and_defaults_to_single() {
+        assert_eq!(Theme::default().border_style, BorderStyle::Single);
+        for (name, style) in [
+            ("single", BorderStyle::Single),
+            ("rounded", BorderStyle::Rounded),
+            ("thick", BorderStyle::Thick),
+            ("double", BorderStyle::Double),
+            ("none", BorderStyle::None),
+        ] {
+            let raw: RawConfig =
+                serde_json::from_str(&format!(r#"{{"theme":{{"border_style":"{name}"}}}}"#))
+                    .unwrap();
+            assert_eq!(raw.theme.border_style, Some(style), "{name} did not parse");
+        }
+        let hidden = BorderStyle::None.glyphs();
+        for glyph in [
+            hidden.horizontal,
+            hidden.vertical,
+            hidden.top_left,
+            hidden.top_right,
+            hidden.bottom_left,
+            hidden.bottom_right,
+        ] {
+            assert_eq!(glyph, " ");
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2850,14 +2850,13 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
                 let argv: Vec<String> =
                     run.into_iter().filter(|argument| !argument.is_empty()).collect();
                 if argv.is_empty() {
-                    eprintln!("cmux-tui: ignoring status_bar.{side} segment with an empty run argv");
+                    eprintln!(
+                        "cmux-tui: ignoring status_bar.{side} segment with an empty run argv"
+                    );
                     continue;
                 }
                 let interval = segment.interval.unwrap_or(5).clamp(1, 3600);
-                StatusSegmentContent::Command {
-                    argv,
-                    interval: Duration::from_secs(interval),
-                }
+                StatusSegmentContent::Command { argv, interval: Duration::from_secs(interval) }
             }
         };
         segments.push(StatusSegment {
@@ -7679,11 +7678,7 @@ mod tests {
             "interval clamps to at least one second"
         );
 
-        let options = StatusBarOptions {
-            left,
-            right,
-            ..StatusBarOptions::default()
-        };
+        let options = StatusBarOptions { left, right, ..StatusBarOptions::default() };
         let commands = options.command_segments();
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].0, 1, "command index counts left segments first");

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -220,6 +220,23 @@ struct RawPane {
 #[serde(deny_unknown_fields)]
 struct RawStatusBar {
     visible: Option<bool>,
+    show_screens: Option<bool>,
+    show_session: Option<bool>,
+    left: Option<Vec<RawStatusSegment>>,
+    right: Option<Vec<RawStatusSegment>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawStatusSegment {
+    /// Literal text with `{variable}` interpolation.
+    text: Option<String>,
+    /// Argv run on an interval; the last stdout line replaces the segment.
+    run: Option<Vec<String>>,
+    /// Refresh interval in seconds for `run` segments.
+    interval: Option<u64>,
+    fg: Option<ColorValue>,
+    bg: Option<ColorValue>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -275,6 +292,9 @@ struct RawTheme {
     notification_warning: Option<ColorValue>,
     notification_error: Option<ColorValue>,
     border_style: Option<BorderStyle>,
+    status_bg: Option<ColorValue>,
+    status_fg: Option<ColorValue>,
+    dim_inactive: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
@@ -812,6 +832,11 @@ pub struct Theme {
     pub notification_warning: Color,
     pub notification_error: Color,
     pub border_style: BorderStyle,
+    /// Status bar background/foreground; `None` follows the chrome theme.
+    pub status_bg: Option<Color>,
+    pub status_fg: Option<Color>,
+    /// Render unfocused terminal panes with the DIM attribute.
+    pub dim_inactive: bool,
 }
 
 impl Default for Theme {
@@ -831,6 +856,9 @@ impl Default for Theme {
             notification_warning: Color::Indexed(179),
             notification_error: Color::Indexed(167),
             border_style: BorderStyle::Single,
+            status_bg: None,
+            status_fg: None,
+            dim_inactive: false,
         }
     }
 }
@@ -2741,15 +2769,104 @@ pub struct PaneOptions {
 
 /// Bottom screens-bar options. A hidden bar gives its row back to the
 /// panes; transient status messages still overlay the last row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusBarOptions {
     pub visible: bool,
+    /// Renders the clickable screens strip.
+    pub show_screens: bool,
+    /// Renders the right-aligned session label when no message is shown.
+    pub show_session: bool,
+    /// Segments before the screens strip.
+    pub left: Vec<StatusSegment>,
+    /// Segments right-aligned before the session label.
+    pub right: Vec<StatusSegment>,
 }
 
 impl Default for StatusBarOptions {
     fn default() -> Self {
-        Self { visible: true }
+        Self {
+            visible: true,
+            show_screens: true,
+            show_session: true,
+            left: Vec::new(),
+            right: Vec::new(),
+        }
     }
+}
+
+impl StatusBarOptions {
+    /// Command segments in draw order: left side first, then right.
+    pub fn command_segments(&self) -> Vec<(usize, Vec<String>, std::time::Duration)> {
+        self.left
+            .iter()
+            .chain(self.right.iter())
+            .enumerate()
+            .filter_map(|(index, segment)| match &segment.content {
+                StatusSegmentContent::Command { argv, interval } => {
+                    Some((index, argv.clone(), *interval))
+                }
+                StatusSegmentContent::Text(_) => None,
+            })
+            .collect()
+    }
+}
+
+/// The maximum number of configured segments per status bar side.
+pub const MAX_STATUS_SEGMENTS: usize = 8;
+
+/// One status bar segment: literal text with `{variable}` interpolation, or
+/// a command whose last stdout line becomes the segment text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusSegment {
+    pub content: StatusSegmentContent,
+    pub fg: Option<Color>,
+    pub bg: Option<Color>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatusSegmentContent {
+    Text(String),
+    Command { argv: Vec<String>, interval: std::time::Duration },
+}
+
+fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<StatusSegment> {
+    let mut segments = Vec::new();
+    for segment in raw {
+        if segments.len() >= MAX_STATUS_SEGMENTS {
+            eprintln!(
+                "cmux-tui: ignoring status_bar.{side} segments beyond the {MAX_STATUS_SEGMENTS}-segment limit"
+            );
+            break;
+        }
+        let content = match (segment.text, segment.run) {
+            (Some(_), Some(_)) | (None, None) => {
+                eprintln!(
+                    "cmux-tui: ignoring status_bar.{side} segment: exactly one of text or run is required"
+                );
+                continue;
+            }
+            (Some(text), None) => StatusSegmentContent::Text(text),
+            (None, Some(run)) => {
+                let argv: Vec<String> =
+                    run.into_iter().filter(|argument| !argument.is_empty()).collect();
+                if argv.is_empty() {
+                    eprintln!("cmux-tui: ignoring status_bar.{side} segment with an empty run argv");
+                    continue;
+                }
+                let interval = segment.interval.unwrap_or(5).clamp(1, 3600);
+                StatusSegmentContent::Command {
+                    argv,
+                    interval: std::time::Duration::from_secs(interval),
+                }
+            }
+        };
+        segments.push(StatusSegment {
+            content,
+            fg: segment.fg.as_ref().and_then(ColorValue::to_color),
+            bg: segment.bg.as_ref().and_then(ColorValue::to_color),
+        });
+    }
+    segments
 }
 
 /// One resolved user command from the top-level `commands` section.
@@ -3205,11 +3322,32 @@ pub fn load() -> Config {
     if let Some(style) = raw.theme.border_style {
         config.theme.border_style = style;
     }
+    if let Some(c) = raw.theme.status_bg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.status_bg = Some(c);
+    }
+    if let Some(c) = raw.theme.status_fg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.status_fg = Some(c);
+    }
+    if let Some(dim) = raw.theme.dim_inactive {
+        config.theme.dim_inactive = dim;
+    }
     if let Some(padding) = raw.pane.padding {
         config.pane.padding = padding.min(MAX_PANE_PADDING);
     }
     if let Some(visible) = raw.status_bar.visible {
         config.status_bar.visible = visible;
+    }
+    if let Some(show_screens) = raw.status_bar.show_screens {
+        config.status_bar.show_screens = show_screens;
+    }
+    if let Some(show_session) = raw.status_bar.show_session {
+        config.status_bar.show_session = show_session;
+    }
+    if let Some(left) = raw.status_bar.left {
+        config.status_bar.left = resolve_status_segments(left, "left");
+    }
+    if let Some(right) = raw.status_bar.right {
+        config.status_bar.right = resolve_status_segments(right, "right");
     }
     if let Some(animation) = raw.viewport.animation {
         config.viewport.animation = animation;
@@ -7505,6 +7643,58 @@ mod tests {
         ] {
             assert_eq!(glyph, " ");
         }
+    }
+
+    #[test]
+    fn status_bar_segments_parse_validate_and_cap() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "status_bar": {
+                "show_screens": false,
+                "show_session": false,
+                "left": [
+                    {"text": " {session} ", "fg": "#87d787", "bg": 236},
+                    {"text": "x", "run": ["true"]},
+                    {"run": []},
+                    {}
+                ],
+                "right": [
+                    {"run": ["date", "+%H:%M"], "interval": 0},
+                    {"text": "{workspace}"}
+                ]
+            }
+        }))
+        .unwrap();
+        let left = resolve_status_segments(raw.status_bar.left.unwrap(), "left");
+        assert_eq!(left.len(), 1, "text+run, empty run, and empty segments are rejected");
+        assert_eq!(left[0].content, StatusSegmentContent::Text(" {session} ".to_string()));
+        assert!(left[0].fg.is_some() && left[0].bg.is_some());
+        let right = resolve_status_segments(raw.status_bar.right.unwrap(), "right");
+        assert_eq!(right.len(), 2);
+        assert_eq!(
+            right[0].content,
+            StatusSegmentContent::Command {
+                argv: vec!["date".to_string(), "+%H:%M".to_string()],
+                interval: std::time::Duration::from_secs(1),
+            },
+            "interval clamps to at least one second"
+        );
+
+        let options = StatusBarOptions {
+            left,
+            right,
+            ..StatusBarOptions::default()
+        };
+        let commands = options.command_segments();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].0, 1, "command index counts left segments first");
+
+        let overflow: Vec<RawStatusSegment> = (0..MAX_STATUS_SEGMENTS + 3)
+            .map(|index| RawStatusSegment {
+                text: Some(format!("{index}")),
+                ..RawStatusSegment::default()
+            })
+            .collect();
+        assert_eq!(resolve_status_segments(overflow, "left").len(), MAX_STATUS_SEGMENTS);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1341,6 +1341,9 @@ impl ActionIndex {
 /// limit are rejected at config load with a visible warning.
 pub const MAX_USER_COMMANDS: usize = 32;
 
+/// The maximum number of chords one command may bind.
+pub const MAX_USER_COMMAND_CHORDS: usize = 8;
+
 /// A validated zero-based index into the configured `commands` list. Its
 /// private field prevents unregistered command actions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -2814,6 +2817,9 @@ impl StatusBarOptions {
 /// The maximum number of configured segments per status bar side.
 pub const MAX_STATUS_SEGMENTS: usize = 8;
 
+/// The maximum length of one literal status segment, in characters.
+pub const MAX_STATUS_SEGMENT_TEXT: usize = 256;
+
 /// One status bar segment: literal text with `{variable}` interpolation, or
 /// a command whose last stdout line becomes the segment text.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2845,18 +2851,17 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
                 );
                 continue;
             }
-            (Some(text), None) => StatusSegmentContent::Text(text),
+            (Some(text), None) => {
+                // Bound per-draw expansion work on the render path.
+                StatusSegmentContent::Text(text.chars().take(MAX_STATUS_SEGMENT_TEXT).collect())
+            }
             (None, Some(run)) => {
-                let argv: Vec<String> =
-                    run.into_iter().filter(|argument| !argument.is_empty()).collect();
-                if argv.is_empty() {
-                    eprintln!(
-                        "cmux-tui: ignoring status_bar.{side} segment with an empty run argv"
-                    );
+                if run.first().is_none_or(|program| program.is_empty()) {
+                    eprintln!("cmux-tui: ignoring status_bar.{side} segment without a run program");
                     continue;
                 }
                 let interval = segment.interval.unwrap_or(5).clamp(1, 3600);
-                StatusSegmentContent::Command { argv, interval: Duration::from_secs(interval) }
+                StatusSegmentContent::Command { argv: run, interval: Duration::from_secs(interval) }
             }
         };
         segments.push(StatusSegment {
@@ -3371,18 +3376,15 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
             eprintln!("cmux-tui: ignoring command with a missing or empty id");
             continue;
         }
-        if !ids.insert(id.clone()) {
+        if ids.contains(&id) {
             eprintln!("cmux-tui: ignoring command with duplicate id {id:?}");
             continue;
         }
-        let run: Vec<String> = command
-            .run
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|argument| !argument.is_empty())
-            .collect();
-        if run.is_empty() {
-            eprintln!("cmux-tui: ignoring command {id:?} with an empty run argv");
+        // Empty positional arguments stay: argv executes directly, and an
+        // empty argument is valid there. Only the program itself must exist.
+        let run = command.run.unwrap_or_default();
+        if run.first().is_none_or(|program| program.is_empty()) {
+            eprintln!("cmux-tui: ignoring command {id:?} without a run program");
             continue;
         }
         let Some(action) = Action::user_command(commands.len()) else {
@@ -3391,10 +3393,20 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
             );
             continue;
         };
+        // The id is reserved only after validation, so an ignored invalid
+        // entry never blocks a later valid entry with the same id.
+        ids.insert(id.clone());
         if let Some(value) = command.keys.as_ref() {
+            let mut bound = 0usize;
             for raw_chord in key_values(value) {
                 if raw_chord.eq_ignore_ascii_case("none") {
                     continue;
+                }
+                if bound >= MAX_USER_COMMAND_CHORDS {
+                    eprintln!(
+                        "cmux-tui: ignoring command {id:?} chords beyond the {MAX_USER_COMMAND_CHORDS}-chord limit"
+                    );
+                    break;
                 }
                 let Some(chord) = parse_chord(raw_chord) else {
                     eprintln!(
@@ -3403,6 +3415,7 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
                     continue;
                 };
                 keys.bind_user_command_chord(&id, action, chord);
+                bound += 1;
             }
         }
         let name = command
@@ -3410,7 +3423,8 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
             .map(|name| name.trim().to_string())
             .filter(|name| !name.is_empty())
             .unwrap_or_else(|| id.clone());
-        commands.push(UserCommandConfig { id, name, run, cwd: command.cwd });
+        let cwd = command.cwd.map(|cwd| cwd.trim().to_string()).filter(|cwd| !cwd.is_empty());
+        commands.push(UserCommandConfig { id, name, run, cwd });
     }
     commands
 }
@@ -7748,6 +7762,29 @@ mod tests {
         let commands = resolve_user_commands(raw, &mut keys);
         assert_eq!(commands.len(), 2);
         assert_eq!(commands[0].id, "lazygit");
+        // An ignored invalid entry does not reserve its id: a later valid
+        // entry with the same id is accepted.
+        let mut keys_retry = Keys::default();
+        let retry = vec![
+            RawUserCommand {
+                id: Some("retry".to_string()),
+                name: None,
+                keys: None,
+                run: Some(Vec::new()),
+                cwd: None,
+            },
+            RawUserCommand {
+                id: Some("retry".to_string()),
+                name: None,
+                keys: None,
+                run: Some(vec!["true".to_string()]),
+                cwd: Some("   ".to_string()),
+            },
+        ];
+        let retried = resolve_user_commands(retry, &mut keys_retry);
+        assert_eq!(retried.len(), 1);
+        assert_eq!(retried[0].id, "retry");
+        assert_eq!(retried[0].cwd, None, "blank cwd is treated as absent");
         assert_eq!(commands[0].name, "LazyGit");
         assert_eq!(commands[0].run, ["lazygit"]);
         assert_eq!(commands[1].name, "scratch");

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -178,6 +178,10 @@ struct RawConfig {
     machine_provider: RawMachineProvider,
     #[serde(default)]
     machines: Vec<RawMachine>,
+    /// User commands: named argv programs, each optionally bound to key
+    /// chords, opened as a new PTY tab in the active pane.
+    #[serde(default)]
+    commands: Vec<RawUserCommand>,
     #[serde(default)]
     browser: RawBrowser,
     #[serde(default)]
@@ -199,6 +203,21 @@ struct RawConfig {
 struct RawServer {
     ws: Option<String>,
     ws_token: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawUserCommand {
+    id: Option<String>,
+    name: Option<String>,
+    /// Chord string, array of chord strings, or absent for an unbound
+    /// command. Alt- and Super-modified chords are modeless; other chords
+    /// run after the prefix.
+    keys: Option<Value>,
+    /// Argv executed directly, without a shell.
+    run: Option<Vec<String>>,
+    /// Working directory; defaults to the target pane's current directory.
+    cwd: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1199,6 +1218,25 @@ impl ActionIndex {
     }
 }
 
+/// The maximum number of configurable user commands. Chords bound past this
+/// limit are rejected at config load with a visible warning.
+pub const MAX_USER_COMMANDS: usize = 32;
+
+/// A validated zero-based index into the configured `commands` list. Its
+/// private field prevents unregistered command actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserCommandIndex(u8);
+
+impl UserCommandIndex {
+    pub const fn new(value: usize) -> Option<Self> {
+        if value < MAX_USER_COMMANDS { Some(Self(value as u8)) } else { None }
+    }
+
+    pub const fn get(self) -> usize {
+        self.0 as usize
+    }
+}
+
 /// Every prefix-key action, so bindings are configurable end to end.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
@@ -1250,6 +1288,9 @@ pub enum Action {
     BrowserEditUrl,
     ShowShortcuts,
     Detach,
+    /// A user-configured command from the top-level `commands` section,
+    /// opened as a new PTY tab through the mux `run` command.
+    UserCommand(UserCommandIndex),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1303,6 +1344,7 @@ pub(crate) enum ActionExecution {
     BrowserEditUrl,
     ShowShortcuts,
     Detach,
+    UserCommand(UserCommandIndex),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1728,6 +1770,17 @@ pub fn action_definitions() -> &'static [&'static ActionDefinition] {
     &DEFINITIONS
 }
 
+/// Fallback definition for `Action::UserCommand`. It is intentionally not in
+/// `action_definitions()`: user commands are named by the user's config, and
+/// presentation surfaces look the display name up there. The `action` field
+/// pins index 0 only because a definition must carry one concrete action.
+static USER_COMMAND_FALLBACK_DEFINITION: ActionDefinition = action_definition!(
+    Action::UserCommand(UserCommandIndex(0)),
+    "user-command",
+    "User command",
+    "ユーザーコマンド"
+);
+
 impl Action {
     /// Compiled source of truth for programmability classification and
     /// execution routing. The specification inventory checker reads this
@@ -2029,6 +2082,12 @@ impl Action {
                 "close frontend transport",
                 ActionExecution::Detach,
             ),
+            Action::UserCommand(index) => ActionMetadata::new(
+                "user-command-{index}",
+                ActionClassification::Composite,
+                "frontend command config + run",
+                ActionExecution::UserCommand(*index),
+            ),
         }
     }
 }
@@ -2084,6 +2143,11 @@ impl Action {
             Action::BrowserEditUrl => &BROWSER_EDIT_URL_DEFINITION,
             Action::ShowShortcuts => &SHOW_SHORTCUTS_DEFINITION,
             Action::Detach => &DETACH_DEFINITION,
+            // One shared fallback: presentation surfaces resolve the
+            // configured display name through the command list instead of
+            // this static definition, which is deliberately outside the
+            // action catalog.
+            Action::UserCommand(_) => &USER_COMMAND_FALLBACK_DEFINITION,
         }
     }
 
@@ -2091,6 +2155,20 @@ impl Action {
         match ActionIndex::new(number) {
             Some(index) => Some(Self::SelectScreen(index)),
             None => None,
+        }
+    }
+
+    pub const fn user_command(number: usize) -> Option<Self> {
+        match UserCommandIndex::new(number) {
+            Some(index) => Some(Self::UserCommand(index)),
+            None => None,
+        }
+    }
+
+    pub fn user_command_index(&self) -> Option<usize> {
+        match self {
+            Action::UserCommand(index) => Some(index.get()),
+            _ => None,
         }
     }
 
@@ -2378,6 +2456,19 @@ impl Keys {
             .collect()
     }
 
+    /// Bind one user-command chord, stealing the chord from any action or
+    /// earlier command that held it. The prefix chord stays reserved.
+    fn bind_user_command_chord(&mut self, id: &str, action: Action, chord: Chord) {
+        if chord == self.prefix {
+            eprintln!(
+                "cmux-tui: ignoring command binding {id:?} because it conflicts with the prefix"
+            );
+            return;
+        }
+        self.bindings.retain(|(existing, _)| existing != &chord);
+        self.bindings.push((chord, action));
+    }
+
     /// Apply config overrides: `"prefix"` rebinds the prefix; any action
     /// name rebinds that action (replacing ALL default chords for it).
     fn apply(&mut self, raw: &HashMap<String, Value>) {
@@ -2541,6 +2632,20 @@ pub struct Config {
     pub viewport: Viewport,
     pub server: Server,
     pub keys: Keys,
+    pub commands: Vec<UserCommandConfig>,
+}
+
+/// One resolved user command from the top-level `commands` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserCommandConfig {
+    /// Stable config identity, unique across the list.
+    pub id: String,
+    /// Display name for shortcut help; defaults to the id.
+    pub name: String,
+    /// Argv executed directly, without a shell.
+    pub run: Vec<String>,
+    /// Working directory; `None` follows the target pane's current directory.
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2986,7 +3091,65 @@ pub fn load() -> Config {
     config.server.ws = raw.server.ws.filter(|value| !value.trim().is_empty());
     config.server.ws_token = raw.server.ws_token.filter(|value| !value.trim().is_empty());
     config.keys.apply(&raw.keys);
+    config.commands = resolve_user_commands(raw.commands, &mut config.keys);
     config
+}
+
+/// Validate the raw `commands` section and bind each command's chords.
+/// Command chords are bound after `keys` overrides, so an explicit command
+/// chord replaces whatever action previously held that chord, matching the
+/// last-write-wins behavior of the `keys` section itself.
+fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserCommandConfig> {
+    let mut commands = Vec::new();
+    let mut ids = HashSet::new();
+    for command in raw {
+        let id = command.id.as_deref().unwrap_or("").trim().to_string();
+        if id.is_empty() {
+            eprintln!("cmux-tui: ignoring command with a missing or empty id");
+            continue;
+        }
+        if !ids.insert(id.clone()) {
+            eprintln!("cmux-tui: ignoring command with duplicate id {id:?}");
+            continue;
+        }
+        let run: Vec<String> = command
+            .run
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|argument| !argument.is_empty())
+            .collect();
+        if run.is_empty() {
+            eprintln!("cmux-tui: ignoring command {id:?} with an empty run argv");
+            continue;
+        }
+        let Some(action) = Action::user_command(commands.len()) else {
+            eprintln!(
+                "cmux-tui: ignoring command {id:?} beyond the {MAX_USER_COMMANDS}-command limit"
+            );
+            continue;
+        };
+        if let Some(value) = command.keys.as_ref() {
+            for raw_chord in key_values(value) {
+                if raw_chord.eq_ignore_ascii_case("none") {
+                    continue;
+                }
+                let Some(chord) = parse_chord(raw_chord) else {
+                    eprintln!(
+                        "cmux-tui: ignoring unparseable command binding {id} = {raw_chord:?}"
+                    );
+                    continue;
+                };
+                keys.bind_user_command_chord(&id, action, chord);
+            }
+        }
+        let name = command
+            .name
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| id.clone());
+        commands.push(UserCommandConfig { id, name, run, cwd: command.cwd });
+    }
+    commands
 }
 
 fn normalize_ssh_machine_port(id: &str, port: Option<u16>) -> Option<u16> {
@@ -7182,6 +7345,111 @@ mod tests {
             "the prefix chord must not remain advertised as a modeless action"
         );
         assert_eq!(collision.shortcut_label(Action::SendPrefix).as_deref(), Some("Alt-n Alt-n"));
+    }
+
+    #[test]
+    fn raw_config_accepts_commands_section() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "commands": [
+                {"id": "lazygit", "name": "LazyGit", "keys": "g", "run": ["lazygit"]},
+                {"id": "scratch", "keys": ["alt+s"], "run": ["nvim", "/tmp/scratch.md"], "cwd": "/tmp"}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(raw.commands.len(), 2);
+    }
+
+    #[test]
+    fn user_commands_bind_chords_and_resolve() {
+        let mut keys = Keys::default();
+        let raw = vec![
+            RawUserCommand {
+                id: Some("lazygit".to_string()),
+                name: Some("LazyGit".to_string()),
+                keys: Some(Value::String("g".to_string())),
+                run: Some(vec!["lazygit".to_string()]),
+                cwd: None,
+            },
+            RawUserCommand {
+                id: Some("scratch".to_string()),
+                name: None,
+                // The prefix chord is reserved, so only alt+s binds.
+                keys: Some(json!(["alt+s", "ctrl+b"])),
+                run: Some(vec!["nvim".to_string(), "/tmp/scratch.md".to_string()]),
+                cwd: Some("/tmp".to_string()),
+            },
+            RawUserCommand {
+                id: Some("lazygit".to_string()),
+                name: None,
+                keys: Some(Value::String("y".to_string())),
+                run: Some(vec!["true".to_string()]),
+                cwd: None,
+            },
+            RawUserCommand {
+                id: Some("empty-run".to_string()),
+                name: None,
+                keys: Some(Value::String("e".to_string())),
+                run: Some(Vec::new()),
+                cwd: None,
+            },
+            RawUserCommand {
+                id: None,
+                name: None,
+                keys: Some(Value::String("i".to_string())),
+                run: Some(vec!["true".to_string()]),
+                cwd: None,
+            },
+        ];
+        let commands = resolve_user_commands(raw, &mut keys);
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].id, "lazygit");
+        assert_eq!(commands[0].name, "LazyGit");
+        assert_eq!(commands[0].run, ["lazygit"]);
+        assert_eq!(commands[1].name, "scratch");
+        assert_eq!(commands[1].cwd.as_deref(), Some("/tmp"));
+
+        let lazygit = Action::user_command(0).unwrap();
+        let scratch = Action::user_command(1).unwrap();
+        // An explicit command chord steals the default chord it collides with.
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            Some(lazygit)
+        );
+        assert_eq!(keys.shortcut_labels(Action::NewPaneRight), Vec::<String>::new());
+        // Alt chords are modeless, exactly like built-in Alt bindings.
+        assert_eq!(
+            keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('s'), KeyModifiers::ALT)),
+            Some(scratch)
+        );
+        // The prefix chord stays reserved for send-prefix.
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)),
+            Some(Action::SendPrefix)
+        );
+        // Rejected chords do not bind: `y`, `e`, and `i` keep their defaults.
+        assert_ne!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE)),
+            Some(Action::user_command(2).unwrap())
+        );
+        assert_eq!(keys.shortcut_labels(lazygit), ["Ctrl-b g"]);
+        assert_eq!(keys.shortcut_labels(scratch), ["Alt-s"]);
+    }
+
+    #[test]
+    fn user_commands_stop_at_the_command_limit() {
+        let mut keys = Keys::default();
+        let raw = (0..MAX_USER_COMMANDS + 2)
+            .map(|index| RawUserCommand {
+                id: Some(format!("command-{index}")),
+                name: None,
+                keys: None,
+                run: Some(vec!["true".to_string()]),
+                cwd: None,
+            })
+            .collect();
+        let commands = resolve_user_commands(raw, &mut keys);
+        assert_eq!(commands.len(), MAX_USER_COMMANDS);
+        assert!(Action::user_command(MAX_USER_COMMANDS).is_none());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -364,9 +364,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     let base = Style::default().bg(status_bg).fg(status_fg);
     let (left_segments, right_segments) = app.resolved_status_segments();
     let segment_style = |segment: &crate::app::StatusSegmentView| {
-        Style::default()
-            .bg(segment.bg.unwrap_or(status_bg))
-            .fg(segment.fg.unwrap_or(status_fg))
+        Style::default().bg(segment.bg.unwrap_or(status_bg)).fg(segment.fg.unwrap_or(status_fg))
     };
     for x in bar_x..area.width {
         frame.buffer_mut()[(x, status_y)].set_symbol(" ").set_style(base);
@@ -425,23 +423,22 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     if status_text.is_none() {
         app.hide_status_message();
     }
-    let label = status_text
-        .as_ref()
-        .map(
-            |message| {
+    let label =
+        status_text
+            .as_ref()
+            .map(|message| {
                 if show_copy { format!(" {message} {copy_label} ") } else { format!(" {message} ") }
-            },
-        )
-        .unwrap_or_else(|| {
-            if app.config.status_bar.show_session {
-                format!(
-                    "[{}] ",
-                    truncate(&app.session_label, available_label_width.saturating_sub(3))
-                )
-            } else {
-                String::new()
-            }
-        });
+            })
+            .unwrap_or_else(|| {
+                if app.config.status_bar.show_session {
+                    format!(
+                        "[{}] ",
+                        truncate(&app.session_label, available_label_width.saturating_sub(3))
+                    )
+                } else {
+                    String::new()
+                }
+            });
     let label_w = label.width().min(area.width as usize) as u16;
     // Right-aligned custom segments sit left of the label; draw them and
     // shrink the viewport track accordingly.

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -362,7 +362,8 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     let status_bg = theme.status_bg.unwrap_or(chrome.status_bg);
     let status_fg = theme.status_fg.unwrap_or(chrome.status_fg);
     let base = Style::default().bg(status_bg).fg(status_fg);
-    let (left_segments, right_segments) = app.resolved_status_segments();
+    let segments = app.resolved_status_segments();
+    let (left_segments, right_segments) = (&segments.0, &segments.1);
     let segment_style = |segment: &crate::app::StatusSegmentView| {
         Style::default().bg(segment.bg.unwrap_or(status_bg)).fg(segment.fg.unwrap_or(status_fg))
     };
@@ -385,7 +386,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
         (start, width)
     };
 
-    for segment in &left_segments {
+    for segment in left_segments {
         put(frame, &mut x, &segment.text, segment_style(segment));
     }
     if app.config.status_bar.show_screens

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -358,7 +358,16 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     let status_y = area.height - 1;
     let bar_x = app.total_sidebar_width().min(area.width);
     let chrome = app.chrome;
-    let base = Style::default().bg(chrome.status_bg).fg(chrome.status_fg);
+    let theme = app.config.theme;
+    let status_bg = theme.status_bg.unwrap_or(chrome.status_bg);
+    let status_fg = theme.status_fg.unwrap_or(chrome.status_fg);
+    let base = Style::default().bg(status_bg).fg(status_fg);
+    let (left_segments, right_segments) = app.resolved_status_segments();
+    let segment_style = |segment: &crate::app::StatusSegmentView| {
+        Style::default()
+            .bg(segment.bg.unwrap_or(status_bg))
+            .fg(segment.fg.unwrap_or(status_fg))
+    };
     for x in bar_x..area.width {
         frame.buffer_mut()[(x, status_y)].set_symbol(" ").set_style(base);
     }
@@ -378,7 +387,12 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
         (start, width)
     };
 
-    if let Some(ws) = app.tree.active_workspace().cloned() {
+    for segment in &left_segments {
+        put(frame, &mut x, &segment.text, segment_style(segment));
+    }
+    if app.config.status_bar.show_screens
+        && let Some(ws) = app.tree.active_workspace().cloned()
+    {
         put(frame, &mut x, " screens ", base.fg(chrome.status_dim_fg));
         for (i, screen) in ws.screens.iter().enumerate() {
             let active = i == ws.active_screen;
@@ -419,10 +433,34 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             },
         )
         .unwrap_or_else(|| {
-            format!("[{}] ", truncate(&app.session_label, available_label_width.saturating_sub(3)))
+            if app.config.status_bar.show_session {
+                format!(
+                    "[{}] ",
+                    truncate(&app.session_label, available_label_width.saturating_sub(3))
+                )
+            } else {
+                String::new()
+            }
         });
     let label_w = label.width().min(area.width as usize) as u16;
-    let track_end = area.width.saturating_sub(label_w);
+    // Right-aligned custom segments sit left of the label; draw them and
+    // shrink the viewport track accordingly.
+    let mut right_x = area.width.saturating_sub(label_w);
+    for segment in right_segments.iter().rev() {
+        let width = (segment.text.width() as u16).min(right_x.saturating_sub(x));
+        if width == 0 {
+            break;
+        }
+        right_x = right_x.saturating_sub(width);
+        frame.buffer_mut().set_stringn(
+            right_x,
+            status_y,
+            &segment.text,
+            width as usize,
+            segment_style(segment),
+        );
+    }
+    let track_end = right_x;
     let track_start = x.saturating_add(1);
     let track_width = track_end.saturating_sub(track_start.saturating_add(1));
     if let Some((content_width, viewport_width, offset)) = app.horizontal_scrollbar_state()

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -444,6 +444,10 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     // shrink the viewport track accordingly.
     let mut right_x = area.width.saturating_sub(label_w);
     for segment in right_segments.iter().rev() {
+        if segment.text.is_empty() {
+            // Normal before a command's first result; later segments still draw.
+            continue;
+        }
         let width = (segment.text.width() as u16).min(right_x.saturating_sub(x));
         if width == 0 {
             break;

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -140,7 +140,9 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
     } else {
         pane::draw_all(app, frame)
     };
-    if app.is_surface_only() {
+    if app.is_surface_only() || !app.config.status_bar.visible {
+        // No reserved status row: transient messages overlay the last row
+        // with foreground styling only, single-surface style.
         draw_surface_status(app, frame);
     } else {
         draw_status_bar(app, frame);

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -531,7 +531,9 @@ pub fn draw_shortcut_help(app: &mut App, frame: &mut Frame) {
     let desired_width = help
         .rows
         .iter()
-        .map(|(action, shortcuts)| catalog.action_label(*action).width() + shortcuts.width() + 9)
+        .map(|(action, shortcuts)| {
+            app.action_display_label(*action).width() + shortcuts.width() + 9
+        })
         .max()
         .unwrap_or(44)
         .max(catalog.shortcuts.title.width() + close_text.width() + 8);
@@ -601,7 +603,7 @@ pub fn draw_shortcut_help(app: &mut App, frame: &mut Frame) {
         help.rows.iter().skip(scroll_offset).take(visible_rows).enumerate()
     {
         let row_y = y + 2 + line as u16;
-        let label = catalog.action_label(*action);
+        let label = app.action_display_label(*action);
         let shortcuts = format!(" {shortcuts} ");
         let shortcut_width = (shortcuts.width() as u16).min(inner_width / 2);
         let shortcut_x = x + width.saturating_sub(shortcut_width + 2);

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -143,29 +143,30 @@ fn draw_box(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool) {
     let style = notification
         .map(|notification| Style::default().fg(notification_color(&theme, notification)))
         .unwrap_or_else(|| border_style(app, focused));
+    let glyphs = theme.border_style.glyphs();
     let (x0, y0) = (rect.x, rect.y);
     let (x1, y1) = (rect.x + rect.width - 1, rect.y + rect.height - 1);
     if x1 >= screen.width || y1 >= screen.height {
         return;
     }
     for x in x0..=x1 {
-        buf[(x, y1)].set_symbol("─").set_style(style);
+        buf[(x, y1)].set_symbol(glyphs.horizontal).set_style(style);
     }
     for y in y0 + 1..y1 {
         if area.has_left_edge() {
-            buf[(x0, y)].set_symbol("│").set_style(style);
+            buf[(x0, y)].set_symbol(glyphs.vertical).set_style(style);
         }
         if area.has_right_edge() {
-            buf[(x1, y)].set_symbol("│").set_style(style);
+            buf[(x1, y)].set_symbol(glyphs.vertical).set_style(style);
         }
     }
     if area.has_left_edge() {
-        buf[(x0, y0)].set_symbol("┌").set_style(style);
-        buf[(x0, y1)].set_symbol("└").set_style(style);
+        buf[(x0, y0)].set_symbol(glyphs.top_left).set_style(style);
+        buf[(x0, y1)].set_symbol(glyphs.bottom_left).set_style(style);
     }
     if area.has_right_edge() {
-        buf[(x1, y0)].set_symbol("┐").set_style(style);
-        buf[(x1, y1)].set_symbol("┘").set_style(style);
+        buf[(x1, y0)].set_symbol(glyphs.top_right).set_style(style);
+        buf[(x1, y1)].set_symbol(glyphs.bottom_right).set_style(style);
     }
 
     if let Some(label) = app.client_border_labels.get(&area.surface) {
@@ -284,15 +285,16 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         Some(logical) => logical,
         None => frame.buffer_mut(),
     };
+    let glyphs = theme.border_style.glyphs();
     let (x0, x1) = (0, full_width - 1);
     for x in x0..=x1 {
-        buf[(origin_x + x, origin_y)].set_symbol("─").set_style(style);
+        buf[(origin_x + x, origin_y)].set_symbol(glyphs.horizontal).set_style(style);
     }
     if area.has_left_edge() {
-        buf[(origin_x + x0, origin_y)].set_symbol("┌").set_style(style);
+        buf[(origin_x + x0, origin_y)].set_symbol(glyphs.top_left).set_style(style);
     }
     if area.has_right_edge() {
-        buf[(origin_x + x1, origin_y)].set_symbol("┐").set_style(style);
+        buf[(origin_x + x1, origin_y)].set_symbol(glyphs.top_right).set_style(style);
     }
 
     // Layout the tab labels: " 1 zsh " ... " + ", scrolled so the range

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -469,6 +469,18 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         &app.chrome,
         |col, row| selection.is_some_and(|s| s.contains_viewport(col, row, selection_offset)),
     );
+    if !focused && theme.dim_inactive {
+        let screen = frame.area();
+        let max_x = rect.x.saturating_add(rect.width).min(screen.width);
+        let max_y = rect.y.saturating_add(rect.height).min(screen.height);
+        let dim = Style::default().add_modifier(Modifier::DIM);
+        let buf = frame.buffer_mut();
+        for y in rect.y..max_y {
+            for x in rect.x..max_x {
+                buf[(x, y)].set_style(dim);
+            }
+        }
+    }
     DrawCursors { input: None, terminal: focused.then_some(cursor).flatten() }
 }
 

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -232,6 +232,29 @@ Terminal panes, the workspace sidebar, and the shortcut modal share the same `â–
 
 WebSocket clients pair through a six-digit browser/TUI comparison by default. WebSocket binds must be loopback unless cmux-tui is started with `--ws-insecure-bind`. The listener has no TLS; use an authenticated TLS reverse proxy for remote access. See the [transport contract](../spec/transports.md#websocket).
 
+## Commands
+
+`commands` is an ordered list of user commands, the cmux-tui equivalent of tmux `bind-key ... command`. Each command names an argv program and optionally binds key chords to it. Pressing a bound chord runs the argv as a new PTY tab in the active pane, exactly like `cmux run`. The child inherits `CMUX_TUI_SOCKET`, so a command script can immediately drive the public CLI against its own session: create workspaces, apply splits, rename tabs, then close its own tab. The working directory defaults to the active pane's current directory.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `commands[].id` | string | required | Stable unique identity; duplicates and empty ids are ignored |
+| `commands[].name` | string | the id | Display name in the shortcut modal |
+| `commands[].run` | string array | required | Argv executed directly, without a shell; empty argv entries are dropped |
+| `commands[].keys` | chord string or array | unset | Chords that run the command; Alt- and Super-modified chords are modeless, other chords run after the prefix |
+| `commands[].cwd` | string | active pane cwd | Working directory for the child process |
+
+Try the tracked example with `CMUX_TUI_CONFIG=examples/user-commands.json cargo run -p cmux-tui -- --session commands`. At most 32 commands are honored; extra entries are ignored with a warning. A command chord replaces whatever action previously held that chord, matching the last-write-wins behavior of the `keys` section, and the prefix chord stays reserved. Shell pipelines need an explicit shell argv, for example `["zsh", "-lc", "git diff | delta"]`.
+
+```json
+{
+  "commands": [
+    {"id": "lazygit", "name": "LazyGit", "keys": "g", "run": ["lazygit"]},
+    {"id": "scratch", "keys": ["alt+s"], "run": ["nvim", "~/notes/scratch.md"], "cwd": "~"}
+  ]
+}
+```
+
 ## Keys
 
 | Key | Type | Default | Effect |

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -277,7 +277,7 @@ WebSocket clients pair through a six-digit browser/TUI comparison by default. We
 
 ## Commands
 
-`commands` is an ordered list of user commands, the cmux-tui equivalent of tmux `bind-key ... command`. Each command names an argv program and optionally binds key chords to it. Pressing a bound chord runs the argv as a new PTY tab in the active pane, exactly like `cmux run`. The child inherits `CMUX_TUI_SOCKET`, so a command script can immediately drive the public CLI against its own session: create workspaces, apply splits, rename tabs, then close its own tab. The working directory defaults to the active pane's current directory.
+`commands` is an ordered list of user commands, the cmux-tui equivalent of tmux `bind-key ... command`. Each command names an argv program and optionally binds key chords to it. Pressing a bound chord runs the argv as a new PTY tab in the active pane, exactly like `cmux run`. The child inherits `CMUX_TUI_SOCKET`, so a command script can immediately drive the public CLI against its own session: create workspaces, apply splits, rename tabs, then close its own tab. The working directory defaults to the active pane's current directory; `cwd` values pass through without shell expansion, so use absolute paths or a shell argv for `~`.
 
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
@@ -293,7 +293,7 @@ Try the tracked example with `CMUX_TUI_CONFIG=examples/user-commands.json cargo 
 {
   "commands": [
     {"id": "lazygit", "name": "LazyGit", "keys": "g", "run": ["lazygit"]},
-    {"id": "scratch", "keys": ["alt+s"], "run": ["nvim", "~/notes/scratch.md"], "cwd": "~"}
+    {"id": "scratch", "keys": ["alt+s"], "run": ["sh", "-lc", "cd \"$HOME/notes\" && exec \"${EDITOR:-vi}\" scratch.md"]}
   ]
 }
 ```

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -22,6 +22,7 @@ Selection colors are resolved in this order: explicit cmux-tui config, Ghostty c
 | `theme.notification_info` | color | `110` | Info notification attention dot and border |
 | `theme.notification_warning` | color | `179` | Warning notification attention dot and border |
 | `theme.notification_error` | color | `167` | Error notification attention dot and border |
+| `theme.border_style` | `"single"`, `"rounded"`, `"thick"`, `"double"`, or `"none"` | `"single"` | Pane border glyph set; `"none"` leaves the border cells blank so panes separate by empty space |
 
 ## Tabs
 
@@ -206,6 +207,22 @@ The cloud connector runs `cmux provider control` and `cmux provider stream` remo
 | `browser.capture_scale` | number or null | `null` | Maximum capture scale from 0.0 through 1.0, reduced further when needed to stay under the megapixel limit |
 
 The compatibility keys `browser.chrome_binary`, `browser.mode`, `browser.discover`, `browser.discover_ports`, `browser.user_data_dir`, and `browser.ephemeral` are still accepted when reading older config files but no longer select or launch a browser. Production browser tabs wait for cmux-browser's connection-scoped provider lease. `browser.cdp_url` and `CMUX_MUX_CDP_URL` bypass that lease only for explicit development harnesses; neither path performs discovery or process launch.
+
+## Pane
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `pane.padding` | integer | `0` | Blank cells between the pane border and the terminal content, on every side, clamped to 0 through 4 |
+
+Padding shrinks the PTY size accordingly and never pads a pane below one content cell. Border geometry, the tab bar, and the scrollbar keep their positions, so `{"theme":{"border_style":"none"},"pane":{"padding":1}}` renders borderless panes separated by whitespace.
+
+## Status bar
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `status_bar.visible` | boolean | `true` | Shows the bottom screens bar |
+
+Hiding the bar gives its row back to the panes. Transient status messages still overlay the bottom row until dismissed, single-surface style. The screens strip, the session label, and the horizontal viewport track are not rendered while hidden; screens stay reachable through `prev-screen`, `next-screen`, `select-screen-N`, and the sidebar.
 
 ## Scrollbar
 

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -23,6 +23,9 @@ Selection colors are resolved in this order: explicit cmux-tui config, Ghostty c
 | `theme.notification_warning` | color | `179` | Warning notification attention dot and border |
 | `theme.notification_error` | color | `167` | Error notification attention dot and border |
 | `theme.border_style` | `"single"`, `"rounded"`, `"thick"`, `"double"`, or `"none"` | `"single"` | Pane border glyph set; `"none"` leaves the border cells blank so panes separate by empty space |
+| `theme.status_bg` | color | chrome default | Status bar background |
+| `theme.status_fg` | color | chrome default | Status bar foreground |
+| `theme.dim_inactive` | boolean | `false` | Renders unfocused terminal panes with the DIM attribute |
 
 ## Tabs
 
@@ -221,6 +224,29 @@ Padding shrinks the PTY size accordingly and never pads a pane below one content
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
 | `status_bar.visible` | boolean | `true` | Shows the bottom screens bar |
+| `status_bar.show_screens` | boolean | `true` | Renders the clickable screens strip |
+| `status_bar.show_session` | boolean | `true` | Renders the right-aligned `[session]` label |
+| `status_bar.left` | array of segments | `[]` | Segments before the screens strip |
+| `status_bar.right` | array of segments | `[]` | Segments right-aligned before the session label |
+| `status_bar.left[].text` | string | one of text/run | Literal text with `{variable}` interpolation |
+| `status_bar.left[].run` | string array | one of text/run | Argv run on an interval; the last nonempty stdout line becomes the segment text, escape sequences stripped, capped at 200 characters |
+| `status_bar.left[].interval` | integer seconds | `5` | Refresh interval for `run` segments, clamped to 1 through 3600 |
+| `status_bar.left[].fg` / `bg` | color | bar colors | Segment colors |
+
+Text segments interpolate `{session}`, `{workspace}`, `{screen}`, `{screens}`, `{title}`, and `{user}`; unknown braces stay literal. `run` segments are the tmux `#()` equivalent: each is executed on its own interval with a five-second runtime bound, so a battery, git, or clock widget is one script. At most 8 segments per side. Transient status messages keep priority over the session label.
+
+```json
+{
+  "theme": {"status_bg": "#1c1c1c", "status_fg": "#87d787"},
+  "status_bar": {
+    "left": [{"text": " {session} · {workspace} ", "fg": "#87d787"}],
+    "right": [
+      {"run": ["sh", "-lc", "git -C \"$HOME/src\" branch --show-current"], "interval": 30},
+      {"run": ["date", "+%H:%M"], "interval": 30, "fg": "#d7af5f"}
+    ]
+  }
+}
+```
 
 Hiding the bar gives its row back to the panes. Transient status messages still overlay the bottom row until dismissed, single-surface style. The screens strip, the session label, and the horizontal viewport track are not rendered while hidden; screens stay reachable through `prev-screen`, `next-screen`, `select-screen-N`, and the sidebar.
 

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -283,7 +283,7 @@ WebSocket clients pair through a six-digit browser/TUI comparison by default. We
 | --- | --- | --- | --- |
 | `commands[].id` | string | required | Stable unique identity; duplicates and empty ids are ignored |
 | `commands[].name` | string | the id | Display name in the shortcut modal |
-| `commands[].run` | string array | required | Argv executed directly, without a shell; empty argv entries are dropped |
+| `commands[].run` | string array | required | Argv executed directly, without a shell; the program must be nonempty, later arguments pass through verbatim (empty ones included) |
 | `commands[].keys` | chord string or array | unset | Chords that run the command; Alt- and Super-modified chords are modeless, other chords run after the prefix |
 | `commands[].cwd` | string | active pane cwd | Working directory for the child process |
 

--- a/cmux-tui/docs/keyboard.md
+++ b/cmux-tui/docs/keyboard.md
@@ -119,6 +119,8 @@ Keys are read from `~/.config/cmux/cmux-tui.json`, with legacy `mux.json` used w
 
 Each action accepts a string, an array of strings, or `"none"`. Setting an action replaces all default chords for that action before adding the configured chords. `"none"` leaves the action unbound.
 
+User commands from the top-level `commands` config section bind through the same chord grammar and appear in the `Ctrl-b ?` shortcut modal under their configured names. A command chord replaces whatever action previously held that chord. See [Configuration](configuration.md#commands).
+
 ```json
 {
   "keys": {

--- a/cmux-tui/examples/user-commands.json
+++ b/cmux-tui/examples/user-commands.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    {"id": "top", "name": "Process monitor", "keys": "g", "run": ["top"]},
+    {"id": "git-status", "name": "Git status", "keys": ["alt+g"], "run": ["sh", "-lc", "git status; exec sh"]},
+    {"id": "scratch", "name": "Scratch note", "keys": ["alt+s"], "run": ["sh", "-lc", "cd \"${TMPDIR:-/tmp}\" && exec \"${EDITOR:-vi}\" scratch.md"]}
+  ]
+}

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -367,7 +367,8 @@
     {"variant": "BrowserReload", "key": "browser-reload", "classification": "direct", "route": "browser-reload"},
     {"variant": "BrowserEditUrl", "key": "browser-edit-url", "classification": "composite", "route": "frontend prompt + browser-navigate"},
     {"variant": "ShowShortcuts", "key": "show-shortcuts", "classification": "presentation-only", "route": "frontend shortcut overlay"},
-    {"variant": "Detach", "key": "detach", "classification": "presentation-only", "route": "close frontend transport"}
+    {"variant": "Detach", "key": "detach", "classification": "presentation-only", "route": "close frontend transport"},
+    {"variant": "UserCommand", "key": "user-command-{index}", "classification": "composite", "route": "frontend command config + run"}
   ],
   "menu_actions": [
     {"variant": "RenameClientMachine", "classification": "composite", "route": "frontend prompt + client-local machine catalog"},


### PR DESCRIPTION
Customization groundwork for a tmux/zellij-style ecosystem, in three parts.

**User commands** (`commands` section): named argv programs, each optionally bound to key chords through the existing chord grammar, the cmux-tui equivalent of tmux `bind-key ... command`. A bound chord runs the argv as a new PTY tab in the active pane through the mux `run` command. The child inherits `CMUX_TUI_SOCKET`, so a command script can drive the public CLI against its own session. Alt/Super chords are modeless; other chords run after the prefix. Chords follow last-write-wins with the `keys` section, the prefix stays reserved, ids are reserved only after validation, chords cap at 8 per command and only successful binds consume the cap, the list caps at 32, and commands appear in the `Ctrl-b ?` modal under their configured names. Implementation: `Action::UserCommand(UserCommandIndex)` reuses the existing chord resolution, routing, and admission plumbing; classified `composite` with route `frontend command config + run` in `spec/inventory.json`; surface-only clients reject the action at dispatch and at execution.

**Pane presentation**: `theme.border_style` (`single`/`rounded`/`thick`/`double`/`none`; `none` blanks the border cells so panes separate by whitespace, geometry unchanged), `pane.padding` (0-4 cells applied in `pane_parts_for_rect`, the single content-geometry source, so PTY sizing, hit testing, selection, and viewport crops follow), and `theme.dim_inactive` (unfocused terminal panes get the DIM attribute via a `set_style` patch that preserves cell colors).

**Status bar** (`status_bar.*`, `theme.status_bg/status_fg`): `visible:false` gives the row back to the panes with transient messages still overlaying; `left`/`right` take ordered segments with `{session} {workspace} {screen} {screens} {title} {user}` interpolation (single-pass, inserted values never rescanned) or `run` argv widgets, the tmux `#()` equivalent. Each command segment runs on its own worker with its own interval; capture is threadless (non-blocking pipe on Unix in the command's own process group, kill-on-close job object plus size-bounded temp file on Windows with suspended-start assignment), output keeps a bounded tail, escape sequences strip, workers coalesce redraw pokes and idle on a condvar, reload retires workers within one poll tick through a bounded handle list, shutdown joins them, and a child stuck in uninterruptible kernel I/O is held (never stacked behind) until the kernel releases it. Resolved segments cache behind an input fingerprint that includes the title only when a template uses it.

Docs: `docs/configuration.md`, `docs/keyboard.md`, example `examples/user-commands.json`.

Review disposition: fifteen local `$autoreview` rounds (gpt-5.6-sol, high) ran against successive heads; every finding through round 15 is fixed in this branch except three, disposed as follows. (1) Dim-inactive "replaces cell styles" (rounds 6 and 15): refuted — ratatui's `Cell::set_style` patches (fg/bg `None` keep the cell's colors, only the DIM modifier is added), and a tmux `capture-pane -e` dogfood shows truecolor SGRs present together with `ESC[2m`. (2) Spawn-vs-stop ordering: round 14 required holding the raise lock across spawn, round 15 flagged exactly that as a shutdown hazard; the shipped design uses an unlocked pre-spawn check plus first-tick kill, a bounded window in which the only thing that can run is a command the user had configured moments earlier (documented in code). (3) Semantic-destination intents for user-command tabs (CodeRabbit): deliberate parity with the existing file-sidebar editor launch and CLI `run`; noted as a follow-up.

Dogfood on hosted macOS binaries, driven in tmux (keys plus injected SGR mouse), verified per feature, including a ticking clock segment and a script-bound key mutating the session through the CLI. Pre-existing bugs found and filed separately: #10394 (Kitty budget retry noise after split), #10395 (eprintln corrupts the TUI frame), #10426 (flaky pointer-paint test on cold parallel runs).