### PR TITLE
Shared backend-environment override model, manaflow switch gate, WebOriginURL

### DIFF
--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthUser.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthUser.swift
@@ -14,6 +14,11 @@ public struct CMUXAuthUser: Codable, Equatable, Sendable {
     public let displayName: String?
     /// The user's Stack Auth profile image URL, if one is set.
     public let profileImageURL: String?
+    /// Whether Stack Auth has verified the primary email. Gates trust in the
+    /// email's domain (e.g. the backend environment switcher); identities
+    /// persisted before this field existed decode as unverified until the
+    /// network session refreshes them.
+    public let primaryEmailVerified: Bool
 
     /// Creates a user value.
     /// - Parameters:
@@ -21,15 +26,29 @@ public struct CMUXAuthUser: Codable, Equatable, Sendable {
     ///   - primaryEmail: The user's primary email, if any.
     ///   - displayName: The user's display name, if any.
     ///   - profileImageURL: The user's profile image URL, if any.
+    ///   - primaryEmailVerified: Whether Stack verified the primary email.
     public init(
         id: String,
         primaryEmail: String?,
         displayName: String?,
-        profileImageURL: String? = nil
+        profileImageURL: String? = nil,
+        primaryEmailVerified: Bool = false
     ) {
         self.id = id
         self.primaryEmail = primaryEmail
         self.displayName = displayName
         self.profileImageURL = profileImageURL
+        self.primaryEmailVerified = primaryEmailVerified
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            primaryEmail: try container.decodeIfPresent(String.self, forKey: .primaryEmail),
+            displayName: try container.decodeIfPresent(String.self, forKey: .displayName),
+            profileImageURL: try container.decodeIfPresent(String.self, forKey: .profileImageURL),
+            primaryEmailVerified: try container.decodeIfPresent(Bool.self, forKey: .primaryEmailVerified) ?? false
+        )
     }
 }

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// The user-selected backend environment, persisted across launches.
+///
+/// Release builds default to production; the Settings picker stores this
+/// override so a device can run against the staging backend (the cmux-staging
+/// Vercel project plus the development Stack project) instead. The composition
+/// roots read it once at startup, below any build-time bake: a tagged dev
+/// build's baked origins always win over this runtime value.
+public enum CMUXBackendEnvironmentOverride: String, CaseIterable, Codable, Sendable {
+    /// The default: https://cmux.com and the production Stack project.
+    case production
+    /// The staging web deployment and the development Stack project.
+    case staging
+
+    /// The UserDefaults key both apps persist the override under.
+    public static let defaultsKey = "cmux.backendEnvironmentOverride"
+
+    /// The staging web origin (the cmux-staging Vercel project). Serves the
+    /// web API, auth handler pages, and the iroh broker for staging.
+    public static let stagingWebOrigin = "https://cmux-staging.vercel.app"
+
+    /// Load the persisted override; absent or unrecognized values are
+    /// production so an old or corrupted default can never strand a build on
+    /// a non-production backend.
+    public static func load(from defaults: UserDefaults) -> CMUXBackendEnvironmentOverride {
+        guard
+            let raw = defaults.string(forKey: defaultsKey),
+            let value = CMUXBackendEnvironmentOverride(rawValue: raw)
+        else { return .production }
+        return value
+    }
+
+    /// Persist the override. Production removes the key entirely, keeping
+    /// "no key" and "production" indistinguishable by design.
+    public func store(in defaults: UserDefaults) {
+        if self == .production {
+            defaults.removeObject(forKey: Self.defaultsKey)
+        } else {
+            defaults.set(rawValue, forKey: Self.defaultsKey)
+        }
+    }
+
+    /// The Stack Auth environment this override selects. Staging uses the
+    /// development Stack project, which is what the staging web deployment
+    /// authenticates against.
+    public var authEnvironment: CMUXAuthEnvironment {
+        switch self {
+        case .production: .production
+        case .staging: .development
+        }
+    }
+}

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentSwitchGate.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentSwitchGate.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Decides who may see the backend environment picker in Settings.
+///
+/// UX gating only, not a security boundary: the staging deployment's own auth
+/// is what protects staging, and its URL is public. The gate exists so the
+/// picker never confuses testers outside the team. Callers additionally show
+/// the picker in DEBUG builds and whenever a non-production override is
+/// already active, so switching back to production is always possible.
+public enum CMUXBackendEnvironmentSwitchGate {
+    /// The email domain whose verified members may switch environments.
+    public static let allowedEmailDomainSuffix = "@manaflow.ai"
+
+    /// Whether the signed-in user unlocks the picker: a verified primary
+    /// email on the allowed domain. Unverified emails never qualify, since a
+    /// user can set an arbitrary unverified address on their own account.
+    public static func allows(_ user: CMUXAuthUser?) -> Bool {
+        guard let user, user.primaryEmailVerified, let email = user.primaryEmail else {
+            return false
+        }
+        return email.lowercased().hasSuffix(allowedEmailDomainSuffix)
+    }
+}

--- a/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentOverrideTests.swift
+++ b/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentOverrideTests.swift
@@ -1,0 +1,113 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+
+@Suite("Backend environment override")
+struct BackendEnvironmentOverrideTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "BackendEnvironmentOverrideTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test("Absent key loads as production")
+    func absentKeyLoadsAsProduction() {
+        let defaults = makeDefaults()
+        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+    }
+
+    @Test("Staging round-trips through defaults")
+    func stagingRoundTrips() {
+        let defaults = makeDefaults()
+        CMUXBackendEnvironmentOverride.staging.store(in: defaults)
+        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .staging)
+    }
+
+    @Test("Storing production removes the key")
+    func storingProductionRemovesKey() {
+        let defaults = makeDefaults()
+        CMUXBackendEnvironmentOverride.staging.store(in: defaults)
+        CMUXBackendEnvironmentOverride.production.store(in: defaults)
+        #expect(defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey) == nil)
+        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+    }
+
+    @Test("Unknown raw value loads as production")
+    func unknownRawValueLoadsAsProduction() {
+        let defaults = makeDefaults()
+        defaults.set("nightly", forKey: CMUXBackendEnvironmentOverride.defaultsKey)
+        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+    }
+
+    @Test("Staging maps to the development Stack environment")
+    func stagingMapsToDevelopmentStack() {
+        #expect(CMUXBackendEnvironmentOverride.staging.authEnvironment == .development)
+        #expect(CMUXBackendEnvironmentOverride.production.authEnvironment == .production)
+    }
+}
+
+@Suite("Backend environment switch gate")
+struct BackendEnvironmentSwitchGateTests {
+    private func user(email: String?, verified: Bool) -> CMUXAuthUser {
+        CMUXAuthUser(
+            id: "user-1",
+            primaryEmail: email,
+            displayName: nil,
+            primaryEmailVerified: verified
+        )
+    }
+
+    @Test("Verified manaflow email unlocks the picker")
+    func verifiedManaflowEmailAllows() {
+        #expect(CMUXBackendEnvironmentSwitchGate.allows(user(email: "aziz@manaflow.ai", verified: true)))
+    }
+
+    @Test("Domain match is case-insensitive")
+    func domainMatchIsCaseInsensitive() {
+        #expect(CMUXBackendEnvironmentSwitchGate.allows(user(email: "Lawrence@Manaflow.AI", verified: true)))
+    }
+
+    @Test("Unverified manaflow email is rejected")
+    func unverifiedManaflowEmailRejected() {
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(user(email: "aziz@manaflow.ai", verified: false)))
+    }
+
+    @Test("Other domains are rejected, including suffix look-alikes")
+    func otherDomainsRejected() {
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(user(email: "someone@example.com", verified: true)))
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(user(email: "someone@notmanaflow.ai", verified: true)))
+    }
+
+    @Test("Missing email or user is rejected")
+    func missingEmailOrUserRejected() {
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(user(email: nil, verified: true)))
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(nil))
+    }
+}
+
+@Suite("CMUXAuthUser verified-email decoding")
+struct CMUXAuthUserVerifiedDecodingTests {
+    @Test("Legacy persisted JSON without the field decodes as unverified")
+    func legacyJSONDecodesUnverified() throws {
+        let legacy = Data(
+            #"{"id":"user-1","primaryEmail":"aziz@manaflow.ai","displayName":"Aziz"}"#.utf8
+        )
+        let user = try JSONDecoder().decode(CMUXAuthUser.self, from: legacy)
+        #expect(user.primaryEmailVerified == false)
+        #expect(!CMUXBackendEnvironmentSwitchGate.allows(user))
+    }
+
+    @Test("Verified flag round-trips through Codable")
+    func verifiedFlagRoundTrips() throws {
+        let user = CMUXAuthUser(
+            id: "user-1",
+            primaryEmail: "aziz@manaflow.ai",
+            displayName: "Aziz",
+            primaryEmailVerified: true
+        )
+        let decoded = try JSONDecoder().decode(CMUXAuthUser.self, from: JSONEncoder().encode(user))
+        #expect(decoded == user)
+        #expect(decoded.primaryEmailVerified)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Client/StackAuthClient.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Client/StackAuthClient.swift
@@ -134,11 +134,13 @@ public struct StackAuthClient: AuthClient {
         let email = await user.primaryEmail
         let name = await user.displayName
         let profileImageURL = await user.profileImageUrl
+        let emailVerified = await user.primaryEmailVerified
         return CMUXAuthUser(
             id: id,
             primaryEmail: email,
             displayName: name,
-            profileImageURL: profileImageURL
+            profileImageURL: profileImageURL,
+            primaryEmailVerified: emailVerified
         )
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
@@ -33,7 +33,11 @@ public struct AuthConfig: Equatable, Sendable {
     ///     otherwise). Decided by the composition root, not read here.
     ///   - overrides: String overrides (e.g. parsed from a bundled
     ///     `LocalConfig.plist`). Recognized keys: `STACK_PROJECT_ID_DEV/PROD`,
-    ///     `STACK_PUBLISHABLE_CLIENT_KEY_DEV/PROD`, and `ApiBaseURL`.
+    ///     `STACK_PUBLISHABLE_CLIENT_KEY_DEV/PROD`, `ApiBaseURL`, and
+    ///     `WebOriginURL`. `WebOriginURL` moves the whole web origin: it
+    ///     retargets the magic-link callback and is the API base when no
+    ///     explicit `ApiBaseURL` is given, so a staging override cannot leave
+    ///     magic-link emails pointing at the per-environment default.
     public init(
         environment: CMUXAuthEnvironment,
         overrides: [String: String] = [:]
@@ -47,7 +51,7 @@ public struct AuthConfig: Equatable, Sendable {
             productionPublishableClientKey: "pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr"
         )
 
-        let callbackURL: String
+        var callbackURL: String
         let defaultAPIBaseURL: String
         switch environment {
         case .development:
@@ -58,13 +62,20 @@ public struct AuthConfig: Equatable, Sendable {
             defaultAPIBaseURL = "https://cmux.com"
         }
 
-        let override = overrides["ApiBaseURL"]
-        let apiBaseURL: String
-        if let override, !override.isEmpty {
-            apiBaseURL = override.hasSuffix("/") ? String(override.dropLast()) : override
-        } else {
-            apiBaseURL = defaultAPIBaseURL
+        var apiBaseURL = defaultAPIBaseURL
+        if let webOrigin = Self.normalizedOrigin(overrides["WebOriginURL"]) {
+            callbackURL = "\(webOrigin)/auth/callback"
+            apiBaseURL = webOrigin
+        }
+        if let override = Self.normalizedOrigin(overrides["ApiBaseURL"]) {
+            apiBaseURL = override
         }
         self.init(stack: stack, magicLinkCallbackURL: callbackURL, apiBaseURL: apiBaseURL)
+    }
+
+    /// A non-empty override origin with any trailing slash removed, or `nil`.
+    private static func normalizedOrigin(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value.hasSuffix("/") ? String(value.dropLast()) : value
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthConfigTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthConfigTests.swift
@@ -9,4 +9,34 @@ import Testing
         #expect(config.magicLinkCallbackURL == "https://cmux.com/auth/callback")
         #expect(config.apiBaseURL == "https://cmux.com")
     }
+
+    @Test func webOriginOverrideMovesCallbackAndAPIBase() {
+        let config = AuthConfig(
+            environment: .development,
+            overrides: ["WebOriginURL": "https://cmux-staging.vercel.app/"]
+        )
+
+        #expect(config.magicLinkCallbackURL == "https://cmux-staging.vercel.app/auth/callback")
+        #expect(config.apiBaseURL == "https://cmux-staging.vercel.app")
+    }
+
+    @Test func explicitApiBaseURLStillBeatsWebOrigin() {
+        let config = AuthConfig(
+            environment: .development,
+            overrides: [
+                "WebOriginURL": "https://cmux-staging.vercel.app",
+                "ApiBaseURL": "http://localhost:3900",
+            ]
+        )
+
+        #expect(config.magicLinkCallbackURL == "https://cmux-staging.vercel.app/auth/callback")
+        #expect(config.apiBaseURL == "http://localhost:3900")
+    }
+
+    @Test func emptyWebOriginOverrideIsIgnored() {
+        let config = AuthConfig(environment: .production, overrides: ["WebOriginURL": ""])
+
+        #expect(config.magicLinkCallbackURL == "https://cmux.com/auth/callback")
+        #expect(config.apiBaseURL == "https://cmux.com")
+    }
 }


### PR DESCRIPTION
Groundwork for the runtime Production/Staging environment switcher (part of the staging-first program with https://github.com/manaflow-ai/cmux/pull/10389). Inert on its own: no UI, and no composition root reads the new model yet. The macOS and iOS switcher PRs build on this.

- `CMUXBackendEnvironmentOverride` (CMUXAuthCore): the persisted picker value under UserDefaults key `cmux.backendEnvironmentOverride`. Absent or unknown raw values load as production, storing production removes the key, and `staging` maps to the development Stack project, which is what https://cmux-staging.vercel.app authenticates against.
- `CMUXBackendEnvironmentSwitchGate` (CMUXAuthCore): picker visibility = verified primary email ending `@manaflow.ai`, case-insensitive, fail closed on missing user/email/verification. This is UX gating; the staging deployment's own auth is the security boundary.
- `CMUXAuthUser.primaryEmailVerified`: mapped from the Stack SDK's `primary_email_verified` in `StackAuthClient.mapped`. A custom `init(from:)` decodes identities persisted before this field as unverified, so a cached identity can never unlock the gate until the network session revalidates it.
- `AuthConfig` `WebOriginURL` override: moves the magic-link callback and the default API base together. The existing `ApiBaseURL` override alone leaves `magicLinkCallbackURL` pinned to the per-environment default (`localhost:3000` for development), which would point staging magic-link emails at localhost. Explicit `ApiBaseURL` still wins for the API base.

Tests: `swift test` green in both packages (CMUXAuthCore 27 tests, CmuxAuthRuntime 240 tests), covering the gate rule (verified/unverified, wrong domain, suffix look-alike `@notmanaflow.ai`, case-insensitivity, nil), override round-trip with unknown-value fallback, legacy-JSON decode, and the `WebOriginURL`/`ApiBaseURL` precedence.

Dictionary:
- **Stack project**: a Stack Auth tenant; dev (454ecd03…) and prod (9790718f…) projects hold separate user accounts.
- **magic-link callback**: the web URL a sign-in email link opens to complete authentication.
- **composition root**: the app-startup code that resolves configuration once and injects it everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707888&installation_model_id=21920&pr_number=10393&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10393&signature=7251498bbf49fa9276ee46458b645b0ab346bdf2dcf04a9f46093a69e6a32239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared runtime Production/Staging backend switch and a visibility gate, and introduces a `WebOriginURL` override so magic-link callbacks move with the selected web origin. App behavior is unchanged for now; no composition root reads the override yet.

- `CMUXBackendEnvironmentOverride` (`CMUXAuthCore`): persisted under `cmux.backendEnvironmentOverride`; missing/unknown loads as production; storing production removes the key; `staging` uses the development Stack project and `https://cmux-staging.vercel.app`.
- `CMUXBackendEnvironmentSwitchGate` (`CMUXAuthCore`): shows the picker only for users with a verified primary email ending `@manaflow.ai` (case-insensitive); UX gating only.
- `CMUXAuthUser.primaryEmailVerified` (`CMUXAuthCore`): mapped from Stack; legacy persisted users decode as unverified, so cached identities cannot unlock the gate until the session refreshes.
- `AuthConfig` (`CmuxAuthRuntime`): new `WebOriginURL` override moves both `magicLinkCallbackURL` and the default API base; explicit `ApiBaseURL` still wins for the API base; trailing slashes are normalized. Tests cover gate rules, override persistence/fallback, legacy decode, and override precedence.

**Migration**
- If you previously targeted staging by only setting `ApiBaseURL`, add `WebOriginURL` to point magic-link emails to staging. No other code changes are required.

<sup>Written for commit a46c4ae7d52bfffc1d2e45656c5efe69effd4a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between production and staging environments.
  * Environment switching is restricted to users with a verified company email address.
  * Added support for verified primary email status.
  * Added configurable web origin overrides for authentication callbacks and API access.

* **Bug Fixes**
  * Preserved compatibility with previously saved user data.
  * Ensured explicit API URL settings take precedence over web origin settings.

* **Tests**
  * Added coverage for environment selection, access rules, email verification, persistence, and URL overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->