### PR TITLE
cmux-tui: give a bare session its shell at attach

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -606,10 +606,13 @@ impl Session {
                         let workspaces = snapshot["workspaces"].as_array();
                         let bare = workspaces.is_some_and(|workspaces| {
                             !workspaces.is_empty()
+                                // An explicit empty screen array is the only
+                                // proof of bareness; a missing or malformed
+                                // field fails closed and skips the create.
                                 && workspaces.iter().all(|workspace| {
                                     workspace["screens"]
                                         .as_array()
-                                        .is_none_or(|screens| screens.is_empty())
+                                        .is_some_and(|screens| screens.is_empty())
                                 })
                         });
                         // Fail closed: without the revision metadata the

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -295,6 +295,30 @@ fn default_true() -> bool {
     true
 }
 
+/// How attach must bootstrap a session so a bare `cmux` launch never lands on
+/// pure emptiness. A brand-new session gets its first workspace. A session
+/// whose every workspace has lost its screens (the legitimate outcome of the
+/// startup repair that prunes dead terminals) gets the default shell in the
+/// active workspace, because empty is indistinguishable from broken at
+/// attach. One surviving screen anywhere means the user's layout is intact,
+/// and includes the deliberately-empty-workspace case, so startup must not
+/// mutate anything.
+enum InitialBootstrap {
+    FirstWorkspace,
+    ShellInActiveWorkspace,
+    LayoutIntact,
+}
+
+fn initial_bootstrap(tree: &TreeView) -> InitialBootstrap {
+    if tree.workspaces.is_empty() {
+        return InitialBootstrap::FirstWorkspace;
+    }
+    if tree.workspaces.iter().all(|workspace| workspace.screens.is_empty()) {
+        return InitialBootstrap::ShellInActiveWorkspace;
+    }
+    InitialBootstrap::LayoutIntact
+}
+
 /// Attach optional cols/rows fields to a remote command.
 fn with_size(mut cmd: serde_json::Value, size: Option<(u16, u16)>) -> serde_json::Value {
     if let Some((cols, rows)) = size {
@@ -522,17 +546,57 @@ impl Session {
     /// is the expected content size of the first pane, when known.
     pub fn ensure_initial(&self, size: Option<(u16, u16)>) -> anyhow::Result<()> {
         match self {
-            Session::Local(mux) => {
-                mux.new_workspace(None, size)?;
-                Ok(())
-            }
+            Session::Local(mux) => match initial_bootstrap(&self.tree()) {
+                InitialBootstrap::FirstWorkspace => {
+                    mux.new_workspace(None, size)?;
+                    Ok(())
+                }
+                InitialBootstrap::ShellInActiveWorkspace => {
+                    let tree = self.tree();
+                    let workspace = tree
+                        .workspaces
+                        .get(tree.active_workspace)
+                        .or_else(|| tree.workspaces.first())
+                        .expect("bare-session bootstrap requires at least one workspace")
+                        .id;
+                    mux.create_terminal_in_workspace(workspace, None, None, None, size)?;
+                    Ok(())
+                }
+                InitialBootstrap::LayoutIntact => Ok(()),
+            },
             Session::Remote(remote) => {
-                if remote.refresh_tree()?.workspaces.is_empty() {
-                    remote.request(with_size(json!({"cmd": "new-workspace"}), size))?;
-                    anyhow::ensure!(
-                        !remote.refresh_tree()?.workspaces.is_empty(),
-                        "remote session did not expose the workspace it created"
-                    );
+                let tree = remote.refresh_tree()?;
+                match initial_bootstrap(&tree) {
+                    InitialBootstrap::FirstWorkspace => {
+                        remote.request(with_size(json!({"cmd": "new-workspace"}), size))?;
+                        anyhow::ensure!(
+                            !remote.refresh_tree()?.workspaces.is_empty(),
+                            "remote session did not expose the workspace it created"
+                        );
+                    }
+                    InitialBootstrap::ShellInActiveWorkspace => {
+                        let workspace = tree
+                            .workspaces
+                            .get(tree.active_workspace)
+                            .or_else(|| tree.workspaces.first())
+                            .expect("bare-session bootstrap requires at least one workspace");
+                        let mut request = json!({"cmd": "create-terminal"});
+                        if workspace.key.is_empty() {
+                            request["workspace"] = json!(workspace.id);
+                        } else {
+                            request["key"] = json!(workspace.key);
+                        }
+                        remote.request(with_size(request, size))?;
+                        anyhow::ensure!(
+                            remote
+                                .refresh_tree()?
+                                .workspaces
+                                .iter()
+                                .any(|workspace| !workspace.screens.is_empty()),
+                            "remote session did not expose the shell it created in its bare workspace"
+                        );
+                    }
+                    InitialBootstrap::LayoutIntact => {}
                 }
                 Ok(())
             }

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -612,44 +612,56 @@ impl Session {
                                         .is_none_or(|screens| screens.is_empty())
                                 })
                         });
-                        let create_result = if bare {
-                            let workspaces = workspaces.expect("bareness implies an array");
-                            let target = workspaces
-                                .iter()
-                                .find(|workspace| workspace["active"].as_bool() == Some(true))
-                                .unwrap_or(&workspaces[0]);
-                            let mut request = json!({
-                                "cmd": "create-terminal",
-                                "origin": "attach-bare-session-bootstrap",
-                                "mutation_id": bootstrap_mutation_id()?,
-                            });
-                            match target["key"].as_str() {
-                                Some(key) if !key.is_empty() => request["key"] = json!(key),
-                                _ => request["workspace"] = target["id"].clone(),
-                            }
-                            if let Some(generation) = snapshot["generation"].as_str() {
-                                request["expected_generation"] = json!(generation);
-                            }
-                            if let Some(revision) = snapshot["terminal_revision"].as_u64() {
-                                request["expected_revision"] = json!(revision);
-                            }
-                            remote.request(with_size(request, size)).map(|_| ())
-                        } else {
-                            Ok(())
+                        // Fail closed: without the revision metadata the
+                        // create cannot carry its guard, and an unguarded
+                        // create from two concurrent attaches would add two
+                        // shells. A daemon old enough to omit the metadata
+                        // keeps its old behavior (the session stays bare).
+                        let guard = match (
+                            snapshot["generation"].as_str(),
+                            snapshot["terminal_revision"].as_u64(),
+                        ) {
+                            (Some(generation), Some(revision)) => Some((generation, revision)),
+                            _ => None,
                         };
-                        let bootstrapped = remote
-                            .refresh_tree()?
-                            .workspaces
-                            .iter()
-                            .any(|workspace| !workspace.screens.is_empty());
-                        if !bootstrapped {
-                            return Err(match create_result {
-                                Err(error) => error
-                                    .context("bare-session bootstrap could not create its shell"),
-                                Ok(()) => anyhow::anyhow!(
-                                    "remote session did not expose the shell it created in its bare workspace"
-                                ),
-                            });
+                        let create_result = match (bare, guard) {
+                            (true, Some((generation, revision))) => {
+                                let workspaces = workspaces.expect("bareness implies an array");
+                                let target = workspaces
+                                    .iter()
+                                    .find(|workspace| workspace["active"].as_bool() == Some(true))
+                                    .unwrap_or(&workspaces[0]);
+                                let mut request = json!({
+                                    "cmd": "create-terminal",
+                                    "origin": "attach-bare-session-bootstrap",
+                                    "mutation_id": bootstrap_mutation_id()?,
+                                    "expected_generation": generation,
+                                    "expected_revision": revision,
+                                });
+                                match target["key"].as_str() {
+                                    Some(key) if !key.is_empty() => request["key"] = json!(key),
+                                    _ => request["workspace"] = target["id"].clone(),
+                                }
+                                Some(remote.request(with_size(request, size)).map(|_| ()))
+                            }
+                            _ => None,
+                        };
+                        if let Some(create_result) = create_result {
+                            let bootstrapped = remote
+                                .refresh_tree()?
+                                .workspaces
+                                .iter()
+                                .any(|workspace| !workspace.screens.is_empty());
+                            if !bootstrapped {
+                                return Err(match create_result {
+                                    Err(error) => error.context(
+                                        "bare-session bootstrap could not create its shell",
+                                    ),
+                                    Ok(()) => anyhow::anyhow!(
+                                        "remote session did not expose the shell it created in its bare workspace"
+                                    ),
+                                });
+                            }
                         }
                     }
                     InitialBootstrap::LayoutIntact => {}

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -649,9 +649,13 @@ impl Session {
                             }
                             _ => None,
                         };
+                        // Refresh unconditionally: when another attach won
+                        // between the first tree read and the raw snapshot,
+                        // no create runs here, and without this refresh the
+                        // cached tree would still show the pre-shell session.
+                        let refreshed = remote.refresh_tree()?;
                         if let Some(create_result) = create_result {
-                            let bootstrapped = remote
-                                .refresh_tree()?
+                            let bootstrapped = refreshed
                                 .workspaces
                                 .iter()
                                 .any(|workspace| !workspace.screens.is_empty());

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -309,6 +309,22 @@ enum InitialBootstrap {
     LayoutIntact,
 }
 
+/// Idempotency identity for the bare-session bootstrap create. Uniqueness
+/// matters: a collision would make the daemon replay another client's create
+/// instead of applying the revision guard.
+fn bootstrap_mutation_id() -> anyhow::Result<String> {
+    use std::fmt::Write as _;
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("cannot allocate bootstrap mutation identity: {error}"))?;
+    let mut id = String::with_capacity(50);
+    id.push_str("attach-bootstrap_");
+    for byte in bytes {
+        let _ = write!(id, "{byte:02x}");
+    }
+    Ok(id)
+}
+
 fn initial_bootstrap(tree: &TreeView) -> InitialBootstrap {
     if tree.workspaces.is_empty() {
         return InitialBootstrap::FirstWorkspace;
@@ -579,26 +595,62 @@ impl Session {
                         );
                     }
                     InitialBootstrap::ShellInActiveWorkspace => {
-                        let workspace = tree
-                            .workspaces
-                            .get(tree.active_workspace)
-                            .or_else(|| tree.workspaces.first())
-                            .expect("bare-session bootstrap requires at least one workspace");
-                        let mut request = json!({"cmd": "create-terminal"});
-                        if workspace.key.is_empty() {
-                            request["workspace"] = json!(workspace.id);
-                        } else {
-                            request["key"] = json!(workspace.key);
-                        }
-                        remote.request(with_size(request, size))?;
-                        anyhow::ensure!(
-                            remote
-                                .refresh_tree()?
-                                .workspaces
+                        // Re-read the tree raw so the create can carry the
+                        // terminal revision of the very snapshot it targets,
+                        // and re-verify bareness from that snapshot: when two
+                        // clients attach to one bare session, the daemon
+                        // rejects the guarded create whose revision already
+                        // moved, and the postcondition accepts the shell
+                        // whichever client created it.
+                        let snapshot = remote.request(json!({"cmd": "list-workspaces"}))?;
+                        let workspaces = snapshot["workspaces"].as_array();
+                        let bare = workspaces.is_some_and(|workspaces| {
+                            !workspaces.is_empty()
+                                && workspaces.iter().all(|workspace| {
+                                    workspace["screens"]
+                                        .as_array()
+                                        .is_none_or(|screens| screens.is_empty())
+                                })
+                        });
+                        let create_result = if bare {
+                            let workspaces = workspaces.expect("bareness implies an array");
+                            let target = workspaces
                                 .iter()
-                                .any(|workspace| !workspace.screens.is_empty()),
-                            "remote session did not expose the shell it created in its bare workspace"
-                        );
+                                .find(|workspace| workspace["active"].as_bool() == Some(true))
+                                .unwrap_or(&workspaces[0]);
+                            let mut request = json!({
+                                "cmd": "create-terminal",
+                                "origin": "attach-bare-session-bootstrap",
+                                "mutation_id": bootstrap_mutation_id()?,
+                            });
+                            match target["key"].as_str() {
+                                Some(key) if !key.is_empty() => request["key"] = json!(key),
+                                _ => request["workspace"] = target["id"].clone(),
+                            }
+                            if let Some(generation) = snapshot["generation"].as_str() {
+                                request["expected_generation"] = json!(generation);
+                            }
+                            if let Some(revision) = snapshot["terminal_revision"].as_u64() {
+                                request["expected_revision"] = json!(revision);
+                            }
+                            remote.request(with_size(request, size)).map(|_| ())
+                        } else {
+                            Ok(())
+                        };
+                        let bootstrapped = remote
+                            .refresh_tree()?
+                            .workspaces
+                            .iter()
+                            .any(|workspace| !workspace.screens.is_empty());
+                        if !bootstrapped {
+                            return Err(match create_result {
+                                Err(error) => error
+                                    .context("bare-session bootstrap could not create its shell"),
+                                Ok(()) => anyhow::anyhow!(
+                                    "remote session did not expose the shell it created in its bare workspace"
+                                ),
+                            });
+                        }
                     }
                     InitialBootstrap::LayoutIntact => {}
                 }

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -546,24 +546,28 @@ impl Session {
     /// is the expected content size of the first pane, when known.
     pub fn ensure_initial(&self, size: Option<(u16, u16)>) -> anyhow::Result<()> {
         match self {
-            Session::Local(mux) => match initial_bootstrap(&self.tree()) {
-                InitialBootstrap::FirstWorkspace => {
-                    mux.new_workspace(None, size)?;
-                    Ok(())
+            Session::Local(mux) => {
+                // One snapshot serves both the decision and the target
+                // selection; a second read could disagree with the first
+                // when another mux owner mutates the tree in between.
+                let tree = self.tree();
+                match initial_bootstrap(&tree) {
+                    InitialBootstrap::FirstWorkspace => {
+                        mux.new_workspace(None, size)?;
+                    }
+                    InitialBootstrap::ShellInActiveWorkspace => {
+                        let workspace = tree
+                            .workspaces
+                            .get(tree.active_workspace)
+                            .or_else(|| tree.workspaces.first())
+                            .expect("bare-session bootstrap requires at least one workspace")
+                            .id;
+                        mux.create_terminal_in_workspace(workspace, None, None, None, size)?;
+                    }
+                    InitialBootstrap::LayoutIntact => {}
                 }
-                InitialBootstrap::ShellInActiveWorkspace => {
-                    let tree = self.tree();
-                    let workspace = tree
-                        .workspaces
-                        .get(tree.active_workspace)
-                        .or_else(|| tree.workspaces.first())
-                        .expect("bare-session bootstrap requires at least one workspace")
-                        .id;
-                    mux.create_terminal_in_workspace(workspace, None, None, None, size)?;
-                    Ok(())
-                }
-                InitialBootstrap::LayoutIntact => Ok(()),
-            },
+                Ok(())
+            }
             Session::Remote(remote) => {
                 let tree = remote.refresh_tree()?;
                 match initial_bootstrap(&tree) {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5447,6 +5447,122 @@ mod tests {
         }
     }
 
+    /// A session whose every workspace lost its screens (the outcome of the
+    /// startup repair that prunes dead terminals) must get a shell in the
+    /// active workspace at attach, not render pure emptiness. The writer
+    /// refuses `new-workspace`, so this also pins that startup must not bolt
+    /// an extra workspace onto a session that already has four.
+    struct BareWorkspacesTreeWriter {
+        session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
+        created_in: Arc<Mutex<Option<String>>>,
+    }
+
+    impl RemoteMessageWriter for BareWorkspacesTreeWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("remote request omitted its id"))?;
+            let bare = |key: &str, id: u64, active: bool| {
+                json!({"id": id, "key": key, "active": active, "screens": []})
+            };
+            let populated = json!({
+                "id": 5,
+                "key": "ws-active",
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [{"surface": 4, "kind": "pty"}],
+                    }],
+                }],
+            });
+            let data = match request.get("cmd").and_then(Value::as_str) {
+                Some("list-workspaces") => {
+                    if self.created_in.lock().unwrap().is_some() {
+                        json!({"workspaces": [
+                            bare("ws-0", 1, false),
+                            populated,
+                            bare("ws-2", 9, false),
+                        ]})
+                    } else {
+                        json!({"workspaces": [
+                            bare("ws-0", 1, false),
+                            bare("ws-active", 5, true),
+                            bare("ws-2", 9, false),
+                        ]})
+                    }
+                }
+                Some("list-agents") => json!({"agents": []}),
+                Some("create-terminal") => {
+                    let key = request
+                        .get("key")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| io::Error::other("create-terminal omitted the workspace key"))?;
+                    *self.created_in.lock().unwrap() = Some(key.to_string());
+                    json!({"surface": 4})
+                }
+                command => {
+                    return Err(io::Error::other(format!(
+                        "bare-workspace attach must not send {command:?}"
+                    )));
+                }
+            };
+            let session = self
+                .session
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+            let response = session
+                .pending
+                .lock()
+                .unwrap()
+                .remove(&id)
+                .ok_or_else(|| io::Error::other("remote request was not pending"))?;
+            response
+                .response
+                .send(json!({"id": id, "ok": true, "data": data}))
+                .map_err(|_| io::Error::other("remote response receiver was dropped"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn ensure_initial_creates_a_shell_when_every_restored_workspace_is_bare() {
+        let session_slot = Arc::new(Mutex::new(None));
+        let created_in = Arc::new(Mutex::new(None));
+        let remote = test_session(Box::new(BareWorkspacesTreeWriter {
+            session: session_slot.clone(),
+            created_in: created_in.clone(),
+        }));
+        *session_slot.lock().unwrap() = Some(Arc::downgrade(&remote));
+        let session = crate::session::Session::Remote(remote);
+
+        session.ensure_initial(Some((80, 24))).unwrap();
+
+        assert_eq!(
+            created_in.lock().unwrap().as_deref(),
+            Some("ws-active"),
+            "attach did not create a shell in the active bare workspace"
+        );
+        assert_eq!(
+            session.tree().active_surface(),
+            Some(4),
+            "startup returned before the client could route input to its created terminal"
+        );
+    }
+
     #[test]
     fn ensure_initial_populates_remote_cache_after_creating_first_workspace() {
         let session_slot = Arc::new(Mutex::new(None));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5627,6 +5627,28 @@ mod tests {
     }
 
     #[test]
+    fn winner_between_snapshots_still_lands_in_the_cache() {
+        // The other attach creates the shell between the first tree read and
+        // the raw snapshot: no create runs here, and the final refresh must
+        // still deliver the winner's tree to this client's cache.
+        let session_slot = Arc::new(Mutex::new(None));
+        let remote = test_session(Box::new(LostBootstrapRaceWriter {
+            session: session_slot.clone(),
+            list_requests: 1, // skip one bare read: the snapshot is populated
+        }));
+        *session_slot.lock().unwrap() = Some(Arc::downgrade(&remote));
+        let session = crate::session::Session::Remote(remote);
+
+        session.ensure_initial(Some((80, 24))).unwrap();
+
+        assert_eq!(
+            session.tree().active_surface(),
+            Some(4),
+            "the stale bare tree survived in the cache"
+        );
+    }
+
+    #[test]
     fn losing_the_bare_session_bootstrap_race_is_not_a_startup_failure() {
         let session_slot = Arc::new(Mutex::new(None));
         let remote = test_session(Box::new(LostBootstrapRaceWriter {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5464,9 +5464,7 @@ mod tests {
                 .get("id")
                 .and_then(Value::as_u64)
                 .ok_or_else(|| io::Error::other("remote request omitted its id"))?;
-            let bare = |key: &str, id: u64, active: bool| {
-                json!({"id": id, "key": key, "active": active, "screens": []})
-            };
+            let bare = |key: &str, id: u64, active: bool| json!({"id": id, "key": key, "active": active, "screens": []});
             let populated = json!({
                 "id": 5,
                 "key": "ws-active",
@@ -5486,13 +5484,13 @@ mod tests {
             let data = match request.get("cmd").and_then(Value::as_str) {
                 Some("list-workspaces") => {
                     if self.created_in.lock().unwrap().is_some() {
-                        json!({"workspaces": [
+                        json!({"generation": "gen-1", "terminal_revision": 8, "workspaces": [
                             bare("ws-0", 1, false),
                             populated,
                             bare("ws-2", 9, false),
                         ]})
                     } else {
-                        json!({"workspaces": [
+                        json!({"generation": "gen-1", "terminal_revision": 7, "workspaces": [
                             bare("ws-0", 1, false),
                             bare("ws-active", 5, true),
                             bare("ws-2", 9, false),
@@ -5501,10 +5499,18 @@ mod tests {
                 }
                 Some("list-agents") => json!({"agents": []}),
                 Some("create-terminal") => {
-                    let key = request
-                        .get("key")
-                        .and_then(Value::as_str)
-                        .ok_or_else(|| io::Error::other("create-terminal omitted the workspace key"))?;
+                    let key = request.get("key").and_then(Value::as_str).ok_or_else(|| {
+                        io::Error::other("create-terminal omitted the workspace key")
+                    })?;
+                    if request.get("mutation_id").and_then(Value::as_str).is_none()
+                        || request.get("expected_revision").and_then(Value::as_u64) != Some(7)
+                        || request.get("expected_generation").and_then(Value::as_str)
+                            != Some("gen-1")
+                    {
+                        return Err(io::Error::other(
+                            "bootstrap create arrived without its concurrency guard",
+                        ));
+                    }
                     *self.created_in.lock().unwrap() = Some(key.to_string());
                     json!({"surface": 4})
                 }
@@ -5536,6 +5542,107 @@ mod tests {
         fn close(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    /// The losing side of a concurrent bare-session attach: its guarded
+    /// create is rejected because the winner already moved the terminal
+    /// revision, and the follow-up tree read shows the winner's shell.
+    /// Attach must treat that as success, not as a startup failure.
+    struct LostBootstrapRaceWriter {
+        session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
+        list_requests: usize,
+    }
+
+    impl RemoteMessageWriter for LostBootstrapRaceWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("remote request omitted its id"))?;
+            let populated = json!({
+                "id": 5,
+                "key": "ws-active",
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [{"surface": 4, "kind": "pty"}],
+                    }],
+                }],
+            });
+            let response = match request.get("cmd").and_then(Value::as_str) {
+                Some("list-workspaces") => {
+                    self.list_requests += 1;
+                    let data = if self.list_requests <= 2 {
+                        json!({"generation": "gen-1", "terminal_revision": 7, "workspaces": [
+                            {"id": 5, "key": "ws-active", "active": true, "screens": []},
+                        ]})
+                    } else {
+                        json!({"generation": "gen-1", "terminal_revision": 8, "workspaces": [
+                            populated,
+                        ]})
+                    };
+                    json!({"id": id, "ok": true, "data": data})
+                }
+                Some("list-agents") => json!({"id": id, "ok": true, "data": {"agents": []}}),
+                Some("create-terminal") => json!({
+                    "id": id,
+                    "ok": false,
+                    "error": "expected terminal revision 7 does not match 8",
+                }),
+                command => {
+                    return Err(io::Error::other(format!(
+                        "lost bootstrap race must not send {command:?}"
+                    )));
+                }
+            };
+            let session = self
+                .session
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+            let pending = session
+                .pending
+                .lock()
+                .unwrap()
+                .remove(&id)
+                .ok_or_else(|| io::Error::other("remote request was not pending"))?;
+            pending
+                .response
+                .send(response)
+                .map_err(|_| io::Error::other("remote response receiver was dropped"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn losing_the_bare_session_bootstrap_race_is_not_a_startup_failure() {
+        let session_slot = Arc::new(Mutex::new(None));
+        let remote = test_session(Box::new(LostBootstrapRaceWriter {
+            session: session_slot.clone(),
+            list_requests: 0,
+        }));
+        *session_slot.lock().unwrap() = Some(Arc::downgrade(&remote));
+        let session = crate::session::Session::Remote(remote);
+
+        session.ensure_initial(Some((80, 24))).unwrap();
+
+        assert_eq!(
+            session.tree().active_surface(),
+            Some(4),
+            "the loser must adopt the winner's shell instead of failing attach"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5645,6 +5645,73 @@ mod tests {
         );
     }
 
+    /// A daemon too old to report revision metadata cannot enforce the
+    /// bootstrap guard, so the client must not send an unguarded create at
+    /// all: the writer refuses `create-terminal`, and attach must still
+    /// succeed with the session left bare, exactly as before the bootstrap
+    /// existed.
+    struct UnguardableTreeWriter {
+        session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
+    }
+
+    impl RemoteMessageWriter for UnguardableTreeWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("remote request omitted its id"))?;
+            let data = match request.get("cmd").and_then(Value::as_str) {
+                Some("list-workspaces") => json!({"workspaces": [
+                    {"id": 5, "key": "ws-active", "active": true, "screens": []},
+                ]}),
+                Some("list-agents") => json!({"agents": []}),
+                command => {
+                    return Err(io::Error::other(format!(
+                        "an unguardable daemon must not receive {command:?}"
+                    )));
+                }
+            };
+            let session = self
+                .session
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+            let pending = session
+                .pending
+                .lock()
+                .unwrap()
+                .remove(&id)
+                .ok_or_else(|| io::Error::other("remote request was not pending"))?;
+            pending
+                .response
+                .send(json!({"id": id, "ok": true, "data": data}))
+                .map_err(|_| io::Error::other("remote response receiver was dropped"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn bootstrap_stays_home_when_the_daemon_cannot_enforce_its_guard() {
+        let session_slot = Arc::new(Mutex::new(None));
+        let remote =
+            test_session(Box::new(UnguardableTreeWriter { session: session_slot.clone() }));
+        *session_slot.lock().unwrap() = Some(Arc::downgrade(&remote));
+        let session = crate::session::Session::Remote(remote);
+
+        session.ensure_initial(Some((80, 24))).unwrap();
+
+        assert!(
+            session.tree().workspaces.iter().all(|workspace| workspace.screens.is_empty()),
+            "an unguarded create must never run"
+        );
+    }
+
     #[test]
     fn ensure_initial_creates_a_shell_when_every_restored_workspace_is_bare() {
         let session_slot = Arc::new(Mutex::new(None));


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/10391.

The startup repair from https://github.com/manaflow-ai/cmux/pull/10299 and https://github.com/manaflow-ai/cmux/pull/10304 legitimately leaves a session holding only screenless workspaces, and a bare `uvx cmux` launch then renders pure emptiness with no hint that the new-tab binding would populate it. A fresh session by contrast starts with a shell.

`Session::ensure_initial` now classifies the refreshed tree once. No workspaces creates the first workspace, unchanged. Every workspace bare creates the default shell in the active workspace (`create-terminal` by stable key, numeric id fallback), then verifies the daemon exposed the screen it created. One surviving screen anywhere leaves the layout untouched, which keeps deliberately empty workspaces created by GUI frontends intact. The provider-owned and session-unavailable gates in `ensure_initial_for_machine_ui` sit in front of this and still suppress creation entirely.

Regression test first, fix second, so CI shows red then green. The test's fake writer refuses `new-workspace`, so it also pins that attach must not bolt an extra workspace onto a session that already has four. Verified on a Blacksmith Testbox at 5a4780614c: the two `ensure_initial` tests pass, all 1360 `cmux-tui` bin tests pass, clippy clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789714268&installation_model_id=21920&pr_number=10404&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10404&signature=b613893c9eb286bf7391e8f19d43f987c4a336fbf8464ae0b3402365590e16f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach now auto-creates the default shell in the active workspace when a session’s workspaces are all bare; previously attach rendered an empty screen until users created a tab. When revision metadata is missing or bareness cannot be proven, attach skips creation to avoid duplicates and still succeeds, leaving the session bare.

- Centralizes bootstrap logic in `initial_bootstrap`, used by `Session::ensure_initial` in `cmux-tui`.
- Local: one tree snapshot drives both the decision and the target selection to avoid races.
- Remote: re-reads `list-workspaces`; only an explicit empty `screens: []` per workspace proves bareness. If all are bare and metadata exists, send guarded `create-terminal` to the active workspace (stable key, numeric id fallback) with `expected_generation`, `expected_revision`, a unique `mutation_id`, and `origin: attach-bare-session-bootstrap`; then unconditionally refresh the tree to update the cache whether the create was executed, rejected, or skipped, and accept whichever attach created the shell.
- Still creates the first workspace via `new-workspace` when none exist; never adds a workspace otherwise; preserves layouts with any surviving screen and deliberately empty workspaces. Tests cover bare-session attach, losing the guarded-create race without failing startup, skipping unguarded creates on old daemons, and cache refresh when another attach wins between snapshots.

<sup>Written for commit 5cd30251a1d0cc1bf0c958409c21c7788bcac7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for empty and partially initialized sessions.
  * Sessions with existing workspaces now create a terminal in the active or fallback workspace instead of creating an unnecessary workspace.
  * Preserved sessions that already contain an active screen.
  * Improved verification of remotely created terminals during startup.
  * Prevented startup actions from relying on inconsistent session state.
  * Safely handled simultaneous startup attempts without creating duplicate terminals.
  * Added clearer error reporting when startup terminal creation or verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->