### PR TITLE
Flip web deploy polarity: staging auto-deploys main, prod promotes manually

### DIFF
--- a/.github/workflows/cloud-vm-migrate.yml
+++ b/.github/workflows/cloud-vm-migrate.yml
@@ -11,6 +11,21 @@ on:
         options:
           - staging
           - production
+  workflow_call:
+    inputs:
+      target:
+        description: Migration target (staging or production)
+        required: true
+        type: string
+      ref:
+        description: >-
+          Commit sha to run a production migration at (must be reviewed main
+          history; the caller is responsible for the ancestor check). Empty
+          keeps the default refs/heads/main pin. Ignored for staging, which
+          always migrates at the calling event's sha.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -31,9 +46,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Staging must rehearse the dispatched branch before it can merge.
-          # Production remains pinned to reviewed main for both preflight and
-          # the prerequisite staging migration.
-          ref: ${{ inputs.target == 'production' && 'refs/heads/main' || github.sha }}
+          # Production runs at the caller-pinned main-history sha (workflow_call
+          # ref, guarded by the caller) or reviewed refs/heads/main, for both
+          # preflight and the prerequisite staging migration.
+          ref: ${{ inputs.target == 'production' && (inputs.ref || 'refs/heads/main') || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -66,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.target == 'production' && 'refs/heads/main' || github.sha }}
+          ref: ${{ inputs.target == 'production' && (inputs.ref || 'refs/heads/main') || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -123,7 +139,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: refs/heads/main
+          ref: ${{ inputs.ref || 'refs/heads/main' }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/cloud-vm-smoke.yml
+++ b/.github/workflows/cloud-vm-smoke.yml
@@ -29,6 +29,12 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      target:
+        description: Smoke target (staging or production)
+        required: true
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/web-deploy-staging.yml
+++ b/.github/workflows/web-deploy-staging.yml
@@ -1,0 +1,62 @@
+name: Web deploy (staging)
+
+# Staging-first deploys: every web-affecting push to main migrates the staging
+# Aurora DB and deploys the cmux-staging Vercel project, so staging always
+# serves current main. Production is NOT deployed from pushes (web/vercel.json
+# disables the git integration); it ships only via web-promote-prod.yml.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - web/**
+      # The changelog page reads ../CHANGELOG.md at build time.
+      - CHANGELOG.md
+      - .github/workflows/web-deploy-staging.yml
+      - .github/workflows/cloud-vm-migrate.yml
+
+permissions:
+  contents: read
+  id-token: write
+
+# Queue pushes; never cancel a run that may be mid-migration.
+concurrency:
+  group: web-deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    uses: ./.github/workflows/cloud-vm-migrate.yml
+    with:
+      target: staging
+    secrets: inherit
+
+  deploy:
+    needs: migrate
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: web
+
+      - name: Deploy cmux-staging
+        run: bun run cloud-vm:deploy -- staging
+        working-directory: web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+  smoke:
+    needs: deploy
+    uses: ./.github/workflows/cloud-vm-smoke.yml
+    with:
+      target: staging
+    secrets: inherit

--- a/.github/workflows/web-promote-prod.yml
+++ b/.github/workflows/web-promote-prod.yml
@@ -1,0 +1,96 @@
+name: Web promote (production)
+
+# Manual promotion of reviewed main history to the cmux production Vercel
+# project (cmux.com). Staging auto-deploys on every web-affecting main push
+# (web-deploy-staging.yml); production ships ONLY through this workflow, after
+# the change has been validated on https://cmux-staging.vercel.app.
+#
+# Rollback: re-dispatch with an older main-history sha (the ancestor guard
+# accepts any commit on origin/main). DB migrations are forward-only
+# (expand/contract discipline), so redeploying older app code does not roll
+# back schema. Fast backstop: Vercel dashboard Instant Rollback on the cmux
+# project.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit sha or ref on main history to promote
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: web-promote-prod
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve and guard promoted sha
+        id: resolve
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse --verify "${REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$sha" origin/main; then
+            echo "::error::${REF} ($sha) is not on origin/main history; only reviewed main commits are promotable"
+            exit 1
+          fi
+          echo "Promoting $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        env:
+          REF: ${{ inputs.ref }}
+
+  # Runs the staging migration first, then the production migration at the
+  # promoted sha, under the cloud-vm-production environment protections.
+  migrate:
+    needs: resolve
+    uses: ./.github/workflows/cloud-vm-migrate.yml
+    with:
+      target: production
+      ref: ${{ needs.resolve.outputs.sha }}
+    secrets: inherit
+
+  deploy:
+    needs: [resolve, migrate]
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: cloud-vm-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: web
+
+      - name: Deploy cmux production
+        run: bun run cloud-vm:deploy -- production
+        working-directory: web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+  smoke:
+    needs: deploy
+    uses: ./.github/workflows/cloud-vm-smoke.yml
+    with:
+      target: production
+    secrets: inherit

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "coderouter:benchmark": "bun scripts/coderouter/benchmark.ts",
     "coderouter:reconcile-billing": "bun scripts/coderouter/reconcile-billing.ts",
     "testflight:backfill-legacy-ownership": "bun scripts/stripe/backfill-pro-testflight-legacy-ownership.ts",
+    "cloud-vm:deploy": "bun scripts/cloud-vm/deploy-vercel.mjs",
     "cloud-vm:env:audit": "bun scripts/cloud-vm/audit-vercel-env.mjs",
     "cloud-vm:migrate": "bun scripts/cloud-vm/migrate-vercel-aurora-iam.mjs",
     "cloud-vm:preflight": "bash scripts/cloud-vm/verify-migration-preflight.sh",

--- a/web/scripts/cloud-vm/deploy-vercel.mjs
+++ b/web/scripts/cloud-vm/deploy-vercel.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parseWebDirAndTarget, runVercel } from "./projects.mjs";
+
+const usage = "Usage: deploy-vercel.mjs [web-dir] <staging|production>";
+const { target, project, webDir } = parseWebDirAndTarget(process.argv.slice(2), usage);
+
+if (!process.env.VERCEL_TOKEN) {
+  console.error("Missing VERCEL_TOKEN in the environment.");
+  process.exit(1);
+}
+
+// Vercel builds from the repo root; the linked project's Root Directory
+// setting (web) picks the app. Link via .vercel/project.json exactly like
+// docs-deploy-reusable.yml so no `vercel link` prompt can appear in CI.
+const repoRoot = path.dirname(webDir);
+const vercelDir = path.join(repoRoot, ".vercel");
+if (existsSync(vercelDir)) {
+  console.error(`Refusing to overwrite existing ${vercelDir}; remove it first.`);
+  process.exit(1);
+}
+
+try {
+  mkdirSync(vercelDir, { recursive: true });
+  writeFileSync(
+    path.join(vercelDir, "project.json"),
+    JSON.stringify({ orgId: project.orgId, projectId: project.projectId }),
+  );
+  const stdout = runVercel(["deploy", "--prod", "--yes", "--cwd", repoRoot], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const deploymentURL = stdout.toString().trim();
+  console.log(
+    JSON.stringify({ ok: true, target, project: project.projectName, url: project.url, deploymentURL }, null, 2),
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+} finally {
+  rmSync(vercelDir, { recursive: true, force: true });
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "main": true,
+      "main": false,
       "**": false
     }
   },


### PR DESCRIPTION
Backend changes currently reach production the moment they merge: `web/vercel.json` had `git.deploymentEnabled.main: true` on the git-linked `cmux` project, while `cmux-staging` deployed manually. That leaves no production-like environment to validate a change before real users (including cmux BETA) get it.

This PR reverses the polarity:

- **`web-deploy-staging.yml`** (new): every push to main touching `web/**` or `CHANGELOG.md` (the changelog page reads it at build time) runs the staging Aurora migration, deploys the `cmux-staging` Vercel project, then smokes it. Queued via a `concurrency` group so a mid-flight migration is never cancelled.
- **`web-promote-prod.yml`** (new): manual dispatch with a `ref` input. Resolves the sha, refuses anything not on `origin/main` history, runs the staging-then-production migration chain at that sha under the `cloud-vm-production` environment, deploys the `cmux` project, then smokes. Rollback = re-dispatch an older main sha (migrations are forward-only) or Vercel Instant Rollback.
- **`web/vercel.json`**: `main: false`, so the git integration stops deploying prod. The merge of this PR is itself the last auto-deploy.
- **`cloud-vm-migrate.yml` / `cloud-vm-smoke.yml`**: gain `workflow_call` triggers so the new workflows reuse them; `workflow_call` keeps the `environment:` bindings that carry the env-scoped secrets (a composite action cannot). Migrate accepts an optional main-history `ref` for promotions; the existing `migrate-production needs: migrate-staging` chain still enforces staging-first migrations. Dispatch behavior is unchanged.
- **`web/scripts/cloud-vm/deploy-vercel.mjs`** (+ `cloud-vm:deploy` script): links the target project from `projects.mjs` exactly like `docs-deploy-reusable.yml` (writes `.vercel/project.json` at repo root, `vercel deploy --prod --yes`), refuses to clobber an existing `.vercel` link. `bun run cloud-vm:deploy -- staging|production` is the break-glass CLI path.

No new secrets or environments: `VERCEL_TOKEN` and the `cloud-vm-staging`/`cloud-vm-production` environments already exist.

First-run verification after merge:
1. Watch the push-triggered staging run end to end (migrate, deploy, smoke).
2. Dispatch `web-promote-prod.yml` once and confirm cmux.com serves the promoted sha.
3. Confirm no prod auto-deploy appears on the next web-touching merge.
4. Confirm required reviewers are set on the `cloud-vm-production` GitHub environment (dashboard-only setting).

actionlint passes on all four workflows (the two SC2129 style notes in `cloud-vm-migrate.yml` predate this PR). No app code changes, so no Vercel preview: git previews are disabled repo-wide and the deploy config exercised here only applies to production deployments of the linked projects.

Dictionary:
- **git integration**: Vercel's GitHub app that builds a project automatically when the linked branch is pushed.
- **workflow_call**: a GitHub Actions trigger that lets one workflow run another workflow's jobs inline, preserving that workflow's environment bindings.
- **GitHub environment**: a named deployment context (e.g. cloud-vm-production) holding scoped secrets and optional required-reviewer approval.
- **expand/contract**: the migration discipline where schema changes stay compatible with the previous app version, so old code can run against the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707151&installation_model_id=21920&pr_number=10389&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10389&signature=54a4351aa9ca4c8e795ca60ffe6dc55d0681984c07fb045faf82d4aa3edb4404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flips web deploys so staging auto-deploys on main pushes and production promotes manually. Previously, production auto-deployed from main via Vercel Git integration while staging was manual, leaving no production-like validation path.

- `web-deploy-staging.yml`: on web-affecting pushes to main, runs the staging PlanetScale migration, deploys `cmux-staging`, then smokes. Uses a concurrency group to avoid canceling mid-migration.
- `web-promote-prod.yml`: manual dispatch with a `ref`. Resolves and guards the sha to reviewed `origin/main`, runs the staging-then-production migration chain under the `cloud-vm-production` environment, deploys `cmux`, then smokes. Roll back by promoting an older main sha or using Vercel Instant Rollback.
- `web/vercel.json`: disables Git integration for `main`, so this merge is the last automatic production deploy from a push.
- `cloud-vm-migrate.yml` and `cloud-vm-smoke.yml`: add `workflow_call`; migrate accepts an optional main-history `ref` for promotions and keeps environment-scoped secrets via environment bindings.
- `web/scripts/cloud-vm/deploy-vercel.mjs` + `cloud-vm:deploy`: links the Vercel project via `.vercel/project.json`, runs `vercel deploy --prod --yes`, and refuses to overwrite an existing `.vercel` link. No new secrets or environments.

Post-merge checks: verify staging auto-deploy + smoke on a web change to main; run a production promotion and confirm cmux.com serves the selected sha; confirm no prod auto-deploy on subsequent merges; ensure required reviewers are set on the `cloud-vm-production` environment.

<sup>Written for commit ee52ae48962e9fdceceaaeb667abf41b90eaca2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated staging deployments for web changes, including database migrations and post-deployment smoke tests.
  - Added a controlled production promotion workflow for deploying a selected commit with production verification.
  - Added reusable workflows for environment-specific migrations and smoke tests.
  - Added a deployment command for publishing the web application to Vercel.

- **Changes**
  - Disabled automatic production deployments from pushes to `main`.
  - Staging deployments are queued to prevent overlapping releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->