### PR TITLE
fix: land persistent SSH panes in the reattachable placeholder instead of a dead prompt

### DIFF
--- a/CLI/CMUXCLI+SSHReconnectPrompt.swift
+++ b/CLI/CMUXCLI+SSHReconnectPrompt.swift
@@ -10,6 +10,29 @@ extension CMUXCLI {
         return "\\n\\033[33m\(status)\\033[0m\\n\\033[2m\(stopHint)\\033[0m\\n"
     }
 
+    /// The note a persistent wrapper prints when it stops retrying.
+    ///
+    /// The remote PTY outlives this wrapper, so the pane is reattachable rather
+    /// than dead; the hint names the affordances that actually work for it.
+    func sshPersistentAttachGiveUpNoteFormat() -> String {
+        let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
+        let status = String(localized: "cli.ssh.persistentGiveUp.status", defaultValue: "[cmux] ssh exited with status %s; the remote session is still running.", bundle: bundle)
+        let hint = String(localized: "cli.ssh.persistentGiveUp.hint", defaultValue: "[cmux] reconnect this pane from its right-click menu (Reconnect Pane) or from the workspace in the sidebar.", bundle: bundle)
+        return "\\n\\033[31m\(status)\\033[0m\\n\\033[2m\(hint)\\033[0m\\n"
+    }
+
+    /// The retry note for the foreground-authentication phase.
+    ///
+    /// Before the first successful authentication the wrapper is bounded by
+    /// `SSHForegroundAuthenticationRetryPolicy.maximumConsecutiveTransientFailures`,
+    /// not by the reconnect budget, so it must report that budget instead.
+    func sshAuthenticationRetryNoteFormat() -> String {
+        let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
+        let status = String(localized: "cli.ssh.authRetry.status", defaultValue: "[cmux] ssh authentication failed with status %s; retrying (attempt %s/%s).", bundle: bundle)
+        let stopHint = String(localized: "cli.ssh.autoReconnect.stopHint", defaultValue: "[cmux] close this pane or press Ctrl-C to stop reconnecting.", bundle: bundle)
+        return "\\n\\033[33m\(status)\\033[0m\\n\\033[2m\(stopHint)\\033[0m\\n"
+    }
+
     func sshManualReconnectExitPromptFormat() -> String {
         let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
         let status = String(localized: "cli.ssh.manualReconnectPrompt.status", defaultValue: "[cmux] ssh exited with status %s.", bundle: bundle)

--- a/CLI/CMUXCLI+SSHStartupScripts.swift
+++ b/CLI/CMUXCLI+SSHStartupScripts.swift
@@ -383,18 +383,22 @@ extension CMUXCLI {
             "cmux_ssh_register_attempt() { \(lifecycleLaunching); }",
             "cmux_ssh_begin_attempt() { CMUX_SSH_ATTEMPT_ID=$(/usr/bin/uuidgen | /usr/bin/tr '[:upper:]' '[:lower:]') || return 1; export CMUX_SSH_ATTEMPT_ID; cmux_ssh_attempt_registration_retry=0; while ! cmux_ssh_register_attempt; do cmux_ssh_attempt_registration_retry=$((cmux_ssh_attempt_registration_retry + 1)); if [ \"$cmux_ssh_attempt_registration_retry\" -ge 3 ]; then return 1; fi; /bin/sleep 0.1; done; }",
             "cmux_ssh_session_end() { if [ \"${CMUX_SSH_SESSION_ENDED:-0}\" = 1 ]; then return; fi; CMUX_SSH_SESSION_ENDED=1; cmux_ssh_cleanup_password; \(lifecycleCleanup); }",
-            "cmux_ssh_retire_for_signal() { cmux_ssh_signal_status=\"$1\"; CMUX_SSH_SESSION_ENDED=1; cmux_ssh_cleanup_password; \(lifecycleRetirement); trap - EXIT HUP INT TERM; exit \"$cmux_ssh_signal_status\"; }",
-            "cmux_ssh_signal_exit() { cmux_ssh_signal_status=\"$1\"; cmux_ssh_signal_name=\"$2\"; if [ -n \"${CMUX_SSH_AUTH_PID:-}\" ]; then cmux_ssh_terminate_auth_process_tree \"$CMUX_SSH_AUTH_PID\" \"$CMUX_SSH_STARTUP_PID\"; wait \"$CMUX_SSH_AUTH_PID\" 2>/dev/null || true; CMUX_SSH_AUTH_PID=; \(backoffBuilder.signalHandlerBranches) elif [ -z \"${CMUX_SSH_CHILD_PID:-}\" ]; then CMUX_SSH_PENDING_SIGNAL=\"$cmux_ssh_signal_status\"; CMUX_SSH_PENDING_SIGNAL_NAME=\"$cmux_ssh_signal_name\"; return; fi; cmux_ssh_retire_for_signal \"$cmux_ssh_signal_status\"; }",
+            // One retirement path for signals AND the persistent give-up: retire only
+            // this attach generation so the remote PTY survives for a later reattach.
+            // `cmux_ssh_retire_status` stays distinct from the signal handler's
+            // `cmux_ssh_signal_status` because sh variables are global.
+            "cmux_ssh_retire_lifecycle_and_exit() { cmux_ssh_retire_status=\"$1\"; CMUX_SSH_SESSION_ENDED=1; cmux_ssh_cleanup_password; \(lifecycleRetirement); trap - EXIT HUP INT TERM; exit \"$cmux_ssh_retire_status\"; }",
+            "cmux_ssh_signal_exit() { cmux_ssh_signal_status=\"$1\"; cmux_ssh_signal_name=\"$2\"; if [ -n \"${CMUX_SSH_AUTH_PID:-}\" ]; then cmux_ssh_terminate_auth_process_tree \"$CMUX_SSH_AUTH_PID\" \"$CMUX_SSH_STARTUP_PID\"; wait \"$CMUX_SSH_AUTH_PID\" 2>/dev/null || true; CMUX_SSH_AUTH_PID=; \(backoffBuilder.signalHandlerBranches) elif [ -z \"${CMUX_SSH_CHILD_PID:-}\" ]; then CMUX_SSH_PENDING_SIGNAL=\"$cmux_ssh_signal_status\"; CMUX_SSH_PENDING_SIGNAL_NAME=\"$cmux_ssh_signal_name\"; return; fi; cmux_ssh_retire_lifecycle_and_exit \"$cmux_ssh_signal_status\"; }",
             "trap 'cmux_ssh_session_end' EXIT",
             "trap 'cmux_ssh_signal_exit 129 HUP' HUP",
             "trap 'cmux_ssh_signal_exit 130 INT' INT",
             "trap 'cmux_ssh_signal_exit 143 TERM' TERM",
             "while :; do",
-            "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_retire_for_signal \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
+            "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_retire_lifecycle_and_exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
         ]
         if hasOneTimeCommand {
             scriptLines.append("  if [ \"$cmux_ssh_reauth_required\" -eq 1 ]; then")
-            scriptLines += ["    ( cmux_ssh_foreground_auth ) <&0 &", "    CMUX_SSH_AUTH_PID=$!; if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_signal_exit \"$CMUX_SSH_PENDING_SIGNAL\" \"${CMUX_SSH_PENDING_SIGNAL_NAME:-TERM}\"; fi; wait \"$CMUX_SSH_AUTH_PID\"; cmux_ssh_status=$?; CMUX_SSH_AUTH_PID=; case \"$cmux_ssh_status\" in 129|130|143) cmux_ssh_retire_for_signal \"$cmux_ssh_status\" ;; esac; if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_session_end; trap - EXIT HUP INT TERM; exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi", "    \(authenticationResult)", "  fi", "  if [ \"$cmux_ssh_reauth_required\" -eq 0 ]; then"]
+            scriptLines += ["    ( cmux_ssh_foreground_auth ) <&0 &", "    CMUX_SSH_AUTH_PID=$!; if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_signal_exit \"$CMUX_SSH_PENDING_SIGNAL\" \"${CMUX_SSH_PENDING_SIGNAL_NAME:-TERM}\"; fi; wait \"$CMUX_SSH_AUTH_PID\"; cmux_ssh_status=$?; CMUX_SSH_AUTH_PID=; case \"$cmux_ssh_status\" in 129|130|143) cmux_ssh_retire_lifecycle_and_exit \"$cmux_ssh_status\" ;; esac; if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_session_end; trap - EXIT HUP INT TERM; exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi", "    \(authenticationResult)", "  fi", "  if [ \"$cmux_ssh_reauth_required\" -eq 0 ]; then"]
         }
         if let trimmedControlPathPreflight, !trimmedControlPathPreflight.isEmpty,
            !hasOneTimeCommand {
@@ -412,7 +416,7 @@ extension CMUXCLI {
         }
         scriptLines += [
             "  cmux_ssh_begin_attempt || exit 1",
-            "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_retire_for_signal \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
+            "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_retire_lifecycle_and_exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
         ]
         if isShellSnippet {
             scriptLines += [
@@ -450,8 +454,23 @@ extension CMUXCLI {
         scriptLines += [
             "  cmux_ssh_retry=$((cmux_ssh_retry + 1))",
             "  \(backoffBuilder.terminalInputModeResetLine)",
-            "  cmux_ssh_note '\\n\\033[33m[cmux] ssh exited with status %s; reconnecting (attempt %s/%s).\\033[0m\\n\\033[2m[cmux] close this pane or press Ctrl-C to stop reconnecting.\\033[0m\\n' \"$cmux_ssh_status\" \"$cmux_ssh_retry\" \"$cmux_ssh_reconnect_limit\"",
         ]
+        let autoReconnectNote = "cmux_ssh_note \(shellQuote(sshAutoReconnectNoteFormat())) " +
+            "\"$cmux_ssh_status\" \"$cmux_ssh_retry\" \"$cmux_ssh_reconnect_limit\""
+        if hasOneTimeCommand {
+            // Before the first successful authentication the wrapper is bounded by the
+            // 20-attempt authentication budget, so the reconnect budget (often '∞')
+            // would be a lie. Report whichever budget actually governs this attempt.
+            scriptLines += [
+                "  if [ \"$cmux_ssh_reauth_required\" -eq 1 ] && [ \"$cmux_ssh_auth_succeeded\" -eq 0 ]; then",
+                "    cmux_ssh_note \(shellQuote(sshAuthenticationRetryNoteFormat())) \"$cmux_ssh_status\" \"$cmux_ssh_auth_retry\" \"$cmux_ssh_auth_retry_limit\"",
+                "  else",
+                "    \(autoReconnectNote)",
+                "  fi",
+            ]
+        } else {
+            scriptLines.append("  \(autoReconnectNote)")
+        }
         scriptLines += backoffBuilder.waitLines
         if retryPTYAttachStatus {
             scriptLines.append("  if [ \"$cmux_ssh_reconnect_delay\" -lt \"$cmux_ssh_reconnect_max_delay\" ]; then cmux_ssh_reconnect_delay=$((cmux_ssh_reconnect_delay * 2)); if [ \"$cmux_ssh_reconnect_delay\" -gt \"$cmux_ssh_reconnect_max_delay\" ]; then cmux_ssh_reconnect_delay=\"$cmux_ssh_reconnect_max_delay\"; fi; fi")
@@ -459,9 +478,32 @@ extension CMUXCLI {
         scriptLines += [
             "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_session_end; trap - EXIT HUP INT TERM; exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
             "done",
+        ]
+        if retryPTYAttachStatus {
+            // The remote PTY outlives this wrapper: retire only this attach generation
+            // and let the pane's child exit, so the app can present its reattachable
+            // placeholder (Workspace.markPersistentRemotePTYAttachFailed) instead of
+            // parking forever at a dead "press Enter to close this pane" prompt.
+            scriptLines += [
+                "if [ \"$cmux_ssh_status\" -ne 0 ]; then",
+                "  if [ -n \"${CMUX_SSH_PENDING_SIGNAL:-}\" ]; then cmux_ssh_retire_lifecycle_and_exit \"$CMUX_SSH_PENDING_SIGNAL\"; fi",
+                "  cmux_ssh_reset_terminal_modes",
+                "  \(backoffBuilder.terminalInputModeResetLine)",
+                "  cmux_ssh_note \(shellQuote(sshPersistentAttachGiveUpNoteFormat())) \"$cmux_ssh_status\"",
+                "  cmux_ssh_retire_lifecycle_and_exit \"$cmux_ssh_status\"",
+                "fi",
+            ]
+        }
+        scriptLines += [
             "trap - EXIT HUP INT TERM",
             "cmux_ssh_session_end",
+        ]
+        if !retryPTYAttachStatus {
+            scriptLines += [
             "if [ \"$cmux_ssh_status\" -ne 0 ]; then",
+            // Mouse tracking must be off before the prompt restores canonical/echo
+            // termios, or the kernel echoes every incoming report as garbage text.
+            "  cmux_ssh_reset_terminal_modes",
             "  \(backoffBuilder.terminalInputModeResetLine)",
             "  cmux_ssh_prompt_tty_state=$(/bin/stty -g <&0 2>/dev/null || true)",
             "  cmux_ssh_prompt_restore_tty() { if [ -n \"${cmux_ssh_prompt_tty_state:-}\" ]; then /bin/stty \"$cmux_ssh_prompt_tty_state\" <&0 2>/dev/null || true; cmux_ssh_prompt_tty_state=; fi; }",
@@ -475,8 +517,9 @@ extension CMUXCLI {
             "  cmux_ssh_prompt_restore_tty",
             "  trap - EXIT HUP INT TERM",
             "fi",
-            "exit $cmux_ssh_status",
-        ]
+            ]
+        }
+        scriptLines.append("exit $cmux_ssh_status")
         return scriptLines.joined(separator: "\n")
     }
     private func writeSSHStartupScript(_ scriptBody: String, remoteRelayPort: Int) throws -> String {

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
@@ -87,8 +87,31 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 0 ] && [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_retry=$((cmux_ssh_attach_retry + 1))",
             "  \(backoffBuilder.terminalInputModeResetLine)",
-            "  if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' \"$(printf \(reattachingFormat) \"$cmux_ssh_attach_retry\" \"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi",
         ])
+        let reattachingNote = "if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' " +
+            "\"$(printf \(reattachingFormat) \"$cmux_ssh_attach_retry\" " +
+            "\"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi"
+        if reauthenticates {
+            // Before the first successful authentication this wrapper is bounded by the
+            // authentication budget, not by `cmux_ssh_attach_reconnect_limit` (often
+            // '∞'), so the note must report whichever budget actually governs it.
+            let authenticationRetryFormat = String(
+                localized: "cli.ssh.authRetry.status",
+                defaultValue: "[cmux] ssh authentication failed with status %s; retrying (attempt %s/%s)."
+            ).remoteCommandShellQuoted
+            let authenticationRetryNote = "if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' " +
+                "\"$(printf \(authenticationRetryFormat) \"$cmux_ssh_attach_status\" " +
+                "\"$cmux_ssh_attach_auth_retry\" \"$cmux_ssh_attach_auth_retry_limit\")\" >&2 || true; fi"
+            lines.append(contentsOf: [
+                "  if [ \"$cmux_ssh_attach_reauth_required\" -eq 1 ] && [ \"$cmux_ssh_attach_auth_succeeded\" -eq 0 ]; then",
+                "    \(authenticationRetryNote)",
+                "  else",
+                "    \(reattachingNote)",
+                "  fi",
+            ])
+        } else {
+            lines.append("  \(reattachingNote)")
+        }
         lines.append(contentsOf: backoffBuilder.waitLines)
         lines.append(contentsOf: [
             "  if [ \"$cmux_ssh_attach_reconnect_delay\" -lt \"$cmux_ssh_attach_reconnect_max_delay\" ]; then cmux_ssh_attach_reconnect_delay=$((cmux_ssh_attach_reconnect_delay * 2)); if [ \"$cmux_ssh_attach_reconnect_delay\" -gt \"$cmux_ssh_attach_reconnect_max_delay\" ]; then cmux_ssh_attach_reconnect_delay=\"$cmux_ssh_attach_reconnect_max_delay\"; fi; fi",

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -226,10 +226,16 @@ struct SSHPTYAttachRetryScriptBuilderTests {
             Thread.sleep(forTimeInterval: 0.01)
         }
         #expect(FileManager.default.fileExists(atPath: markerURL.path))
+        // The retry note names whichever budget governs the attempt: a reauthenticating
+        // wrapper that has never authenticated is bounded by the authentication budget,
+        // and its bridge never closed, so claiming otherwise would be misleading.
+        let expectedBackoffNote = reauthenticates
+            ? "ssh authentication failed with status"
+            : "remote PTY bridge closed; reattaching"
         #expect(
             waitForFile(
                 at: transcriptURL,
-                containing: "remote PTY bridge closed; reattaching",
+                containing: expectedBackoffNote,
                 while: process,
                 timeout: 3
             )

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -229,9 +229,14 @@ struct SSHPTYAttachRetryScriptBuilderTests {
         // The retry note names whichever budget governs the attempt: a reauthenticating
         // wrapper that has never authenticated is bounded by the authentication budget,
         // and its bridge never closed, so claiming otherwise would be misleading.
+        // Asserting the whole note pins the governing budget: the authentication branch
+        // must count auth attempts against 20, not the attach counter against the
+        // unbounded attach limit. `cmux_ssh_attach_foreground_auth` returns 254 and
+        // `cmux_test_attach` returns 255, and no CMUX_SSH_RECONNECT_LIMIT is set here,
+        // so both attempt numbers and both limits are deterministic.
         let expectedBackoffNote = reauthenticates
-            ? "ssh authentication failed with status"
-            : "remote PTY bridge closed; reattaching"
+            ? "ssh authentication failed with status 254; retrying (attempt 1/20)."
+            : "remote PTY bridge closed; reattaching (attempt 1/∞)."
         #expect(
             waitForFile(
                 at: transcriptURL,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53733,6 +53733,23 @@
         }
       }
     },
+    "cli.ssh.authRetry.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] ssh authentication failed with status %s; retrying (attempt %s/%s)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] ssh 認証がステータス %s で失敗しました。再試行しています（試行 %s/%s）。"
+          }
+        }
+      }
+    },
     "cli.ssh.autoReconnect.status": {
       "extractionState": "manual",
       "localizations": {
@@ -55246,6 +55263,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "ssh：--transport 後必須指定 'ssh' 或 'mosh'"
+          }
+        }
+      }
+    },
+    "cli.ssh.persistentGiveUp.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] reconnect this pane from its right-click menu (Reconnect Pane) or from the workspace in the sidebar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] このペインを右クリックメニュー（ペインを再接続）またはサイドバーのワークスペースから再接続してください。"
+          }
+        }
+      }
+    },
+    "cli.ssh.persistentGiveUp.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] ssh exited with status %s; the remote session is still running."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] ssh がステータス %s で終了しました。リモートセッションはまだ実行中です。"
           }
         }
       }

--- a/Sources/GhosttyNSView+RemoteReconnect.swift
+++ b/Sources/GhosttyNSView+RemoteReconnect.swift
@@ -3,8 +3,7 @@ import AppKit
 extension GhosttyNSView {
     func appendReconnectRemotePaneMenuItem(to menu: NSMenu) {
         guard let workspace = remoteWorkspaceForCurrentSurface(),
-              canReconnectRemotePane(in: workspace),
-              remoteReconnectablePanel(in: workspace) != nil else { return }
+              remotePaneReconnectAction(in: workspace) != nil else { return }
         menu.addItem(.separator())
         let item = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.reconnectPane", defaultValue: "Reconnect Pane"),
@@ -26,33 +25,46 @@ extension GhosttyNSView {
         return workspace
     }
 
-    private func canReconnectRemotePane(in workspace: Workspace) -> Bool {
-        switch workspace.remoteConnectionState {
-        case .connected, .disconnected, .suspended, .error:
-            return true
-        case .connecting, .reconnecting:
-            return false
-        }
+    /// What Reconnect Pane would do for the current surface.
+    private enum RemotePaneReconnectAction {
+        /// Respawn through the shared persistent-reattach path.
+        case reattach(UUID)
+        /// Answer a dead non-persistent wrapper's own retry prompt.
+        case promptRetry(TerminalPanel)
     }
 
-    private func remoteReconnectablePanel(in workspace: Workspace) -> TerminalPanel? {
+    /// Resolves appearance and behavior from one place so they cannot diverge.
+    private func remotePaneReconnectAction(in workspace: Workspace) -> RemotePaneReconnectAction? {
         guard let surfaceId = terminalSurface?.id,
-              workspace.remoteDisconnectPlaceholderPanelIds.contains(surfaceId) ||
-                  workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId),
               let panel = workspace.panels[surfaceId] as? TerminalPanel else { return nil }
-        return panel
+        if workspace.remoteConfiguration?.preserveAfterTerminalExit == true {
+            // Persistent sessions may be reattached while the wrapper is still alive:
+            // respawn HUPs the wrapper, which retires only its lifecycle generation.
+            return workspace.canReattachRemoteTerminalSurface(surfaceId) ? .reattach(surfaceId) : nil
+        }
+        guard workspace.remoteDisconnectPlaceholderPanelIds.contains(surfaceId)
+                || workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId) else {
+            return nil
+        }
+        switch workspace.remoteConnectionState {
+        case .connecting, .reconnecting:
+            return nil
+        case .connected, .disconnected, .suspended, .error:
+            // The keystroke fallback is only ever reachable for a dead wrapper sitting
+            // at its own prompt; the preserveAfterTerminalExit split guarantees a live
+            // pane never lands here.
+            return .promptRetry(panel)
+        }
     }
 
     @objc private func reconnectRemotePane(_ sender: Any?) {
         guard let workspace = remoteWorkspaceForCurrentSurface(),
-              canReconnectRemotePane(in: workspace),
-              let panel = remoteReconnectablePanel(in: workspace) else { return }
-        if workspace.remoteConfiguration?.preserveAfterTerminalExit == true,
-           workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id) ||
-           workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(panel.id) {
-            workspace.reconnectRemoteConnection(surfaceId: panel.id)
-            return
+              let action = remotePaneReconnectAction(in: workspace) else { return }
+        switch action {
+        case .reattach(let surfaceId):
+            workspace.reconnectRemoteConnection(surfaceId: surfaceId)
+        case .promptRetry(let panel):
+            panel.sendInput("r\r")
         }
-        panel.sendInput("r\r")
     }
 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -558,7 +558,9 @@ struct SidebarWorkspaceRowMenuBuilder {
         let reconnectLabel = label(
             multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
             single: String(localized: "contextMenu.reconnectWorkspace", defaultValue: "Reconnect Workspace"))
-        menu.addItem(item(reconnectLabel, enabled: !commands.allRemoteContextMenuTargetsConnecting) {
+        // Reconnect stays enabled while connecting/reconnecting: a wedged coordinator is
+        // exactly when the user reaches for it. Disconnect keeps its gate.
+        menu.addItem(item(reconnectLabel) {
             for workspace in remoteWorkspaces() {
                 workspace.reconnectRemoteConnection()
             }

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -84,9 +84,12 @@ struct SidebarWorkspaceSnapshotFactory {
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
+            // A pure function of remoteConnectionState; `.error` is included so a failed
+            // remote workspace offers its reconnect button too.
             showsRemoteReconnectAffordance: !workspace.isManagedCloudVMWorkspace
                 && (workspace.remoteConnectionState == .suspended
-                    || workspace.remoteConnectionState == .disconnected),
+                    || workspace.remoteConnectionState == .disconnected
+                    || workspace.remoteConnectionState == .error),
             copyableSidebarSSHError: copyableSidebarSSHError,
             latestConversationMessage: workspace.latestConversationMessage,
             metadataEntries: detailVisibility.showsMetadata

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -84,12 +84,14 @@ struct SidebarWorkspaceSnapshotFactory {
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
-            // A pure function of remoteConnectionState; `.error` is included so a failed
-            // remote workspace offers its reconnect button too.
+            // A pure function of remoteConnectionState. Every non-connected state offers
+            // the button, including `.connecting`/`.reconnecting`: a coordinator wedged
+            // mid-connect is exactly when the user reaches for Reconnect, and
+            // reconnectRemoteConnection force-retries in those states rather than
+            // no-opping. Pressing it during a healthy connect is harmless because
+            // resetReconnectPolicyLocked only schedules when actually stalled.
             showsRemoteReconnectAffordance: !workspace.isManagedCloudVMWorkspace
-                && (workspace.remoteConnectionState == .suspended
-                    || workspace.remoteConnectionState == .disconnected
-                    || workspace.remoteConnectionState == .error),
+                && workspace.remoteConnectionState != .connected,
             copyableSidebarSSHError: copyableSidebarSSHError,
             latestConversationMessage: workspace.latestConversationMessage,
             metadataEntries: detailVisibility.showsMetadata

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -128,10 +128,11 @@ extension TabItemView {
         if !context.remoteTargetWorkspaceIds.isEmpty {
             Divider()
 
+            // Reconnect stays enabled while connecting/reconnecting: a wedged coordinator
+            // is exactly when the user reaches for it. Disconnect keeps its gate.
             Button(reconnectLabel) {
                 actions.reconnectTargets(context.remoteTargetWorkspaceIds)
             }
-            .disabled(context.allRemoteTargetsConnecting)
 
             Button(disconnectLabel) {
                 actions.disconnectTargets(context.remoteTargetWorkspaceIds)

--- a/Sources/Workspace+PersistentRemotePTYReattach.swift
+++ b/Sources/Workspace+PersistentRemotePTYReattach.swift
@@ -16,9 +16,13 @@ extension Workspace {
     /// a healthy connection is left alone.
     func forceRemoteSessionReconnectRetry(reason: String) {
 #if DEBUG
-        // Recorded before the controller lookup so the shared path stays
-        // observable in tests that never boot a session coordinator.
-        recordedRemoteSessionForceReconnectReasonsForTesting.append(reason)
+        // The coordinator logs `remote.session.reconnect.rearmed`, but not which
+        // entrypoint asked; without this a reconnect storm cannot be attributed to
+        // system wake versus a user action. Logged before the controller lookup so a
+        // request that finds no controller is still visible.
+        cmuxDebugLog(
+            "remote.session.forceReconnect workspace=\(id.uuidString.prefix(5)) reason=\(reason)"
+        )
 #endif
         remotePTYSessionControllerForSocketCommand()?.resetReconnectPolicyAndReconnect(
             reason: reason

--- a/Sources/Workspace+PersistentRemotePTYReattach.swift
+++ b/Sources/Workspace+PersistentRemotePTYReattach.swift
@@ -6,9 +6,51 @@ extension Workspace {
     }
 
     func rearmRemoteSessionAfterSystemWake() {
+        forceRemoteSessionReconnectRetry(reason: "system wake")
+    }
+
+    /// Re-arms the remote session's reconnect policy through one shared path.
+    ///
+    /// `resetReconnectPolicyLocked` only schedules when the coordinator is
+    /// suspended, retrying, missing a proxy endpoint, or has no ready daemon, so
+    /// a healthy connection is left alone.
+    func forceRemoteSessionReconnectRetry(reason: String) {
+#if DEBUG
+        // Recorded before the controller lookup so the shared path stays
+        // observable in tests that never boot a session coordinator.
+        recordedRemoteSessionForceReconnectReasonsForTesting.append(reason)
+#endif
         remotePTYSessionControllerForSocketCommand()?.resetReconnectPolicyAndReconnect(
-            reason: "system wake"
+            reason: reason
         )
+    }
+
+    /// True when a persistent remote attach is running or retrying but has never
+    /// published a ready bridge for this surface.
+    ///
+    /// Every wrapper attempt registers `workspace.remote.terminal_session_launching`
+    /// and only a ready bridge reaches `.connected`, so "not connected" is the
+    /// failing-or-pending signal. During the wrapper's foreground-auth phase no
+    /// launching attempt is registered at all, which is why this cannot test for
+    /// `.launching`.
+    func isPersistentRemoteAttachAwaitingReadiness(_ panelId: UUID) -> Bool {
+        guard remoteConfiguration?.preserveAfterTerminalExit == true,
+              terminalPanel(for: panelId) != nil,
+              activeRemoteTerminalSurfaceIds.contains(panelId) else { return false }
+        return remoteTerminalSessionStatesBySurfaceId[panelId]?.phase != .connected
+    }
+
+    /// True for panes the shared reattach path can act on.
+    ///
+    /// A persistent pane may be reattached while its wrapper is still alive:
+    /// respawning HUPs the wrapper, which retires only its lifecycle generation
+    /// and leaves the remote PTY running.
+    func canReattachRemoteTerminalSurface(_ panelId: UUID) -> Bool {
+        guard terminalPanel(for: panelId) != nil, remoteConfiguration != nil else { return false }
+        return remoteDisconnectPlaceholderPanelIds.contains(panelId)
+            || pendingRemoteTerminalChildExitSurfaceIds.contains(panelId)
+            || endedPersistentRemotePTYAttachSurfaceIds.contains(panelId)
+            || isPersistentRemoteAttachAwaitingReadiness(panelId)
     }
 
     func markPersistentRemotePTYAttachFailed(surfaceId: UUID) {
@@ -36,11 +78,20 @@ extension Workspace {
     @discardableResult
     func reattachPersistentRemotePTYPanels(
         requestedSurfaceId: UUID? = nil,
-        restartEndedSessions: Bool = false
+        restartEndedSessions: Bool = false,
+        includesLiveFailingAttaches: Bool = false
     ) -> Set<UUID> {
         guard let configuration = remoteConfiguration,
               configuration.preserveAfterTerminalExit == true else { return [] }
-        let candidateIDs = requestedSurfaceId.map { Set([$0]) } ?? remoteDisconnectPlaceholderPanelIds
+        var candidateIDs = requestedSurfaceId.map { Set([$0]) } ?? remoteDisconnectPlaceholderPanelIds
+        // Default false so the automatic `.connected` transition cannot let a sibling
+        // pane's connect event respawn a pane still working through its first attempt.
+        if requestedSurfaceId == nil, includesLiveFailingAttaches {
+            candidateIDs.formUnion(pendingRemoteTerminalChildExitSurfaceIds)
+            candidateIDs.formUnion(activeRemoteTerminalSurfaceIds.filter {
+                isPersistentRemoteAttachAwaitingReadiness($0)
+            })
+        }
         var reattached = Set<UUID>()
 
         for panelId in candidateIDs.sorted(by: { $0.uuidString < $1.uuidString }) {

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -157,7 +157,11 @@ extension Workspace {
         }
         if configuration.preserveAfterTerminalExit {
             if remoteControllerIsReady {
-                let reattached = reattachPersistentRemotePTYPanels(requestedSurfaceId: surfaceId, restartEndedSessions: true)
+                let reattached = reattachPersistentRemotePTYPanels(
+                    requestedSurfaceId: surfaceId,
+                    restartEndedSessions: true,
+                    includesLiveFailingAttaches: surfaceId == nil
+                )
                 didRespawnTerminal = surfaceId.map(reattached.contains) ?? !reattached.isEmpty
             }
         } else if let startupCommand = effectiveRemoteTerminalStartupCommand(from: configuration),
@@ -186,7 +190,13 @@ extension Workspace {
             if didRespawnTerminal || !shouldRespawnSurface { trackRemoteTerminalSurface(reconnectingSurfaceId) }
         }
         if reconnectingSurfaceId != nil, remoteControllerIsReady { return didRespawnTerminal }
-        guard remoteConnectionState != .connecting, remoteConnectionState != .reconnecting else { return didRespawnTerminal }
+        guard remoteConnectionState != .connecting, remoteConnectionState != .reconnecting else {
+            // A wedged coordinator is exactly when the user presses Reconnect: re-arm the
+            // policy instead of doing nothing. Healthy connections are left alone by
+            // resetReconnectPolicyLocked's shouldReconnect check.
+            forceRemoteSessionReconnectRetry(reason: "manual reconnect")
+            return didRespawnTerminal
+        }
         configureRemoteConnection(configuration, autoConnect: true)
         return didRespawnTerminal
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5746,7 +5746,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     func shouldKeepPersistentRemoteSurfaceOpenAfterChildExit(_ panelId: UUID) -> Bool {
         guard remoteConfiguration?.preserveAfterTerminalExit == true else { return false }
         return activeRemoteTerminalSurfaceIds.contains(panelId) ||
-            endedPersistentRemotePTYAttachSurfaceIds.contains(panelId)
+            endedPersistentRemotePTYAttachSurfaceIds.contains(panelId) ||
+            // A full session end already untracked this surface; a persistent workspace
+            // still owns the remote PTY, so keep the pane and offer reattach instead of
+            // closing it and orphaning the live remote session.
+            pendingRemoteTerminalChildExitSurfaceIds.contains(panelId)
     }
 
     @MainActor

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2602,6 +2602,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// the package process-runner seam (replaces the legacy process-wide
     /// `WorkspaceRemoteSessionController.runProcessOverrideForTesting` static).
     var remoteSessionProcessRunnerOverrideForTesting: (any RemoteSessionProcessRunning)?
+
+    /// XCTest seam: every reason passed to `forceRemoteSessionReconnectRetry`,
+    /// in call order. Recorded even when no session controller exists so the
+    /// shared force-retry path is observable without booting a coordinator.
+    var recordedRemoteSessionForceReconnectReasonsForTesting: [String] = []
 #endif
     /// The shell-activity classification per panel id; stored in the
     /// surface-registry sub-model.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2602,11 +2602,6 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// the package process-runner seam (replaces the legacy process-wide
     /// `WorkspaceRemoteSessionController.runProcessOverrideForTesting` static).
     var remoteSessionProcessRunnerOverrideForTesting: (any RemoteSessionProcessRunning)?
-
-    /// XCTest seam: every reason passed to `forceRemoteSessionReconnectRetry`,
-    /// in call order. Recorded even when no session controller exists so the
-    /// shared force-retry path is observable without booting a coordinator.
-    var recordedRemoteSessionForceReconnectReasonsForTesting: [String] = []
 #endif
     /// The shell-activity classification per panel id; stored in the
     /// surface-registry sub-model.

--- a/cmuxTests/SSHDeepSleepReattachTests.swift
+++ b/cmuxTests/SSHDeepSleepReattachTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CMUXDebugLog
 import CmuxCore
 import Foundation
 import Testing
@@ -302,19 +303,79 @@ struct SSHDeepSleepReattachTests {
             detail: "Reconnecting to cmux-macmini via shared local proxy 127.0.0.1:64007",
             target: "cmux-macmini"
         )
-        workspace.recordedRemoteSessionForceReconnectReasonsForTesting.removeAll()
+        let marker = "remote.session.forceReconnect workspace=\(workspace.id.uuidString.prefix(5))"
 
         // A wedged coordinator is exactly when the user presses Reconnect; doing
         // nothing is the silent no-op this fix removes.
         workspace.reconnectRemoteConnection()
-        #expect(workspace.recordedRemoteSessionForceReconnectReasonsForTesting == ["manual reconnect"])
+        #expect(Self.waitForDebugLogLine(containing: "\(marker) reason=manual reconnect"))
 
         // System wake must keep sharing that one force-retry path.
         workspace.rearmRemoteSessionAfterSystemWake()
-        #expect(workspace.recordedRemoteSessionForceReconnectReasonsForTesting == [
-            "manual reconnect",
-            "system wake",
-        ])
+        #expect(Self.waitForDebugLogLine(containing: "\(marker) reason=system wake"))
+    }
+
+    @MainActor
+    @Test func sidebarReconnectAffordanceShowsForEveryNonConnectedState() throws {
+        let states: [WorkspaceRemoteConnectionState] = [
+            .disconnected, .connecting, .reconnecting, .connected, .error, .suspended,
+        ]
+        for state in states {
+            let workspace = Workspace()
+            workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+            // Set the state directly: the affordance must stay a pure function of
+            // remoteConnectionState, independent of the update policy's remapping.
+            workspace.remoteConnectionState = state
+
+            let snapshot = Self.sidebarSnapshot(for: workspace)
+
+            // `.connecting`/`.reconnecting` included: a wedged coordinator is exactly
+            // when the sidebar button must be reachable.
+            #expect(
+                snapshot.showsRemoteReconnectAffordance == (state != .connected),
+                Comment(rawValue: "state=\(state.rawValue)")
+            )
+        }
+    }
+
+    @MainActor
+    @Test func sidebarReconnectAffordanceStaysHiddenForManagedCloudVMs() throws {
+        let workspace = Workspace()
+        workspace.configureRemoteConnection(Self.persistentCloudConfiguration(), autoConnect: false)
+        workspace.remoteConnectionState = .reconnecting
+        #expect(workspace.isManagedCloudVMWorkspace)
+
+        #expect(!Self.sidebarSnapshot(for: workspace).showsRemoteReconnectAffordance)
+    }
+
+    /// Polls the debug event log, whose appends are serialized onto its own queue.
+    private static func waitForDebugLogLine(
+        containing expected: String,
+        timeout: TimeInterval = 3
+    ) -> Bool {
+        let path = CMUXDebugLog.DebugEventLog.currentLogPath()
+        let deadline = Date.now.addingTimeInterval(timeout)
+        while Date.now < deadline {
+            if let contents = try? String(contentsOfFile: path, encoding: .utf8),
+               contents.contains(expected) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return (try? String(contentsOfFile: path, encoding: .utf8))?.contains(expected) ?? false
+    }
+
+    @MainActor
+    private static func sidebarSnapshot(
+        for workspace: Workspace
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+        let defaults = UserDefaults(suiteName: "cmux.sidebar.reconnect.\(UUID().uuidString)")!
+        defer { defaults.removePersistentDomain(forName: defaults.description) }
+        return SidebarWorkspaceSnapshotFactory(
+            workspace: workspace,
+            settings: SidebarTabItemSettingsSnapshot(defaults: defaults),
+            showsAgentActivity: false
+        ).makeSnapshot()
     }
 
     @MainActor

--- a/cmuxTests/SSHDeepSleepReattachTests.swift
+++ b/cmuxTests/SSHDeepSleepReattachTests.swift
@@ -118,6 +118,206 @@ struct SSHDeepSleepReattachTests {
     }
 
     @MainActor
+    @Test func fullSessionEndBeforeChildExitKeepsPersistentPaneReattachable() throws {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let tabManager = TabManager()
+        let windowID = appDelegate.registerMainWindowContextForTesting(tabManager: tabManager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowID)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let workspace = try #require(tabManager.selectedWorkspace)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to cmux-macmini via shared local proxy 127.0.0.1:64007",
+            target: "cmux-macmini"
+        )
+        let expectedSessionID = Workspace.defaultSSHPTYSessionID(
+            workspaceId: workspace.id,
+            panelId: panel.id
+        )
+        #expect(workspace.isRemoteTerminalSurface(panel.id))
+
+        // A give-up path that reported a FULL session end untracks the surface, so the
+        // child exit that follows must still keep the persistent pane reattachable.
+        #expect(workspace.markRemoteTerminalSessionEnded(
+            surfaceId: panel.id,
+            relayPort: 64007,
+            terminalLifecycleID: panel.surface.terminalLifecycleId
+        ))
+        #expect(!workspace.isRemoteTerminalSurface(panel.id))
+        #expect(workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(panel.id))
+
+        tabManager.closePanelAfterChildExited(tabId: workspace.id, surfaceId: panel.id)
+
+        #expect(workspace.terminalPanel(for: panel.id) != nil)
+        #expect(workspace.remoteDisconnectPlaceholderPanelIds.contains(panel.id))
+        #expect(workspace.remotePTYSessionIDsByPanelId[panel.id] == expectedSessionID)
+        #expect(workspace.isRemoteTerminalSurface(panel.id))
+    }
+
+    @MainActor
+    @Test func liveFailingPersistentPaneOffersReconnectPaneMenuItem() throws {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let tabManager = TabManager()
+        let windowID = appDelegate.registerMainWindowContextForTesting(tabManager: tabManager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowID)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let workspace = try #require(tabManager.selectedWorkspace)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        let originalSurface = panel.surface
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        workspace.applyRemoteConnectionStateUpdate(
+            .reconnecting,
+            detail: "Reconnecting to cmux-macmini via shared local proxy 127.0.0.1:64007",
+            target: "cmux-macmini"
+        )
+        workspace.trackRemoteTerminalSurface(panel.id)
+        workspace.markRemoteTerminalSessionLaunching(surfaceId: panel.id)
+        #expect(workspace.remoteTerminalSessionStatesBySurfaceId[panel.id]?.phase == .launching)
+
+        // The wrapper is still alive but has never published a ready bridge, which is
+        // exactly when the user needs Reconnect Pane.
+        let menu = NSMenu()
+        panel.hostedView.surfaceView.appendReconnectRemotePaneMenuItem(to: menu)
+        let reconnectItem = try #require(menu.items.last)
+        let action = try #require(reconnectItem.action)
+        #expect(NSApplication.shared.sendAction(action, to: reconnectItem.target, from: reconnectItem))
+
+        let reattached = try #require(workspace.terminalPanel(for: panel.id))
+        #expect(reattached.surface !== originalSurface)
+        let command = try #require(reattached.surface.initialCommand)
+        #expect(command.contains("--require-existing"))
+        #expect(command.contains(Workspace.defaultSSHPTYSessionID(
+            workspaceId: workspace.id,
+            panelId: panel.id
+        )))
+    }
+
+    @MainActor
+    @Test func connectedPersistentPaneHidesReconnectPaneMenuItem() throws {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let tabManager = TabManager()
+        let windowID = appDelegate.registerMainWindowContextForTesting(tabManager: tabManager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowID)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let workspace = try #require(tabManager.selectedWorkspace)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        workspace.trackRemoteTerminalSurface(panel.id)
+        // `configureRemoteConnection` scopes the configuration to its owner workspace,
+        // and that owner id feeds `proxyBrokerTransportKey`, so the authority must be
+        // derived from the workspace's stored configuration exactly as production does.
+        let authority = try #require(
+            workspace.remoteConfiguration.flatMap(WorkspaceRemoteTerminalAuthority.init(configuration:))
+        )
+        #expect(workspace.markRemoteTerminalSessionConnected(
+            surfaceId: panel.id,
+            authority: authority,
+            terminalLifecycleID: panel.surface.terminalLifecycleId
+        ))
+        #expect(workspace.remoteTerminalSessionStatesBySurfaceId[panel.id]?.phase == .connected)
+
+        let menu = NSMenu()
+        panel.hostedView.surfaceView.appendReconnectRemotePaneMenuItem(to: menu)
+
+        #expect(menu.items.isEmpty)
+    }
+
+    @MainActor
+    @Test func workspaceReconnectReattachesLiveFailingPaneAndLeavesConnectedPane() throws {
+        let workspace = Workspace()
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        let connectedPanel = try #require(workspace.focusedTerminalPanel)
+        let failingPanel = try #require(workspace.newTerminalSplit(
+            from: connectedPanel.id,
+            orientation: .horizontal,
+            focus: false
+        ))
+        let connectedSurface = connectedPanel.surface
+        let failingSurface = failingPanel.surface
+        workspace.trackRemoteTerminalSurface(connectedPanel.id)
+        workspace.trackRemoteTerminalSurface(failingPanel.id)
+        let authority = try #require(
+            workspace.remoteConfiguration.flatMap(WorkspaceRemoteTerminalAuthority.init(configuration:))
+        )
+        #expect(workspace.markRemoteTerminalSessionConnected(
+            surfaceId: connectedPanel.id,
+            authority: authority,
+            terminalLifecycleID: connectedPanel.surface.terminalLifecycleId
+        ))
+        workspace.markRemoteTerminalSessionLaunching(surfaceId: failingPanel.id)
+
+        workspace.reconnectRemoteConnection()
+
+        #expect(workspace.terminalPanel(for: connectedPanel.id)?.surface === connectedSurface)
+        let reattached = try #require(workspace.terminalPanel(for: failingPanel.id))
+        #expect(reattached.surface !== failingSurface)
+        let command = try #require(reattached.surface.initialCommand)
+        #expect(command.contains("--require-existing"))
+        #expect(command.contains(Workspace.defaultSSHPTYSessionID(
+            workspaceId: workspace.id,
+            panelId: failingPanel.id
+        )))
+    }
+
+    @MainActor
+    @Test func connectedTransitionDoesNotRespawnLaunchingPane() throws {
+        let workspace = Workspace()
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        let originalSurface = panel.surface
+        workspace.trackRemoteTerminalSurface(panel.id)
+        workspace.markRemoteTerminalSessionLaunching(surfaceId: panel.id)
+
+        // A sibling pane's connect event must never restart a pane that is still
+        // working through its first attach attempt.
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to cmux-macmini via shared local proxy 127.0.0.1:64007",
+            target: "cmux-macmini"
+        )
+
+        #expect(workspace.terminalPanel(for: panel.id)?.surface === originalSurface)
+    }
+
+    @MainActor
+    @Test func manualReconnectRearmsWedgedRemoteSession() throws {
+        let workspace = Workspace()
+        workspace.configureRemoteConnection(Self.persistentConfiguration(), autoConnect: false)
+        workspace.applyRemoteConnectionStateUpdate(
+            .reconnecting,
+            detail: "Reconnecting to cmux-macmini via shared local proxy 127.0.0.1:64007",
+            target: "cmux-macmini"
+        )
+        workspace.recordedRemoteSessionForceReconnectReasonsForTesting.removeAll()
+
+        // A wedged coordinator is exactly when the user presses Reconnect; doing
+        // nothing is the silent no-op this fix removes.
+        workspace.reconnectRemoteConnection()
+        #expect(workspace.recordedRemoteSessionForceReconnectReasonsForTesting == ["manual reconnect"])
+
+        // System wake must keep sharing that one force-retry path.
+        workspace.rearmRemoteSessionAfterSystemWake()
+        #expect(workspace.recordedRemoteSessionForceReconnectReasonsForTesting == [
+            "manual reconnect",
+            "system wake",
+        ])
+    }
+
+    @MainActor
     @Test func confirmedSSHPTYExitRestartsWithInheritedCustomIdentity() throws {
         let workspace = Workspace()
         let foregroundAuthToken = "foreground-auth-restored-session"

--- a/cmuxTests/SSHStartupManualReconnectTests.swift
+++ b/cmuxTests/SSHStartupManualReconnectTests.swift
@@ -405,54 +405,181 @@ struct SSHStartupManualReconnectTests {
         #expect(process.terminationStatus == 130)
     }
 
-    @Test func initialStartupStopsAtForegroundAuthenticationFailureLimit() throws {
+    @Test func persistentStartupGiveUpRetiresLifecycleWithoutParkingAtPrompt() throws {
+        let fixture = try Self.makePersistentAuthenticationFailureFixture(
+            slug: "cmux-ssh-foreground-auth-limit"
+        )
+        defer { fixture.cleanUp() }
+
+        let result = Self.runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", fixture.startupCommand],
+            environment: fixture.environment,
+            timeout: 60
+        )
+
+        // A persistent wrapper owns a remote PTY that outlives it, so exhausting the
+        // foreground-authentication budget must retire only this attach generation and
+        // exit. Parking at `__ssh-terminal-exit-prompt` strands the pane instead.
+        // (The reusable base64 launcher unsets its status variable before `exit`, so the
+        // observable contract here is termination plus the recorded retirement, not the
+        // propagated status.)
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        // 20 authentication attempts, each invoking the fake ssh twice: once for the
+        // `ssh -G` control-path probe in the resolved-ControlMaster lock, then once for
+        // the authentication itself. (The pre-rewrite test asserted a bare "20" and had
+        // been failing ever since that probe was added.)
+        let observedAttempts = (try? String(contentsOf: fixture.attemptFile, encoding: .utf8)) ?? "<none>"
+        #expect(
+            observedAttempts == "40",
+            Comment(rawValue: "attempts=\(observedAttempts) cli=\(fixture.recordedCLICalls())")
+        )
+        let sessionEndCalls = Self.recordedSessionEndCalls(in: fixture.cliLogFile)
+        #expect(!sessionEndCalls.isEmpty, Comment(rawValue: fixture.recordedCLICalls()))
+        #expect(
+            sessionEndCalls.allSatisfy { $0.contains("--lifecycle-only") },
+            Comment(rawValue: fixture.recordedCLICalls())
+        )
+    }
+
+    @Test func persistentAttachGiveUpNeverRunsTheTerminalExitPrompt() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
-            .appendingPathComponent("cmux-ssh-foreground-auth-limit-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-ssh-attach-give-up-\(UUID().uuidString)", isDirectory: true)
+        let fakeSSH = root.appendingPathComponent("ssh")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+        try Self.writeShellFile(at: fakeSSH, lines: ["#!/bin/sh", "exit 0"])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+
+        // Structural contract on the generated wrapper. The behavioral proof that a
+        // persistent give-up terminates and retires lifecycle-only lives in
+        // persistentStartupGiveUpRetiresLifecycleWithoutParkingAtPrompt; asserting it
+        // again through an attach attempt would depend on the real bundled CLI's
+        // behavior against an absent socket.
+        let persistentScript = try Self.decodedStartupScript(
+            from: Self.generatedPersistentSSHForegroundAuthenticationStartupCommand(
+                replacingSystemSSHWith: fakeSSH
+            )
+        )
+        #expect(!persistentScript.contains("__ssh-terminal-exit-prompt"))
+        #expect(!persistentScript.contains("press Enter to close this pane"))
+        #expect(persistentScript.contains("--lifecycle-only"))
+
+        // Scoping contrast: the prompt is a non-persistent affordance and stays there.
+        let nonPersistentCommand = try Self.generatedVMSSHInitialStartupCommand(
+            replacingSystemSSHWith: fakeSSH
+        )
+        defer {
+            try? fileManager.removeItem(
+                at: URL(fileURLWithPath: nonPersistentCommand.trimmingCharacters(in: .whitespacesAndNewlines))
+            )
+        }
+        let nonPersistentScript = try Self.decodedStartupScript(from: nonPersistentCommand)
+        #expect(nonPersistentScript.contains("__ssh-terminal-exit-prompt"))
+        #expect(!nonPersistentScript.contains("--lifecycle-only"))
+    }
+
+    @Test func nonPersistentStartupStillPromptsBeforeClosing() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-non-persistent-prompt-\(UUID().uuidString)", isDirectory: true)
         let fakeCLI = root.appendingPathComponent("cmux")
         let fakeSSH = root.appendingPathComponent("ssh")
-        let fakeSleep = root.appendingPathComponent("sleep")
-        let attemptFile = root.appendingPathComponent("ssh-attempts.txt")
+        let cliLogFile = root.appendingPathComponent("cli-calls.log")
 
         try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? fileManager.removeItem(at: root) }
 
-        try Self.writeShellFile(at: fakeCLI, lines: ["#!/bin/sh", "exit 0"])
-        try Self.writeShellFile(at: fakeSSH, lines: [
-            "#!/bin/sh",
-            "count=$(cat \"${CMUX_TEST_ATTEMPT_FILE}\" 2>/dev/null || printf 0)",
-            "count=$((count + 1))",
-            "printf '%s' \"$count\" > \"${CMUX_TEST_ATTEMPT_FILE}\"",
-            "printf '%s\\n' 'ssh: connect to host boot-retry.example.test port 22: Network is unreachable' >&2",
-            "exit 255",
-        ])
-        try Self.writeShellFile(at: fakeSleep, lines: ["#!/bin/sh", "exit 0"])
-        for executable in [fakeCLI, fakeSSH, fakeSleep] {
+        try Self.writeShellFile(at: fakeCLI, lines: Self.recordingFakeCLILines)
+        try Self.writeShellFile(at: fakeSSH, lines: ["#!/bin/sh", "exit 7"])
+        for executable in [fakeCLI, fakeSSH] {
             try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
         }
 
-        let startupCommand = try Self.generatedPersistentSSHForegroundAuthenticationStartupCommand(
+        let startupCommand = try Self.generatedVMSSHInitialStartupCommand(
             replacingSystemSSHWith: fakeSSH
         )
+        defer {
+            try? fileManager.removeItem(
+                at: URL(fileURLWithPath: startupCommand.trimmingCharacters(in: .whitespacesAndNewlines))
+            )
+        }
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
         environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
         environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
         environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
         environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
-        environment["CMUX_TEST_ATTEMPT_FILE"] = attemptFile.path
-        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "2"
-        environment["CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS"] = "2"
+        environment["CMUX_TEST_CLI_LOG"] = cliLogFile.path
+        environment["CMUX_SSH_RECONNECT_LIMIT"] = "0"
 
+        // No Enter is sent: the prompt flushes bytes queued before its boundary, so a
+        // pre-prompt newline cannot dismiss it. Parking on closed stdin is the correct
+        // non-persistent behavior, so this pins the prompt and the session-end scoping
+        // rather than a timing-dependent exit status.
         let result = Self.runProcess(
-            executablePath: "/bin/sh",
-            arguments: ["-c", startupCommand],
+            executablePath: "/usr/bin/script",
+            arguments: ["-q", "-F", "/dev/null", "/bin/sh", "-c", startupCommand],
             environment: environment,
-            timeout: 2
+            timeout: 10
         )
 
-        #expect(result.timedOut, "closed stdin must not dismiss the terminal failure prompt")
-        #expect(try String(contentsOf: attemptFile, encoding: .utf8) == "20")
+        let transcript = result.stdout + result.stderr
+        // Non-persistent panes own no remote session to preserve: the Enter prompt and
+        // the full session-end must both survive the persistent give-up rework.
+        #expect(transcript.contains("press Enter to close this pane"), Comment(rawValue: transcript))
+        let sessionEndCalls = Self.recordedSessionEndCalls(in: cliLogFile)
+        #expect(!sessionEndCalls.isEmpty, Comment(rawValue: transcript))
+        #expect(
+            sessionEndCalls.allSatisfy { !$0.contains("--lifecycle-only") },
+            Comment(rawValue: transcript)
+        )
+    }
+
+    @Test func authenticationPhaseRetryNoteReportsItsOwnBudget() throws {
+        let fixture = try Self.makePersistentAuthenticationFailureFixture(
+            slug: "cmux-ssh-auth-note-budget"
+        )
+        defer { fixture.cleanUp() }
+
+        let result = Self.runProcess(
+            executablePath: "/usr/bin/script",
+            arguments: ["-q", "-F", "/dev/null", "/bin/sh", "-c", fixture.startupCommand],
+            environment: fixture.environment,
+            timeout: 60
+        )
+        let transcript = result.stdout + result.stderr
+
+        // While `cmux_ssh_auth_succeeded` is 0 the wrapper hard-breaks after 20
+        // authentication attempts, so advertising an unbounded reconnect budget lies.
+        #expect(
+            transcript.contains("authentication failed with status"),
+            Comment(rawValue: transcript)
+        )
+        #expect(transcript.contains("/20"), Comment(rawValue: transcript))
+        #expect(!transcript.contains("∞"), Comment(rawValue: transcript))
+    }
+
+    @Test func persistentGiveUpDisablesMouseReportingBeforeExit() throws {
+        let fixture = try Self.makePersistentAuthenticationFailureFixture(
+            slug: "cmux-ssh-give-up-mouse-reset"
+        )
+        defer { fixture.cleanUp() }
+
+        let result = Self.runProcess(
+            executablePath: "/usr/bin/script",
+            arguments: ["-q", "-F", "/dev/null", "/bin/sh", "-c", fixture.startupCommand],
+            environment: fixture.environment,
+            timeout: 60
+        )
+        let transcript = result.stdout + result.stderr
+
+        #expect(!result.timedOut, Comment(rawValue: transcript))
+        // Without this reset the pane keeps mouse tracking enabled and the local
+        // terminal echoes every incoming `\u{1B}[<35;…M` report as garbage text.
+        #expect(transcript.contains("\u{1B}[?1000l"), Comment(rawValue: transcript))
+        #expect(transcript.contains("\u{1B}[?1006l"), Comment(rawValue: transcript))
     }
 
     @Test func establishedStartupRetriesUnclassifiedReauthenticationFailure() throws {
@@ -752,6 +879,117 @@ struct SSHStartupManualReconnectTests {
         #expect(!FileManager.default.fileExists(atPath: replayPath))
     }
 
+    /// A fake `cmux` CLI that records every invocation's arguments.
+    private static let recordingFakeCLILines = [
+        "#!/bin/sh",
+        "printf '%s\\n' \"$*\" >> \"${CMUX_TEST_CLI_LOG}\"",
+        "exit 0",
+    ]
+
+    /// Returns the shell script a generated startup command will actually run,
+    /// whether the command is a script path or the reusable base64 launcher.
+    private static func decodedStartupScript(from startupCommand: String) throws -> String {
+        let trimmed = startupCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: trimmed, isDirectory: &isDirectory),
+           !isDirectory.boolValue {
+            return try String(contentsOfFile: trimmed, encoding: .utf8)
+        }
+        let encodedPrefix = "(printf %s "
+        let encodedSuffix = " | base64"
+        let prefixRange = try #require(startupCommand.range(of: encodedPrefix))
+        let suffixRange = try #require(
+            startupCommand.range(
+                of: encodedSuffix,
+                range: prefixRange.upperBound..<startupCommand.endIndex
+            )
+        )
+        let encoded = String(startupCommand[prefixRange.upperBound..<suffixRange.lowerBound])
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'"))
+        let data = try #require(Data(base64Encoded: encoded))
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private static func recordedSessionEndCalls(in logFile: URL) -> [String] {
+        let contents = (try? String(contentsOf: logFile, encoding: .utf8)) ?? ""
+        return contents
+            .split(separator: "\n")
+            .map(String.init)
+            .filter { $0.contains("ssh-session-end") }
+    }
+
+    private struct PersistentAuthenticationFailureFixture {
+        let startupCommand: String
+        let environment: [String: String]
+        let attemptFile: URL
+        let cliLogFile: URL
+        let temporaryDirectory: URL
+
+        func recordedCLICalls() -> String {
+            (try? String(contentsOf: cliLogFile, encoding: .utf8)) ?? ""
+        }
+
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+    }
+
+    /// Builds a persistent `cmux ssh` wrapper whose foreground authentication always
+    /// fails transiently, so the wrapper exhausts its 20-attempt authentication budget.
+    private static func makePersistentAuthenticationFailureFixture(
+        slug: String
+    ) throws -> PersistentAuthenticationFailureFixture {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("\(slug)-\(UUID().uuidString)", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let fakeSleep = root.appendingPathComponent("sleep")
+        let attemptFile = root.appendingPathComponent("ssh-attempts.txt")
+        let cliLogFile = root.appendingPathComponent("cli-calls.log")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+
+        do {
+            try writeShellFile(at: fakeCLI, lines: recordingFakeCLILines)
+            try writeShellFile(at: fakeSSH, lines: [
+                "#!/bin/sh",
+                "count=$(cat \"${CMUX_TEST_ATTEMPT_FILE}\" 2>/dev/null || printf 0)",
+                "count=$((count + 1))",
+                "printf '%s' \"$count\" > \"${CMUX_TEST_ATTEMPT_FILE}\"",
+                "printf '%s\\n' 'ssh: connect to host boot-retry.example.test port 22: Network is unreachable' >&2",
+                "exit 255",
+            ])
+            try writeShellFile(at: fakeSleep, lines: ["#!/bin/sh", "exit 0"])
+            for executable in [fakeCLI, fakeSSH, fakeSleep] {
+                try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+            }
+
+            let startupCommand = try generatedPersistentSSHForegroundAuthenticationStartupCommand(
+                replacingSystemSSHWith: fakeSSH
+            )
+            var environment = ProcessInfo.processInfo.environment
+            environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+            environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+            environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+            environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+            environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+            environment["CMUX_TEST_ATTEMPT_FILE"] = attemptFile.path
+            environment["CMUX_TEST_CLI_LOG"] = cliLogFile.path
+            environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "2"
+            environment["CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS"] = "2"
+            return PersistentAuthenticationFailureFixture(
+                startupCommand: startupCommand,
+                environment: environment,
+                attemptFile: attemptFile,
+                cliLogFile: cliLogFile,
+                temporaryDirectory: root
+            )
+        } catch {
+            try? fileManager.removeItem(at: root)
+            throw error
+        }
+    }
+
     private static func makeRemoteConfiguration() -> WorkspaceRemoteConfiguration {
         WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",
@@ -1019,7 +1257,11 @@ struct SSHStartupManualReconnectTests {
                 try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
             }
 
-            let startupCommand = try generatedPersistentSSHForegroundAuthenticationStartupCommand(
+            // The exit prompt is a NON-persistent affordance: a persistent wrapper owns a
+            // remote PTY that outlives it and now retires lifecycle-only instead of
+            // parking here, so these prompt-input tests must drive the non-persistent
+            // wrapper to keep exercising the prompt at all.
+            let startupCommand = try generatedVMSSHInitialStartupCommand(
                 replacingSystemSSHWith: fakeSSH
             )
             var environment = ProcessInfo.processInfo.environment
@@ -1028,6 +1270,8 @@ struct SSHStartupManualReconnectTests {
             environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
             environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
             environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+            // Reach the prompt immediately instead of after the default retry budget.
+            environment["CMUX_SSH_RECONNECT_LIMIT"] = "0"
             environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "2"
             environment["CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS"] = "2"
             return TerminalExitPromptFixture(


### PR DESCRIPTION
## Summary

**What changed?** Persistent SSH panes whose connection drops are no longer permanently stranded.

A persistent `cmux ssh` wrapper owns a remote PTY that **outlives the wrapper**, but its give-up path printed the terminal-exit prompt and reported a **FULL** `ssh-session-end`. Three things followed: the pane parked forever at a dead "press Enter to close this pane" prompt; closing it orphaned the still-running remote session; and because the full session end had already untracked the surface, the child-exit race closed the pane instead of presenting the reattachable placeholder.

- **A — give-up is a retirement, not a prompt.** The shared retirement helper is renamed `cmux_ssh_retire_lifecycle_and_exit` (one path for signals *and* give-up, all four call sites moved together). The wrapper tail is split: a persistent wrapper with a non-zero status resets terminal modes, prints an honest note, and retires **lifecycle-only**. The prompt block is now only emitted for non-persistent wrappers. `cmux_ssh_status == 0` (user typed `exit`) keeps today's full-session-end path byte-for-byte. App side, `shouldKeepPersistentRemoteSurfaceOpenAfterChildExit` also honors `pendingRemoteTerminalChildExitSurfaceIds`, so a stale or racing full session end can never close a persistent pane.
- **B — "Reconnect Pane" appears while the wrapper is still alive.** One action resolver replaces the `.connecting`/`.reconnecting` veto that hid the item exactly when it was needed, so appearance and behavior cannot diverge. Respawn HUPs the wrapper, which retires only its lifecycle generation and leaves the remote PTY running. The `sendInput("r\r")` fallback is now unreachable for a live pane.
- **C — "Reconnect Workspace" stops silently no-opping.** It sweeps live-but-failing panes (`includesLiveFailingAttaches`, defaulting to `false` so the automatic `.connected` transition still cannot respawn a pane mid-first-attempt) and re-arms a wedged coordinator via a shared `forceRemoteSessionReconnectRetry`. The reconnect context-menu items are no longer disabled while connecting/reconnecting (Disconnect keeps its gate), and `.error` now shows the sidebar affordance.
- **D — one shared path.** Every entrypoint still funnels into `Workspace.reconnectRemoteConnection` → `reattachPersistentRemotePTYPanels`; the only new decision surface is two predicates (`isPersistentRemoteAttachAwaitingReadiness`, `canReattachRemoteTerminalSurface`). System wake and manual reconnect now share the same force-retry method.
- **E — honest messaging.** `sshAutoReconnectNoteFormat()` had **zero call sites** while the script carried hardcoded English; it is now wired up (a localization fix). The retry note reports the authentication budget (`%s/20`) while authentication has never succeeded, instead of claiming the unbounded `∞` reconnect budget that a 20-strike break contradicts. Mirrored in `SSHPTYAttachRetryScriptBuilder`, whose note had the identical mismatch.
- **F — mouse-report garbage.** `cmux_ssh_reset_terminal_modes` was only reachable inside the retry loop, so an auth-phase give-up left mouse tracking enabled and the prompt's canonical/echo termios echoed every incoming `\e[<35;…M` report as text. Both tails now reset before exiting.

### Deliberately out of scope

- **Enter-to-reconnect inside a dead persistent pane.** That needs a respawned placeholder script, which would destroy the failure transcript the user needs to read (and `SSHDeepSleepReattachTests` asserts surface preservation). Reconnect is offered via the pane context menu, the sidebar/tab menu and row button, `workspace.remote.reconnect`, and `cmux workspace reconnect`.
- **`CmuxFoundation`'s `String(localized:)` resolving against `.main` inside the CLI process** — a pre-existing English fallback for `cli.sshPtyAttach.*`. Not introduced here.
- **Removing the now-unused `allRemoteTargetsConnecting` snapshot field.** The reconnect items no longer read it; Disconnect's aggregate still does. Deleting the reconnect half would be six files of churn for zero behavior change.
- **Raised auth budget for `--require-existing` reattachers** (plan §5.3). Dropped: it would have required a 60-iteration script test for a bound that only matters after the give-up path already degrades gracefully into the placeholder.
- **`unset cmux_status` before `exit $cmux_status`** in the reusable base64 launcher (see Testing) — pre-existing, left alone.

## Testing

Two commits so CI shows the tests catching the bug: commit 1 is tests only (red), commit 2 is the fix (green).

**Commit 1 rewrites a test that encoded the bug.** `initialStartupStopsAtForegroundAuthenticationFailureLimit` asserted `#expect(result.timedOut)` — it asserted that a persistent wrapper *parks forever* at the exit prompt. It is renamed `persistentStartupGiveUpRetiresLifecycleWithoutParkingAtPrompt` and the assertion is **flipped** to `!result.timedOut` plus a lifecycle-only retirement, because parking is the defect, not the contract.

11 test items: 5 shell-seam (`SSHStartupManualReconnectTests`, driving the real generated wrapper with fake ssh/sleep/cmux on `PATH`) and 6 Swift-state (`SSHDeepSleepReattachTests`). Items 3, 8 and 10 are intentional negative/scoping guards that pass both before and after.

Red (commit 1) → green (commit 2), all 11 items:

| item | commit 1 | commit 2 |
|---|---|---|
| persistentStartupGiveUpRetiresLifecycleWithoutParkingAtPrompt (rewrite) | FAIL | PASS |
| persistentAttachGiveUpNeverRunsTheTerminalExitPrompt | FAIL | PASS |
| nonPersistentStartupStillPromptsBeforeClosing (scoping guard) | PASS | PASS |
| authenticationPhaseRetryNoteReportsItsOwnBudget | FAIL | PASS |
| persistentGiveUpDisablesMouseReportingBeforeExit | FAIL | PASS |
| fullSessionEndBeforeChildExitKeepsPersistentPaneReattachable | FAIL | PASS |
| liveFailingPersistentPaneOffersReconnectPaneMenuItem | FAIL | PASS |
| connectedPersistentPaneHidesReconnectPaneMenuItem (negative guard) | PASS | PASS |
| workspaceReconnectReattachesLiveFailingPaneAndLeavesConnectedPane | FAIL | PASS |
| connectedTransitionDoesNotRespawnLaunchingPane (scoping guard) | PASS | PASS |
| manualReconnectRearmsWedgedRemoteSession | FAIL | PASS |

Commands (`-derivedDataPath /tmp/cmux-fix-ssh-reconnect-reattachable`):

- `xcodebuild -scheme cmux-unit ... test-without-building` over `SSHDeepSleepReattachTests`, `SSHStartupManualReconnectTests`, `RemoteDisconnectLifecycleTests`, `TabManagerUnitTests`, `VMSSHCommandTests`, `SSHPersistentPTYRetryLifecycleTests` — non-zero executed counts, all 11 items green, **no regression against a pristine-base run of the same suites**.
- The signal-lifecycle guards live in an extension of `CLINotifyProcessIntegrationRegressionTests`, so `-only-testing:cmuxTests/SSHStartupSignalLifecycleTests` reports "Executed 0 tests" — exactly the trap CLAUDE.md warns about. Run by their real host class, `testSSHPaneCloseSignalDoesNotReportSessionEndToSharedTransport` and `testSSHPaneCloseSignalDoesNotTerminateWrappedSSHChild` pass (Executed 2 tests, 0 failures), which is what pins the unchanged non-persistent signal path.
- `swift test --package-path Packages/macOS/CmuxFoundation` — 215 tests; `SSHPTYAttachRetryScriptBuilderTests` (6) and `SSHForegroundAuthenticationRetryPolicyTests` (23) green.
- Tagged compile-only build: `xcodebuild -scheme cmux -configuration Debug -destination 'platform=macOS' ... build` — **succeeded**. The app was never launched.
- `./scripts/lint-pbxproj-test-wiring.sh` (693 test files), `./scripts/check-pbxproj.sh`, `check-package-resolved-policy.py`, `check-workspace-package-groups.py --check` — all pass. No new test files, so no pbxproj change.

**Two environment findings, both pre-existing and worth recording:**

1. **The reusable base64 launcher swallows its exit status.** It runs `unset cmux_tmp cmux_status` immediately before `exit $cmux_status`, so a persistent `cmux ssh` wrapper always exits 0. This is why the give-up tests assert *termination plus the recorded lifecycle-only retirement* rather than a propagated status. Untouched here.
2. **The root `GhosttyKit.xcframework` was a stale real directory** (sha `bb30526`) where it should be a symlink into the ghostty cache for the recorded submodule sha (`f76c132`), so `CmuxTerminal` could not find `ghostty_font_size_action_cb`. Repaired with `scripts/ensure-ghosttykit.sh`.

Also of note: several process/PTY-heavy tests in these suites are timing-sensitive and flake on a loaded macOS 26 box (`invalidDelayIsClamped`, `processTreeTerminationUsesOneOverallDeadline`, `signalInterruptsReconnectBackoffPromptly`, `terminalExitPrompt*`); each passes in isolation. CLAUDE.md notes CI runs macOS 15.7.4. Separately, the rewritten test's inherited `attempts == "20"` assertion was **stale, not flaky**: with `defaultControlPath` each auth attempt invokes ssh twice (an `ssh -G` control-path probe plus the authentication), so the real count is 40 — the assertion has been failing since that probe was added, and it is now correct and documented.

### Localization audit

Three new keys in `Resources/Localizable.xcstrings`, `en` + `ja`, `extractionState: "manual"`, `state: "translated"`, matching the `cli.ssh.terminalExitPrompt.prompt` convention:

| key | `%s` arity (en/ja) |
|---|---|
| `cli.ssh.persistentGiveUp.status` | 1 / 1 |
| `cli.ssh.persistentGiveUp.hint` | 0 / 0 |
| `cli.ssh.authRetry.status` | 3 / 3 |

Four newly-reachable existing keys: `cli.ssh.autoReconnect.status` and `.stopHint` (previously dead code while the script hardcoded English — a localization fix), plus `cli.sshPtyAttach.bridgeClosedReattaching` and `cli.ssh.terminalExitPrompt.prompt`, which keep their existing behavior for non-persistent panes. `printf` arity is preserved and identical across `en`/`ja` for every changed key; the file parses as JSON and the diff is a 51-line insertion with no reformatting. Every new string passes through `shellQuote(...)` before being embedded in a script (a stray `%` in a translation would corrupt `printf` — the same pre-existing exposure as `cli.ssh.autoReconnect.status`). No bare English was introduced in any changed Swift file; no web message catalogs are touched by this change.

## Demo Video

No video: the change is a terminal-transcript and context-menu behavior, and the transcripts below are the artifact. Captured by driving the **real** generated `cmux ssh` wrapper (built CLI + mock socket + fake `ssh`/`sleep`/`cmux`), before and after, on the auth-give-up path:

**Before** — the pane is stranded:

```
timed_out:                        true      <- parks forever at a dead prompt
session_end recorded:             FULL      <- ends the session record; closing orphans the remote PTY
__ssh-terminal-exit-prompt:       present
mouse reset (?1000l / ?1006l):    absent    <- terminal echoes \e[<35;…M as garbage
retry note:                       "∞"       <- lies; a 20-strike auth break is in force
transcript:                       "[cmux] press Enter to close this pane."
```

**After** — the pane is reattachable:

```
timed_out:                        false     <- wrapper exits; pane lands in the placeholder
session_end recorded:             --lifecycle-only ONLY   (no FULL session end)
__ssh-terminal-exit-prompt:       absent from the persistent script
mouse reset (?1000l / ?1006l):    present
retry note:                       "attempt 3/20"          (no "∞")
transcript:                       "[cmux] ssh exited with status 255; the remote session is still running."
                                  "[cmux] reconnect this pane from its right-click menu (Reconnect Pane)
                                   or from the workspace in the sidebar."
ssh attempts:                     20 auth attempts, budget honored
```

Non-persistent panes re-verified unchanged on the same harness: prompt still shown, FULL `ssh-session-end` still recorded, generated script still valid (`sh -n` clean).

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789715025&installation_model_id=21920&pr_number=10405&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10405&signature=1dc451daff0b71d1521a426765e9fee921d236001896647497a0d0a19c885d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persistent SSH panes now land in the reattachable placeholder when the SSH wrapper gives up, instead of parking at a dead “press Enter to close this pane” prompt. This avoids orphaning the still‑running remote PTY and keeps Reconnect available.

- Persistent give-up retires lifecycle-only and exits; non‑persistent wrappers still show the exit prompt. Status 0 (user typed exit) remains a full session end.
- Pane retention after child exit is robust: `shouldKeepPersistentRemoteSurfaceOpenAfterChildExit` now also honors pending child exits, so stale/racing full session ends cannot close persistent panes.
- Reconnect Pane appears and works while the wrapper is alive via a single resolver: persistent panes reattach (send HUP; retire this generation), non‑persistent dead panes use the prompt-retry keystroke.
- Reconnect Workspace sweeps live‑but‑failing panes and force‑retries the session’s reconnect policy; reconnect actions stay enabled while connecting/reconnecting. The sidebar Reconnect button shows for every non‑connected state; managed cloud VMs remain excluded.
- One shared reconnect path: `Workspace.reconnectRemoteConnection` → `reattachPersistentRemotePTYPanels`; system wake shares the same force‑retry. The force‑retry now logs its reason in the debug event log (e.g., system wake vs manual).
- Honest messaging and terminal cleanup: auto‑reconnect notes are localized; the auth‑phase retry note reports its 20‑attempt budget; persistent give‑up prints that the remote session is still running; terminal modes reset before exit to prevent mouse‑report garbage.

<sup>Written for commit 36f40f3dc8831c104feefb9403faef42f48882dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconnect actions are now available while remote sessions are connecting or reconnecting.
  * Persistent sessions can be reattached after failures, interruptions, deep sleep, or full session termination.
  * Retry messages now distinguish authentication attempts from session reattachment attempts.
  * Added English and Japanese guidance for retry status and persistent-session recovery.

* **Bug Fixes**
  * Prevented persistent sessions from closing prematurely after connection failures.
  * Manual reconnect and system wake now restart retry handling when needed.
  * Non-persistent sessions retain the existing exit prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->