### PR TITLE
macOS runtime backend-environment switcher (Production/Staging)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4229,14 +4229,18 @@ struct CMUXCLI {
                 }
                 // auth.sign_out awaits the token clear before replying.
                 let result = try client.sendV2(method: "auth.sign_out")
-                let returnedToProduction = (result["returned_to_production"] as? Bool) == true
-                if (result["signed_in"] as? Bool) == true && !returnedToProduction {
+                // `returned_to_lane` is the accurate flag; older apps only
+                // send the historical `returned_to_production`.
+                let returnedToLane = (result["returned_to_lane"] as? Bool) == true
+                    || (result["returned_to_production"] as? Bool) == true
+                if (result["signed_in"] as? Bool) == true && !returnedToLane {
                     print("Sign-out requested but state hasn't cleared yet. Run `cmux auth status` to confirm.")
-                } else if returnedToProduction {
-                    // Signing out on a non-production environment chains a
-                    // switch back to Production, which restores the saved
-                    // Production session (so signed_in may be true again).
-                    print("Signed out. Returned to the Production environment.")
+                } else if returnedToLane {
+                    // Signing out on an explicitly chosen staging environment
+                    // chains a switch back to the build's own default
+                    // environment (Production on release builds), restoring
+                    // its saved session (so signed_in may be true again).
+                    print("Signed out. Returned to this build's default environment.")
                 } else {
                     print("Signed out.")
                 }
@@ -16099,10 +16103,11 @@ struct CMUXCLI {
 
             status   Print whether the user is signed in (add `cmux --json` for JSON).
             login    Open the sign-in popup on the cmux web app and wait for it to finish.
-            logout   Clear the current session. On a non-production backend
-                     environment this also returns the app to Production and
-                     restores its saved Production session (reported as
-                     `returned_to_production` in the JSON result).
+            logout   Clear the current session. On an explicitly chosen staging
+                     backend this also returns the app to its build's default
+                     environment and restores that saved session (reported as
+                     `returned_to_lane`, plus the historical
+                     `returned_to_production`, in the JSON result).
             """
         case "login":
             return """

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4229,10 +4229,16 @@ struct CMUXCLI {
                 }
                 // auth.sign_out awaits the token clear before replying.
                 let result = try client.sendV2(method: "auth.sign_out")
-                if (result["signed_in"] as? Bool) != true {
-                    print("Signed out.")
-                } else {
+                let returnedToProduction = (result["returned_to_production"] as? Bool) == true
+                if (result["signed_in"] as? Bool) == true && !returnedToProduction {
                     print("Sign-out requested but state hasn't cleared yet. Run `cmux auth status` to confirm.")
+                } else if returnedToProduction {
+                    // Signing out on a non-production environment chains a
+                    // switch back to Production, which restores the saved
+                    // Production session (so signed_in may be true again).
+                    print("Signed out. Returned to the Production environment.")
+                } else {
+                    print("Signed out.")
                 }
 
             default:
@@ -16093,7 +16099,10 @@ struct CMUXCLI {
 
             status   Print whether the user is signed in (add `cmux --json` for JSON).
             login    Open the sign-in popup on the cmux web app and wait for it to finish.
-            logout   Clear the current session.
+            logout   Clear the current session. On a non-production backend
+                     environment this also returns the app to Production and
+                     restores its saved Production session (reported as
+                     `returned_to_production` in the JSON result).
             """
         case "login":
             return """

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
@@ -50,4 +50,12 @@ public enum CMUXBackendEnvironmentOverride: String, CaseIterable, Codable, Senda
         case .staging: .development
         }
     }
+
+    /// Whether entering this environment requires an established, eligible
+    /// session before the switch may complete. Staging gates (a verified
+    /// team session, or DEBUG); production NEVER gates, so switching back is
+    /// always possible — the switch transaction's revert path relies on this.
+    public var requiresGatedSession: Bool {
+        self == .staging
+    }
 }

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentOverride.swift
@@ -1,12 +1,17 @@
 import Foundation
 
-/// The user-selected backend environment, persisted across launches.
+/// An explicitly selectable backend environment, persisted across launches.
 ///
-/// Release builds default to production; the Settings picker stores this
-/// override so a device can run against the staging backend (the cmux-staging
-/// Vercel project plus the development Stack project) instead. The composition
-/// roots read it once at startup, below any build-time bake: a tagged dev
-/// build's baked origins always win over this runtime value.
+/// Persistence is TRI-STATE on ``defaultsKey``: an ABSENT key means "no
+/// explicit choice" — the build runs its own lane
+/// (``CMUXBackendEnvironmentBuildLane``) — while a persisted value
+/// (production INCLUDED) is an explicit WHOLESALE choice replacing the
+/// entire backend key set, beating build-time bakes, launch environment
+/// variables, and DEBUG compile defaults atomically. This supersedes the
+/// earlier design in which storing production removed the key ("no key" and
+/// "production" indistinguishable by design): under wholesale overrides the
+/// two differ — an absent key follows the bake, an explicit "production"
+/// pins the production backend even on a staging- or dev-baked build.
 public enum CMUXBackendEnvironmentOverride: String, CaseIterable, Codable, Sendable {
     /// The default: https://cmux.com and the production Stack project.
     case production
@@ -20,25 +25,25 @@ public enum CMUXBackendEnvironmentOverride: String, CaseIterable, Codable, Senda
     /// web API, auth handler pages, and the iroh broker for staging.
     public static let stagingWebOrigin = "https://cmux-staging.vercel.app"
 
-    /// Load the persisted override; absent or unrecognized values are
-    /// production so an old or corrupted default can never strand a build on
-    /// a non-production backend.
-    public static func load(from defaults: UserDefaults) -> CMUXBackendEnvironmentOverride {
-        guard
-            let raw = defaults.string(forKey: defaultsKey),
-            let value = CMUXBackendEnvironmentOverride(rawValue: raw)
-        else { return .production }
-        return value
+    /// Load the persisted EXPLICIT choice, or nil when no choice is
+    /// persisted (the build lane). An unrecognized raw value is also nil, so
+    /// an old or corrupted default fails safe toward the build's own bake.
+    public static func explicitChoice(from defaults: UserDefaults) -> CMUXBackendEnvironmentOverride? {
+        guard let raw = defaults.string(forKey: defaultsKey) else { return nil }
+        return CMUXBackendEnvironmentOverride(rawValue: raw)
     }
 
-    /// Persist the override. Production removes the key entirely, keeping
-    /// "no key" and "production" indistinguishable by design.
-    public func store(in defaults: UserDefaults) {
-        if self == .production {
-            defaults.removeObject(forKey: Self.defaultsKey)
-        } else {
-            defaults.set(rawValue, forKey: Self.defaultsKey)
-        }
+    /// Persist this environment as the explicit choice. ALWAYS writes the
+    /// raw value — production included — because an explicit production
+    /// choice is a real wholesale override on a non-production-lane build,
+    /// not the absence of one. Returning to the lane is ``clearChoice(in:)``.
+    public func storeChoice(in defaults: UserDefaults) {
+        defaults.set(rawValue, forKey: Self.defaultsKey)
+    }
+
+    /// Remove the explicit choice, returning the build to its own lane.
+    public static func clearChoice(in defaults: UserDefaults) {
+        defaults.removeObject(forKey: defaultsKey)
     }
 
     /// The Stack Auth environment this override selects. Staging uses the
@@ -51,10 +56,12 @@ public enum CMUXBackendEnvironmentOverride: String, CaseIterable, Codable, Senda
         }
     }
 
-    /// Whether entering this environment requires an established, eligible
-    /// session before the switch may complete. Staging gates (a verified
-    /// team session, or DEBUG); production NEVER gates, so switching back is
-    /// always possible — the switch transaction's revert path relies on this.
+    /// Whether an EXPLICIT switch into this environment requires an
+    /// established, eligible session before the switch may complete. Staging
+    /// gates (a verified team session, or DEBUG); production NEVER gates, so
+    /// switching back is always possible. The switch transaction gates on
+    /// ``CMUXBackendEnvironmentSelection/requiresGatedSession``, which is
+    /// true only for `.explicit(.staging)` — a staging LANE never gates.
     public var requiresGatedSession: Bool {
         self == .staging
     }

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentSelection.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXBackendEnvironmentSelection.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Which backend a build resolves when NO explicit environment choice is
+/// persisted: its build lane.
+///
+/// Classified once per process by the composition root from the launch
+/// environment alone (any persisted explicit choice is ignored for
+/// classification), so the lane is a stable property of the installed build:
+/// unpinned Release builds are the production lane, staging-baked dev rigs
+/// are the staging lane, and tagged dev builds with baked localhost origins
+/// (or an untagged Debug build on the development Stack channel) are a custom
+/// lane labeled with their origin. The lane powers the picker's
+/// "Build lane (…)" option and the return-to-lane sign-out chain.
+public enum CMUXBackendEnvironmentBuildLane: Equatable, Sendable {
+    /// The unpinned Release lane: cmux.com and the production Stack project.
+    case production
+    /// A lane baked to the staging origin (device dev rigs default here).
+    case staging
+    /// Any other bake: tagged dev builds on a localhost origin, or a Debug
+    /// build whose Stack channel is development. `label` is the human name
+    /// shown in the picker's "Build lane (…)" option (host, or host:port).
+    case custom(label: String)
+
+    /// The environment this lane resolves to: the staging lane resolves
+    /// staging, every other lane (production and custom) resolves
+    /// production. Drives badges and the `.lane` selection's resolved
+    /// environment; custom lanes resolve production so gating and recovery
+    /// routing fail safe.
+    public var resolvedEnvironment: CMUXBackendEnvironmentOverride {
+        self == .staging ? .staging : .production
+    }
+}
+
+/// The user's backend-environment selection: the build's own lane (no
+/// persisted choice), or an explicitly persisted environment.
+///
+/// The distinction is load-bearing everywhere the raw environment is not
+/// enough: an EXPLICIT choice is a wholesale override replacing the entire
+/// backend key set (beating Info.plist bakes, LSEnvironment env vars, and
+/// DEBUG compile defaults atomically), only explicit staging gates entry,
+/// only explicit staging intercepts sign-out, and the switch transaction's
+/// no-op guard compares SELECTION identity — so a staging-lane build may
+/// still explicitly pick staging (lane(staging) ≠ explicit(staging)) even
+/// though both resolve the same environment.
+public enum CMUXBackendEnvironmentSelection: Equatable, Sendable {
+    /// No explicit choice persisted: the build runs its own lane, resolving
+    /// `resolves` (the lane's ``CMUXBackendEnvironmentBuildLane/resolvedEnvironment``).
+    case lane(resolves: CMUXBackendEnvironmentOverride)
+    /// An explicitly persisted choice: the full fixed backend value set for
+    /// this environment, regardless of what the build bakes.
+    case explicit(CMUXBackendEnvironmentOverride)
+
+    /// The environment this selection resolves to. Badges, About, and
+    /// recovery routing key on this (a staging-lane build IS on staging).
+    public var resolvedEnvironment: CMUXBackendEnvironmentOverride {
+        switch self {
+        case .lane(let resolves): resolves
+        case .explicit(let choice): choice
+        }
+    }
+
+    /// Whether this selection is an explicitly persisted choice (the
+    /// defaults key is present) rather than the build's own lane.
+    public var isExplicit: Bool {
+        if case .explicit = self { return true }
+        return false
+    }
+
+    /// Whether ENTERING this selection requires an established, eligible
+    /// session before the switch may complete. ONLY explicit staging gates:
+    /// the lane never gates (returning a build to its own bake — including a
+    /// staging-lane dev rig — must never prompt, which the switch
+    /// transaction's revert path relies on), and explicit production never
+    /// gates, so switching back is always possible.
+    public var requiresGatedSession: Bool {
+        self == .explicit(.staging)
+    }
+}

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Persistence/CMUXBackendEnvironmentSwitchRebuildMarker.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Persistence/CMUXBackendEnvironmentSwitchRebuildMarker.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// One-shot marker distinguishing a backend-environment-switch rebuild from an
+/// organic Stack-project flip at composition time.
+///
+/// The launch hygiene (`detectAuthProjectSwitch` → `clearStaleAuthOnLaunch`)
+/// wipes the persisted session whenever the resolved Stack project changed,
+/// which is exactly right for organic flips (a tagged Debug bundle rebuilt
+/// with different baked auth) but would destroy the session the switch
+/// transaction just PARKED for the target environment. The transaction arms
+/// this marker inside every `storeOverride` step (both directions, including
+/// a revert's), and the composition consumes it where `clearStaleAuthOnLaunch`
+/// is computed: `detectAuthProjectSwitch` still RUNS (it must update the
+/// stored project id), but its verdict is suppressed exactly once, so the
+/// rebuilt graph restores the target's parked slot instead of clearing it.
+///
+/// Crash safety: a crash after arm leaves the marker persisted; the next
+/// LAUNCH consumes it and restores the target's parked slot, which is the
+/// correct outcome for a crash mid-switch (the override was already stored).
+/// Every organic flip after that sees a consumed (absent) marker and keeps
+/// today's pinned clear semantics.
+public enum CMUXBackendEnvironmentSwitchRebuildMarker {
+    /// The UserDefaults key the marker persists under.
+    public static let defaultsKey = "cmux.backendEnvironmentSwitch.suppressAuthClearOnce"
+
+    /// Arm the marker: the next composition pass suppresses the launch clear
+    /// once. Called inside the switch transaction's `storeOverride` step, so
+    /// the marker is set iff an override commit happened.
+    public static func arm(in defaults: UserDefaults) {
+        defaults.set(true, forKey: defaultsKey)
+    }
+
+    /// Consume the marker: returns whether it was armed and removes it, so a
+    /// single arm suppresses exactly one composition pass's clear.
+    public static func consume(from defaults: UserDefaults) -> Bool {
+        let armed = defaults.bool(forKey: defaultsKey)
+        defaults.removeObject(forKey: defaultsKey)
+        return armed
+    }
+}

--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Persistence/CMUXBackendEnvironmentSwitchRebuildMarker.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Persistence/CMUXBackendEnvironmentSwitchRebuildMarker.swift
@@ -8,8 +8,9 @@ import Foundation
 /// which is exactly right for organic flips (a tagged Debug bundle rebuilt
 /// with different baked auth) but would destroy the session the switch
 /// transaction just PARKED for the target environment. The transaction arms
-/// this marker inside every `storeOverride` step (both directions, including
-/// a revert's), and the composition consumes it where `clearStaleAuthOnLaunch`
+/// this marker inside every `storeSelection` step (both directions —
+/// explicit stores and lane clears alike, including a revert's), and the
+/// composition consumes it where `clearStaleAuthOnLaunch`
 /// is computed: `detectAuthProjectSwitch` still RUNS (it must update the
 /// stored project id), but its verdict is suppressed exactly once, so the
 /// rebuilt graph restores the target's parked slot instead of clearing it.
@@ -24,8 +25,8 @@ public enum CMUXBackendEnvironmentSwitchRebuildMarker {
     public static let defaultsKey = "cmux.backendEnvironmentSwitch.suppressAuthClearOnce"
 
     /// Arm the marker: the next composition pass suppresses the launch clear
-    /// once. Called inside the switch transaction's `storeOverride` step, so
-    /// the marker is set iff an override commit happened.
+    /// once. Called inside the switch transaction's `storeSelection` step, so
+    /// the marker is set iff a selection commit happened.
     public static func arm(in defaults: UserDefaults) {
         defaults.set(true, forKey: defaultsKey)
     }

--- a/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentOverrideTests.swift
+++ b/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentOverrideTests.swift
@@ -2,7 +2,7 @@ import CMUXAuthCore
 import Foundation
 import Testing
 
-@Suite("Backend environment override")
+@Suite("Backend environment explicit choice (tri-state persistence)")
 struct BackendEnvironmentOverrideTests {
     private func makeDefaults() -> UserDefaults {
         let suiteName = "BackendEnvironmentOverrideTests-\(UUID().uuidString)"
@@ -11,39 +11,111 @@ struct BackendEnvironmentOverrideTests {
         return defaults
     }
 
-    @Test("Absent key loads as production")
-    func absentKeyLoadsAsProduction() {
+    @Test("An absent key is no explicit choice (the build lane)")
+    func absentKeyIsNoExplicitChoice() {
         let defaults = makeDefaults()
-        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+        #expect(CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) == nil)
     }
 
     @Test("Staging round-trips through defaults")
     func stagingRoundTrips() {
         let defaults = makeDefaults()
-        CMUXBackendEnvironmentOverride.staging.store(in: defaults)
-        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .staging)
+        CMUXBackendEnvironmentOverride.staging.storeChoice(in: defaults)
+        #expect(CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) == .staging)
     }
 
-    @Test("Storing production removes the key")
-    func storingProductionRemovesKey() {
+    @Test("Storing production WRITES the key: explicit, not absent")
+    func storingProductionWritesTheKey() {
         let defaults = makeDefaults()
-        CMUXBackendEnvironmentOverride.staging.store(in: defaults)
-        CMUXBackendEnvironmentOverride.production.store(in: defaults)
-        #expect(defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey) == nil)
-        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+        CMUXBackendEnvironmentOverride.staging.storeChoice(in: defaults)
+        CMUXBackendEnvironmentOverride.production.storeChoice(in: defaults)
+        #expect(
+            defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey) == "production"
+        )
+        #expect(CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) == .production)
     }
 
-    @Test("Unknown raw value loads as production")
-    func unknownRawValueLoadsAsProduction() {
+    @Test("clearChoice removes the key, returning to the build lane")
+    func clearChoiceRemovesTheKey() {
+        let defaults = makeDefaults()
+        CMUXBackendEnvironmentOverride.staging.storeChoice(in: defaults)
+        CMUXBackendEnvironmentOverride.clearChoice(in: defaults)
+        #expect(defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey) == nil)
+        #expect(CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) == nil)
+    }
+
+    @Test("An unknown raw value is no explicit choice (fail-safe toward the bake)")
+    func unknownRawValueIsNoExplicitChoice() {
         let defaults = makeDefaults()
         defaults.set("nightly", forKey: CMUXBackendEnvironmentOverride.defaultsKey)
-        #expect(CMUXBackendEnvironmentOverride.load(from: defaults) == .production)
+        #expect(CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) == nil)
     }
 
     @Test("Staging maps to the development Stack environment")
     func stagingMapsToDevelopmentStack() {
         #expect(CMUXBackendEnvironmentOverride.staging.authEnvironment == .development)
         #expect(CMUXBackendEnvironmentOverride.production.authEnvironment == .production)
+    }
+}
+
+@Suite("Backend environment selection model")
+struct BackendEnvironmentSelectionTests {
+    @Test("Selections resolve their environment")
+    func selectionsResolveTheirEnvironment() {
+        #expect(
+            CMUXBackendEnvironmentSelection.lane(resolves: .staging).resolvedEnvironment == .staging
+        )
+        #expect(
+            CMUXBackendEnvironmentSelection.lane(resolves: .production).resolvedEnvironment
+                == .production
+        )
+        #expect(
+            CMUXBackendEnvironmentSelection.explicit(.staging).resolvedEnvironment == .staging
+        )
+        #expect(
+            CMUXBackendEnvironmentSelection.explicit(.production).resolvedEnvironment
+                == .production
+        )
+    }
+
+    @Test("isExplicit distinguishes a persisted choice from the lane")
+    func isExplicitDistinguishesChoiceFromLane() {
+        #expect(CMUXBackendEnvironmentSelection.explicit(.production).isExplicit)
+        #expect(CMUXBackendEnvironmentSelection.explicit(.staging).isExplicit)
+        #expect(!CMUXBackendEnvironmentSelection.lane(resolves: .production).isExplicit)
+        #expect(!CMUXBackendEnvironmentSelection.lane(resolves: .staging).isExplicit)
+    }
+
+    @Test("PIN: ONLY explicit staging gates — the lane and explicit production never do")
+    func onlyExplicitStagingGates() {
+        #expect(CMUXBackendEnvironmentSelection.explicit(.staging).requiresGatedSession)
+        #expect(!CMUXBackendEnvironmentSelection.explicit(.production).requiresGatedSession)
+        // A staging LANE never gates: dev rigs baked to staging keep plain
+        // sign-in/sign-out, and the transaction's revert-to-lane can't loop.
+        #expect(!CMUXBackendEnvironmentSelection.lane(resolves: .staging).requiresGatedSession)
+        #expect(!CMUXBackendEnvironmentSelection.lane(resolves: .production).requiresGatedSession)
+    }
+
+    @Test("Selection identity: a lane and an explicit choice resolving the same environment differ")
+    func laneAndExplicitAreDistinctIdentities() {
+        #expect(
+            CMUXBackendEnvironmentSelection.lane(resolves: .staging)
+                != CMUXBackendEnvironmentSelection.explicit(.staging)
+        )
+        #expect(
+            CMUXBackendEnvironmentSelection.lane(resolves: .production)
+                != CMUXBackendEnvironmentSelection.explicit(.production)
+        )
+    }
+
+    @Test("Build lanes resolve staging only for the staging lane")
+    func buildLanesResolve() {
+        #expect(CMUXBackendEnvironmentBuildLane.production.resolvedEnvironment == .production)
+        #expect(CMUXBackendEnvironmentBuildLane.staging.resolvedEnvironment == .staging)
+        #expect(
+            CMUXBackendEnvironmentBuildLane.custom(label: "localhost:4123").resolvedEnvironment
+                == .production
+        )
     }
 }
 

--- a/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentSwitchRebuildMarkerTests.swift
+++ b/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/BackendEnvironmentSwitchRebuildMarkerTests.swift
@@ -1,0 +1,51 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+
+@Suite("Backend environment switch rebuild marker")
+struct BackendEnvironmentSwitchRebuildMarkerTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "BackendEnvironmentSwitchRebuildMarkerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test("Armed marker is consumed exactly once")
+    func armedMarkerConsumesOnce() {
+        let defaults = makeDefaults()
+        CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: defaults)
+        #expect(CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+        // The second consumer (an organic flip after a crash-recovered
+        // switch) must see today's clear semantics.
+        #expect(!CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+        #expect(defaults.object(
+            forKey: CMUXBackendEnvironmentSwitchRebuildMarker.defaultsKey
+        ) == nil)
+    }
+
+    @Test("Unarmed marker consumes false")
+    func unarmedMarkerConsumesFalse() {
+        let defaults = makeDefaults()
+        #expect(!CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+    }
+
+    @Test("Re-arming after consumption suppresses one more pass")
+    func reArmingSuppressesOneMorePass() {
+        let defaults = makeDefaults()
+        CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: defaults)
+        #expect(CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+        CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: defaults)
+        #expect(CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+        #expect(!CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults))
+    }
+}
+
+@Suite("Backend environment gated-session flag")
+struct BackendEnvironmentGatedSessionTests {
+    @Test("Only staging requires a gated session; production never gates")
+    func onlyStagingRequiresGatedSession() {
+        #expect(CMUXBackendEnvironmentOverride.staging.requiresGatedSession)
+        #expect(!CMUXBackendEnvironmentOverride.production.requiresGatedSession)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
@@ -9,25 +9,40 @@ public import Observation
 ///    while the old environment's token slot survives for the return switch
 ///    (no revocation, no token delete),
 /// 2. quiesce the old environment-frozen graph,
-/// 3. store the override (the commit point: per-use resolvers flip here),
+/// 3. store the selection (the commit point: an explicit choice persists its
+///    raw value, a lane target clears the key; per-use resolvers flip here),
 /// 4. rebuild the frozen graph against the new environment,
 /// 5. ESTABLISH a session on the target: restore its parked slot, and for a
-///    gated target (staging) require an eligible signed-in user — restoring
+///    gated target (EXPLICIT staging only — a lane target never gates, even
+///    a staging lane) require an eligible signed-in user — restoring
 ///    silently when the parked session qualifies, prompting inline otherwise,
-///    and REVERTING to the previous environment (which never gates and never
+///    and REVERTING to the previous selection (which never gates and never
 ///    prompts) when the prompt is cancelled, fails, or yields an ineligible
 ///    user.
 ///
-/// Storing the override before the park completes would mint tokens for one
+/// Storing the selection before the park completes would mint tokens for one
 /// Stack project into a client configured for the other, so steps 1–4 may
-/// never reorder; the override is never stored while `parkSession` is in
+/// never reorder; the selection is never stored while `parkSession` is in
 /// flight. The park is local-first and unconditional (no failure branch). A
 /// crash before the commit point leaves the old environment parked; after
 /// it, the next launch resolves the new environment and (thanks to the
-/// one-shot rebuild marker armed by every `storeOverride`) restores the
+/// one-shot rebuild marker armed by every `storeSelection`) restores the
 /// target's parked slot. A crash mid-establishing strands the device on the
 /// target signed out with the previous slot still parked — exactly the state
 /// the Settings recovery card handles.
+///
+/// Targets are SELECTIONS, not environments: the no-op guard compares
+/// selection identity, so a staging-LANE build may still run an explicit
+/// staging switch (`lane(staging)` ≠ `explicit(staging)`) while lane→lane
+/// and explicit→same-explicit are refused. Shared-slot aliasing: when the
+/// lane and explicit staging resolve the same dev Stack project, the two
+/// selections share ONE parked token slot (slots key on the resolved Stack
+/// project), so the explicit switch restores the lane's session silently —
+/// that silent restore is the feature — and an explicit-staging sign-out
+/// also empties the lane's slot (a DEBUG rig's auto-login recovers it).
+/// The revert path is structurally never-gated: the only gated selection is
+/// `explicit(.staging)`, and reverting TO it would mean the run started
+/// FROM it toward itself, which the no-op guard refuses.
 @MainActor @Observable
 public final class BackendEnvironmentSwitchTransaction {
     /// Why a switch ended back on the previous environment.
@@ -87,11 +102,9 @@ public final class BackendEnvironmentSwitchTransaction {
     /// the documented order; none may throw. Timeouts live inside the
     /// platform steps (the engine never sleeps).
     public struct Steps {
-        /// Whether a build-time bake pins this build's backend. A pinned
-        /// build can never start the transaction, independent of UI hiding.
-        public let isPinnedByBuild: @MainActor () -> Bool
-        /// The environment the running process resolved at composition time.
-        public let activeEnvironment: @MainActor () -> CMUXBackendEnvironmentOverride
+        /// The selection the running process resolved at composition time
+        /// (`.explicit` when the choice key is persisted, `.lane` otherwise).
+        public let activeSelection: @MainActor () -> CMUXBackendEnvironmentSelection
         /// Parks the session under the OLD defaults: detaches the published
         /// state and clears platform session surfaces, leaving the token
         /// slot untouched and skipping every server-side teardown.
@@ -99,12 +112,15 @@ public final class BackendEnvironmentSwitchTransaction {
         /// Stops services that read the environment per use, closing the
         /// window where they would flip ahead of the still-frozen auth graph.
         public let quiesce: @MainActor () async -> Void
-        /// Persists the override; the commit point. Platforms also arm the
-        /// one-shot rebuild marker here so the rebuild (or a post-crash
-        /// launch) restores the target's parked slot instead of clearing it.
-        public let storeOverride: @MainActor (CMUXBackendEnvironmentOverride) -> Void
+        /// Persists the selection; the commit point. Platforms write an
+        /// explicit choice's raw value (`storeChoice`) and CLEAR the key for
+        /// a lane target (`clearChoice`), and BOTH arm the one-shot rebuild
+        /// marker — a lane↔explicit flip can change the resolved Stack
+        /// project too, and the rebuild (or a post-crash launch) must
+        /// restore the target's parked slot instead of clearing it.
+        public let storeSelection: @MainActor (CMUXBackendEnvironmentSelection) -> Void
         /// Rebuilds the environment-frozen graph and unblocks the app.
-        public let rebuild: @MainActor (CMUXBackendEnvironmentOverride) async -> Void
+        public let rebuild: @MainActor (CMUXBackendEnvironmentSelection) async -> Void
         /// Awaits the rebuilt graph's launch restore and returns the user it
         /// restored from the target's parked slot, or `nil` when the slot
         /// was empty or the restore did not produce a session.
@@ -129,12 +145,11 @@ public final class BackendEnvironmentSwitchTransaction {
         public let signInPromptFailure: @MainActor () -> SignInPromptFailure
 
         public init(
-            isPinnedByBuild: @escaping @MainActor () -> Bool,
-            activeEnvironment: @escaping @MainActor () -> CMUXBackendEnvironmentOverride,
+            activeSelection: @escaping @MainActor () -> CMUXBackendEnvironmentSelection,
             parkSession: @escaping @MainActor () async -> Void,
             quiesce: @escaping @MainActor () async -> Void,
-            storeOverride: @escaping @MainActor (CMUXBackendEnvironmentOverride) -> Void,
-            rebuild: @escaping @MainActor (CMUXBackendEnvironmentOverride) async -> Void,
+            storeSelection: @escaping @MainActor (CMUXBackendEnvironmentSelection) -> Void,
+            rebuild: @escaping @MainActor (CMUXBackendEnvironmentSelection) async -> Void,
             awaitRestoredUser: @escaping @MainActor () async -> CMUXAuthUser?,
             promptSignIn: @escaping @MainActor () async -> CMUXAuthUser?,
             cancelSignInPrompt: @escaping @MainActor () -> Void,
@@ -142,11 +157,10 @@ public final class BackendEnvironmentSwitchTransaction {
             isEligible: @escaping @MainActor (CMUXAuthUser) -> Bool,
             signInPromptFailure: @escaping @MainActor () -> SignInPromptFailure
         ) {
-            self.isPinnedByBuild = isPinnedByBuild
-            self.activeEnvironment = activeEnvironment
+            self.activeSelection = activeSelection
             self.parkSession = parkSession
             self.quiesce = quiesce
-            self.storeOverride = storeOverride
+            self.storeSelection = storeSelection
             self.rebuild = rebuild
             self.awaitRestoredUser = awaitRestoredUser
             self.promptSignIn = promptSignIn
@@ -171,8 +185,11 @@ public final class BackendEnvironmentSwitchTransaction {
     public init() {}
 
     /// Run one switch to `target`. Joins an already-active run; refuses when
-    /// the build is pinned or `target` is already the active environment.
-    public func run(to target: CMUXBackendEnvironmentOverride, steps: Steps) async {
+    /// `target` is already the active SELECTION. Selection identity — not the
+    /// resolved environment — is the guard, so a staging-lane build may run
+    /// an explicit staging switch, while lane→lane and explicit→same-explicit
+    /// are no-ops.
+    public func run(to target: CMUXBackendEnvironmentSelection, steps: Steps) async {
         if let activeRun {
             await activeRun.value
             return
@@ -181,8 +198,7 @@ public final class BackendEnvironmentSwitchTransaction {
             phase = .idle
         }
         guard phase == .idle else { return }
-        guard !steps.isPinnedByBuild() else { return }
-        let previous = steps.activeEnvironment()
+        let previous = steps.activeSelection()
         guard previous != target else { return }
 
         revertRequested = false
@@ -192,7 +208,7 @@ public final class BackendEnvironmentSwitchTransaction {
             await steps.parkSession()
             await steps.quiesce()
             self.phase = .retargeting
-            steps.storeOverride(target)
+            steps.storeSelection(target)
             await steps.rebuild(target)
             await self.establish(target: target, previous: previous, steps: steps)
         }
@@ -222,17 +238,19 @@ public final class BackendEnvironmentSwitchTransaction {
 
     /// Establish a session on the (already rebuilt) target.
     ///
-    /// Ungated targets (production) NEVER consult the prompt or the gate:
-    /// they await the launch restore of the parked slot and finish switched,
-    /// signed in or not. Gated targets (staging) finish switched only with
-    /// an eligible user: a restored eligible session completes silently
-    /// (repeated switching never re-prompts); a restored ineligible session
-    /// is signed out for real (under the target's defaults) before the
-    /// inline prompt; a cancelled / failed prompt, an ineligible prompted
-    /// user, or a ``requestRevert()`` reverts to `previous`.
+    /// Ungated targets (explicit production, and EVERY lane target — a
+    /// staging lane included) NEVER consult the prompt or the gate: they
+    /// await the launch restore of the parked slot and finish switched,
+    /// signed in or not. The one gated target (explicit staging) finishes
+    /// switched only with an eligible user: a restored eligible session
+    /// completes silently (repeated switching never re-prompts); a restored
+    /// ineligible session is signed out for real (under the target's
+    /// defaults) before the inline prompt; a cancelled / failed prompt, an
+    /// ineligible prompted user, or a ``requestRevert()`` reverts to
+    /// `previous`.
     private func establish(
-        target: CMUXBackendEnvironmentOverride,
-        previous: CMUXBackendEnvironmentOverride,
+        target: CMUXBackendEnvironmentSelection,
+        previous: CMUXBackendEnvironmentSelection,
         steps: Steps
     ) async {
         phase = .establishing
@@ -287,18 +305,19 @@ public final class BackendEnvironmentSwitchTransaction {
         await revert(to: previous, reason: reason, steps: steps)
     }
 
-    /// Undo the switch: quiesce the target's graph, store the previous
-    /// override (arming the rebuild marker again), rebuild, and await the
+    /// Undo the switch: quiesce the target's graph, store the ORIGINAL
+    /// selection — including `.lane`, whose store step clears the choice key
+    /// (arming the rebuild marker again either way) — rebuild, and await the
     /// previous environment's parked session. NEVER gates and NEVER prompts
     /// (pinned by tests), so a revert can't loop.
     private func revert(
-        to previous: CMUXBackendEnvironmentOverride,
+        to previous: CMUXBackendEnvironmentSelection,
         reason: RevertReason,
         steps: Steps
     ) async {
         phase = .reverting
         await steps.quiesce()
-        steps.storeOverride(previous)
+        steps.storeSelection(previous)
         await steps.rebuild(previous)
         _ = await steps.awaitRestoredUser()
         phase = .finished(.reverted(reason))

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
@@ -5,68 +5,155 @@ public import Observation
 /// The one apply path for a live backend-environment switch, shared by both
 /// apps so the ordering invariant has a single owner:
 ///
-/// 1. full sign-out under the OLD defaults (the bounded server tail — Stack
-///    revocation, push-token delete, iroh binding revoke — must hit the old
-///    backend),
+/// 1. PARK the session under the OLD defaults — detach the published state
+///    while the old environment's token slot survives for the return switch
+///    (no revocation, no token delete),
 /// 2. quiesce the old environment-frozen graph,
 /// 3. store the override (the commit point: per-use resolvers flip here),
-/// 4. rebuild the frozen graph against the new environment.
+/// 4. rebuild the frozen graph against the new environment,
+/// 5. ESTABLISH a session on the target: restore its parked slot, and for a
+///    gated target (staging) require an eligible signed-in user — restoring
+///    silently when the parked session qualifies, prompting inline otherwise,
+///    and REVERTING to the previous environment (which never gates and never
+///    prompts) when the prompt is cancelled, fails, or yields an ineligible
+///    user.
 ///
-/// Storing the override before sign-out completes would mint tokens for one
-/// Stack project into a client configured for the other, so steps may never
-/// reorder. There is deliberately no failure branch: the platform `signOut`
-/// step is local-first with a bounded best-effort server tail (the
-/// coordinator's injected-clock deadline), and the transaction proceeds
-/// unconditionally once it returns. A crash before the commit point leaves
-/// the old environment signed out; after it, the next launch resolves the
-/// new environment and the project-switch launch hygiene clears stale state.
+/// Storing the override before the park completes would mint tokens for one
+/// Stack project into a client configured for the other, so steps 1–4 may
+/// never reorder; the override is never stored while `parkSession` is in
+/// flight. The park is local-first and unconditional (no failure branch). A
+/// crash before the commit point leaves the old environment parked; after
+/// it, the next launch resolves the new environment and (thanks to the
+/// one-shot rebuild marker armed by every `storeOverride`) restores the
+/// target's parked slot. A crash mid-establishing strands the device on the
+/// target signed out with the previous slot still parked — exactly the state
+/// the Settings recovery card handles.
 @MainActor @Observable
 public final class BackendEnvironmentSwitchTransaction {
+    /// Why a switch ended back on the previous environment.
+    public enum RevertReason: Equatable, Sendable {
+        /// The user cancelled the target's sign-in prompt (or requested the
+        /// revert explicitly through ``requestRevert()``).
+        case signInCancelled
+        /// The target's sign-in prompt failed (timeout, network, server).
+        case signInFailed
+        /// The sign-in completed but the account is not eligible for the
+        /// gated target; the established session was signed out for real
+        /// (under the target's defaults) before reverting.
+        case notEligible
+    }
+
+    /// How a completed run ended.
+    public enum Outcome: Equatable, Sendable {
+        /// The device is on the requested target with a session established
+        /// (or with none required).
+        case switched
+        /// The device is back on the previous environment with its parked
+        /// session restored.
+        case reverted(RevertReason)
+    }
+
+    /// The platform's classification of a `promptSignIn` that resolved
+    /// without a user, mapping onto the two prompt-driven revert reasons.
+    public enum SignInPromptFailure: Equatable, Sendable {
+        /// The user backed out (closed the browser popup / dismissed the
+        /// sheet); no error to surface.
+        case cancelled
+        /// The attempt failed (timeout, network, server, unusable browser).
+        case failed
+    }
+
     /// Where the transaction currently is; drives the Settings progress UI.
     public enum Phase: Equatable, Sendable {
         /// No switch in progress.
         case idle
-        /// Signing out of the old environment (old defaults still active).
-        case signingOut
+        /// Parking the old environment's session (old defaults still
+        /// active): published state detaches, the token slot survives.
+        case parking
         /// Override stored; rebuilding the frozen graph for the new
         /// environment.
         case retargeting
-        /// Switch complete; the UI shows the switched note until `reset()`.
-        case finished
+        /// Rebuilt on the target; restoring its parked session and — for a
+        /// gated target — waiting for an eligible sign-in.
+        case establishing
+        /// Undoing the switch: rebuilding the previous environment and
+        /// restoring its parked session. Never gates, never prompts.
+        case reverting
+        /// Run complete; the UI shows the outcome until `reset()`.
+        case finished(Outcome)
     }
 
     /// The platform-injected steps. Each closure runs on the main actor in
-    /// the documented order; none may throw.
+    /// the documented order; none may throw. Timeouts live inside the
+    /// platform steps (the engine never sleeps).
     public struct Steps {
         /// Whether a build-time bake pins this build's backend. A pinned
         /// build can never start the transaction, independent of UI hiding.
         public let isPinnedByBuild: @MainActor () -> Bool
         /// The environment the running process resolved at composition time.
         public let activeEnvironment: @MainActor () -> CMUXBackendEnvironmentOverride
-        /// The platform's complete sign-out flow, run under the OLD defaults.
-        public let signOut: @MainActor () async -> Void
+        /// Parks the session under the OLD defaults: detaches the published
+        /// state and clears platform session surfaces, leaving the token
+        /// slot untouched and skipping every server-side teardown.
+        public let parkSession: @MainActor () async -> Void
         /// Stops services that read the environment per use, closing the
         /// window where they would flip ahead of the still-frozen auth graph.
         public let quiesce: @MainActor () async -> Void
-        /// Persists the override; the commit point.
+        /// Persists the override; the commit point. Platforms also arm the
+        /// one-shot rebuild marker here so the rebuild (or a post-crash
+        /// launch) restores the target's parked slot instead of clearing it.
         public let storeOverride: @MainActor (CMUXBackendEnvironmentOverride) -> Void
         /// Rebuilds the environment-frozen graph and unblocks the app.
         public let rebuild: @MainActor (CMUXBackendEnvironmentOverride) async -> Void
+        /// Awaits the rebuilt graph's launch restore and returns the user it
+        /// restored from the target's parked slot, or `nil` when the slot
+        /// was empty or the restore did not produce a session.
+        public let awaitRestoredUser: @MainActor () async -> CMUXAuthUser?
+        /// Runs the platform's interactive sign-in against the CURRENT
+        /// (target) environment and returns the signed-in user, or `nil` on
+        /// cancel / failure / timeout (classified by
+        /// ``Steps/signInPromptFailure``).
+        public let promptSignIn: @MainActor () async -> CMUXAuthUser?
+        /// Resolves an in-flight `promptSignIn` as cancelled (used by
+        /// ``requestRevert()``).
+        public let cancelSignInPrompt: @MainActor () -> Void
+        /// The REAL sign-out chain, run under the CURRENT (target) defaults
+        /// so revoking an ineligible session hits the target's backend.
+        public let signOutEstablishedSession: @MainActor () async -> Void
+        /// Whether `user` may hold a session on a gated target (the switch
+        /// gate, or a DEBUG build).
+        public let isEligible: @MainActor (CMUXAuthUser) -> Bool
+        /// Classifies a `promptSignIn` that returned `nil` (consulted only
+        /// when no revert was requested; ``requestRevert()`` always reverts
+        /// as cancelled).
+        public let signInPromptFailure: @MainActor () -> SignInPromptFailure
 
         public init(
             isPinnedByBuild: @escaping @MainActor () -> Bool,
             activeEnvironment: @escaping @MainActor () -> CMUXBackendEnvironmentOverride,
-            signOut: @escaping @MainActor () async -> Void,
+            parkSession: @escaping @MainActor () async -> Void,
             quiesce: @escaping @MainActor () async -> Void,
             storeOverride: @escaping @MainActor (CMUXBackendEnvironmentOverride) -> Void,
-            rebuild: @escaping @MainActor (CMUXBackendEnvironmentOverride) async -> Void
+            rebuild: @escaping @MainActor (CMUXBackendEnvironmentOverride) async -> Void,
+            awaitRestoredUser: @escaping @MainActor () async -> CMUXAuthUser?,
+            promptSignIn: @escaping @MainActor () async -> CMUXAuthUser?,
+            cancelSignInPrompt: @escaping @MainActor () -> Void,
+            signOutEstablishedSession: @escaping @MainActor () async -> Void,
+            isEligible: @escaping @MainActor (CMUXAuthUser) -> Bool,
+            signInPromptFailure: @escaping @MainActor () -> SignInPromptFailure
         ) {
             self.isPinnedByBuild = isPinnedByBuild
             self.activeEnvironment = activeEnvironment
-            self.signOut = signOut
+            self.parkSession = parkSession
             self.quiesce = quiesce
             self.storeOverride = storeOverride
             self.rebuild = rebuild
+            self.awaitRestoredUser = awaitRestoredUser
+            self.promptSignIn = promptSignIn
+            self.cancelSignInPrompt = cancelSignInPrompt
+            self.signOutEstablishedSession = signOutEstablishedSession
+            self.isEligible = isEligible
+            self.signInPromptFailure = signInPromptFailure
         }
     }
 
@@ -74,6 +161,12 @@ public final class BackendEnvironmentSwitchTransaction {
     /// The in-flight run; concurrent callers join it instead of starting a
     /// second transaction (mirroring `HostBrowserSignOutCoordinator`).
     private var activeRun: Task<Void, Never>?
+    /// Set by ``requestRevert()`` during `.establishing`; checked after each
+    /// establishing await so the revert wins over a racing prompt result.
+    private var revertRequested = false
+    /// The active run's steps, kept so ``requestRevert()`` can resolve an
+    /// in-flight sign-in prompt.
+    @ObservationIgnored private var activeSteps: Steps?
 
     public init() {}
 
@@ -84,31 +177,130 @@ public final class BackendEnvironmentSwitchTransaction {
             await activeRun.value
             return
         }
-        if phase == .finished {
+        if case .finished = phase {
             phase = .idle
         }
         guard phase == .idle else { return }
         guard !steps.isPinnedByBuild() else { return }
-        guard steps.activeEnvironment() != target else { return }
+        let previous = steps.activeEnvironment()
+        guard previous != target else { return }
 
+        revertRequested = false
+        activeSteps = steps
         let run = Task { @MainActor in
-            self.phase = .signingOut
-            await steps.signOut()
+            self.phase = .parking
+            await steps.parkSession()
             await steps.quiesce()
             self.phase = .retargeting
             steps.storeOverride(target)
             await steps.rebuild(target)
-            self.phase = .finished
+            await self.establish(target: target, previous: previous, steps: steps)
         }
         activeRun = run
         await run.value
         activeRun = nil
+        activeSteps = nil
     }
 
-    /// Returns to `.idle` after the UI has shown the switched note. A new
-    /// `run` also clears `.finished` defensively.
+    /// Request that an in-flight switch revert to the previous environment.
+    /// Valid only during `.establishing` (the sign-in wait); resolves the
+    /// prompt as cancelled and the run finishes `.reverted(.signInCancelled)`.
+    public func requestRevert() {
+        guard phase == .establishing else { return }
+        revertRequested = true
+        activeSteps?.cancelSignInPrompt()
+    }
+
+    /// Returns to `.idle` after the UI has shown the outcome. A new `run`
+    /// also clears a stale `.finished` defensively.
     public func reset() {
-        guard phase == .finished else { return }
+        guard case .finished = phase else { return }
         phase = .idle
+    }
+
+    // MARK: - Establishing
+
+    /// Establish a session on the (already rebuilt) target.
+    ///
+    /// Ungated targets (production) NEVER consult the prompt or the gate:
+    /// they await the launch restore of the parked slot and finish switched,
+    /// signed in or not. Gated targets (staging) finish switched only with
+    /// an eligible user: a restored eligible session completes silently
+    /// (repeated switching never re-prompts); a restored ineligible session
+    /// is signed out for real (under the target's defaults) before the
+    /// inline prompt; a cancelled / failed prompt, an ineligible prompted
+    /// user, or a ``requestRevert()`` reverts to `previous`.
+    private func establish(
+        target: CMUXBackendEnvironmentOverride,
+        previous: CMUXBackendEnvironmentOverride,
+        steps: Steps
+    ) async {
+        phase = .establishing
+        guard target.requiresGatedSession else {
+            _ = await steps.awaitRestoredUser()
+            phase = .finished(.switched)
+            return
+        }
+
+        let restored = await steps.awaitRestoredUser()
+        if revertRequested {
+            await revert(to: previous, reason: .signInCancelled, steps: steps)
+            return
+        }
+        if let restored {
+            if steps.isEligible(restored) {
+                phase = .finished(.switched)
+                return
+            }
+            // An ineligible parked session must not survive on the gated
+            // target: sign it out for real (revocation hits the target's
+            // backend, since its defaults are active) and fall through to
+            // the prompt.
+            await steps.signOutEstablishedSession()
+            if revertRequested {
+                await revert(to: previous, reason: .signInCancelled, steps: steps)
+                return
+            }
+        }
+
+        let prompted = await steps.promptSignIn()
+        if let prompted {
+            guard steps.isEligible(prompted) else {
+                // Sign the just-established ineligible session out for real
+                // before reverting — regardless of a concurrent revert
+                // request, so an ineligible session never stays parked on
+                // the gated target.
+                await steps.signOutEstablishedSession()
+                await revert(to: previous, reason: .notEligible, steps: steps)
+                return
+            }
+            if revertRequested {
+                await revert(to: previous, reason: .signInCancelled, steps: steps)
+                return
+            }
+            phase = .finished(.switched)
+            return
+        }
+        let reason: RevertReason = revertRequested
+            ? .signInCancelled
+            : (steps.signInPromptFailure() == .cancelled ? .signInCancelled : .signInFailed)
+        await revert(to: previous, reason: reason, steps: steps)
+    }
+
+    /// Undo the switch: quiesce the target's graph, store the previous
+    /// override (arming the rebuild marker again), rebuild, and await the
+    /// previous environment's parked session. NEVER gates and NEVER prompts
+    /// (pinned by tests), so a revert can't loop.
+    private func revert(
+        to previous: CMUXBackendEnvironmentOverride,
+        reason: RevertReason,
+        steps: Steps
+    ) async {
+        phase = .reverting
+        await steps.quiesce()
+        steps.storeOverride(previous)
+        await steps.rebuild(previous)
+        _ = await steps.awaitRestoredUser()
+        phase = .finished(.reverted(reason))
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BackendSwitch/BackendEnvironmentSwitchTransaction.swift
@@ -1,0 +1,114 @@
+public import CMUXAuthCore
+import Foundation
+public import Observation
+
+/// The one apply path for a live backend-environment switch, shared by both
+/// apps so the ordering invariant has a single owner:
+///
+/// 1. full sign-out under the OLD defaults (the bounded server tail — Stack
+///    revocation, push-token delete, iroh binding revoke — must hit the old
+///    backend),
+/// 2. quiesce the old environment-frozen graph,
+/// 3. store the override (the commit point: per-use resolvers flip here),
+/// 4. rebuild the frozen graph against the new environment.
+///
+/// Storing the override before sign-out completes would mint tokens for one
+/// Stack project into a client configured for the other, so steps may never
+/// reorder. There is deliberately no failure branch: the platform `signOut`
+/// step is local-first with a bounded best-effort server tail (the
+/// coordinator's injected-clock deadline), and the transaction proceeds
+/// unconditionally once it returns. A crash before the commit point leaves
+/// the old environment signed out; after it, the next launch resolves the
+/// new environment and the project-switch launch hygiene clears stale state.
+@MainActor @Observable
+public final class BackendEnvironmentSwitchTransaction {
+    /// Where the transaction currently is; drives the Settings progress UI.
+    public enum Phase: Equatable, Sendable {
+        /// No switch in progress.
+        case idle
+        /// Signing out of the old environment (old defaults still active).
+        case signingOut
+        /// Override stored; rebuilding the frozen graph for the new
+        /// environment.
+        case retargeting
+        /// Switch complete; the UI shows the switched note until `reset()`.
+        case finished
+    }
+
+    /// The platform-injected steps. Each closure runs on the main actor in
+    /// the documented order; none may throw.
+    public struct Steps {
+        /// Whether a build-time bake pins this build's backend. A pinned
+        /// build can never start the transaction, independent of UI hiding.
+        public let isPinnedByBuild: @MainActor () -> Bool
+        /// The environment the running process resolved at composition time.
+        public let activeEnvironment: @MainActor () -> CMUXBackendEnvironmentOverride
+        /// The platform's complete sign-out flow, run under the OLD defaults.
+        public let signOut: @MainActor () async -> Void
+        /// Stops services that read the environment per use, closing the
+        /// window where they would flip ahead of the still-frozen auth graph.
+        public let quiesce: @MainActor () async -> Void
+        /// Persists the override; the commit point.
+        public let storeOverride: @MainActor (CMUXBackendEnvironmentOverride) -> Void
+        /// Rebuilds the environment-frozen graph and unblocks the app.
+        public let rebuild: @MainActor (CMUXBackendEnvironmentOverride) async -> Void
+
+        public init(
+            isPinnedByBuild: @escaping @MainActor () -> Bool,
+            activeEnvironment: @escaping @MainActor () -> CMUXBackendEnvironmentOverride,
+            signOut: @escaping @MainActor () async -> Void,
+            quiesce: @escaping @MainActor () async -> Void,
+            storeOverride: @escaping @MainActor (CMUXBackendEnvironmentOverride) -> Void,
+            rebuild: @escaping @MainActor (CMUXBackendEnvironmentOverride) async -> Void
+        ) {
+            self.isPinnedByBuild = isPinnedByBuild
+            self.activeEnvironment = activeEnvironment
+            self.signOut = signOut
+            self.quiesce = quiesce
+            self.storeOverride = storeOverride
+            self.rebuild = rebuild
+        }
+    }
+
+    public private(set) var phase: Phase = .idle
+    /// The in-flight run; concurrent callers join it instead of starting a
+    /// second transaction (mirroring `HostBrowserSignOutCoordinator`).
+    private var activeRun: Task<Void, Never>?
+
+    public init() {}
+
+    /// Run one switch to `target`. Joins an already-active run; refuses when
+    /// the build is pinned or `target` is already the active environment.
+    public func run(to target: CMUXBackendEnvironmentOverride, steps: Steps) async {
+        if let activeRun {
+            await activeRun.value
+            return
+        }
+        if phase == .finished {
+            phase = .idle
+        }
+        guard phase == .idle else { return }
+        guard !steps.isPinnedByBuild() else { return }
+        guard steps.activeEnvironment() != target else { return }
+
+        let run = Task { @MainActor in
+            self.phase = .signingOut
+            await steps.signOut()
+            await steps.quiesce()
+            self.phase = .retargeting
+            steps.storeOverride(target)
+            await steps.rebuild(target)
+            self.phase = .finished
+        }
+        activeRun = run
+        await run.value
+        activeRun = nil
+    }
+
+    /// Returns to `.idle` after the UI has shown the switched note. A new
+    /// `run` also clears `.finished` defensively.
+    public func reset() {
+        guard phase == .finished else { return }
+        phase = .idle
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -29,6 +29,15 @@ public final class HostBrowserSignInFlow {
     private let browserAttemptTimeout: TimeInterval
     private let slowSignInThreshold: TimeInterval
     private let signOutCoordinator: HostBrowserSignOutCoordinator
+    /// The browser-session-only prologue for ``parkSession()`` (macOS wires
+    /// `browserAppSession.beginAuthTransition()`); deliberately NOT
+    /// `beginSignOut`, which also durably queues an iroh binding revocation
+    /// that would kill the parked environment's pairing.
+    private let beginSessionPark: @MainActor @Sendable () -> Void
+    /// The browser-session teardown shared with sign-out (macOS wires
+    /// `browserAppSession.clearCmuxWebSession()`); kept for ``parkSession()``,
+    /// which runs it without the coordinator's real sign-out.
+    private let localSignOut: @MainActor @Sendable () async -> Void
     private let callbackStateGenerator = HostBrowserCallbackStateGenerator()
     private let deadline: HostBrowserDeadline
     private let log = AuthDebugLog()
@@ -60,6 +69,7 @@ public final class HostBrowserSignInFlow {
         browserAttemptTimeout: TimeInterval = 10 * 60,
         slowSignInThreshold: TimeInterval = 30,
         beginSignOut: @escaping @MainActor @Sendable () -> Void = {},
+        beginSessionPark: @escaping @MainActor @Sendable () -> Void = {},
         localSignOut: @escaping @MainActor @Sendable () async -> Void = {},
         onSignedOut: @escaping @Sendable (
             _ accessToken: String?,
@@ -76,6 +86,8 @@ public final class HostBrowserSignInFlow {
         self.clock = clock
         self.browserAttemptTimeout = browserAttemptTimeout
         self.slowSignInThreshold = slowSignInThreshold
+        self.beginSessionPark = beginSessionPark
+        self.localSignOut = localSignOut
         deadline = HostBrowserDeadline(clock: clock)
         signOutCoordinator = HostBrowserSignOutCoordinator(
             beginSignOut: beginSignOut,
@@ -183,6 +195,37 @@ public final class HostBrowserSignInFlow {
             return true
         }
         _ = await deadline.resolve(attempt, timeout: timeout)
+    }
+
+    /// Park the session for a backend-environment switch: end the published
+    /// session and clear the cmux web panes' session, but leave the token
+    /// store untouched (the slot survives for the return switch) and skip
+    /// the iroh sign-out closures entirely (`beginSignOut` durably queues a
+    /// binding revocation that would kill the parked environment's pairing).
+    ///
+    /// Mirrors ``signOut()``'s local prologue — generation bump so a late
+    /// callback cannot resurrect the parked session, active-attempt cancel —
+    /// then runs only the browser-session closures plus
+    /// ``AuthCoordinator/detachSessionLeavingTokens()``.
+    public func parkSession() async {
+        log.log("auth.browser.parkSession.begin signingIn=\(isSigningIn) activeAttempt=\(activeAttemptID.map(String.init) ?? "nil") generation=\(signOutGeneration)")
+        signOutGeneration &+= 1
+        lastFailure = nil
+        cancelActiveAttempt()
+        beginSessionPark()
+        async let localCleanup: Void = localSignOut()
+        await coordinator.detachSessionLeavingTokens()
+        await localCleanup
+        log.log("auth.browser.parkSession.end generation=\(signOutGeneration)")
+    }
+
+    /// Cancel the active hosted-browser sign-in attempt (popup, timers,
+    /// parked continuation) without touching the session. The attempt
+    /// resolves as not-signed-in with ``lastFailure`` left `nil`, which is
+    /// how the backend-environment switch distinguishes a user cancel from a
+    /// failure when it revokes an in-flight `promptSignIn`.
+    public func cancelSignIn() {
+        cancelActiveAttempt()
     }
 
     // MARK: - Attempt lifecycle

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Detach.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Detach.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension AuthCoordinator {
+    /// Detach the published session WITHOUT touching the token store: the
+    /// "park" half of a backend-environment switch.
+    ///
+    /// Assembled from the exact local pieces of
+    /// ``signOut(onSignedOut:teardownTimeout:)`` that end the published
+    /// session, and nothing else:
+    ///
+    /// 1. cancel every in-flight sign-in exchange, session validation,
+    ///    post-sign-in hook, and token-touching phase (the SDK's token-write
+    ///    chokepoint then refuses a parked exchange's late store write),
+    /// 2. advance the session generation (announcing the transition) and bump
+    ///    the sign-out epoch, so any flow parked across this call takes its
+    ///    rollback path instead of publishing over the detach,
+    /// 3. clear the sign-in phase timeouts,
+    /// 4. drop `latestSignInRefreshToken` and clear the published auth state
+    ///    plus the self-healing caches (cached user, has-tokens flag, teams).
+    ///
+    /// Deliberately absent, in contrast to sign-out: NO
+    /// `client.clearLocalSession()` (the tokens stay in this project's slot,
+    /// parked for the return switch), NO `onSignedOut` hook and NO
+    /// `revokeSession` (the parked session must stay valid server-side), and
+    /// NO bounded teardown group (there is no server tail to bound).
+    ///
+    /// Residual risk (same loss class as today's raced sign-out): a sign-in
+    /// exchange whose store write already raced past the cancellation
+    /// chokepoint before this detach ran takes the stale-completion rollback
+    /// in `completeSignIn`, whose `clearLocalSession()` clears the OLD slot
+    /// even though this detach meant to park it. The window is the same one
+    /// interactive sign-out already accepts; the parked session is then
+    /// simply absent on return and the user signs in again.
+    public func detachSessionLeavingTokens() async {
+        log.log("auth.detach: parking session (tokens left in store)")
+        for exchange in activeSignInExchanges.values { exchange.task.cancel() }
+        for validation in activeSessionValidations.values { validation.cancel() }
+        cancelPostSignInHooksForSignOut()
+        for phase in activeTokenTouchingPhases.values { phase.cancel() }
+        advanceSessionGeneration()
+        signOutEpoch &+= 1
+        publishAuthenticatedSessionIdentity()
+        await phaseTimeoutRegistry.clear([.sendCode, .verifyCode, .passwordSignIn, .oauth, .validateSession])
+        latestSignInRefreshToken = nil
+        clearAuthState(sessionTransitionAlreadyAnnounced: true)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -1,4 +1,5 @@
-internal import CMUXAuthCore
+// `public`: ``waitForNextSignedInUser()`` returns ``CMUXAuthUser``.
+public import CMUXAuthCore
 import Foundation
 import OSLog
 
@@ -490,6 +491,29 @@ public extension AuthCoordinator {
         _ identity: AuthenticatedSessionIdentity
     ) -> Bool {
         publishedAuthenticatedSessionIdentity == identity
+    }
+
+    /// The signed-in user, waiting for one to be published when none is yet.
+    ///
+    /// Returns ``currentUser`` immediately when a session is already
+    /// authenticated; otherwise suspends on the identity stream until the
+    /// next non-nil identity is published (a sign-in or restore completing)
+    /// and returns the user it named. Returns `nil` only when the awaiting
+    /// task is cancelled before a session is published — there is no
+    /// timeout here; callers that need a deadline own it.
+    ///
+    /// Used by the backend-environment switch's `promptSignIn`/
+    /// `awaitRestoredUser` platform steps, which need an awaitable "the next
+    /// user, whoever signs in" rather than a poll.
+    func waitForNextSignedInUser() async -> CMUXAuthUser? {
+        if isAuthenticated, let currentUser { return currentUser }
+        for await identity in authenticatedSessionIdentities() {
+            guard identity != nil else { continue }
+            return currentUser
+        }
+        // The stream finished without a signed-in identity: the awaiting
+        // task was cancelled.
+        return nil
     }
 }
 

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -704,7 +704,9 @@ public final class AuthCoordinator {
         apply(.cleared())
     }
 
-    private func advanceSessionGeneration(notifySessionWillTransition: Bool = true) {
+    /// Internal (not private): the detach flow in `AuthCoordinator+Detach`
+    /// advances the generation with the same announce semantics as sign-out.
+    func advanceSessionGeneration(notifySessionWillTransition: Bool = true) {
         if notifySessionWillTransition {
             onSessionWillTransition()
         }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
@@ -22,14 +22,51 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
 
     private let log = AuthDebugLog()
     private let fileURL: URL
+    /// The un-suffixed single-slot file every install used before per-project
+    /// slots. Non-nil only when this store is project-keyed; its contents are
+    /// adopted into the per-project file on first read and the legacy file is
+    /// deleted (mirroring the Keychain store's legacy adoption).
+    private let legacyFileURL: URL?
     private var cache: Snapshot?
 
-    /// Creates a file store persisting to `credentials.json` inside `directory`.
-    /// - Parameter directory: The directory to create (0700) and write into;
-    ///   injected so the type never reaches for the user's filesystem layout
-    ///   itself and tests can use a temp directory.
-    public init(directory: URL) {
-        self.fileURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+    /// Creates a file store persisting to ``fileName(projectID:)`` inside
+    /// `directory`.
+    /// - Parameters:
+    ///   - directory: The directory to create (0700) and write into; injected
+    ///     so the type never reaches for the user's filesystem layout itself
+    ///     and tests can use a temp directory.
+    ///   - projectID: The Stack project keying this store's per-project file
+    ///     (`credentials.<projectID>.json`); `nil` keeps the historical
+    ///     single-file behavior.
+    public init(directory: URL, projectID: String? = nil) {
+        let fileName = Self.fileName(projectID: projectID)
+        self.fileURL = directory.appendingPathComponent(fileName, isDirectory: false)
+        if fileName == Self.legacyFileName {
+            self.legacyFileURL = nil
+        } else {
+            self.legacyFileURL = directory.appendingPathComponent(
+                Self.legacyFileName,
+                isDirectory: false
+            )
+        }
+    }
+
+    private static let legacyFileName = "credentials.json"
+
+    /// The credentials file name for one token slot. A non-nil `projectID`
+    /// yields `credentials.<projectID>.json`, with every character outside
+    /// `[A-Za-z0-9_-]` replaced by `-` so a project id can never traverse the
+    /// path or collide with the legacy name; `nil` or empty returns the
+    /// historical `credentials.json`.
+    public static func fileName(projectID: String?) -> String {
+        guard let projectID, !projectID.isEmpty else { return legacyFileName }
+        let sanitized = String(projectID.map { character in
+            (character.isASCII && (character.isLetter || character.isNumber))
+                || character == "-" || character == "_"
+                ? character
+                : "-"
+        })
+        return "credentials.\(sanitized).json"
     }
 
     public func getStoredAccessToken() async -> String? {
@@ -48,9 +85,14 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
         write(snapshot)
     }
 
+    /// Clears this store's OWN slot plus the un-suffixed legacy file it may
+    /// adopt from. Another project's `credentials.<projectID>.json` is
+    /// deliberately untouched, so signing out of one backend environment
+    /// never destroys a session parked for the other.
     public func clearTokens() async {
         log.log("clearTokens called")
         write(Snapshot(accessToken: nil, refreshToken: nil))
+        deleteLegacyFile()
     }
 
     @discardableResult
@@ -66,6 +108,7 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
         }
         log.log("file.clearTokensIfCurrent: cleared matching tokens")
         write(Snapshot(accessToken: nil, refreshToken: nil))
+        deleteLegacyFile()
         return true
     }
 
@@ -98,14 +141,46 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
 
     private func readFromDisk() -> Snapshot {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: fileURL.path) else { return Snapshot() }
+        if fm.fileExists(atPath: fileURL.path) {
+            return decodeSnapshot(at: fileURL) ?? Snapshot()
+        }
+        // Un-suffixed legacy tier: adopt the single-slot `credentials.json`
+        // into this store's per-project file, then delete it (mirroring the
+        // Keychain store). Its owner is by construction the last-resolved
+        // project — this store's project, because an organic project flip
+        // clears the store before any read. A legacy file that fails to
+        // decode is left in place rather than destroyed.
+        guard let legacyFileURL, fm.fileExists(atPath: legacyFileURL.path) else {
+            return Snapshot()
+        }
+        guard let adopted = decodeSnapshot(at: legacyFileURL) else { return Snapshot() }
+        write(adopted)
         do {
-            let data = try Data(contentsOf: fileURL)
-            let snapshot = try JSONDecoder().decode(Snapshot.self, from: data)
-            return snapshot
+            try fm.removeItem(at: legacyFileURL)
+        } catch {
+            log.log("legacy credentials delete failed: \(error)")
+        }
+        return adopted
+    }
+
+    private func decodeSnapshot(at url: URL) -> Snapshot? {
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(Snapshot.self, from: data)
         } catch {
             log.log("credentials read failed: \(error)")
-            return Snapshot()
+            return nil
+        }
+    }
+
+    private func deleteLegacyFile() {
+        guard let legacyFileURL else { return }
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: legacyFileURL.path) else { return }
+        do {
+            try fm.removeItem(at: legacyFileURL)
+        } catch {
+            log.log("legacy credentials delete failed: \(error)")
         }
     }
 

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
@@ -21,6 +21,11 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     private let service: String
     private let accessGroup: String?
     private let legacyProjectID: String?
+    /// The Stack project this store's slot belongs to. Non-nil keys the
+    /// account names per project (`cmux-auth-access-token.<projectID>`), so a
+    /// parked session for one backend environment survives while another is
+    /// active. `nil` preserves the historical single-slot account names.
+    private let projectID: String?
     private let log = AuthDebugLog()
 
     private var cachedAccessToken: String?
@@ -33,14 +38,36 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     ///   - accessGroup: The app's exact signed Keychain access group.
     ///   - legacyProjectID: The Stack project whose older account-only items
     ///     may be adopted from this same access group.
+    ///   - projectID: The Stack project keying this store's per-project token
+    ///     slot; `nil` keeps the historical single-slot behavior.
     public init(
         service: String,
         accessGroup: String? = nil,
-        legacyProjectID: String? = nil
+        legacyProjectID: String? = nil,
+        projectID: String? = nil
     ) {
         self.service = service
         self.accessGroup = accessGroup
         self.legacyProjectID = legacyProjectID
+        self.projectID = projectID
+    }
+
+    /// The Keychain account name for one token slot. A non-nil `projectID`
+    /// suffixes the base account (`<base>.<projectID>`) so each Stack project
+    /// gets its own slot inside the bundle-scoped service; `nil` (or empty)
+    /// returns the base account unchanged, matching every pre-per-project
+    /// install.
+    public static func account(base: String, projectID: String?) -> String {
+        guard let projectID, !projectID.isEmpty else { return base }
+        return "\(base).\(projectID)"
+    }
+
+    private var accessTokenAccountName: String {
+        Self.account(base: Self.accessTokenAccount, projectID: projectID)
+    }
+
+    private var refreshTokenAccountName: String {
+        Self.account(base: Self.refreshTokenAccount, projectID: projectID)
     }
 
     /// The keychain service name auth tokens are stored under, namespaced by
@@ -57,7 +84,8 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     public func getStoredAccessToken() async -> String? {
         if let cachedAccessToken { return cachedAccessToken }
         return readOrAdoptLegacyToken(
-            account: Self.accessTokenAccount,
+            account: accessTokenAccountName,
+            unsuffixedLegacyAccount: Self.accessTokenAccount,
             legacyAccount: legacyProjectID.map { "stack-auth-access-\($0)" }
         )
     }
@@ -65,7 +93,8 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     public func getStoredRefreshToken() async -> String? {
         if let cachedRefreshToken { return cachedRefreshToken }
         return readOrAdoptLegacyToken(
-            account: Self.refreshTokenAccount,
+            account: refreshTokenAccountName,
+            unsuffixedLegacyAccount: Self.refreshTokenAccount,
             legacyAccount: legacyProjectID.map { "stack-auth-refresh-\($0)" }
         )
     }
@@ -84,24 +113,30 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
 
         var allOK = true
         if let accessToken, !accessToken.isEmpty {
-            allOK = keychainWrite(accessToken, account: Self.accessTokenAccount) && allOK
+            allOK = keychainWrite(accessToken, account: accessTokenAccountName) && allOK
         } else {
-            keychainDelete(account: Self.accessTokenAccount)
+            keychainDelete(account: accessTokenAccountName)
         }
         if let refreshToken, !refreshToken.isEmpty {
-            allOK = keychainWrite(refreshToken, account: Self.refreshTokenAccount) && allOK
+            allOK = keychainWrite(refreshToken, account: refreshTokenAccountName) && allOK
         } else {
-            keychainDelete(account: Self.refreshTokenAccount)
+            keychainDelete(account: refreshTokenAccountName)
         }
         return allOK
     }
 
+    /// Clears this store's OWN slot plus both legacy tiers it may adopt from
+    /// (the un-suffixed single-slot accounts and the old SDK's account-only
+    /// items). Another project's suffixed slot is deliberately untouched, so
+    /// signing out of one backend environment never destroys a session parked
+    /// for the other.
     public func clearTokens() async {
         log.log("clearTokens called")
         cachedAccessToken = nil
         cachedRefreshToken = nil
-        keychainDelete(account: Self.accessTokenAccount)
-        keychainDelete(account: Self.refreshTokenAccount)
+        keychainDelete(account: accessTokenAccountName)
+        keychainDelete(account: refreshTokenAccountName)
+        deleteUnsuffixedLegacyTokens()
         deleteLegacyTokens()
     }
 
@@ -109,11 +144,13 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     public func clearTokensIfCurrent(accessToken: String?, refreshToken: String?) async -> Bool {
         let snapshot = AuthTokenSnapshot(
             accessToken: readOrAdoptLegacyToken(
-                account: Self.accessTokenAccount,
+                account: accessTokenAccountName,
+                unsuffixedLegacyAccount: Self.accessTokenAccount,
                 legacyAccount: legacyProjectID.map { "stack-auth-access-\($0)" }
             ),
             refreshToken: readOrAdoptLegacyToken(
-                account: Self.refreshTokenAccount,
+                account: refreshTokenAccountName,
+                unsuffixedLegacyAccount: Self.refreshTokenAccount,
                 legacyAccount: legacyProjectID.map { "stack-auth-refresh-\($0)" }
             )
         )
@@ -137,7 +174,8 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
         newAccessToken: String?
     ) async {
         let current = readOrAdoptLegacyToken(
-            account: Self.refreshTokenAccount,
+            account: refreshTokenAccountName,
+            unsuffixedLegacyAccount: Self.refreshTokenAccount,
             legacyAccount: legacyProjectID.map { "stack-auth-refresh-\($0)" }
         )
         let matches = current == compareRefreshToken
@@ -152,10 +190,24 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
 #if canImport(Security)
     private func readOrAdoptLegacyToken(
         account: String,
+        unsuffixedLegacyAccount: String,
         legacyAccount: String?
     ) -> String? {
         if let current = keychainRead(account: account) {
             return current
+        }
+        // Un-suffixed legacy tier: the single-slot account name every install
+        // used before per-project slots. It lives in this store's own
+        // bundle-scoped service, so no access-group gate is needed (unlike
+        // the SDK tier below), and its owner is by construction the
+        // last-resolved project — which is exactly this store's project,
+        // because an organic project flip clears the store before any read.
+        // Adopt it into the suffixed slot and delete the un-suffixed item.
+        if account != unsuffixedLegacyAccount,
+           let unsuffixed = keychainRead(account: unsuffixedLegacyAccount),
+           keychainWrite(unsuffixed, account: account) {
+            keychainDelete(account: unsuffixedLegacyAccount)
+            return unsuffixed
         }
         // Legacy account-only items are ambiguous without the exact signed
         // access group. Never let a caller using the current-token-only API
@@ -168,6 +220,15 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
         }
         keychainDeleteLegacy(account: legacyAccount)
         return legacy
+    }
+
+    /// Deletes the un-suffixed single-slot legacy items this store may adopt
+    /// from. A no-op for a store with no `projectID` (its own slot IS the
+    /// un-suffixed account, already deleted by the caller).
+    private func deleteUnsuffixedLegacyTokens() {
+        guard accessTokenAccountName != Self.accessTokenAccount else { return }
+        keychainDelete(account: Self.accessTokenAccount)
+        keychainDelete(account: Self.refreshTokenAccount)
     }
 
     private func deleteLegacyTokens() {
@@ -264,7 +325,12 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
         _ = SecItemDelete(legacyBaseQuery(account: account) as CFDictionary)
     }
 #else
-    private func readOrAdoptLegacyToken(account: String, legacyAccount: String?) -> String? { nil }
+    private func readOrAdoptLegacyToken(
+        account: String,
+        unsuffixedLegacyAccount: String,
+        legacyAccount: String?
+    ) -> String? { nil }
+    private func deleteUnsuffixedLegacyTokens() {}
     private func deleteLegacyTokens() {}
     private func keychainRead(account: String) -> String? { nil }
     private func keychainWrite(_ value: String, account: String) -> Bool { false }

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorDetachTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorDetachTests.swift
@@ -1,0 +1,163 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+/// ``AuthCoordinator/detachSessionLeavingTokens()`` — the "park" half of a
+/// backend-environment switch: it must end the published session exactly like
+/// sign-out's local clear while leaving the token store byte-for-byte intact
+/// (no `clearLocalSession`, no `revokeSession`, no sign-out hook).
+@MainActor
+@Suite struct AuthCoordinatorDetachTests {
+    private let user = CMUXAuthUser(
+        id: "park-user",
+        primaryEmail: "aziz@manaflow.ai",
+        displayName: "Aziz"
+    )
+
+    private func makeCoordinator(
+        client: FakeAuthClient,
+        store: FakeKeyValueStore = FakeKeyValueStore()
+    ) -> (AuthCoordinator, FakeKeyValueStore) {
+        let coordinator = AuthCoordinator(
+            client: client,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain()
+        )
+        return (coordinator, store)
+    }
+
+    @Test func detachClearsPublishedStateButLeavesTokenStoreUntouched() async throws {
+        let client = FakeAuthClient(refresh: "parked-refresh", user: user)
+        let (coordinator, store) = makeCoordinator(client: client)
+        try await coordinator.signInWithPassword(email: "aziz@manaflow.ai", password: "pw")
+        #expect(coordinator.isAuthenticated)
+        #expect(store.bool(forKey: "has_tokens"))
+        let accessBefore = await client.storedAccessToken()
+        try #require(accessBefore != nil)
+
+        await coordinator.detachSessionLeavingTokens()
+
+        // Published state + self-healing caches cleared, like sign-out...
+        #expect(coordinator.isAuthenticated == false)
+        #expect(coordinator.currentUser == nil)
+        #expect(coordinator.availableTeams.isEmpty)
+        #expect(coordinator.selectedTeamID == nil)
+        #expect(store.bool(forKey: "has_tokens") == false)
+        #expect(store.data(forKey: "cached_user") == nil)
+        // ...but the token store is untouched and nothing was revoked.
+        let clears = await client.clearLocalSessionCount
+        let revokes = await client.revokeCount
+        #expect(clears == 0)
+        #expect(revokes == 0)
+        let access = await client.storedAccessToken()
+        let refresh = await client.refreshToken()
+        #expect(access == accessBefore)
+        #expect(refresh == "parked-refresh")
+    }
+
+    @Test func detachAdvancesSessionGenerationAndPublishesSignedOutIdentity() async throws {
+        let client = FakeAuthClient(user: user)
+        let (coordinator, _) = makeCoordinator(client: client)
+        try await coordinator.signInWithPassword(email: "aziz@manaflow.ai", password: "pw")
+        let generationBefore = coordinator.authSessionGeneration
+        let stream = coordinator.authenticatedSessionIdentities()
+        var iterator = stream.makeAsyncIterator()
+        // First element is the current (signed-in) identity.
+        let first = await iterator.next()
+        #expect(first.flatMap { $0 } != nil)
+
+        await coordinator.detachSessionLeavingTokens()
+
+        #expect(coordinator.authSessionGeneration > generationBefore)
+        // The detach published a signed-out identity to live consumers.
+        let next = await iterator.next()
+        #expect(next != nil)
+        #expect(next.flatMap { $0 } == nil)
+    }
+
+    @Test func detachIsSafeWhenAlreadySignedOut() async throws {
+        let client = FakeAuthClient()
+        let (coordinator, store) = makeCoordinator(client: client)
+        #expect(coordinator.isAuthenticated == false)
+
+        await coordinator.detachSessionLeavingTokens()
+
+        #expect(coordinator.isAuthenticated == false)
+        #expect(coordinator.currentUser == nil)
+        #expect(store.bool(forKey: "has_tokens") == false)
+        let clears = await client.clearLocalSessionCount
+        let revokes = await client.revokeCount
+        #expect(clears == 0)
+        #expect(revokes == 0)
+    }
+}
+
+/// ``AuthCoordinator/waitForNextSignedInUser()`` — the awaitable "next user"
+/// primitive the switch transaction's restore/prompt steps are built on.
+@MainActor
+@Suite struct AuthCoordinatorWaitForNextSignedInUserTests {
+    private let user = CMUXAuthUser(
+        id: "wait-user",
+        primaryEmail: "aziz@manaflow.ai",
+        displayName: "Aziz"
+    )
+
+    private func makeCoordinator(client: FakeAuthClient) -> AuthCoordinator {
+        AuthCoordinator(
+            client: client,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: FakeKeyValueStore(), key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: FakeKeyValueStore(), key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(
+                keyValueStore: FakeKeyValueStore(),
+                key: "selected_team"
+            ),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain()
+        )
+    }
+
+    @Test func returnsCurrentUserImmediatelyWhenAuthenticated() async throws {
+        let client = FakeAuthClient(user: user)
+        let coordinator = makeCoordinator(client: client)
+        try await coordinator.signInWithPassword(email: "aziz@manaflow.ai", password: "pw")
+
+        let resolved = await coordinator.waitForNextSignedInUser()
+        #expect(resolved == user)
+    }
+
+    @Test func suspendsUntilTheNextSignInPublishes() async throws {
+        let client = FakeAuthClient(user: user)
+        let coordinator = makeCoordinator(client: client)
+        #expect(coordinator.isAuthenticated == false)
+
+        let waiter = Task { @MainActor in
+            await coordinator.waitForNextSignedInUser()
+        }
+        // Let the waiter subscribe before the sign-in publishes.
+        await Task.yield()
+        try await coordinator.signInWithPassword(email: "aziz@manaflow.ai", password: "pw")
+
+        let resolved = await waiter.value
+        #expect(resolved == user)
+    }
+
+    @Test func resolvesNilWhenTheAwaitingTaskIsCancelled() async throws {
+        let client = FakeAuthClient()
+        let coordinator = makeCoordinator(client: client)
+
+        let waiter = Task { @MainActor in
+            await coordinator.waitForNextSignedInUser()
+        }
+        await Task.yield()
+        waiter.cancel()
+
+        let resolved = await waiter.value
+        #expect(resolved == nil)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorEnvironmentSwitchClearTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorEnvironmentSwitchClearTests.swift
@@ -198,6 +198,76 @@ import Testing
         #expect(revokesB == 0)
     }
 
+    @Test func suppressedClearRebuildRestoresAParkedSession() async throws {
+        // The backend-environment switch parks the old session
+        // (detachSessionLeavingTokens leaves the token slot intact) and arms
+        // the one-shot rebuild marker, so the rebuilt coordinator is
+        // composed WITHOUT clearStaleAuthOnLaunch even though the resolved
+        // Stack project changed. The rebuilt coordinator must restore the
+        // TARGET's parked session from its surviving tokens: no local clear,
+        // no revocation, signed in without any prompt.
+        let store = FakeKeyValueStore()
+        let parkedUser = CMUXAuthUser(
+            id: "parked-user",
+            primaryEmail: "aziz@manaflow.ai",
+            displayName: "Aziz"
+        )
+        let clientA = FakeAuthClient(user: parkedUser)
+        let coordinatorA = AuthCoordinator(
+            client: clientA,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain()
+        )
+        try await coordinatorA.signInWithPassword(email: "aziz@manaflow.ai", password: "pw")
+        await coordinatorA.detachSessionLeavingTokens()
+        #expect(coordinatorA.isAuthenticated == false)
+        let parkedAccess = await clientA.storedAccessToken()
+        try #require(parkedAccess != nil)
+
+        // The rebuilt coordinator resolves the parked project's own slot
+        // (per-project stores), so its client still holds the parked tokens.
+        let clientB = FakeAuthClient(
+            access: parkedAccess,
+            refresh: "parked-refresh",
+            user: parkedUser
+        )
+        let coordinatorB = AuthCoordinator(
+            client: clientB,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: AuthLaunchOptions(
+                clearAuthRequested: false,
+                mockDataEnabled: false,
+                environment: [:],
+                includesDevAuth: false,
+                // The consumed rebuild marker suppressed the project-switch
+                // verdict, so the composition passes false here.
+                clearStaleAuthOnLaunch: false
+            )
+        )
+
+        coordinatorB.start()
+        await coordinatorB.awaitBootstrapped()
+
+        #expect(coordinatorB.isAuthenticated)
+        #expect(coordinatorB.currentUser == parkedUser)
+        let clearsA = await clientA.clearLocalSessionCount
+        let clearsB = await clientB.clearLocalSessionCount
+        let revokesA = await clientA.revokeCount
+        let revokesB = await clientB.revokeCount
+        #expect(clearsA == 0)
+        #expect(clearsB == 0)
+        #expect(revokesA == 0)
+        #expect(revokesB == 0)
+    }
+
     @Test func uiTestClearKeepsSuppressingAutoLogin() async throws {
         // The pre-existing CMUX_UITEST_CLEAR_AUTH contract is untouched: it
         // clears and stops, credentials and all.

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorEnvironmentSwitchClearTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorEnvironmentSwitchClearTests.swift
@@ -135,6 +135,69 @@ import Testing
         #expect(coordinator.currentUser == selectedUser)
     }
 
+    @Test func secondCoordinatorInSameProcessPrimesSignedOutAndClearsLocally() async throws {
+        // The live backend-environment switch rebuilds the auth graph
+        // IN-PROCESS: coordinator A (the old environment) is signed in over
+        // the shared stores, then coordinator B is built over the SAME
+        // stores with clearStaleAuthOnLaunch. B must prime signed-out
+        // synchronously at init (no stale-identity flash while A still
+        // exists) and clear the local session on start() without any network
+        // revocation (the switch's sign-out step already revoked under the
+        // old environment).
+        let store = FakeKeyValueStore()
+        let signedInUser = CMUXAuthUser(id: "old-env-user", primaryEmail: "old@x.com", displayName: "Old")
+        let clientA = FakeAuthClient(user: signedInUser)
+        let coordinatorA = AuthCoordinator(
+            client: clientA,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain()
+        )
+        try await coordinatorA.signInWithPassword(email: "old@x.com", password: "pw")
+        #expect(coordinatorA.isAuthenticated)
+        #expect(store.bool(forKey: "has_tokens"))
+
+        let clientB = FakeAuthClient(access: "old-env-access", refresh: "old-env-refresh")
+        let coordinatorB = AuthCoordinator(
+            client: clientB,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: AuthLaunchOptions(
+                clearAuthRequested: false,
+                mockDataEnabled: false,
+                environment: [:],
+                includesDevAuth: false,
+                clearStaleAuthOnLaunch: true
+            )
+        )
+
+        // Synchronous priming, before start(): the shared caches are already
+        // signed out even though coordinator A lives on in the process.
+        #expect(coordinatorB.isAuthenticated == false)
+        #expect(coordinatorB.currentUser == nil)
+        #expect(store.bool(forKey: "has_tokens") == false)
+
+        coordinatorB.start()
+        await coordinatorB.awaitBootstrapped()
+
+        // Local clear only: the persisted tokens were dropped through B's
+        // client, with no network revocation from either coordinator.
+        let clears = await clientB.clearLocalSessionCount
+        #expect(clears >= 1)
+        #expect(coordinatorB.isAuthenticated == false)
+        #expect(coordinatorB.currentUser == nil)
+        let revokesA = await clientA.revokeCount
+        let revokesB = await clientB.revokeCount
+        #expect(revokesA == 0)
+        #expect(revokesB == 0)
+    }
+
     @Test func uiTestClearKeepsSuppressingAutoLogin() async throws {
         // The pre-existing CMUX_UITEST_CLEAR_AUTH contract is untouched: it
         // clears and stops, credentials and all.

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
@@ -1,0 +1,139 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+/// Records step invocations and lets a test park the sign-out step on a
+/// continuation to probe the transaction's ordering guarantees.
+@MainActor
+private final class StepRecorder {
+    private(set) var events: [String] = []
+    private(set) var storedOverrides: [CMUXBackendEnvironmentOverride] = []
+    var pinned = false
+    var active: CMUXBackendEnvironmentOverride = .production
+
+    private var signOutGate: CheckedContinuation<Void, Never>?
+    var parkSignOut = false
+    private(set) var signOutParked = false
+
+    func releaseSignOut() {
+        signOutParked = false
+        signOutGate?.resume()
+        signOutGate = nil
+    }
+
+    func steps() -> BackendEnvironmentSwitchTransaction.Steps {
+        BackendEnvironmentSwitchTransaction.Steps(
+            isPinnedByBuild: { self.pinned },
+            activeEnvironment: { self.active },
+            signOut: {
+                self.events.append("signOut")
+                if self.parkSignOut {
+                    self.signOutParked = true
+                    await withCheckedContinuation { self.signOutGate = $0 }
+                }
+            },
+            quiesce: { self.events.append("quiesce") },
+            storeOverride: { target in
+                self.events.append("store")
+                self.storedOverrides.append(target)
+            },
+            rebuild: { _ in self.events.append("rebuild") }
+        )
+    }
+}
+
+@MainActor
+@Suite("Backend environment switch transaction")
+struct BackendEnvironmentSwitchTransactionTests {
+    @Test("Override is not stored until sign-out completes, and steps run in order")
+    func orderingHazard() async {
+        let recorder = StepRecorder()
+        recorder.parkSignOut = true
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        let run = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        while !recorder.signOutParked { await Task.yield() }
+
+        #expect(recorder.events == ["signOut"])
+        #expect(recorder.storedOverrides.isEmpty)
+        #expect(transaction.phase == .signingOut)
+
+        recorder.releaseSignOut()
+        await run.value
+
+        #expect(recorder.events == ["signOut", "quiesce", "store", "rebuild"])
+        #expect(recorder.storedOverrides == [.staging])
+        #expect(transaction.phase == .finished)
+    }
+
+    @Test("A concurrent run joins the active one instead of double-switching")
+    func reentrancyJoins() async {
+        let recorder = StepRecorder()
+        recorder.parkSignOut = true
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        let first = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        while !recorder.signOutParked { await Task.yield() }
+        let second = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+
+        recorder.releaseSignOut()
+        await first.value
+        await second.value
+
+        #expect(recorder.storedOverrides == [.staging])
+        #expect(recorder.events.filter { $0 == "rebuild" }.count == 1)
+    }
+
+    @Test("Pinned builds cannot start the transaction")
+    func pinnedRefusal() async {
+        let recorder = StepRecorder()
+        recorder.pinned = true
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(recorder.events.isEmpty)
+        #expect(transaction.phase == .idle)
+    }
+
+    @Test("Switching to the already-active environment is a no-op")
+    func noOpRefusal() async {
+        let recorder = StepRecorder()
+        recorder.active = .staging
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(recorder.events.isEmpty)
+        #expect(transaction.phase == .idle)
+    }
+
+    @Test("Production is switchable back after a finished staging switch")
+    func switchBackAfterFinish() async {
+        let recorder = StepRecorder()
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+        #expect(transaction.phase == .finished)
+
+        recorder.active = .staging
+        await transaction.run(to: .production, steps: recorder.steps())
+
+        #expect(recorder.storedOverrides == [.staging, .production])
+        #expect(transaction.phase == .finished)
+    }
+
+    @Test("Reset returns to idle only from finished")
+    func resetSemantics() async {
+        let transaction = BackendEnvironmentSwitchTransaction()
+        transaction.reset()
+        #expect(transaction.phase == .idle)
+
+        let recorder = StepRecorder()
+        await transaction.run(to: .staging, steps: recorder.steps())
+        #expect(transaction.phase == .finished)
+        transaction.reset()
+        #expect(transaction.phase == .idle)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
@@ -3,15 +3,24 @@ import Foundation
 import Testing
 @testable import CmuxAuthRuntime
 
+extension CMUXBackendEnvironmentSelection {
+    /// Compact event label: `lane(production)`, `explicit(staging)`, …
+    fileprivate var eventLabel: String {
+        switch self {
+        case .lane(let resolves): "lane(\(resolves.rawValue))"
+        case .explicit(let choice): "explicit(\(choice.rawValue))"
+        }
+    }
+}
+
 /// Records step invocations and lets a test park the park/prompt steps on
 /// continuations to probe the transaction's ordering guarantees.
 @MainActor
 private final class StepRecorder {
     private(set) var events: [String] = []
-    private(set) var storedOverrides: [CMUXBackendEnvironmentOverride] = []
-    private(set) var rebuiltOverrides: [CMUXBackendEnvironmentOverride] = []
-    var pinned = false
-    var active: CMUXBackendEnvironmentOverride = .production
+    private(set) var storedSelections: [CMUXBackendEnvironmentSelection] = []
+    private(set) var rebuiltSelections: [CMUXBackendEnvironmentSelection] = []
+    var active: CMUXBackendEnvironmentSelection = .lane(resolves: .production)
 
     /// The user `awaitRestoredUser` resolves per call (consumed head-first;
     /// empty = nil). The revert's trailing restore also consumes one.
@@ -46,8 +55,7 @@ private final class StepRecorder {
 
     func steps() -> BackendEnvironmentSwitchTransaction.Steps {
         BackendEnvironmentSwitchTransaction.Steps(
-            isPinnedByBuild: { self.pinned },
-            activeEnvironment: { self.active },
+            activeSelection: { self.active },
             parkSession: {
                 self.events.append("park")
                 if self.parkPark {
@@ -56,13 +64,13 @@ private final class StepRecorder {
                 }
             },
             quiesce: { self.events.append("quiesce") },
-            storeOverride: { target in
-                self.events.append("store(\(target.rawValue))")
-                self.storedOverrides.append(target)
+            storeSelection: { target in
+                self.events.append("store(\(target.eventLabel))")
+                self.storedSelections.append(target)
             },
             rebuild: { target in
-                self.events.append("rebuild(\(target.rawValue))")
-                self.rebuiltOverrides.append(target)
+                self.events.append("rebuild(\(target.eventLabel))")
+                self.rebuiltSelections.append(target)
             },
             awaitRestoredUser: {
                 self.events.append("awaitRestoredUser")
@@ -105,7 +113,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         displayName: "Someone"
     )
 
-    @Test("Override is not stored until the park completes, and steps run in order")
+    @Test("Selection is not stored until the park completes, and steps run in order")
     func orderingHazard() async {
         let recorder = StepRecorder()
         recorder.parkPark = true
@@ -113,21 +121,23 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        let run = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        let run = Task {
+            await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+        }
         while !recorder.parkParked { await Task.yield() }
 
         #expect(recorder.events == ["park"])
-        #expect(recorder.storedOverrides.isEmpty)
+        #expect(recorder.storedSelections.isEmpty)
         #expect(transaction.phase == .parking)
 
         recorder.releasePark()
         await run.value
 
         #expect(recorder.events == [
-            "park", "quiesce", "store(staging)", "rebuild(staging)",
+            "park", "quiesce", "store(explicit(staging))", "rebuild(explicit(staging))",
             "awaitRestoredUser", "isEligible(team-user)",
         ])
-        #expect(recorder.storedOverrides == [.staging])
+        #expect(recorder.storedSelections == [.explicit(.staging)])
         #expect(transaction.phase == .finished(.switched))
     }
 
@@ -138,7 +148,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.switched))
         #expect(!recorder.events.contains("promptSignIn"))
@@ -153,7 +163,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.switched))
         let signOuts = recorder.events.filter { $0 == "signOutEstablished" }
@@ -172,7 +182,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.switched))
         #expect(recorder.events.contains("promptSignIn"))
@@ -186,15 +196,18 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.promptedUser = Self.outsideUser
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.reverted(.notEligible)))
         #expect(recorder.events.filter { $0 == "signOutEstablished" }.count == 1)
         // Revert order: quiesce → store(previous) → rebuild(previous) →
         // awaitRestoredUser.
         let suffix = Array(recorder.events.drop(while: { $0 != "signOutEstablished" }).dropFirst())
-        #expect(suffix == ["quiesce", "store(production)", "rebuild(production)", "awaitRestoredUser"])
-        #expect(recorder.storedOverrides == [.staging, .production])
+        #expect(suffix == [
+            "quiesce", "store(lane(production))", "rebuild(lane(production))",
+            "awaitRestoredUser",
+        ])
+        #expect(recorder.storedSelections == [.explicit(.staging), .lane(resolves: .production)])
     }
 
     @Test("A cancelled prompt reverts(.signInCancelled)")
@@ -205,11 +218,11 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.promptFailure = .cancelled
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.reverted(.signInCancelled)))
-        #expect(recorder.storedOverrides == [.staging, .production])
-        #expect(recorder.rebuiltOverrides == [.staging, .production])
+        #expect(recorder.storedSelections == [.explicit(.staging), .lane(resolves: .production)])
+        #expect(recorder.rebuiltSelections == [.explicit(.staging), .lane(resolves: .production)])
     }
 
     @Test("A failed prompt reverts(.signInFailed)")
@@ -220,25 +233,61 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.promptFailure = .failed
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.reverted(.signInFailed)))
     }
 
-    @Test("PIN: a production target never consults the gate or the prompt")
+    @Test("Revert restores the ORIGINAL selection, including .lane")
+    func revertRestoresTheOriginalLaneSelection() async {
+        // A staging-LANE build running an explicit staging switch that gets
+        // cancelled must land back on the LANE (key cleared), not on some
+        // explicit reconstruction of it.
+        let recorder = StepRecorder()
+        recorder.active = .lane(resolves: .staging)
+        recorder.restoredUsers = [nil, nil]
+        recorder.promptedUser = nil
+        recorder.promptFailure = .cancelled
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.reverted(.signInCancelled)))
+        #expect(recorder.storedSelections == [.explicit(.staging), .lane(resolves: .staging)])
+    }
+
+    @Test("PIN: an explicit production target never consults the gate or the prompt")
     func productionNeverGates() async {
         let recorder = StepRecorder()
-        recorder.active = .staging
+        recorder.active = .explicit(.staging)
         // Even a restored INELIGIBLE user must complete the switch silently.
         recorder.restoredUsers = [Self.outsideUser]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .production, steps: recorder.steps())
+        await transaction.run(to: .explicit(.production), steps: recorder.steps())
 
         #expect(transaction.phase == .finished(.switched))
         #expect(!recorder.events.contains("promptSignIn"))
         #expect(!recorder.events.contains { $0.hasPrefix("isEligible") })
         #expect(!recorder.events.contains("signOutEstablished"))
+    }
+
+    @Test("PIN: a lane target never gates — a STAGING lane included")
+    func laneTargetNeverGates() async {
+        // Returning to a staging-baked build's own lane resolves staging but
+        // must stay ungated: dev rigs keep plain switch-backs, and the
+        // sign-out chain's return-to-lane can never prompt.
+        let recorder = StepRecorder()
+        recorder.active = .explicit(.production)
+        recorder.restoredUsers = [Self.outsideUser]
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .lane(resolves: .staging), steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        #expect(!recorder.events.contains("promptSignIn"))
+        #expect(!recorder.events.contains { $0.hasPrefix("isEligible") })
+        #expect(recorder.storedSelections == [.lane(resolves: .staging)])
     }
 
     @Test("PIN: a revert never gates and never prompts, so it cannot loop")
@@ -249,7 +298,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.promptFailure = .failed
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         // One prompt total (the staging establish); the revert's trailing
         // restore returned an ineligible user and STILL finished reverted
@@ -266,7 +315,9 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.parkPrompt = true
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        let run = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        let run = Task {
+            await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+        }
         while !recorder.promptParked { await Task.yield() }
         #expect(transaction.phase == .establishing)
 
@@ -294,56 +345,80 @@ struct BackendEnvironmentSwitchTransactionTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        let first = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        let first = Task {
+            await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+        }
         while !recorder.parkParked { await Task.yield() }
-        let second = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        let second = Task {
+            await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+        }
 
         recorder.releasePark()
         await first.value
         await second.value
 
-        #expect(recorder.storedOverrides == [.staging])
+        #expect(recorder.storedSelections == [.explicit(.staging)])
         #expect(recorder.events.filter { $0.hasPrefix("rebuild") }.count == 1)
     }
 
-    @Test("Pinned builds cannot start the transaction")
-    func pinnedRefusal() async {
+    // MARK: - Selection-identity guard matrix
+
+    @Test("GUARD: lane(staging) → explicit(staging) RUNS (same environment, new identity)")
+    func laneStagingToExplicitStagingRuns() async {
+        // The device-lane pick Part F unblocks: a staging-baked build
+        // explicitly choosing Staging is a REAL switch (the choice key gets
+        // written, gating and interception attach), even though the resolved
+        // environment does not change.
         let recorder = StepRecorder()
-        recorder.pinned = true
+        recorder.active = .lane(resolves: .staging)
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        #expect(recorder.storedSelections == [.explicit(.staging)])
+    }
+
+    @Test("GUARD: explicit(staging) → explicit(staging) refuses")
+    func explicitStagingToSameRefuses() async {
+        let recorder = StepRecorder()
+        recorder.active = .explicit(.staging)
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
 
         #expect(recorder.events.isEmpty)
         #expect(transaction.phase == .idle)
     }
 
-    @Test("Switching to the already-active environment is a no-op")
-    func noOpRefusal() async {
+    @Test("GUARD: lane → lane refuses")
+    func laneToLaneRefuses() async {
         let recorder = StepRecorder()
-        recorder.active = .staging
+        recorder.active = .lane(resolves: .production)
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .lane(resolves: .production), steps: recorder.steps())
 
         #expect(recorder.events.isEmpty)
         #expect(transaction.phase == .idle)
     }
 
-    @Test("Production is switchable back after a finished staging switch")
+    @Test("A production lane is switchable back after a finished explicit staging switch")
     func switchBackAfterFinish() async {
         let recorder = StepRecorder()
         recorder.restoredUsers = [Self.teamUser, Self.teamUser]
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
         #expect(transaction.phase == .finished(.switched))
 
-        recorder.active = .staging
-        await transaction.run(to: .production, steps: recorder.steps())
+        recorder.active = .explicit(.staging)
+        await transaction.run(to: .lane(resolves: .production), steps: recorder.steps())
 
-        #expect(recorder.storedOverrides == [.staging, .production])
+        #expect(recorder.storedSelections == [.explicit(.staging), .lane(resolves: .production)])
         #expect(transaction.phase == .finished(.switched))
     }
 
@@ -356,7 +431,7 @@ struct BackendEnvironmentSwitchTransactionTests {
         let recorder = StepRecorder()
         recorder.restoredUsers = [Self.teamUser]
         recorder.eligibleUserIDs = [Self.teamUser.id]
-        await transaction.run(to: .staging, steps: recorder.steps())
+        await transaction.run(to: .explicit(.staging), steps: recorder.steps())
         #expect(transaction.phase == .finished(.switched))
         transaction.reset()
         #expect(transaction.phase == .idle)

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/BackendEnvironmentSwitchTransactionTests.swift
@@ -3,42 +3,90 @@ import Foundation
 import Testing
 @testable import CmuxAuthRuntime
 
-/// Records step invocations and lets a test park the sign-out step on a
-/// continuation to probe the transaction's ordering guarantees.
+/// Records step invocations and lets a test park the park/prompt steps on
+/// continuations to probe the transaction's ordering guarantees.
 @MainActor
 private final class StepRecorder {
     private(set) var events: [String] = []
     private(set) var storedOverrides: [CMUXBackendEnvironmentOverride] = []
+    private(set) var rebuiltOverrides: [CMUXBackendEnvironmentOverride] = []
     var pinned = false
     var active: CMUXBackendEnvironmentOverride = .production
 
-    private var signOutGate: CheckedContinuation<Void, Never>?
-    var parkSignOut = false
-    private(set) var signOutParked = false
+    /// The user `awaitRestoredUser` resolves per call (consumed head-first;
+    /// empty = nil). The revert's trailing restore also consumes one.
+    var restoredUsers: [CMUXAuthUser?] = [nil]
+    /// The user `promptSignIn` resolves.
+    var promptedUser: CMUXAuthUser?
+    /// The eligibility verdict per user id (default: ineligible).
+    var eligibleUserIDs: Set<String> = []
+    /// The platform classification of a nil prompt.
+    var promptFailure: BackendEnvironmentSwitchTransaction.SignInPromptFailure = .failed
 
-    func releaseSignOut() {
-        signOutParked = false
-        signOutGate?.resume()
-        signOutGate = nil
+    private var parkGate: CheckedContinuation<Void, Never>?
+    var parkPark = false
+    private(set) var parkParked = false
+
+    private var promptGate: CheckedContinuation<CMUXAuthUser?, Never>?
+    var parkPrompt = false
+    private(set) var promptParked = false
+
+    func releasePark() {
+        parkParked = false
+        parkGate?.resume()
+        parkGate = nil
+    }
+
+    /// Resolve a parked prompt with `user` (nil = cancel/failure).
+    func resolvePrompt(with user: CMUXAuthUser?) {
+        promptParked = false
+        promptGate?.resume(returning: user)
+        promptGate = nil
     }
 
     func steps() -> BackendEnvironmentSwitchTransaction.Steps {
         BackendEnvironmentSwitchTransaction.Steps(
             isPinnedByBuild: { self.pinned },
             activeEnvironment: { self.active },
-            signOut: {
-                self.events.append("signOut")
-                if self.parkSignOut {
-                    self.signOutParked = true
-                    await withCheckedContinuation { self.signOutGate = $0 }
+            parkSession: {
+                self.events.append("park")
+                if self.parkPark {
+                    self.parkParked = true
+                    await withCheckedContinuation { self.parkGate = $0 }
                 }
             },
             quiesce: { self.events.append("quiesce") },
             storeOverride: { target in
-                self.events.append("store")
+                self.events.append("store(\(target.rawValue))")
                 self.storedOverrides.append(target)
             },
-            rebuild: { _ in self.events.append("rebuild") }
+            rebuild: { target in
+                self.events.append("rebuild(\(target.rawValue))")
+                self.rebuiltOverrides.append(target)
+            },
+            awaitRestoredUser: {
+                self.events.append("awaitRestoredUser")
+                guard !self.restoredUsers.isEmpty else { return nil }
+                return self.restoredUsers.removeFirst()
+            },
+            promptSignIn: {
+                self.events.append("promptSignIn")
+                if self.parkPrompt {
+                    self.promptParked = true
+                    return await withCheckedContinuation { self.promptGate = $0 }
+                }
+                return self.promptedUser
+            },
+            cancelSignInPrompt: {
+                self.events.append("cancelSignInPrompt")
+                self.resolvePrompt(with: nil)
+            },
+            signOutEstablishedSession: { self.events.append("signOutEstablished") },
+            isEligible: { user in
+                self.events.append("isEligible(\(user.id))")
+                return self.eligibleUserIDs.contains(user.id)
+            },
+            signInPromptFailure: { self.promptFailure }
         )
     }
 }
@@ -46,43 +94,216 @@ private final class StepRecorder {
 @MainActor
 @Suite("Backend environment switch transaction")
 struct BackendEnvironmentSwitchTransactionTests {
-    @Test("Override is not stored until sign-out completes, and steps run in order")
+    private static let teamUser = CMUXAuthUser(
+        id: "team-user",
+        primaryEmail: "aziz@manaflow.ai",
+        displayName: "Aziz"
+    )
+    private static let outsideUser = CMUXAuthUser(
+        id: "outside-user",
+        primaryEmail: "someone@example.com",
+        displayName: "Someone"
+    )
+
+    @Test("Override is not stored until the park completes, and steps run in order")
     func orderingHazard() async {
         let recorder = StepRecorder()
-        recorder.parkSignOut = true
+        recorder.parkPark = true
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
         let run = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
-        while !recorder.signOutParked { await Task.yield() }
+        while !recorder.parkParked { await Task.yield() }
 
-        #expect(recorder.events == ["signOut"])
+        #expect(recorder.events == ["park"])
         #expect(recorder.storedOverrides.isEmpty)
-        #expect(transaction.phase == .signingOut)
+        #expect(transaction.phase == .parking)
 
-        recorder.releaseSignOut()
+        recorder.releasePark()
         await run.value
 
-        #expect(recorder.events == ["signOut", "quiesce", "store", "rebuild"])
+        #expect(recorder.events == [
+            "park", "quiesce", "store(staging)", "rebuild(staging)",
+            "awaitRestoredUser", "isEligible(team-user)",
+        ])
         #expect(recorder.storedOverrides == [.staging])
-        #expect(transaction.phase == .finished)
+        #expect(transaction.phase == .finished(.switched))
+    }
+
+    @Test("A restored eligible session completes the switch with zero prompt")
+    func restoredEligibleSkipsPrompt() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        #expect(!recorder.events.contains("promptSignIn"))
+        #expect(!recorder.events.contains("signOutEstablished"))
+    }
+
+    @Test("A restored ineligible session is signed out for real, then prompted")
+    func restoredIneligibleSignsOutThenPrompts() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [Self.outsideUser]
+        recorder.promptedUser = Self.teamUser
+        recorder.eligibleUserIDs = [Self.teamUser.id]
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        let signOuts = recorder.events.filter { $0 == "signOutEstablished" }
+        #expect(signOuts.count == 1)
+        // The real sign-out lands BEFORE the prompt (under target defaults).
+        let signOutIndex = recorder.events.firstIndex(of: "signOutEstablished")
+        let promptIndex = recorder.events.firstIndex(of: "promptSignIn")
+        #expect(signOutIndex != nil && promptIndex != nil && signOutIndex! < promptIndex!)
+    }
+
+    @Test("No parked session prompts inline; an eligible sign-in switches")
+    func noSessionPromptsInline() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil]
+        recorder.promptedUser = Self.teamUser
+        recorder.eligibleUserIDs = [Self.teamUser.id]
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        #expect(recorder.events.contains("promptSignIn"))
+        #expect(!recorder.events.contains("signOutEstablished"))
+    }
+
+    @Test("An ineligible prompted user signs out exactly once and reverts(.notEligible)")
+    func ineligiblePromptRevertsWithOneRealSignOut() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil, nil]
+        recorder.promptedUser = Self.outsideUser
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.reverted(.notEligible)))
+        #expect(recorder.events.filter { $0 == "signOutEstablished" }.count == 1)
+        // Revert order: quiesce → store(previous) → rebuild(previous) →
+        // awaitRestoredUser.
+        let suffix = Array(recorder.events.drop(while: { $0 != "signOutEstablished" }).dropFirst())
+        #expect(suffix == ["quiesce", "store(production)", "rebuild(production)", "awaitRestoredUser"])
+        #expect(recorder.storedOverrides == [.staging, .production])
+    }
+
+    @Test("A cancelled prompt reverts(.signInCancelled)")
+    func cancelledPromptReverts() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil, nil]
+        recorder.promptedUser = nil
+        recorder.promptFailure = .cancelled
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.reverted(.signInCancelled)))
+        #expect(recorder.storedOverrides == [.staging, .production])
+        #expect(recorder.rebuiltOverrides == [.staging, .production])
+    }
+
+    @Test("A failed prompt reverts(.signInFailed)")
+    func failedPromptReverts() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil, nil]
+        recorder.promptedUser = nil
+        recorder.promptFailure = .failed
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.reverted(.signInFailed)))
+    }
+
+    @Test("PIN: a production target never consults the gate or the prompt")
+    func productionNeverGates() async {
+        let recorder = StepRecorder()
+        recorder.active = .staging
+        // Even a restored INELIGIBLE user must complete the switch silently.
+        recorder.restoredUsers = [Self.outsideUser]
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .production, steps: recorder.steps())
+
+        #expect(transaction.phase == .finished(.switched))
+        #expect(!recorder.events.contains("promptSignIn"))
+        #expect(!recorder.events.contains { $0.hasPrefix("isEligible") })
+        #expect(!recorder.events.contains("signOutEstablished"))
+    }
+
+    @Test("PIN: a revert never gates and never prompts, so it cannot loop")
+    func revertNeverPrompts() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil, Self.outsideUser]
+        recorder.promptedUser = nil
+        recorder.promptFailure = .failed
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        await transaction.run(to: .staging, steps: recorder.steps())
+
+        // One prompt total (the staging establish); the revert's trailing
+        // restore returned an ineligible user and STILL finished reverted
+        // without consulting the gate or prompting again.
+        #expect(transaction.phase == .finished(.reverted(.signInFailed)))
+        #expect(recorder.events.filter { $0 == "promptSignIn" }.count == 1)
+        #expect(recorder.events.filter { $0.hasPrefix("isEligible") }.isEmpty)
+    }
+
+    @Test("requestRevert during the prompt cancels it and reverts(.signInCancelled)")
+    func requestRevertCancelsPrompt() async {
+        let recorder = StepRecorder()
+        recorder.restoredUsers = [nil, nil]
+        recorder.parkPrompt = true
+        let transaction = BackendEnvironmentSwitchTransaction()
+
+        let run = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
+        while !recorder.promptParked { await Task.yield() }
+        #expect(transaction.phase == .establishing)
+
+        transaction.requestRevert()
+        await run.value
+
+        #expect(recorder.events.contains("cancelSignInPrompt"))
+        #expect(transaction.phase == .finished(.reverted(.signInCancelled)))
+    }
+
+    @Test("requestRevert outside establishing is a no-op")
+    func requestRevertOutsideEstablishingIsNoOp() async {
+        let recorder = StepRecorder()
+        let transaction = BackendEnvironmentSwitchTransaction()
+        transaction.requestRevert()
+        #expect(transaction.phase == .idle)
+        #expect(recorder.events.isEmpty)
     }
 
     @Test("A concurrent run joins the active one instead of double-switching")
     func reentrancyJoins() async {
         let recorder = StepRecorder()
-        recorder.parkSignOut = true
+        recorder.parkPark = true
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
         let first = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
-        while !recorder.signOutParked { await Task.yield() }
+        while !recorder.parkParked { await Task.yield() }
         let second = Task { await transaction.run(to: .staging, steps: recorder.steps()) }
 
-        recorder.releaseSignOut()
+        recorder.releasePark()
         await first.value
         await second.value
 
         #expect(recorder.storedOverrides == [.staging])
-        #expect(recorder.events.filter { $0 == "rebuild" }.count == 1)
+        #expect(recorder.events.filter { $0.hasPrefix("rebuild") }.count == 1)
     }
 
     @Test("Pinned builds cannot start the transaction")
@@ -112,16 +333,18 @@ struct BackendEnvironmentSwitchTransactionTests {
     @Test("Production is switchable back after a finished staging switch")
     func switchBackAfterFinish() async {
         let recorder = StepRecorder()
+        recorder.restoredUsers = [Self.teamUser, Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let transaction = BackendEnvironmentSwitchTransaction()
 
         await transaction.run(to: .staging, steps: recorder.steps())
-        #expect(transaction.phase == .finished)
+        #expect(transaction.phase == .finished(.switched))
 
         recorder.active = .staging
         await transaction.run(to: .production, steps: recorder.steps())
 
         #expect(recorder.storedOverrides == [.staging, .production])
-        #expect(transaction.phase == .finished)
+        #expect(transaction.phase == .finished(.switched))
     }
 
     @Test("Reset returns to idle only from finished")
@@ -131,8 +354,10 @@ struct BackendEnvironmentSwitchTransactionTests {
         #expect(transaction.phase == .idle)
 
         let recorder = StepRecorder()
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         await transaction.run(to: .staging, steps: recorder.steps())
-        #expect(transaction.phase == .finished)
+        #expect(transaction.phase == .finished(.switched))
         transaction.reset()
         #expect(transaction.phase == .idle)
     }

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TokenStoreProjectSlotTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TokenStoreProjectSlotTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+#if canImport(Security)
+import Security
+#endif
+import Testing
+@testable import CmuxAuthRuntime
+
+/// Per-project token slots (backend-environment switch parking): naming,
+/// coexistence of two projects' slots, un-suffixed legacy adoption, and
+/// own-slot-only clears.
+@Suite struct TokenStoreProjectSlotTests {
+    // MARK: - Naming statics (pure)
+
+    @Test func keychainAccountNamingSuffixesProjectID() {
+        #expect(
+            KeychainStackTokenStore.account(base: "cmux-auth-access-token", projectID: "pid-1")
+                == "cmux-auth-access-token.pid-1"
+        )
+        #expect(
+            KeychainStackTokenStore.account(base: "cmux-auth-access-token", projectID: nil)
+                == "cmux-auth-access-token"
+        )
+        #expect(
+            KeychainStackTokenStore.account(base: "cmux-auth-refresh-token", projectID: "")
+                == "cmux-auth-refresh-token"
+        )
+    }
+
+    @Test func fileNameKeysPerProjectAndSanitizes() {
+        #expect(FileStackTokenStore.fileName(projectID: nil) == "credentials.json")
+        #expect(FileStackTokenStore.fileName(projectID: "") == "credentials.json")
+        #expect(
+            FileStackTokenStore.fileName(projectID: "454ecd03-abcd")
+                == "credentials.454ecd03-abcd.json"
+        )
+        // Path separators and dots can never traverse or alias the legacy name.
+        #expect(
+            FileStackTokenStore.fileName(projectID: "../evil")
+                == "credentials.---evil.json"
+        )
+        #expect(
+            FileStackTokenStore.fileName(projectID: "a/b.c")
+                == "credentials.a-b-c.json"
+        )
+    }
+
+    // MARK: - File store slots
+
+    @Test func fileStoresForDifferentProjectsCoexist() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let production = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        let staging = FileStackTokenStore(directory: directory, projectID: "dev-project")
+        await production.setTokens(accessToken: "prod-access", refreshToken: "prod-refresh")
+        await staging.setTokens(accessToken: "stg-access", refreshToken: "stg-refresh")
+
+        #expect(await production.getStoredAccessToken() == "prod-access")
+        #expect(await staging.getStoredAccessToken() == "stg-access")
+
+        // Fresh instances prove the slots persisted independently on disk.
+        let production2 = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        let staging2 = FileStackTokenStore(directory: directory, projectID: "dev-project")
+        #expect(await production2.getStoredRefreshToken() == "prod-refresh")
+        #expect(await staging2.getStoredRefreshToken() == "stg-refresh")
+    }
+
+    @Test func fileStoreAdoptsUnsuffixedLegacyFileAndDeletesIt() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Seed the pre-per-project single slot.
+        let legacy = FileStackTokenStore(directory: directory)
+        await legacy.setTokens(accessToken: "legacy-access", refreshToken: "legacy-refresh")
+        let legacyURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path))
+
+        let keyed = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        #expect(await keyed.getStoredAccessToken() == "legacy-access")
+        #expect(await keyed.getStoredRefreshToken() == "legacy-refresh")
+
+        // Adopted into the per-project file; un-suffixed slot deleted.
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        let keyedURL = directory.appendingPathComponent(
+            "credentials.prod-project.json",
+            isDirectory: false
+        )
+        #expect(FileManager.default.fileExists(atPath: keyedURL.path))
+
+        // A fresh keyed instance reads the adopted slot without the legacy file.
+        let keyed2 = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        #expect(await keyed2.getStoredAccessToken() == "legacy-access")
+    }
+
+    @Test func fileStorePerProjectSlotWinsOverLegacyFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let keyed = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        await keyed.setTokens(accessToken: "own-access", refreshToken: "own-refresh")
+        let legacy = FileStackTokenStore(directory: directory)
+        await legacy.setTokens(accessToken: "legacy-access", refreshToken: "legacy-refresh")
+
+        let keyed2 = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        #expect(await keyed2.getStoredAccessToken() == "own-access")
+        // The legacy file is not adopted (own slot existed), so it survives.
+        let legacyURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    @Test func fileStoreClearTokensClearsOwnSlotAndLegacyOnly() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let production = FileStackTokenStore(directory: directory, projectID: "prod-project")
+        let staging = FileStackTokenStore(directory: directory, projectID: "dev-project")
+        let legacy = FileStackTokenStore(directory: directory)
+        await production.setTokens(accessToken: "prod-access", refreshToken: "prod-refresh")
+        await staging.setTokens(accessToken: "stg-access", refreshToken: "stg-refresh")
+        await legacy.setTokens(accessToken: "legacy-access", refreshToken: "legacy-refresh")
+
+        await production.clearTokens()
+
+        #expect(await production.getStoredAccessToken() == nil)
+        #expect(await production.getStoredRefreshToken() == nil)
+        // The legacy adoption source is cleared with the own slot...
+        let legacyURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        // ...but the OTHER project's parked slot survives.
+        let staging2 = FileStackTokenStore(directory: directory, projectID: "dev-project")
+        #expect(await staging2.getStoredAccessToken() == "stg-access")
+        #expect(await staging2.getStoredRefreshToken() == "stg-refresh")
+    }
+
+    @Test func nilProjectIDFileStoreKeepsHistoricalBehavior() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = FileStackTokenStore(directory: directory)
+        await store.setTokens(accessToken: "access-1", refreshToken: "refresh-1")
+        let legacyURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path))
+
+        await store.clearTokens()
+        #expect(await store.getStoredAccessToken() == nil)
+        let fresh = FileStackTokenStore(directory: directory)
+        #expect(await fresh.getStoredRefreshToken() == nil)
+    }
+
+    // MARK: - Keychain slots (real Keychain, unique service names)
+
+    #if canImport(Security)
+    @Test func keychainStoresForDifferentProjectsCoexistAndClearOwnSlotOnly() async throws {
+        let service = "com.cmux.tests.TokenStoreProjectSlotTests.\(UUID().uuidString)"
+        defer { deleteAllItems(service: service) }
+
+        let production = KeychainStackTokenStore(service: service, projectID: "prod-project")
+        let staging = KeychainStackTokenStore(service: service, projectID: "dev-project")
+        guard await production.trySetTokens(
+            accessToken: "prod-access",
+            refreshToken: "prod-refresh"
+        ) else {
+            // Ad-hoc test hosts without a keychain entitlement cannot exercise
+            // the data-protection keychain; the file-store suite carries the
+            // slot semantics there.
+            return
+        }
+        #expect(await staging.trySetTokens(accessToken: "stg-access", refreshToken: "stg-refresh"))
+
+        // Fresh instances (no warm cache) prove the slots persisted independently.
+        let production2 = KeychainStackTokenStore(service: service, projectID: "prod-project")
+        let staging2 = KeychainStackTokenStore(service: service, projectID: "dev-project")
+        #expect(await production2.getStoredAccessToken() == "prod-access")
+        #expect(await staging2.getStoredAccessToken() == "stg-access")
+
+        await production2.clearTokens()
+        let production3 = KeychainStackTokenStore(service: service, projectID: "prod-project")
+        let staging3 = KeychainStackTokenStore(service: service, projectID: "dev-project")
+        #expect(await production3.getStoredAccessToken() == nil)
+        #expect(await staging3.getStoredAccessToken() == "stg-access")
+        #expect(await staging3.getStoredRefreshToken() == "stg-refresh")
+    }
+
+    @Test func keychainStoreAdoptsUnsuffixedLegacySlotAndDeletesIt() async throws {
+        let service = "com.cmux.tests.TokenStoreProjectSlotTests.\(UUID().uuidString)"
+        defer { deleteAllItems(service: service) }
+
+        // Seed the pre-per-project single slot (un-suffixed account names).
+        let legacy = KeychainStackTokenStore(service: service)
+        guard await legacy.trySetTokens(
+            accessToken: "legacy-access",
+            refreshToken: "legacy-refresh"
+        ) else { return }
+
+        let keyed = KeychainStackTokenStore(service: service, projectID: "prod-project")
+        #expect(await keyed.getStoredAccessToken() == "legacy-access")
+        #expect(await keyed.getStoredRefreshToken() == "legacy-refresh")
+
+        // Adopted into the suffixed slot; the un-suffixed items are gone, so a
+        // fresh un-suffixed store reads nothing.
+        let legacy2 = KeychainStackTokenStore(service: service)
+        #expect(await legacy2.getStoredAccessToken() == nil)
+        #expect(await legacy2.getStoredRefreshToken() == nil)
+        let keyed2 = KeychainStackTokenStore(service: service, projectID: "prod-project")
+        #expect(await keyed2.getStoredAccessToken() == "legacy-access")
+    }
+
+    private func deleteAllItems(service: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+        _ = SecItemDelete(query as CFDictionary)
+    }
+    #endif
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CmuxAuthRuntimeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return directory
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironment.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironment.swift
@@ -31,14 +31,4 @@ public enum AccountBackendEnvironment: String, CaseIterable, Sendable {
         }
     }
 
-    /// Whether a relaunch is required for `pending` to become the running
-    /// process's environment. The host resolves its backend once at launch,
-    /// so any divergence between the persisted selection and the active
-    /// value only heals on relaunch.
-    public static func requiresRelaunch(
-        pending: AccountBackendEnvironment,
-        active: AccountBackendEnvironment
-    ) -> Bool {
-        pending != active
-    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironment.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironment.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The backend environment shown by the Account section's environment
+/// picker.
+///
+/// A package-local mirror of the host's persisted backend override:
+/// `CmuxSettingsUI` deliberately does not link the host's auth library
+/// (`CMUXAuthCore`), so the host's ``AccountFlow`` implementation maps its
+/// own type to and from this one. Production is always selectable so a
+/// device can always switch back.
+public enum AccountBackendEnvironment: String, CaseIterable, Sendable {
+    /// The default backend (cmux.com and the production Stack project).
+    case production
+    /// The staging backend (a separate deployment with separate accounts
+    /// and data).
+    case staging
+
+    /// User-facing picker label.
+    public var displayName: String {
+        switch self {
+        case .production:
+            return String(
+                localized: "settings.account.backendEnvironment.production",
+                defaultValue: "Production"
+            )
+        case .staging:
+            return String(
+                localized: "settings.account.backendEnvironment.staging",
+                defaultValue: "Staging"
+            )
+        }
+    }
+
+    /// Whether a relaunch is required for `pending` to become the running
+    /// process's environment. The host resolves its backend once at launch,
+    /// so any divergence between the persisted selection and the active
+    /// value only heals on relaunch.
+    public static func requiresRelaunch(
+        pending: AccountBackendEnvironment,
+        active: AccountBackendEnvironment
+    ) -> Bool {
+        pending != active
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentBuildLane.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentBuildLane.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The backend a build resolves with NO explicit environment choice
+/// persisted: its build lane.
+///
+/// A package-local mirror of the host's lane descriptor (`CmuxSettingsUI`
+/// deliberately does not link the host's auth library). Unpinned Release
+/// builds are the production lane, staging-baked dev rigs the staging lane,
+/// and tagged dev builds (or untagged Debug builds) a custom lane labeled
+/// with their baked origin. Powers the picker's option-set rule
+/// (``AccountBackendEnvironmentSelection/pickerOptions(for:)``) and the
+/// "Build lane (…)" labels.
+public enum AccountBackendEnvironmentBuildLane: Equatable, Sendable {
+    /// cmux.com and the production Stack project (unpinned Release builds).
+    case production
+    /// The staging deployment (staging-baked dev rigs).
+    case staging
+    /// Any other bake; `label` names the baked origin (host, or host:port).
+    case custom(label: String)
+
+    /// The environment this lane resolves to; only the staging lane
+    /// resolves staging.
+    public var resolvedEnvironment: AccountBackendEnvironment {
+        self == .staging ? .staging : .production
+    }
+
+    /// The human name substituted into "Build lane (%@)" strings.
+    public var label: String {
+        switch self {
+        case .production:
+            return AccountBackendEnvironment.production.displayName
+        case .staging:
+            return AccountBackendEnvironment.staging.displayName
+        case .custom(let label):
+            return label
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSelection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSelection.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The Account section picker's selection: the build's own lane, or an
+/// explicitly chosen environment.
+///
+/// A package-local mirror of the host's selection (`CmuxSettingsUI`
+/// deliberately does not link the host's auth library). `.production` and
+/// `.staging` are EXPLICIT wholesale choices; `.buildLane` clears the choice
+/// so the build's bake resolves again. Only explicit `.staging` gates entry
+/// and intercepts sign-out, which is why the recovery card's switch-back
+/// button keys on the selection rather than the resolved environment.
+public enum AccountBackendEnvironmentSelection: Equatable, Hashable, Sendable {
+    /// No explicit choice: run whatever this build is baked to.
+    case buildLane
+    /// Explicitly pin the production backend.
+    case production
+    /// Explicitly pin the staging backend (gated, intercepts sign-out).
+    case staging
+
+    /// The option-set rule: a production-lane build shows today's
+    /// two-position picker (its "Production" maps to clearing the choice
+    /// host-side, so the lane and the option coincide); every other lane
+    /// gets a third "Build lane (…)" position ahead of the explicit pair.
+    public static func pickerOptions(
+        for lane: AccountBackendEnvironmentBuildLane
+    ) -> [AccountBackendEnvironmentSelection] {
+        lane == .production
+            ? [.production, .staging]
+            : [.buildLane, .production, .staging]
+    }
+
+    /// The environment this selection resolves to on a build with `lane`.
+    public func resolvedEnvironment(
+        lane: AccountBackendEnvironmentBuildLane
+    ) -> AccountBackendEnvironment {
+        switch self {
+        case .buildLane: lane.resolvedEnvironment
+        case .production: .production
+        case .staging: .staging
+        }
+    }
+
+    /// User-facing picker label; the lane option names the lane it returns
+    /// to.
+    public func displayName(lane: AccountBackendEnvironmentBuildLane) -> String {
+        switch self {
+        case .buildLane:
+            String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.buildLaneOption",
+                    defaultValue: "Build lane (%@)"
+                ),
+                lane.label
+            )
+        case .production:
+            AccountBackendEnvironment.production.displayName
+        case .staging:
+            AccountBackendEnvironment.staging.displayName
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSwitchPhase.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSwitchPhase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Where the host's live backend-environment switch currently is.
+///
+/// A package-local mirror of the host's switch-transaction phase:
+/// `CmuxSettingsUI` deliberately does not link the host's auth runtime, so
+/// the host's ``AccountFlow`` implementation maps its own phase type to this
+/// one. ``BackendEnvironmentCard`` replaces the picker with a progress row
+/// during the transitional phases and shows a switched note at ``finished``.
+public enum AccountBackendEnvironmentSwitchPhase: Equatable, Sendable {
+    /// No switch in progress; the picker is interactive.
+    case idle
+    /// Signing out of the old environment (its defaults still active).
+    case signingOut
+    /// Override committed; the host is rebuilding its auth stack for the
+    /// new environment.
+    case retargeting
+    /// Switch complete; the card shows the switched note until the host
+    /// flow's ``AccountFlow/resetBackendEnvironmentSwitchPhase()`` runs.
+    case finished
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSwitchPhase.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountBackendEnvironmentSwitchPhase.swift
@@ -6,16 +6,50 @@ import Foundation
 /// `CmuxSettingsUI` deliberately does not link the host's auth runtime, so
 /// the host's ``AccountFlow`` implementation maps its own phase type to this
 /// one. ``BackendEnvironmentCard`` replaces the picker with a progress row
-/// during the transitional phases and shows a switched note at ``finished``.
+/// during the transitional phases and shows an outcome note at ``finished(_:)``.
 public enum AccountBackendEnvironmentSwitchPhase: Equatable, Sendable {
     /// No switch in progress; the picker is interactive.
     case idle
-    /// Signing out of the old environment (its defaults still active).
-    case signingOut
+    /// Parking the old environment's session (its defaults still active):
+    /// the session is kept on this device for the return switch.
+    case parking
     /// Override committed; the host is rebuilding its auth stack for the
     /// new environment.
     case retargeting
-    /// Switch complete; the card shows the switched note until the host
+    /// Rebuilt on the target; restoring its parked session and — for a
+    /// gated target — waiting for an eligible sign-in.
+    case establishing
+    /// Undoing the switch: rebuilding the previous environment and
+    /// restoring its parked session.
+    case reverting
+    /// Switch complete; the card shows the outcome note until the host
     /// flow's ``AccountFlow/resetBackendEnvironmentSwitchPhase()`` runs.
-    case finished
+    case finished(AccountBackendEnvironmentSwitchOutcome)
+
+    /// Whether a run is in flight (any phase between `idle` and `finished`).
+    public var isInFlight: Bool {
+        switch self {
+        case .idle, .finished: return false
+        case .parking, .retargeting, .establishing, .reverting: return true
+        }
+    }
+}
+
+/// How a completed switch ended.
+public enum AccountBackendEnvironmentSwitchOutcome: Equatable, Sendable {
+    /// The device is on the requested environment.
+    case switched
+    /// The device is back on the previous environment with its session
+    /// restored.
+    case reverted(AccountBackendEnvironmentSwitchRevertReason)
+}
+
+/// Why a switch ended back on the previous environment.
+public enum AccountBackendEnvironmentSwitchRevertReason: Equatable, Sendable {
+    /// The user cancelled the target's sign-in prompt.
+    case signInCancelled
+    /// The target's sign-in prompt failed (timeout, network, server).
+    case signInFailed
+    /// The sign-in completed but the account may not use the gated target.
+    case notEligible
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
@@ -92,23 +92,32 @@ public protocol AccountFlow: AnyObject {
     /// launch. Drives the "Staging" badge on the account card.
     var activeBackendEnvironment: AccountBackendEnvironment { get }
 
-    /// The persisted backend selection, applied at next launch. When this
-    /// differs from ``activeBackendEnvironment`` the UI shows a relaunch
-    /// notice.
+    /// The persisted backend selection. With the live switch this normally
+    /// matches ``activeBackendEnvironment``; it only diverges when another
+    /// writer changed the persisted value outside the switch transaction.
     var pendingBackendEnvironment: AccountBackendEnvironment { get }
 
     /// Whether this build's backend is pinned by explicit launch-environment
     /// variables (tagged dev builds bake `CMUX_*` origins via LSEnvironment),
-    /// in which case the picker's selection only takes effect in unpinned
-    /// builds.
+    /// in which case the picker is inert and the card shows a pinned note.
     var backendEnvironmentPinnedByLaunchEnvironment: Bool { get }
 
-    /// Persists `value` as the backend environment for the next launch.
-    func selectBackendEnvironment(_ value: AccountBackendEnvironment)
+    /// Where the host's live backend-environment switch currently is. The
+    /// card replaces the picker with a progress row while this is a
+    /// transitional phase and shows the switched note at ``AccountBackendEnvironmentSwitchPhase/finished``.
+    var backendEnvironmentSwitchPhase: AccountBackendEnvironmentSwitchPhase { get }
 
-    /// Persists session state and relaunches the app so the pending backend
-    /// environment becomes active.
-    func relaunchToApplyBackendEnvironment()
+    /// Runs the host's live backend-environment switch to `value`: full
+    /// sign-out under the old environment, then retargeting the auth stack,
+    /// without relaunching the app. A no-op on pinned builds and when
+    /// `value` is already active. Returns when the switch has finished.
+    func applyBackendEnvironment(_ value: AccountBackendEnvironment) async
+
+    /// Returns ``backendEnvironmentSwitchPhase`` to
+    /// ``AccountBackendEnvironmentSwitchPhase/idle`` after the UI has shown
+    /// the finished note (the card calls this when it disappears or when a
+    /// new selection starts).
+    func resetBackendEnvironmentSwitchPhase()
 }
 
 extension AccountFlow {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
@@ -99,10 +99,18 @@ public protocol AccountFlow: AnyObject {
     /// writer changed the persisted value outside the switch transaction.
     var pendingBackendEnvironment: AccountBackendEnvironment { get }
 
-    /// Whether this build's backend is pinned by explicit launch-environment
-    /// variables (tagged dev builds bake `CMUX_*` origins via LSEnvironment),
-    /// in which case the picker is inert and the card shows a pinned note.
-    var backendEnvironmentPinnedByLaunchEnvironment: Bool { get }
+    /// The active SELECTION: `.buildLane` when no explicit choice is
+    /// persisted, otherwise the explicit environment. Distinct from
+    /// ``activeBackendEnvironment`` (the resolved environment) because a
+    /// staging-lane build resolves staging without an explicit choice —
+    /// the picker's selected option, the recovery card's switch-back
+    /// affordance, and the lane confirm copy all key on this.
+    var activeBackendEnvironmentSelection: AccountBackendEnvironmentSelection { get }
+
+    /// The build's own lane. Drives the picker's option set (two positions
+    /// on the production lane, three with "Build lane (…)" otherwise) and
+    /// the lane footers explaining the bake.
+    var backendEnvironmentBuildLane: AccountBackendEnvironmentBuildLane { get }
 
     /// Where the host's live backend-environment switch currently is. The
     /// card replaces the picker with a progress row while this is a
@@ -113,11 +121,13 @@ public protocol AccountFlow: AnyObject {
     /// Runs the host's live backend-environment switch to `value`: the
     /// current environment's session is PARKED on this device (kept for the
     /// return switch), the auth stack retargets, and the target's parked
-    /// session restores — with an inline sign-in for a gated target, which
-    /// reverts to the previous environment on cancel / failure / an
-    /// ineligible account. No relaunch. A no-op on pinned builds and when
-    /// `value` is already active. Returns when the switch has finished.
-    func applyBackendEnvironment(_ value: AccountBackendEnvironment) async
+    /// session restores — with an inline sign-in for a gated target
+    /// (explicit staging only), which reverts to the previous selection on
+    /// cancel / failure / an ineligible account. No relaunch. A no-op when
+    /// `value` is already the active selection (on a production-lane build
+    /// the host maps `.production` to the lane, keeping the two-position
+    /// picker's semantics). Returns when the switch has finished.
+    func applyBackendEnvironment(_ value: AccountBackendEnvironmentSelection) async
 
     /// Returns ``backendEnvironmentSwitchPhase`` to
     /// ``AccountBackendEnvironmentSwitchPhase/idle`` after the UI has shown

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
@@ -81,6 +81,34 @@ public protocol AccountFlow: AnyObject {
     /// Whether the current Pro entitlement can be managed through the hosted
     /// Stripe billing portal.
     var canManageBilling: Bool { get }
+
+    /// Whether the backend environment picker should render. The host gates
+    /// this to team members (verified team email), DEBUG builds, and any
+    /// device whose persisted or active environment is already
+    /// non-production, so switching back is always possible.
+    var backendEnvironmentSwitcherVisible: Bool { get }
+
+    /// The backend environment the running process actually resolved at
+    /// launch. Drives the "Staging" badge on the account card.
+    var activeBackendEnvironment: AccountBackendEnvironment { get }
+
+    /// The persisted backend selection, applied at next launch. When this
+    /// differs from ``activeBackendEnvironment`` the UI shows a relaunch
+    /// notice.
+    var pendingBackendEnvironment: AccountBackendEnvironment { get }
+
+    /// Whether this build's backend is pinned by explicit launch-environment
+    /// variables (tagged dev builds bake `CMUX_*` origins via LSEnvironment),
+    /// in which case the picker's selection only takes effect in unpinned
+    /// builds.
+    var backendEnvironmentPinnedByLaunchEnvironment: Bool { get }
+
+    /// Persists `value` as the backend environment for the next launch.
+    func selectBackendEnvironment(_ value: AccountBackendEnvironment)
+
+    /// Persists session state and relaunches the app so the pending backend
+    /// environment becomes active.
+    func relaunchToApplyBackendEnvironment()
 }
 
 extension AccountFlow {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountFlow.swift
@@ -82,11 +82,13 @@ public protocol AccountFlow: AnyObject {
     /// Stripe billing portal.
     var canManageBilling: Bool { get }
 
-    /// Whether the backend environment picker should render. The host gates
-    /// this to team members (verified team email), DEBUG builds, and any
-    /// device whose persisted or active environment is already
-    /// non-production, so switching back is always possible.
-    var backendEnvironmentSwitcherVisible: Bool { get }
+    /// Whether the current user may use the FULL backend environment picker:
+    /// gate-allowed (verified team email) or a DEBUG build — nothing else.
+    /// Visibility itself is derived through
+    /// ``AccountFlow/backendEnvironmentCardVisibility``, whose recovery tier
+    /// keeps a "Switch Back to Production" card reachable on a non-production
+    /// device even when this is `false`.
+    var backendEnvironmentPickerAllowed: Bool { get }
 
     /// The backend environment the running process actually resolved at
     /// launch. Drives the "Staging" badge on the account card.
@@ -104,12 +106,16 @@ public protocol AccountFlow: AnyObject {
 
     /// Where the host's live backend-environment switch currently is. The
     /// card replaces the picker with a progress row while this is a
-    /// transitional phase and shows the switched note at ``AccountBackendEnvironmentSwitchPhase/finished``.
+    /// transitional phase and shows the outcome note at
+    /// ``AccountBackendEnvironmentSwitchPhase/finished(_:)``.
     var backendEnvironmentSwitchPhase: AccountBackendEnvironmentSwitchPhase { get }
 
-    /// Runs the host's live backend-environment switch to `value`: full
-    /// sign-out under the old environment, then retargeting the auth stack,
-    /// without relaunching the app. A no-op on pinned builds and when
+    /// Runs the host's live backend-environment switch to `value`: the
+    /// current environment's session is PARKED on this device (kept for the
+    /// return switch), the auth stack retargets, and the target's parked
+    /// session restores — with an inline sign-in for a gated target, which
+    /// reverts to the previous environment on cancel / failure / an
+    /// ineligible account. No relaunch. A no-op on pinned builds and when
     /// `value` is already active. Returns when the switch has finished.
     func applyBackendEnvironment(_ value: AccountBackendEnvironment) async
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountIdentityCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountIdentityCard.swift
@@ -25,7 +25,7 @@ struct AccountIdentityCard: View {
                         Text(titleText)
                             .cmuxFont(size: 13, weight: .medium)
                         if flow?.activeBackendEnvironment == .staging {
-                            stagingBadge
+                            StagingEnvironmentBadge()
                         }
                     }
                     if let subtitle = subtitleText {
@@ -50,18 +50,6 @@ struct AccountIdentityCard: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
-    }
-
-    /// Visible marker that this process is running against the staging
-    /// backend (the ACTIVE environment, not a pending selection), so a
-    /// switched device is never mistaken for production.
-    private var stagingBadge: some View {
-        Text(String(localized: "settings.account.stagingBadge", defaultValue: "Staging"))
-            .cmuxFont(size: 10, weight: .semibold)
-            .foregroundColor(.orange)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1)
-            .background(Capsule().fill(Color.orange.opacity(0.16)))
     }
 
     /// The system sign-in window can hang without redirecting back. When the

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountIdentityCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/AccountIdentityCard.swift
@@ -21,8 +21,13 @@ struct AccountIdentityCard: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(titleText)
-                        .cmuxFont(size: 13, weight: .medium)
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(titleText)
+                            .cmuxFont(size: 13, weight: .medium)
+                        if flow?.activeBackendEnvironment == .staging {
+                            stagingBadge
+                        }
+                    }
                     if let subtitle = subtitleText {
                         Text(subtitle)
                             .cmuxFont(size: 11)
@@ -45,6 +50,18 @@ struct AccountIdentityCard: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+    }
+
+    /// Visible marker that this process is running against the staging
+    /// backend (the ACTIVE environment, not a pending selection), so a
+    /// switched device is never mistaken for production.
+    private var stagingBadge: some View {
+        Text(String(localized: "settings.account.stagingBadge", defaultValue: "Staging"))
+            .cmuxFont(size: 10, weight: .semibold)
+            .foregroundColor(.orange)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(Color.orange.opacity(0.16)))
     }
 
     /// The system sign-in window can hang without redirecting back. When the

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
@@ -3,27 +3,33 @@ import SwiftUI
 
 /// Backend environment card rendered below the identity card in the Account
 /// section, in the tier chosen by ``AccountFlow/backendEnvironmentCardVisibility``:
-/// the full Production/Staging picker for gate-allowed users and DEBUG
-/// builds, or a recovery-only "Switch Back to Production" card for everyone
-/// else stranded off production.
+/// the full environment picker for gate-allowed users and DEBUG builds, or a
+/// recovery-only card for everyone else stranded off production.
 ///
-/// Neither variant writes through on selection: a choice stages through
+/// The picker's option set follows the build lane
+/// (``AccountBackendEnvironmentSelection/pickerOptions(for:)``): a
+/// production-lane build keeps the two-position Production/Staging picker,
+/// any other lane adds a "Build lane (…)" position that returns the build to
+/// its own bake, with a footer explaining that bake. Neither variant writes
+/// through on selection: a choice stages through
 /// ``BackendEnvironmentSwitchConfirmation`` and presents a confirmation
 /// dialog whose action runs the host's live switch
 /// (``AccountFlow/applyBackendEnvironment(_:)``); cancel reverts. While the
 /// switch runs the trailing control is replaced by a per-phase progress row
 /// driven by ``AccountFlow/backendEnvironmentSwitchPhase``, and when it
 /// finishes the card shows the outcome (switched, or reverted with the
-/// reason) until the flow's phase is reset. Pinned builds (tagged dev builds
-/// with baked `CMUX_*` launch environment) show a pinned note, keep the
-/// controls disabled, and never present the dialog.
+/// reason) until the flow's phase is reset. The recovery variant offers the
+/// switch-back button only for an EXPLICIT staging selection; a staging-LANE
+/// build shows the lane explanation instead (its home is the bake, and
+/// sign-out there stays plain).
 @MainActor
 struct BackendEnvironmentCard: View {
     /// Which tier of the card renders.
     enum Variant {
-        /// The full Production/Staging picker.
+        /// The full environment picker.
         case fullPicker
-        /// Recovery-only: explanation + a single switch-back button.
+        /// Recovery-only: explanation + (for explicit staging) a single
+        /// switch-back button.
         case recovery
     }
 
@@ -58,14 +64,11 @@ struct BackendEnvironmentCard: View {
                 Spacer(minLength: 12)
                 trailingControl
             }
-            if flow.backendEnvironmentPinnedByLaunchEnvironment {
-                Text(String(
-                    localized: "settings.account.backendEnvironment.pinnedNote",
-                    defaultValue: "This build's backend is pinned by its launch environment; the picker takes effect only in unpinned builds."
-                ))
-                .cmuxFont(size: 11)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            if variant == .fullPicker, flow.backendEnvironmentBuildLane != .production {
+                Text(laneFooterText)
+                    .cmuxFont(size: 11)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             if case let .finished(outcome) = flow.backendEnvironmentSwitchPhase {
                 Text(outcomeText(outcome))
@@ -111,6 +114,19 @@ struct BackendEnvironmentCard: View {
         }
     }
 
+    /// The picker option representing the ACTIVE selection. On a
+    /// production-lane build the lane has no option of its own (the
+    /// option-set rule keeps the two-position picker), so `.buildLane`
+    /// normalizes to `.production` — the same option the host maps back to
+    /// the lane on apply, making re-picking it a no-op.
+    private var activeOption: AccountBackendEnvironmentSelection {
+        let active = flow.activeBackendEnvironmentSelection
+        if flow.backendEnvironmentBuildLane == .production, active == .buildLane {
+            return .production
+        }
+        return active
+    }
+
     // MARK: - Trailing control
 
     @ViewBuilder
@@ -141,7 +157,10 @@ struct BackendEnvironmentCard: View {
             case .fullPicker:
                 picker
             case .recovery:
-                if flow.activeBackendEnvironment != .production {
+                // Only an EXPLICIT staging selection offers the switch-back
+                // route; a staging-lane build's card is explanatory (the
+                // lane is that build's home).
+                if flow.activeBackendEnvironmentSelection == .staging {
                     switchBackButton
                 }
             }
@@ -156,37 +175,35 @@ struct BackendEnvironmentCard: View {
             ),
             selection: Binding(
                 get: {
-                    confirmation.displayedSelection(active: flow.activeBackendEnvironment)
+                    confirmation.displayedSelection(active: activeOption)
                 },
                 set: { newValue in
                     // A new selection settles the previous round's outcome
                     // note before staging the next confirmation.
                     flow.resetBackendEnvironmentSwitchPhase()
-                    confirmation.select(
-                        newValue,
-                        active: flow.activeBackendEnvironment,
-                        pinned: flow.backendEnvironmentPinnedByLaunchEnvironment
-                    )
+                    confirmation.select(newValue, active: activeOption)
                 }
             )
         ) {
-            ForEach(AccountBackendEnvironment.allCases, id: \.self) { environment in
-                Text(environment.displayName).tag(environment)
+            ForEach(
+                AccountBackendEnvironmentSelection.pickerOptions(
+                    for: flow.backendEnvironmentBuildLane
+                ),
+                id: \.self
+            ) { option in
+                Text(option.displayName(lane: flow.backendEnvironmentBuildLane)).tag(option)
             }
         }
         .labelsHidden()
         .controlSize(.small)
         .fixedSize()
-        .disabled(flow.backendEnvironmentPinnedByLaunchEnvironment || flow.isWorkingOnAuth)
+        .disabled(flow.isWorkingOnAuth)
     }
 
     private var switchBackButton: some View {
         Button {
             flow.resetBackendEnvironmentSwitchPhase()
-            confirmation.requestSwitchBackToProduction(
-                active: flow.activeBackendEnvironment,
-                pinned: flow.backendEnvironmentPinnedByLaunchEnvironment
-            )
+            confirmation.requestSwitchBackToProduction(active: activeOption)
         } label: {
             Text(String(
                 localized: "settings.account.backendEnvironment.recovery.switchBack",
@@ -195,7 +212,7 @@ struct BackendEnvironmentCard: View {
         }
         .controlSize(.small)
         .fixedSize()
-        .disabled(flow.backendEnvironmentPinnedByLaunchEnvironment || flow.isWorkingOnAuth)
+        .disabled(flow.isWorkingOnAuth)
     }
 
     private func progressRow(label: String) -> some View {
@@ -218,6 +235,11 @@ struct BackendEnvironmentCard: View {
                 defaultValue: "Staging is a separate environment with separate accounts and data. Each environment keeps its own session on this Mac, and your Mac and iPhone must be on the same environment to pair."
             )
         case .recovery:
+            // A staging-lane build (no explicit choice) explains the bake;
+            // the switch-back copy is reserved for explicit staging.
+            if flow.activeBackendEnvironmentSelection == .buildLane {
+                return laneFooterText
+            }
             return String(
                 localized: "settings.account.backendEnvironment.recovery.explanation",
                 defaultValue: "This cmux is using the Staging environment, a separate deployment with separate accounts and data. Switch back to Production to use your normal account."
@@ -225,7 +247,29 @@ struct BackendEnvironmentCard: View {
         }
     }
 
+    private var laneFooterText: String {
+        String(
+            format: String(
+                localized: "settings.account.backendEnvironment.laneFooter",
+                defaultValue: "This build's own lane is %@, baked in at build time. The build lane option returns to it."
+            ),
+            flow.backendEnvironmentBuildLane.label
+        )
+    }
+
     private func outcomeText(_ outcome: AccountBackendEnvironmentSwitchOutcome) -> String {
+        // After a finished run the flow has rebound, so the ACTIVE selection
+        // names where the device ended up (target on switched, previous on
+        // reverted).
+        if case .switched = outcome, flow.activeBackendEnvironmentSelection == .buildLane {
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.switchedLane",
+                    defaultValue: "Now on the build lane (%@)."
+                ),
+                flow.backendEnvironmentBuildLane.label
+            )
+        }
         let environmentName = flow.activeBackendEnvironment.displayName
         switch outcome {
         case .switched:
@@ -263,24 +307,51 @@ struct BackendEnvironmentCard: View {
         }
     }
 
+    private var displayedTarget: AccountBackendEnvironmentSelection {
+        confirmation.displayedSelection(active: activeOption)
+    }
+
     private var confirmationTitle: String {
-        String(
+        if displayedTarget == .buildLane {
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.confirmTitleLane",
+                    defaultValue: "Switch back to the build lane (%@)?"
+                ),
+                flow.backendEnvironmentBuildLane.label
+            )
+        }
+        return String(
             format: String(
                 localized: "settings.account.backendEnvironment.confirmTitle",
                 defaultValue: "Switch to %@?"
             ),
-            confirmation.displayedSelection(active: flow.activeBackendEnvironment).displayName
+            displayedTarget
+                .resolvedEnvironment(lane: flow.backendEnvironmentBuildLane)
+                .displayName
         )
     }
 
     private var confirmationMessage: String {
-        String(
+        if displayedTarget == .buildLane {
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.confirmMessageLane",
+                    defaultValue: "Your %1$@ session is kept on this Mac, and cmux returns to what this build is baked to (%2$@). Each environment has separate accounts and data."
+                ),
+                flow.activeBackendEnvironment.displayName,
+                flow.backendEnvironmentBuildLane.label
+            )
+        }
+        return String(
             format: String(
                 localized: "settings.account.backendEnvironment.confirmMessage",
                 defaultValue: "Your %1$@ session is kept on this Mac, and you'll be asked to sign in to %2$@. Each environment has separate accounts and data, and your Mac and iPhone must be on the same environment to pair."
             ),
             flow.activeBackendEnvironment.displayName,
-            confirmation.displayedSelection(active: flow.activeBackendEnvironment).displayName
+            displayedTarget
+                .resolvedEnvironment(lane: flow.backendEnvironmentBuildLane)
+                .displayName
         )
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
@@ -4,16 +4,20 @@ import SwiftUI
 /// Backend environment picker rendered below the identity card in the
 /// Account section, only when ``AccountFlow/backendEnvironmentSwitcherVisible``.
 ///
-/// The picker writes the host's persisted selection immediately
-/// (``AccountFlow/selectBackendEnvironment(_:)``); the running process keeps
-/// its launch-resolved environment, so when the pending selection diverges
-/// from the active one the card shows a relaunch notice with a button that
-/// asks the host to persist state and relaunch. Pinned builds (tagged dev
-/// builds with baked `CMUX_*` launch environment) additionally get a note
-/// that the picker only takes effect in unpinned builds.
+/// The picker never writes through on selection: choosing a different
+/// environment stages the choice (``BackendEnvironmentSwitchConfirmation``)
+/// and presents a confirmation dialog whose action runs the host's live
+/// switch (``AccountFlow/applyBackendEnvironment(_:)``); cancel reverts the
+/// picker to the active environment. While the switch runs the picker row is
+/// replaced by a progress row driven by
+/// ``AccountFlow/backendEnvironmentSwitchPhase``, and when it finishes the
+/// card shows a switched note until the flow's phase is reset. Pinned builds
+/// (tagged dev builds with baked `CMUX_*` launch environment) show a pinned
+/// note, keep the picker disabled, and never present the dialog.
 @MainActor
 struct BackendEnvironmentCard: View {
     let flow: AccountFlow
+    @State private var confirmation = BackendEnvironmentSwitchConfirmation()
 
     init(flow: AccountFlow) {
         self.flow = flow
@@ -37,23 +41,20 @@ struct BackendEnvironmentCard: View {
                     .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 12)
-                Picker(
-                    String(
-                        localized: "settings.account.backendEnvironment.title",
-                        defaultValue: "Backend Environment"
-                    ),
-                    selection: Binding(
-                        get: { flow.pendingBackendEnvironment },
-                        set: { flow.selectBackendEnvironment($0) }
-                    )
-                ) {
-                    ForEach(AccountBackendEnvironment.allCases, id: \.self) { environment in
-                        Text(environment.displayName).tag(environment)
-                    }
+                switch flow.backendEnvironmentSwitchPhase {
+                case .signingOut:
+                    progressRow(label: String(
+                        localized: "settings.account.backendEnvironment.progressSigningOut",
+                        defaultValue: "Signing out…"
+                    ))
+                case .retargeting:
+                    progressRow(label: String(
+                        localized: "settings.account.backendEnvironment.progressSwitching",
+                        defaultValue: "Switching backend…"
+                    ))
+                case .idle, .finished:
+                    picker
                 }
-                .labelsHidden()
-                .controlSize(.small)
-                .fixedSize()
             }
             if flow.backendEnvironmentPinnedByLaunchEnvironment {
                 Text(String(
@@ -64,33 +65,108 @@ struct BackendEnvironmentCard: View {
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
-            if AccountBackendEnvironment.requiresRelaunch(
-                pending: flow.pendingBackendEnvironment,
-                active: flow.activeBackendEnvironment
-            ) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(String(
-                        localized: "settings.account.backendEnvironment.relaunchNotice",
-                        defaultValue: "cmux must relaunch to apply the new backend environment."
-                    ))
-                    .cmuxFont(size: 11)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    Spacer(minLength: 8)
-                    Button {
-                        flow.relaunchToApplyBackendEnvironment()
-                    } label: {
-                        Text(String(
-                            localized: "settings.account.backendEnvironment.relaunch",
-                            defaultValue: "Relaunch cmux"
-                        ))
-                    }
-                    .controlSize(.small)
-                    .fixedSize()
-                }
+            if flow.backendEnvironmentSwitchPhase == .finished {
+                Text(String(
+                    format: String(
+                        localized: "settings.account.backendEnvironment.switched",
+                        defaultValue: "Now on %@. Sign in to continue."
+                    ),
+                    flow.activeBackendEnvironment.displayName
+                ))
+                .cmuxFont(size: 11)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+        .confirmationDialog(
+            confirmationTitle,
+            isPresented: Binding(
+                get: { confirmation.isPresentingDialog },
+                set: { presented in
+                    // Any dismissal that did not go through the switch action
+                    // (Cancel, Escape, click-away) reverts the staged choice.
+                    if !presented { confirmation.cancel() }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            // Capture at content-build time: the staged selection is cleared
+            // on dismissal, and the action must not depend on whether the
+            // action or the dismissal binding runs first.
+            let target = confirmation.pendingSelection
+            Button {
+                confirmation.cancel()
+                if let target {
+                    Task { await flow.applyBackendEnvironment(target) }
+                }
+            } label: {
+                Text(String(
+                    localized: "settings.account.backendEnvironment.confirmAction",
+                    defaultValue: "Switch & Sign Out"
+                ))
+            }
+        } message: {
+            Text(String(
+                localized: "settings.account.backendEnvironment.confirmMessage",
+                defaultValue: "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+            ))
+        }
+        .onDisappear {
+            flow.resetBackendEnvironmentSwitchPhase()
+        }
+    }
+
+    private var picker: some View {
+        Picker(
+            String(
+                localized: "settings.account.backendEnvironment.title",
+                defaultValue: "Backend Environment"
+            ),
+            selection: Binding(
+                get: {
+                    confirmation.displayedSelection(active: flow.activeBackendEnvironment)
+                },
+                set: { newValue in
+                    // A new selection settles the previous round's switched
+                    // note before staging the next confirmation.
+                    flow.resetBackendEnvironmentSwitchPhase()
+                    confirmation.select(
+                        newValue,
+                        active: flow.activeBackendEnvironment,
+                        pinned: flow.backendEnvironmentPinnedByLaunchEnvironment
+                    )
+                }
+            )
+        ) {
+            ForEach(AccountBackendEnvironment.allCases, id: \.self) { environment in
+                Text(environment.displayName).tag(environment)
+            }
+        }
+        .labelsHidden()
+        .controlSize(.small)
+        .fixedSize()
+        .disabled(flow.backendEnvironmentPinnedByLaunchEnvironment || flow.isWorkingOnAuth)
+    }
+
+    private func progressRow(label: String) -> some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text(label)
+                .cmuxFont(size: 11)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var confirmationTitle: String {
+        String(
+            format: String(
+                localized: "settings.account.backendEnvironment.confirmTitle",
+                defaultValue: "Switch to %@?"
+            ),
+            confirmation.displayedSelection(active: flow.activeBackendEnvironment).displayName
+        )
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
@@ -1,60 +1,62 @@
 import CmuxFoundation
 import SwiftUI
 
-/// Backend environment picker rendered below the identity card in the
-/// Account section, only when ``AccountFlow/backendEnvironmentSwitcherVisible``.
+/// Backend environment card rendered below the identity card in the Account
+/// section, in the tier chosen by ``AccountFlow/backendEnvironmentCardVisibility``:
+/// the full Production/Staging picker for gate-allowed users and DEBUG
+/// builds, or a recovery-only "Switch Back to Production" card for everyone
+/// else stranded off production.
 ///
-/// The picker never writes through on selection: choosing a different
-/// environment stages the choice (``BackendEnvironmentSwitchConfirmation``)
-/// and presents a confirmation dialog whose action runs the host's live
-/// switch (``AccountFlow/applyBackendEnvironment(_:)``); cancel reverts the
-/// picker to the active environment. While the switch runs the picker row is
-/// replaced by a progress row driven by
-/// ``AccountFlow/backendEnvironmentSwitchPhase``, and when it finishes the
-/// card shows a switched note until the flow's phase is reset. Pinned builds
-/// (tagged dev builds with baked `CMUX_*` launch environment) show a pinned
-/// note, keep the picker disabled, and never present the dialog.
+/// Neither variant writes through on selection: a choice stages through
+/// ``BackendEnvironmentSwitchConfirmation`` and presents a confirmation
+/// dialog whose action runs the host's live switch
+/// (``AccountFlow/applyBackendEnvironment(_:)``); cancel reverts. While the
+/// switch runs the trailing control is replaced by a per-phase progress row
+/// driven by ``AccountFlow/backendEnvironmentSwitchPhase``, and when it
+/// finishes the card shows the outcome (switched, or reverted with the
+/// reason) until the flow's phase is reset. Pinned builds (tagged dev builds
+/// with baked `CMUX_*` launch environment) show a pinned note, keep the
+/// controls disabled, and never present the dialog.
 @MainActor
 struct BackendEnvironmentCard: View {
+    /// Which tier of the card renders.
+    enum Variant {
+        /// The full Production/Staging picker.
+        case fullPicker
+        /// Recovery-only: explanation + a single switch-back button.
+        case recovery
+    }
+
     let flow: AccountFlow
+    let variant: Variant
     @State private var confirmation = BackendEnvironmentSwitchConfirmation()
 
-    init(flow: AccountFlow) {
+    init(flow: AccountFlow, variant: Variant = .fullPicker) {
         self.flow = flow
+        self.variant = variant
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(String(
-                        localized: "settings.account.backendEnvironment.title",
-                        defaultValue: "Backend Environment"
-                    ))
-                    .cmuxFont(size: 13, weight: .medium)
-                    Text(String(
-                        localized: "settings.account.backendEnvironment.footer",
-                        defaultValue: "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
-                    ))
-                    .cmuxFont(size: 11)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(String(
+                            localized: "settings.account.backendEnvironment.title",
+                            defaultValue: "Backend Environment"
+                        ))
+                        .cmuxFont(size: 13, weight: .medium)
+                        if variant == .recovery, flow.activeBackendEnvironment == .staging {
+                            StagingEnvironmentBadge()
+                        }
+                    }
+                    Text(explanationText)
+                        .cmuxFont(size: 11)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 12)
-                switch flow.backendEnvironmentSwitchPhase {
-                case .signingOut:
-                    progressRow(label: String(
-                        localized: "settings.account.backendEnvironment.progressSigningOut",
-                        defaultValue: "Signing out…"
-                    ))
-                case .retargeting:
-                    progressRow(label: String(
-                        localized: "settings.account.backendEnvironment.progressSwitching",
-                        defaultValue: "Switching backend…"
-                    ))
-                case .idle, .finished:
-                    picker
-                }
+                trailingControl
             }
             if flow.backendEnvironmentPinnedByLaunchEnvironment {
                 Text(String(
@@ -65,17 +67,11 @@ struct BackendEnvironmentCard: View {
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
-            if flow.backendEnvironmentSwitchPhase == .finished {
-                Text(String(
-                    format: String(
-                        localized: "settings.account.backendEnvironment.switched",
-                        defaultValue: "Now on %@. Sign in to continue."
-                    ),
-                    flow.activeBackendEnvironment.displayName
-                ))
-                .cmuxFont(size: 11)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            if case let .finished(outcome) = flow.backendEnvironmentSwitchPhase {
+                Text(outcomeText(outcome))
+                    .cmuxFont(size: 11)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(.horizontal, 14)
@@ -104,17 +100,51 @@ struct BackendEnvironmentCard: View {
             } label: {
                 Text(String(
                     localized: "settings.account.backendEnvironment.confirmAction",
-                    defaultValue: "Switch & Sign Out"
+                    defaultValue: "Switch Environment"
                 ))
             }
         } message: {
-            Text(String(
-                localized: "settings.account.backendEnvironment.confirmMessage",
-                defaultValue: "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
-            ))
+            Text(confirmationMessage)
         }
         .onDisappear {
             flow.resetBackendEnvironmentSwitchPhase()
+        }
+    }
+
+    // MARK: - Trailing control
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch flow.backendEnvironmentSwitchPhase {
+        case .parking:
+            progressRow(label: String(
+                localized: "settings.account.backendEnvironment.progressParking",
+                defaultValue: "Saving your session…"
+            ))
+        case .retargeting:
+            progressRow(label: String(
+                localized: "settings.account.backendEnvironment.progressSwitching",
+                defaultValue: "Switching backend…"
+            ))
+        case .establishing:
+            progressRow(label: String(
+                localized: "settings.account.backendEnvironment.progressEstablishing",
+                defaultValue: "Waiting for sign-in…"
+            ))
+        case .reverting:
+            progressRow(label: String(
+                localized: "settings.account.backendEnvironment.progressReverting",
+                defaultValue: "Switching back…"
+            ))
+        case .idle, .finished:
+            switch variant {
+            case .fullPicker:
+                picker
+            case .recovery:
+                if flow.activeBackendEnvironment != .production {
+                    switchBackButton
+                }
+            }
         }
     }
 
@@ -129,7 +159,7 @@ struct BackendEnvironmentCard: View {
                     confirmation.displayedSelection(active: flow.activeBackendEnvironment)
                 },
                 set: { newValue in
-                    // A new selection settles the previous round's switched
+                    // A new selection settles the previous round's outcome
                     // note before staging the next confirmation.
                     flow.resetBackendEnvironmentSwitchPhase()
                     confirmation.select(
@@ -150,6 +180,24 @@ struct BackendEnvironmentCard: View {
         .disabled(flow.backendEnvironmentPinnedByLaunchEnvironment || flow.isWorkingOnAuth)
     }
 
+    private var switchBackButton: some View {
+        Button {
+            flow.resetBackendEnvironmentSwitchPhase()
+            confirmation.requestSwitchBackToProduction(
+                active: flow.activeBackendEnvironment,
+                pinned: flow.backendEnvironmentPinnedByLaunchEnvironment
+            )
+        } label: {
+            Text(String(
+                localized: "settings.account.backendEnvironment.recovery.switchBack",
+                defaultValue: "Switch Back to Production"
+            ))
+        }
+        .controlSize(.small)
+        .fixedSize()
+        .disabled(flow.backendEnvironmentPinnedByLaunchEnvironment || flow.isWorkingOnAuth)
+    }
+
     private func progressRow(label: String) -> some View {
         HStack(spacing: 6) {
             ProgressView()
@@ -160,12 +208,78 @@ struct BackendEnvironmentCard: View {
         }
     }
 
+    // MARK: - Copy
+
+    private var explanationText: String {
+        switch variant {
+        case .fullPicker:
+            return String(
+                localized: "settings.account.backendEnvironment.footer",
+                defaultValue: "Staging is a separate environment with separate accounts and data. Each environment keeps its own session on this Mac, and your Mac and iPhone must be on the same environment to pair."
+            )
+        case .recovery:
+            return String(
+                localized: "settings.account.backendEnvironment.recovery.explanation",
+                defaultValue: "This cmux is using the Staging environment, a separate deployment with separate accounts and data. Switch back to Production to use your normal account."
+            )
+        }
+    }
+
+    private func outcomeText(_ outcome: AccountBackendEnvironmentSwitchOutcome) -> String {
+        let environmentName = flow.activeBackendEnvironment.displayName
+        switch outcome {
+        case .switched:
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.switched",
+                    defaultValue: "Now on %@."
+                ),
+                environmentName
+            )
+        case .reverted(.signInCancelled):
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.revertedSignInCancelled",
+                    defaultValue: "Sign-in was cancelled, so you're back on %@."
+                ),
+                environmentName
+            )
+        case .reverted(.signInFailed):
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.revertedSignInFailed",
+                    defaultValue: "Sign-in didn't complete, so you're back on %@."
+                ),
+                environmentName
+            )
+        case .reverted(.notEligible):
+            return String(
+                format: String(
+                    localized: "settings.account.backendEnvironment.revertedNotEligible",
+                    defaultValue: "That account can't use Staging, so you're back on %@."
+                ),
+                environmentName
+            )
+        }
+    }
+
     private var confirmationTitle: String {
         String(
             format: String(
                 localized: "settings.account.backendEnvironment.confirmTitle",
                 defaultValue: "Switch to %@?"
             ),
+            confirmation.displayedSelection(active: flow.activeBackendEnvironment).displayName
+        )
+    }
+
+    private var confirmationMessage: String {
+        String(
+            format: String(
+                localized: "settings.account.backendEnvironment.confirmMessage",
+                defaultValue: "Your %1$@ session is kept on this Mac, and you'll be asked to sign in to %2$@. Each environment has separate accounts and data, and your Mac and iPhone must be on the same environment to pair."
+            ),
+            flow.activeBackendEnvironment.displayName,
             confirmation.displayedSelection(active: flow.activeBackendEnvironment).displayName
         )
     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCard.swift
@@ -1,0 +1,96 @@
+import CmuxFoundation
+import SwiftUI
+
+/// Backend environment picker rendered below the identity card in the
+/// Account section, only when ``AccountFlow/backendEnvironmentSwitcherVisible``.
+///
+/// The picker writes the host's persisted selection immediately
+/// (``AccountFlow/selectBackendEnvironment(_:)``); the running process keeps
+/// its launch-resolved environment, so when the pending selection diverges
+/// from the active one the card shows a relaunch notice with a button that
+/// asks the host to persist state and relaunch. Pinned builds (tagged dev
+/// builds with baked `CMUX_*` launch environment) additionally get a note
+/// that the picker only takes effect in unpinned builds.
+@MainActor
+struct BackendEnvironmentCard: View {
+    let flow: AccountFlow
+
+    init(flow: AccountFlow) {
+        self.flow = flow
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(
+                        localized: "settings.account.backendEnvironment.title",
+                        defaultValue: "Backend Environment"
+                    ))
+                    .cmuxFont(size: 13, weight: .medium)
+                    Text(String(
+                        localized: "settings.account.backendEnvironment.footer",
+                        defaultValue: "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+                    ))
+                    .cmuxFont(size: 11)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 12)
+                Picker(
+                    String(
+                        localized: "settings.account.backendEnvironment.title",
+                        defaultValue: "Backend Environment"
+                    ),
+                    selection: Binding(
+                        get: { flow.pendingBackendEnvironment },
+                        set: { flow.selectBackendEnvironment($0) }
+                    )
+                ) {
+                    ForEach(AccountBackendEnvironment.allCases, id: \.self) { environment in
+                        Text(environment.displayName).tag(environment)
+                    }
+                }
+                .labelsHidden()
+                .controlSize(.small)
+                .fixedSize()
+            }
+            if flow.backendEnvironmentPinnedByLaunchEnvironment {
+                Text(String(
+                    localized: "settings.account.backendEnvironment.pinnedNote",
+                    defaultValue: "This build's backend is pinned by its launch environment; the picker takes effect only in unpinned builds."
+                ))
+                .cmuxFont(size: 11)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            if AccountBackendEnvironment.requiresRelaunch(
+                pending: flow.pendingBackendEnvironment,
+                active: flow.activeBackendEnvironment
+            ) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(String(
+                        localized: "settings.account.backendEnvironment.relaunchNotice",
+                        defaultValue: "cmux must relaunch to apply the new backend environment."
+                    ))
+                    .cmuxFont(size: 11)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 8)
+                    Button {
+                        flow.relaunchToApplyBackendEnvironment()
+                    } label: {
+                        Text(String(
+                            localized: "settings.account.backendEnvironment.relaunch",
+                            defaultValue: "Relaunch cmux"
+                        ))
+                    }
+                    .controlSize(.small)
+                    .fixedSize()
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCardVisibility.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCardVisibility.swift
@@ -17,7 +17,12 @@ public enum BackendEnvironmentCardVisibility: Equatable, Sendable {
     /// No card.
     case hidden
 
-    /// Derive the tier.
+    /// Derive the tier from the SELECTION and the build lane (not just the
+    /// resolved environment): a non-gate user off production gets the
+    /// recovery card whether that comes from an explicit staging choice
+    /// (switch-back offered) or a staging LANE (the card explains the bake
+    /// instead — see `BackendEnvironmentCard`, which keys the button on the
+    /// selection).
     ///
     /// The recovery clause deliberately also fires while a switch is in any
     /// non-idle phase: (a) a release-build gate user's card would otherwise
@@ -29,12 +34,14 @@ public enum BackendEnvironmentCardVisibility: Equatable, Sendable {
     /// through the whole run.
     public init(
         pickerAllowed: Bool,
-        activeEnvironment: AccountBackendEnvironment,
+        selection: AccountBackendEnvironmentSelection,
+        buildLane: AccountBackendEnvironmentBuildLane,
         switchPhase: AccountBackendEnvironmentSwitchPhase
     ) {
         if pickerAllowed {
             self = .fullPicker
-        } else if activeEnvironment != .production || switchPhase != .idle {
+        } else if selection.resolvedEnvironment(lane: buildLane) != .production
+            || switchPhase != .idle {
             self = .recovery
         } else {
             self = .hidden
@@ -47,7 +54,8 @@ extension AccountFlow {
     public var backendEnvironmentCardVisibility: BackendEnvironmentCardVisibility {
         BackendEnvironmentCardVisibility(
             pickerAllowed: backendEnvironmentPickerAllowed,
-            activeEnvironment: activeBackendEnvironment,
+            selection: activeBackendEnvironmentSelection,
+            buildLane: backendEnvironmentBuildLane,
             switchPhase: backendEnvironmentSwitchPhase
         )
     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCardVisibility.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentCardVisibility.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Which backend-environment card, if any, the Account section renders.
+///
+/// Three tiers so the strict picker gate never strands a device off
+/// production:
+/// - gate-allowed user or DEBUG build → the full picker,
+/// - everyone else on a non-production device (or with a switch in flight)
+///   → a recovery-only "Switch Back to Production" card,
+/// - everyone else on production, idle → nothing.
+public enum BackendEnvironmentCardVisibility: Equatable, Sendable {
+    /// The full Production/Staging picker (gate-allowed user or DEBUG).
+    case fullPicker
+    /// The recovery-only card: staging badge, explanation, and a single
+    /// "Switch Back to Production" button.
+    case recovery
+    /// No card.
+    case hidden
+
+    /// Derive the tier.
+    ///
+    /// The recovery clause deliberately also fires while a switch is in any
+    /// non-idle phase: (a) a release-build gate user's card would otherwise
+    /// vanish mid-switch (parking detaches `currentUser`, killing the gate
+    /// clause while the active environment still reads production), and
+    /// (b) the recovery card would disappear the instant the switch-back
+    /// rebind flips active to production, so the progress row and outcome
+    /// note would never render. The phase term keeps one card visible
+    /// through the whole run.
+    public init(
+        pickerAllowed: Bool,
+        activeEnvironment: AccountBackendEnvironment,
+        switchPhase: AccountBackendEnvironmentSwitchPhase
+    ) {
+        if pickerAllowed {
+            self = .fullPicker
+        } else if activeEnvironment != .production || switchPhase != .idle {
+            self = .recovery
+        } else {
+            self = .hidden
+        }
+    }
+}
+
+extension AccountFlow {
+    /// The card tier this flow's current state resolves to.
+    public var backendEnvironmentCardVisibility: BackendEnvironmentCardVisibility {
+        BackendEnvironmentCardVisibility(
+            pickerAllowed: backendEnvironmentPickerAllowed,
+            activeEnvironment: activeBackendEnvironment,
+            switchPhase: backendEnvironmentSwitchPhase
+        )
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
@@ -53,4 +53,14 @@ struct BackendEnvironmentSwitchConfirmation: Equatable {
         }
         return pendingSelection
     }
+
+    /// The recovery card's named route: stage a switch back to production
+    /// through the SAME select/confirm contract as the picker (pinned and
+    /// already-on-production requests still never stage or present).
+    mutating func requestSwitchBackToProduction(
+        active: AccountBackendEnvironment,
+        pinned: Bool
+    ) {
+        select(.production, active: active, pinned: pinned)
+    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
@@ -5,24 +5,25 @@ import Foundation
 ///
 /// The picker never writes through on selection: a selection stages the
 /// choice here and presents a confirmation dialog, and only an explicit
-/// ``confirm()`` hands the staged environment back to the caller to apply.
-/// Extracted from the view so the contract (no apply without confirm, pinned
-/// builds never stage or present) is testable without rendering SwiftUI.
+/// ``confirm()`` hands the staged selection back to the caller to apply.
+/// Extracted from the view so the contract (no apply without confirm) is
+/// testable without rendering SwiftUI. Selections are the picker's option
+/// mirror (`.buildLane` / `.production` / `.staging`); the host maps them to
+/// its own lane/explicit model on apply.
 struct BackendEnvironmentSwitchConfirmation: Equatable {
     /// The staged, not-yet-confirmed picker choice.
-    private(set) var pendingSelection: AccountBackendEnvironment?
+    private(set) var pendingSelection: AccountBackendEnvironmentSelection?
     /// Whether the confirmation dialog is up for ``pendingSelection``.
     private(set) var isPresentingDialog = false
 
-    /// Handle a picker selection. Selecting the active environment settles
-    /// (clears any staged choice); a different environment stages the choice
-    /// and presents the dialog. Pinned builds never stage or present.
+    /// Handle a picker selection. Selecting the active option settles
+    /// (clears any staged choice); a different option stages the choice and
+    /// presents the dialog.
     mutating func select(
-        _ value: AccountBackendEnvironment,
-        active: AccountBackendEnvironment,
-        pinned: Bool
+        _ value: AccountBackendEnvironmentSelection,
+        active: AccountBackendEnvironmentSelection
     ) {
-        guard !pinned, value != active else {
+        guard value != active else {
             pendingSelection = nil
             isPresentingDialog = false
             return
@@ -31,14 +32,16 @@ struct BackendEnvironmentSwitchConfirmation: Equatable {
         isPresentingDialog = true
     }
 
-    /// The environment the picker row shows: the staged choice while one is
+    /// The option the picker row shows: the staged choice while one is
     /// pending, otherwise the active one (so cancel visibly reverts).
-    func displayedSelection(active: AccountBackendEnvironment) -> AccountBackendEnvironment {
+    func displayedSelection(
+        active: AccountBackendEnvironmentSelection
+    ) -> AccountBackendEnvironmentSelection {
         pendingSelection ?? active
     }
 
     /// Dialog cancelled or dismissed: drop the staged choice, reverting the
-    /// picker to the active environment.
+    /// picker to the active option.
     mutating func cancel() {
         pendingSelection = nil
         isPresentingDialog = false
@@ -46,7 +49,7 @@ struct BackendEnvironmentSwitchConfirmation: Equatable {
 
     /// Dialog confirmed: consume and return the staged choice for the caller
     /// to apply. Returns `nil` when nothing was staged (already cancelled).
-    mutating func confirm() -> AccountBackendEnvironment? {
+    mutating func confirm() -> AccountBackendEnvironmentSelection? {
         defer {
             pendingSelection = nil
             isPresentingDialog = false
@@ -55,12 +58,11 @@ struct BackendEnvironmentSwitchConfirmation: Equatable {
     }
 
     /// The recovery card's named route: stage a switch back to production
-    /// through the SAME select/confirm contract as the picker (pinned and
-    /// already-on-production requests still never stage or present).
+    /// through the SAME select/confirm contract as the picker (an
+    /// already-on-production request still never stages or presents).
     mutating func requestSwitchBackToProduction(
-        active: AccountBackendEnvironment,
-        pinned: Bool
+        active: AccountBackendEnvironmentSelection
     ) {
-        select(.production, active: active, pinned: pinned)
+        select(.production, active: active)
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/BackendEnvironmentSwitchConfirmation.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The confirm-before-apply state machine behind ``BackendEnvironmentCard``'s
+/// picker.
+///
+/// The picker never writes through on selection: a selection stages the
+/// choice here and presents a confirmation dialog, and only an explicit
+/// ``confirm()`` hands the staged environment back to the caller to apply.
+/// Extracted from the view so the contract (no apply without confirm, pinned
+/// builds never stage or present) is testable without rendering SwiftUI.
+struct BackendEnvironmentSwitchConfirmation: Equatable {
+    /// The staged, not-yet-confirmed picker choice.
+    private(set) var pendingSelection: AccountBackendEnvironment?
+    /// Whether the confirmation dialog is up for ``pendingSelection``.
+    private(set) var isPresentingDialog = false
+
+    /// Handle a picker selection. Selecting the active environment settles
+    /// (clears any staged choice); a different environment stages the choice
+    /// and presents the dialog. Pinned builds never stage or present.
+    mutating func select(
+        _ value: AccountBackendEnvironment,
+        active: AccountBackendEnvironment,
+        pinned: Bool
+    ) {
+        guard !pinned, value != active else {
+            pendingSelection = nil
+            isPresentingDialog = false
+            return
+        }
+        pendingSelection = value
+        isPresentingDialog = true
+    }
+
+    /// The environment the picker row shows: the staged choice while one is
+    /// pending, otherwise the active one (so cancel visibly reverts).
+    func displayedSelection(active: AccountBackendEnvironment) -> AccountBackendEnvironment {
+        pendingSelection ?? active
+    }
+
+    /// Dialog cancelled or dismissed: drop the staged choice, reverting the
+    /// picker to the active environment.
+    mutating func cancel() {
+        pendingSelection = nil
+        isPresentingDialog = false
+    }
+
+    /// Dialog confirmed: consume and return the staged choice for the caller
+    /// to apply. Returns `nil` when nothing was staged (already cancelled).
+    mutating func confirm() -> AccountBackendEnvironment? {
+        defer {
+            pendingSelection = nil
+            isPresentingDialog = false
+        }
+        return pendingSelection
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/StagingEnvironmentBadge.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Account/StagingEnvironmentBadge.swift
@@ -1,0 +1,18 @@
+import CmuxFoundation
+import SwiftUI
+
+/// Visible marker that this process is running against the staging backend
+/// (the ACTIVE environment, not a pending selection), so a switched device
+/// is never mistaken for production. Shared by the account identity card and
+/// the backend-environment recovery card.
+@MainActor
+struct StagingEnvironmentBadge: View {
+    var body: some View {
+        Text(String(localized: "settings.account.stagingBadge", defaultValue: "Staging"))
+            .cmuxFont(size: 10, weight: .semibold)
+            .foregroundColor(.orange)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(Color.orange.opacity(0.16)))
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AccountSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AccountSection.swift
@@ -32,6 +32,12 @@ public struct AccountSection: View {
                 AccountIdentityCard(flow: accountFlow)
             }
             .settingsSearchAnchors(["setting:account:account"])
+            if let accountFlow, accountFlow.backendEnvironmentSwitcherVisible {
+                SettingsCard {
+                    BackendEnvironmentCard(flow: accountFlow)
+                }
+                .settingsSearchAnchors(["setting:account:backend-environment"])
+            }
             if accountFlow?.isProUpgradeAvailable ?? false {
                 SettingsCard {
                     ProUpgradeCard(flow: accountFlow)

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AccountSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AccountSection.swift
@@ -32,11 +32,21 @@ public struct AccountSection: View {
                 AccountIdentityCard(flow: accountFlow)
             }
             .settingsSearchAnchors(["setting:account:account"])
-            if let accountFlow, accountFlow.backendEnvironmentSwitcherVisible {
-                SettingsCard {
-                    BackendEnvironmentCard(flow: accountFlow)
+            if let accountFlow {
+                switch accountFlow.backendEnvironmentCardVisibility {
+                case .fullPicker:
+                    SettingsCard {
+                        BackendEnvironmentCard(flow: accountFlow, variant: .fullPicker)
+                    }
+                    .settingsSearchAnchors(["setting:account:backend-environment"])
+                case .recovery:
+                    SettingsCard {
+                        BackendEnvironmentCard(flow: accountFlow, variant: .recovery)
+                    }
+                    .settingsSearchAnchors(["setting:account:backend-environment"])
+                case .hidden:
+                    EmptyView()
                 }
-                .settingsSearchAnchors(["setting:account:backend-environment"])
             }
             if accountFlow?.isProUpgradeAvailable ?? false {
                 SettingsCard {

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
@@ -16,13 +16,6 @@ struct AccountBackendEnvironmentTests {
         #expect(AccountBackendEnvironment(rawValue: "staging") == .staging)
     }
 
-    @Test func relaunchIsRequiredExactlyWhenPendingDiffersFromActive() {
-        #expect(!AccountBackendEnvironment.requiresRelaunch(pending: .production, active: .production))
-        #expect(!AccountBackendEnvironment.requiresRelaunch(pending: .staging, active: .staging))
-        #expect(AccountBackendEnvironment.requiresRelaunch(pending: .staging, active: .production))
-        #expect(AccountBackendEnvironment.requiresRelaunch(pending: .production, active: .staging))
-    }
-
     @Test func displayNamesAreNonEmptyAndDistinct() {
         #expect(!AccountBackendEnvironment.production.displayName.isEmpty)
         #expect(!AccountBackendEnvironment.staging.displayName.isEmpty)

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import CmuxSettingsUI
 
-/// The package-local backend environment enum mirrors the host's persisted
-/// override; these tests pin the contract the host mapping relies on.
+/// The package-local backend environment enum mirrors the host's explicit
+/// choice; these tests pin the contract the host mapping relies on.
 @Suite("AccountBackendEnvironment")
 struct AccountBackendEnvironmentTests {
     @Test func productionAndStagingAreTheOnlyCasesWithProductionFirst() {
@@ -23,5 +23,97 @@ struct AccountBackendEnvironmentTests {
             AccountBackendEnvironment.production.displayName
                 != AccountBackendEnvironment.staging.displayName
         )
+    }
+}
+
+/// The build-lane mirror and the picker's option-set rule.
+@Suite("AccountBackendEnvironmentBuildLane")
+struct AccountBackendEnvironmentBuildLaneTests {
+    @Test func lanesResolveStagingOnlyForTheStagingLane() {
+        #expect(AccountBackendEnvironmentBuildLane.production.resolvedEnvironment == .production)
+        #expect(AccountBackendEnvironmentBuildLane.staging.resolvedEnvironment == .staging)
+        #expect(
+            AccountBackendEnvironmentBuildLane.custom(label: "localhost:4123")
+                .resolvedEnvironment == .production
+        )
+    }
+
+    @Test func laneLabelsNameTheLane() {
+        #expect(
+            AccountBackendEnvironmentBuildLane.production.label
+                == AccountBackendEnvironment.production.displayName
+        )
+        #expect(
+            AccountBackendEnvironmentBuildLane.staging.label
+                == AccountBackendEnvironment.staging.displayName
+        )
+        #expect(
+            AccountBackendEnvironmentBuildLane.custom(label: "localhost:4123").label
+                == "localhost:4123"
+        )
+    }
+}
+
+/// The selection mirror: the picker's option-set rule and resolution.
+@Suite("AccountBackendEnvironmentSelection")
+struct AccountBackendEnvironmentSelectionTests {
+    @Test func productionLaneKeepsTheTwoPositionPicker() {
+        // The option-set rule: production-lane builds see exactly today's
+        // Production/Staging pair — no "Build lane" option, because the host
+        // maps "Production" back to the lane (clearChoice).
+        #expect(
+            AccountBackendEnvironmentSelection.pickerOptions(for: .production)
+                == [.production, .staging]
+        )
+    }
+
+    @Test func nonProductionLanesGetTheThreePositionPicker() {
+        #expect(
+            AccountBackendEnvironmentSelection.pickerOptions(for: .staging)
+                == [.buildLane, .production, .staging]
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.pickerOptions(
+                for: .custom(label: "localhost:4123")
+            ) == [.buildLane, .production, .staging]
+        )
+    }
+
+    @Test func selectionsResolveAgainstTheLane() {
+        #expect(
+            AccountBackendEnvironmentSelection.buildLane
+                .resolvedEnvironment(lane: .staging) == .staging
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.buildLane
+                .resolvedEnvironment(lane: .production) == .production
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.buildLane
+                .resolvedEnvironment(lane: .custom(label: "x")) == .production
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.production
+                .resolvedEnvironment(lane: .staging) == .production
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.staging
+                .resolvedEnvironment(lane: .production) == .staging
+        )
+    }
+
+    @Test func displayNamesDistinguishTheLaneOptionFromExplicitChoices() {
+        let laneName = AccountBackendEnvironmentSelection.buildLane
+            .displayName(lane: .custom(label: "localhost:4123"))
+        #expect(laneName.contains("localhost:4123"))
+        #expect(
+            AccountBackendEnvironmentSelection.production.displayName(lane: .staging)
+                == AccountBackendEnvironment.production.displayName
+        )
+        #expect(
+            AccountBackendEnvironmentSelection.staging.displayName(lane: .production)
+                == AccountBackendEnvironment.staging.displayName
+        )
+        #expect(laneName != AccountBackendEnvironment.staging.displayName)
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AccountBackendEnvironmentTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import CmuxSettingsUI
+
+/// The package-local backend environment enum mirrors the host's persisted
+/// override; these tests pin the contract the host mapping relies on.
+@Suite("AccountBackendEnvironment")
+struct AccountBackendEnvironmentTests {
+    @Test func productionAndStagingAreTheOnlyCasesWithProductionFirst() {
+        #expect(AccountBackendEnvironment.allCases == [.production, .staging])
+    }
+
+    @Test func rawValuesMatchTheHostOverrideStorageValues() {
+        #expect(AccountBackendEnvironment.production.rawValue == "production")
+        #expect(AccountBackendEnvironment.staging.rawValue == "staging")
+        #expect(AccountBackendEnvironment(rawValue: "production") == .production)
+        #expect(AccountBackendEnvironment(rawValue: "staging") == .staging)
+    }
+
+    @Test func relaunchIsRequiredExactlyWhenPendingDiffersFromActive() {
+        #expect(!AccountBackendEnvironment.requiresRelaunch(pending: .production, active: .production))
+        #expect(!AccountBackendEnvironment.requiresRelaunch(pending: .staging, active: .staging))
+        #expect(AccountBackendEnvironment.requiresRelaunch(pending: .staging, active: .production))
+        #expect(AccountBackendEnvironment.requiresRelaunch(pending: .production, active: .staging))
+    }
+
+    @Test func displayNamesAreNonEmptyAndDistinct() {
+        #expect(!AccountBackendEnvironment.production.displayName.isEmpty)
+        #expect(!AccountBackendEnvironment.staging.displayName.isEmpty)
+        #expect(
+            AccountBackendEnvironment.production.displayName
+                != AccountBackendEnvironment.staging.displayName
+        )
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentCardVisibilityTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentCardVisibilityTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import CmuxSettingsUI
+
+/// The three-tier backend-environment card visibility: full picker for
+/// gate-allowed/DEBUG, recovery for everyone else off production (or with a
+/// switch in flight), hidden otherwise.
+@Suite("BackendEnvironmentCardVisibility")
+struct BackendEnvironmentCardVisibilityTests {
+    private static let allPhases: [AccountBackendEnvironmentSwitchPhase] = [
+        .idle, .parking, .retargeting, .establishing, .reverting,
+        .finished(.switched),
+        .finished(.reverted(.signInCancelled)),
+        .finished(.reverted(.signInFailed)),
+        .finished(.reverted(.notEligible)),
+    ]
+
+    @Test func pickerAllowedIsAlwaysFullPickerAcrossEnvironmentsAndPhases() {
+        for environment in AccountBackendEnvironment.allCases {
+            for phase in Self.allPhases {
+                #expect(
+                    BackendEnvironmentCardVisibility(
+                        pickerAllowed: true,
+                        activeEnvironment: environment,
+                        switchPhase: phase
+                    ) == .fullPicker
+                )
+            }
+        }
+    }
+
+    @Test func nonGateUserOnStagingGetsRecovery() {
+        #expect(
+            BackendEnvironmentCardVisibility(
+                pickerAllowed: false,
+                activeEnvironment: .staging,
+                switchPhase: .idle
+            ) == .recovery
+        )
+    }
+
+    @Test func nonGateUserOnProductionIdleIsHidden() {
+        #expect(
+            BackendEnvironmentCardVisibility(
+                pickerAllowed: false,
+                activeEnvironment: .production,
+                switchPhase: .idle
+            ) == .hidden
+        )
+    }
+
+    @Test func nonGateUserWithAnyNonIdlePhaseGetsRecoveryEvenOnProduction() {
+        // Pins the deliberate deviation: mid-switch the gate clause can drop
+        // (parking detaches the user) and the switch-back rebind flips
+        // active to production before the run finishes; the phase term keeps
+        // one card visible through the whole run and its outcome note.
+        for phase in Self.allPhases where phase != .idle {
+            #expect(
+                BackendEnvironmentCardVisibility(
+                    pickerAllowed: false,
+                    activeEnvironment: .production,
+                    switchPhase: phase
+                ) == .recovery,
+                "phase \(phase) should keep the recovery card visible"
+            )
+        }
+    }
+}
+
+/// The package-local switch phase model the host maps onto.
+@Suite("AccountBackendEnvironmentSwitchPhase")
+struct AccountBackendEnvironmentSwitchPhaseTests {
+    @Test func inFlightCoversExactlyTheTransitionalPhases() {
+        #expect(!AccountBackendEnvironmentSwitchPhase.idle.isInFlight)
+        #expect(AccountBackendEnvironmentSwitchPhase.parking.isInFlight)
+        #expect(AccountBackendEnvironmentSwitchPhase.retargeting.isInFlight)
+        #expect(AccountBackendEnvironmentSwitchPhase.establishing.isInFlight)
+        #expect(AccountBackendEnvironmentSwitchPhase.reverting.isInFlight)
+        #expect(!AccountBackendEnvironmentSwitchPhase.finished(.switched).isInFlight)
+        #expect(
+            !AccountBackendEnvironmentSwitchPhase
+                .finished(.reverted(.notEligible)).isInFlight
+        )
+    }
+
+    @Test func outcomesCarryTheRevertReason() {
+        let reverted = AccountBackendEnvironmentSwitchOutcome.reverted(.signInFailed)
+        #expect(reverted != .switched)
+        #expect(reverted != .reverted(.signInCancelled))
+        #expect(reverted == .reverted(.signInFailed))
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentCardVisibilityTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentCardVisibilityTests.swift
@@ -2,8 +2,9 @@ import Testing
 @testable import CmuxSettingsUI
 
 /// The three-tier backend-environment card visibility: full picker for
-/// gate-allowed/DEBUG, recovery for everyone else off production (or with a
-/// switch in flight), hidden otherwise.
+/// gate-allowed/DEBUG, recovery for everyone else resolving off production
+/// (explicit staging AND a staging lane, or with a switch in flight), hidden
+/// otherwise.
 @Suite("BackendEnvironmentCardVisibility")
 struct BackendEnvironmentCardVisibilityTests {
     private static let allPhases: [AccountBackendEnvironmentSwitchPhase] = [
@@ -14,35 +15,80 @@ struct BackendEnvironmentCardVisibilityTests {
         .finished(.reverted(.notEligible)),
     ]
 
-    @Test func pickerAllowedIsAlwaysFullPickerAcrossEnvironmentsAndPhases() {
-        for environment in AccountBackendEnvironment.allCases {
-            for phase in Self.allPhases {
-                #expect(
-                    BackendEnvironmentCardVisibility(
-                        pickerAllowed: true,
-                        activeEnvironment: environment,
-                        switchPhase: phase
-                    ) == .fullPicker
-                )
+    private static let allSelections: [AccountBackendEnvironmentSelection] = [
+        .buildLane, .production, .staging,
+    ]
+
+    private static let allLanes: [AccountBackendEnvironmentBuildLane] = [
+        .production, .staging, .custom(label: "localhost:4123"),
+    ]
+
+    @Test func pickerAllowedIsAlwaysFullPickerAcrossSelectionsLanesAndPhases() {
+        for selection in Self.allSelections {
+            for lane in Self.allLanes {
+                for phase in Self.allPhases {
+                    #expect(
+                        BackendEnvironmentCardVisibility(
+                            pickerAllowed: true,
+                            selection: selection,
+                            buildLane: lane,
+                            switchPhase: phase
+                        ) == .fullPicker
+                    )
+                }
             }
         }
     }
 
-    @Test func nonGateUserOnStagingGetsRecovery() {
+    @Test func nonGateUserOnExplicitStagingGetsRecovery() {
         #expect(
             BackendEnvironmentCardVisibility(
                 pickerAllowed: false,
-                activeEnvironment: .staging,
+                selection: .staging,
+                buildLane: .production,
                 switchPhase: .idle
             ) == .recovery
         )
     }
 
-    @Test func nonGateUserOnProductionIdleIsHidden() {
+    @Test func nonGateUserOnAStagingLaneGetsRecovery() {
+        // The lane resolves staging even with no explicit choice: the card
+        // must render (its copy explains the bake; the switch-back button is
+        // reserved for explicit staging inside the card itself).
         #expect(
             BackendEnvironmentCardVisibility(
                 pickerAllowed: false,
-                activeEnvironment: .production,
+                selection: .buildLane,
+                buildLane: .staging,
+                switchPhase: .idle
+            ) == .recovery
+        )
+    }
+
+    @Test func nonGateUserOnProductionResolvingSelectionsIsHidden() {
+        // Lane on a production or custom lane, and explicit production, all
+        // resolve production: nothing to recover from.
+        #expect(
+            BackendEnvironmentCardVisibility(
+                pickerAllowed: false,
+                selection: .buildLane,
+                buildLane: .production,
+                switchPhase: .idle
+            ) == .hidden
+        )
+        #expect(
+            BackendEnvironmentCardVisibility(
+                pickerAllowed: false,
+                selection: .buildLane,
+                buildLane: .custom(label: "localhost:4123"),
+                switchPhase: .idle
+            ) == .hidden
+        )
+        #expect(
+            BackendEnvironmentCardVisibility(
+                pickerAllowed: false,
+                selection: .production,
+                buildLane: .staging,
                 switchPhase: .idle
             ) == .hidden
         )
@@ -57,7 +103,8 @@ struct BackendEnvironmentCardVisibilityTests {
             #expect(
                 BackendEnvironmentCardVisibility(
                     pickerAllowed: false,
-                    activeEnvironment: .production,
+                    selection: .buildLane,
+                    buildLane: .production,
                     switchPhase: phase
                 ) == .recovery,
                 "phase \(phase) should keep the recovery card visible"

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
@@ -2,14 +2,13 @@ import Testing
 @testable import CmuxSettingsUI
 
 /// The confirm-before-apply contract behind ``BackendEnvironmentCard``'s
-/// picker: a selection never applies without an explicit confirm, and pinned
-/// builds never stage a choice or present the dialog.
+/// picker: a selection never applies without an explicit confirm.
 @Suite("BackendEnvironmentSwitchConfirmation")
 struct BackendEnvironmentSwitchConfirmationTests {
     @Test func selectionStagesAndPresentsButDoesNotApply() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
 
-        confirmation.select(.staging, active: .production, pinned: false)
+        confirmation.select(.staging, active: .production)
 
         // The only apply path is `confirm()`; selection alone just stages
         // the choice, presents the dialog, and previews the selection.
@@ -20,7 +19,7 @@ struct BackendEnvironmentSwitchConfirmationTests {
 
     @Test func confirmConsumesTheStagedChoiceExactlyOnce() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
-        confirmation.select(.staging, active: .production, pinned: false)
+        confirmation.select(.staging, active: .production)
 
         #expect(confirmation.confirm() == .staging)
         #expect(confirmation.pendingSelection == nil)
@@ -31,7 +30,7 @@ struct BackendEnvironmentSwitchConfirmationTests {
 
     @Test func cancelRevertsTheDisplayedSelectionToActive() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
-        confirmation.select(.staging, active: .production, pinned: false)
+        confirmation.select(.staging, active: .production)
 
         confirmation.cancel()
 
@@ -41,33 +40,35 @@ struct BackendEnvironmentSwitchConfirmationTests {
         #expect(confirmation.confirm() == nil)
     }
 
-    @Test func pinnedBuildsNeverStageOrPresent() {
+    @Test func selectingTheActiveOptionSettlesWithoutPresenting() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
+        confirmation.select(.staging, active: .production)
 
-        confirmation.select(.staging, active: .production, pinned: true)
+        // Re-picking the active option settles the staged choice.
+        confirmation.select(.production, active: .production)
 
         #expect(confirmation.pendingSelection == nil)
         #expect(!confirmation.isPresentingDialog)
-        #expect(confirmation.displayedSelection(active: .production) == .production)
         #expect(confirmation.confirm() == nil)
     }
 
-    @Test func selectingTheActiveEnvironmentSettlesWithoutPresenting() {
+    @Test func buildLaneStagesThroughTheSameContract() {
+        // The three-position picker's lane option is a first-class staged
+        // choice: stage, present, apply only on confirm.
         var confirmation = BackendEnvironmentSwitchConfirmation()
-        confirmation.select(.staging, active: .production, pinned: false)
 
-        // Re-picking the active environment settles the staged choice.
-        confirmation.select(.production, active: .production, pinned: false)
+        confirmation.select(.buildLane, active: .staging)
 
-        #expect(confirmation.pendingSelection == nil)
-        #expect(!confirmation.isPresentingDialog)
-        #expect(confirmation.confirm() == nil)
+        #expect(confirmation.pendingSelection == .buildLane)
+        #expect(confirmation.isPresentingDialog)
+        #expect(confirmation.displayedSelection(active: .staging) == .buildLane)
+        #expect(confirmation.confirm() == .buildLane)
     }
 
     @Test func switchBackRequestStagesProductionAndStillRequiresConfirm() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
 
-        confirmation.requestSwitchBackToProduction(active: .staging, pinned: false)
+        confirmation.requestSwitchBackToProduction(active: .staging)
 
         // The recovery button routes through the SAME staged-confirm
         // contract as the picker: production staged, dialog presented,
@@ -77,20 +78,10 @@ struct BackendEnvironmentSwitchConfirmationTests {
         #expect(confirmation.confirm() == .production)
     }
 
-    @Test func pinnedSwitchBackRequestNeverStages() {
-        var confirmation = BackendEnvironmentSwitchConfirmation()
-
-        confirmation.requestSwitchBackToProduction(active: .staging, pinned: true)
-
-        #expect(confirmation.pendingSelection == nil)
-        #expect(!confirmation.isPresentingDialog)
-        #expect(confirmation.confirm() == nil)
-    }
-
     @Test func switchBackRequestOnProductionSettlesWithoutPresenting() {
         var confirmation = BackendEnvironmentSwitchConfirmation()
 
-        confirmation.requestSwitchBackToProduction(active: .production, pinned: false)
+        confirmation.requestSwitchBackToProduction(active: .production)
 
         #expect(confirmation.pendingSelection == nil)
         #expect(!confirmation.isPresentingDialog)

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import CmuxSettingsUI
+
+/// The confirm-before-apply contract behind ``BackendEnvironmentCard``'s
+/// picker: a selection never applies without an explicit confirm, and pinned
+/// builds never stage a choice or present the dialog.
+@Suite("BackendEnvironmentSwitchConfirmation")
+struct BackendEnvironmentSwitchConfirmationTests {
+    @Test func selectionStagesAndPresentsButDoesNotApply() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+
+        confirmation.select(.staging, active: .production, pinned: false)
+
+        // The only apply path is `confirm()`; selection alone just stages
+        // the choice, presents the dialog, and previews the selection.
+        #expect(confirmation.pendingSelection == .staging)
+        #expect(confirmation.isPresentingDialog)
+        #expect(confirmation.displayedSelection(active: .production) == .staging)
+    }
+
+    @Test func confirmConsumesTheStagedChoiceExactlyOnce() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+        confirmation.select(.staging, active: .production, pinned: false)
+
+        #expect(confirmation.confirm() == .staging)
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        // A second confirm (dialog already dismissed) applies nothing.
+        #expect(confirmation.confirm() == nil)
+    }
+
+    @Test func cancelRevertsTheDisplayedSelectionToActive() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+        confirmation.select(.staging, active: .production, pinned: false)
+
+        confirmation.cancel()
+
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        #expect(confirmation.displayedSelection(active: .production) == .production)
+        #expect(confirmation.confirm() == nil)
+    }
+
+    @Test func pinnedBuildsNeverStageOrPresent() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+
+        confirmation.select(.staging, active: .production, pinned: true)
+
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        #expect(confirmation.displayedSelection(active: .production) == .production)
+        #expect(confirmation.confirm() == nil)
+    }
+
+    @Test func selectingTheActiveEnvironmentSettlesWithoutPresenting() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+        confirmation.select(.staging, active: .production, pinned: false)
+
+        // Re-picking the active environment settles the staged choice.
+        confirmation.select(.production, active: .production, pinned: false)
+
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        #expect(confirmation.confirm() == nil)
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/BackendEnvironmentSwitchConfirmationTests.swift
@@ -63,4 +63,37 @@ struct BackendEnvironmentSwitchConfirmationTests {
         #expect(!confirmation.isPresentingDialog)
         #expect(confirmation.confirm() == nil)
     }
+
+    @Test func switchBackRequestStagesProductionAndStillRequiresConfirm() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+
+        confirmation.requestSwitchBackToProduction(active: .staging, pinned: false)
+
+        // The recovery button routes through the SAME staged-confirm
+        // contract as the picker: production staged, dialog presented,
+        // apply only on confirm.
+        #expect(confirmation.pendingSelection == .production)
+        #expect(confirmation.isPresentingDialog)
+        #expect(confirmation.confirm() == .production)
+    }
+
+    @Test func pinnedSwitchBackRequestNeverStages() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+
+        confirmation.requestSwitchBackToProduction(active: .staging, pinned: true)
+
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        #expect(confirmation.confirm() == nil)
+    }
+
+    @Test func switchBackRequestOnProductionSettlesWithoutPresenting() {
+        var confirmation = BackendEnvironmentSwitchConfirmation()
+
+        confirmation.requestSwitchBackToProduction(active: .production, pinned: false)
+
+        #expect(confirmation.pendingSelection == nil)
+        #expect(!confirmation.isPresentingDialog)
+        #expect(confirmation.confirm() == nil)
+    }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -150058,6 +150058,125 @@
         }
       }
     },
+    "settings.account.backendEnvironment.footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステージングはアカウントとデータが別の独立した環境です。切り替えるとサインアウトされます。MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.pinnedNote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This build's backend is pinned by its launch environment; the picker takes effect only in unpinned builds."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このビルドのバックエンドは起動環境で固定されています。この選択は固定されていないビルドでのみ有効になります。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.production": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Production"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本番"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.relaunch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunch cmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxを再起動"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.relaunchNotice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux must relaunch to apply the new backend environment."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバックエンド環境を適用するには cmux の再起動が必要です。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.staging": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staging"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステージング"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backend Environment"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックエンド環境"
+          }
+        }
+      }
+    },
     "settings.account.error.invalidCallback": {
       "extractionState": "manual",
       "localizations": {
@@ -150446,6 +150565,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ви не ввійшли"
+          }
+        }
+      }
+    },
+    "settings.account.stagingBadge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staging"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステージング"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -150064,13 +150064,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Switch & Sign Out"
+            "value": "Switch Environment"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "切り替えてサインアウト"
+            "value": "環境を切り替える"
           }
         }
       }
@@ -150081,13 +150081,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+            "value": "Your %1$@ session is kept on this Mac, and you'll be asked to sign in to %2$@. Each environment has separate accounts and data, and your Mac and iPhone must be on the same environment to pair."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ステージングはアカウントとデータが別の独立した環境です。切り替えるとサインアウトされます。MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
+            "value": "%1$@のセッションはこのMacに保持され、%2$@へのサインインを求められます。環境ごとにアカウントとデータは別々で、MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
           }
         }
       }
@@ -150115,13 +150115,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+            "value": "Staging is a separate environment with separate accounts and data. Each environment keeps its own session on this Mac, and your Mac and iPhone must be on the same environment to pair."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ステージングはアカウントとデータが別の独立した環境です。切り替えるとサインアウトされます。MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
+            "value": "ステージングはアカウントとデータが別の独立した環境です。環境ごとのセッションはこのMacに保持されます。MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
           }
         }
       }
@@ -150160,19 +150160,53 @@
         }
       }
     },
-    "settings.account.backendEnvironment.progressSigningOut": {
+    "settings.account.backendEnvironment.progressEstablishing": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Signing out…"
+            "value": "Waiting for sign-in…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サインアウト中…"
+            "value": "サインインを待っています…"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.progressParking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saving your session…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションを保存しています…"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.progressReverting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switching back…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元の環境に戻しています…"
           }
         }
       }
@@ -150190,6 +150224,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "バックエンドを切り替え中…"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.recovery.explanation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This cmux is using the Staging environment, a separate deployment with separate accounts and data. Switch back to Production to use your normal account."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このcmuxはステージング環境（アカウントとデータが別の独立した環境）を使用しています。通常のアカウントを使用するには本番環境に戻してください。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.recovery.switchBack": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch Back to Production"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本番環境に戻す"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.revertedNotEligible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That account can't use Staging, so you're back on %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "そのアカウントはステージングを利用できないため、%@に戻りました。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.revertedSignInCancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in was cancelled, so you're back on %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインがキャンセルされたため、%@に戻りました。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.revertedSignInFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in didn't complete, so you're back on %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインが完了しなかったため、%@に戻りました。"
           }
         }
       }
@@ -150217,13 +150336,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Now on %@. Sign in to continue."
+            "value": "Now on %@."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在は%@です。続行するにはサインインしてください。"
+            "value": "現在%@を使用しています。"
           }
         }
       }
@@ -150650,6 +150769,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "ステージング"
+          }
+        }
+      }
+    },
+    "settings.account.stagingSignOut.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
+    "settings.account.stagingSignOut.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインアウト"
+          }
+        }
+      }
+    },
+    "settings.account.stagingSignOut.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing out here signs you out of Staging and returns this Mac to Production, restoring your saved Production session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここでサインアウトするとステージングからサインアウトし、このMacは本番環境に戻り、保存された本番環境のセッションが復元されます。"
+          }
+        }
+      }
+    },
+    "settings.account.stagingSignOut.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign out and return to Production?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインアウトして本番環境に戻りますか？"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -150058,6 +150058,23 @@
         }
       }
     },
+    "settings.account.backendEnvironment.buildLaneOption": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build lane (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルドレーン（%@）"
+          }
+        }
+      }
+    },
     "settings.account.backendEnvironment.confirmAction": {
       "extractionState": "manual",
       "localizations": {
@@ -150092,6 +150109,23 @@
         }
       }
     },
+    "settings.account.backendEnvironment.confirmMessageLane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your %1$@ session is kept on this Mac, and cmux returns to what this build is baked to (%2$@). Each environment has separate accounts and data."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@のセッションはこのMacに保持され、cmuxはこのビルドに組み込まれた環境（%2$@）に戻ります。環境ごとにアカウントとデータは別々です。"
+          }
+        }
+      }
+    },
     "settings.account.backendEnvironment.confirmTitle": {
       "extractionState": "manual",
       "localizations": {
@@ -150105,6 +150139,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@に切り替えますか？"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.confirmTitleLane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch back to the build lane (%@)?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルドレーン（%@）に戻しますか？"
           }
         }
       }
@@ -150126,19 +150177,19 @@
         }
       }
     },
-    "settings.account.backendEnvironment.pinnedNote": {
+    "settings.account.backendEnvironment.laneFooter": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This build's backend is pinned by its launch environment; the picker takes effect only in unpinned builds."
+            "value": "This build's own lane is %@, baked in at build time. The build lane option returns to it."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このビルドのバックエンドは起動環境で固定されています。この選択は固定されていないビルドでのみ有効になります。"
+            "value": "このビルド自体のレーンは%@で、ビルド時に組み込まれています。ビルドレーンの選択肢でそこに戻ります。"
           }
         }
       }
@@ -150343,6 +150394,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "現在%@を使用しています。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.switchedLane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now on the build lane (%@)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在ビルドレーン（%@）を使用しています。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -150058,6 +150058,57 @@
         }
       }
     },
+    "settings.account.backendEnvironment.confirmAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch & Sign Out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切り替えてサインアウト"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.confirmMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staging is a separate environment with separate accounts and data. Switching signs you out, and your Mac and iPhone must be on the same environment to pair."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステージングはアカウントとデータが別の独立した環境です。切り替えるとサインアウトされます。MacとiPhoneをペアリングするには両方が同じ環境である必要があります。"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.confirmTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to %@?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に切り替えますか？"
+          }
+        }
+      }
+    },
     "settings.account.backendEnvironment.footer": {
       "extractionState": "manual",
       "localizations": {
@@ -150109,36 +150160,36 @@
         }
       }
     },
-    "settings.account.backendEnvironment.relaunch": {
+    "settings.account.backendEnvironment.progressSigningOut": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relaunch cmux"
+            "value": "Signing out…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxを再起動"
+            "value": "サインアウト中…"
           }
         }
       }
     },
-    "settings.account.backendEnvironment.relaunchNotice": {
+    "settings.account.backendEnvironment.progressSwitching": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux must relaunch to apply the new backend environment."
+            "value": "Switching backend…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新しいバックエンド環境を適用するには cmux の再起動が必要です。"
+            "value": "バックエンドを切り替え中…"
           }
         }
       }
@@ -150156,6 +150207,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "ステージング"
+          }
+        }
+      }
+    },
+    "settings.account.backendEnvironment.switched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now on %@. Sign in to continue."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在は%@です。続行するにはサインインしてください。"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -817,7 +817,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // cluster did move into the package this wave: the reveal-in-Finder side effect now lives in
     // `NotificationClickPerformer` (behind `FinderRevealing`), and the entire focused-mark state
     // machine lives in `FocusedNotificationMarker` (behind `FocusedNotificationResolving`).
-    /// The auth graph, injected once via `configure(...)` at app startup.
+    /// The auth graph: injected via `configure(...)` at app startup and
+    /// replaced by ``adoptRebuiltAuth(_:)`` when a live backend-environment
+    /// switch rebuilds it. This is the live handle; `cmuxApp.authComposition`
+    /// is init-only wiring.
     private(set) var auth: MacAuthComposition?
     /// Strongly-held observers for every active TabManager. Each observer owns
     /// Combine subscriptions that publish workspace.updated to mobile clients.
@@ -2324,11 +2327,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
         self.auth = auth
-        VMClient.bootstrap(auth: auth.coordinator)
-        RemotesClient.bootstrap(auth: auth.coordinator)
-        AIAccountsClient.bootstrap(auth: auth.coordinator)
-        PhonePushClient.shared.configure(auth: auth.coordinator)
-        MobileHostService.shared.configure(auth: auth.coordinator)
+        bootstrapAuthConsumers(auth: auth)
         caffeineController.onStateChange = { [weak self] enabled in
             self?.menuBarExtraController?.refreshForDebugControls()
             MobileHostService.emitEvent(
@@ -2336,14 +2335,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 payload: ["enabled": enabled]
             )
         }
-        DeviceRegistryClient.shared.configure(auth: auth.coordinator)
-        PresenceHeartbeatClient.shared.configure(auth: auth.coordinator)
-        connectivityInvalidationSubscriberCoordinator.configure(auth: auth.coordinator)
-        // DEV-only: auto-publish this Mac's attach route to the signed-in user's
-        // pairedMacs backup so a fresh dev iOS build restores it (no manual host
-        // entry). No-op on Release / when the flag is off.
-        MacPairedMacBackupPublisher.shared.configure(auth: auth.coordinator)
-        TerminalController.shared.attachAuth(coordinator: auth.coordinator, accountFlow: auth.accountFlow)
         TerminalController.shared.attachCaffeineController(caffeineController)
         TerminalController.shared.agentChatTranscriptService = agentChatTranscriptService
         if !isRunningUnderXCTest(ProcessInfo.processInfo.environment) {
@@ -2384,6 +2375,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // keeps working. No-op when already set or the legacy file is absent.
         Task { await DevWindowDisplayDefault.migrateLegacyFileIfNeeded(runtime: settingsRuntime) }
 #endif
+    }
+
+    /// Wire every auth-consuming service to `auth`'s coordinator. Extracted
+    /// from `configure(...)` unchanged so it runs identically at startup and
+    /// again from ``adoptRebuiltAuth(_:)`` after a live backend-environment
+    /// switch; each call either rebuilds its shared instance or re-arms its
+    /// observation on the new coordinator.
+    private func bootstrapAuthConsumers(auth: MacAuthComposition) {
+        VMClient.bootstrap(auth: auth.coordinator)
+        RemotesClient.bootstrap(auth: auth.coordinator)
+        AIAccountsClient.bootstrap(auth: auth.coordinator)
+        PhonePushClient.shared.configure(auth: auth.coordinator)
+        MobileHostService.shared.configure(auth: auth.coordinator)
+        DeviceRegistryClient.shared.configure(auth: auth.coordinator)
+        PresenceHeartbeatClient.shared.configure(auth: auth.coordinator)
+        connectivityInvalidationSubscriberCoordinator.configure(auth: auth.coordinator)
+        // DEV-only: auto-publish this Mac's attach route to the signed-in user's
+        // pairedMacs backup so a fresh dev iOS build restores it (no manual host
+        // entry). No-op on Release / when the flag is off.
+        MacPairedMacBackupPublisher.shared.configure(auth: auth.coordinator)
+        TerminalController.shared.attachAuth(coordinator: auth.coordinator, accountFlow: auth.accountFlow)
+    }
+
+    /// Adopt the rebuilt auth graph after a live backend-environment switch
+    /// (the transaction's `rebuild` step). Replaces the live handle every
+    /// runtime consumer reads (`AppDelegate.shared?.auth`), rewires the
+    /// auth-consuming services, moves app-session store/panel ownership onto
+    /// the new `BrowserAppSessionController` so open browser panels stay
+    /// registered, then starts the new coordinator (whose fresh
+    /// `AuthLaunchOptions` prime the project-switch clear) and restarts
+    /// `MobileHostService`, ending the quiesce window the switch opened.
+    func adoptRebuiltAuth(_ auth: MacAuthComposition) {
+        let previousBrowserAppSession = self.auth?.browserAppSession
+        self.auth = auth
+        bootstrapAuthConsumers(auth: auth)
+        if let previousBrowserAppSession {
+            auth.browserAppSession.adoptAppSessionOwnership(from: previousBrowserAppSession)
+        }
+        auth.start()
+        MobileHostService.shared.start()
     }
 
     private func scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: TerminalNotificationStore) {

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -7,17 +7,117 @@ enum AuthEnvironment {
     private static let productionStackProjectID = "9790718f-14cd-4f7e-824d-eaf527a82b82"
     private static let productionStackPublishableClientKey = "pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr"
 
-    /// The persisted runtime backend selection (Settings > Account > Backend
-    /// Environment). Replaces only the BUILD DEFAULT layer of every resolution
-    /// below: explicit `CMUX_*` environment variables (including the
-    /// LSEnvironment values tagged dev builds bake in via `scripts/reload.sh`)
-    /// keep winning, since they are the dev-lane isolation mechanism.
+    /// The persisted EXPLICIT backend environment choice (Settings > Account
+    /// > Backend Environment), or nil when no choice is persisted and the
+    /// build runs its own lane. An explicit choice is a WHOLESALE override:
+    /// every backend `resolved*` function below consults it as its FIRST
+    /// tier — ABOVE explicit `CMUX_*` environment variables (including the
+    /// LSEnvironment values tagged dev builds bake in via
+    /// `scripts/reload.sh`), the DEBUG-only `~/.cmux-dev.env` file, and
+    /// `#if DEBUG` compile defaults — replacing the entire backend key set
+    /// atomically, so a switched build can never run half on one environment
+    /// and half on another. With NO choice (absent key) every resolution is
+    /// byte-identical to the pre-choice behavior, keeping the bake as the
+    /// dev-lane isolation mechanism. `callbackScheme` deliberately stays
+    /// outside the wholesale set: tagged deep-link routing must survive a
+    /// switch.
     ///
     /// Loaded fresh at each ProcessInfo-reading resolution site. The
-    /// composition root still resolves once at startup, so a newly stored
-    /// value takes effect at the next launch.
-    static var backendEnvironmentOverride: CMUXBackendEnvironmentOverride {
-        CMUXBackendEnvironmentOverride.load(from: .standard)
+    /// composition root still resolves once at startup; the live switch
+    /// transaction rebuilds that frozen graph when the choice changes.
+    static var backendEnvironmentExplicitChoice: CMUXBackendEnvironmentOverride? {
+        CMUXBackendEnvironmentOverride.explicitChoice(from: .standard)
+    }
+
+    /// The full fixed backend value set an explicit environment choice
+    /// selects, wholesale. One helper so a choice can never mix tiers:
+    /// either every value below comes from this table, or none does.
+    private struct ExplicitBackendValues {
+        let webOrigin: String
+        /// Explicit production uses api.cmux.sh for Release-lane parity
+        /// (the unpinned Release default); staging's Next.js app serves the
+        /// same `/api/*` routes itself.
+        let apiBaseURL: String
+        let vmAPIOrigin: String
+        /// The push relay follows the VM-API origin under a choice.
+        let pushAPIOrigin: String
+        let irohBrokerOrigin: String
+        let stackAuthEnvironment: CMUXAuthEnvironment
+        let stackProjectID: String
+        let stackPublishableClientKey: String
+        /// Credential-bearing handoffs stay pinned to the two compiled-in
+        /// origins; an explicit choice picks one, never a computed value.
+        let sessionHandoffOrigin: String
+
+        static func values(
+            for choice: CMUXBackendEnvironmentOverride
+        ) -> ExplicitBackendValues {
+            switch choice {
+            case .production:
+                ExplicitBackendValues(
+                    webOrigin: "https://cmux.com",
+                    apiBaseURL: "https://api.cmux.sh",
+                    vmAPIOrigin: "https://cmux.com",
+                    pushAPIOrigin: "https://cmux.com",
+                    irohBrokerOrigin: "https://cmux.com",
+                    stackAuthEnvironment: .production,
+                    stackProjectID: productionStackProjectID,
+                    stackPublishableClientKey: productionStackPublishableClientKey,
+                    sessionHandoffOrigin: "https://cmux.com"
+                )
+            case .staging:
+                ExplicitBackendValues(
+                    webOrigin: CMUXBackendEnvironmentOverride.stagingWebOrigin,
+                    apiBaseURL: CMUXBackendEnvironmentOverride.stagingWebOrigin,
+                    vmAPIOrigin: CMUXBackendEnvironmentOverride.stagingWebOrigin,
+                    pushAPIOrigin: CMUXBackendEnvironmentOverride.stagingWebOrigin,
+                    irohBrokerOrigin: CMUXBackendEnvironmentOverride.stagingWebOrigin,
+                    stackAuthEnvironment: .development,
+                    stackProjectID: developmentStackProjectID,
+                    stackPublishableClientKey: developmentStackPublishableClientKey,
+                    sessionHandoffOrigin: CMUXBackendEnvironmentOverride.stagingWebOrigin
+                )
+            }
+        }
+    }
+
+    /// Classify this build's LANE: the backend the process resolves with NO
+    /// explicit choice, from the launch environment and build flags alone.
+    /// Powers the Settings picker's "Build lane (…)" option and the
+    /// return-to-lane sign-out chain; an unpinned Release build is the
+    /// production lane, a staging-baked build the staging lane, and every
+    /// other bake (tagged dev builds on a localhost origin, untagged Debug
+    /// builds on the development Stack channel) a custom lane labeled with
+    /// its lane web origin.
+    static func resolvedBackendEnvironmentBuildLane(
+        environment: [String: String],
+        isDebugBuild: Bool
+    ) -> CMUXBackendEnvironmentBuildLane {
+        let laneWebOrigin = resolvedWebsiteOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: nil
+        )
+        let laneStackEnvironment = resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: nil
+        )
+        if laneWebOrigin.absoluteString == CMUXBackendEnvironmentOverride.stagingWebOrigin {
+            return .staging
+        }
+        if laneStackEnvironment == .production,
+           laneWebOrigin.absoluteString == "https://cmux.com" {
+            return .production
+        }
+        return .custom(label: buildLaneLabel(for: laneWebOrigin))
+    }
+
+    /// Human label for a custom lane: host, or host:port.
+    private static func buildLaneLabel(for origin: URL) -> String {
+        guard let host = origin.host else { return origin.absoluteString }
+        guard let port = origin.port else { return host }
+        return "\(host):\(port)"
     }
 
     /// Whether this binary was compiled as a Debug build. The pure
@@ -111,29 +211,24 @@ enum AuthEnvironment {
         resolvedWebsiteOrigin(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedWebsiteOrigin(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        // With the production override this keeps today's fixed cmux.com
-        // fallback (Debug included). Under the staging override the fallback
-        // follows the resolved default web origin, so a Release build lands
-        // on the staging deployment while explicit env still wins.
-        let fallback = override == .staging
-            ? resolvedDefaultWebOrigin(
-                environment: environment,
-                isDebugBuild: isDebugBuild,
-                override: override
-            )
-            : "https://cmux.com"
+        // Wholesale head: an explicit choice's fixed web origin beats env
+        // (baked LSEnvironment included). No choice keeps the fixed cmux.com
+        // fallback below env, byte-identical to the pre-choice behavior.
+        if let explicitChoice {
+            return URL(string: ExplicitBackendValues.values(for: explicitChoice).webOrigin)!
+        }
         return resolvedURL(
             environmentKey: "CMUX_WWW_ORIGIN",
-            fallback: fallback,
+            fallback: "https://cmux.com",
             environment: environment
         )
     }
@@ -146,35 +241,42 @@ enum AuthEnvironment {
     static var pricingURL: URL {
         resolvedPricingURL(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
+    /// Delegators like this one carry no head of their own: the wholesale
+    /// head lives in ``appWebOrigin(environment:isDebugBuild:explicitChoice:)``,
+    /// which every pricing/billing URL below derives from.
     static func resolvedPricingURL(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
-            .appendingPathComponent("pricing")
+        appWebOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: explicitChoice
+        )
+        .appendingPathComponent("pricing")
     }
 
     static var appPricingURL: URL {
         resolvedAppPricingURL(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static var appWebOrigin: URL {
         resolvedAppWebOrigin(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     /// Credential-bearing native-to-web handoffs are pinned to cmux.com in
-    /// release builds. Under the persisted staging override, exactly the
-    /// fixed staging origin is additionally allowed (URL equality with
+    /// release builds. An explicit backend choice hands off to exactly its
+    /// fixed compiled-in origin (cmux.com, or
     /// ``CMUXBackendEnvironmentOverride/stagingWebOrigin``); the destination
     /// set never widens beyond those two fixed origins. Debug builds may
     /// additionally use an exact loopback origin so tagged local web servers
@@ -184,25 +286,32 @@ enum AuthEnvironment {
         resolvedAppSessionHandoffOrigin(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedAppSessionHandoffOrigin(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
+        // Wholesale head: an explicit choice hands off to exactly its fixed
+        // compiled-in origin — never a computed or env-derived value, so an
+        // env-injected lookalike can never become a token destination.
+        if let explicitChoice {
+            return URL(
+                string: ExplicitBackendValues.values(for: explicitChoice).sessionHandoffOrigin
+            )!
+        }
         let productionOrigin = URL(string: "https://cmux.com")!
-        let stagingOrigin = URL(string: CMUXBackendEnvironmentOverride.stagingWebOrigin)!
         let candidate = canonicalizedLoopbackURL(
-            appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+            appWebOrigin(
+                environment: environment,
+                isDebugBuild: isDebugBuild,
+                explicitChoice: nil
+            )
         )
         if candidate == productionOrigin { return productionOrigin }
-        // Only the fixed staging origin, and only when the user opted into
-        // staging: an env-injected lookalike can never become a token
-        // destination because equality is against the compiled-in constant.
-        if override == .staging, candidate == stagingOrigin { return stagingOrigin }
         guard isDebugBuild else { return productionOrigin }
         guard let components = URLComponents(
             url: candidate,
@@ -222,32 +331,44 @@ enum AuthEnvironment {
 
     static func resolvedAppWebOrigin(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+        appWebOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: explicitChoice
+        )
     }
 
     static func resolvedAppPricingURL(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
-            .appendingPathComponent("app-pricing")
+        appWebOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: explicitChoice
+        )
+        .appendingPathComponent("app-pricing")
     }
 
     static var appProWelcomeURL: URL {
         resolvedAppProWelcomeURL(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedAppProWelcomeURL(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
-            .appendingPathComponent("app-pro-welcome")
+        appWebOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: explicitChoice
+        )
+        .appendingPathComponent("app-pro-welcome")
     }
 
     /// Payment entrypoint used by native app UI. `CMUX_BILLING_WWW_ORIGIN`
@@ -259,16 +380,19 @@ enum AuthEnvironment {
     static var billingCheckoutURL: URL {
         resolvedBillingCheckoutURL(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedBillingCheckoutURL(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
         billingCheckoutURL(
-            origin: billingWebsiteOrigin(environment: environment, override: override),
+            origin: billingWebsiteOrigin(
+                environment: environment,
+                explicitChoice: explicitChoice
+            ),
             callbackScheme: callbackScheme(environment: environment, bundleIdentifier: nil)
         )
     }
@@ -276,29 +400,27 @@ enum AuthEnvironment {
     static var billingPortalURL: URL {
         resolvedBillingPortalURL(
             environment: ProcessInfo.processInfo.environment,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedBillingPortalURL(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        billingWebsiteOrigin(environment: environment, override: override)
+        billingWebsiteOrigin(environment: environment, explicitChoice: explicitChoice)
             .appendingPathComponent("api/billing/portal")
     }
 
-    static var signInWebsiteOrigin: URL {
-        canonicalizedLoopbackURL(
-            resolvedURL(
-                environmentKey: "CMUX_AUTH_WWW_ORIGIN",
-                fallback: defaultWebOrigin
-            )
-        )
-    }
-
     static var apiBaseURL: URL {
-        canonicalizedLoopbackURL(
+        // Wholesale head: an explicit choice's fixed API base beats
+        // `CMUX_API_BASE_URL` (baked LSEnvironment included).
+        if let choice = backendEnvironmentExplicitChoice {
+            return canonicalizedLoopbackURL(
+                URL(string: ExplicitBackendValues.values(for: choice).apiBaseURL)!
+            )
+        }
+        return canonicalizedLoopbackURL(
             resolvedURL(
                 environmentKey: "CMUX_API_BASE_URL",
                 fallback: defaultAPIBaseURL
@@ -306,17 +428,20 @@ enum AuthEnvironment {
         )
     }
 
-    /// Build-default API base. Release production is api.cmux.sh; under the
-    /// staging override it becomes the staging web origin, whose Next.js app
-    /// serves the same `/api/*` routes (api.cmux.sh only fronts calls like
-    /// `/api/billing/plan` that the staging deployment also serves). Debug
-    /// keeps the tag-local dev port. An explicit `CMUX_API_BASE_URL` always
-    /// wins.
+    /// API base resolution. An explicit choice is a wholesale head: explicit
+    /// production is api.cmux.sh (Release-lane parity; it only fronts calls
+    /// like `/api/billing/plan`), explicit staging is the staging web
+    /// origin, whose Next.js app serves the same `/api/*` routes itself.
+    /// With no choice, `CMUX_API_BASE_URL` wins, Debug keeps the tag-local
+    /// dev port, and Release stays on api.cmux.sh.
     static func resolvedDefaultAPIBaseURL(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> String {
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).apiBaseURL
+        }
         if let url = environment["CMUX_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !url.isEmpty {
@@ -325,19 +450,24 @@ enum AuthEnvironment {
         if isDebugBuild {
             return "http://localhost:\(resolvedCmuxPort(environment: environment))"
         }
-        return override == .staging
-            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
-            : "https://api.cmux.sh"
+        return "https://api.cmux.sh"
     }
 
     /// Base URL for the cmux-owned cloud VM backend (`/api/vm`).
     ///
     /// Resolution order (first hit wins):
+    ///   0. the persisted explicit backend choice — a wholesale override
+    ///      beating every tier below.
     ///   1. process env `CMUX_VM_API_BASE_URL` — works when the app is launched from a shell.
     ///   2. `~/.cmux-dev.env` file `CMUX_VM_API_BASE_URL=...` line — works regardless of how
     ///      the app was launched (click-through, Dock, `open`, etc.). Only honored in DEBUG.
     ///   3. VM backend dev origin (`http://localhost:$CMUX_PORT` in Debug, cmux.com in Release).
     static var vmAPIBaseURL: URL {
+        if let choice = backendEnvironmentExplicitChoice {
+            return canonicalizedLoopbackURL(
+                URL(string: ExplicitBackendValues.values(for: choice).vmAPIOrigin)!
+            )
+        }
         if let overridden = ProcessInfo.processInfo.environment["CMUX_VM_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty,
@@ -359,10 +489,16 @@ enum AuthEnvironment {
     /// every forward would die queued. The tag rig BAKES a localhost
     /// `CMUX_VM_API_BASE_URL` into every Debug bundle, so that knob must not
     /// steer the push lane; a deliberately local push rig sets
-    /// `CMUX_PUSH_API_BASE_URL` (env or `~/.cmux-dev.env`) instead. Debug
-    /// defaults to shared staging (mirroring `irohBrokerBaseURL`); Release
-    /// keeps the production VM-API origin.
+    /// `CMUX_PUSH_API_BASE_URL` (env or `~/.cmux-dev.env`) instead. An
+    /// explicit backend choice is a wholesale head following its VM-API
+    /// origin; with no choice, Debug defaults to shared staging (mirroring
+    /// `irohBrokerBaseURL`) and Release keeps the production VM-API origin.
     static var pushAPIBaseURL: URL {
+        if let choice = backendEnvironmentExplicitChoice {
+            return canonicalizedLoopbackURL(
+                URL(string: ExplicitBackendValues.values(for: choice).pushAPIOrigin)!
+            )
+        }
         let environment = ProcessInfo.processInfo.environment
         if let overridden = environment["CMUX_PUSH_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -381,12 +517,56 @@ enum AuthEnvironment {
         #endif
     }
 
+    /// Pure mirror of ``pushAPIBaseURL`` for tests (the computed var adds
+    /// only the DEBUG-only `~/.cmux-dev.env` tier, which reads a file and so
+    /// stays out of the pure resolution).
+    static func resolvedPushAPIBaseURL(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
+    ) -> URL {
+        if let explicitChoice {
+            return canonicalizedLoopbackURL(
+                URL(string: ExplicitBackendValues.values(for: explicitChoice).pushAPIOrigin)!
+            )
+        }
+        if let overridden = environment["CMUX_PUSH_API_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridden.isEmpty,
+           let url = URL(string: overridden) {
+            return canonicalizedLoopbackURL(url)
+        }
+        if isDebugBuild {
+            return URL(string: CMUXBackendEnvironmentOverride.stagingWebOrigin)!
+        }
+        // The Release lane follows the VM-API origin: explicit env first,
+        // then the build default.
+        if let overridden = environment["CMUX_VM_API_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridden.isEmpty,
+           let url = URL(string: overridden) {
+            return canonicalizedLoopbackURL(url)
+        }
+        return canonicalizedLoopbackURL(
+            URL(string: resolvedDefaultVMAPIOrigin(
+                environment: environment,
+                isDebugBuild: isDebugBuild
+            ))!
+        )
+    }
+
     /// Authenticated route broker shared by matching tagged Mac and iOS builds.
     ///
     /// General tagged APIs remain on their isolated localhost origin. Iroh uses
     /// shared staging in Debug so separately launched processes publish into one
-    /// account-scoped registry. Release keeps the production cmux origin.
+    /// account-scoped registry. Release keeps the production cmux origin. An
+    /// explicit backend choice is a wholesale head over all of it.
     static var irohBrokerBaseURL: URL? {
+        if let choice = backendEnvironmentExplicitChoice {
+            return validatedIrohBrokerURL(
+                ExplicitBackendValues.values(for: choice).irohBrokerOrigin
+            )
+        }
         let environment = ProcessInfo.processInfo.environment
         if let overridden = environment["CMUX_IROH_BROKER_BASE_URL"]?
            .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -399,14 +579,12 @@ enum AuthEnvironment {
         }
         return resolvedIrohBrokerBaseURL(
             environment: environment,
-            isDebugBuild: true,
-            override: backendEnvironmentOverride
+            isDebugBuild: true
         )
         #else
         return resolvedIrohBrokerBaseURL(
             environment: environment,
-            isDebugBuild: false,
-            override: backendEnvironmentOverride
+            isDebugBuild: false
         )
         #endif
     }
@@ -414,17 +592,23 @@ enum AuthEnvironment {
     static func resolvedIrohBrokerBaseURL(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL? {
+        // Wholesale head: an explicit choice brokers through its own fixed
+        // origin — a staging Mac and phone publish into one account-scoped
+        // registry, an explicit-production pick leaves the shared Debug
+        // staging registry.
+        if let explicitChoice {
+            return validatedIrohBrokerURL(
+                ExplicitBackendValues.values(for: explicitChoice).irohBrokerOrigin
+            )
+        }
         if let explicit = environment["CMUX_IROH_BROKER_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !explicit.isEmpty {
             return validatedIrohBrokerURL(explicit)
         }
-        // Debug already brokers through shared staging; the staging override
-        // sends Release there too, so a staging Mac and phone publish into
-        // the same account-scoped registry.
-        let fallback = isDebugBuild || override == .staging
+        let fallback = isDebugBuild
             ? CMUXBackendEnvironmentOverride.stagingWebOrigin
             : "https://cmux.com"
         return validatedIrohBrokerURL(fallback)
@@ -475,19 +659,33 @@ enum AuthEnvironment {
 
     private static func billingWebsiteOrigin(
         environment: [String: String],
-        override: CMUXBackendEnvironmentOverride
+        explicitChoice: CMUXBackendEnvironmentOverride?
     ) -> URL {
+        // Wholesale head: an explicit choice pins checkout to its fixed web
+        // origin, above even the dedicated CMUX_BILLING_WWW_ORIGIN knob —
+        // billing must never cross environments.
+        if let explicitChoice {
+            return URL(string: ExplicitBackendValues.values(for: explicitChoice).webOrigin)!
+        }
         if let overridden = environmentURL("CMUX_BILLING_WWW_ORIGIN", environment: environment) {
             return overridden
         }
-        return appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+        return appWebOrigin(
+            environment: environment,
+            isDebugBuild: isDebugBuild,
+            explicitChoice: nil
+        )
     }
 
     private static func appWebOrigin(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride
+        explicitChoice: CMUXBackendEnvironmentOverride?
     ) -> URL {
+        // Wholesale head over both origin env vars and the Debug port bake.
+        if let explicitChoice {
+            return URL(string: ExplicitBackendValues.values(for: explicitChoice).webOrigin)!
+        }
         if let explicitWebsite = environmentURL("CMUX_WWW_ORIGIN", environment: environment) {
             return canonicalizedLoopbackURL(explicitWebsite)
         }
@@ -499,8 +697,7 @@ enum AuthEnvironment {
                 environmentPort("PORT", environment: environment) != nil {
                 return URL(string: resolvedDefaultWebOrigin(
                     environment: environment,
-                    isDebugBuild: isDebugBuild,
-                    override: override
+                    isDebugBuild: isDebugBuild
                 ))!
             }
             // `devOverride` is itself compiled out of Release builds, so this
@@ -515,8 +712,7 @@ enum AuthEnvironment {
             environmentKey: "CMUX_WWW_ORIGIN",
             fallback: resolvedDefaultWebOrigin(
                 environment: environment,
-                isDebugBuild: isDebugBuild,
-                override: override
+                isDebugBuild: isDebugBuild
             ),
             environment: environment
         )
@@ -557,69 +753,65 @@ enum AuthEnvironment {
         resolvedDefaultWebOrigin(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
-    /// Build-default web origin. Release production is cmux.com; under the
-    /// staging override it becomes the staging web origin. Debug defaults to
-    /// the tag-local dev port; an untagged Debug build (no `CMUX_PORT`/`PORT`
-    /// baked into its launch environment) with the staging override also
-    /// prefers the staging origin, while any explicit origin or port env
-    /// keeps winning as today.
+    /// Build-default web origin. An explicit choice is a wholesale head
+    /// (fixed cmux.com or staging origin, above even `CMUX_WWW_ORIGIN`).
+    /// With no choice: env wins, Debug defaults to the tag-local dev port,
+    /// Release to cmux.com.
     static func resolvedDefaultWebOrigin(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> String {
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).webOrigin
+        }
         if let origin = environment["CMUX_WWW_ORIGIN"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !origin.isEmpty {
             return origin
         }
         if isDebugBuild {
-            if override == .staging,
-               environmentPort("CMUX_PORT", environment: environment) == nil,
-               environmentPort("PORT", environment: environment) == nil {
-                return CMUXBackendEnvironmentOverride.stagingWebOrigin
-            }
             return "http://localhost:\(resolvedCmuxPort(environment: environment))"
         }
-        return override == .staging
-            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
-            : "https://cmux.com"
+        return "https://cmux.com"
     }
 
     private static var defaultVMAPIOrigin: String {
         resolvedDefaultVMAPIOrigin(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
-    /// Build-default VM API origin. Release production is cmux.com; under
-    /// the staging override it becomes the staging web origin. Debug keeps
-    /// the tag-local dev port. Explicit `CMUX_VM_API_BASE_URL` layers are
-    /// checked by ``vmAPIBaseURL`` before this default is consulted.
+    /// Build-default VM API origin. An explicit choice is a wholesale head;
+    /// with no choice, Debug keeps the tag-local dev port and Release is
+    /// cmux.com. Explicit `CMUX_VM_API_BASE_URL` layers are checked by
+    /// ``vmAPIBaseURL`` before this default is consulted (and after its
+    /// choice head).
     static func resolvedDefaultVMAPIOrigin(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> String {
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).vmAPIOrigin
+        }
         if isDebugBuild {
             return "http://localhost:\(resolvedCmuxPort(environment: environment))"
         }
-        return override == .staging
-            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
-            : "https://cmux.com"
+        return "https://cmux.com"
     }
 
     private static var defaultAPIBaseURL: String {
         resolvedDefaultAPIBaseURL(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
@@ -634,22 +826,27 @@ enum AuthEnvironment {
         resolvedStackProjectID(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
-    /// Resolve the Stack channel for a macOS build. Debug defaults to the
-    /// development project, while `scripts/reload.sh --prod-auth` bakes an
-    /// explicit production override into the tagged app's launch environment.
-    /// Invalid values fail toward the build's normal channel: Debug stays on
-    /// development regardless of the persisted override; Release follows the
-    /// override (staging selects the development Stack project, which is
-    /// what the staging web deployment authenticates against).
+    /// Resolve the Stack channel for a macOS build. An explicit backend
+    /// choice is a wholesale head — even the DEBUG development default
+    /// yields to it, so an explicit production pick on a Debug build talks
+    /// to the production Stack project (and dev auto-login, which keys on
+    /// the resolved channel, disables itself for free). With no choice,
+    /// `CMUX_AUTH_ENVIRONMENT` wins (`scripts/reload.sh --prod-auth` bakes
+    /// it into the tagged app's launch environment), invalid values fail
+    /// toward the build's normal channel, Debug defaults to development,
+    /// and Release to production.
     static func resolvedStackAuthEnvironment(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> CMUXAuthEnvironment {
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).stackAuthEnvironment
+        }
         switch environment["CMUX_AUTH_ENVIRONMENT"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased() {
@@ -658,15 +855,20 @@ enum AuthEnvironment {
         case "development":
             return .development
         default:
-            return isDebugBuild ? .development : override.authEnvironment
+            return isDebugBuild ? .development : .production
         }
     }
 
     static func resolvedStackProjectID(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> String {
+        // Wholesale head: above CMUX_STACK_PROJECT_ID too, so a choice can
+        // never pair one project's id with another environment's key.
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).stackProjectID
+        }
         if let projectID = environment["CMUX_STACK_PROJECT_ID"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !projectID.isEmpty {
@@ -674,8 +876,7 @@ enum AuthEnvironment {
         }
         switch resolvedStackAuthEnvironment(
             environment: environment,
-            isDebugBuild: isDebugBuild,
-            override: override
+            isDebugBuild: isDebugBuild
         ) {
         case .development:
             return developmentStackProjectID
@@ -688,15 +889,18 @@ enum AuthEnvironment {
         resolvedStackPublishableClientKey(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedStackPublishableClientKey(
         environment: [String: String],
         isDebugBuild: Bool,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> String {
+        if let explicitChoice {
+            return ExplicitBackendValues.values(for: explicitChoice).stackPublishableClientKey
+        }
         if let clientKey = environment["CMUX_STACK_PUBLISHABLE_CLIENT_KEY"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !clientKey.isEmpty {
@@ -704,8 +908,7 @@ enum AuthEnvironment {
         }
         switch resolvedStackAuthEnvironment(
             environment: environment,
-            isDebugBuild: isDebugBuild,
-            override: override
+            isDebugBuild: isDebugBuild
         ) {
         case .development:
             return developmentStackPublishableClientKey
@@ -719,21 +922,25 @@ enum AuthEnvironment {
         resolvedAfterSignInOrigin(
             environment: ProcessInfo.processInfo.environment,
             isDebugBuild: isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: backendEnvironmentExplicitChoice
         )
     }
 
     static func resolvedAfterSignInOrigin(
         environment: [String: String],
         isDebugBuild: Bool = AuthEnvironment.isDebugBuild,
-        override: CMUXBackendEnvironmentOverride = .production
+        explicitChoice: CMUXBackendEnvironmentOverride? = nil
     ) -> URL {
-        resolvedURL(
+        // Wholesale head: sign-in must enter the chosen environment's own
+        // handler pages, above the CMUX_AUTH_WWW_ORIGIN bake.
+        if let explicitChoice {
+            return URL(string: ExplicitBackendValues.values(for: explicitChoice).webOrigin)!
+        }
+        return resolvedURL(
             environmentKey: "CMUX_AUTH_WWW_ORIGIN",
             fallback: resolvedDefaultWebOrigin(
                 environment: environment,
-                isDebugBuild: isDebugBuild,
-                override: override
+                isDebugBuild: isDebugBuild
             ),
             environment: environment
         )

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -7,6 +7,30 @@ enum AuthEnvironment {
     private static let productionStackProjectID = "9790718f-14cd-4f7e-824d-eaf527a82b82"
     private static let productionStackPublishableClientKey = "pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr"
 
+    /// The persisted runtime backend selection (Settings > Account > Backend
+    /// Environment). Replaces only the BUILD DEFAULT layer of every resolution
+    /// below: explicit `CMUX_*` environment variables (including the
+    /// LSEnvironment values tagged dev builds bake in via `scripts/reload.sh`)
+    /// keep winning, since they are the dev-lane isolation mechanism.
+    ///
+    /// Loaded fresh at each ProcessInfo-reading resolution site. The
+    /// composition root still resolves once at startup, so a newly stored
+    /// value takes effect at the next launch.
+    static var backendEnvironmentOverride: CMUXBackendEnvironmentOverride {
+        CMUXBackendEnvironmentOverride.load(from: .standard)
+    }
+
+    /// Whether this binary was compiled as a Debug build. The pure
+    /// `resolved*` functions take this as a parameter so tests can exercise
+    /// Release resolution; ProcessInfo-reading computed vars pass this value.
+    static var isDebugBuild: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }
+
     static var callbackScheme: String {
         callbackScheme(
             environment: ProcessInfo.processInfo.environment,
@@ -84,9 +108,33 @@ enum AuthEnvironment {
     }
 
     static var websiteOrigin: URL {
-        resolvedURL(
+        resolvedWebsiteOrigin(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
+        )
+    }
+
+    static func resolvedWebsiteOrigin(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        // With the production override this keeps today's fixed cmux.com
+        // fallback (Debug included). Under the staging override the fallback
+        // follows the resolved default web origin, so a Release build lands
+        // on the staging deployment while explicit env still wins.
+        let fallback = override == .staging
+            ? resolvedDefaultWebOrigin(
+                environment: environment,
+                isDebugBuild: isDebugBuild,
+                override: override
+            )
+            : "https://cmux.com"
+        return resolvedURL(
             environmentKey: "CMUX_WWW_ORIGIN",
-            fallback: "https://cmux.com"
+            fallback: fallback,
+            environment: environment
         )
     }
 
@@ -96,46 +144,66 @@ enum AuthEnvironment {
     /// `~/.cmux-dev.env` file (so a deeplink-launched dev build can point at
     /// a local web server), then the production website.
     static var pricingURL: URL {
-        resolvedPricingURL(environment: ProcessInfo.processInfo.environment)
+        resolvedPricingURL(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
-    static func resolvedPricingURL(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment).appendingPathComponent("pricing")
+    static func resolvedPricingURL(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+            .appendingPathComponent("pricing")
     }
 
     static var appPricingURL: URL {
-        resolvedAppPricingURL(environment: ProcessInfo.processInfo.environment)
+        resolvedAppPricingURL(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
     static var appWebOrigin: URL {
-        resolvedAppWebOrigin(environment: ProcessInfo.processInfo.environment)
+        resolvedAppWebOrigin(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
     /// Credential-bearing native-to-web handoffs are pinned to cmux.com in
-    /// release builds. Debug builds may additionally use an exact loopback
-    /// origin so tagged local web servers can participate without making an
-    /// arbitrary launch environment variable a token destination.
+    /// release builds. Under the persisted staging override, exactly the
+    /// fixed staging origin is additionally allowed (URL equality with
+    /// ``CMUXBackendEnvironmentOverride/stagingWebOrigin``); the destination
+    /// set never widens beyond those two fixed origins. Debug builds may
+    /// additionally use an exact loopback origin so tagged local web servers
+    /// can participate without making an arbitrary launch environment
+    /// variable a token destination.
     static var appSessionHandoffOrigin: URL {
-        #if DEBUG
-        let isDebugBuild = true
-        #else
-        let isDebugBuild = false
-        #endif
-        return resolvedAppSessionHandoffOrigin(
+        resolvedAppSessionHandoffOrigin(
             environment: ProcessInfo.processInfo.environment,
-            isDebugBuild: isDebugBuild
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
         )
     }
 
     static func resolvedAppSessionHandoffOrigin(
         environment: [String: String],
-        isDebugBuild: Bool
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
     ) -> URL {
         let productionOrigin = URL(string: "https://cmux.com")!
-        guard isDebugBuild else { return productionOrigin }
-
-        let candidate = canonicalizedLoopbackURL(appWebOrigin(environment: environment))
+        let stagingOrigin = URL(string: CMUXBackendEnvironmentOverride.stagingWebOrigin)!
+        let candidate = canonicalizedLoopbackURL(
+            appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+        )
         if candidate == productionOrigin { return productionOrigin }
+        // Only the fixed staging origin, and only when the user opted into
+        // staging: an env-injected lookalike can never become a token
+        // destination because equality is against the compiled-in constant.
+        if override == .staging, candidate == stagingOrigin { return stagingOrigin }
+        guard isDebugBuild else { return productionOrigin }
         guard let components = URLComponents(
             url: candidate,
             resolvingAgainstBaseURL: false
@@ -152,20 +220,34 @@ enum AuthEnvironment {
         return candidate
     }
 
-    static func resolvedAppWebOrigin(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment)
+    static func resolvedAppWebOrigin(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
     }
 
-    static func resolvedAppPricingURL(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment).appendingPathComponent("app-pricing")
+    static func resolvedAppPricingURL(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+            .appendingPathComponent("app-pricing")
     }
 
     static var appProWelcomeURL: URL {
-        resolvedAppProWelcomeURL(environment: ProcessInfo.processInfo.environment)
+        resolvedAppProWelcomeURL(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
-    static func resolvedAppProWelcomeURL(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment).appendingPathComponent("app-pro-welcome")
+    static func resolvedAppProWelcomeURL(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
+            .appendingPathComponent("app-pro-welcome")
     }
 
     /// Payment entrypoint used by native app UI. `CMUX_BILLING_WWW_ORIGIN`
@@ -175,22 +257,35 @@ enum AuthEnvironment {
     /// request on the same origin that rendered pricing instead of crossing to
     /// production.
     static var billingCheckoutURL: URL {
-        resolvedBillingCheckoutURL(environment: ProcessInfo.processInfo.environment)
+        resolvedBillingCheckoutURL(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
-    static func resolvedBillingCheckoutURL(environment: [String: String]) -> URL {
+    static func resolvedBillingCheckoutURL(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
         billingCheckoutURL(
-            origin: billingWebsiteOrigin(environment: environment),
+            origin: billingWebsiteOrigin(environment: environment, override: override),
             callbackScheme: callbackScheme(environment: environment, bundleIdentifier: nil)
         )
     }
 
     static var billingPortalURL: URL {
-        resolvedBillingPortalURL(environment: ProcessInfo.processInfo.environment)
+        resolvedBillingPortalURL(
+            environment: ProcessInfo.processInfo.environment,
+            override: backendEnvironmentOverride
+        )
     }
 
-    static func resolvedBillingPortalURL(environment: [String: String]) -> URL {
-        billingWebsiteOrigin(environment: environment).appendingPathComponent("api/billing/portal")
+    static func resolvedBillingPortalURL(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
+        billingWebsiteOrigin(environment: environment, override: override)
+            .appendingPathComponent("api/billing/portal")
     }
 
     static var signInWebsiteOrigin: URL {
@@ -209,6 +304,30 @@ enum AuthEnvironment {
                 fallback: defaultAPIBaseURL
             )
         )
+    }
+
+    /// Build-default API base. Release production is api.cmux.sh; under the
+    /// staging override it becomes the staging web origin, whose Next.js app
+    /// serves the same `/api/*` routes (api.cmux.sh only fronts calls like
+    /// `/api/billing/plan` that the staging deployment also serves). Debug
+    /// keeps the tag-local dev port. An explicit `CMUX_API_BASE_URL` always
+    /// wins.
+    static func resolvedDefaultAPIBaseURL(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> String {
+        if let url = environment["CMUX_API_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !url.isEmpty {
+            return url
+        }
+        if isDebugBuild {
+            return "http://localhost:\(resolvedCmuxPort(environment: environment))"
+        }
+        return override == .staging
+            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
+            : "https://api.cmux.sh"
     }
 
     /// Base URL for the cmux-owned cloud VM backend (`/api/vm`).
@@ -278,23 +397,35 @@ enum AuthEnvironment {
         if let override = devOverride(key: "CMUX_IROH_BROKER_BASE_URL") {
             return validatedIrohBrokerURL(override)
         }
-        return resolvedIrohBrokerBaseURL(environment: environment, isDebugBuild: true)
+        return resolvedIrohBrokerBaseURL(
+            environment: environment,
+            isDebugBuild: true,
+            override: backendEnvironmentOverride
+        )
         #else
-        return resolvedIrohBrokerBaseURL(environment: environment, isDebugBuild: false)
+        return resolvedIrohBrokerBaseURL(
+            environment: environment,
+            isDebugBuild: false,
+            override: backendEnvironmentOverride
+        )
         #endif
     }
 
     static func resolvedIrohBrokerBaseURL(
         environment: [String: String],
-        isDebugBuild: Bool
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
     ) -> URL? {
         if let explicit = environment["CMUX_IROH_BROKER_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !explicit.isEmpty {
             return validatedIrohBrokerURL(explicit)
         }
-        let fallback = isDebugBuild
-            ? "https://cmux-staging.vercel.app"
+        // Debug already brokers through shared staging; the staging override
+        // sends Release there too, so a staging Mac and phone publish into
+        // the same account-scoped registry.
+        let fallback = isDebugBuild || override == .staging
+            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
             : "https://cmux.com"
         return validatedIrohBrokerURL(fallback)
     }
@@ -342,37 +473,51 @@ enum AuthEnvironment {
         #endif
     }
 
-    private static var cmuxPort: String {
-        resolvedCmuxPort(environment: ProcessInfo.processInfo.environment)
-    }
-
-    private static func billingWebsiteOrigin(environment: [String: String]) -> URL {
+    private static func billingWebsiteOrigin(
+        environment: [String: String],
+        override: CMUXBackendEnvironmentOverride
+    ) -> URL {
         if let overridden = environmentURL("CMUX_BILLING_WWW_ORIGIN", environment: environment) {
             return overridden
         }
-        return appWebOrigin(environment: environment)
+        return appWebOrigin(environment: environment, isDebugBuild: isDebugBuild, override: override)
     }
 
-    private static func appWebOrigin(environment: [String: String]) -> URL {
+    private static func appWebOrigin(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride
+    ) -> URL {
         if let explicitWebsite = environmentURL("CMUX_WWW_ORIGIN", environment: environment) {
             return canonicalizedLoopbackURL(explicitWebsite)
         }
         if let authWebsite = environmentURL("CMUX_AUTH_WWW_ORIGIN", environment: environment) {
             return canonicalizedLoopbackURL(authWebsite)
         }
-        #if DEBUG
-        if environmentPort("CMUX_PORT", environment: environment) != nil ||
-            environmentPort("PORT", environment: environment) != nil {
-            return URL(string: resolvedDefaultWebOrigin(environment: environment))!
+        if isDebugBuild {
+            if environmentPort("CMUX_PORT", environment: environment) != nil ||
+                environmentPort("PORT", environment: environment) != nil {
+                return URL(string: resolvedDefaultWebOrigin(
+                    environment: environment,
+                    isDebugBuild: isDebugBuild,
+                    override: override
+                ))!
+            }
+            // `devOverride` is itself compiled out of Release builds, so this
+            // runtime branch changes nothing for real builds while keeping
+            // Release resolution testable from the Debug-built test target.
+            if let devValue = devOverride(key: "CMUX_WWW_ORIGIN"),
+               let url = URL(string: devValue) {
+                return canonicalizedLoopbackURL(url)
+            }
         }
-        if let override = devOverride(key: "CMUX_WWW_ORIGIN"),
-           let url = URL(string: override) {
-            return canonicalizedLoopbackURL(url)
-        }
-        #endif
         return resolvedURL(
             environmentKey: "CMUX_WWW_ORIGIN",
-            fallback: resolvedDefaultWebOrigin(environment: environment),
+            fallback: resolvedDefaultWebOrigin(
+                environment: environment,
+                isDebugBuild: isDebugBuild,
+                override: override
+            ),
             environment: environment
         )
     }
@@ -397,10 +542,6 @@ enum AuthEnvironment {
             ?? "3777"
     }
 
-    private static func environmentPort(_ key: String) -> String? {
-        environmentPort(key, environment: ProcessInfo.processInfo.environment)
-    }
-
     private static func environmentPort(_ key: String, environment: [String: String]) -> String? {
         guard let port = environment[key]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -413,41 +554,73 @@ enum AuthEnvironment {
     }
 
     private static var defaultWebOrigin: String {
-        resolvedDefaultWebOrigin(environment: ProcessInfo.processInfo.environment)
+        resolvedDefaultWebOrigin(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
+        )
     }
 
-    private static func resolvedDefaultWebOrigin(environment: [String: String]) -> String {
+    /// Build-default web origin. Release production is cmux.com; under the
+    /// staging override it becomes the staging web origin. Debug defaults to
+    /// the tag-local dev port; an untagged Debug build (no `CMUX_PORT`/`PORT`
+    /// baked into its launch environment) with the staging override also
+    /// prefers the staging origin, while any explicit origin or port env
+    /// keeps winning as today.
+    static func resolvedDefaultWebOrigin(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> String {
         if let origin = environment["CMUX_WWW_ORIGIN"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !origin.isEmpty {
             return origin
         }
-        #if DEBUG
-        return "http://localhost:\(resolvedCmuxPort(environment: environment))"
-        #else
-        return "https://cmux.com"
-        #endif
+        if isDebugBuild {
+            if override == .staging,
+               environmentPort("CMUX_PORT", environment: environment) == nil,
+               environmentPort("PORT", environment: environment) == nil {
+                return CMUXBackendEnvironmentOverride.stagingWebOrigin
+            }
+            return "http://localhost:\(resolvedCmuxPort(environment: environment))"
+        }
+        return override == .staging
+            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
+            : "https://cmux.com"
     }
 
     private static var defaultVMAPIOrigin: String {
-        #if DEBUG
-        return "http://localhost:\(cmuxPort)"
-        #else
-        return "https://cmux.com"
-        #endif
+        resolvedDefaultVMAPIOrigin(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
+        )
+    }
+
+    /// Build-default VM API origin. Release production is cmux.com; under
+    /// the staging override it becomes the staging web origin. Debug keeps
+    /// the tag-local dev port. Explicit `CMUX_VM_API_BASE_URL` layers are
+    /// checked by ``vmAPIBaseURL`` before this default is consulted.
+    static func resolvedDefaultVMAPIOrigin(
+        environment: [String: String],
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> String {
+        if isDebugBuild {
+            return "http://localhost:\(resolvedCmuxPort(environment: environment))"
+        }
+        return override == .staging
+            ? CMUXBackendEnvironmentOverride.stagingWebOrigin
+            : "https://cmux.com"
     }
 
     private static var defaultAPIBaseURL: String {
-        if let url = ProcessInfo.processInfo.environment["CMUX_API_BASE_URL"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !url.isEmpty {
-            return url
-        }
-        #if DEBUG
-        return "http://localhost:\(cmuxPort)"
-        #else
-        return "https://api.cmux.sh"
-        #endif
+        resolvedDefaultAPIBaseURL(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
+        )
     }
 
     static var stackBaseURL: URL {
@@ -458,26 +631,24 @@ enum AuthEnvironment {
     }
 
     static var stackProjectID: String {
-        #if DEBUG
-        return resolvedStackProjectID(
+        resolvedStackProjectID(
             environment: ProcessInfo.processInfo.environment,
-            isDebugBuild: true
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
         )
-        #else
-        return resolvedStackProjectID(
-            environment: ProcessInfo.processInfo.environment,
-            isDebugBuild: false
-        )
-        #endif
     }
 
     /// Resolve the Stack channel for a macOS build. Debug defaults to the
     /// development project, while `scripts/reload.sh --prod-auth` bakes an
     /// explicit production override into the tagged app's launch environment.
-    /// Invalid values fail toward the build's normal channel.
+    /// Invalid values fail toward the build's normal channel: Debug stays on
+    /// development regardless of the persisted override; Release follows the
+    /// override (staging selects the development Stack project, which is
+    /// what the staging web deployment authenticates against).
     static func resolvedStackAuthEnvironment(
         environment: [String: String],
-        isDebugBuild: Bool
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
     ) -> CMUXAuthEnvironment {
         switch environment["CMUX_AUTH_ENVIRONMENT"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -487,13 +658,14 @@ enum AuthEnvironment {
         case "development":
             return .development
         default:
-            return isDebugBuild ? .development : .production
+            return isDebugBuild ? .development : override.authEnvironment
         }
     }
 
     static func resolvedStackProjectID(
         environment: [String: String],
-        isDebugBuild: Bool
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
     ) -> String {
         if let projectID = environment["CMUX_STACK_PROJECT_ID"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -502,7 +674,8 @@ enum AuthEnvironment {
         }
         switch resolvedStackAuthEnvironment(
             environment: environment,
-            isDebugBuild: isDebugBuild
+            isDebugBuild: isDebugBuild,
+            override: override
         ) {
         case .development:
             return developmentStackProjectID
@@ -512,22 +685,17 @@ enum AuthEnvironment {
     }
 
     static var stackPublishableClientKey: String {
-        #if DEBUG
-        return resolvedStackPublishableClientKey(
+        resolvedStackPublishableClientKey(
             environment: ProcessInfo.processInfo.environment,
-            isDebugBuild: true
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
         )
-        #else
-        return resolvedStackPublishableClientKey(
-            environment: ProcessInfo.processInfo.environment,
-            isDebugBuild: false
-        )
-        #endif
     }
 
     static func resolvedStackPublishableClientKey(
         environment: [String: String],
-        isDebugBuild: Bool
+        isDebugBuild: Bool,
+        override: CMUXBackendEnvironmentOverride = .production
     ) -> String {
         if let clientKey = environment["CMUX_STACK_PUBLISHABLE_CLIENT_KEY"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -536,7 +704,8 @@ enum AuthEnvironment {
         }
         switch resolvedStackAuthEnvironment(
             environment: environment,
-            isDebugBuild: isDebugBuild
+            isDebugBuild: isDebugBuild,
+            override: override
         ) {
         case .development:
             return developmentStackPublishableClientKey
@@ -547,13 +716,25 @@ enum AuthEnvironment {
 
     /// The website origin used for the after-sign-in handler.
     static var afterSignInOrigin: URL {
-        resolvedAfterSignInOrigin(environment: ProcessInfo.processInfo.environment)
+        resolvedAfterSignInOrigin(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild,
+            override: backendEnvironmentOverride
+        )
     }
 
-    static func resolvedAfterSignInOrigin(environment: [String: String]) -> URL {
+    static func resolvedAfterSignInOrigin(
+        environment: [String: String],
+        isDebugBuild: Bool = AuthEnvironment.isDebugBuild,
+        override: CMUXBackendEnvironmentOverride = .production
+    ) -> URL {
         resolvedURL(
             environmentKey: "CMUX_AUTH_WWW_ORIGIN",
-            fallback: resolvedDefaultWebOrigin(environment: environment),
+            fallback: resolvedDefaultWebOrigin(
+                environment: environment,
+                isDebugBuild: isDebugBuild,
+                override: override
+            ),
             environment: environment
         )
     }

--- a/Sources/Auth/BrowserAppSession/BrowserAppSessionController.swift
+++ b/Sources/Auth/BrowserAppSession/BrowserAppSessionController.swift
@@ -135,6 +135,26 @@ final class BrowserAppSessionController {
         storeRegistry.register(panel)
     }
 
+    /// Adopt the previous controller's live app-session store and panel
+    /// ownership after a live backend-environment switch rebuilds the auth
+    /// graph. Open browser panels register once at creation (through
+    /// `AppDelegate.shared?.auth?.browserAppSession`), so without this
+    /// transfer a replacement controller would not know them; ownership that
+    /// survived the switch's sign-out cleanup (a failed WebKit callback
+    /// leaves a fail-closed retry token) must keep blocking admission and
+    /// retrying cleanup under the new controller.
+    func adoptAppSessionOwnership(from previous: BrowserAppSessionController) {
+        let ownership = previous.storeRegistry.ownershipForTransfer()
+        // Stores first: panel registration only sticks when the panel's
+        // store is already registered.
+        for store in ownership.stores {
+            storeRegistry.register(store)
+        }
+        for panel in ownership.panels {
+            storeRegistry.register(panel)
+        }
+    }
+
     /// Synchronously closes the handoff admission gate before any auth
     /// transition publishes or clears coordinator state. Cleanup runs once and
     /// the next authenticated generation cannot reopen admission until it joins.

--- a/Sources/Auth/BrowserAppSession/BrowserAppSessionStoreRegistry.swift
+++ b/Sources/Auth/BrowserAppSession/BrowserAppSessionStoreRegistry.swift
@@ -104,6 +104,18 @@ final class BrowserAppSessionStoreRegistry {
         livePanels.removeAll()
     }
 
+    /// Snapshot of the live ownership for transfer to a replacement registry
+    /// when the auth graph is rebuilt in-process (live backend-environment
+    /// switch). The receiver registers the stores first so the panels' store
+    /// pairings are accepted by ``register(_:)-(BrowserPanel)``.
+    func ownershipForTransfer() -> (stores: [WKWebsiteDataStore], panels: [BrowserPanel]) {
+        pruneReleasedOwnership()
+        return (
+            stores: liveStores.values.compactMap { $0.value },
+            panels: livePanels.values.compactMap { $0.panel.value }
+        )
+    }
+
     private func pruneReleasedOwnership() {
         liveStores = liveStores.filter { $0.value.value != nil }
         // Mutable panel state is only a read-time cleanup filter. Retain the

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -41,13 +41,20 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     /// The live-switch engine. Attached once by `MacAuthComposition`'s
     /// startup initializer and kept stable across switches.
     private var backendEnvironmentSwitchController: MacBackendEnvironmentSwitchController?
+    /// Presents the "signing out on staging returns you to Production"
+    /// confirmation. Injected (production: an NSAlert presenter; tests: a
+    /// fake) so the interception at the ``signOut()`` choke point is
+    /// testable without AppKit. Only consulted while the active environment
+    /// is non-production; the socket variant ``signOut(timeout:)`` skips it.
+    @ObservationIgnored private let confirmStagingSignOut: @MainActor () async -> Bool
 
     init(
         coordinator: AuthCoordinator,
         browserSignIn: HostBrowserSignInFlow,
         activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride = .production,
         backendEnvironmentPinnedByLaunchEnvironment: Bool = false,
-        backendEnvironmentDefaults: UserDefaults = .standard
+        backendEnvironmentDefaults: UserDefaults = .standard,
+        confirmStagingSignOut: @escaping @MainActor () async -> Bool = { true }
     ) {
         self.coordinator = coordinator
         self.browserSignIn = browserSignIn
@@ -57,6 +64,7 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         )
         self.backendEnvironmentPinnedByLaunchEnvironment = backendEnvironmentPinnedByLaunchEnvironment
         self.backendEnvironmentDefaults = backendEnvironmentDefaults
+        self.confirmStagingSignOut = confirmStagingSignOut
         isProUpgradeAvailable = featureFlags.isProUpgradeUIEnabled
         featureFlagsObserver = NotificationCenter.default.addObserver(
             forName: .cmuxFeatureFlagsDidChange,
@@ -179,18 +187,65 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         )
     }
 
+    /// The ONE interactive sign-out choke point (Settings card, sidebar
+    /// popover, command palette all land here). Sign-out is
+    /// per-environment: on production it is the plain chain; on a
+    /// non-production environment it first asks the injected confirmation
+    /// ("this returns you to Production"), then runs the REAL sign-out under
+    /// the current (staging) defaults — so the revocation hits staging — and
+    /// chains a switch back to production, which restores the parked
+    /// production session (production never gates, so the chain can't
+    /// prompt).
     func signOut() async {
+        guard activeBackendEnvironmentOverride != .production else {
+            await signOutDirect()
+            return
+        }
+        guard await confirmStagingSignOut() else { return }
+        await signOutDirect()
+        await returnToProductionAfterSignOut()
+    }
+
+    /// Socket variant of sign-out (`auth.sign_out`). Stays non-interactive:
+    /// it SKIPS the staging confirmation (a modal or a refusal would break
+    /// automation and strand staging) but chains the same
+    /// return-to-production switch, reported to the caller through the
+    /// returned flag. The underlying sign-out continues if the caller's
+    /// deadline expires, matching the browser flow contract.
+    /// - Returns: Whether the sign-out chained a switch back to production
+    ///   (the socket payload's `returned_to_production`).
+    @discardableResult
+    func signOut(timeout: TimeInterval) async -> Bool {
+        let chainsBackToProduction = activeBackendEnvironmentOverride != .production
+        await browserSignIn.signOut(timeout: timeout)
+        isProActive = false
+        canManageBilling = false
+        guard chainsBackToProduction else { return false }
+        return await returnToProductionAfterSignOut()
+    }
+
+    /// The plain sign-out chain with no environment interception: the
+    /// browser flow's full teardown plus the Pro-state reset. Used directly
+    /// by production sign-out, by the confirmed staging sign-out, and as the
+    /// switch transaction's `signOutEstablishedSession` step (which must
+    /// never re-enter the staging confirmation).
+    func signOutDirect() async {
         await browserSignIn.signOut()
         isProActive = false
         canManageBilling = false
     }
 
-    /// Socket variant of sign-out. The underlying sign-out continues if the
-    /// caller's deadline expires, matching the browser flow contract.
-    func signOut(timeout: TimeInterval) async {
-        await browserSignIn.signOut(timeout: timeout)
-        isProActive = false
-        canManageBilling = false
+    /// Chain the per-environment sign-out back to production through the
+    /// SAME switch transaction as the picker. Parking the just-signed-out
+    /// coordinator is a safe no-op, and the production restore never gates
+    /// or prompts.
+    /// - Returns: Whether the switch chain actually ran.
+    @discardableResult
+    private func returnToProductionAfterSignOut() async -> Bool {
+        guard !backendEnvironmentPinnedByLaunchEnvironment,
+              let backendEnvironmentSwitchController else { return false }
+        await backendEnvironmentSwitchController.switchEnvironment(to: .production)
+        return true
     }
 
     func refreshCurrentUser() async {
@@ -245,13 +300,13 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
 
     // MARK: - Backend environment switcher
 
-    /// The picker shows for verified team members, always in DEBUG builds,
-    /// and whenever the persisted or active environment is already
-    /// non-production, so switching back to production is always possible.
-    var backendEnvironmentSwitcherVisible: Bool {
+    /// STRICT full-picker gate: a verified team member or a DEBUG build,
+    /// nothing else. Switch-back reachability for everyone else is handled
+    /// by the package's recovery visibility tier
+    /// (`AccountFlow.backendEnvironmentCardVisibility`), not by widening
+    /// this gate.
+    var backendEnvironmentPickerAllowed: Bool {
         if Self.isDebugBuild { return true }
-        if pendingBackendEnvironmentOverride != .production { return true }
-        if activeBackendEnvironmentOverride != .production { return true }
         return CMUXBackendEnvironmentSwitchGate.allows(coordinator.currentUser)
     }
 
@@ -266,9 +321,11 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     var backendEnvironmentSwitchPhase: AccountBackendEnvironmentSwitchPhase {
         switch backendEnvironmentSwitchController?.phase {
         case .none, .idle: .idle
-        case .signingOut: .signingOut
+        case .parking: .parking
         case .retargeting: .retargeting
-        case .finished: .finished
+        case .establishing: .establishing
+        case .reverting: .reverting
+        case .finished(let outcome): .finished(Self.accountOutcome(from: outcome))
         }
     }
 
@@ -287,6 +344,62 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
 
     func resetBackendEnvironmentSwitchPhase() {
         backendEnvironmentSwitchController?.reset()
+    }
+
+    // MARK: - Backend environment switch steps
+
+    /// How long the switch's inline sign-in prompt waits before resolving
+    /// `nil`. Matches `HostBrowserSignInFlow`'s browser-attempt timeout (the
+    /// attempt's own deadline fires first and records `.timedOut`, so a
+    /// timeout classifies as a failure, not a cancel).
+    static let backendSwitchSignInPromptTimeout: TimeInterval = 10 * 60
+
+    /// The transaction's `parkSession` step: the browser flow's park (which
+    /// detaches the coordinator session, leaving its token slot untouched)
+    /// plus the same Pro-state reset sign-out performs.
+    func parkSession() async {
+        await browserSignIn.parkSession()
+        isProActive = false
+        canManageBilling = false
+    }
+
+    /// The transaction's `awaitRestoredUser` step: await the CURRENT
+    /// (post-rebind) coordinator's launch restore and report the user it
+    /// restored from the target's parked slot. `coordinator` is read at call
+    /// time, so after `rebind` this resolves the rebuilt graph.
+    func awaitRestoredUser() async -> CMUXAuthUser? {
+        await coordinator.awaitBootstrapped()
+        return coordinator.currentUser
+    }
+
+    /// The transaction's `promptSignIn` step: run the same hosted-browser
+    /// sign-in as every other entrypoint (against the CURRENT rebound
+    /// graph), bounded by ``backendSwitchSignInPromptTimeout``. Returns the
+    /// signed-in user, or `nil` on cancel / failure / timeout — classified
+    /// afterwards by ``backendSwitchSignInPromptFailure()``.
+    func promptSignInForBackendSwitch() async -> CMUXAuthUser? {
+        let signedIn = await browserSignIn.signIn(timeout: Self.backendSwitchSignInPromptTimeout)
+        guard signedIn else {
+            // The deadline resolves without cancelling the underlying
+            // attempt; end it so a stale popup can't complete into the
+            // environment the transaction is about to revert away from.
+            browserSignIn.cancelSignIn()
+            return nil
+        }
+        return coordinator.currentUser
+    }
+
+    /// The transaction's `cancelSignInPrompt` step (`requestRevert()`).
+    func cancelBackendSwitchSignInPrompt() {
+        browserSignIn.cancelSignIn()
+    }
+
+    /// Classify a `nil` ``promptSignInForBackendSwitch()``: no recorded
+    /// failure means the user backed out (cancel); anything else is a
+    /// failure. Drives the revert reason shown in the outcome note.
+    func backendSwitchSignInPromptFailure()
+        -> BackendEnvironmentSwitchTransaction.SignInPromptFailure {
+        browserSignIn.lastFailure == nil ? .cancelled : .failed
     }
 
     /// Attach the live-switch engine. Called once from `MacAuthComposition`'s
@@ -360,6 +473,17 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         switch value {
         case .production: .production
         case .staging: .staging
+        }
+    }
+
+    private static func accountOutcome(
+        from outcome: BackendEnvironmentSwitchTransaction.Outcome
+    ) -> AccountBackendEnvironmentSwitchOutcome {
+        switch outcome {
+        case .switched: .switched
+        case .reverted(.signInCancelled): .reverted(.signInCancelled)
+        case .reverted(.signInFailed): .reverted(.signInFailed)
+        case .reverted(.notEligible): .reverted(.notEligible)
         }
     }
 

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -17,24 +17,30 @@ import Observation
 @MainActor
 @Observable
 final class HostAccountFlow: AccountFlow, AccountSignInFlow {
-    private let coordinator: AuthCoordinator
-    private let browserSignIn: HostBrowserSignInFlow
+    /// The live auth graph pieces. `var` because a live backend-environment
+    /// switch replaces them via ``rebind(coordinator:browserSignIn:activeBackendEnvironmentOverride:)``
+    /// while this flow object (and the Settings UI observing it) survives.
+    private var coordinator: AuthCoordinator
+    private var browserSignIn: HostBrowserSignInFlow
     private let featureFlags = CmuxFeatureFlags.shared
     @ObservationIgnored private var featureFlagsObserver: (any NSObjectProtocol)?
     private(set) var isProUpgradeAvailable: Bool
     private(set) var isProActive = false
     private(set) var canManageBilling = false
-    /// The backend environment the composition root actually resolved at
-    /// startup (threaded in rather than re-read from defaults, so the value
-    /// always describes the running process even after the user flips the
-    /// picker).
-    private let activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
-    /// The persisted selection, applied at next launch. Stored (not
-    /// re-loaded per read) so `@Observable` re-renders the Settings card
-    /// when ``selectBackendEnvironment(_:)`` changes it.
+    /// The backend environment the composition root actually resolved
+    /// (threaded in rather than re-read from defaults, so the value always
+    /// describes the running graph). Updated by ``rebind`` after a live
+    /// switch.
+    private(set) var activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    /// The persisted selection. With the live switch this only diverges from
+    /// the active value if another writer changed the defaults key outside
+    /// the transaction; ``rebind`` re-reads it so the UI converges.
     private var pendingBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
     let backendEnvironmentPinnedByLaunchEnvironment: Bool
     @ObservationIgnored private let backendEnvironmentDefaults: UserDefaults
+    /// The live-switch engine. Attached once by `MacAuthComposition`'s
+    /// startup initializer and kept stable across switches.
+    private var backendEnvironmentSwitchController: MacBackendEnvironmentSwitchController?
 
     init(
         coordinator: AuthCoordinator,
@@ -85,7 +91,10 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     }
 
     var isWorkingOnAuth: Bool {
-        coordinator.isLoading || coordinator.isRestoringSession || browserSignIn.isPresentingSignIn
+        coordinator.isLoading
+            || coordinator.isRestoringSession
+            || browserSignIn.isPresentingSignIn
+            || (backendEnvironmentSwitchController?.isSwitching ?? false)
     }
 
     var isAuthenticated: Bool {
@@ -254,28 +263,57 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         Self.accountBackendEnvironment(from: pendingBackendEnvironmentOverride)
     }
 
-    func selectBackendEnvironment(_ value: AccountBackendEnvironment) {
-        let override = Self.backendEnvironmentOverride(from: value)
-        guard override != pendingBackendEnvironmentOverride else { return }
-        override.store(in: backendEnvironmentDefaults)
-        pendingBackendEnvironmentOverride = override
+    var backendEnvironmentSwitchPhase: AccountBackendEnvironmentSwitchPhase {
+        switch backendEnvironmentSwitchController?.phase {
+        case .none, .idle: .idle
+        case .signingOut: .signingOut
+        case .retargeting: .retargeting
+        case .finished: .finished
+        }
     }
 
-    /// Relaunches through the same seams the app already trusts: the
-    /// Sparkle-updater session persist (``AppDelegate/persistSessionForUpdateRelaunch()``)
-    /// followed by the `open -n` + terminate mechanism of
-    /// ``HostSettingsActions/restartApp()``. The new instance resolves the
-    /// pending override at startup and
-    /// ``MacAuthComposition/detectAuthProjectSwitch(resolvedProjectID:buildDefaultProjectID:defaults:)``
-    /// wipes the stale cross-project session.
-    func relaunchToApplyBackendEnvironment() {
-        AppDelegate.shared?.persistSessionForUpdateRelaunch()
-        let bundlePath = Bundle.main.bundlePath
-        let task = Process()
-        task.launchPath = "/usr/bin/open"
-        task.arguments = ["-n", bundlePath]
-        try? task.run()
-        NSApp.terminate(nil)
+    /// Runs the live transactional switch (sign-out under the old defaults,
+    /// quiesce, store, rebuild) through the attached
+    /// ``MacBackendEnvironmentSwitchController``. Pinned builds never start
+    /// it (the transaction guards again, but the flow refuses first so the
+    /// UI contract is enforceable without a controller).
+    func applyBackendEnvironment(_ value: AccountBackendEnvironment) async {
+        guard !backendEnvironmentPinnedByLaunchEnvironment else { return }
+        guard let backendEnvironmentSwitchController else { return }
+        await backendEnvironmentSwitchController.switchEnvironment(
+            to: Self.backendEnvironmentOverride(from: value)
+        )
+    }
+
+    func resetBackendEnvironmentSwitchPhase() {
+        backendEnvironmentSwitchController?.reset()
+    }
+
+    /// Attach the live-switch engine. Called once from `MacAuthComposition`'s
+    /// startup initializer (after both objects exist; the controller's steps
+    /// reference this flow weakly, so neither owns the other strongly in a
+    /// cycle).
+    func attachBackendEnvironmentSwitchController(
+        _ controller: MacBackendEnvironmentSwitchController
+    ) {
+        backendEnvironmentSwitchController = controller
+    }
+
+    /// Adopt the freshly built auth graph after a live backend-environment
+    /// switch, keeping this flow object (and everything observing it) alive.
+    /// Re-reads the persisted selection so active and pending converge on
+    /// the committed override.
+    func rebind(
+        coordinator: AuthCoordinator,
+        browserSignIn: HostBrowserSignInFlow,
+        activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    ) {
+        self.coordinator = coordinator
+        self.browserSignIn = browserSignIn
+        self.activeBackendEnvironmentOverride = activeBackendEnvironmentOverride
+        pendingBackendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(
+            from: backendEnvironmentDefaults
+        )
     }
 
     /// Tagged dev builds bake `CMUX_*` origins into their LSEnvironment via

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -24,10 +24,33 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     private(set) var isProUpgradeAvailable: Bool
     private(set) var isProActive = false
     private(set) var canManageBilling = false
+    /// The backend environment the composition root actually resolved at
+    /// startup (threaded in rather than re-read from defaults, so the value
+    /// always describes the running process even after the user flips the
+    /// picker).
+    private let activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    /// The persisted selection, applied at next launch. Stored (not
+    /// re-loaded per read) so `@Observable` re-renders the Settings card
+    /// when ``selectBackendEnvironment(_:)`` changes it.
+    private var pendingBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    let backendEnvironmentPinnedByLaunchEnvironment: Bool
+    @ObservationIgnored private let backendEnvironmentDefaults: UserDefaults
 
-    init(coordinator: AuthCoordinator, browserSignIn: HostBrowserSignInFlow) {
+    init(
+        coordinator: AuthCoordinator,
+        browserSignIn: HostBrowserSignInFlow,
+        activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride = .production,
+        backendEnvironmentPinnedByLaunchEnvironment: Bool = false,
+        backendEnvironmentDefaults: UserDefaults = .standard
+    ) {
         self.coordinator = coordinator
         self.browserSignIn = browserSignIn
+        self.activeBackendEnvironmentOverride = activeBackendEnvironmentOverride
+        self.pendingBackendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(
+            from: backendEnvironmentDefaults
+        )
+        self.backendEnvironmentPinnedByLaunchEnvironment = backendEnvironmentPinnedByLaunchEnvironment
+        self.backendEnvironmentDefaults = backendEnvironmentDefaults
         isProUpgradeAvailable = featureFlags.isProUpgradeUIEnabled
         featureFlagsObserver = NotificationCenter.default.addObserver(
             forName: .cmuxFeatureFlagsDidChange,
@@ -209,6 +232,97 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
 
     func openBillingPortal() {
         ProUpgradePresenter.presentBillingPortal()
+    }
+
+    // MARK: - Backend environment switcher
+
+    /// The picker shows for verified team members, always in DEBUG builds,
+    /// and whenever the persisted or active environment is already
+    /// non-production, so switching back to production is always possible.
+    var backendEnvironmentSwitcherVisible: Bool {
+        if Self.isDebugBuild { return true }
+        if pendingBackendEnvironmentOverride != .production { return true }
+        if activeBackendEnvironmentOverride != .production { return true }
+        return CMUXBackendEnvironmentSwitchGate.allows(coordinator.currentUser)
+    }
+
+    var activeBackendEnvironment: AccountBackendEnvironment {
+        Self.accountBackendEnvironment(from: activeBackendEnvironmentOverride)
+    }
+
+    var pendingBackendEnvironment: AccountBackendEnvironment {
+        Self.accountBackendEnvironment(from: pendingBackendEnvironmentOverride)
+    }
+
+    func selectBackendEnvironment(_ value: AccountBackendEnvironment) {
+        let override = Self.backendEnvironmentOverride(from: value)
+        guard override != pendingBackendEnvironmentOverride else { return }
+        override.store(in: backendEnvironmentDefaults)
+        pendingBackendEnvironmentOverride = override
+    }
+
+    /// Relaunches through the same seams the app already trusts: the
+    /// Sparkle-updater session persist (``AppDelegate/persistSessionForUpdateRelaunch()``)
+    /// followed by the `open -n` + terminate mechanism of
+    /// ``HostSettingsActions/restartApp()``. The new instance resolves the
+    /// pending override at startup and
+    /// ``MacAuthComposition/detectAuthProjectSwitch(resolvedProjectID:buildDefaultProjectID:defaults:)``
+    /// wipes the stale cross-project session.
+    func relaunchToApplyBackendEnvironment() {
+        AppDelegate.shared?.persistSessionForUpdateRelaunch()
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = ["-n", bundlePath]
+        try? task.run()
+        NSApp.terminate(nil)
+    }
+
+    /// Tagged dev builds bake `CMUX_*` origins into their LSEnvironment via
+    /// `scripts/reload.sh`; those explicit env layers outrank the persisted
+    /// override everywhere in `AuthEnvironment`, so the Settings card shows
+    /// a "pinned" note instead of pretending the picker applies. Computed in
+    /// the host because the package deliberately never reads ProcessInfo.
+    nonisolated static func launchEnvironmentPinsBackendEnvironment(
+        _ environment: [String: String]
+    ) -> Bool {
+        let pinningKeys = [
+            "CMUX_WWW_ORIGIN",
+            "CMUX_API_BASE_URL",
+            "CMUX_AUTH_ENVIRONMENT",
+            "CMUX_VM_API_BASE_URL",
+        ]
+        return pinningKeys.contains { key in
+            guard let value = environment[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+            return !value.isEmpty
+        }
+    }
+
+    private static var isDebugBuild: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }
+
+    private static func accountBackendEnvironment(
+        from override: CMUXBackendEnvironmentOverride
+    ) -> AccountBackendEnvironment {
+        switch override {
+        case .production: .production
+        case .staging: .staging
+        }
+    }
+
+    private static func backendEnvironmentOverride(
+        from value: AccountBackendEnvironment
+    ) -> CMUXBackendEnvironmentOverride {
+        switch value {
+        case .production: .production
+        case .staging: .staging
+        }
     }
 
     private static func identity(from user: CMUXAuthUser?) -> AccountIdentity? {

--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -18,7 +18,8 @@ import Observation
 @Observable
 final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     /// The live auth graph pieces. `var` because a live backend-environment
-    /// switch replaces them via ``rebind(coordinator:browserSignIn:activeBackendEnvironmentOverride:)``
+    /// switch replaces them via
+    /// ``rebind(coordinator:browserSignIn:activeBackendEnvironmentSelection:backendEnvironmentBuildLane:)``
     /// while this flow object (and the Settings UI observing it) survives.
     private var coordinator: AuthCoordinator
     private var browserSignIn: HostBrowserSignInFlow
@@ -27,16 +28,21 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     private(set) var isProUpgradeAvailable: Bool
     private(set) var isProActive = false
     private(set) var canManageBilling = false
-    /// The backend environment the composition root actually resolved
+    /// The backend selection the composition root actually resolved
     /// (threaded in rather than re-read from defaults, so the value always
     /// describes the running graph). Updated by ``rebind`` after a live
-    /// switch.
-    private(set) var activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    /// switch. Named to avoid colliding with the `AccountFlow` protocol's
+    /// package-mirror ``activeBackendEnvironmentSelection``.
+    private(set) var activeBackendEnvironmentHostSelection: CMUXBackendEnvironmentSelection
+    /// The build's own lane, classified once per process from the launch
+    /// environment (the explicit choice is ignored for classification).
+    /// Threaded through ``rebind`` for consistency even though a live
+    /// process's lane never changes.
+    private(set) var hostBackendEnvironmentBuildLane: CMUXBackendEnvironmentBuildLane
     /// The persisted selection. With the live switch this only diverges from
     /// the active value if another writer changed the defaults key outside
     /// the transaction; ``rebind`` re-reads it so the UI converges.
-    private var pendingBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
-    let backendEnvironmentPinnedByLaunchEnvironment: Bool
+    private var pendingBackendEnvironmentSelection: CMUXBackendEnvironmentSelection
     @ObservationIgnored private let backendEnvironmentDefaults: UserDefaults
     /// The live-switch engine. Attached once by `MacAuthComposition`'s
     /// startup initializer and kept stable across switches.
@@ -44,25 +50,28 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     /// Presents the "signing out on staging returns you to Production"
     /// confirmation. Injected (production: an NSAlert presenter; tests: a
     /// fake) so the interception at the ``signOut()`` choke point is
-    /// testable without AppKit. Only consulted while the active environment
-    /// is non-production; the socket variant ``signOut(timeout:)`` skips it.
+    /// testable without AppKit. Only consulted while the active selection is
+    /// EXPLICIT staging (a staging-lane rig keeps plain sign-outs); the
+    /// socket variant ``signOut(timeout:)`` skips it.
     @ObservationIgnored private let confirmStagingSignOut: @MainActor () async -> Bool
 
     init(
         coordinator: AuthCoordinator,
         browserSignIn: HostBrowserSignInFlow,
-        activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride = .production,
-        backendEnvironmentPinnedByLaunchEnvironment: Bool = false,
+        activeBackendEnvironmentSelection: CMUXBackendEnvironmentSelection =
+            .lane(resolves: .production),
+        backendEnvironmentBuildLane: CMUXBackendEnvironmentBuildLane = .production,
         backendEnvironmentDefaults: UserDefaults = .standard,
         confirmStagingSignOut: @escaping @MainActor () async -> Bool = { true }
     ) {
         self.coordinator = coordinator
         self.browserSignIn = browserSignIn
-        self.activeBackendEnvironmentOverride = activeBackendEnvironmentOverride
-        self.pendingBackendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(
-            from: backendEnvironmentDefaults
+        self.activeBackendEnvironmentHostSelection = activeBackendEnvironmentSelection
+        self.hostBackendEnvironmentBuildLane = backendEnvironmentBuildLane
+        self.pendingBackendEnvironmentSelection = Self.persistedSelection(
+            in: backendEnvironmentDefaults,
+            lane: backendEnvironmentBuildLane
         )
-        self.backendEnvironmentPinnedByLaunchEnvironment = backendEnvironmentPinnedByLaunchEnvironment
         self.backendEnvironmentDefaults = backendEnvironmentDefaults
         self.confirmStagingSignOut = confirmStagingSignOut
         isProUpgradeAvailable = featureFlags.isProUpgradeUIEnabled
@@ -189,39 +198,41 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
 
     /// The ONE interactive sign-out choke point (Settings card, sidebar
     /// popover, command palette all land here). Sign-out is
-    /// per-environment: on production it is the plain chain; on a
-    /// non-production environment it first asks the injected confirmation
-    /// ("this returns you to Production"), then runs the REAL sign-out under
-    /// the current (staging) defaults — so the revocation hits staging — and
-    /// chains a switch back to production, which restores the parked
-    /// production session (production never gates, so the chain can't
-    /// prompt).
+    /// per-environment, keyed on the SELECTION: only EXPLICIT staging
+    /// intercepts (a staging-LANE rig keeps today's plain sign-out, as does
+    /// explicit production). The intercepted path first asks the injected
+    /// confirmation ("this returns you to Production"), then runs the REAL
+    /// sign-out under the current (staging) defaults — so the revocation
+    /// hits staging — and chains a switch back to the build's LANE, which
+    /// restores its parked session (a lane target never gates, so the chain
+    /// can't prompt).
     func signOut() async {
-        guard activeBackendEnvironmentOverride != .production else {
+        guard activeBackendEnvironmentHostSelection == .explicit(.staging) else {
             await signOutDirect()
             return
         }
         guard await confirmStagingSignOut() else { return }
         await signOutDirect()
-        await returnToProductionAfterSignOut()
+        await returnToLaneAfterSignOut()
     }
 
     /// Socket variant of sign-out (`auth.sign_out`). Stays non-interactive:
     /// it SKIPS the staging confirmation (a modal or a refusal would break
-    /// automation and strand staging) but chains the same
-    /// return-to-production switch, reported to the caller through the
-    /// returned flag. The underlying sign-out continues if the caller's
-    /// deadline expires, matching the browser flow contract.
-    /// - Returns: Whether the sign-out chained a switch back to production
-    ///   (the socket payload's `returned_to_production`).
+    /// automation and strand staging) but chains the same return-to-lane
+    /// switch, reported to the caller through the returned flag. The
+    /// underlying sign-out continues if the caller's deadline expires,
+    /// matching the browser flow contract.
+    /// - Returns: Whether the sign-out chained a switch back to the build's
+    ///   lane (the socket payload's `returned_to_lane`, and — kept for
+    ///   automation compatibility — `returned_to_production`).
     @discardableResult
     func signOut(timeout: TimeInterval) async -> Bool {
-        let chainsBackToProduction = activeBackendEnvironmentOverride != .production
+        let chainsBackToLane = activeBackendEnvironmentHostSelection == .explicit(.staging)
         await browserSignIn.signOut(timeout: timeout)
         isProActive = false
         canManageBilling = false
-        guard chainsBackToProduction else { return false }
-        return await returnToProductionAfterSignOut()
+        guard chainsBackToLane else { return false }
+        return await returnToLaneAfterSignOut()
     }
 
     /// The plain sign-out chain with no environment interception: the
@@ -235,16 +246,18 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         canManageBilling = false
     }
 
-    /// Chain the per-environment sign-out back to production through the
-    /// SAME switch transaction as the picker. Parking the just-signed-out
-    /// coordinator is a safe no-op, and the production restore never gates
-    /// or prompts.
+    /// Chain the per-environment sign-out back to the build's LANE through
+    /// the SAME switch transaction as the picker. Parking the just-signed-out
+    /// coordinator is a safe no-op, and a lane restore never gates or
+    /// prompts. On an unpinned Release build the lane is production, so this
+    /// is the identical key-removal behavior the chain always had.
     /// - Returns: Whether the switch chain actually ran.
     @discardableResult
-    private func returnToProductionAfterSignOut() async -> Bool {
-        guard !backendEnvironmentPinnedByLaunchEnvironment,
-              let backendEnvironmentSwitchController else { return false }
-        await backendEnvironmentSwitchController.switchEnvironment(to: .production)
+    private func returnToLaneAfterSignOut() async -> Bool {
+        guard let backendEnvironmentSwitchController else { return false }
+        await backendEnvironmentSwitchController.switchEnvironment(
+            to: .lane(resolves: hostBackendEnvironmentBuildLane.resolvedEnvironment)
+        )
         return true
     }
 
@@ -311,11 +324,30 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     }
 
     var activeBackendEnvironment: AccountBackendEnvironment {
-        Self.accountBackendEnvironment(from: activeBackendEnvironmentOverride)
+        Self.accountBackendEnvironment(
+            from: activeBackendEnvironmentHostSelection.resolvedEnvironment
+        )
     }
 
     var pendingBackendEnvironment: AccountBackendEnvironment {
-        Self.accountBackendEnvironment(from: pendingBackendEnvironmentOverride)
+        Self.accountBackendEnvironment(
+            from: pendingBackendEnvironmentSelection.resolvedEnvironment
+        )
+    }
+
+    /// The package mirror of the active selection (`.buildLane` for the
+    /// lane, `.production`/`.staging` for an explicit choice). Drives the
+    /// picker's selected option, the interception-aware recovery routing,
+    /// and the lane-target confirm copy.
+    var activeBackendEnvironmentSelection: AccountBackendEnvironmentSelection {
+        Self.accountSelection(from: activeBackendEnvironmentHostSelection)
+    }
+
+    /// The package mirror of the build lane, powering the option-set rule
+    /// (two positions on a production lane, three otherwise) and the
+    /// "Build lane (…)" labels.
+    var backendEnvironmentBuildLane: AccountBackendEnvironmentBuildLane {
+        Self.accountBuildLane(from: hostBackendEnvironmentBuildLane)
     }
 
     var backendEnvironmentSwitchPhase: AccountBackendEnvironmentSwitchPhase {
@@ -329,17 +361,38 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         }
     }
 
-    /// Runs the live transactional switch (sign-out under the old defaults,
-    /// quiesce, store, rebuild) through the attached
-    /// ``MacBackendEnvironmentSwitchController``. Pinned builds never start
-    /// it (the transaction guards again, but the flow refuses first so the
-    /// UI contract is enforceable without a controller).
-    func applyBackendEnvironment(_ value: AccountBackendEnvironment) async {
-        guard !backendEnvironmentPinnedByLaunchEnvironment else { return }
+    /// Runs the live transactional switch (park under the old defaults,
+    /// quiesce, store, rebuild, establish) through the attached
+    /// ``MacBackendEnvironmentSwitchController``. The package's selection
+    /// mirror maps host-side: `.buildLane` is the lane; on a PRODUCTION lane
+    /// the picker's "Production" option also maps to the lane (clearChoice —
+    /// the key stays absent, preserving the pre-tri-state semantics of the
+    /// two-position picker), while on any other lane "Production" is the
+    /// explicit wholesale choice.
+    func applyBackendEnvironment(_ value: AccountBackendEnvironmentSelection) async {
         guard let backendEnvironmentSwitchController else { return }
         await backendEnvironmentSwitchController.switchEnvironment(
-            to: Self.backendEnvironmentOverride(from: value)
+            to: hostSelection(from: value)
         )
+    }
+
+    /// Map the package's picker option to the host selection the transaction
+    /// runs on. See ``applyBackendEnvironment(_:)`` for the production-lane
+    /// "Production"→lane rule.
+    private func hostSelection(
+        from value: AccountBackendEnvironmentSelection
+    ) -> CMUXBackendEnvironmentSelection {
+        let lane = CMUXBackendEnvironmentSelection.lane(
+            resolves: hostBackendEnvironmentBuildLane.resolvedEnvironment
+        )
+        switch value {
+        case .buildLane:
+            return lane
+        case .production:
+            return hostBackendEnvironmentBuildLane == .production ? lane : .explicit(.production)
+        case .staging:
+            return .explicit(.staging)
+        }
     }
 
     func resetBackendEnvironmentSwitchPhase() {
@@ -415,39 +468,32 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
     /// Adopt the freshly built auth graph after a live backend-environment
     /// switch, keeping this flow object (and everything observing it) alive.
     /// Re-reads the persisted selection so active and pending converge on
-    /// the committed override.
+    /// the committed choice.
     func rebind(
         coordinator: AuthCoordinator,
         browserSignIn: HostBrowserSignInFlow,
-        activeBackendEnvironmentOverride: CMUXBackendEnvironmentOverride
+        activeBackendEnvironmentSelection: CMUXBackendEnvironmentSelection,
+        backendEnvironmentBuildLane: CMUXBackendEnvironmentBuildLane
     ) {
         self.coordinator = coordinator
         self.browserSignIn = browserSignIn
-        self.activeBackendEnvironmentOverride = activeBackendEnvironmentOverride
-        pendingBackendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(
-            from: backendEnvironmentDefaults
+        self.activeBackendEnvironmentHostSelection = activeBackendEnvironmentSelection
+        self.hostBackendEnvironmentBuildLane = backendEnvironmentBuildLane
+        pendingBackendEnvironmentSelection = Self.persistedSelection(
+            in: backendEnvironmentDefaults,
+            lane: backendEnvironmentBuildLane
         )
     }
 
-    /// Tagged dev builds bake `CMUX_*` origins into their LSEnvironment via
-    /// `scripts/reload.sh`; those explicit env layers outrank the persisted
-    /// override everywhere in `AuthEnvironment`, so the Settings card shows
-    /// a "pinned" note instead of pretending the picker applies. Computed in
-    /// the host because the package deliberately never reads ProcessInfo.
-    nonisolated static func launchEnvironmentPinsBackendEnvironment(
-        _ environment: [String: String]
-    ) -> Bool {
-        let pinningKeys = [
-            "CMUX_WWW_ORIGIN",
-            "CMUX_API_BASE_URL",
-            "CMUX_AUTH_ENVIRONMENT",
-            "CMUX_VM_API_BASE_URL",
-        ]
-        return pinningKeys.contains { key in
-            guard let value = environment[key]?
-                .trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
-            return !value.isEmpty
-        }
+    /// The selection the defaults currently persist: an explicit choice when
+    /// the tri-state key holds a recognized value, otherwise the lane.
+    private nonisolated static func persistedSelection(
+        in defaults: UserDefaults,
+        lane: CMUXBackendEnvironmentBuildLane
+    ) -> CMUXBackendEnvironmentSelection {
+        CMUXBackendEnvironmentOverride.explicitChoice(from: defaults)
+            .map { .explicit($0) }
+            ?? .lane(resolves: lane.resolvedEnvironment)
     }
 
     private static var isDebugBuild: Bool {
@@ -467,12 +513,23 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         }
     }
 
-    private static func backendEnvironmentOverride(
-        from value: AccountBackendEnvironment
-    ) -> CMUXBackendEnvironmentOverride {
-        switch value {
+    private static func accountSelection(
+        from selection: CMUXBackendEnvironmentSelection
+    ) -> AccountBackendEnvironmentSelection {
+        switch selection {
+        case .lane: .buildLane
+        case .explicit(.production): .production
+        case .explicit(.staging): .staging
+        }
+    }
+
+    private static func accountBuildLane(
+        from lane: CMUXBackendEnvironmentBuildLane
+    ) -> AccountBackendEnvironmentBuildLane {
+        switch lane {
         case .production: .production
         case .staging: .staging
+        case .custom(let label): .custom(label: label)
         }
     }
 

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -41,8 +41,12 @@ struct MacAuthComposition {
         let tokenStore: any StackAuthTokenStoreProtocol
         let browserSignIn: HostBrowserSignInFlow
         let browserAppSession: BrowserAppSessionController
-        /// The persisted backend override this pass resolved against.
-        let backendEnvironmentOverride: CMUXBackendEnvironmentOverride
+        /// The backend selection this pass resolved against: `.explicit`
+        /// when the wholesale choice key is persisted, `.lane` otherwise.
+        let backendEnvironmentSelection: CMUXBackendEnvironmentSelection
+        /// The build's own lane, classified from the launch environment with
+        /// the explicit choice ignored (a per-process constant).
+        let backendEnvironmentBuildLane: CMUXBackendEnvironmentBuildLane
     }
 
     /// Build the auth graph at app startup.
@@ -63,9 +67,8 @@ struct MacAuthComposition {
         let accountFlow = HostAccountFlow(
             coordinator: graph.coordinator,
             browserSignIn: graph.browserSignIn,
-            activeBackendEnvironmentOverride: graph.backendEnvironmentOverride,
-            backendEnvironmentPinnedByLaunchEnvironment:
-                HostAccountFlow.launchEnvironmentPinsBackendEnvironment(environment),
+            activeBackendEnvironmentSelection: graph.backendEnvironmentSelection,
+            backendEnvironmentBuildLane: graph.backendEnvironmentBuildLane,
             backendEnvironmentDefaults: defaults,
             confirmStagingSignOut: {
                 StagingSignOutConfirmationPresenter().confirmStagingSignOut()
@@ -105,7 +108,8 @@ struct MacAuthComposition {
         accountFlow.rebind(
             coordinator: graph.coordinator,
             browserSignIn: graph.browserSignIn,
-            activeBackendEnvironmentOverride: graph.backendEnvironmentOverride
+            activeBackendEnvironmentSelection: graph.backendEnvironmentSelection,
+            backendEnvironmentBuildLane: graph.backendEnvironmentBuildLane
         )
     }
 
@@ -120,11 +124,9 @@ struct MacAuthComposition {
     ) -> MacBackendEnvironmentSwitchController {
         MacBackendEnvironmentSwitchController(
             steps: BackendEnvironmentSwitchTransaction.Steps(
-                isPinnedByBuild: { [weak accountFlow] in
-                    accountFlow?.backendEnvironmentPinnedByLaunchEnvironment ?? true
-                },
-                activeEnvironment: { [weak accountFlow] in
-                    accountFlow?.activeBackendEnvironmentOverride ?? .production
+                activeSelection: { [weak accountFlow] in
+                    accountFlow?.activeBackendEnvironmentHostSelection
+                        ?? .lane(resolves: .production)
                 },
                 parkSession: { [weak accountFlow] in
                     // Park under the OLD defaults: HostBrowserSignInFlow
@@ -142,12 +144,22 @@ struct MacAuthComposition {
                     // AppDelegate.adoptRebuiltAuth(_:) after the rebuild.
                     MobileHostService.shared.stop()
                 },
-                storeOverride: { override in
-                    override.store(in: defaults)
-                    // EVERY committed override (including a revert's) arms the
-                    // one-shot suppression so the immediate rebuild — or the
-                    // next launch after a crash — restores the target's PARKED
-                    // slot instead of running the organic project-flip clear.
+                storeSelection: { selection in
+                    // The commit point: an explicit choice persists its raw
+                    // value (production included — tri-state), a lane target
+                    // clears the key so the build's own bake resolves again.
+                    switch selection {
+                    case .explicit(let choice):
+                        choice.storeChoice(in: defaults)
+                    case .lane:
+                        CMUXBackendEnvironmentOverride.clearChoice(in: defaults)
+                    }
+                    // EVERY committed selection (including a revert's, and
+                    // lane clears — a lane↔explicit flip can change the Stack
+                    // project too) arms the one-shot suppression so the
+                    // immediate rebuild — or the next launch after a crash —
+                    // restores the target's PARKED slot instead of running
+                    // the organic project-flip clear.
                     CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: defaults)
                 },
                 rebuild: { [weak accountFlow] _ in
@@ -187,32 +199,43 @@ struct MacAuthComposition {
         )
     }
 
-    /// One environment-frozen build pass over the persisted override.
+    /// One environment-frozen build pass over the persisted selection.
     private static func buildGraph(
         environment: [String: String],
         defaults: UserDefaults
     ) -> Graph {
         let bundleIdentifier = Bundle.main.bundleIdentifier
-        // The persisted backend override resolves ONCE per build pass (at
-        // startup, and again when the live switch rebuilds the graph), and
-        // replaces only the build-default layer: explicit env (including the
-        // LSEnvironment values tagged dev builds bake in) still wins inside
-        // every resolved* function.
-        let backendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(from: defaults)
+        // The persisted explicit choice resolves ONCE per build pass (at
+        // startup, and again when the live switch rebuilds the graph). A
+        // choice is a WHOLESALE override — it beats explicit env, including
+        // the LSEnvironment values tagged dev builds bake in — while an
+        // absent key keeps the build's own lane byte-identical to the
+        // pre-choice behavior.
+        let explicitChoice = CMUXBackendEnvironmentOverride.explicitChoice(from: defaults)
+        // The lane classifies with the choice IGNORED: it is the stable
+        // "what this build is baked to" descriptor powering the picker's
+        // "Build lane (…)" option and the return-to-lane sign-out chain.
+        let backendEnvironmentBuildLane = AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: environment,
+            isDebugBuild: Self.isDebugBuild
+        )
+        let backendEnvironmentSelection: CMUXBackendEnvironmentSelection =
+            explicitChoice.map { .explicit($0) }
+                ?? .lane(resolves: backendEnvironmentBuildLane.resolvedEnvironment)
         let resolvedAuthEnvironment = AuthEnvironment.resolvedStackAuthEnvironment(
             environment: environment,
             isDebugBuild: Self.isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: explicitChoice
         )
         let stackProjectID = AuthEnvironment.resolvedStackProjectID(
             environment: environment,
             isDebugBuild: Self.isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: explicitChoice
         )
         let stackPublishableClientKey = AuthEnvironment.resolvedStackPublishableClientKey(
             environment: environment,
             isDebugBuild: Self.isDebugBuild,
-            override: backendEnvironmentOverride
+            explicitChoice: explicitChoice
         )
         // Per-project token slots: keying the stores by the resolved Stack
         // project lets a live backend-environment switch PARK the old
@@ -380,7 +403,8 @@ struct MacAuthComposition {
             tokenStore: tokenStore,
             browserSignIn: browserSignIn,
             browserAppSession: browserAppSession,
-            backendEnvironmentOverride: backendEnvironmentOverride
+            backendEnvironmentSelection: backendEnvironmentSelection,
+            backendEnvironmentBuildLane: backendEnvironmentBuildLane
         )
     }
 
@@ -420,7 +444,7 @@ struct MacAuthComposition {
 
     /// Keep cached identities and Stack tokens from crossing projects when one
     /// tagged Debug bundle is rebuilt with `--prod-auth`, or switched back.
-    /// The persisted backend environment override flows through the same
+    /// The persisted explicit backend environment choice flows through the same
     /// check: flipping production<->staging flips the resolved Stack project
     /// id, so the next launch wipes the stale session automatically.
     nonisolated static func detectAuthProjectSwitch(

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -37,17 +37,25 @@ struct MacAuthComposition {
         defaults: UserDefaults = .standard
     ) {
         let bundleIdentifier = Bundle.main.bundleIdentifier
+        // The persisted backend override resolves ONCE, here at startup, and
+        // replaces only the build-default layer: explicit env (including the
+        // LSEnvironment values tagged dev builds bake in) still wins inside
+        // every resolved* function.
+        let backendEnvironmentOverride = CMUXBackendEnvironmentOverride.load(from: defaults)
         let resolvedAuthEnvironment = AuthEnvironment.resolvedStackAuthEnvironment(
             environment: environment,
-            isDebugBuild: Self.isDebugBuild
+            isDebugBuild: Self.isDebugBuild,
+            override: backendEnvironmentOverride
         )
         let stackProjectID = AuthEnvironment.resolvedStackProjectID(
             environment: environment,
-            isDebugBuild: Self.isDebugBuild
+            isDebugBuild: Self.isDebugBuild,
+            override: backendEnvironmentOverride
         )
         let stackPublishableClientKey = AuthEnvironment.resolvedStackPublishableClientKey(
             environment: environment,
-            isDebugBuild: Self.isDebugBuild
+            isDebugBuild: Self.isDebugBuild,
+            override: backendEnvironmentOverride
         )
         let tokenStore = FallbackTokenStore(
             primary: KeychainStackTokenStore(
@@ -193,7 +201,11 @@ struct MacAuthComposition {
         self.browserSignIn = browserSignIn
         self.accountFlow = HostAccountFlow(
             coordinator: coordinator,
-            browserSignIn: browserSignIn
+            browserSignIn: browserSignIn,
+            activeBackendEnvironmentOverride: backendEnvironmentOverride,
+            backendEnvironmentPinnedByLaunchEnvironment:
+                HostAccountFlow.launchEnvironmentPinsBackendEnvironment(environment),
+            backendEnvironmentDefaults: defaults
         )
     }
 
@@ -233,6 +245,9 @@ struct MacAuthComposition {
 
     /// Keep cached identities and Stack tokens from crossing projects when one
     /// tagged Debug bundle is rebuilt with `--prod-auth`, or switched back.
+    /// The persisted backend environment override flows through the same
+    /// check: flipping production<->staging flips the resolved Stack project
+    /// id, so the next launch wipes the stale session automatically.
     nonisolated static func detectAuthProjectSwitch(
         resolvedProjectID: String,
         buildDefaultProjectID: String,

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -66,7 +66,10 @@ struct MacAuthComposition {
             activeBackendEnvironmentOverride: graph.backendEnvironmentOverride,
             backendEnvironmentPinnedByLaunchEnvironment:
                 HostAccountFlow.launchEnvironmentPinsBackendEnvironment(environment),
-            backendEnvironmentDefaults: defaults
+            backendEnvironmentDefaults: defaults,
+            confirmStagingSignOut: {
+                StagingSignOutConfirmationPresenter().confirmStagingSignOut()
+            }
         )
         self.accountFlow = accountFlow
         accountFlow.attachBackendEnvironmentSwitchController(
@@ -123,13 +126,14 @@ struct MacAuthComposition {
                 activeEnvironment: { [weak accountFlow] in
                     accountFlow?.activeBackendEnvironmentOverride ?? .production
                 },
-                signOut: { [weak accountFlow] in
-                    // The complete existing teardown chain, under the OLD
-                    // defaults: HostBrowserSignInFlow.signOut() (cancels
-                    // in-flight sign-in attempts, clears the cmux web
-                    // session, revokes the iroh binding) plus the flow's
-                    // Pro-state reset.
-                    await accountFlow?.signOut()
+                parkSession: { [weak accountFlow] in
+                    // Park under the OLD defaults: HostBrowserSignInFlow
+                    // .parkSession() (cancels in-flight sign-in attempts,
+                    // clears the cmux web session, detaches the coordinator
+                    // session while its token slot survives — NO revocation,
+                    // NO iroh binding teardown) plus the flow's Pro-state
+                    // reset.
+                    await accountFlow?.parkSession()
                 },
                 quiesce: {
                     // Stop mobile RPC (listener + iroh + caller verification)
@@ -140,6 +144,11 @@ struct MacAuthComposition {
                 },
                 storeOverride: { override in
                     override.store(in: defaults)
+                    // EVERY committed override (including a revert's) arms the
+                    // one-shot suppression so the immediate rebuild — or the
+                    // next launch after a crash — restores the target's PARKED
+                    // slot instead of running the organic project-flip clear.
+                    CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: defaults)
                 },
                 rebuild: { [weak accountFlow] _ in
                     guard let accountFlow, let appDelegate = AppDelegate.shared else { return }
@@ -150,6 +159,29 @@ struct MacAuthComposition {
                             defaults: defaults
                         )
                     )
+                },
+                awaitRestoredUser: { [weak accountFlow] in
+                    // Resolves the CURRENT (rebound) coordinator's launch
+                    // restore of the target's parked slot.
+                    await accountFlow?.awaitRestoredUser()
+                },
+                promptSignIn: { [weak accountFlow] in
+                    await accountFlow?.promptSignInForBackendSwitch()
+                },
+                cancelSignInPrompt: { [weak accountFlow] in
+                    accountFlow?.cancelBackendSwitchSignInPrompt()
+                },
+                signOutEstablishedSession: { [weak accountFlow] in
+                    // The REAL sign-out chain under the CURRENT (target)
+                    // defaults, through the internal direct path that
+                    // bypasses the staging sign-out confirmation.
+                    await accountFlow?.signOutDirect()
+                },
+                isEligible: { user in
+                    CMUXBackendEnvironmentSwitchGate.allows(user) || Self.isDebugBuild
+                },
+                signInPromptFailure: { [weak accountFlow] in
+                    accountFlow?.backendSwitchSignInPromptFailure() ?? .failed
                 }
             )
         )
@@ -182,11 +214,20 @@ struct MacAuthComposition {
             isDebugBuild: Self.isDebugBuild,
             override: backendEnvironmentOverride
         )
+        // Per-project token slots: keying the stores by the resolved Stack
+        // project lets a live backend-environment switch PARK the old
+        // environment's session (its slot survives untouched) and restore it
+        // on return. Each store adopts the pre-per-project single slot on
+        // first read.
         let tokenStore = FallbackTokenStore(
             primary: KeychainStackTokenStore(
-                service: KeychainStackTokenStore.serviceName(bundleIdentifier: bundleIdentifier)
+                service: KeychainStackTokenStore.serviceName(bundleIdentifier: bundleIdentifier),
+                projectID: stackProjectID
             ),
-            fallback: FileStackTokenStore(directory: Self.credentialsDirectory(bundleIdentifier: bundleIdentifier))
+            fallback: FileStackTokenStore(
+                directory: Self.credentialsDirectory(bundleIdentifier: bundleIdentifier),
+                projectID: stackProjectID
+            )
         )
 
         let userCache = CMUXAuthIdentityStore(
@@ -238,6 +279,11 @@ struct MacAuthComposition {
         // existing `CMUXAuthAutoLoginCredentials` + `shouldStartAutoLogin` gate
         // then fires unchanged. Compiled out of release builds.
         let resolvedEnvironment = Self.environmentWithDogfoodAutoSignIn(environment)
+        // detectAuthProjectSwitch must RUN unconditionally (it updates the
+        // stored project id); the switch-rebuild marker only suppresses its
+        // verdict. A backend-environment switch parks the old session and
+        // must restore the target's parked slot, while an organic project
+        // flip (rebaked tagged build) keeps today's pinned clear semantics.
         let authProjectSwitched = Self.detectAuthProjectSwitch(
             resolvedProjectID: stackProjectID,
             buildDefaultProjectID: AuthEnvironment.resolvedStackProjectID(
@@ -246,6 +292,8 @@ struct MacAuthComposition {
             ),
             defaults: defaults
         )
+        let switchRebuildSuppressesClear =
+            CMUXBackendEnvironmentSwitchRebuildMarker.consume(from: defaults)
         let includesDevAuth = Self.includesDevAuth(
             resolvedAuthEnvironment: resolvedAuthEnvironment
         )
@@ -256,7 +304,7 @@ struct MacAuthComposition {
             mockDataEnabled: false,
             environment: resolvedEnvironment,
             includesDevAuth: includesDevAuth,
-            clearStaleAuthOnLaunch: authProjectSwitched,
+            clearStaleAuthOnLaunch: authProjectSwitched && !switchRebuildSuppressesClear,
             replaceStoredSessionWithAutoLogin: replacesStoredDevSession
         )
 
@@ -308,6 +356,13 @@ struct MacAuthComposition {
             beginSignOut: {
                 browserAppSession.beginAuthTransition()
                 MobileHostIrohRuntime.shared.beginSignOutPreparation()
+            },
+            // Park (backend-environment switch) clears the browser session
+            // like sign-out but must NOT touch iroh: beginSignOutPreparation
+            // durably queues a binding revocation, which would kill the
+            // parked environment's pairing.
+            beginSessionPark: {
+                browserAppSession.beginAuthTransition()
             },
             localSignOut: {
                 await browserAppSession.clearCmuxWebSession()

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -6,12 +6,17 @@ import StackAuth
 
 /// The macOS auth composition root.
 ///
-/// Constructs the de-singletonized auth graph once at app startup, mirroring
-/// the iOS `MobileAuthComposition`: the keychain/file fallback token store, a
+/// Constructs the de-singletonized auth graph, mirroring the iOS
+/// `MobileAuthComposition`: the keychain/file fallback token store, a
 /// `StackClientApp` over it (wrapped in ``CmuxAuthRuntime/StackAuthClient``),
 /// the shared ``CmuxAuthRuntime/AuthCoordinator`` bound to the historical mac
 /// defaults keys, and the ``HostBrowserSignInFlow``. Replaces
 /// `AuthManager.shared`.
+///
+/// Built once at app startup, and rebuilt in-process by the live
+/// backend-environment switch through ``init(rebinding:environment:defaults:)``,
+/// which reuses the existing ``HostAccountFlow`` and hands the fresh graph to
+/// `AppDelegate.adoptRebuiltAuth(_:)`.
 @MainActor
 struct MacAuthComposition {
     /// The shared auth orchestrator (session state, tokens, teams).
@@ -27,7 +32,20 @@ struct MacAuthComposition {
     /// Shared observable account projection used by Settings and sidebar UI.
     let accountFlow: HostAccountFlow
 
-    /// Build the auth graph.
+    /// The environment-frozen pieces one build pass produces. Shared by the
+    /// startup initializer and the live-switch rebinding initializer so the
+    /// graph is constructed identically both times.
+    private struct Graph {
+        let coordinator: AuthCoordinator
+        let callbackRouter: AuthCallbackRouter
+        let tokenStore: any StackAuthTokenStoreProtocol
+        let browserSignIn: HostBrowserSignInFlow
+        let browserAppSession: BrowserAppSessionController
+        /// The persisted backend override this pass resolved against.
+        let backendEnvironmentOverride: CMUXBackendEnvironmentOverride
+    }
+
+    /// Build the auth graph at app startup.
     /// - Parameters:
     ///   - environment: The process environment (UI-test launch options).
     ///   - defaults: Persistence for the cached user / has-tokens flag /
@@ -36,8 +54,115 @@ struct MacAuthComposition {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard
     ) {
+        let graph = Self.buildGraph(environment: environment, defaults: defaults)
+        coordinator = graph.coordinator
+        callbackRouter = graph.callbackRouter
+        tokenStore = graph.tokenStore
+        browserSignIn = graph.browserSignIn
+        browserAppSession = graph.browserAppSession
+        let accountFlow = HostAccountFlow(
+            coordinator: graph.coordinator,
+            browserSignIn: graph.browserSignIn,
+            activeBackendEnvironmentOverride: graph.backendEnvironmentOverride,
+            backendEnvironmentPinnedByLaunchEnvironment:
+                HostAccountFlow.launchEnvironmentPinsBackendEnvironment(environment),
+            backendEnvironmentDefaults: defaults
+        )
+        self.accountFlow = accountFlow
+        accountFlow.attachBackendEnvironmentSwitchController(
+            Self.makeBackendEnvironmentSwitchController(
+                accountFlow: accountFlow,
+                environment: environment,
+                defaults: defaults
+            )
+        )
+    }
+
+    /// Build a fresh auth graph for the (already committed) new backend
+    /// environment and rebind the existing ``HostAccountFlow`` to it, instead
+    /// of constructing a new flow. Used by the live backend-environment
+    /// switch: the flow object, its attached switch controller, and every
+    /// Settings view observing it survive; only the environment-frozen graph
+    /// underneath is replaced. The fresh ``AuthLaunchOptions`` re-run
+    /// ``detectAuthProjectSwitch(resolvedProjectID:buildDefaultProjectID:defaults:)``,
+    /// so a project flip primes `clearStaleAuthOnLaunch` on the new
+    /// coordinator's `start()`.
+    init(
+        rebinding accountFlow: HostAccountFlow,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard
+    ) {
+        let graph = Self.buildGraph(environment: environment, defaults: defaults)
+        coordinator = graph.coordinator
+        callbackRouter = graph.callbackRouter
+        tokenStore = graph.tokenStore
+        browserSignIn = graph.browserSignIn
+        browserAppSession = graph.browserAppSession
+        self.accountFlow = accountFlow
+        accountFlow.rebind(
+            coordinator: graph.coordinator,
+            browserSignIn: graph.browserSignIn,
+            activeBackendEnvironmentOverride: graph.backendEnvironmentOverride
+        )
+    }
+
+    /// The production step wiring for the live backend-environment switch.
+    /// Every closure resolves the flow's CURRENT graph at run time (weakly,
+    /// so the controller the flow owns never retains the flow back), which
+    /// keeps a second switch correct after the first rebind.
+    private static func makeBackendEnvironmentSwitchController(
+        accountFlow: HostAccountFlow,
+        environment: [String: String],
+        defaults: UserDefaults
+    ) -> MacBackendEnvironmentSwitchController {
+        MacBackendEnvironmentSwitchController(
+            steps: BackendEnvironmentSwitchTransaction.Steps(
+                isPinnedByBuild: { [weak accountFlow] in
+                    accountFlow?.backendEnvironmentPinnedByLaunchEnvironment ?? true
+                },
+                activeEnvironment: { [weak accountFlow] in
+                    accountFlow?.activeBackendEnvironmentOverride ?? .production
+                },
+                signOut: { [weak accountFlow] in
+                    // The complete existing teardown chain, under the OLD
+                    // defaults: HostBrowserSignInFlow.signOut() (cancels
+                    // in-flight sign-in attempts, clears the cmux web
+                    // session, revokes the iroh binding) plus the flow's
+                    // Pro-state reset.
+                    await accountFlow?.signOut()
+                },
+                quiesce: {
+                    // Stop mobile RPC (listener + iroh + caller verification)
+                    // so nothing verifies tokens against flipped defaults
+                    // while the old coordinator still lives. Restarted by
+                    // AppDelegate.adoptRebuiltAuth(_:) after the rebuild.
+                    MobileHostService.shared.stop()
+                },
+                storeOverride: { override in
+                    override.store(in: defaults)
+                },
+                rebuild: { [weak accountFlow] _ in
+                    guard let accountFlow, let appDelegate = AppDelegate.shared else { return }
+                    appDelegate.adoptRebuiltAuth(
+                        MacAuthComposition(
+                            rebinding: accountFlow,
+                            environment: environment,
+                            defaults: defaults
+                        )
+                    )
+                }
+            )
+        )
+    }
+
+    /// One environment-frozen build pass over the persisted override.
+    private static func buildGraph(
+        environment: [String: String],
+        defaults: UserDefaults
+    ) -> Graph {
         let bundleIdentifier = Bundle.main.bundleIdentifier
-        // The persisted backend override resolves ONCE, here at startup, and
+        // The persisted backend override resolves ONCE per build pass (at
+        // startup, and again when the live switch rebuilds the graph), and
         // replaces only the build-default layer: explicit env (including the
         // LSEnvironment values tagged dev builds bake in) still wins inside
         // every resolved* function.
@@ -63,7 +188,6 @@ struct MacAuthComposition {
             ),
             fallback: FileStackTokenStore(directory: Self.credentialsDirectory(bundleIdentifier: bundleIdentifier))
         )
-        self.tokenStore = tokenStore
 
         let userCache = CMUXAuthIdentityStore(
             keyValueStore: defaults,
@@ -156,14 +280,12 @@ struct MacAuthComposition {
                 await browserAppSessionSignInRelay.signedIn()
             }
         )
-        self.coordinator = coordinator
         let browserAppSession = BrowserAppSessionController(
             coordinator: coordinator,
             webOrigin: AuthEnvironment.appSessionHandoffOrigin,
             projectID: stackProjectID,
             defaults: defaults
         )
-        self.browserAppSession = browserAppSession
         browserAppSessionSignInRelay.bind(
             beginTransition: { [weak browserAppSession] in
                 browserAppSession?.beginAuthTransition()
@@ -175,7 +297,6 @@ struct MacAuthComposition {
         let callbackRouter = AuthCallbackRouter(
             extraAllowedScheme: AuthEnvironment.callbackScheme
         )
-        self.callbackRouter = callbackRouter
         let browserSignIn = HostBrowserSignInFlow(
             coordinator: coordinator,
             tokenStore: tokenStore,
@@ -198,14 +319,13 @@ struct MacAuthComposition {
                 )
             }
         )
-        self.browserSignIn = browserSignIn
-        self.accountFlow = HostAccountFlow(
+        return Graph(
             coordinator: coordinator,
+            callbackRouter: callbackRouter,
+            tokenStore: tokenStore,
             browserSignIn: browserSignIn,
-            activeBackendEnvironmentOverride: backendEnvironmentOverride,
-            backendEnvironmentPinnedByLaunchEnvironment:
-                HostAccountFlow.launchEnvironmentPinsBackendEnvironment(environment),
-            backendEnvironmentDefaults: defaults
+            browserAppSession: browserAppSession,
+            backendEnvironmentOverride: backendEnvironmentOverride
         )
     }
 

--- a/Sources/Auth/MacBackendEnvironmentSwitchController.swift
+++ b/Sources/Auth/MacBackendEnvironmentSwitchController.swift
@@ -1,0 +1,66 @@
+import CMUXAuthCore
+import CmuxAuthRuntime
+import Foundation
+import Observation
+
+/// Drives the live macOS backend-environment switch from the Settings card.
+///
+/// Owned by ``HostAccountFlow`` (constructed once in ``MacAuthComposition``'s
+/// startup initializer and kept stable across switches, since the flow itself
+/// survives the rebuild). The controller owns the shared
+/// ``CmuxAuthRuntime/BackendEnvironmentSwitchTransaction`` and takes the
+/// macOS steps as an injected
+/// ``CmuxAuthRuntime/BackendEnvironmentSwitchTransaction/Steps`` value, so
+/// tests can run it against pure fakes without AppKit. The production steps
+/// (built in ``MacAuthComposition``) are:
+///
+/// - `signOut` runs the complete existing teardown chain under the OLD
+///   defaults (``HostAccountFlow/signOut()`` →
+///   `HostBrowserSignInFlow.signOut()`, which also cancels in-flight sign-in
+///   attempts).
+/// - `quiesce` stops `MobileHostService` so mobile RPC caller verification
+///   (which builds ephemeral `StackClientApp`s from per-use `AuthEnvironment`
+///   reads) cannot run against flipped defaults while the old coordinator
+///   still lives. Other per-use `AuthEnvironment` readers (`VMClient`,
+///   `RemotesClient`, billing fetches, …) are token-less after the sign-out
+///   step and fail closed, so they need no quiesce of their own.
+/// - `storeOverride` persists the override (the commit point); per-use
+///   resolvers (and `PresenceHeartbeatClient`, which self-restarts on
+///   `UserDefaults.didChangeNotification`) flip here.
+/// - `rebuild` constructs the fresh auth graph for the new environment and
+///   hands it to `AppDelegate.adoptRebuiltAuth(_:)`, which restarts
+///   `MobileHostService` and ends the quiesce window.
+@MainActor
+@Observable
+final class MacBackendEnvironmentSwitchController {
+    private let transaction = BackendEnvironmentSwitchTransaction()
+    @ObservationIgnored private let steps: BackendEnvironmentSwitchTransaction.Steps
+    /// Whether a switch call is currently in flight. `HostAccountFlow` ORs
+    /// this into `isWorkingOnAuth` so every account/auth entrypoint disables
+    /// for the whole window, including the brief spans before the transaction
+    /// publishes `.signingOut` and after it publishes `.finished`.
+    private(set) var isSwitching = false
+
+    /// The transaction's phase; drives the Settings progress UI.
+    var phase: BackendEnvironmentSwitchTransaction.Phase {
+        transaction.phase
+    }
+
+    init(steps: BackendEnvironmentSwitchTransaction.Steps) {
+        self.steps = steps
+    }
+
+    /// Run one live switch to `target`. Joins an already-active transaction
+    /// run; refuses pinned builds and no-op targets (the transaction owns
+    /// those guards).
+    func switchEnvironment(to target: CMUXBackendEnvironmentOverride) async {
+        isSwitching = true
+        defer { isSwitching = false }
+        await transaction.run(to: target, steps: steps)
+    }
+
+    /// Returns the phase to `.idle` after the UI has shown the switched note.
+    func reset() {
+        transaction.reset()
+    }
+}

--- a/Sources/Auth/MacBackendEnvironmentSwitchController.swift
+++ b/Sources/Auth/MacBackendEnvironmentSwitchController.swift
@@ -24,10 +24,12 @@ import Observation
 ///   still lives. Other per-use `AuthEnvironment` readers (`VMClient`,
 ///   `RemotesClient`, billing fetches, …) are token-less after the park
 ///   step and fail closed, so they need no quiesce of their own.
-/// - `storeOverride` persists the override (the commit point; per-use
+/// - `storeSelection` persists the selection (the commit point; per-use
 ///   resolvers and `PresenceHeartbeatClient`, which self-restarts on
-///   `UserDefaults.didChangeNotification`, flip here) and arms the one-shot
-///   rebuild marker so the rebuild restores the target's parked slot.
+///   `UserDefaults.didChangeNotification`, flip here): an explicit choice
+///   writes the tri-state key, a lane target clears it, and both arm the
+///   one-shot rebuild marker so the rebuild restores the target's parked
+///   slot.
 /// - `rebuild` constructs the fresh auth graph for the new environment and
 ///   hands it to `AppDelegate.adoptRebuiltAuth(_:)`, which restarts
 ///   `MobileHostService` and ends the quiesce window.
@@ -58,9 +60,9 @@ final class MacBackendEnvironmentSwitchController {
     }
 
     /// Run one live switch to `target`. Joins an already-active transaction
-    /// run; refuses pinned builds and no-op targets (the transaction owns
-    /// those guards).
-    func switchEnvironment(to target: CMUXBackendEnvironmentOverride) async {
+    /// run; refuses same-selection no-ops (the transaction owns that guard —
+    /// selection identity, so lane(staging) → explicit(staging) still runs).
+    func switchEnvironment(to target: CMUXBackendEnvironmentSelection) async {
         isSwitching = true
         defer { isSwitching = false }
         await transaction.run(to: target, steps: steps)

--- a/Sources/Auth/MacBackendEnvironmentSwitchController.swift
+++ b/Sources/Auth/MacBackendEnvironmentSwitchController.swift
@@ -14,22 +14,29 @@ import Observation
 /// tests can run it against pure fakes without AppKit. The production steps
 /// (built in ``MacAuthComposition``) are:
 ///
-/// - `signOut` runs the complete existing teardown chain under the OLD
-///   defaults (``HostAccountFlow/signOut()`` →
-///   `HostBrowserSignInFlow.signOut()`, which also cancels in-flight sign-in
-///   attempts).
+/// - `parkSession` detaches the session under the OLD defaults
+///   (``HostAccountFlow/parkSession()`` → `HostBrowserSignInFlow.parkSession()`,
+///   which also cancels in-flight sign-in attempts) while its token slot
+///   survives for the return switch. No revocation, no iroh teardown.
 /// - `quiesce` stops `MobileHostService` so mobile RPC caller verification
 ///   (which builds ephemeral `StackClientApp`s from per-use `AuthEnvironment`
 ///   reads) cannot run against flipped defaults while the old coordinator
 ///   still lives. Other per-use `AuthEnvironment` readers (`VMClient`,
-///   `RemotesClient`, billing fetches, …) are token-less after the sign-out
+///   `RemotesClient`, billing fetches, …) are token-less after the park
 ///   step and fail closed, so they need no quiesce of their own.
-/// - `storeOverride` persists the override (the commit point); per-use
-///   resolvers (and `PresenceHeartbeatClient`, which self-restarts on
-///   `UserDefaults.didChangeNotification`) flip here.
+/// - `storeOverride` persists the override (the commit point; per-use
+///   resolvers and `PresenceHeartbeatClient`, which self-restarts on
+///   `UserDefaults.didChangeNotification`, flip here) and arms the one-shot
+///   rebuild marker so the rebuild restores the target's parked slot.
 /// - `rebuild` constructs the fresh auth graph for the new environment and
 ///   hands it to `AppDelegate.adoptRebuiltAuth(_:)`, which restarts
 ///   `MobileHostService` and ends the quiesce window.
+/// - `awaitRestoredUser` / `promptSignIn` / `cancelSignInPrompt` /
+///   `signOutEstablishedSession` / `isEligible` / `signInPromptFailure`
+///   drive the establishing phase through ``HostAccountFlow``: restore the
+///   target's parked session, gate staging on an eligible account with an
+///   inline hosted-browser sign-in, and revert on cancel / failure /
+///   ineligibility.
 @MainActor
 @Observable
 final class MacBackendEnvironmentSwitchController {
@@ -59,7 +66,14 @@ final class MacBackendEnvironmentSwitchController {
         await transaction.run(to: target, steps: steps)
     }
 
-    /// Returns the phase to `.idle` after the UI has shown the switched note.
+    /// Request that an in-flight switch revert to the previous environment
+    /// (valid during the establishing sign-in wait; resolves the prompt as
+    /// cancelled).
+    func requestRevert() {
+        transaction.requestRevert()
+    }
+
+    /// Returns the phase to `.idle` after the UI has shown the outcome note.
     func reset() {
         transaction.reset()
     }

--- a/Sources/Auth/StagingSignOutConfirmationPresenter.swift
+++ b/Sources/Auth/StagingSignOutConfirmationPresenter.swift
@@ -1,0 +1,37 @@
+import AppKit
+
+/// Presents the per-environment sign-out warning: signing out on a
+/// non-production environment returns this Mac to Production (restoring the
+/// parked Production session), so the user must confirm before the chain
+/// runs.
+///
+/// Injected into ``HostAccountFlow`` as its `confirmStagingSignOut` seam so
+/// the interception at the `signOut()` choke point is testable with a fake;
+/// this type is the production presenter. `NSAlert.runModal()` blocks the
+/// main run loop by design — the confirmation is intentionally modal, like
+/// every destructive-action alert in the app.
+@MainActor
+struct StagingSignOutConfirmationPresenter {
+    /// Present the alert and report whether the user confirmed.
+    func confirmStagingSignOut() -> Bool {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "settings.account.stagingSignOut.title",
+            defaultValue: "Sign out and return to Production?"
+        )
+        alert.informativeText = String(
+            localized: "settings.account.stagingSignOut.message",
+            defaultValue: "Signing out here signs you out of Staging and returns this Mac to Production, restoring your saved Production session."
+        )
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(
+            localized: "settings.account.stagingSignOut.confirm",
+            defaultValue: "Sign Out"
+        ))
+        alert.addButton(withTitle: String(
+            localized: "settings.account.stagingSignOut.cancel",
+            defaultValue: "Cancel"
+        ))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}

--- a/Sources/Cloud/PresenceHeartbeatClient.swift
+++ b/Sources/Cloud/PresenceHeartbeatClient.swift
@@ -105,15 +105,27 @@ final class PresenceHeartbeatClient {
         PresenceSettings.isEnabled()
     }
 
-    /// Resolved service base URL: env override first (dev/tagged builds), then
-    /// the defaults key, then the build default (dev worker for Debug builds
-    /// and for Release builds running under the persisted staging backend
-    /// override, production worker otherwise). Nil disables the client
+    /// Resolved service base URL: the persisted EXPLICIT backend choice
+    /// first (a wholesale head above the env override and the defaults-key
+    /// tuning knob, so a leftover per-build presence pin cannot outlive an
+    /// environment switch — the worker must be the one that verifies the
+    /// chosen Stack project's tokens), then env (dev/tagged builds), then
+    /// the defaults key, then the build default (dev worker for Debug
+    /// builds, production worker for Release). Nil disables the client
     /// entirely.
     static func resolvedServiceURL(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard
     ) -> URL? {
+        if let choice = CMUXBackendEnvironmentOverride.explicitChoice(from: defaults) {
+            // Explicit staging signs into the dev Stack project, which only
+            // the dev/staging worker verifies; explicit production is the
+            // production worker.
+            let raw = choice == .staging
+                ? PresenceSettings.debugDefaultServiceURL
+                : PresenceSettings.productionServiceURL
+            return URL(string: raw)
+        }
         var raw = environment[PresenceSettings.serviceURLEnvKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             ?? defaults.string(forKey: PresenceSettings.serviceURLKey)?
@@ -124,12 +136,7 @@ final class PresenceHeartbeatClient {
             // what the dev/staging worker verifies — see PresenceSettings.
             raw = PresenceSettings.debugDefaultServiceURL
             #else
-            // A Release build switched to the staging backend signs into the
-            // dev Stack project, so only the dev/staging worker can verify its
-            // tokens; production Release builds keep the production worker.
-            raw = CMUXBackendEnvironmentOverride.load(from: defaults) == .staging
-                ? PresenceSettings.debugDefaultServiceURL
-                : PresenceSettings.productionServiceURL
+            raw = PresenceSettings.productionServiceURL
             #endif
         }
         guard let raw, !raw.isEmpty else { return nil }

--- a/Sources/Cloud/PresenceHeartbeatClient.swift
+++ b/Sources/Cloud/PresenceHeartbeatClient.swift
@@ -1,3 +1,4 @@
+import CMUXAuthCore
 import CMUXMobileCore
 import CmuxAuthRuntime
 import Foundation
@@ -105,8 +106,10 @@ final class PresenceHeartbeatClient {
     }
 
     /// Resolved service base URL: env override first (dev/tagged builds), then
-    /// the defaults key, then the Debug-build dev-instance default. Nil
-    /// disables the client entirely.
+    /// the defaults key, then the build default (dev worker for Debug builds
+    /// and for Release builds running under the persisted staging backend
+    /// override, production worker otherwise). Nil disables the client
+    /// entirely.
     static func resolvedServiceURL(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard
@@ -121,9 +124,12 @@ final class PresenceHeartbeatClient {
             // what the dev/staging worker verifies — see PresenceSettings.
             raw = PresenceSettings.debugDefaultServiceURL
             #else
-            // Release builds talk to the production presence worker, so stable
-            // cmux announces presence once mobile is enabled (gated by isEnabled).
-            raw = PresenceSettings.productionServiceURL
+            // A Release build switched to the staging backend signs into the
+            // dev Stack project, so only the dev/staging worker can verify its
+            // tokens; production Release builds keep the production worker.
+            raw = CMUXBackendEnvironmentOverride.load(from: defaults) == .staging
+                ? PresenceSettings.debugDefaultServiceURL
+                : PresenceSettings.productionServiceURL
             #endif
         }
         guard let raw, !raw.isEmpty else { return nil }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1414,12 +1414,20 @@ class TerminalController {
             return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: !signedIn))
         case "auth.sign_out":
             let semaphore = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var returnedToProduction = false
             Task { @MainActor [weak self] in
-                await self?.accountFlow?.signOut(timeout: 5)
+                // Non-interactive sign-out: skips the staging confirmation
+                // but chains the same return-to-production switch, so a
+                // socket sign-out can never strand the device on staging.
+                returnedToProduction = await self?.accountFlow?.signOut(timeout: 5) ?? false
                 semaphore.signal()
             }
             semaphore.wait()
-            return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: false))
+            var result = v2AuthStatusPayload(timedOut: false)
+            if returnedToProduction {
+                result["returned_to_production"] = true
+            }
+            return v2Ok(id: request.id, result: result)
         case "feedback.submit":
             return v2Result(id: request.id, v2FeedbackSubmit(params: request.params))
         case "feed.push":

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1414,18 +1414,24 @@ class TerminalController {
             return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: !signedIn))
         case "auth.sign_out":
             let semaphore = DispatchSemaphore(value: 0)
-            nonisolated(unsafe) var returnedToProduction = false
+            nonisolated(unsafe) var returnedToLane = false
             Task { @MainActor [weak self] in
                 // Non-interactive sign-out: skips the staging confirmation
-                // but chains the same return-to-production switch, so a
-                // socket sign-out can never strand the device on staging.
-                returnedToProduction = await self?.accountFlow?.signOut(timeout: 5) ?? false
+                // but chains the same return-to-lane switch, so a socket
+                // sign-out can never strand the device on explicit staging.
+                returnedToLane = await self?.accountFlow?.signOut(timeout: 5) ?? false
                 semaphore.signal()
             }
             semaphore.wait()
             var result = v2AuthStatusPayload(timedOut: false)
-            if returnedToProduction {
+            if returnedToLane {
+                // `returned_to_production` is the historical key, kept true
+                // whenever the chain ran so existing automation keeps
+                // working; `returned_to_lane` is the accurate name (the
+                // chain restores the build's own lane, which is production
+                // on unpinned Release builds).
                 result["returned_to_production"] = true
+                result["returned_to_lane"] = true
             }
             return v2Ok(id: request.id, result: result)
         case "feedback.submit":

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -54,6 +54,13 @@ struct cmuxApp: App {
     /// The de-singletonized auth graph (shared AuthCoordinator + the macOS
     /// hosted-browser sign-in flow). Constructed once at app launch and
     /// injected into AppDelegate and the auth-consuming services.
+    ///
+    /// Init-only wiring: after a live backend-environment switch,
+    /// `AppDelegate.adoptRebuiltAuth(_:)` replaces the graph and
+    /// `AppDelegate.auth` is the live handle. This stored copy is never read
+    /// again after `init`, so it deliberately keeps pointing at the launch
+    /// graph; the stable objects the UI holds (`accountFlow`,
+    /// `settingsRuntime`) are rebound in place by the switch.
     private let authComposition: MacAuthComposition
     @StateObject private var tabManager: TabManager
     @StateObject private var notificationStore: TerminalNotificationStore

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1313,6 +1313,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
+		A47E00010000000000000005 /* MacBackendEnvironmentSwitchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000006 /* MacBackendEnvironmentSwitchController.swift */; };
+		A47E00010000000000000003 /* MacBackendEnvironmentSwitchControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000004 /* MacBackendEnvironmentSwitchControllerTests.swift */; };
 		D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */; };
 		D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */; };
 		D1F0A00100000000000000C1 /* MacPairedMacBackupPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000C2 /* MacPairedMacBackupPublisher.swift */; };
@@ -4101,6 +4103,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
+		A47E00010000000000000006 /* MacBackendEnvironmentSwitchController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacBackendEnvironmentSwitchController.swift; sourceTree = "<group>"; };
+		A47E00010000000000000004 /* MacBackendEnvironmentSwitchControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBackendEnvironmentSwitchControllerTests.swift; sourceTree = "<group>"; };
 		D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupBody.swift; sourceTree = "<group>"; };
 		D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupOpWire.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000C2 /* MacPairedMacBackupPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupPublisher.swift; sourceTree = "<group>"; };
@@ -5748,6 +5752,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B5A5E5570000000000000002 /* BrowserAppSessionWeakReference.swift */,
 				DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */,
 				53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */,
+				A47E00010000000000000006 /* MacBackendEnvironmentSwitchController.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
 				A5C017000000000000000006 /* StackAccountAvatarView.swift */,
 			);
@@ -8472,6 +8477,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F33200000000000000000001 /* MobileSimulatorReaderAttachmentTests.swift */,
 				C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
+				A47E00010000000000000004 /* MacBackendEnvironmentSwitchControllerTests.swift */,
 				A7C0F0010000000000000001 /* MacPairedMacBackupPublisherScopeTests.swift */,
 				5E2701030000000000000002 /* MacSentryStartupPolicyTests.swift */,
 			);
@@ -9705,6 +9711,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
 				8561C0128561C0128561C012 /* KeyboardShortcutSettingsObserver.swift in Sources */,
 				53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */,
+				A47E00010000000000000005 /* MacBackendEnvironmentSwitchController.swift in Sources */,
 				D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */,
 				D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */,
 				D1F0A00100000000000000C1 /* MacPairedMacBackupPublisher.swift in Sources */,
@@ -11326,6 +11333,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8582A1000000000000000002 /* KimiResumeReviewRegressionTests.swift in Sources */,
 				87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */,
 				9492CAFE0000000000000002 /* LastTerminalChildExitRecoveryTests.swift in Sources */,
+				A47E00010000000000000003 /* MacBackendEnvironmentSwitchControllerTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,
 				5E2701030000000000000001 /* MacSentryStartupPolicyTests.swift in Sources */,
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1255,6 +1255,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		9520A0019520A0019520A001 /* HermesFirstClassSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
+		A47E00010000000000000009 /* HostAccountFlowSignOutInterceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E0001000000000000000A /* HostAccountFlowSignOutInterceptionTests.swift */; };
 		B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */; };
 		B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */; };
 		F17A00000000000000000002 /* HostLatencyTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A00000000000000000001 /* HostLatencyTrace.swift */; };
@@ -2191,6 +2192,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */; };
 		A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C017000000000000000006 /* StackAccountAvatarView.swift */; };
 		F20F85FC5900550685FA33AD /* StackAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A8BD195031FC4B82B4354297 /* StackAuth */; };
+		A47E00010000000000000007 /* StagingSignOutConfirmationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000008 /* StagingSignOutConfirmationPresenter.swift */; };
 		C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70500000000000000001 /* start-cmux-profiling */; };
 		D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B71010000000000000002 /* StartupBreadcrumbLog.swift */; };
 		C0DE70530000000000000002 /* submit-cmux-profile in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70530000000000000001 /* submit-cmux-profile */; };
@@ -4048,6 +4050,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesFirstClassSupportTests.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
+		A47E0001000000000000000A /* HostAccountFlowSignOutInterceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAccountFlowSignOutInterceptionTests.swift; sourceTree = "<group>"; };
 		B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/HostedInspectorDockControlScript.swift; sourceTree = "<group>"; };
 		B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorDockControlScriptTests.swift; sourceTree = "<group>"; };
 		F17A00000000000000000001 /* HostLatencyTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/HostLatencyTrace.swift; sourceTree = "<group>"; };
@@ -4966,6 +4969,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupManualReconnectTests.swift; sourceTree = "<group>"; };
 		F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupSignalLifecycleTests.swift; sourceTree = "<group>"; };
 		A5C017000000000000000006 /* StackAccountAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAccountAvatarView.swift; sourceTree = "<group>"; };
+		A47E00010000000000000008 /* StagingSignOutConfirmationPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StagingSignOutConfirmationPresenter.swift; sourceTree = "<group>"; };
 		C0DE70500000000000000001 /* start-cmux-profiling */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/start-cmux-profiling"; sourceTree = SOURCE_ROOT; };
 		D35B71010000000000000002 /* StartupBreadcrumbLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/StartupBreadcrumbLog.swift; sourceTree = "<group>"; };
 		C0DE70530000000000000001 /* submit-cmux-profile */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/submit-cmux-profile"; sourceTree = SOURCE_ROOT; };
@@ -5755,6 +5759,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A47E00010000000000000006 /* MacBackendEnvironmentSwitchController.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
 				A5C017000000000000000006 /* StackAccountAvatarView.swift */,
+				A47E00010000000000000008 /* StagingSignOutConfirmationPresenter.swift */,
 			);
 			name = Auth;
 			path = Auth;
@@ -8478,6 +8483,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
 				A47E00010000000000000004 /* MacBackendEnvironmentSwitchControllerTests.swift */,
+				A47E0001000000000000000A /* HostAccountFlowSignOutInterceptionTests.swift */,
 				A7C0F0010000000000000001 /* MacPairedMacBackupPublisherScopeTests.swift */,
 				5E2701030000000000000002 /* MacSentryStartupPolicyTests.swift */,
 			);
@@ -10306,6 +10312,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A6AC72070000000000000001 /* SpinnerSpec.swift in Sources */,
 					E30780000000000000000012 /* SSHPTYAttachStartupCommandBuilder.swift in Sources */,
 				A5C017000000000000000005 /* StackAccountAvatarView.swift in Sources */,
+				A47E00010000000000000007 /* StagingSignOutConfirmationPresenter.swift in Sources */,
 				D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */,
 				D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */,
 				875200000000000000000014 /* SurfacePaneMovement.swift in Sources */,
@@ -11313,6 +11320,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					937700020000000000000001 /* GrokVaultAgentPersistenceTests.swift in Sources */,
 				9520A0019520A0019520A001 /* HermesFirstClassSupportTests.swift in Sources */,
 				4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */,
+				A47E00010000000000000009 /* HostAccountFlowSignOutInterceptionTests.swift in Sources */,
 				B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */,
 				809100000000000000000001 /* HostSettingsShortcutNotificationTests.swift in Sources */,
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CMUXAuthCore
 import Foundation
 import Testing
 
@@ -533,176 +534,387 @@ struct AuthEnvironmentTests {
         #expect(appDelegate.focusProUpgradeWorkspace(workspaceId: workspace.id, url: pricingURL) == false)
     }
 
-    @Test("staging backend override flips release build defaults to the staging backend")
-    func stagingBackendOverrideFlipsReleaseBuildDefaults() {
+    @Test("explicit staging is a wholesale set of fixed staging values")
+    func explicitStagingWholesaleValues() {
         let staging = "https://cmux-staging.vercel.app"
         #expect(AuthEnvironment.resolvedDefaultWebOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ) == staging)
         #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ) == staging)
         #expect(AuthEnvironment.resolvedDefaultVMAPIOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ) == staging)
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == staging)
         #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         )?.absoluteString == staging)
         #expect(AuthEnvironment.resolvedStackAuthEnvironment(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ) == .development)
         #expect(AuthEnvironment.resolvedStackProjectID(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ) == "454ecd03-1db2-4050-845e-4ce5b0cd9895")
         #expect(AuthEnvironment.resolvedWebsiteOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ).absoluteString == staging)
         #expect(AuthEnvironment.resolvedAfterSignInOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .staging
+            explicitChoice: .staging
         ).absoluteString == staging)
     }
 
-    @Test("explicit environment variables still beat the staging override")
-    func explicitEnvironmentVariablesBeatStagingOverride() {
-        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
-            environment: ["CMUX_WWW_ORIGIN": "https://web.example.test"],
-            isDebugBuild: false,
-            override: .staging
-        ) == "https://web.example.test")
-        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
-            environment: ["CMUX_API_BASE_URL": "https://api.example.test"],
-            isDebugBuild: false,
-            override: .staging
-        ) == "https://api.example.test")
-        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
-            environment: ["CMUX_AUTH_ENVIRONMENT": "production"],
-            isDebugBuild: false,
-            override: .staging
-        ) == .production)
-        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
-            environment: ["CMUX_IROH_BROKER_BASE_URL": "https://broker.example.test"],
-            isDebugBuild: false,
-            override: .staging
-        )?.absoluteString == "https://broker.example.test")
-        #expect(AuthEnvironment.resolvedAfterSignInOrigin(
-            environment: ["CMUX_AUTH_WWW_ORIGIN": "https://auth.example.test"],
-            isDebugBuild: false,
-            override: .staging
-        ).absoluteString == "https://auth.example.test")
-        #expect(AuthEnvironment.resolvedStackProjectID(
-            environment: ["CMUX_STACK_PROJECT_ID": "explicit-project"],
-            isDebugBuild: false,
-            override: .staging
-        ) == "explicit-project")
-    }
-
-    @Test("production backend override reproduces the unswitched release defaults")
-    func productionBackendOverrideReproducesReleaseDefaults() {
+    @Test("explicit production is a wholesale set matching the unpinned Release lane")
+    func explicitProductionWholesaleValues() {
         #expect(AuthEnvironment.resolvedDefaultWebOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ) == "https://cmux.com")
+        // api.cmux.sh, for Release-lane parity.
         #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ) == "https://api.cmux.sh")
         #expect(AuthEnvironment.resolvedDefaultVMAPIOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ) == "https://cmux.com")
+        // Push follows the VM-API origin under a choice.
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            explicitChoice: .production
+        ).absoluteString == "https://cmux.com")
         #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         )?.absoluteString == "https://cmux.com")
         #expect(AuthEnvironment.resolvedStackAuthEnvironment(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ) == .production)
         #expect(AuthEnvironment.resolvedStackProjectID(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ) == "9790718f-14cd-4f7e-824d-eaf527a82b82")
         #expect(AuthEnvironment.resolvedWebsiteOrigin(
             environment: [:],
             isDebugBuild: false,
-            override: .production
+            explicitChoice: .production
         ).absoluteString == "https://cmux.com")
     }
 
-    @Test("session handoff allows exactly the staging origin under the staging override")
-    func sessionHandoffAllowsExactlyStagingOriginUnderStagingOverride() {
-        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
-            environment: [:],
-            isDebugBuild: false,
-            override: .staging
-        ).absoluteString == "https://cmux-staging.vercel.app")
-        // Env-injected origins never become a credential destination, even
-        // with the override active.
-        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
-            environment: ["CMUX_WWW_ORIGIN": "https://attacker.example"],
-            isDebugBuild: false,
-            override: .staging
-        ).absoluteString == "https://cmux.com")
-        // Without the override the pin stays on production even when env
-        // points at the (publicly known) staging origin.
-        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
-            environment: ["CMUX_WWW_ORIGIN": "https://cmux-staging.vercel.app"],
-            isDebugBuild: false,
-            override: .production
-        ).absoluteString == "https://cmux.com")
-        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
-            environment: [:],
-            isDebugBuild: false,
-            override: .production
-        ).absoluteString == "https://cmux.com")
-    }
-
-    @Test("untagged debug build with staging override prefers staging unless a dev port is baked")
-    func untaggedDebugStagingOverridePrefersStagingWebOrigin() {
+    @Test("PIN: an explicit choice beats explicit environment variables, per function")
+    func wholesaleBeatsEnvironmentVariablesPerFunction() {
+        let staging = "https://cmux-staging.vercel.app"
+        // Part F reverses the old layering: the persisted choice used to sit
+        // BELOW env (tagged dev builds' LSEnvironment bakes won); a wholesale
+        // choice now beats every CMUX_* knob, per function.
         #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://web.example.test"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ) == staging)
+        #expect(AuthEnvironment.resolvedWebsiteOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://web.example.test"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == staging)
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: ["CMUX_API_BASE_URL": "https://api.example.test"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ) == staging)
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: [
+                "CMUX_PUSH_API_BASE_URL": "https://push.example.test",
+                "CMUX_VM_API_BASE_URL": "https://vm.example.test",
+            ],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == staging)
+        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: ["CMUX_IROH_BROKER_BASE_URL": "https://broker.example.test"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        )?.absoluteString == staging)
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "production"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ) == .development)
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: ["CMUX_STACK_PROJECT_ID": "explicit-project"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ) == "454ecd03-1db2-4050-845e-4ce5b0cd9895")
+        #expect(AuthEnvironment.resolvedStackPublishableClientKey(
+            environment: ["CMUX_STACK_PUBLISHABLE_CLIENT_KEY": "explicit-key"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ) == "pck_xb63160bwe9699vtxfzfj6emmxpafg5mkjrtp6ehzxv5g")
+        #expect(AuthEnvironment.resolvedAfterSignInOrigin(
+            environment: ["CMUX_AUTH_WWW_ORIGIN": "https://auth.example.test"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == staging)
+        // The other direction too: explicit production beats a baked
+        // development auth environment.
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "development"],
+            isDebugBuild: false,
+            explicitChoice: .production
+        ) == .production)
+    }
+
+    @Test("PIN: an explicit choice beats the DEBUG compile defaults and baked dev ports")
+    func wholesaleBeatsDebugDefaults() {
+        // Explicit production on a Debug build selects the production Stack
+        // channel (the DEBUG development default yields), which also
+        // disables dev auto-login for free (it keys on the resolved
+        // channel).
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
             environment: [:],
             isDebugBuild: true,
-            override: .staging
-        ) == "https://cmux-staging.vercel.app")
-        // A baked dev port (tagged builds) keeps winning as today.
+            explicitChoice: .production
+        ) == .production)
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: [:],
+            isDebugBuild: true,
+            explicitChoice: .production
+        ) == "9790718f-14cd-4f7e-824d-eaf527a82b82")
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: true,
+            explicitChoice: .staging
+        ) == .development)
+        // A tagged Debug build's baked dev port no longer outranks the
+        // choice (the old pinning rationale): the whole point of Part F is
+        // that the picker works in pinned dev builds.
         #expect(AuthEnvironment.resolvedDefaultWebOrigin(
             environment: ["CMUX_PORT": "4123"],
             isDebugBuild: true,
-            override: .staging
+            explicitChoice: .staging
+        ) == "https://cmux-staging.vercel.app")
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_PORT": "4123"],
+            isDebugBuild: true,
+            explicitChoice: .production
+        ) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: ["CMUX_PORT": "4123"],
+            isDebugBuild: true,
+            explicitChoice: .production
+        ) == "https://api.cmux.sh")
+    }
+
+    @Test("PIN: the lane (no explicit choice) is byte-identical to the pre-choice defaults")
+    func laneResolutionIsByteIdenticalToPreChoiceDefaults() {
+        // Release lane defaults.
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: [:],
+            isDebugBuild: false
+        ) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false
+        ) == "https://api.cmux.sh")
+        #expect(AuthEnvironment.resolvedDefaultVMAPIOrigin(
+            environment: [:],
+            isDebugBuild: false
+        ) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false
+        ).absoluteString == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: [:],
+            isDebugBuild: false
+        )?.absoluteString == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: false
+        ) == .production)
+        // Env vars keep winning on the lane (the dev-rig isolation
+        // mechanism).
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://web.example.test"],
+            isDebugBuild: false
+        ) == "https://web.example.test")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: ["CMUX_API_BASE_URL": "https://api.example.test"],
+            isDebugBuild: false
+        ) == "https://api.example.test")
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: ["CMUX_STACK_PROJECT_ID": "explicit-project"],
+            isDebugBuild: false
+        ) == "explicit-project")
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: ["CMUX_PUSH_API_BASE_URL": "https://push.example.test"],
+            isDebugBuild: false
+        ).absoluteString == "https://push.example.test")
+        // Debug lane defaults: tag-local ports, dev Stack channel, shared
+        // staging push/broker.
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_PORT": "4123"],
+            isDebugBuild: true
         ) == "http://localhost:4123")
-        // The Debug Stack channel never follows the override.
         #expect(AuthEnvironment.resolvedStackAuthEnvironment(
             environment: [:],
-            isDebugBuild: true,
-            override: .staging
+            isDebugBuild: true
         ) == .development)
-        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: ["CMUX_VM_API_BASE_URL": "http://localhost:4123"],
+            isDebugBuild: true
+        ).absoluteString == "https://cmux-staging.vercel.app")
+        // Release push follows the VM-API env when set.
+        #expect(AuthEnvironment.resolvedPushAPIBaseURL(
+            environment: ["CMUX_VM_API_BASE_URL": "https://vm.example.test"],
+            isDebugBuild: false
+        ).absoluteString == "https://vm.example.test")
+    }
+
+    @Test("session handoff pins explicit choices to exactly their fixed origins")
+    func sessionHandoffPinsExplicitChoicesToFixedOrigins() {
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
             environment: [:],
-            isDebugBuild: true,
-            override: .production
-        ) == .development)
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == "https://cmux-staging.vercel.app")
+        // Env-injected origins never become a credential destination, even
+        // with a choice active.
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://attacker.example"],
+            isDebugBuild: false,
+            explicitChoice: .staging
+        ).absoluteString == "https://cmux-staging.vercel.app")
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://attacker.example"],
+            isDebugBuild: false,
+            explicitChoice: .production
+        ).absoluteString == "https://cmux.com")
+        // Without a choice the pin stays on production even when env points
+        // at the (publicly known) staging origin.
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://cmux-staging.vercel.app"],
+            isDebugBuild: false
+        ).absoluteString == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: [:],
+            isDebugBuild: false
+        ).absoluteString == "https://cmux.com")
+    }
+
+    @Test("build lane classification: production, staging, and custom bakes")
+    func buildLaneClassification() {
+        // Unpinned Release: the production lane.
+        #expect(AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: [:],
+            isDebugBuild: false
+        ) == .production)
+        // A staging-baked build (device rigs, the STAGING Release app).
+        #expect(AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: ["CMUX_WWW_ORIGIN": "https://cmux-staging.vercel.app"],
+            isDebugBuild: false
+        ) == .staging)
+        // A tagged Debug build baked to a localhost origin.
+        #expect(AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: [
+                "CMUX_WWW_ORIGIN": "http://localhost:4123",
+                "CMUX_PORT": "4123",
+            ],
+            isDebugBuild: true
+        ) == .custom(label: "localhost:4123"))
+        // An untagged Debug build: cmux.com web fallback but the development
+        // Stack channel, so it is NOT the production lane — it gets a custom
+        // lane (and thereby the three-position picker).
+        #expect(AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: [:],
+            isDebugBuild: true
+        ) == .custom(label: "cmux.com"))
+        // A Release build pinned to prod-auth but a custom web origin.
+        #expect(AuthEnvironment.resolvedBackendEnvironmentBuildLane(
+            environment: ["CMUX_WWW_ORIGIN": "https://preview.example.test"],
+            isDebugBuild: false
+        ) == .custom(label: "preview.example.test"))
+    }
+
+    @MainActor
+    @Test("presence service URL: the explicit choice heads env, defaults key, and build default")
+    func presenceServiceURLExplicitChoiceHead() throws {
+        let suiteName = "cmuxTests.presenceChoiceHead.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let devWorker = PresenceSettings.debugDefaultServiceURL
+        let prodWorker = PresenceSettings.productionServiceURL
+
+        // Explicit staging → the dev worker (the only one that verifies dev
+        // Stack tokens), even when the env override AND the defaults tuning
+        // knob point elsewhere: a leftover per-build pin must not outlive a
+        // switch.
+        CMUXBackendEnvironmentOverride.staging.storeChoice(in: defaults)
+        defaults.set("https://tuned.example.test", forKey: PresenceSettings.serviceURLKey)
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [PresenceSettings.serviceURLEnvKey: "https://env.example.test"],
+            defaults: defaults
+        )?.absoluteString == devWorker)
+
+        // Explicit production → the production worker, same tiers beaten.
+        CMUXBackendEnvironmentOverride.production.storeChoice(in: defaults)
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [PresenceSettings.serviceURLEnvKey: "https://env.example.test"],
+            defaults: defaults
+        )?.absoluteString == prodWorker)
+
+        // No choice: today's tiers, byte-identical — env first, then the
+        // defaults key.
+        CMUXBackendEnvironmentOverride.clearChoice(in: defaults)
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [PresenceSettings.serviceURLEnvKey: "https://env.example.test"],
+            defaults: defaults
+        )?.absoluteString == "https://env.example.test")
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [:],
+            defaults: defaults
+        )?.absoluteString == "https://tuned.example.test")
+
+        // No choice, no env, no key: the build default.
+        defaults.removeObject(forKey: PresenceSettings.serviceURLKey)
+        #if DEBUG
+        let expectedBuildDefault = devWorker
+        #else
+        let expectedBuildDefault = prodWorker
+        #endif
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [:],
+            defaults: defaults
+        )?.absoluteString == expectedBuildDefault)
     }
 }
 

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -532,6 +532,178 @@ struct AuthEnvironmentTests {
 
         #expect(appDelegate.focusProUpgradeWorkspace(workspaceId: workspace.id, url: pricingURL) == false)
     }
+
+    @Test("staging backend override flips release build defaults to the staging backend")
+    func stagingBackendOverrideFlipsReleaseBuildDefaults() {
+        let staging = "https://cmux-staging.vercel.app"
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ) == staging)
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ) == staging)
+        #expect(AuthEnvironment.resolvedDefaultVMAPIOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ) == staging)
+        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        )?.absoluteString == staging)
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ) == .development)
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ) == "454ecd03-1db2-4050-845e-4ce5b0cd9895")
+        #expect(AuthEnvironment.resolvedWebsiteOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ).absoluteString == staging)
+        #expect(AuthEnvironment.resolvedAfterSignInOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ).absoluteString == staging)
+    }
+
+    @Test("explicit environment variables still beat the staging override")
+    func explicitEnvironmentVariablesBeatStagingOverride() {
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://web.example.test"],
+            isDebugBuild: false,
+            override: .staging
+        ) == "https://web.example.test")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: ["CMUX_API_BASE_URL": "https://api.example.test"],
+            isDebugBuild: false,
+            override: .staging
+        ) == "https://api.example.test")
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "production"],
+            isDebugBuild: false,
+            override: .staging
+        ) == .production)
+        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: ["CMUX_IROH_BROKER_BASE_URL": "https://broker.example.test"],
+            isDebugBuild: false,
+            override: .staging
+        )?.absoluteString == "https://broker.example.test")
+        #expect(AuthEnvironment.resolvedAfterSignInOrigin(
+            environment: ["CMUX_AUTH_WWW_ORIGIN": "https://auth.example.test"],
+            isDebugBuild: false,
+            override: .staging
+        ).absoluteString == "https://auth.example.test")
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: ["CMUX_STACK_PROJECT_ID": "explicit-project"],
+            isDebugBuild: false,
+            override: .staging
+        ) == "explicit-project")
+    }
+
+    @Test("production backend override reproduces the unswitched release defaults")
+    func productionBackendOverrideReproducesReleaseDefaults() {
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ) == "https://api.cmux.sh")
+        #expect(AuthEnvironment.resolvedDefaultVMAPIOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        )?.absoluteString == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ) == .production)
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ) == "9790718f-14cd-4f7e-824d-eaf527a82b82")
+        #expect(AuthEnvironment.resolvedWebsiteOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ).absoluteString == "https://cmux.com")
+    }
+
+    @Test("session handoff allows exactly the staging origin under the staging override")
+    func sessionHandoffAllowsExactlyStagingOriginUnderStagingOverride() {
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .staging
+        ).absoluteString == "https://cmux-staging.vercel.app")
+        // Env-injected origins never become a credential destination, even
+        // with the override active.
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://attacker.example"],
+            isDebugBuild: false,
+            override: .staging
+        ).absoluteString == "https://cmux.com")
+        // Without the override the pin stays on production even when env
+        // points at the (publicly known) staging origin.
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: ["CMUX_WWW_ORIGIN": "https://cmux-staging.vercel.app"],
+            isDebugBuild: false,
+            override: .production
+        ).absoluteString == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedAppSessionHandoffOrigin(
+            environment: [:],
+            isDebugBuild: false,
+            override: .production
+        ).absoluteString == "https://cmux.com")
+    }
+
+    @Test("untagged debug build with staging override prefers staging unless a dev port is baked")
+    func untaggedDebugStagingOverridePrefersStagingWebOrigin() {
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: [:],
+            isDebugBuild: true,
+            override: .staging
+        ) == "https://cmux-staging.vercel.app")
+        // A baked dev port (tagged builds) keeps winning as today.
+        #expect(AuthEnvironment.resolvedDefaultWebOrigin(
+            environment: ["CMUX_PORT": "4123"],
+            isDebugBuild: true,
+            override: .staging
+        ) == "http://localhost:4123")
+        // The Debug Stack channel never follows the override.
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: true,
+            override: .staging
+        ) == .development)
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: [:],
+            isDebugBuild: true,
+            override: .production
+        ) == .development)
+    }
 }
 
 private func assertNativeSignInURL(_ url: URL) {

--- a/cmuxTests/HostAccountFlowSignOutInterceptionTests.swift
+++ b/cmuxTests/HostAccountFlowSignOutInterceptionTests.swift
@@ -1,0 +1,257 @@
+import AuthenticationServices
+import CMUXAuthCore
+import CmuxAuthRuntime
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Minimal scriptable ``AuthClient`` for the interception tests: records the
+/// calls that distinguish a REAL sign-out (local clear + revocation attempt)
+/// from a park (neither).
+private actor InterceptionFakeAuthClient: AuthClient {
+    private(set) var clearLocalSessionCount = 0
+    private(set) var revokeCount = 0
+
+    func accessToken() async -> String? { nil }
+    func refreshToken() async -> String? { nil }
+    func forceRefreshAccessToken() async -> String? { nil }
+    func currentUser(throwOnMissing: Bool) async throws -> CMUXAuthUser? { nil }
+    func listTeams() async throws -> [CMUXAuthTeam] { [] }
+    func sendMagicLinkEmail(email: String, callbackURL: String) async throws -> String { "nonce" }
+    func signInWithMagicLink(code: String) async throws {}
+    func signInWithCredential(email: String, password: String) async throws {}
+    func signInWithOAuth(provider: String, anchor: any AuthPresentationAnchoring) async throws {}
+    func storedAccessToken() async -> String? { nil }
+    func clearLocalSession() async { clearLocalSessionCount += 1 }
+    func clearLocalSession(ifRefreshTokenMatches refreshToken: String) async {
+        clearLocalSessionCount += 1
+    }
+    func revokeSession(accessToken: String?, refreshToken: String?) async throws {
+        revokeCount += 1
+    }
+    func freshAccessToken(accessToken: String?, refreshToken: String) async -> String? { nil }
+}
+
+private final class InterceptionAnchor: NSObject, AuthPresentationAnchoring {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        ASPresentationAnchor()
+    }
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        ASPresentationAnchor()
+    }
+}
+
+/// Never-started browser session; the interception tests never sign in.
+private final class InterceptionNoopSession: HostBrowserAuthSession {
+    func start() -> Bool { false }
+    func cancel() {}
+}
+
+@MainActor
+private struct InterceptionNoopSessionFactory: HostBrowserAuthSessionFactory {
+    func makeSession(
+        signInURL: URL,
+        callbackScheme: String,
+        completion: @escaping @MainActor (HostBrowserAuthSessionResult) -> Void
+    ) -> any HostBrowserAuthSession {
+        InterceptionNoopSession()
+    }
+}
+
+/// One fully wired ``HostAccountFlow`` over fakes, with an event log shared
+/// by the sign-out chain (`beginSignOut`), the staging confirmation, and the
+/// attached switch controller's steps, so the tests can assert the
+/// interception ORDER (confirm → real sign-out → switch back), not just that
+/// each piece ran.
+@MainActor
+private final class InterceptionHarness {
+    private(set) var events: [String] = []
+    let client = InterceptionFakeAuthClient()
+    let defaults: UserDefaults
+    private let suiteName: String
+    var confirmAnswer = true
+    private(set) var flow: HostAccountFlow!
+
+    init(activeEnvironment: CMUXBackendEnvironmentOverride) {
+        suiteName = "test.cmux.hostAccountFlowInterception.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let config = AuthConfig(
+            stack: CMUXAuthConfig(projectId: "test", publishableClientKey: "test"),
+            magicLinkCallbackURL: "http://localhost/auth/callback",
+            apiBaseURL: "http://localhost"
+        )
+        let coordinator = AuthCoordinator(
+            client: client,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: defaults, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: defaults, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: defaults, key: "selected_team"),
+            anchor: InterceptionAnchor(),
+            config: config,
+            launch: AuthLaunchOptions(
+                clearAuthRequested: false,
+                mockDataEnabled: false,
+                environment: [:],
+                includesDevAuth: false
+            )
+        )
+        let tokenStore = FileStackTokenStore(
+            directory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-interception-\(UUID().uuidString)", isDirectory: true)
+        )
+        let browserSignIn = HostBrowserSignInFlow(
+            coordinator: coordinator,
+            tokenStore: tokenStore,
+            sessionFactory: InterceptionNoopSessionFactory(),
+            callbackRouter: AuthCallbackRouter(),
+            makeSignInURL: { _ in URL(string: "https://example.com/sign-in")! },
+            callbackScheme: { "cmux" },
+            openExternalURL: { _ in false },
+            beginSignOut: { [weak self] in self?.events.append("realSignOut") },
+            beginSessionPark: { [weak self] in self?.events.append("park") },
+            localSignOut: {},
+            onSignedOut: { _, _ in }
+        )
+        let flow = HostAccountFlow(
+            coordinator: coordinator,
+            browserSignIn: browserSignIn,
+            activeBackendEnvironmentOverride: activeEnvironment,
+            backendEnvironmentPinnedByLaunchEnvironment: false,
+            backendEnvironmentDefaults: defaults,
+            confirmStagingSignOut: { [weak self] in
+                self?.events.append("confirm")
+                return self?.confirmAnswer ?? false
+            }
+        )
+        self.flow = flow
+        flow.attachBackendEnvironmentSwitchController(
+            MacBackendEnvironmentSwitchController(
+                steps: BackendEnvironmentSwitchTransaction.Steps(
+                    isPinnedByBuild: { false },
+                    activeEnvironment: { activeEnvironment },
+                    parkSession: { [weak self] in self?.events.append("switch.park") },
+                    quiesce: { [weak self] in self?.events.append("switch.quiesce") },
+                    storeOverride: { [weak self] override in
+                        override.store(in: self?.defaults ?? .standard)
+                        self?.events.append("switch.store(\(override.rawValue))")
+                    },
+                    rebuild: { [weak self] override in
+                        self?.events.append("switch.rebuild(\(override.rawValue))")
+                    },
+                    awaitRestoredUser: { nil },
+                    promptSignIn: { [weak self] in
+                        self?.events.append("switch.promptSignIn")
+                        return nil
+                    },
+                    cancelSignInPrompt: {},
+                    signOutEstablishedSession: {},
+                    isEligible: { _ in false },
+                    signInPromptFailure: { .failed }
+                )
+            )
+        )
+    }
+
+    func cleanUp() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    var switchedBackToProduction: Bool {
+        events.contains("switch.store(production)")
+    }
+}
+
+@MainActor
+@Suite("HostAccountFlow sign-out interception")
+struct HostAccountFlowSignOutInterceptionTests {
+    @Test("Production sign-out is direct: no confirmation, no switch")
+    func productionSignOutIsDirect() async {
+        let harness = InterceptionHarness(activeEnvironment: .production)
+        defer { harness.cleanUp() }
+
+        await harness.flow.signOut()
+
+        #expect(!harness.events.contains("confirm"))
+        #expect(harness.events.contains("realSignOut"))
+        #expect(!harness.switchedBackToProduction)
+        let revokes = await harness.client.revokeCount
+        #expect(revokes == 1)
+    }
+
+    @Test("Declined staging confirmation signs nothing out and switches nothing")
+    func declinedStagingConfirmationDoesNothing() async {
+        let harness = InterceptionHarness(activeEnvironment: .staging)
+        defer { harness.cleanUp() }
+        harness.confirmAnswer = false
+
+        await harness.flow.signOut()
+
+        #expect(harness.events == ["confirm"])
+        let clears = await harness.client.clearLocalSessionCount
+        let revokes = await harness.client.revokeCount
+        #expect(clears == 0)
+        #expect(revokes == 0)
+    }
+
+    @Test("Confirmed staging sign-out runs confirm → real sign-out → switch to production")
+    func confirmedStagingSignOutChainsInOrder() async {
+        let harness = InterceptionHarness(activeEnvironment: .staging)
+        defer { harness.cleanUp() }
+        harness.confirmAnswer = true
+
+        await harness.flow.signOut()
+
+        let confirmIndex = harness.events.firstIndex(of: "confirm")
+        let signOutIndex = harness.events.firstIndex(of: "realSignOut")
+        let switchIndex = harness.events.firstIndex(of: "switch.park")
+        #expect(confirmIndex != nil && signOutIndex != nil && switchIndex != nil)
+        if let confirmIndex, let signOutIndex, let switchIndex {
+            #expect(confirmIndex < signOutIndex)
+            #expect(signOutIndex < switchIndex)
+        }
+        // The REAL sign-out ran (local clear + revocation attempt), and the
+        // chain committed production (which removes the override key).
+        let clears = await harness.client.clearLocalSessionCount
+        let revokes = await harness.client.revokeCount
+        #expect(clears >= 1)
+        #expect(revokes == 1)
+        #expect(harness.switchedBackToProduction)
+        #expect(harness.defaults.string(
+            forKey: CMUXBackendEnvironmentOverride.defaultsKey
+        ) == nil)
+        // Production restore never prompts.
+        #expect(!harness.events.contains("switch.promptSignIn"))
+    }
+
+    @Test("The socket sign-out skips the confirmation but chains and reports the switch")
+    func socketSignOutSkipsConfirmationButChains() async {
+        let harness = InterceptionHarness(activeEnvironment: .staging)
+        defer { harness.cleanUp() }
+
+        let returnedToProduction = await harness.flow.signOut(timeout: 5)
+
+        #expect(returnedToProduction)
+        #expect(!harness.events.contains("confirm"))
+        #expect(harness.events.contains("realSignOut"))
+        #expect(harness.switchedBackToProduction)
+    }
+
+    @Test("The socket sign-out on production reports no environment change")
+    func socketSignOutOnProductionReportsNoSwitch() async {
+        let harness = InterceptionHarness(activeEnvironment: .production)
+        defer { harness.cleanUp() }
+
+        let returnedToProduction = await harness.flow.signOut(timeout: 5)
+
+        #expect(!returnedToProduction)
+        #expect(!harness.events.contains("confirm"))
+        #expect(!harness.switchedBackToProduction)
+    }
+}

--- a/cmuxTests/HostAccountFlowSignOutInterceptionTests.swift
+++ b/cmuxTests/HostAccountFlowSignOutInterceptionTests.swift
@@ -10,6 +10,16 @@ import Testing
 @testable import cmux
 #endif
 
+extension CMUXBackendEnvironmentSelection {
+    /// Compact event label: `lane(production)`, `explicit(staging)`, …
+    fileprivate var eventLabel: String {
+        switch self {
+        case .lane(let resolves): "lane(\(resolves.rawValue))"
+        case .explicit(let choice): "explicit(\(choice.rawValue))"
+        }
+    }
+}
+
 /// Minimal scriptable ``AuthClient`` for the interception tests: records the
 /// calls that distinguish a REAL sign-out (local clear + revocation attempt)
 /// from a park (neither).
@@ -67,8 +77,8 @@ private struct InterceptionNoopSessionFactory: HostBrowserAuthSessionFactory {
 /// One fully wired ``HostAccountFlow`` over fakes, with an event log shared
 /// by the sign-out chain (`beginSignOut`), the staging confirmation, and the
 /// attached switch controller's steps, so the tests can assert the
-/// interception ORDER (confirm → real sign-out → switch back), not just that
-/// each piece ran.
+/// interception ORDER (confirm → real sign-out → switch back to the lane),
+/// not just that each piece ran.
 @MainActor
 private final class InterceptionHarness {
     private(set) var events: [String] = []
@@ -78,10 +88,16 @@ private final class InterceptionHarness {
     var confirmAnswer = true
     private(set) var flow: HostAccountFlow!
 
-    init(activeEnvironment: CMUXBackendEnvironmentOverride) {
+    init(
+        activeSelection: CMUXBackendEnvironmentSelection,
+        buildLane: CMUXBackendEnvironmentBuildLane = .production
+    ) {
         suiteName = "test.cmux.hostAccountFlowInterception.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
+        if case .explicit(let choice) = activeSelection {
+            choice.storeChoice(in: defaults)
+        }
 
         let config = AuthConfig(
             stack: CMUXAuthConfig(projectId: "test", publishableClientKey: "test"),
@@ -122,8 +138,8 @@ private final class InterceptionHarness {
         let flow = HostAccountFlow(
             coordinator: coordinator,
             browserSignIn: browserSignIn,
-            activeBackendEnvironmentOverride: activeEnvironment,
-            backendEnvironmentPinnedByLaunchEnvironment: false,
+            activeBackendEnvironmentSelection: activeSelection,
+            backendEnvironmentBuildLane: buildLane,
             backendEnvironmentDefaults: defaults,
             confirmStagingSignOut: { [weak self] in
                 self?.events.append("confirm")
@@ -134,16 +150,22 @@ private final class InterceptionHarness {
         flow.attachBackendEnvironmentSwitchController(
             MacBackendEnvironmentSwitchController(
                 steps: BackendEnvironmentSwitchTransaction.Steps(
-                    isPinnedByBuild: { false },
-                    activeEnvironment: { activeEnvironment },
+                    activeSelection: { activeSelection },
                     parkSession: { [weak self] in self?.events.append("switch.park") },
                     quiesce: { [weak self] in self?.events.append("switch.quiesce") },
-                    storeOverride: { [weak self] override in
-                        override.store(in: self?.defaults ?? .standard)
-                        self?.events.append("switch.store(\(override.rawValue))")
+                    storeSelection: { [weak self] selection in
+                        switch selection {
+                        case .explicit(let choice):
+                            choice.storeChoice(in: self?.defaults ?? .standard)
+                        case .lane:
+                            CMUXBackendEnvironmentOverride.clearChoice(
+                                in: self?.defaults ?? .standard
+                            )
+                        }
+                        self?.events.append("switch.store(\(selection.eventLabel))")
                     },
-                    rebuild: { [weak self] override in
-                        self?.events.append("switch.rebuild(\(override.rawValue))")
+                    rebuild: { [weak self] selection in
+                        self?.events.append("switch.rebuild(\(selection.eventLabel))")
                     },
                     awaitRestoredUser: { nil },
                     promptSignIn: { [weak self] in
@@ -163,31 +185,61 @@ private final class InterceptionHarness {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
-    var switchedBackToProduction: Bool {
-        events.contains("switch.store(production)")
+    var switchedBackToLane: Bool {
+        events.contains { $0.hasPrefix("switch.store(lane") }
     }
 }
 
 @MainActor
 @Suite("HostAccountFlow sign-out interception")
 struct HostAccountFlowSignOutInterceptionTests {
-    @Test("Production sign-out is direct: no confirmation, no switch")
-    func productionSignOutIsDirect() async {
-        let harness = InterceptionHarness(activeEnvironment: .production)
+    @Test("Production-lane sign-out is direct: no confirmation, no switch")
+    func productionLaneSignOutIsDirect() async {
+        let harness = InterceptionHarness(activeSelection: .lane(resolves: .production))
         defer { harness.cleanUp() }
 
         await harness.flow.signOut()
 
         #expect(!harness.events.contains("confirm"))
         #expect(harness.events.contains("realSignOut"))
-        #expect(!harness.switchedBackToProduction)
+        #expect(!harness.switchedBackToLane)
         let revokes = await harness.client.revokeCount
         #expect(revokes == 1)
     }
 
+    @Test("MATRIX: a staging LANE never intercepts — plain sign-out, no chain")
+    func stagingLaneNeverIntercepts() async {
+        // Dev rigs baked to staging keep today's plain sign-out: no
+        // confirmation modal, no return-to-lane chain (the lane IS home).
+        let harness = InterceptionHarness(
+            activeSelection: .lane(resolves: .staging),
+            buildLane: .staging
+        )
+        defer { harness.cleanUp() }
+
+        await harness.flow.signOut()
+
+        #expect(!harness.events.contains("confirm"))
+        #expect(harness.events.contains("realSignOut"))
+        #expect(!harness.switchedBackToLane)
+        #expect(!harness.events.contains("switch.park"))
+    }
+
+    @Test("MATRIX: explicit production never intercepts")
+    func explicitProductionNeverIntercepts() async {
+        let harness = InterceptionHarness(activeSelection: .explicit(.production))
+        defer { harness.cleanUp() }
+
+        await harness.flow.signOut()
+
+        #expect(!harness.events.contains("confirm"))
+        #expect(harness.events.contains("realSignOut"))
+        #expect(!harness.switchedBackToLane)
+    }
+
     @Test("Declined staging confirmation signs nothing out and switches nothing")
     func declinedStagingConfirmationDoesNothing() async {
-        let harness = InterceptionHarness(activeEnvironment: .staging)
+        let harness = InterceptionHarness(activeSelection: .explicit(.staging))
         defer { harness.cleanUp() }
         harness.confirmAnswer = false
 
@@ -200,9 +252,9 @@ struct HostAccountFlowSignOutInterceptionTests {
         #expect(revokes == 0)
     }
 
-    @Test("Confirmed staging sign-out runs confirm → real sign-out → switch to production")
+    @Test("Confirmed explicit-staging sign-out runs confirm → real sign-out → switch to the lane")
     func confirmedStagingSignOutChainsInOrder() async {
-        let harness = InterceptionHarness(activeEnvironment: .staging)
+        let harness = InterceptionHarness(activeSelection: .explicit(.staging))
         defer { harness.cleanUp() }
         harness.confirmAnswer = true
 
@@ -217,41 +269,56 @@ struct HostAccountFlowSignOutInterceptionTests {
             #expect(signOutIndex < switchIndex)
         }
         // The REAL sign-out ran (local clear + revocation attempt), and the
-        // chain committed production (which removes the override key).
+        // chain committed the LANE, whose store step clears the tri-state
+        // choice key.
         let clears = await harness.client.clearLocalSessionCount
         let revokes = await harness.client.revokeCount
         #expect(clears >= 1)
         #expect(revokes == 1)
-        #expect(harness.switchedBackToProduction)
+        #expect(harness.switchedBackToLane)
         #expect(harness.defaults.string(
             forKey: CMUXBackendEnvironmentOverride.defaultsKey
         ) == nil)
-        // Production restore never prompts.
+        // A lane restore never prompts.
         #expect(!harness.events.contains("switch.promptSignIn"))
     }
 
     @Test("The socket sign-out skips the confirmation but chains and reports the switch")
     func socketSignOutSkipsConfirmationButChains() async {
-        let harness = InterceptionHarness(activeEnvironment: .staging)
+        let harness = InterceptionHarness(activeSelection: .explicit(.staging))
         defer { harness.cleanUp() }
 
-        let returnedToProduction = await harness.flow.signOut(timeout: 5)
+        let returnedToLane = await harness.flow.signOut(timeout: 5)
 
-        #expect(returnedToProduction)
+        #expect(returnedToLane)
         #expect(!harness.events.contains("confirm"))
         #expect(harness.events.contains("realSignOut"))
-        #expect(harness.switchedBackToProduction)
+        #expect(harness.switchedBackToLane)
     }
 
-    @Test("The socket sign-out on production reports no environment change")
-    func socketSignOutOnProductionReportsNoSwitch() async {
-        let harness = InterceptionHarness(activeEnvironment: .production)
+    @Test("The socket sign-out on the production lane reports no environment change")
+    func socketSignOutOnProductionLaneReportsNoSwitch() async {
+        let harness = InterceptionHarness(activeSelection: .lane(resolves: .production))
         defer { harness.cleanUp() }
 
-        let returnedToProduction = await harness.flow.signOut(timeout: 5)
+        let returnedToLane = await harness.flow.signOut(timeout: 5)
 
-        #expect(!returnedToProduction)
+        #expect(!returnedToLane)
         #expect(!harness.events.contains("confirm"))
-        #expect(!harness.switchedBackToProduction)
+        #expect(!harness.switchedBackToLane)
+    }
+
+    @Test("The socket sign-out on a staging LANE reports no environment change")
+    func socketSignOutOnStagingLaneReportsNoSwitch() async {
+        let harness = InterceptionHarness(
+            activeSelection: .lane(resolves: .staging),
+            buildLane: .staging
+        )
+        defer { harness.cleanUp() }
+
+        let returnedToLane = await harness.flow.signOut(timeout: 5)
+
+        #expect(!returnedToLane)
+        #expect(!harness.switchedBackToLane)
     }
 }

--- a/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
+++ b/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
@@ -12,7 +12,7 @@ import Testing
 /// Fake step wiring for ``MacBackendEnvironmentSwitchController``: records
 /// the step order, stands in for `MobileHostService.stop()`/`start()` around
 /// the quiesce window, persists the override into a scratch defaults suite,
-/// and can park the sign-out step on a continuation so a test can observe
+/// and can park the park/prompt steps on continuations so a test can observe
 /// the world mid-switch.
 @MainActor
 private final class SwitchStepsRecorder {
@@ -20,9 +20,22 @@ private final class SwitchStepsRecorder {
     let defaults: UserDefaults
     private let suiteName: String
 
-    private var signOutGate: CheckedContinuation<Void, Never>?
-    var parkSignOut = false
-    private(set) var signOutParked = false
+    /// Scripted results for `awaitRestoredUser`, consumed head-first
+    /// (empty = nil; a revert's trailing restore also consumes one).
+    var restoredUsers: [CMUXAuthUser?] = []
+    /// Scripted result for `promptSignIn` when it is not parked.
+    var promptedUser: CMUXAuthUser?
+    /// Which user ids the gate treats as eligible.
+    var eligibleUserIDs: Set<String> = []
+    var promptFailure: BackendEnvironmentSwitchTransaction.SignInPromptFailure = .failed
+
+    private var parkGate: CheckedContinuation<Void, Never>?
+    var parkThePark = false
+    private(set) var parkParked = false
+
+    private var promptGate: CheckedContinuation<CMUXAuthUser?, Never>?
+    var parkThePrompt = false
+    private(set) var promptParked = false
 
     init() {
         suiteName = "test.cmux.backendEnvironmentSwitch.\(UUID().uuidString)"
@@ -34,25 +47,36 @@ private final class SwitchStepsRecorder {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
-    func releaseSignOut() {
-        signOutParked = false
-        signOutGate?.resume()
-        signOutGate = nil
+    func releasePark() {
+        parkParked = false
+        parkGate?.resume()
+        parkGate = nil
+    }
+
+    func resolvePrompt(with user: CMUXAuthUser?) {
+        promptParked = false
+        promptGate?.resume(returning: user)
+        promptGate = nil
     }
 
     var storedOverrideRawValue: String? {
         defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey)
     }
 
-    func steps() -> BackendEnvironmentSwitchTransaction.Steps {
+    var rebuildMarkerArmed: Bool {
+        defaults.bool(forKey: CMUXBackendEnvironmentSwitchRebuildMarker.defaultsKey)
+    }
+
+    func steps(active: CMUXBackendEnvironmentOverride = .production)
+        -> BackendEnvironmentSwitchTransaction.Steps {
         BackendEnvironmentSwitchTransaction.Steps(
             isPinnedByBuild: { false },
-            activeEnvironment: { .production },
-            signOut: {
-                self.events.append("signOut")
-                if self.parkSignOut {
-                    self.signOutParked = true
-                    await withCheckedContinuation { self.signOutGate = $0 }
+            activeEnvironment: { active },
+            parkSession: {
+                self.events.append("park")
+                if self.parkThePark {
+                    self.parkParked = true
+                    await withCheckedContinuation { self.parkGate = $0 }
                 }
             },
             quiesce: {
@@ -60,15 +84,37 @@ private final class SwitchStepsRecorder {
                 self.events.append("mobileHost.stop")
             },
             storeOverride: { override in
+                // Production wiring also arms the one-shot rebuild marker.
                 override.store(in: self.defaults)
-                self.events.append("store")
+                CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: self.defaults)
+                self.events.append("store(\(override.rawValue))")
             },
-            rebuild: { _ in
+            rebuild: { override in
                 // Production wiring: AppDelegate.adoptRebuiltAuth(_:), which
                 // ends with MobileHostService.shared.start().
-                self.events.append("rebuild")
+                self.events.append("rebuild(\(override.rawValue))")
                 self.events.append("mobileHost.start")
-            }
+            },
+            awaitRestoredUser: {
+                self.events.append("awaitRestoredUser")
+                guard !self.restoredUsers.isEmpty else { return nil }
+                return self.restoredUsers.removeFirst()
+            },
+            promptSignIn: {
+                self.events.append("promptSignIn")
+                if self.parkThePrompt {
+                    self.promptParked = true
+                    return await withCheckedContinuation { self.promptGate = $0 }
+                }
+                return self.promptedUser
+            },
+            cancelSignInPrompt: {
+                self.events.append("cancelSignInPrompt")
+                self.resolvePrompt(with: nil)
+            },
+            signOutEstablishedSession: { self.events.append("signOutEstablished") },
+            isEligible: { user in self.eligibleUserIDs.contains(user.id) },
+            signInPromptFailure: { self.promptFailure }
         )
     }
 }
@@ -76,41 +122,55 @@ private final class SwitchStepsRecorder {
 @MainActor
 @Suite("MacBackendEnvironmentSwitchController")
 struct MacBackendEnvironmentSwitchControllerTests {
-    @Test("The defaults key is untouched until sign-out completes")
-    func defaultsKeyUntouchedUntilSignOutCompletes() async {
+    private static let teamUser = CMUXAuthUser(
+        id: "team-user",
+        primaryEmail: "aziz@manaflow.ai",
+        displayName: "Aziz",
+        primaryEmailVerified: true
+    )
+
+    @Test("The defaults key is untouched until the park completes")
+    func defaultsKeyUntouchedUntilParkCompletes() async {
         let recorder = SwitchStepsRecorder()
         defer { recorder.cleanUp() }
-        recorder.parkSignOut = true
+        recorder.parkThePark = true
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
 
         let run = Task { await controller.switchEnvironment(to: .staging) }
-        while !recorder.signOutParked { await Task.yield() }
+        while !recorder.parkParked { await Task.yield() }
 
-        // Mid-sign-out: still the old environment on disk, phase visible.
+        // Mid-park: still the old environment on disk, phase visible.
         #expect(recorder.storedOverrideRawValue == nil)
-        #expect(controller.phase == .signingOut)
+        #expect(!recorder.rebuildMarkerArmed)
+        #expect(controller.phase == .parking)
 
-        recorder.releaseSignOut()
+        recorder.releasePark()
         await run.value
 
         #expect(recorder.storedOverrideRawValue == "staging")
-        #expect(controller.phase == .finished)
+        #expect(recorder.rebuildMarkerArmed)
+        #expect(controller.phase == .finished(.switched))
     }
 
     @Test("MobileHostService stops before the commit and restarts after the rebuild")
     func mobileHostStopStartBracketTheQuiesceWindow() async {
         let recorder = SwitchStepsRecorder()
         defer { recorder.cleanUp() }
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
 
         await controller.switchEnvironment(to: .staging)
 
         #expect(recorder.events == [
-            "signOut",
+            "park",
             "mobileHost.stop",
-            "store",
-            "rebuild",
+            "store(staging)",
+            "rebuild(staging)",
             "mobileHost.start",
+            "awaitRestoredUser",
         ])
     }
 
@@ -118,23 +178,64 @@ struct MacBackendEnvironmentSwitchControllerTests {
     func isSwitchingReflectsTheRunWindow() async {
         let recorder = SwitchStepsRecorder()
         defer { recorder.cleanUp() }
-        recorder.parkSignOut = true
+        recorder.parkThePark = true
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
         #expect(!controller.isSwitching)
 
         let run = Task { await controller.switchEnvironment(to: .staging) }
-        while !recorder.signOutParked { await Task.yield() }
+        while !recorder.parkParked { await Task.yield() }
 
         // HostAccountFlow ORs this into isWorkingOnAuth, disabling the
         // account/auth entrypoints for the whole switch window.
         #expect(controller.isSwitching)
 
-        recorder.releaseSignOut()
+        recorder.releasePark()
         await run.value
 
         #expect(!controller.isSwitching)
-        #expect(controller.phase == .finished)
+        #expect(controller.phase == .finished(.switched))
         controller.reset()
         #expect(controller.phase == .idle)
+    }
+
+    @Test("requestRevert during the sign-in wait cancels the prompt and reverts")
+    func requestRevertCancelsThePromptAndReverts() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.parkThePrompt = true
+        let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
+
+        let run = Task { await controller.switchEnvironment(to: .staging) }
+        while !recorder.promptParked { await Task.yield() }
+        #expect(controller.phase == .establishing)
+
+        controller.requestRevert()
+        await run.value
+
+        #expect(recorder.events.contains("cancelSignInPrompt"))
+        #expect(controller.phase == .finished(.reverted(.signInCancelled)))
+        // The revert re-committed the previous environment (production
+        // removes the key) and re-armed the rebuild marker.
+        #expect(recorder.storedOverrideRawValue == nil)
+        #expect(recorder.rebuildMarkerArmed)
+    }
+
+    @Test("Switching back to production never consults the gate or the prompt")
+    func switchBackToProductionNeverPrompts() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.restoredUsers = [nil]
+        let controller = MacBackendEnvironmentSwitchController(
+            steps: recorder.steps(active: .staging)
+        )
+
+        await controller.switchEnvironment(to: .production)
+
+        #expect(controller.phase == .finished(.switched))
+        #expect(!recorder.events.contains("promptSignIn"))
+        #expect(!recorder.events.contains("signOutEstablished"))
+        #expect(recorder.storedOverrideRawValue == nil)
     }
 }

--- a/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
+++ b/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
@@ -9,11 +9,23 @@ import Testing
 @testable import cmux
 #endif
 
+extension CMUXBackendEnvironmentSelection {
+    /// Compact event label: `lane(production)`, `explicit(staging)`, …
+    fileprivate var eventLabel: String {
+        switch self {
+        case .lane(let resolves): "lane(\(resolves.rawValue))"
+        case .explicit(let choice): "explicit(\(choice.rawValue))"
+        }
+    }
+}
+
 /// Fake step wiring for ``MacBackendEnvironmentSwitchController``: records
 /// the step order, stands in for `MobileHostService.stop()`/`start()` around
-/// the quiesce window, persists the override into a scratch defaults suite,
-/// and can park the park/prompt steps on continuations so a test can observe
-/// the world mid-switch.
+/// the quiesce window, persists the selection into a scratch defaults suite
+/// exactly as the production wiring does (explicit → storeChoice, lane →
+/// clearChoice, both arming the rebuild marker), and can park the
+/// park/prompt steps on continuations so a test can observe the world
+/// mid-switch.
 @MainActor
 private final class SwitchStepsRecorder {
     private(set) var events: [String] = []
@@ -67,11 +79,11 @@ private final class SwitchStepsRecorder {
         defaults.bool(forKey: CMUXBackendEnvironmentSwitchRebuildMarker.defaultsKey)
     }
 
-    func steps(active: CMUXBackendEnvironmentOverride = .production)
-        -> BackendEnvironmentSwitchTransaction.Steps {
+    func steps(
+        active: CMUXBackendEnvironmentSelection = .lane(resolves: .production)
+    ) -> BackendEnvironmentSwitchTransaction.Steps {
         BackendEnvironmentSwitchTransaction.Steps(
-            isPinnedByBuild: { false },
-            activeEnvironment: { active },
+            activeSelection: { active },
             parkSession: {
                 self.events.append("park")
                 if self.parkThePark {
@@ -83,16 +95,23 @@ private final class SwitchStepsRecorder {
                 // Production wiring: MobileHostService.shared.stop().
                 self.events.append("mobileHost.stop")
             },
-            storeOverride: { override in
-                // Production wiring also arms the one-shot rebuild marker.
-                override.store(in: self.defaults)
+            storeSelection: { selection in
+                // Production wiring: explicit choices write the tri-state
+                // key, lane targets clear it, and BOTH arm the one-shot
+                // rebuild marker.
+                switch selection {
+                case .explicit(let choice):
+                    choice.storeChoice(in: self.defaults)
+                case .lane:
+                    CMUXBackendEnvironmentOverride.clearChoice(in: self.defaults)
+                }
                 CMUXBackendEnvironmentSwitchRebuildMarker.arm(in: self.defaults)
-                self.events.append("store(\(override.rawValue))")
+                self.events.append("store(\(selection.eventLabel))")
             },
-            rebuild: { override in
+            rebuild: { selection in
                 // Production wiring: AppDelegate.adoptRebuiltAuth(_:), which
                 // ends with MobileHostService.shared.start().
-                self.events.append("rebuild(\(override.rawValue))")
+                self.events.append("rebuild(\(selection.eventLabel))")
                 self.events.append("mobileHost.start")
             },
             awaitRestoredUser: {
@@ -138,10 +157,10 @@ struct MacBackendEnvironmentSwitchControllerTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
 
-        let run = Task { await controller.switchEnvironment(to: .staging) }
+        let run = Task { await controller.switchEnvironment(to: .explicit(.staging)) }
         while !recorder.parkParked { await Task.yield() }
 
-        // Mid-park: still the old environment on disk, phase visible.
+        // Mid-park: still the old selection on disk, phase visible.
         #expect(recorder.storedOverrideRawValue == nil)
         #expect(!recorder.rebuildMarkerArmed)
         #expect(controller.phase == .parking)
@@ -162,13 +181,13 @@ struct MacBackendEnvironmentSwitchControllerTests {
         recorder.eligibleUserIDs = [Self.teamUser.id]
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
 
-        await controller.switchEnvironment(to: .staging)
+        await controller.switchEnvironment(to: .explicit(.staging))
 
         #expect(recorder.events == [
             "park",
             "mobileHost.stop",
-            "store(staging)",
-            "rebuild(staging)",
+            "store(explicit(staging))",
+            "rebuild(explicit(staging))",
             "mobileHost.start",
             "awaitRestoredUser",
         ])
@@ -184,7 +203,7 @@ struct MacBackendEnvironmentSwitchControllerTests {
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
         #expect(!controller.isSwitching)
 
-        let run = Task { await controller.switchEnvironment(to: .staging) }
+        let run = Task { await controller.switchEnvironment(to: .explicit(.staging)) }
         while !recorder.parkParked { await Task.yield() }
 
         // HostAccountFlow ORs this into isWorkingOnAuth, disabling the
@@ -200,14 +219,14 @@ struct MacBackendEnvironmentSwitchControllerTests {
         #expect(controller.phase == .idle)
     }
 
-    @Test("requestRevert during the sign-in wait cancels the prompt and reverts")
-    func requestRevertCancelsThePromptAndReverts() async {
+    @Test("requestRevert during the sign-in wait cancels the prompt and reverts to the LANE")
+    func requestRevertCancelsThePromptAndRevertsToTheLane() async {
         let recorder = SwitchStepsRecorder()
         defer { recorder.cleanUp() }
         recorder.parkThePrompt = true
         let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
 
-        let run = Task { await controller.switchEnvironment(to: .staging) }
+        let run = Task { await controller.switchEnvironment(to: .explicit(.staging)) }
         while !recorder.promptParked { await Task.yield() }
         #expect(controller.phase == .establishing)
 
@@ -216,26 +235,98 @@ struct MacBackendEnvironmentSwitchControllerTests {
 
         #expect(recorder.events.contains("cancelSignInPrompt"))
         #expect(controller.phase == .finished(.reverted(.signInCancelled)))
-        // The revert re-committed the previous environment (production
-        // removes the key) and re-armed the rebuild marker.
+        // The revert re-committed the ORIGINAL selection — the lane, whose
+        // store step CLEARS the tri-state key — and re-armed the rebuild
+        // marker.
+        #expect(recorder.events.contains("store(lane(production))"))
         #expect(recorder.storedOverrideRawValue == nil)
         #expect(recorder.rebuildMarkerArmed)
     }
 
-    @Test("Switching back to production never consults the gate or the prompt")
-    func switchBackToProductionNeverPrompts() async {
+    @Test("Switching back to the lane never consults the gate or the prompt")
+    func switchBackToTheLaneNeverPrompts() async {
         let recorder = SwitchStepsRecorder()
         defer { recorder.cleanUp() }
         recorder.restoredUsers = [nil]
+        CMUXBackendEnvironmentOverride.staging.storeChoice(in: recorder.defaults)
         let controller = MacBackendEnvironmentSwitchController(
-            steps: recorder.steps(active: .staging)
+            steps: recorder.steps(active: .explicit(.staging))
         )
 
-        await controller.switchEnvironment(to: .production)
+        await controller.switchEnvironment(to: .lane(resolves: .production))
 
         #expect(controller.phase == .finished(.switched))
         #expect(!recorder.events.contains("promptSignIn"))
         #expect(!recorder.events.contains("signOutEstablished"))
+        // The lane target cleared the tri-state key.
         #expect(recorder.storedOverrideRawValue == nil)
+        #expect(recorder.rebuildMarkerArmed)
+    }
+
+    @Test("An explicit production pick WRITES the key (tri-state, not removal)")
+    func explicitProductionWritesTheKey() async {
+        // On a non-production lane the picker's "Production" is an explicit
+        // wholesale choice; the controller must persist it, not clear it.
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.restoredUsers = [nil]
+        let controller = MacBackendEnvironmentSwitchController(
+            steps: recorder.steps(active: .lane(resolves: .staging))
+        )
+
+        await controller.switchEnvironment(to: .explicit(.production))
+
+        #expect(controller.phase == .finished(.switched))
+        #expect(recorder.storedOverrideRawValue == "production")
+        #expect(!recorder.events.contains("promptSignIn"))
+    }
+
+    // MARK: - Selection-identity guard matrix
+
+    @Test("GUARD: lane(staging) → explicit(staging) RUNS")
+    func laneStagingToExplicitStagingRuns() async {
+        // The Part F unblock: a staging-baked build explicitly picking
+        // Staging is a real switch even though the resolved environment
+        // does not change (the choice key gets written, gating attaches).
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.restoredUsers = [Self.teamUser]
+        recorder.eligibleUserIDs = [Self.teamUser.id]
+        let controller = MacBackendEnvironmentSwitchController(
+            steps: recorder.steps(active: .lane(resolves: .staging))
+        )
+
+        await controller.switchEnvironment(to: .explicit(.staging))
+
+        #expect(controller.phase == .finished(.switched))
+        #expect(recorder.storedOverrideRawValue == "staging")
+    }
+
+    @Test("GUARD: explicit(staging) → explicit(staging) refuses")
+    func explicitStagingToSameRefuses() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        let controller = MacBackendEnvironmentSwitchController(
+            steps: recorder.steps(active: .explicit(.staging))
+        )
+
+        await controller.switchEnvironment(to: .explicit(.staging))
+
+        #expect(recorder.events.isEmpty)
+        #expect(controller.phase == .idle)
+    }
+
+    @Test("GUARD: lane → lane refuses")
+    func laneToLaneRefuses() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        let controller = MacBackendEnvironmentSwitchController(
+            steps: recorder.steps(active: .lane(resolves: .production))
+        )
+
+        await controller.switchEnvironment(to: .lane(resolves: .production))
+
+        #expect(recorder.events.isEmpty)
+        #expect(controller.phase == .idle)
     }
 }

--- a/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
+++ b/cmuxTests/MacBackendEnvironmentSwitchControllerTests.swift
@@ -1,0 +1,140 @@
+import CMUXAuthCore
+import CmuxAuthRuntime
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Fake step wiring for ``MacBackendEnvironmentSwitchController``: records
+/// the step order, stands in for `MobileHostService.stop()`/`start()` around
+/// the quiesce window, persists the override into a scratch defaults suite,
+/// and can park the sign-out step on a continuation so a test can observe
+/// the world mid-switch.
+@MainActor
+private final class SwitchStepsRecorder {
+    private(set) var events: [String] = []
+    let defaults: UserDefaults
+    private let suiteName: String
+
+    private var signOutGate: CheckedContinuation<Void, Never>?
+    var parkSignOut = false
+    private(set) var signOutParked = false
+
+    init() {
+        suiteName = "test.cmux.backendEnvironmentSwitch.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func cleanUp() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func releaseSignOut() {
+        signOutParked = false
+        signOutGate?.resume()
+        signOutGate = nil
+    }
+
+    var storedOverrideRawValue: String? {
+        defaults.string(forKey: CMUXBackendEnvironmentOverride.defaultsKey)
+    }
+
+    func steps() -> BackendEnvironmentSwitchTransaction.Steps {
+        BackendEnvironmentSwitchTransaction.Steps(
+            isPinnedByBuild: { false },
+            activeEnvironment: { .production },
+            signOut: {
+                self.events.append("signOut")
+                if self.parkSignOut {
+                    self.signOutParked = true
+                    await withCheckedContinuation { self.signOutGate = $0 }
+                }
+            },
+            quiesce: {
+                // Production wiring: MobileHostService.shared.stop().
+                self.events.append("mobileHost.stop")
+            },
+            storeOverride: { override in
+                override.store(in: self.defaults)
+                self.events.append("store")
+            },
+            rebuild: { _ in
+                // Production wiring: AppDelegate.adoptRebuiltAuth(_:), which
+                // ends with MobileHostService.shared.start().
+                self.events.append("rebuild")
+                self.events.append("mobileHost.start")
+            }
+        )
+    }
+}
+
+@MainActor
+@Suite("MacBackendEnvironmentSwitchController")
+struct MacBackendEnvironmentSwitchControllerTests {
+    @Test("The defaults key is untouched until sign-out completes")
+    func defaultsKeyUntouchedUntilSignOutCompletes() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.parkSignOut = true
+        let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
+
+        let run = Task { await controller.switchEnvironment(to: .staging) }
+        while !recorder.signOutParked { await Task.yield() }
+
+        // Mid-sign-out: still the old environment on disk, phase visible.
+        #expect(recorder.storedOverrideRawValue == nil)
+        #expect(controller.phase == .signingOut)
+
+        recorder.releaseSignOut()
+        await run.value
+
+        #expect(recorder.storedOverrideRawValue == "staging")
+        #expect(controller.phase == .finished)
+    }
+
+    @Test("MobileHostService stops before the commit and restarts after the rebuild")
+    func mobileHostStopStartBracketTheQuiesceWindow() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
+
+        await controller.switchEnvironment(to: .staging)
+
+        #expect(recorder.events == [
+            "signOut",
+            "mobileHost.stop",
+            "store",
+            "rebuild",
+            "mobileHost.start",
+        ])
+    }
+
+    @Test("isSwitching covers the whole run window")
+    func isSwitchingReflectsTheRunWindow() async {
+        let recorder = SwitchStepsRecorder()
+        defer { recorder.cleanUp() }
+        recorder.parkSignOut = true
+        let controller = MacBackendEnvironmentSwitchController(steps: recorder.steps())
+        #expect(!controller.isSwitching)
+
+        let run = Task { await controller.switchEnvironment(to: .staging) }
+        while !recorder.signOutParked { await Task.yield() }
+
+        // HostAccountFlow ORs this into isWorkingOnAuth, disabling the
+        // account/auth entrypoints for the whole switch window.
+        #expect(controller.isSwitching)
+
+        recorder.releaseSignOut()
+        await run.value
+
+        #expect(!controller.isSwitching)
+        #expect(controller.phase == .finished)
+        controller.reset()
+        #expect(controller.phase == .idle)
+    }
+}

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1221,6 +1221,15 @@ if [[ -n "$TAG" ]]; then
   fi
   cleanup_stale_cli_pointer_target || true
   cleanup_stale_tag_state "$TAG_SLUG" || true
+  # Rig determinism: a persisted explicit backend-environment choice is a
+  # WHOLESALE override that would beat the freshly baked CMUX_* launch
+  # environment, so a leftover pick (or the one-shot switch-rebuild marker)
+  # from an earlier dogfood round must not leak into this reload. Clear both
+  # tri-state keys for the tagged bundle before the app relaunches
+  # (precedent: scripts/lib/mobile-attach.sh writing the pairing-host
+  # default pre-launch).
+  defaults delete "$BUNDLE_ID" cmux.backendEnvironmentOverride 2>/dev/null || true
+  defaults delete "$BUNDLE_ID" cmux.backendEnvironmentSwitch.suppressAuthClearOnce 2>/dev/null || true
 fi
 
 CMUX_DEV_PORT="$(choose_cmux_dev_port)"


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/10393 (base branch `feat-backend-env-core`); part of the staging-first program with https://github.com/manaflow-ai/cmux/pull/10389.

Release/nightly Macs hard-resolve to cmux.com, api.cmux.sh, and the prod Stack project. This adds a persisted runtime override (`CMUXBackendEnvironmentOverride`, UserDefaults) that replaces only the build-default layer of `AuthEnvironment` resolution and applies on relaunch:

- Staging flips web origin / API base / VM API / iroh broker fallback to `https://cmux-staging.vercel.app`, the Stack channel to the development project, and the presence default to the dev worker (which verifies dev-Stack tokens). `pushAPIBaseURL` and the sign-in origins follow existing fallbacks; verified, not special-cased.
- Precedence everywhere: explicit `CMUX_*` env vars (including the `LSEnvironment` origins reload.sh bakes into tagged dev builds) > DEBUG-only `~/.cmux-dev.env` > runtime override > build default. Dev-lane isolation is untouched, and the Settings card shows a "pinned by launch environment" note in baked builds instead of silently ignoring the picker.
- The credential-bearing app-session handoff origin allowlist grows by exactly the compiled-in staging origin, only while the override is staging; env values can never widen it.
- Settings > Account: Production/Staging picker visible when `CMUXBackendEnvironmentSwitchGate.allows(currentUser)` (verified @manaflow.ai) OR DEBUG OR the state is already non-production (switch-back always possible), consequence footer (separate accounts/data, signs you out, Mac + iPhone must match to pair), relaunch notice with a "Relaunch cmux" button composing the updater's `persistSessionForUpdateRelaunch` with the existing `restartApp` seam, orange Staging badge on the identity card, settings-search anchor.
- Session wipe on flip rides the existing `detectAuthProjectSwitch` (resolved Stack project id changes).
- Feature flags (`Sources/FeatureFlags.swift`, PostHog via cmux.com) deliberately stay on prod.

Tests: 5 new precedence tests in `cmuxTests/AuthEnvironmentTests.swift` (run in CI; local test runs are forbidden on dev Macs), CmuxSettingsUI package suite green locally (154 tests, includes 4 new). Localization audited: 8 new keys in `Resources/Localizable.xcstrings`, en + ja.

Merge gate (per program plan): all five sign-in methods (password, magic link, Apple, Google, GitHub) must be proven working on staging on both platforms first. Staging's Stack project (`cmux-dev`) already has all providers enabled; the one config blocker is adding `https://cmux-staging.vercel.app` to its trusted domains in the Stack dashboard.

Dictionary:
- **LSEnvironment**: Info.plist dictionary of environment variables macOS injects when launching an app bundle; tagged dev builds get their origins baked there.
- **handoff origin**: the single web origin the app is willing to send session credentials to during native-to-web handoff.
- **Stack project**: a Stack Auth tenant with its own user accounts; dev and prod are separate tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789710702&installation_model_id=21920&pr_number=10398&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10398&signature=514882571860ea9c98178a557ee9798ca5d649f8ca9feebaa80e0470704b6d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
macOS can now switch backend environments live with a tri‑state selection (build lane or explicit Production/Staging) that prevents mixed environments. Previously builds were pinned or needed a relaunch and a partial override; now a confirmed switch parks the current session, rebuilds auth in‑process, gates explicit staging as needed, and automatically reverts on cancel/failure.

- Selection and resolution: an explicit choice is a wholesale override that precedes `CMUX_*` env vars, `~/.cmux-dev.env`, and DEBUG defaults; an absent key resolves the build lane (`production`, `staging`, or custom). Dev-baked builds show a three-position picker (Build lane / Production / Staging); unpinned Release stays two-position. Presence resolution now follows the same head tier. The handoff allowlist adds exactly the compiled-in staging origin only while staging is active. Devices must match environments to pair.
- Live switch transaction (`CmuxAuthRuntime`): park (detach) the old session without revocation; quiesce; commit the selection (explicit → store, lane → clear); rebuild; establish the target by restoring its parked slot; gate explicit staging entry (eligible team session or DEBUG); revert to the prior selection on cancel/failure/ineligibility. Concurrent callers join; true no-ops are refused. A one-shot rebuild marker suppresses the launch-time clear exactly once so the parked slot is restored.
- Token stores: per‑Stack‑project slots in Keychain and file stores with adopt‑and‑delete migration from the legacy single slot; clears never touch another project’s slot.
- macOS wiring and UI: `MacBackendEnvironmentSwitchController` runs the shared transaction; `MacAuthComposition` rebuilds and rebinds live objects and transfers browser app-session ownership. `CmuxSettingsUI` shows the full picker only for gate‑allowed users (verified `@manaflow.ai`) or DEBUG; everyone else off production sees a recovery-only “Switch Back to Production” card. The identity card shows a “Staging” badge when active. Sign‑out intercepts only when selection is explicit staging; confirming returns to the build lane and restores its parked session. Socket/CLI sign‑out chains the same return and reports `returned_to_lane` (keeps `returned_to_production` for older clients).
- Tests: tri‑state persistence and rebuild marker; per‑project slot naming/adoption; detach‑without‑revocation; second‑coordinator clear‑on‑rebuild; transaction ordering/gating/revert matrix; UI confirmation/visibility. `reload.sh` clears any persisted explicit choice and rebuild marker for tagged bundles to keep rig runs deterministic.

- Required rollout: add `https://cmux-staging.vercel.app` to the staging Stack project’s trusted domains; validate password, magic link, Apple, Google, and GitHub sign‑in on staging on both macOS and iOS.

<sup>Written for commit 8bbd903c71cc5e22863abbdde8902ea69c92ecfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

