### PR TITLE
Mobile host: one terminal-theme resolver, fix status/observer divergence

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2351,6 +2351,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         auth.start()
         ensureMobileWorkspaceListObserver(for: tabManager)
+        MobileTerminalThemeResolver.start()
         MobileTerminalRenderObserver.shared.start()
         agentChatTranscriptService.start()
         installMobileHostSettingsObserver()

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -237,12 +237,10 @@ final class MobileHostService {
     /// are never on this unauthenticated surface.
     nonisolated static func publicStatusPayload(routes: [CmxAttachRoute], now: Date = Date()) -> [String: Any] {
         // The Mac's resolved terminal theme is caller-independent, so it rides
-        // the public payload (identity merges on top). `GhosttyConfig.load()`
-        // resolves named ghostty themes, cmux's managed defaults, and explicit
-        // color overrides into a complete effective palette; the phone applies
-        // it so its embedded terminal renders with the Mac's colors instead of
-        // the built-in Monokai default.
-        let theme = TerminalTheme(ghosttyConfig: GhosttyConfig.load())
+        // the public payload (identity merges on top). The shared resolver
+        // serves the same runtime snapshot the render-grid frames carry, so
+        // the status colors cannot diverge from the frames the phone renders.
+        let theme = MobileTerminalThemeResolver.statusPayloadTheme()
         return [
             "routes": routes.mobileHostJSONObjects(for: .publicStatus, at: now),
             "terminal_fidelity": "render_grid",

--- a/Sources/Mobile/MobileHostTerminalTheme.swift
+++ b/Sources/Mobile/MobileHostTerminalTheme.swift
@@ -2,6 +2,7 @@ import CMUXMobileCore
 import CmuxFoundation
 import CmuxTerminalCore
 import Foundation
+import os
 
 extension TerminalTheme {
     /// Builds the wire ``TerminalTheme`` from the Mac's resolved terminal config.
@@ -19,24 +20,18 @@ extension TerminalTheme {
         let palette: [String] = (0...15).map { index in
             config.palette[index]?.hexString() ?? monokai.palette[index]
         }
+        func semantic<S: RawRepresentable>(
+            _ value: S?
+        ) -> TerminalTheme.CellRelativeColor? where S.RawValue == String {
+            value.flatMap { TerminalTheme.CellRelativeColor(rawValue: $0.rawValue) }
+        }
+        let cursorTextSemantic = semantic(config.cursorTextColorSemantic)
         // Only carry cursor-text when the Mac config actually parsed a
         // `cursor-text` directive. When it did not, `config.cursorTextColor` is
         // just a placeholder default that ghostty never applies (it derives
         // cursor-text contrast automatically), so forwarding it would make the
         // phone emit an explicit `cursor-text` line the Mac never had and mis-
         // color the cursor label. `nil` here lets the phone derive contrast too.
-        let cursorColorSemantic = config.cursorColorSemantic.flatMap {
-            TerminalTheme.CellRelativeColor(rawValue: $0.rawValue)
-        }
-        let cursorTextSemantic = config.cursorTextColorSemantic.flatMap {
-            TerminalTheme.CellRelativeColor(rawValue: $0.rawValue)
-        }
-        let selectionBackgroundSemantic = config.selectionBackgroundSemantic.flatMap {
-            TerminalTheme.CellRelativeColor(rawValue: $0.rawValue)
-        }
-        let selectionForegroundSemantic = config.selectionForegroundSemantic.flatMap {
-            TerminalTheme.CellRelativeColor(rawValue: $0.rawValue)
-        }
         let cursorText = config.hasParsedCursorTextColor && cursorTextSemantic == nil
             ? config.cursorTextColor.hexString()
             : nil
@@ -45,49 +40,25 @@ extension TerminalTheme {
             foreground: config.foregroundColor.hexString(),
             boldColor: config.boldColor,
             cursor: config.cursorColor.hexString(),
-            cursorColorSemantic: cursorColorSemantic,
+            cursorColorSemantic: semantic(config.cursorColorSemantic),
             cursorText: cursorText,
             cursorTextSemantic: cursorTextSemantic,
             selectionBackground: config.selectionBackground.hexString(),
-            selectionBackgroundSemantic: selectionBackgroundSemantic,
+            selectionBackgroundSemantic: semantic(config.selectionBackgroundSemantic),
             selectionForeground: config.selectionForeground.hexString(),
-            selectionForegroundSemantic: selectionForegroundSemantic,
+            selectionForegroundSemantic: semantic(config.selectionForegroundSemantic),
             palette: palette
         )
     }
 
     /// The JSON object the `mobile.host.status` payload carries under the
-    /// `theme` key. Keys match ``TerminalTheme``'s synthesized `Codable`
-    /// `CodingKeys` so the iOS side decodes it straight back into a
-    /// ``TerminalTheme`` via ``MobileHostStatusResponse``.
+    /// `theme` key. Derived from ``TerminalTheme``'s synthesized `Codable`
+    /// encoding, so the keys are by construction the `CodingKeys` the iOS
+    /// side decodes straight back into a ``TerminalTheme`` via
+    /// ``MobileHostStatusResponse``.
     var mobileHostJSONObject: [String: Any] {
-        var object: [String: Any] = [
-            "background": background,
-            "foreground": foreground,
-            "cursor": cursor,
-            "selectionBackground": selectionBackground,
-            "selectionForeground": selectionForeground,
-            "palette": palette,
-        ]
-        if let cursorText {
-            object["cursorText"] = cursorText
-        }
-        if let boldColor {
-            object["boldColor"] = boldColor
-        }
-        if let cursorColorSemantic {
-            object["cursorColorSemantic"] = cursorColorSemantic.rawValue
-        }
-        if let cursorTextSemantic {
-            object["cursorTextSemantic"] = cursorTextSemantic.rawValue
-        }
-        if let selectionBackgroundSemantic {
-            object["selectionBackgroundSemantic"] = selectionBackgroundSemantic.rawValue
-        }
-        if let selectionForegroundSemantic {
-            object["selectionForegroundSemantic"] = selectionForegroundSemantic.rawValue
-        }
-        return object
+        let data = (try? JSONEncoder().encode(self)) ?? Data()
+        return ((try? JSONSerialization.jsonObject(with: data)) as? [String: Any]) ?? [:]
     }
 
     /// Captures the theme currently applied by the Mac Ghostty runtime.
@@ -103,21 +74,14 @@ extension TerminalTheme {
             useCache: false,
             globalFontMagnificationPercent: GlobalFontMagnification.storedPercent
         )
-        let resolvedConfigTheme = TerminalTheme(ghosttyConfig: config)
-        return TerminalTheme(
-            background: app.defaultBackgroundColor.hexString(),
-            foreground: app.defaultForegroundColor.hexString(),
-            boldColor: resolvedConfigTheme.boldColor,
-            cursor: app.defaultCursorColor.hexString(),
-            cursorColorSemantic: resolvedConfigTheme.cursorColorSemantic,
-            cursorText: resolvedConfigTheme.cursorText,
-            cursorTextSemantic: resolvedConfigTheme.cursorTextSemantic,
-            selectionBackground: app.defaultSelectionBackground.hexString(),
-            selectionBackgroundSemantic: resolvedConfigTheme.selectionBackgroundSemantic,
-            selectionForeground: app.defaultSelectionForeground.hexString(),
-            selectionForegroundSemantic: resolvedConfigTheme.selectionForegroundSemantic,
-            palette: resolvedConfigTheme.palette
-        ).validatedOrDefault()
+        // Config-resolved theme, with the runtime colors GhosttyApp paints with overlaid.
+        var theme = TerminalTheme(ghosttyConfig: config)
+        theme.background = app.defaultBackgroundColor.hexString()
+        theme.foreground = app.defaultForegroundColor.hexString()
+        theme.cursor = app.defaultCursorColor.hexString()
+        theme.selectionBackground = app.defaultSelectionBackground.hexString()
+        theme.selectionForeground = app.defaultSelectionForeground.hexString()
+        return theme.validatedOrDefault()
     }
 
     /// Returns this config-resolved theme with surface-effective OSC colors
@@ -153,5 +117,54 @@ extension TerminalTheme {
             resolved.cursorColorSemantic = nil
         }
         return resolved
+    }
+}
+
+/// Single source of the Mac's resolved terminal theme for every mobile
+/// consumer: render-grid frames, replay decoration, and the
+/// `mobile.host.status` payload all read the same cached
+/// ``TerminalTheme/currentMacTerminalThemeSnapshot()``, so status colors can
+/// never disagree with the frames the phone renders.
+@MainActor
+enum MobileTerminalThemeResolver {
+    private static var cachedTheme: TerminalTheme?
+    private static var observersInstalled = false
+    /// The last MainActor-resolved theme, mirrored behind a lock so the
+    /// nonisolated status-payload builders can read it from any thread.
+    private nonisolated static let latestResolvedTheme =
+        OSAllocatedUnfairLock<TerminalTheme?>(initialState: nil)
+
+    /// Installs process-lifetime invalidation observers and seeds the cache.
+    /// Called once at app startup, before the mobile listener serves status.
+    static func start() {
+        guard !observersInstalled else { return }
+        observersInstalled = true
+        for name: Notification.Name in [.ghosttyConfigDidReload, .ghosttyDefaultBackgroundDidChange] {
+            _ = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in
+                MainActor.assumeIsolated {
+                    cachedTheme = nil
+                    // Eager, so nonisolated status readers never serve colors older than this reload.
+                    _ = resolvedTheme()
+                }
+            }
+        }
+        _ = resolvedTheme()
+    }
+
+    /// The Mac's effective terminal theme, resolved at most once between
+    /// invalidations.
+    static func resolvedTheme() -> TerminalTheme {
+        if let cachedTheme { return cachedTheme }
+        let theme = TerminalTheme.currentMacTerminalThemeSnapshot()
+        cachedTheme = theme
+        latestResolvedTheme.withLock { $0 = theme }
+        return theme
+    }
+
+    /// The theme the `mobile.host.status` payload carries: the last MainActor-
+    /// resolved snapshot, or (before the first resolution, early startup only)
+    /// the config-file theme the payload historically used.
+    nonisolated static func statusPayloadTheme() -> TerminalTheme {
+        latestResolvedTheme.withLock { $0 } ?? TerminalTheme(ghosttyConfig: GhosttyConfig.load())
     }
 }

--- a/Sources/Mobile/MobileTerminalRenderObserver.swift
+++ b/Sources/Mobile/MobileTerminalRenderObserver.swift
@@ -24,8 +24,6 @@ final class MobileTerminalRenderObserver {
     private var terminalConfigThemesBySurfaceID: [UUID: TerminalTheme] = [:]
     private var runtimeSurfaceGenerationsBySurfaceID: [UUID: UInt64] = [:]
     private var reconciledSurfaceTopologyGeneration: UInt64?
-    private var cachedTerminalTheme: TerminalTheme = .monokai
-    private var hasLoadedTerminalTheme = false
     private var terminalThemeRevision: UInt64 = 0
     private lazy var themeInvalidationScheduler = MobileTerminalThemeInvalidationScheduler {
         [weak self] surfaceIDs in
@@ -123,7 +121,6 @@ final class MobileTerminalRenderObserver {
         terminalThemesBySurfaceID.removeAll()
         terminalConfigThemesBySurfaceID.removeAll()
         runtimeSurfaceGenerationsBySurfaceID.removeAll()
-        hasLoadedTerminalTheme = false
     }
 
     func noteTerminalBytes(surfaceID: UUID) {
@@ -151,12 +148,8 @@ final class MobileTerminalRenderObserver {
 
     private func refreshNotificationDemand() {
         let shouldRetainDemand = hasAnyRenderEventSubscribers
-        let hasRenderGridSubscribers = MobileHostService.hasEventSubscribers(topic: "terminal.render_grid")
-        if hasRenderGridSubscribers, !hasLoadedTerminalTheme {
-            refreshTerminalTheme()
-        } else if !hasRenderGridSubscribers {
+        if !MobileHostService.hasEventSubscribers(topic: "terminal.render_grid") {
             clearRenderGridCaches()
-            hasLoadedTerminalTheme = false
         }
         if shouldRetainDemand {
             if releaseFrameDemand == nil {
@@ -392,17 +385,18 @@ final class MobileTerminalRenderObserver {
             if let sharedTheme {
                 resolvedTheme = sharedTheme
             } else {
+                let macTheme = MobileTerminalThemeResolver.resolvedTheme()
                 let configTheme = MobileTerminalThemeEmissionDecision.resolveConfigTheme(
                     candidate: themedFrame.terminalConfigTheme,
                     cached: terminalConfigThemesBySurfaceID[surfaceID],
-                    fallbackBoldColor: cachedTerminalTheme.boldColor
+                    fallbackBoldColor: macTheme.boldColor
                 )
                 if snapshot.frame.terminalConfigTheme != nil, let configTheme {
                     terminalConfigThemesBySurfaceID[surfaceID] = configTheme
                 }
                 let candidateTheme = (themedFrame.terminalTheme
                     ?? terminalThemesBySurfaceID[surfaceID]
-                    ?? cachedTerminalTheme).applyingSurfaceColors(from: snapshot.frame)
+                    ?? macTheme).applyingSurfaceColors(from: snapshot.frame)
                 let themeDecision = MobileTerminalThemeEmissionDecision.resolve(
                     candidate: candidateTheme,
                     cached: terminalThemesBySurfaceID[surfaceID],
@@ -445,11 +439,6 @@ final class MobileTerminalRenderObserver {
         }
     }
 
-    private func refreshTerminalTheme() {
-        cachedTerminalTheme = TerminalTheme.currentMacTerminalThemeSnapshot()
-        hasLoadedTerminalTheme = true
-    }
-
     /// Rebase the screen-anchored delta chain onto an authoritative replay
     /// frame served outside the event lane (the `mobile.terminal.replay` RPC).
     /// The next emitted delta is then diffed against exactly the state the
@@ -467,14 +456,14 @@ final class MobileTerminalRenderObserver {
     }
 
     func decorateReplayFrame(_ frame: MobileTerminalRenderGridFrame) -> MobileTerminalRenderGridFrame {
-        if !hasLoadedTerminalTheme { refreshTerminalTheme() }
+        let macTheme = MobileTerminalThemeResolver.resolvedTheme()
         var themedFrame = frame
-        themedFrame.terminalTheme = (frame.terminalTheme ?? cachedTerminalTheme)
+        themedFrame.terminalTheme = (frame.terminalTheme ?? macTheme)
             .applyingSurfaceColors(from: frame)
         themedFrame.terminalConfigTheme = MobileTerminalThemeEmissionDecision.resolveConfigTheme(
             candidate: frame.terminalConfigTheme,
             cached: nil,
-            fallbackBoldColor: cachedTerminalTheme.boldColor
+            fallbackBoldColor: macTheme.boldColor
         )
         themedFrame.terminalThemeRevision = nextTerminalThemeRevision()
         return themedFrame
@@ -486,11 +475,9 @@ final class MobileTerminalRenderObserver {
     }
 
     private func invalidateTerminalThemes() {
-        guard MobileHostService.hasEventSubscribers(topic: "terminal.render_grid") else {
-            hasLoadedTerminalTheme = false
-            return
-        }
-        refreshTerminalTheme()
+        // The resolver re-resolves on these same notifications; the flush task
+        // runs after all handlers of the post, so it reads the fresh theme.
+        guard MobileHostService.hasEventSubscribers(topic: "terminal.render_grid") else { return }
         hasPendingThemeInvalidation = true
         enqueueTerminalUpdate(surfaceID: nil)
     }


### PR DESCRIPTION
The mobile.host.status theme was built from GhosttyConfig.load() alone while render-grid frames used TerminalTheme.currentMacTerminalThemeSnapshot(), which also folds in GhosttyApp runtime colors, so the status payload and the frames the phone renders could disagree. A MainActor MobileTerminalThemeResolver now caches that snapshot, re-resolves on ghosttyConfigDidReload and ghosttyDefaultBackgroundDidChange, and mirrors the result behind a lock so the nonisolated status payload builders read the same theme from any thread. mobileHostJSONObject is now derived from the synthesized Codable encoding, so wire keys stay identical by construction; event topics and JSON keys are unchanged. Net delta versus origin/main: 4 files changed, 88 insertions, 89 deletions.

Part of the mobile-sync rip-out wave 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789715659&installation_model_id=21920&pr_number=10406&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10406&signature=7bb098456b2e43941afa60fb7628a12e448007311b0fe38584eb8ab8935ce654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies mobile terminal theme resolution so `mobile.host.status` and render-grid/replay use the same runtime snapshot. Previously status used a config-only theme; now both use a cached snapshot that overlays Ghostty runtime colors, eliminating color mismatches.

- Adds a MainActor `MobileTerminalThemeResolver` that caches `currentMacTerminalThemeSnapshot()`, re-resolves on `ghosttyConfigDidReload` and `ghosttyDefaultBackgroundDidChange`, and exposes a thread-safe last snapshot for status payloads (config-only fallback before first resolve). App startup calls `MobileTerminalThemeResolver.start()`.
- `MobileHostService.publicStatusPayload` now reads the theme from the resolver. `MobileTerminalRenderObserver` drops its local theme cache and resolves via the shared resolver for both deltas and replay decoration.
- `TerminalTheme.mobileHostJSONObject` now derives from synthesized `Codable` encoding to keep wire keys consistent by construction. Event topics and JSON keys are unchanged.

<sup>Written for commit 8e151c9dc643b48bd64ea56920d2c5010e46117c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal theme handling across mobile views and rendering.
  * Applied effective terminal colors more consistently, including during render updates and replay decoration.
  * Added validation and fallback behavior to help prevent invalid or unavailable theme data.

* **Performance**
  * Reduced redundant theme resolution by sharing cached results and refreshing them only when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->