### PR TITLE
CmuxTerminal: cheap terminalGridSize(); stop full grid-JSON export in tmux mirror readiness probe

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Mobile.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Mobile.swift
@@ -104,6 +104,16 @@ extension TerminalSurface {
         didAcceptExplicitInput()
     }
 
+    /// Current terminal grid dimensions straight from libghostty, without the
+    /// grid-to-JSON export that `mobileRenderGridFrame` pays. Returns nil when
+    /// the live surface pointer is unavailable.
+    @MainActor
+    public func terminalGridSize() -> (columns: Int, rows: Int)? {
+        guard let surface = liveSurfaceForGhosttyAccess(reason: "terminalGridSize") else { return nil }
+        let size = ghostty_surface_size(surface)
+        return (Int(size.columns), Int(size.rows))
+    }
+
     /// Exports the surface grid as a mobile render frame (optionally filtered
     /// to changed rows). Set `includeTheme` to `false` for ordinary live ticks
     /// after the caller has cached this surface's theme; replay and invalidation

--- a/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
+++ b/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
@@ -211,12 +211,9 @@ extension RemoteTmuxSessionMirror {
         paneId: Int,
         target: (columns: Int, rows: Int)
     ) -> Bool {
-        guard let frame = terminalSurface(forPane: paneId)?.mobileRenderGridFrame(
-            stateSeq: 0,
-            scrollbackLines: 0,
-            includeTheme: false
-        )?.frame else { return false }
-        return frame.columns >= target.columns && frame.rows >= target.rows
+        guard let size = terminalSurface(forPane: paneId)?.terminalGridSize()
+        else { return false }
+        return size.columns >= target.columns && size.rows >= target.rows
     }
 
     private func drainPendingPaneSeedDelivery(paneId: Int) {


### PR DESCRIPTION
The tmux mirror readiness probe called mobileRenderGridFrame per rendered frame per pending pane, paying a full grid-to-JSON export and decode just to read columns and rows. This adds TerminalSurface.terminalGridSize(), which reads ghostty_surface_size directly through liveSurfaceForGhosttyAccess, and switches the probe to it. Semantics are unchanged (nil surface pointer still means not ready, same dimension comparison) and mobileRenderGridFrame is untouched. Net delta from git diff origin/main...HEAD --shortstat: 2 files changed, 13 insertions, 6 deletions.

Part of the mobile-sync rip-out wave 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789717987&installation_model_id=21920&pr_number=10411&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10411&signature=304f5246c30d0d817a2b4264b473a5a099ff70811755aca9658c8411754ae7b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids a full grid-to-JSON export in the tmux mirror readiness probe by adding TerminalSurface.terminalGridSize(), which reads ghostty_surface_size directly. Old behavior: export and decode a frame per render to get columns/rows. New behavior: read size directly; nil surface still means not ready; same dimension comparison.

- New API: TerminalSurface.terminalGridSize() uses liveSurfaceForGhosttyAccess and returns (columns, rows) or nil.
- terminalGridIsReady(...) now calls terminalGridSize(); mobileRenderGridFrame is unchanged.
- No migration required; behavior is unchanged with lower per-frame overhead.

<sup>Written for commit dc07103badf7902aa56941e586d1ffbe23a5c01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal size detection for remote session rendering.
  - Rendering now waits until the live terminal surface has sufficient rows and columns.
  - Correctly reports the terminal as unavailable when its surface or dimensions cannot be accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->