### PR TITLE
fix(web): treat header-less push callers as the legacy namespace

### DIFF
--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -140,7 +140,7 @@ async function sendPush(
   // allowed to omit the routing hint, new builds must send a valid one.
   const requestedNamespace = request.headers.get("x-cmux-ios-target-namespace");
   let targetNamespace: ReturnType<typeof normalizeApnsBundle> = null;
-  if (requestedNamespace) {
+  if (requestedNamespace !== null) {
     targetNamespace = normalizeApnsBundle(requestedNamespace);
     if (!targetNamespace) {
       return jsonResponse({ error: "invalid_target_namespace" }, 400);

--- a/web/app/api/notifications/push/route.ts
+++ b/web/app/api/notifications/push/route.ts
@@ -133,19 +133,24 @@ async function sendPush(
 
   const payload = parsePushPayload(body.value);
   if (!payload.ok) return jsonResponse({ error: payload.error }, 400);
+  // Macs from before the namespace rollout (0.64.x) never send this header.
+  // They are the `legacy` namespace: deliver to every iOS token the account
+  // registered, each on its own bundle topic, matching pre-namespace reach.
+  // A present-but-unknown value is still a hard error: only old builds are
+  // allowed to omit the routing hint, new builds must send a valid one.
   const requestedNamespace = request.headers.get("x-cmux-ios-target-namespace");
-  if (!requestedNamespace) {
-    return jsonResponse({ error: "missing_target_namespace" }, 400);
-  }
-  const targetNamespace = normalizeApnsBundle(requestedNamespace);
-  if (!targetNamespace) {
-    return jsonResponse({ error: "invalid_target_namespace" }, 400);
+  let targetNamespace: ReturnType<typeof normalizeApnsBundle> = null;
+  if (requestedNamespace) {
+    targetNamespace = normalizeApnsBundle(requestedNamespace);
+    if (!targetNamespace) {
+      return jsonResponse({ error: "invalid_target_namespace" }, 400);
+    }
   }
   const correlationId =
     payload.value.correlationId ?? crypto.randomUUID();
   const payloadFingerprint = pushPayloadFingerprint(
     payload.value,
-    targetNamespace.bundleId,
+    targetNamespace?.bundleId ?? "legacy",
   );
   const startedAt = new Date();
   const nowEpochSeconds = Math.floor(startedAt.getTime() / 1_000);
@@ -181,7 +186,7 @@ async function sendPush(
       const delivery = yield* PushDeliveryService;
       return yield* delivery.deliver({
         userId: user.id,
-        targetBundleId: targetNamespace.bundleId,
+        targetBundleId: targetNamespace?.bundleId ?? null,
         correlationId,
         payloadFingerprint,
         startedAt,

--- a/web/services/apns/deviceDeliveryLease.ts
+++ b/web/services/apns/deviceDeliveryLease.ts
@@ -35,9 +35,17 @@ export interface DeviceDeliveryClaim {
 export async function claimDeviceDeliveryTargets(
   db: PushDatabase,
   userId: string,
-  targetBundleId: string,
+  targetBundleId: string | null,
   now = new Date(),
 ): Promise<DeviceDeliveryClaim> {
+  // A null bundle is the legacy namespace: pre-rollout Macs cannot name a
+  // target lane, so they keep their historical account-wide reach and each
+  // token row supplies its own bundle topic to the sender.
+  const tokenScope = (bundleId: string | null) => and(
+    eq(deviceTokens.userId, userId),
+    eq(deviceTokens.platform, "ios"),
+    ...(bundleId == null ? [] : [eq(deviceTokens.bundleId, bundleId)]),
+  );
   return db.transaction(async (tx) => {
     // This uses the same account advisory lock as deletion startup. Once the
     // tombstone wins that linearization point, no later push can renew a device
@@ -52,11 +60,7 @@ export async function claimDeviceDeliveryTargets(
         deliveryLeaseUntil: deviceTokens.deliveryLeaseUntil,
       })
       .from(deviceTokens)
-      .where(and(
-        eq(deviceTokens.userId, userId),
-        eq(deviceTokens.platform, "ios"),
-        eq(deviceTokens.bundleId, targetBundleId),
-      ))
+      .where(tokenScope(targetBundleId))
       .limit(MAX_DEVICE_TOKENS_PER_USER)
       .for("update");
 
@@ -86,9 +90,7 @@ export async function claimDeviceDeliveryTargets(
         deliveryLeaseToken: leaseToken,
       })
       .where(and(
-        eq(deviceTokens.userId, userId),
-        eq(deviceTokens.platform, "ios"),
-        eq(deviceTokens.bundleId, targetBundleId),
+        tokenScope(targetBundleId),
         inArray(deviceTokens.id, rows.map((row) => row.targetId)),
       ));
 

--- a/web/services/apns/pushDeliveryService.ts
+++ b/web/services/apns/pushDeliveryService.ts
@@ -45,7 +45,8 @@ export type PushDeliveryPayload = PushPayload & {
 
 export interface PushDeliveryInput {
   readonly userId: string;
-  readonly targetBundleId: string;
+  /** Bundle to deliver to, or null for the legacy account-wide fan-out. */
+  readonly targetBundleId: string | null;
   readonly correlationId: string;
   readonly payloadFingerprint: string;
   readonly startedAt: Date;

--- a/web/tests/notifications-push-route.test.ts
+++ b/web/tests/notifications-push-route.test.ts
@@ -200,7 +200,10 @@ describe("notifications push route", () => {
     expect(cloudDb).not.toHaveBeenCalled();
   });
 
-  test("rejects a missing target namespace before DB access", async () => {
+  test("a missing target namespace is treated as legacy, not rejected", async () => {
+    // Macs older than the namespace rollout (0.64.x) never send the header.
+    // Rejecting them kills phone push forwarding for the whole legacy fleet,
+    // so a header-less request must proceed to delivery instead of 400ing.
     checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
     const response = await pushRoute.POST(
       new Request("https://cmux.test/api/notifications/push", {
@@ -213,11 +216,57 @@ describe("notifications push route", () => {
       }),
     );
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "missing_target_namespace",
-    });
-    expect(cloudDb).not.toHaveBeenCalled();
+    expect(response.status).not.toBe(400);
+    expect(cloudDb).toHaveBeenCalled();
+  });
+
+  dbTest("a header-less legacy Mac fans out to every registered iOS token", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    useStubDb = false;
+    await sql`
+      truncate device_tokens, notification_send_events restart identity cascade
+    `;
+    await sql`
+      insert into device_tokens (
+        user_id, device_token, platform, bundle_id, environment
+      ) values
+        ('user-1', ${"a".repeat(64)}, 'ios', 'com.cmux.app', 'production'),
+        ('user-1', ${"b".repeat(64)}, 'ios', 'dev.cmux.app.beta', 'production')
+    `;
+
+    const response = await pushRoute.sendPushWithTransport(
+      new Request("https://cmux.test/api/notifications/push", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+        },
+        body: JSON.stringify({
+          title: "agent",
+          body: "done",
+          correlationId: "7f1f7a48-9f38-4a0f-9a71-a4c14f0f6d59",
+        }),
+      }),
+      sendApnsNotificationReliably as Parameters<
+        typeof pushRoute.sendPushWithTransport
+      >[1],
+    );
+
+    expect(response.status).toBe(200);
+    const targets = (
+      (sendApnsNotificationReliably as unknown as {
+        mock: { calls: unknown[][] };
+      }).mock.calls[0]?.[1] as Array<{
+        deviceToken: string;
+        bundleId: string;
+      }>
+    );
+    // Pre-namespace reach: every token the account registered, each keeping
+    // its own bundle topic, exactly like delivery before the namespace header.
+    expect(targets).toHaveLength(2);
+    expect(new Set(targets.map((target) => target.bundleId))).toEqual(
+      new Set(["com.cmux.app", "dev.cmux.app.beta"]),
+    );
   });
 
   dbTest("delivers to BETA without selecting INTERNAL tokens", async () => {

--- a/web/tests/notifications-push-route.test.ts
+++ b/web/tests/notifications-push-route.test.ts
@@ -231,7 +231,8 @@ describe("notifications push route", () => {
         user_id, device_token, platform, bundle_id, environment
       ) values
         ('user-1', ${"a".repeat(64)}, 'ios', 'com.cmux.app', 'production'),
-        ('user-1', ${"b".repeat(64)}, 'ios', 'dev.cmux.app.beta', 'production')
+        ('user-1', ${"b".repeat(64)}, 'ios', 'dev.cmux.app.beta', 'production'),
+        ('user-1', ${"c".repeat(64)}, 'ios', 'dev.cmux.ios.tsgate', 'sandbox')
     `;
 
     const response = await pushRoute.sendPushWithTransport(
@@ -259,14 +260,41 @@ describe("notifications push route", () => {
       }).mock.calls[0]?.[1] as Array<{
         deviceToken: string;
         bundleId: string;
+        environment: string;
       }>
     );
     // Pre-namespace reach: every token the account registered, each keeping
-    // its own bundle topic, exactly like delivery before the namespace header.
-    expect(targets).toHaveLength(2);
-    expect(new Set(targets.map((target) => target.bundleId))).toEqual(
-      new Set(["com.cmux.app", "dev.cmux.app.beta"]),
+    // its own bundle topic AND environment, exactly like delivery before the
+    // namespace header existed.
+    expect(targets).toHaveLength(3);
+    expect(
+      new Set(targets.map((target) => `${target.bundleId}|${target.environment}`)),
+    ).toEqual(new Set([
+      "com.cmux.app|production",
+      "dev.cmux.app.beta|production",
+      "dev.cmux.ios.tsgate|sandbox",
+    ]));
+  });
+
+  test("an explicitly empty target namespace is rejected, not legacy", async () => {
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
+    const response = await pushRoute.POST(
+      new Request("https://cmux.test/api/notifications/push", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+          "x-cmux-ios-target-namespace": "",
+        },
+        body: JSON.stringify({ title: "Agent", body: "Done" }),
+      }),
     );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_target_namespace",
+    });
+    expect(cloudDb).not.toHaveBeenCalled();
   });
 
   dbTest("delivers to BETA without selecting INTERNAL tokens", async () => {


### PR DESCRIPTION
Fallout from https://github.com/manaflow-ai/cmux/pull/9183, same family as the pairing fix in https://github.com/manaflow-ai/cmux/pull/10381: the push route made `X-Cmux-IOS-Target-Namespace` mandatory, but 0.64.x Macs never send it, so since the web deploy every push they forward has been 400ed (`missing_target_namespace`) and their users silently lost phone notifications.

Header-less callers are now treated as the `legacy` namespace, the convention the relay-token and device-token routes already use. Delivery restores the exact pre-namespace reach: the device-token claim drops the bundle filter and fans out to every iOS token the account registered, with each row supplying its own bundle topic and environment to the sender (that per-row plumbing already existed). Namespaced callers keep exact-bundle scoping, a present-but-unknown header still 400s, and the delivery fingerprint pins the literal `legacy` so retry dedupe stays stable for old Macs.

Two commits per the regression convention: the failing tests land first (header-less request must reach delivery; db-backed fan-out test), then the fix. Verified with `bun test` against a real Postgres (`CMUX_DB_TEST=1`): all 23 route tests pass, including the existing beta-vs-internal scoping test over the modified claim query. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789712193&installation_model_id=21920&pr_number=10400&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10400&signature=4f4cc8e3a5f700be740dfcb32d9fc20fdd7e6396ed4d5aed15a27ab7856526eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores push delivery for 0.64.x Macs by treating requests without X-Cmux-IOS-Target-Namespace as the legacy namespace. Previously these 400ed with missing_target_namespace; now omitted headers fan out to all iOS tokens for the user, while empty or invalid headers still 400 with invalid_target_namespace.

- Review notes
  - Routing: missing header => legacy; empty or invalid value => 400 invalid_target_namespace; namespaced callers keep exact-bundle scoping. Fingerprint pins "legacy" when the header is absent to keep retry dedupe stable.
  - DB leasing: `claimDeviceDeliveryTargets` accepts `string | null`; null removes the bundle filter to fan out across all iOS tokens. Query scope is shared via a `tokenScope` helper.
  - Delivery: `targetBundleId` is `string | null`; null triggers legacy fan-out with each row providing its own bundle and environment.
  - Tests: added a DB-backed fan-out test asserting bundle-and-environment pairs (including sandbox); added a rejection test for an explicitly empty header; updated route tests to accept header-less requests.

- Rollout
  - No client changes or migrations required. Monitor APNs send volume; legacy clients may emit broader fan-out until upgraded.

<sup>Written for commit 31d8c405987e55533e2381d3b2b2cb99b0c7c6d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored push notification delivery for legacy Mac clients that omit the target namespace.
  * Legacy notifications now reach all registered iOS devices while preserving each device’s bundle topic and environment.
  * Invalid or explicitly empty namespace values continue to return a clear validation error.
  * Notifications with a valid namespace remain restricted to the specified app bundle.

* **Tests**
  * Added coverage for header-less legacy requests and account-wide device delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->