### PR TITLE
Spread Codex placements and pin sessions to accounts

### DIFF
--- a/web/db/migrations/20260818090000_coderouter_session_accounts/migration.sql
+++ b/web/db/migrations/20260818090000_coderouter_session_accounts/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "coderouter_session_accounts" (
+  "team_id" text NOT NULL,
+  "provider" text NOT NULL,
+  "session_key" text NOT NULL,
+  "account_id" uuid NOT NULL
+    REFERENCES "coderouter_accounts" ("id") ON DELETE CASCADE,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "coderouter_session_accounts_pkey"
+    PRIMARY KEY ("team_id", "provider", "session_key"),
+  CONSTRAINT "coderouter_session_accounts_provider_check"
+    CHECK ("provider" IN ('codex', 'opencode-go'))
+);
+
+CREATE INDEX "coderouter_session_accounts_account_idx"
+  ON "coderouter_session_accounts" ("account_id");
+
+CREATE INDEX "coderouter_session_accounts_last_seen_idx"
+  ON "coderouter_session_accounts" ("last_seen_at");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   uniqueIndex,
@@ -578,6 +579,38 @@ export const coderouterVaultLeases = pgTable(
   },
   (table) => [
     index("coderouter_vault_leases_expiry_idx").on(table.expiresAt),
+  ],
+);
+
+/**
+ * Session -> account stickiness for coderouter routing.
+ *
+ * Providers cache prompt prefixes per account, so moving a live session to a
+ * different account re-bills its whole prompt prefix as uncached input. A row
+ * here pins one agent session (the Codex CLI `session_id` header) to one
+ * account. Placement of a new session spreads across the least-loaded usable
+ * accounts under FOR UPDATE SKIP LOCKED, so concurrent session starts cannot
+ * herd onto a single account (port of subrouter PR #228).
+ */
+export const coderouterSessionAccounts = pgTable(
+  "coderouter_session_accounts",
+  {
+    teamId: text("team_id").notNull(),
+    provider: text("provider").$type<"codex" | "opencode-go">().notNull(),
+    sessionKey: text("session_key").notNull(),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => coderouterAccounts.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      name: "coderouter_session_accounts_pkey",
+      columns: [table.teamId, table.provider, table.sessionKey],
+    }),
+    index("coderouter_session_accounts_account_idx").on(table.accountId),
+    index("coderouter_session_accounts_last_seen_idx").on(table.lastSeenAt),
   ],
 );
 

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -2,6 +2,7 @@ import {
   authenticateRouteToken,
   markAccountCooldown,
   selectAccountForRequest,
+  selectAccountForSession,
 } from "./repository";
 import { freshCredential } from "./refresh";
 import { fetchProviderRead } from "./providerFetch";
@@ -24,7 +25,41 @@ const ALLOWED_REQUEST_HEADERS = [
   "user-agent",
 ] as const;
 
-export async function proxyCodexRequest(request: Request): Promise<Response> {
+type CodexResponsesDependencies = {
+  readonly authenticate: typeof authenticateRouteToken;
+  readonly select: typeof selectAccountForSession;
+  readonly credential: typeof freshCredential;
+  readonly cooldown: typeof markAccountCooldown;
+};
+
+/**
+ * The Codex CLI sends a stable `session_id` header for every request of one
+ * agent session. That key pins the session to one account so the provider's
+ * prompt cache stays warm across turns.
+ */
+function sessionKeyFromRequest(request: Request): string | null {
+  const raw = request.headers.get("session_id")?.trim();
+  if (!raw || raw.length > 512) return null;
+  return raw;
+}
+
+export function createCodexResponsesProxy(
+  dependencies: CodexResponsesDependencies,
+): (request: Request) => Promise<Response> {
+  return async (request) => proxyCodexRequestWith(dependencies, request);
+}
+
+export const proxyCodexRequest = createCodexResponsesProxy({
+  authenticate: authenticateRouteToken,
+  select: selectAccountForSession,
+  credential: freshCredential,
+  cooldown: markAccountCooldown,
+});
+
+async function proxyCodexRequestWith(
+  dependencies: CodexResponsesDependencies,
+  request: Request,
+): Promise<Response> {
   const startedAt = performance.now();
   const token = bearerToken(request);
   if (!token) {
@@ -51,7 +86,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
       false,
     );
   }
-  const identity = await authenticateRouteToken(token);
+  const identity = await dependencies.authenticate(token);
   if (!identity) {
     addCoderouterBreadcrumb("auth", "Route token rejected", {}, "warning");
     captureCoderouterEvent({
@@ -85,26 +120,29 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     const value = request.headers.get(name);
     if (value) forwardedHeaders.set(name, value);
   }
+  const sessionKey = sessionKeyFromRequest(request);
   const attempted: string[] = [];
   let refreshRetries = 0;
   let failureStage: "account_selection" | "credential_refresh" | "upstream_transport" =
     "account_selection";
   let upstream: Response | null = null;
   for (let attempt = 0; attempt < 8; attempt++) {
-    const account = await selectAccountForRequest(
-      identity.teamId,
-      "codex",
-      attempted,
-    );
+    const account = await dependencies.select({
+      teamId: identity.teamId,
+      provider: "codex",
+      sessionKey,
+      excludedAccountIds: attempted,
+    });
     if (!account) break;
     attempted.push(account.id);
     addCoderouterBreadcrumb("routing", "Selected provider account", {
       provider: "codex",
       attempt: attempt + 1,
+      sticky: account.sticky,
     });
     let credential;
     try {
-      credential = await freshCredential({
+      credential = await dependencies.credential({
         teamId: identity.teamId,
         accountId: account.id,
         expectedRevision: account.vaultRevision,
@@ -141,7 +179,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
         "warning",
       );
       try {
-        const refreshed = await freshCredential({
+        const refreshed = await dependencies.credential({
           teamId: identity.teamId,
           accountId: account.id,
           expectedRevision: account.vaultRevision,
@@ -172,7 +210,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
           status: 429,
         },
       );
-      await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
+      await dependencies.cooldown(account.id, rateLimitDelay(upstream.headers));
       continue;
     }
     break;

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -43,6 +43,35 @@ function sessionKeyFromRequest(request: Request): string | null {
   return raw;
 }
 
+const STICKY_REFRESH_RETRIES = 4;
+const STICKY_REFRESH_RETRY_DELAY_MS = 500;
+
+/**
+ * A sticky session that hits a refresh already in flight should wait for the
+ * winner's fresh credential rather than move to another account: a move
+ * discards the session's prompt cache and re-bills its whole prefix, while
+ * the in-flight refresh completes within seconds. Non-sticky requests keep
+ * the fail-fast behavior.
+ */
+async function credentialWithStickyPatience(
+  dependencies: Pick<CodexResponsesDependencies, "credential">,
+  input: { teamId: string; accountId: string; expectedRevision: number },
+  sticky: boolean,
+): Promise<Awaited<ReturnType<CodexResponsesDependencies["credential"]>>> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await dependencies.credential(input);
+    } catch (error) {
+      const busy = error && typeof error === "object" && "_tag" in error &&
+        (error as { _tag: string })._tag === "CodeRouterRefreshBusy";
+      if (!busy || !sticky || attempt >= STICKY_REFRESH_RETRIES) throw error;
+      await new Promise((resolve) =>
+        setTimeout(resolve, STICKY_REFRESH_RETRY_DELAY_MS)
+      );
+    }
+  }
+}
+
 export function createCodexResponsesProxy(
   dependencies: CodexResponsesDependencies,
 ): (request: Request) => Promise<Response> {
@@ -142,11 +171,15 @@ async function proxyCodexRequestWith(
     });
     let credential;
     try {
-      credential = await dependencies.credential({
-        teamId: identity.teamId,
-        accountId: account.id,
-        expectedRevision: account.vaultRevision,
-      });
+      credential = await credentialWithStickyPatience(
+        dependencies,
+        {
+          teamId: identity.teamId,
+          accountId: account.id,
+          expectedRevision: account.vaultRevision,
+        },
+        account.sticky,
+      );
     } catch (error) {
       failureStage = "credential_refresh";
       if (error && typeof error === "object" && "_tag" in error) {

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -489,7 +489,10 @@ async function findSessionAccountStatement(
       and binding."provider" = ${provider}
       and binding."session_key" = ${sessionKey}
       and account."id" = binding."account_id"
-      and account."state" = 'active'
+      -- 'refreshing' is a healthy account with a credential refresh in
+      -- flight (seconds). Moving the session would discard its prompt
+      -- cache for no reason, so the binding stays usable.
+      and account."state" in ('active', 'refreshing')
       and (account."cooldown_until" is null or account."cooldown_until" <= now())
       ${accountExclusion(sql`account."id"`, excludedAccountIds)}
     returning

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,10 +1,11 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, eq, gt, isNotNull, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import {
   coderouterAccounts,
   coderouterCredentials,
   coderouterRouteTokens,
+  coderouterSessionAccounts,
   coderouterVaultLeases,
 } from "../../db/schema";
 import type { EncryptedCredential } from "./encryption";
@@ -407,15 +408,23 @@ export async function findAccountByProviderIdentity(
   return row ?? null;
 }
 
-export async function selectAccountForRequest(
-  teamId: string,
-  provider: CodeRouterProvider,
-  excludedAccountIds: readonly string[] = [],
-): Promise<{
+export type RoutedAccount = {
   id: string;
   vaultRevision: number;
   credentialExpiresAt: Date | null;
-} | null> {
+};
+
+export type StickyRoutedAccount = RoutedAccount & {
+  /** True when the session's existing account binding was honored. */
+  sticky: boolean;
+};
+
+/** Bindings older than this stop counting toward an account's session load. */
+const SESSION_BINDING_LOAD_WINDOW = "6 hours";
+/** Bindings idle longer than this are pruned opportunistically. */
+const SESSION_BINDING_RETENTION = "7 days";
+
+async function sweepExpiredRefreshLeases(teamId: string): Promise<void> {
   const now = new Date();
   await cloudDb()
     .update(coderouterAccounts)
@@ -430,33 +439,230 @@ export async function selectAccountForRequest(
       eq(coderouterAccounts.state, "refreshing"),
       lte(coderouterAccounts.refreshLeaseExpiresAt, now),
     ));
-  const [row] = await cloudDb()
-    .select({
-      id: coderouterAccounts.id,
-      vaultRevision: coderouterAccounts.vaultRevision,
-      credentialExpiresAt: coderouterAccounts.credentialExpiresAt,
-    })
-    .from(coderouterAccounts)
-    .where(and(
-      eq(coderouterAccounts.teamId, teamId),
-      eq(coderouterAccounts.provider, provider),
-      eq(coderouterAccounts.state, "active"),
-      or(
-        isNull(coderouterAccounts.cooldownUntil),
-        lte(coderouterAccounts.cooldownUntil, now),
-      ),
-      excludedAccountIds.length === 0
-        ? sql`true`
-        : notInArray(coderouterAccounts.id, [...excludedAccountIds]),
-    ))
-    .orderBy(sql`${coderouterAccounts.lastUsedAt} asc nulls first`, coderouterAccounts.createdAt)
-    .limit(1);
+}
+
+/**
+ * Returns the session's bound account when that account is still usable.
+ * Bumps the binding's last-seen time and the account's last-used time so
+ * new-session placement steers away from accounts with live traffic.
+ */
+export async function findSessionAccount(
+  teamId: string,
+  provider: CodeRouterProvider,
+  sessionKey: string,
+  excludedAccountIds: readonly string[] = [],
+): Promise<RoutedAccount | null> {
+  const result = await cloudDb().execute(sql`
+    update "coderouter_session_accounts" as binding
+    set "last_seen_at" = now()
+    from "coderouter_accounts" as account
+    where binding."team_id" = ${teamId}
+      and binding."provider" = ${provider}
+      and binding."session_key" = ${sessionKey}
+      and account."id" = binding."account_id"
+      and account."state" = 'active'
+      and (account."cooldown_until" is null or account."cooldown_until" <= now())
+      ${accountExclusion(sql`account."id"`, excludedAccountIds)}
+    returning
+      account."id" as "id",
+      account."vault_revision" as "vaultRevision",
+      account."credential_expires_at" as "credentialExpiresAt"
+  `);
+  const [row] = databaseRows(result);
   if (!row) return null;
   await cloudDb()
     .update(coderouterAccounts)
     .set({ lastUsedAt: new Date() })
-    .where(eq(coderouterAccounts.id, row.id));
-  return row;
+    .where(eq(coderouterAccounts.id, String(row.id)));
+  return routedAccountRow(row);
+}
+
+/**
+ * Atomically claims the best placement candidate for a new session or an
+ * unbound request. One statement performs read, pick, and write:
+ * FOR UPDATE SKIP LOCKED makes concurrent claims take different accounts
+ * instead of all reading the same snapshot and herding onto one account
+ * (the TypeScript port of subrouter PR #228's placement spread). Ordering
+ * prefers the fewest recently-active bound sessions, then least-recently-used.
+ */
+export async function claimAccountForPlacement(
+  teamId: string,
+  provider: CodeRouterProvider,
+  excludedAccountIds: readonly string[] = [],
+): Promise<RoutedAccount | null> {
+  // First pass skips rows other placements hold locked, so overlapping claims
+  // fan out across different accounts instead of herding onto one.
+  const spread = await claimStatement(teamId, provider, excludedAccountIds, true);
+  if (spread) return spread;
+  // Every usable account was locked by a concurrent claim (or none exists).
+  // Fall back to a blocking claim: colliding with another placement is far
+  // better than telling the caller no account is available.
+  return await claimStatement(teamId, provider, excludedAccountIds, false);
+}
+
+async function claimStatement(
+  teamId: string,
+  provider: CodeRouterProvider,
+  excludedAccountIds: readonly string[],
+  skipLocked: boolean,
+): Promise<RoutedAccount | null> {
+  const result = await cloudDb().execute(sql`
+    with candidate as (
+      select account."id"
+      from "coderouter_accounts" as account
+      where account."team_id" = ${teamId}
+        and account."provider" = ${provider}
+        and account."state" = 'active'
+        and (account."cooldown_until" is null or account."cooldown_until" <= now())
+        ${accountExclusion(sql`account."id"`, excludedAccountIds)}
+      order by
+        (
+          select count(*)
+          from "coderouter_session_accounts" as binding
+          where binding."account_id" = account."id"
+            and binding."last_seen_at" > now() - interval '${sql.raw(SESSION_BINDING_LOAD_WINDOW)}'
+        ) asc,
+        account."last_used_at" asc nulls first,
+        account."created_at" asc
+      limit 1
+      ${skipLocked ? sql.raw("for update of account skip locked") : sql``}
+    )
+    update "coderouter_accounts" as claimed
+    set "last_used_at" = now(), "updated_at" = now()
+    from candidate
+    where claimed."id" = candidate."id"
+    returning
+      claimed."id" as "id",
+      claimed."vault_revision" as "vaultRevision",
+      claimed."credential_expires_at" as "credentialExpiresAt"
+  `);
+  const [row] = databaseRows(result);
+  return row ? routedAccountRow(row) : null;
+}
+
+/** Pins a session to an account. Last write wins on a same-session race. */
+export async function bindSessionAccount(
+  teamId: string,
+  provider: CodeRouterProvider,
+  sessionKey: string,
+  accountId: string,
+): Promise<void> {
+  const db = cloudDb();
+  await db
+    .insert(coderouterSessionAccounts)
+    .values({ teamId, provider, sessionKey, accountId })
+    .onConflictDoUpdate({
+      target: [
+        coderouterSessionAccounts.teamId,
+        coderouterSessionAccounts.provider,
+        coderouterSessionAccounts.sessionKey,
+      ],
+      set: { accountId, lastSeenAt: new Date() },
+    });
+  await db.execute(sql`
+    delete from "coderouter_session_accounts"
+    where "team_id" = ${teamId}
+      and "last_seen_at" < now() - interval '${sql.raw(SESSION_BINDING_RETENTION)}'
+  `);
+}
+
+export type SessionAccountSelectorDependencies = {
+  readonly sweepLeases: typeof sweepExpiredRefreshLeases;
+  readonly findBound: typeof findSessionAccount;
+  readonly claim: typeof claimAccountForPlacement;
+  readonly bind: typeof bindSessionAccount;
+};
+
+/**
+ * Session-sticky account selection.
+ *
+ * A bound session keeps riding its account while that account is usable, so
+ * the provider's prompt cache stays warm. A session moves only when its
+ * account is broken, cooling down, removed, or already attempted this request
+ * (the move-worthiness gate from subrouter PR #228, reduced to the binary
+ * usability signal this schema has). Placement of a new or moving session
+ * spreads across the least-loaded usable accounts.
+ */
+export function createSessionAccountSelector(
+  dependencies: SessionAccountSelectorDependencies,
+): (input: {
+  teamId: string;
+  provider: CodeRouterProvider;
+  sessionKey: string | null;
+  excludedAccountIds?: readonly string[];
+}) => Promise<StickyRoutedAccount | null> {
+  return async (input) => {
+    const excluded = input.excludedAccountIds ?? [];
+    await dependencies.sweepLeases(input.teamId);
+    if (input.sessionKey) {
+      const bound = await dependencies.findBound(
+        input.teamId,
+        input.provider,
+        input.sessionKey,
+        excluded,
+      );
+      if (bound) return { ...bound, sticky: true };
+    }
+    const placed = await dependencies.claim(
+      input.teamId,
+      input.provider,
+      excluded,
+    );
+    if (!placed) return null;
+    if (input.sessionKey) {
+      await dependencies.bind(
+        input.teamId,
+        input.provider,
+        input.sessionKey,
+        placed.id,
+      );
+    }
+    return { ...placed, sticky: false };
+  };
+}
+
+export const selectAccountForSession = createSessionAccountSelector({
+  sweepLeases: sweepExpiredRefreshLeases,
+  findBound: findSessionAccount,
+  claim: claimAccountForPlacement,
+  bind: bindSessionAccount,
+});
+
+export async function selectAccountForRequest(
+  teamId: string,
+  provider: CodeRouterProvider,
+  excludedAccountIds: readonly string[] = [],
+): Promise<RoutedAccount | null> {
+  await sweepExpiredRefreshLeases(teamId);
+  return await claimAccountForPlacement(teamId, provider, excludedAccountIds);
+}
+
+function accountExclusion(
+  column: ReturnType<typeof sql>,
+  excludedAccountIds: readonly string[],
+) {
+  if (excludedAccountIds.length === 0) return sql``;
+  return sql` and ${column} not in (${
+    sql.join(excludedAccountIds.map((id) => sql`${id}`), sql`, `)
+  })`;
+}
+
+function routedAccountRow(row: Record<string, unknown>): RoutedAccount {
+  return {
+    id: String(row.id),
+    vaultRevision: Number(row.vaultRevision),
+    credentialExpiresAt: row.credentialExpiresAt instanceof Date
+      ? row.credentialExpiresAt
+      : row.credentialExpiresAt
+      ? new Date(String(row.credentialExpiresAt))
+      : null,
+  };
+}
+
+function databaseRows(result: unknown): readonly Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as readonly Record<string, unknown>[];
+  const rows = (result as { readonly rows?: unknown } | null)?.rows;
+  return Array.isArray(rows) ? rows as readonly Record<string, unknown>[] : [];
 }
 
 export async function markAccountCooldown(

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -452,7 +452,36 @@ export async function findSessionAccount(
   sessionKey: string,
   excludedAccountIds: readonly string[] = [],
 ): Promise<RoutedAccount | null> {
-  const result = await cloudDb().execute(sql`
+  let result: unknown;
+  try {
+    result = await findSessionAccountStatement(
+      teamId,
+      provider,
+      sessionKey,
+      excludedAccountIds,
+    );
+  } catch (error) {
+    // The session table's migration has not been applied yet. Route without
+    // stickiness rather than failing the request.
+    if (isMissingSessionTableError(error)) return null;
+    throw error;
+  }
+  const [row] = databaseRows(result);
+  if (!row) return null;
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(coderouterAccounts.id, String(row.id)));
+  return routedAccountRow(row);
+}
+
+async function findSessionAccountStatement(
+  teamId: string,
+  provider: CodeRouterProvider,
+  sessionKey: string,
+  excludedAccountIds: readonly string[],
+): Promise<unknown> {
+  return await cloudDb().execute(sql`
     update "coderouter_session_accounts" as binding
     set "last_seen_at" = now()
     from "coderouter_accounts" as account
@@ -468,13 +497,6 @@ export async function findSessionAccount(
       account."vault_revision" as "vaultRevision",
       account."credential_expires_at" as "credentialExpiresAt"
   `);
-  const [row] = databaseRows(result);
-  if (!row) return null;
-  await cloudDb()
-    .update(coderouterAccounts)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(coderouterAccounts.id, String(row.id)));
-  return routedAccountRow(row);
 }
 
 /**
@@ -490,14 +512,42 @@ export async function claimAccountForPlacement(
   provider: CodeRouterProvider,
   excludedAccountIds: readonly string[] = [],
 ): Promise<RoutedAccount | null> {
+  try {
+    return await claimWithOrdering(teamId, provider, excludedAccountIds, true);
+  } catch (error) {
+    // The session table's migration has not been applied yet. Claim without
+    // the session-load ordering term rather than failing the request.
+    if (!isMissingSessionTableError(error)) throw error;
+    return await claimWithOrdering(teamId, provider, excludedAccountIds, false);
+  }
+}
+
+async function claimWithOrdering(
+  teamId: string,
+  provider: CodeRouterProvider,
+  excludedAccountIds: readonly string[],
+  withSessionLoad: boolean,
+): Promise<RoutedAccount | null> {
   // First pass skips rows other placements hold locked, so overlapping claims
   // fan out across different accounts instead of herding onto one.
-  const spread = await claimStatement(teamId, provider, excludedAccountIds, true);
+  const spread = await claimStatement(
+    teamId,
+    provider,
+    excludedAccountIds,
+    true,
+    withSessionLoad,
+  );
   if (spread) return spread;
   // Every usable account was locked by a concurrent claim (or none exists).
   // Fall back to a blocking claim: colliding with another placement is far
   // better than telling the caller no account is available.
-  return await claimStatement(teamId, provider, excludedAccountIds, false);
+  return await claimStatement(
+    teamId,
+    provider,
+    excludedAccountIds,
+    false,
+    withSessionLoad,
+  );
 }
 
 async function claimStatement(
@@ -505,6 +555,7 @@ async function claimStatement(
   provider: CodeRouterProvider,
   excludedAccountIds: readonly string[],
   skipLocked: boolean,
+  withSessionLoad: boolean,
 ): Promise<RoutedAccount | null> {
   const result = await cloudDb().execute(sql`
     with candidate as (
@@ -516,12 +567,14 @@ async function claimStatement(
         and (account."cooldown_until" is null or account."cooldown_until" <= now())
         ${accountExclusion(sql`account."id"`, excludedAccountIds)}
       order by
-        (
-          select count(*)
-          from "coderouter_session_accounts" as binding
-          where binding."account_id" = account."id"
-            and binding."last_seen_at" > now() - interval '${sql.raw(SESSION_BINDING_LOAD_WINDOW)}'
-        ) asc,
+        ${withSessionLoad
+          ? sql`(
+              select count(*)
+              from "coderouter_session_accounts" as binding
+              where binding."account_id" = account."id"
+                and binding."last_seen_at" > now() - interval '${sql.raw(SESSION_BINDING_LOAD_WINDOW)}'
+            ) asc,`
+          : sql``}
         account."last_used_at" asc nulls first,
         account."created_at" asc
       limit 1
@@ -548,22 +601,48 @@ export async function bindSessionAccount(
   accountId: string,
 ): Promise<void> {
   const db = cloudDb();
-  await db
-    .insert(coderouterSessionAccounts)
-    .values({ teamId, provider, sessionKey, accountId })
-    .onConflictDoUpdate({
-      target: [
-        coderouterSessionAccounts.teamId,
-        coderouterSessionAccounts.provider,
-        coderouterSessionAccounts.sessionKey,
-      ],
-      set: { accountId, lastSeenAt: new Date() },
-    });
-  await db.execute(sql`
-    delete from "coderouter_session_accounts"
-    where "team_id" = ${teamId}
-      and "last_seen_at" < now() - interval '${sql.raw(SESSION_BINDING_RETENTION)}'
-  `);
+  try {
+    await db
+      .insert(coderouterSessionAccounts)
+      .values({ teamId, provider, sessionKey, accountId })
+      .onConflictDoUpdate({
+        target: [
+          coderouterSessionAccounts.teamId,
+          coderouterSessionAccounts.provider,
+          coderouterSessionAccounts.sessionKey,
+        ],
+        set: { accountId, lastSeenAt: new Date() },
+      });
+    await db.execute(sql`
+      delete from "coderouter_session_accounts"
+      where "team_id" = ${teamId}
+        and "last_seen_at" < now() - interval '${sql.raw(SESSION_BINDING_RETENTION)}'
+    `);
+  } catch (error) {
+    // The session table's migration has not been applied yet. Skip the pin
+    // rather than failing the request; routing degrades to the legacy
+    // per-request behavior until the migration lands.
+    if (isMissingSessionTableError(error)) return;
+    throw error;
+  }
+}
+
+/** Postgres undefined_table (42P01), possibly wrapped by the ORM. */
+function isMissingSessionTableError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (
+      typeof current === "object" &&
+      "code" in current &&
+      (current as { code?: unknown }).code === "42P01"
+    ) {
+      return true;
+    }
+    current = typeof current === "object" && current !== null && "cause" in current
+      ? (current as { cause?: unknown }).cause
+      : undefined;
+  }
+  return false;
 }
 
 export type SessionAccountSelectorDependencies = {

--- a/web/tests/coderouter-responses-proxy.test.ts
+++ b/web/tests/coderouter-responses-proxy.test.ts
@@ -11,6 +11,8 @@ let selectInputs: SelectInput[] = [];
 let accountsToServe: { id: string; sticky: boolean }[] = [];
 let cooldowns: string[] = [];
 let upstreamStatuses: number[] = [];
+let credentialBusyBudgets = new Map<string, number>();
+let credentialCalls: string[] = [];
 
 const originalFetch = globalThis.fetch;
 beforeAll(() => {
@@ -45,15 +47,25 @@ const proxy = createCodexResponsesProxy({
       }
       : null;
   },
-  credential: async ({ accountId }) => ({
-    provider: "codex",
-    accessToken: `access-${accountId}`,
-    refreshToken: "refresh",
-    idToken: "id",
-    accountId: "chatgpt-account",
-    email: "person@example.com",
-    expiresAt: Date.now() + 60_000,
-  }),
+  credential: async ({ accountId }) => {
+    if (credentialBusyBudgets.get(accountId)) {
+      credentialBusyBudgets.set(
+        accountId,
+        (credentialBusyBudgets.get(accountId) ?? 1) - 1,
+      );
+      throw Object.assign(new Error("busy"), { _tag: "CodeRouterRefreshBusy" });
+    }
+    credentialCalls.push(accountId);
+    return {
+      provider: "codex",
+      accessToken: `access-${accountId}`,
+      refreshToken: "refresh",
+      idToken: "id",
+      accountId: "chatgpt-account",
+      email: "person@example.com",
+      expiresAt: Date.now() + 60_000,
+    };
+  },
   cooldown: async (accountId) => {
     cooldowns.push(accountId);
   },
@@ -64,6 +76,8 @@ beforeEach(() => {
   accountsToServe = [];
   cooldowns = [];
   upstreamStatuses = [];
+  credentialBusyBudgets = new Map();
+  credentialCalls = [];
 });
 
 function responsesRequest(headers: Record<string, string> = {}): Request {
@@ -114,6 +128,27 @@ describe("codex responses proxy session routing", () => {
     expect(selectInputs).toHaveLength(2);
     expect(selectInputs[1]?.excludedAccountIds).toEqual(["acct-1"]);
     expect(selectInputs[1]?.sessionKey).toBe("session-move");
+  });
+
+  test("a sticky session waits out an in-flight refresh instead of moving", async () => {
+    accountsToServe = [{ id: "acct-1", sticky: true }];
+    credentialBusyBudgets.set("acct-1", 2);
+    const response = await proxy(responsesRequest({ session_id: "session-wait" }));
+    expect(response.status).toBe(200);
+    expect(selectInputs).toHaveLength(1);
+    expect(credentialCalls).toEqual(["acct-1"]);
+  });
+
+  test("a non-sticky request moves immediately on refresh-busy", async () => {
+    accountsToServe = [
+      { id: "acct-1", sticky: false },
+      { id: "acct-2", sticky: false },
+    ];
+    credentialBusyBudgets.set("acct-1", 1);
+    const response = await proxy(responsesRequest());
+    expect(response.status).toBe(200);
+    expect(credentialCalls).toEqual(["acct-2"]);
+    expect(selectInputs).toHaveLength(2);
   });
 
   test("returns no_usable_account when selection is exhausted", async () => {

--- a/web/tests/coderouter-responses-proxy.test.ts
+++ b/web/tests/coderouter-responses-proxy.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type SelectInput = {
+  teamId: string;
+  provider: string;
+  sessionKey: string | null;
+  excludedAccountIds?: readonly string[];
+};
+
+let selectInputs: SelectInput[] = [];
+let accountsToServe: { id: string; sticky: boolean }[] = [];
+let cooldowns: string[] = [];
+let upstreamStatuses: number[] = [];
+
+const originalFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = mock(async () => {
+    const status = upstreamStatuses.shift() ?? 200;
+    return new Response("data: done\n\n", {
+      status,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }) as typeof fetch;
+});
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const { createCodexResponsesProxy } = await import("../services/coderouter/codexProxy");
+
+const proxy = createCodexResponsesProxy({
+  authenticate: async () => ({ teamId: "team-1", stackUserId: "stack-user-1" }),
+  select: async (input) => {
+    selectInputs.push({
+      ...(input as SelectInput),
+      excludedAccountIds: [...(input.excludedAccountIds ?? [])],
+    });
+    const next = accountsToServe.shift();
+    return next
+      ? {
+        id: next.id,
+        vaultRevision: 1,
+        credentialExpiresAt: null,
+        sticky: next.sticky,
+      }
+      : null;
+  },
+  credential: async ({ accountId }) => ({
+    provider: "codex",
+    accessToken: `access-${accountId}`,
+    refreshToken: "refresh",
+    idToken: "id",
+    accountId: "chatgpt-account",
+    email: "person@example.com",
+    expiresAt: Date.now() + 60_000,
+  }),
+  cooldown: async (accountId) => {
+    cooldowns.push(accountId);
+  },
+});
+
+beforeEach(() => {
+  selectInputs = [];
+  accountsToServe = [];
+  cooldowns = [];
+  upstreamStatuses = [];
+});
+
+function responsesRequest(headers: Record<string, string> = {}): Request {
+  return new Request("https://coderouter.dev/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer crt_token",
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({ model: "gpt-test", input: [] }),
+  });
+}
+
+describe("codex responses proxy session routing", () => {
+  test("passes the session_id header to account selection", async () => {
+    accountsToServe = [{ id: "acct-1", sticky: true }];
+    const response = await proxy(responsesRequest({ session_id: "session-abc" }));
+    expect(response.status).toBe(200);
+    expect(selectInputs).toHaveLength(1);
+    expect(selectInputs[0]?.sessionKey).toBe("session-abc");
+    expect(selectInputs[0]?.teamId).toBe("team-1");
+    expect(selectInputs[0]?.provider).toBe("codex");
+  });
+
+  test("selects without a session key when the header is missing", async () => {
+    accountsToServe = [{ id: "acct-1", sticky: false }];
+    const response = await proxy(responsesRequest());
+    expect(response.status).toBe(200);
+    expect(selectInputs[0]?.sessionKey).toBeNull();
+  });
+
+  test("ignores oversized session ids", async () => {
+    accountsToServe = [{ id: "acct-1", sticky: false }];
+    await proxy(responsesRequest({ session_id: "x".repeat(600) }));
+    expect(selectInputs[0]?.sessionKey).toBeNull();
+  });
+
+  test("cools down a rate-limited account and retries excluding it", async () => {
+    accountsToServe = [
+      { id: "acct-1", sticky: true },
+      { id: "acct-2", sticky: false },
+    ];
+    upstreamStatuses = [429, 200];
+    const response = await proxy(responsesRequest({ session_id: "session-move" }));
+    expect(response.status).toBe(200);
+    expect(cooldowns).toEqual(["acct-1"]);
+    expect(selectInputs).toHaveLength(2);
+    expect(selectInputs[1]?.excludedAccountIds).toEqual(["acct-1"]);
+    expect(selectInputs[1]?.sessionKey).toBe("session-move");
+  });
+
+  test("returns no_usable_account when selection is exhausted", async () => {
+    accountsToServe = [];
+    const response = await proxy(responsesRequest({ session_id: "session-dry" }));
+    expect(response.status).toBe(503);
+    const body = await response.json() as { error: string };
+    expect(body.error).toBe("no_usable_account");
+  });
+});

--- a/web/tests/coderouter-routing-db-behavior.test.ts
+++ b/web/tests/coderouter-routing-db-behavior.test.ts
@@ -188,6 +188,31 @@ describe("coderouter routing db behavior", () => {
     expect(bound).toBeNull();
   });
 
+  dbTest("a binding survives its account being mid-refresh", async () => {
+    if (!sql) throw new Error("no sql client");
+    await insertAccounts(2);
+    const first = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "refreshing-session",
+    });
+    expect(first).not.toBeNull();
+    await sql`
+      update coderouter_accounts
+      set state = 'refreshing',
+          refresh_lease_id = ${randomUUID()},
+          refresh_lease_expires_at = now() + interval '30 seconds'
+      where id = ${first?.id ?? ""}
+    `;
+    const during = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "refreshing-session",
+    });
+    expect(during?.id).toBe(first?.id ?? "");
+    expect(during?.sticky).toBe(true);
+  });
+
   dbTest("routes without stickiness while the session table is missing", async () => {
     if (!sql) throw new Error("no sql client");
     await insertAccounts(2);

--- a/web/tests/coderouter-routing-db-behavior.test.ts
+++ b/web/tests/coderouter-routing-db-behavior.test.ts
@@ -188,6 +188,29 @@ describe("coderouter routing db behavior", () => {
     expect(bound).toBeNull();
   });
 
+  dbTest("routes without stickiness while the session table is missing", async () => {
+    if (!sql) throw new Error("no sql client");
+    await insertAccounts(2);
+    await sql`alter table coderouter_session_accounts rename to coderouter_session_accounts_gone`;
+    try {
+      const placed = await selectAccountForSession({
+        teamId: TEAM,
+        provider: "codex",
+        sessionKey: "pre-migration-session",
+      });
+      expect(placed).not.toBeNull();
+      expect(placed?.sticky).toBe(false);
+      const again = await selectAccountForSession({
+        teamId: TEAM,
+        provider: "codex",
+        sessionKey: "pre-migration-session",
+      });
+      expect(again).not.toBeNull();
+    } finally {
+      await sql`alter table coderouter_session_accounts_gone rename to coderouter_session_accounts`;
+    }
+  });
+
   dbTest("bind is last-write-wins for a session key", async () => {
     const accounts = await insertAccounts(2);
     await bindSessionAccount(TEAM, "codex", "raced-session", accounts[0] ?? "");

--- a/web/tests/coderouter-routing-db-behavior.test.ts
+++ b/web/tests/coderouter-routing-db-behavior.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import postgres, { type Sql } from "postgres";
+import { closeCloudDbForTests } from "../db/client";
+import {
+  bindSessionAccount,
+  claimAccountForPlacement,
+  findSessionAccount,
+  markAccountCooldown,
+  selectAccountForSession,
+} from "../services/coderouter/repository";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+const TEAM = "team-routing-test";
+let sql: Sql | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  sql = postgres(databaseURL, { max: 4 });
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  if (!sql) return;
+  await sql`truncate coderouter_session_accounts, coderouter_accounts cascade`;
+});
+
+async function insertAccounts(count: number): Promise<string[]> {
+  if (!sql) throw new Error("no sql client");
+  const ids: string[] = [];
+  for (let index = 0; index < count; index++) {
+    const id = randomUUID();
+    ids.push(id);
+    await sql`
+      insert into coderouter_accounts
+        (id, team_id, provider, provider_account_id, label, state)
+      values
+        (${id}, ${TEAM}, 'codex', ${`provider-${id}`}, ${`Account ${index}`}, 'active')
+    `;
+  }
+  return ids;
+}
+
+async function bindingCounts(): Promise<Map<string, number>> {
+  if (!sql) throw new Error("no sql client");
+  const rows = await sql`
+    select account_id, count(*)::int as sessions
+    from coderouter_session_accounts
+    where team_id = ${TEAM}
+    group by account_id
+  `;
+  return new Map(rows.map((row) => [String(row.account_id), Number(row.sessions)]));
+}
+
+describe("coderouter routing db behavior", () => {
+  dbTest("sequential new sessions spread evenly across accounts", async () => {
+    const accounts = await insertAccounts(4);
+    for (let index = 0; index < 8; index++) {
+      const placed = await selectAccountForSession({
+        teamId: TEAM,
+        provider: "codex",
+        sessionKey: `session-${index}`,
+      });
+      expect(placed).not.toBeNull();
+      expect(placed?.sticky).toBe(false);
+    }
+    const counts = await bindingCounts();
+    expect(counts.size).toBe(4);
+    for (const accountId of accounts) {
+      expect(counts.get(accountId)).toBe(2);
+    }
+  });
+
+  dbTest("concurrent new sessions do not all land on one account", async () => {
+    await insertAccounts(4);
+    const placements = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        selectAccountForSession({
+          teamId: TEAM,
+          provider: "codex",
+          sessionKey: `burst-${index}`,
+        })),
+    );
+    const ids = placements.map((placed) => {
+      expect(placed).not.toBeNull();
+      return placed?.id ?? "";
+    });
+    const concentration = new Map<string, number>();
+    for (const id of ids) {
+      concentration.set(id, (concentration.get(id) ?? 0) + 1);
+    }
+    // The old read-pick-write race let all 12 pick the same account.
+    expect(concentration.size).toBeGreaterThanOrEqual(2);
+    const max = Math.max(...concentration.values());
+    expect(max).toBeLessThan(12);
+  });
+
+  dbTest("a session sticks to its account across requests", async () => {
+    await insertAccounts(3);
+    const first = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "sticky-session",
+    });
+    expect(first?.sticky).toBe(false);
+    for (let index = 0; index < 5; index++) {
+      const again = await selectAccountForSession({
+        teamId: TEAM,
+        provider: "codex",
+        sessionKey: "sticky-session",
+      });
+      expect(again?.id).toBe(first?.id ?? "");
+      expect(again?.sticky).toBe(true);
+    }
+    // Other sessions in between must not steal the binding.
+    await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "other-session",
+    });
+    const after = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "sticky-session",
+    });
+    expect(after?.id).toBe(first?.id ?? "");
+  });
+
+  dbTest("a session moves once when its account cools down, then resticks", async () => {
+    await insertAccounts(3);
+    const first = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "moving-session",
+    });
+    expect(first).not.toBeNull();
+    await markAccountCooldown(first?.id ?? "", 60_000);
+    const moved = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "moving-session",
+    });
+    expect(moved).not.toBeNull();
+    expect(moved?.id).not.toBe(first?.id ?? "");
+    expect(moved?.sticky).toBe(false);
+    const stuck = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "moving-session",
+    });
+    expect(stuck?.id).toBe(moved?.id ?? "");
+    expect(stuck?.sticky).toBe(true);
+  });
+
+  dbTest("claim skips excluded accounts and drains to null", async () => {
+    const accounts = await insertAccounts(2);
+    const first = await claimAccountForPlacement(TEAM, "codex", []);
+    expect(first).not.toBeNull();
+    const second = await claimAccountForPlacement(TEAM, "codex", [first?.id ?? ""]);
+    expect(second).not.toBeNull();
+    expect(second?.id).not.toBe(first?.id ?? "");
+    const drained = await claimAccountForPlacement(TEAM, "codex", accounts);
+    expect(drained).toBeNull();
+  });
+
+  dbTest("bindings honor exclusion and report null when excluded", async () => {
+    await insertAccounts(2);
+    const placed = await selectAccountForSession({
+      teamId: TEAM,
+      provider: "codex",
+      sessionKey: "excluded-session",
+    });
+    expect(placed).not.toBeNull();
+    const bound = await findSessionAccount(
+      TEAM,
+      "codex",
+      "excluded-session",
+      [placed?.id ?? ""],
+    );
+    expect(bound).toBeNull();
+  });
+
+  dbTest("bind is last-write-wins for a session key", async () => {
+    const accounts = await insertAccounts(2);
+    await bindSessionAccount(TEAM, "codex", "raced-session", accounts[0] ?? "");
+    await bindSessionAccount(TEAM, "codex", "raced-session", accounts[1] ?? "");
+    const bound = await findSessionAccount(TEAM, "codex", "raced-session", []);
+    expect(bound?.id).toBe(accounts[1] ?? "");
+  });
+});

--- a/web/tests/coderouter-session-selector.test.ts
+++ b/web/tests/coderouter-session-selector.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import { createSessionAccountSelector } from "../services/coderouter/repository";
+
+type Call = { fn: string; args: unknown[] };
+
+function makeDependencies(options: {
+  bound?: { id: string; vaultRevision: number; credentialExpiresAt: Date | null } | null;
+  placed?: { id: string; vaultRevision: number; credentialExpiresAt: Date | null } | null;
+}) {
+  const calls: Call[] = [];
+  return {
+    calls,
+    dependencies: {
+      sweepLeases: async (...args: unknown[]) => {
+        calls.push({ fn: "sweepLeases", args });
+      },
+      findBound: async (...args: unknown[]) => {
+        calls.push({ fn: "findBound", args });
+        return options.bound ?? null;
+      },
+      claim: async (...args: unknown[]) => {
+        calls.push({ fn: "claim", args });
+        return options.placed ?? null;
+      },
+      bind: async (...args: unknown[]) => {
+        calls.push({ fn: "bind", args });
+      },
+    },
+  };
+}
+
+const account = (id: string) => ({
+  id,
+  vaultRevision: 3,
+  credentialExpiresAt: null,
+});
+
+describe("coderouter session account selector", () => {
+  test("honors an existing usable binding and does not place", async () => {
+    const { calls, dependencies } = makeDependencies({ bound: account("acct-1") });
+    const select = createSessionAccountSelector(dependencies);
+    const result = await select({
+      teamId: "team-1",
+      provider: "codex",
+      sessionKey: "session-a",
+    });
+    expect(result).toEqual({ ...account("acct-1"), sticky: true });
+    expect(calls.map((c) => c.fn)).toEqual(["sweepLeases", "findBound"]);
+  });
+
+  test("places and binds a new session when no binding exists", async () => {
+    const { calls, dependencies } = makeDependencies({
+      bound: null,
+      placed: account("acct-2"),
+    });
+    const select = createSessionAccountSelector(dependencies);
+    const result = await select({
+      teamId: "team-1",
+      provider: "codex",
+      sessionKey: "session-b",
+    });
+    expect(result).toEqual({ ...account("acct-2"), sticky: false });
+    expect(calls.map((c) => c.fn)).toEqual([
+      "sweepLeases",
+      "findBound",
+      "claim",
+      "bind",
+    ]);
+    expect(calls[3]?.args).toEqual(["team-1", "codex", "session-b", "acct-2"]);
+  });
+
+  test("rebinds when the bound account is no longer usable", async () => {
+    const { calls, dependencies } = makeDependencies({
+      bound: null,
+      placed: account("acct-3"),
+    });
+    const select = createSessionAccountSelector(dependencies);
+    const result = await select({
+      teamId: "team-1",
+      provider: "codex",
+      sessionKey: "session-c",
+      excludedAccountIds: ["acct-1"],
+    });
+    expect(result?.sticky).toBe(false);
+    expect(result?.id).toBe("acct-3");
+    const findBound = calls.find((c) => c.fn === "findBound");
+    expect(findBound?.args).toEqual(["team-1", "codex", "session-c", ["acct-1"]]);
+    const claim = calls.find((c) => c.fn === "claim");
+    expect(claim?.args).toEqual(["team-1", "codex", ["acct-1"]]);
+  });
+
+  test("skips stickiness entirely without a session key", async () => {
+    const { calls, dependencies } = makeDependencies({ placed: account("acct-4") });
+    const select = createSessionAccountSelector(dependencies);
+    const result = await select({
+      teamId: "team-1",
+      provider: "codex",
+      sessionKey: null,
+    });
+    expect(result).toEqual({ ...account("acct-4"), sticky: false });
+    expect(calls.map((c) => c.fn)).toEqual(["sweepLeases", "claim"]);
+  });
+
+  test("returns null when no account is usable", async () => {
+    const { calls, dependencies } = makeDependencies({ bound: null, placed: null });
+    const select = createSessionAccountSelector(dependencies);
+    const result = await select({
+      teamId: "team-1",
+      provider: "codex",
+      sessionKey: "session-d",
+    });
+    expect(result).toBeNull();
+    expect(calls.some((c) => c.fn === "bind")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Symptom

The same failure shape as manaflow-ai/subrouter#228, in the coderouter TypeScript data plane. Parallel Codex sessions herd onto one account, drain it, then herd onto the next one. And because routing has no session stickiness, the provider prompt cache is discarded on nearly every turn, which re-bills the whole prefix as uncached input.

## Root cause

Two mechanisms in `web/services/coderouter`:

1. **Read-pick-write race.** `selectAccountForRequest` (`repository.ts`) ran three independent statements: lease sweep, `SELECT ... ORDER BY last_used_at ASC LIMIT 1`, then a separate `UPDATE last_used_at`. No lock or transaction spans the sequence. N parallel session starts all read the same snapshot and pick the same account.
2. **No session→account stickiness.** The Codex CLI `session_id` header was forwarded upstream but never used for routing. Every request re-ran the LRU pick, so a session hopped accounts turn by turn and never built a cache anywhere.

## Fix (port of subrouter PR #228 to TypeScript/Postgres)

- New `coderouter_session_accounts` table (additive migration) pins one agent session to one account.
- `selectAccountForSession`: a bound session keeps its account while that account is usable (sticky reuse). It moves only when the account is broken, cooling down, removed, or already attempted in this request — the move-worthiness gate reduced to the binary usability signal this schema has. An account mid-refresh (`state = 'refreshing'`) counts as usable, and a sticky session waits out a busy refresh lease (4 × 500 ms) instead of moving and discarding its cache.
- Placement of a new or moving session is one atomic statement: `UPDATE ... WHERE id = (SELECT ... ORDER BY recently-active bound sessions ASC, last_used_at ASC NULLS FIRST LIMIT 1 FOR UPDATE SKIP LOCKED) RETURNING`. Overlapping placements lock different rows, so concurrent session starts spread across the pool instead of stacking on the argmax. If every candidate row is locked, a blocking fallback claim accepts a collision rather than failing the request.
- `selectAccountForRequest` (models catalog, opencode) now uses the same atomic claim, which closes its race too.
- **Deploy-order safety:** if the code reaches production before the migration, every session-table statement degrades to the exact legacy behavior (42P01 guard) instead of erroring requests. Covered by a test that renames the table away and back.
- `proxyCodexRequest` is now built by `createCodexResponsesProxy(deps)` for dependency-injected tests, mirroring `createCodexModelsProxy`.

## Not needed here (verified)

The two Claude credential bugs from the same review are already covered in this codebase: `freshCredential` is single-flight per account through a DB lease with a compare-and-swap write, and `failRefreshLease` marks an account `broken` only on terminal errors (`invalid_grant`-class), never on transient ones. Claude OAuth refresh does not exist in this data plane yet ("coming soon"), so no Claude-specific carve-out applies. (The Go subrouter equivalents all landed on its main: #228, #229, #231.)

## Tests

- `tests/coderouter-session-selector.test.ts` — sticky reuse, place+bind, rebind on unusable, no-session-key path, drained pool.
- `tests/coderouter-responses-proxy.test.ts` — `session_id` extraction and bounds, cooldown + retry excludes the rate-limited account, sticky waits out refresh-busy while non-sticky moves, 503 when drained.
- `tests/coderouter-routing-db-behavior.test.ts` (CMUX_DB_TEST-gated, real Postgres) — sequential placements balance exactly; 12 concurrent placements never all land on one account; a session sticks across requests and through a mid-refresh account; a cooled-down session moves once and re-sticks; exclusion, last-write-wins binding, and the missing-table fallback.

`bun run test`: full suite green. DB behavior tests repeated 10× without a flake. `bun run typecheck` and eslint on the changed files: clean. Dispatched CI: https://github.com/manaflow-ai/cmux/actions/runs/32216813805

## Deploy note

The migration is additive and the code tolerates either order. Dispatch the "Cloud VM DB migration" workflow (staging → production) after merge so stickiness activates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-aware account routing for CodeRouter requests.
  * Requests with a session identifier now consistently use the same available account when possible.
  * Added load-aware account placement, cooldown handling, and automatic reassignment when an account is unavailable.
  * Added safeguards for missing or oversized session identifiers and exhausted account availability.
  * Added brief retries during credential refresh to improve sticky-session continuity.

* **Tests**
  * Added coverage for session stickiness, concurrent routing, rate limits, exclusions, and account exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->