### PR TITLE
iOS: delete dead retry-schedule half of MobileIrohConnectionReadinessOwner

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohConnectionReadinessOwner.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohConnectionReadinessOwner.swift
@@ -1,5 +1,4 @@
 import CMUXMobileCore
-import CmuxIrohTransport
 import Foundation
 
 /// A stable, retry-aware failure returned by every connection entrypoint after
@@ -26,31 +25,13 @@ enum MobileIrohConnectionReadinessOutcome: Equatable, Sendable {
     }
 }
 
-/// Owns endpoint activation readiness, failure backoff, and all waiters for the
-/// latest lifecycle revision.
+/// Owns endpoint activation readiness and all waiters for the latest
+/// lifecycle revision.
 @MainActor
 final class MobileIrohConnectionReadinessOwner {
-    private let retrySchedule: CmxIrohRetrySchedule
-    private let jitterUnitInterval: @MainActor () -> Double
     private var pendingRevision: UInt64?
     private var settledOutcome = MobileIrohConnectionReadinessOutcome.inactive
-    private var retryAccountID: String?
-    private var retryAt: Date?
-    private var consecutiveFailureCount = 0
     private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
-
-    init(
-        retrySchedule: CmxIrohRetrySchedule = CmxIrohRetrySchedule(
-            initialDelay: 30,
-            maximumDelay: 3_600
-        ),
-        jitterUnitInterval: @escaping @MainActor () -> Double = {
-            Double.random(in: 0 ... 1)
-        }
-    ) {
-        self.retrySchedule = retrySchedule
-        self.jitterUnitInterval = jitterUnitInterval
-    }
 
     var isPending: Bool { pendingRevision != nil }
 
@@ -71,9 +52,6 @@ final class MobileIrohConnectionReadinessOwner {
         guard pendingRevision == revision else { return false }
         pendingRevision = nil
         settledOutcome = .inactive
-        retryAccountID = nil
-        retryAt = nil
-        consecutiveFailureCount = 0
         resumeWaiters()
         return true
     }
@@ -86,57 +64,8 @@ final class MobileIrohConnectionReadinessOwner {
         guard pendingRevision == revision else { return false }
         pendingRevision = nil
         settledOutcome = outcome
-        switch outcome {
-        case .failed:
-            break
-        case .inactive, .ready:
-            retryAccountID = nil
-            retryAt = nil
-            consecutiveFailureCount = 0
-        }
         resumeWaiters()
         return true
-    }
-
-    @discardableResult
-    func completeFailure(
-        revision: UInt64,
-        accountID: String,
-        error: any Error,
-        retryAfterSeconds: Int?,
-        now: Date
-    ) -> MobileIrohRuntimePreparationError? {
-        guard pendingRevision == revision else { return nil }
-        if retryAccountID != accountID {
-            consecutiveFailureCount = 0
-        }
-        let serverFloor = max(
-            retryAfterSeconds ?? 0,
-            (error as? any CmxRetryAfterProviding)?.retryAfterSeconds ?? 0
-        )
-        let delay = retrySchedule.delay(
-            failureCount: consecutiveFailureCount,
-            retryAfterSeconds: serverFloor > 0 ? serverFloor : nil,
-            jitterUnitInterval: jitterUnitInterval()
-        )
-        let boundedDelay = max(1, Int(delay.rounded(.up)))
-        retryAccountID = accountID
-        retryAt = now.addingTimeInterval(delay)
-        consecutiveFailureCount = min(consecutiveFailureCount + 1, 20)
-        pendingRevision = nil
-        let failure = MobileIrohRuntimePreparationError(
-            diagnosticFailureKind: DiagnosticFailureKind.classify(error),
-            retryAfterSeconds: boundedDelay
-        )
-        settledOutcome = .failed(failure)
-        resumeWaiters()
-        return failure
-    }
-
-    func shouldStartActivation(accountID: String, now: Date) -> Bool {
-        guard !isPending else { return false }
-        guard retryAccountID == accountID, let retryAt else { return true }
-        return now >= retryAt
     }
 
     func wait(
@@ -160,18 +89,7 @@ final class MobileIrohConnectionReadinessOwner {
             }
             guard !Task.isCancelled else { return .inactive }
         }
-        guard case let .failed(failure) = settledOutcome,
-              let retryAt else {
-            return settledOutcome
-        }
-        let remaining = max(
-            1,
-            Int(retryAt.timeIntervalSince(now()).rounded(.up))
-        )
-        return .failed(MobileIrohRuntimePreparationError(
-            diagnosticFailureKind: failure.diagnosticFailureKind,
-            retryAfterSeconds: remaining
-        ))
+        return settledOutcome
     }
 
     private func resumeWaiters() {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -229,41 +229,6 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
-    func connectionReadinessReadsClockAfterActivationSettles() async throws {
-        let start = Date(timeIntervalSince1970: 100)
-        var observedNow = start
-        let readiness = MobileIrohConnectionReadinessOwner(
-            retrySchedule: CmxIrohRetrySchedule(
-                initialDelay: 30,
-                maximumDelay: 3_600,
-                jitterFraction: 0
-            ),
-            jitterUnitInterval: { 0 }
-        )
-        readiness.begin(revision: 1)
-        let waiter = Task {
-            await readiness.wait(now: { observedNow })
-        }
-        await Task.yield()
-
-        observedNow = start.addingTimeInterval(45)
-        _ = try #require(readiness.completeFailure(
-            revision: 1,
-            accountID: "account-a",
-            error: CmxIrohTrustBrokerClientError.connectivity,
-            retryAfterSeconds: nil,
-            now: start
-        ))
-
-        let outcome = await waiter.value
-        guard case let .failed(failure) = outcome else {
-            Issue.record("Expected failed readiness outcome")
-            return
-        }
-        #expect(failure.retryAfterSeconds == 1)
-    }
-
-    @Test
     func discoveryRefreshDiagnosticPreservesTypedFailureCategory() throws {
         let offline = try #require(
             MobileIrohRuntimeComposition.discoveryRefreshFailureEvent(


### PR DESCRIPTION
Production only calls begin, complete, abandon, and wait on MobileIrohConnectionReadinessOwner; activation backoff is computed by MobileIrohRuntimeComposition itself and settled through complete(revision:outcome:). This deletes the unreachable retry half (CmxIrohRetrySchedule storage, jitter closure, retryAt and consecutiveFailureCount state, completeFailure, shouldStartActivation) plus the one test that was its only caller. Net delta is 2 files changed, 3 insertions, 120 deletions. Part of the mobile-sync rip-out wave 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707796&installation_model_id=21920&pr_number=10392&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10392&signature=b8ee4b1df380549772f8d62649c288ed90a7a2bb23103a4c2f47dde34c8c17c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes unreachable retry-scheduling logic from MobileIrohConnectionReadinessOwner, since MobileIrohRuntimeComposition already computes activation backoff and settles readiness. In production, callers only use begin, complete, abandon, and wait.

- Remove retry state and helpers: `CmxIrohRetrySchedule`, jitter closure, `retryAt`, `retryAccountID`, `consecutiveFailureCount`, plus completeFailure and shouldStartActivation; drop import of `CmuxIrohTransport`.
- Change wait(): old behavior recalculated retryAfterSeconds when failed with a retryAt; new behavior returns the settled outcome. Signature unchanged; no production behavior change because retryAt was only set by the removed method.
- Remove the single test that exercised the deleted path. No migration required; production call sites continue to use begin/complete/abandon/wait.

<sup>Written for commit 12f5d17a718cef7bfc9eff4d2b28517f493a0c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified mobile connection readiness handling.
  * Removed retry delays, jitter, backoff, and activation-gating behavior.
  * Connection readiness now returns the settled result directly.

* **Tests**
  * Removed coverage for retry timing after a failed readiness completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->