### PR TITLE
cmux-tui: journal restore preserves topology across server restart with honest exited terminals

### DIFF
--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -355,7 +355,15 @@ struct QueuedEvent {
 
 impl EventQueue {
     fn new() -> Self {
-        Self { state: Mutex::new(EventQueueState::default()) }
+        // The ingress queue is hard-capped at this size. Preallocate the
+        // ring buffer once so a burst of small events does not repeatedly
+        // grow and copy its backing storage while the reader is draining it.
+        Self {
+            state: Mutex::new(EventQueueState {
+                events: VecDeque::with_capacity(CDP_INGRESS_EVENT_CAPACITY),
+                ..EventQueueState::default()
+            }),
+        }
     }
 
     fn push(&self, event: CdpEvent) -> Result<(), ()> {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2035,6 +2035,18 @@ struct RestoredTerminalBinding {
     placements: Vec<(SurfaceId, TabResourceIdentity)>,
 }
 
+/// Topology policy for one durable exit commit. A live exit detaches its
+/// views in the same transaction. Restart reconciliation preserves the
+/// journaled tree: a process that died while the daemon was down is recorded
+/// as exited, never respawned, and never costs the session its layout.
+#[derive(Clone, Copy, PartialEq, Eq)]
+// Preserve is constructed only by the unix restart-reconciliation paths.
+#[cfg_attr(not(unix), allow(dead_code))]
+enum TerminalExitTopology {
+    Detach,
+    Preserve,
+}
+
 impl Mux {
     fn default_workspace_name(state: &State) -> String {
         state.workspaces.len().to_string()
@@ -2613,12 +2625,11 @@ impl Mux {
                 // never be allowed to terminate a replacement process.
                 continue;
             }
-            self.persist_terminal_exit(
+            self.persist_terminal_exit_preserving_topology(
                 &record.terminal_id,
                 Some(&record.incarnation),
                 &record.exit,
             )?;
-            self.detach_exited_terminal_topology(&record.terminal_id)?;
             let _ = crate::terminal_host_runtime::acknowledge_terminal_host_exit_record(
                 &exit_path, &record,
             )?;
@@ -2673,7 +2684,8 @@ impl Mux {
                 continue;
             }
             if terminal.lifecycle == TerminalLifecycle::Exited {
-                self.detach_exited_terminal_topology(&terminal.terminal_id)?;
+                // Restoration keeps the exited terminal's journaled views;
+                // only an explicit close mutates topology after restart.
                 handled_terminals.insert(terminal_id.clone());
                 if !cleanup_terminal_host_record(&record, &record_path) {
                     self.schedule_terminal_adoption(options.clone(), record, record_path);
@@ -2681,7 +2693,7 @@ impl Mux {
                 continue;
             }
             if terminal.incarnation.as_deref().is_some_and(|value| value != record.incarnation) {
-                self.mark_terminal_exited_and_detach(
+                self.mark_terminal_exited_preserving_topology(
                     &terminal_id,
                     "terminal-incarnation-mismatch",
                     "host-incarnation-mismatch",
@@ -2709,12 +2721,6 @@ impl Mux {
                         TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
                     )
                 }) {
-                    if current
-                        .as_ref()
-                        .is_some_and(|terminal| terminal.lifecycle == TerminalLifecycle::Exited)
-                    {
-                        self.detach_exited_terminal_topology(&terminal_id)?;
-                    }
                     handled_terminals.insert(terminal_id.clone());
                     if !cleanup_terminal_host_record(&record, &record_path) {
                         self.schedule_terminal_adoption(options.clone(), record, record_path);
@@ -2728,7 +2734,7 @@ impl Mux {
                 // record is the only proof that this host ever existed, so a
                 // failed commit must leave the next startup able to retry
                 // instead of facing a lifecycle row with no evidence.
-                self.mark_terminal_exited_and_detach(
+                self.mark_terminal_exited_preserving_topology(
                     &terminal_id,
                     "terminal-host-proven-dead",
                     "host-process-ended-before-adoption",
@@ -2755,7 +2761,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        self.mark_terminal_exited_and_detach(
+                        self.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -2786,7 +2792,7 @@ impl Mux {
                 surface.disconnect_for_daemon_shutdown();
                 handled_terminals.insert(terminal_id.clone());
                 if host_is_dead {
-                    self.mark_terminal_exited_and_detach(
+                    self.mark_terminal_exited_preserving_topology(
                         &terminal_id,
                         "terminal-adoption-failed",
                         "host-exited-during-adoption",
@@ -2816,10 +2822,9 @@ impl Mux {
                 continue;
             }
             if terminal.lifecycle == TerminalLifecycle::Exited {
-                self.detach_exited_terminal_topology(&terminal.terminal_id)?;
                 continue;
             }
-            self.mark_terminal_exited_and_detach(
+            self.mark_terminal_exited_preserving_topology(
                 &terminal.terminal_id,
                 "terminal-record-missing",
                 "missing-host-record",
@@ -2829,8 +2834,13 @@ impl Mux {
         Ok(())
     }
 
+    /// Latch a restart-window death as a durable exit while preserving the
+    /// terminal's journaled tab placements and split tree. The daemon never
+    /// respawns the process and never mutates topology on behalf of a process
+    /// it did not observe exiting; the restored view represents the terminal
+    /// honestly as not running until an explicit close or respawn action.
     #[cfg(unix)]
-    fn mark_terminal_exited_and_detach(
+    fn mark_terminal_exited_preserving_topology(
         self: &Arc<Self>,
         terminal_id: &str,
         _operation: &str,
@@ -2867,14 +2877,13 @@ impl Mux {
                 .as_ref()
                 .map(|(_, record)| record.incarnation.as_str())
                 .or(terminal.incarnation.as_deref());
-            self.persist_terminal_exit(terminal_id, incarnation, &observed)?;
+            self.persist_terminal_exit_preserving_topology(terminal_id, incarnation, &observed)?;
         }
         if let Some((path, record)) = sidecar {
             let _ = crate::terminal_host_runtime::acknowledge_terminal_host_exit_record(
                 &path, &record,
             )?;
         }
-        self.detach_exited_terminal_topology(terminal_id)?;
         Ok(())
     }
 
@@ -2887,7 +2896,10 @@ impl Mux {
     ) -> anyhow::Result<()> {
         let _pending_host_release = PendingTerminalHostRelease(surface.clone());
         if surface.is_dead() {
-            self.persist_terminal_exit(
+            // Adoption is restart reconciliation: the daemon never observed
+            // this process exit while owning it, so the restored topology
+            // stays and the terminal is recorded honestly as exited.
+            self.persist_terminal_exit_preserving_topology(
                 terminal_id,
                 Some(incarnation),
                 &TerminalExit::unknown("host-exited-during-adoption"),
@@ -3037,16 +3049,8 @@ impl Mux {
                         terminal.lifecycle,
                         TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
                     ) {
-                        if terminal.lifecycle == TerminalLifecycle::Exited
-                            && let Err(error) = mux.detach_exited_terminal_topology(&terminal_id)
-                        {
-                            eprintln!(
-                                "cmux-tui: could not detach exited terminal \
-                                 {terminal_id}: {error:#}"
-                            );
-                            delay = (delay * 2).min(Duration::from_secs(5));
-                            continue;
-                        }
+                        // Restoration keeps the exited terminal's journaled
+                        // views; only an explicit close mutates topology.
                         if cleanup_terminal_host_record(&record, &record_path) {
                             break;
                         }
@@ -3058,7 +3062,7 @@ impl Mux {
                         .as_deref()
                         .is_some_and(|incarnation| incarnation != record.incarnation)
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-incarnation-mismatch",
                             "host-incarnation-mismatch",
@@ -3103,7 +3107,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -3152,7 +3156,7 @@ impl Mux {
                                 == TerminalHostLiveness::Dead;
                         surface.disconnect_for_daemon_shutdown();
                         if host_is_dead {
-                            if let Err(error) = mux.mark_terminal_exited_and_detach(
+                            if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                                 &terminal_id,
                                 "terminal-adoption-failed",
                                 "host-exited-during-adoption",
@@ -3177,7 +3181,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -4437,6 +4441,20 @@ impl Mux {
         terminal_id: &TerminalPublicId,
     ) -> Option<SurfaceId> {
         self.state.lock().unwrap().terminal_catalog.get(terminal_id).map(|surface| surface.id)
+    }
+
+    /// First tab placement of a terminal's content, present even when the
+    /// terminal has no runtime because it was restored as exited.
+    pub(crate) fn first_terminal_placement(
+        &self,
+        terminal_id: &TerminalPublicId,
+    ) -> Option<SurfaceId> {
+        self.state
+            .lock()
+            .unwrap()
+            .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
+            .first()
+            .copied()
     }
 
     pub(crate) fn resource_selectors_for_pane(
@@ -12818,6 +12836,41 @@ impl Mux {
         incarnation: Option<&str>,
         exit: &TerminalExit,
     ) -> anyhow::Result<bool> {
+        self.persist_terminal_exit_with_topology(
+            terminal_id,
+            incarnation,
+            exit,
+            TerminalExitTopology::Detach,
+        )
+    }
+
+    /// Commit a durable terminal exit without touching topology. Restart
+    /// reconciliation uses this so a restored session keeps its journaled
+    /// tab placements and split tree, representing the terminal honestly as
+    /// exited instead of silently discarding its layout. Live exits observed
+    /// while the daemon runs keep the atomic detach path.
+    #[cfg(unix)]
+    fn persist_terminal_exit_preserving_topology(
+        &self,
+        terminal_id: &str,
+        incarnation: Option<&str>,
+        exit: &TerminalExit,
+    ) -> anyhow::Result<bool> {
+        self.persist_terminal_exit_with_topology(
+            terminal_id,
+            incarnation,
+            exit,
+            TerminalExitTopology::Preserve,
+        )
+    }
+
+    fn persist_terminal_exit_with_topology(
+        &self,
+        terminal_id: &str,
+        incarnation: Option<&str>,
+        exit: &TerminalExit,
+        topology_policy: TerminalExitTopology,
+    ) -> anyhow::Result<bool> {
         let mut registry = self.workspace_registry.lock().unwrap();
         let terminal = registry
             .terminal_record(terminal_id)?
@@ -12858,7 +12911,8 @@ impl Mux {
         let detach_projection = if matches!(
             terminal.lifecycle,
             TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
-        ) {
+        ) || topology_policy == TerminalExitTopology::Preserve
+        {
             None
         } else if let Some(public_terminal_id) = public_terminal_id.as_ref() {
             self.terminal_exit_detach_projection_locked(
@@ -14822,14 +14876,29 @@ fn terminal_exit_snapshot_in_state(
         .ok_or_else(|| anyhow::anyhow!("terminal {terminal_id} has no public resource id"))?;
     let content_id = ContentPublicId::Terminal(public_id.clone());
     let topology = registry.resource_topology_snapshot()?;
-    let tab_ids = topology
-        .tabs
-        .iter()
-        .filter(|tab| tab.content_id == content_id)
-        .map(|tab| tab.public_id.clone())
-        .collect::<Vec<_>>();
+    let tab_ids = crate::resource_api::terminal_tab_ids_in_canonical_order(
+        topology.tabs.iter().filter(|tab| tab.content_id == content_id).map(|tab| {
+            (public_id.clone(), tab.pane_id.clone(), tab.position, tab.public_id.clone())
+        }),
+    )
+    .remove(&public_id)
+    .unwrap_or_default();
     let surface = state.surface_by_content_public_id(&content_id);
-    let (cols, rows) = surface.map(|surface| surface.size()).unwrap_or((80, 24));
+    // Match the public projection's fallback exactly. A restart-window exit
+    // has no surface, and the preserved topology makes this snapshot the
+    // durable view later restarts and restore previews must agree on.
+    let durable = registry.terminal_record(terminal_id)?;
+    let durable_size = |field: &str, fallback: u16| {
+        durable
+            .as_ref()
+            .and_then(|terminal| terminal.launch_spec[field].as_u64())
+            .and_then(|value| u16::try_from(value).ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(fallback)
+    };
+    let (cols, rows) = surface
+        .map(|surface| surface.size())
+        .unwrap_or_else(|| (durable_size("cols", 80), durable_size("rows", 24)));
     let mut snapshot = serde_json::json!({
         "id": public_id,
         "tab_id": tab_ids.first(),
@@ -18506,10 +18575,13 @@ mod tests {
             assert_eq!(replay["result"]["replayed"], true, "{operation}");
         }
         assert_eq!(reopened.resource_notifications(256).len(), 1);
-        assert!(
-            reopened.list_agents(None, None).is_empty(),
-            "the legacy live-surface cache must not retain a detached terminal"
+        let restored_agents = reopened.list_agents(None, None);
+        assert_eq!(
+            restored_agents.len(),
+            1,
+            "a restored exited terminal keeps its placement, so its agent record stays listed"
         );
+        assert_eq!(restored_agents[0].terminal_id, terminal_public_id);
         assert_eq!(
             reopened
                 .workspace_registry
@@ -20791,9 +20863,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(reopened.resource_agent_projection_count_for_test().unwrap(), 1);
-        assert!(
-            reopened.list_agents(None, None).is_empty(),
-            "the legacy live-surface cache must not retain a detached terminal"
+        let restored_agents = reopened.list_agents(None, None);
+        assert_eq!(
+            restored_agents.iter().map(|record| record.terminal_id.clone()).collect::<Vec<_>>(),
+            vec![terminal_id.clone()],
+            "a restored exited terminal keeps its placement, so its agent record stays listed"
         );
         assert_eq!(
             crate::resource_api::public_session_snapshot(&reopened).unwrap()["agents"],
@@ -24595,10 +24669,14 @@ mod tests {
                 && change["id"] == terminal_public_id.as_str()
                 && change["value"]["lifecycle"] == "exited"
         }));
+        assert!(
+            !changes.iter().any(|change| change["kind"] == "delete" && change["resource"] == "tab"),
+            "sidecar recovery must preserve the restored tab placement"
+        );
         assert!(changes.iter().any(|change| {
-            change["kind"] == "delete"
-                && change["resource"] == "tab"
-                && change["id"] == tab.as_str()
+            change["kind"] == "upsert"
+                && change["resource"] == "terminal"
+                && change["value"]["tab_ids"][0] == tab.as_str()
         }));
         assert!(!changes.iter().any(|change| {
             change["kind"] == "delete"

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2205,7 +2205,11 @@ impl Mux {
             fingerprint,
             move |state| {
                 anyhow::ensure!(
-                    state.terminal_runtime_by_id(surface).is_some(),
+                    state.terminal_runtime_by_id(surface).is_some()
+                        || matches!(
+                            state.resource_indexes.content_ids.get(&surface),
+                            Some(ContentPublicId::Terminal(_))
+                        ),
                     "terminal disappeared"
                 );
                 Ok(EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) })
@@ -2279,12 +2283,34 @@ impl Mux {
                 &notifications,
             )?;
             (target, plan)
-        } else {
-            if !state.placements_of_content(&content_id).is_empty() {
-                return Err(terminal_close_state_error(format!(
+        } else if let Some(&slot) = state.placements_of_content(&content_id).first() {
+            // A restored exited terminal keeps its journaled views without a
+            // runtime owner. Explicit close is the mutation that removes them.
+            let durable = registry.terminal_record(terminal_id)?.ok_or_else(|| {
+                terminal_close_state_error(format!(
+                    "terminal close target omitted host {terminal_id}"
+                ))
+            })?;
+            anyhow::ensure!(
+                durable.lifecycle == TerminalLifecycle::Exited,
+                terminal_close_state_error(format!(
                     "live terminal resource {public_id} has views but no runtime owner"
-                )));
+                ))
+            );
+            if let (Some(expected), Some(stored)) =
+                (expected_incarnation, durable.incarnation.as_deref())
+            {
+                anyhow::ensure!(expected == stored, "terminal_incarnation_mismatch");
             }
+            let plan = self.resource_close_plan_locked(
+                ResourceOperation::TerminalClose,
+                EffectSlots { workspace: None, screen: None, pane: None, tab: Some(slot) },
+                &registry,
+                &state,
+                &notifications,
+            )?;
+            (Some(slot), plan)
+        } else {
             (
                 None,
                 ResourceClosePlan {
@@ -2538,9 +2564,13 @@ impl Mux {
         self.emit_empty_if_current(effects.empty_revision);
     }
 
-    /// Reconcile a lifecycle row that was committed before topology detach was
-    /// introduced, or whose daemon stopped between those two older commits.
-    /// The durable terminal receipt remains queryable after every view leaves.
+    /// Detach the views of a terminal whose exit this daemon observed live
+    /// but whose lifecycle-and-detach commit did not land atomically (for
+    /// example a dead surface discovered after its host connection dropped).
+    /// Restart reconciliation deliberately never calls this: a restored
+    /// session keeps the journaled topology of terminals that died while the
+    /// daemon was down. The durable terminal receipt remains queryable after
+    /// every view leaves.
     pub(super) fn detach_exited_terminal_topology(
         &self,
         terminal_id: &str,
@@ -2705,7 +2735,7 @@ impl Mux {
         &self,
         operation: ResourceOperation,
         slots: EffectSlots,
-        _registry: &WorkspaceRegistry,
+        registry: &WorkspaceRegistry,
         state: &State,
         notifications: &HashMap<SurfaceId, SurfaceNotification>,
     ) -> anyhow::Result<ResourceClosePlan> {
@@ -2794,17 +2824,36 @@ impl Mux {
             }
             ResourceOperation::TerminalClose => {
                 let surface = slots.tab.context("terminal disappeared")?;
-                let runtime = state
-                    .terminal_runtime_by_id(surface)
-                    .cloned()
-                    .context("terminal disappeared")?;
-                let public_id = runtime
-                    .terminal_public_id()
-                    .cloned()
-                    .context("terminal catalog entry omitted its public identity")?;
-                let host = self
-                    .resource_terminal_host_identity(&runtime)
-                    .context("terminal omitted its durable host identity")?;
+                let runtime = state.terminal_runtime_by_id(surface).cloned();
+                let (public_id, terminal_batch) = match runtime.as_ref() {
+                    Some(runtime) => {
+                        let public_id = runtime
+                            .terminal_public_id()
+                            .cloned()
+                            .context("terminal catalog entry omitted its public identity")?;
+                        let host = self
+                            .resource_terminal_host_identity(runtime)
+                            .context("terminal omitted its durable host identity")?;
+                        (public_id, vec![(host.terminal_id, Some(host.incarnation))])
+                    }
+                    None => {
+                        // A restored exited terminal keeps views without a
+                        // runtime. Its durable identity comes from the
+                        // registry, and the close still tombstones the host.
+                        let public_id = match state.resource_indexes.content_ids.get(&surface) {
+                            Some(ContentPublicId::Terminal(public_id)) => public_id.clone(),
+                            _ => anyhow::bail!("terminal disappeared"),
+                        };
+                        let host_id = registry
+                            .terminal_host_id(&public_id)?
+                            .context("terminal omitted its durable host identity")?;
+                        let incarnation = registry
+                            .terminal_record(&host_id)?
+                            .context("terminal close target omitted its durable row")?
+                            .incarnation;
+                        (public_id, vec![(host_id, incarnation)])
+                    }
+                };
                 let placements = state
                     .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
                     .to_vec();
@@ -2814,8 +2863,8 @@ impl Mux {
                 ResourceCloseInputs {
                     surface_ids: placements,
                     changed_screens: screens,
-                    terminal_runtime: Some(runtime),
-                    terminal_batch: vec![(host.terminal_id, Some(host.incarnation))],
+                    terminal_runtime: runtime,
+                    terminal_batch,
                     terminal_public_id: Some(public_id),
                     ..Default::default()
                 }
@@ -2829,10 +2878,13 @@ impl Mux {
             let (removed_runtime, terminal_views, changed) =
                 remove_terminal_content_from_state(self, &mut projected, public_id);
             anyhow::ensure!(
-                removed_runtime
-                    .as_ref()
-                    .zip(terminal_runtime.as_ref())
-                    .is_some_and(|(removed, planned)| removed.shares_terminal_runtime(planned)),
+                match (removed_runtime.as_ref(), terminal_runtime.as_ref()) {
+                    (Some(removed), Some(planned)) => removed.shares_terminal_runtime(planned),
+                    // A restored exited terminal has journaled views but no
+                    // catalog runtime to remove.
+                    (None, None) => true,
+                    _ => false,
+                },
                 "terminal close lost its catalog runtime"
             );
             removed = terminal_views;

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2297,10 +2297,11 @@ impl Mux {
                     "live terminal resource {public_id} has views but no runtime owner"
                 ))
             );
-            if let (Some(expected), Some(stored)) =
-                (expected_incarnation, durable.incarnation.as_deref())
-            {
-                anyhow::ensure!(expected == stored, "terminal_incarnation_mismatch");
+            if let Some(expected) = expected_incarnation {
+                anyhow::ensure!(
+                    durable.incarnation.as_deref() == Some(expected.as_str()),
+                    "terminal_incarnation_mismatch"
+                );
             }
             let plan = self.resource_close_plan_locked(
                 ResourceOperation::TerminalClose,

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2850,7 +2850,7 @@ impl Mux {
                             .context("terminal omitted its durable host identity")?;
                         let incarnation = registry
                             .terminal_record(&host_id)?
-                            .context("terminal close target omitted its durable row")?
+                            .context("terminal close failed")?
                             .incarnation;
                         (public_id, vec![(host_id, incarnation)])
                     }

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2712,6 +2712,8 @@ impl Mux {
         if let Some(runtime) = effects.terminal_runtime {
             self.purge_terminal_runtime_side_tables(&runtime);
             self.terminate_terminal_runtime(&runtime);
+        } else if let Some(terminal_id) = effects.closed_terminal_public_id.as_ref() {
+            self.purge_terminal_side_tables(terminal_id);
         }
         match effects.tree_publication {
             ResourceCloseTreePublication::PendingDelta(delta) => {

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -353,6 +353,19 @@ fn execute_terminal_effect(
         Err(error) => return effects::commit_known_failure(mux, prepared, error),
     };
     let Some(surface_id) = mux.resource_surface_for_terminal(&terminal_id) else {
+        // A restored exited terminal keeps its journaled views without a
+        // runtime. Explicit close is the one effect that still applies to it.
+        if prepared.operation == "terminal.close"
+            && let Some(slot) = mux.first_terminal_placement(&terminal_id)
+        {
+            let commit = mux.commit_resource_terminal_close_effect(
+                slot,
+                &prepared.idempotency_key,
+                &prepared.operation,
+                &prepared.fingerprint,
+            );
+            return finish_projection_commit(mux, prepared, commit);
+        }
         return effects::commit_known_failure(
             mux,
             prepared,

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -326,7 +326,15 @@ fn terminal_effect(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Val
     validate_terminal_effect_fields(&request)?;
     let fields = request.fields.clone();
     let preparation = effects::prepare(mux, &request, || {
-        let (terminal_id, _) = resolve_terminal_surface(mux, &request.selectors)?;
+        let path = mux.resolve_resource_path(ResourceTarget::Terminal, &request.selectors)?;
+        let terminal_id = path
+            .terminal
+            .ok_or_else(|| ResourceError::not_found("terminal", "<resolved>"))?;
+        if request.envelope.operation != ResourceOperation::TerminalClose {
+            let _ = mux
+                .resource_surface_for_terminal(&terminal_id)
+                .ok_or_else(|| ResourceError::not_found("terminal", terminal_id.as_str()))?;
+        }
         Ok(json!({"terminal_id":terminal_id,"fields":fields}))
     })?;
     match preparation {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
@@ -148,10 +148,6 @@ impl WorkspaceRegistry {
             apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
         }
 
-        if let Some((patch, _)) = topology {
-            apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
-        }
-
         tx.execute(
             "UPDATE terminal_hosts
              SET incarnation = ?1, lifecycle = 'exited', exit_json = ?2,

--- a/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
@@ -1,0 +1,380 @@
+#![cfg(unix)]
+
+//! Journal-based session restoration. A fresh `server start` on the same
+//! session and state root reconstructs the durable topology recorded in the
+//! SQLite journal: workspace identity, order, and names; screens; split trees
+//! with committed ratios; tab placements; and terminal resources represented
+//! honestly as exited when their processes died while the daemon was down.
+//! `session journal restore preview` must agree with that applied state.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use cmux_tui_core::platform::transport;
+use cmux_tui_core::terminal_host_runtime::{
+    TerminalHostLiveness, load_terminal_host_records, terminal_host_record_liveness,
+    terminal_host_root,
+};
+use serde_json::{Value, json};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cmux-tui")
+}
+
+struct RestoreHarness {
+    child: Option<Child>,
+    dir: PathBuf,
+    socket: PathBuf,
+    state: PathBuf,
+    session: String,
+}
+
+impl RestoreHarness {
+    fn start(name: &str) -> Self {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = PathBuf::from("/tmp")
+            .join(format!("cmux-journal-restore-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let mut harness = Self {
+            child: None,
+            socket: dir.join("mux.sock"),
+            state: dir.join("state"),
+            session: format!("journal-restore-{name}"),
+            dir,
+        };
+        harness.restart();
+        harness
+    }
+
+    fn restart(&mut self) {
+        assert!(self.child.is_none());
+        let config = self.dir.join("config.json");
+        let child = Command::new(bin())
+            .args(["--headless", "--session", &self.session, "--socket"])
+            .arg(&self.socket)
+            .arg("--state")
+            .arg(&self.state)
+            .env("CMUX_TUI_CONFIG", &config)
+            // Deterministic default shell for panes created by `split`,
+            // independent of the developer or CI login shell.
+            .env("SHELL", "/bin/sh")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        self.child = Some(child);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if transport::connect(&self.socket).is_ok() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("server did not accept connections at {}", self.socket.display());
+    }
+
+    fn host_root(&self) -> PathBuf {
+        terminal_host_root(&self.state, &self.session)
+    }
+
+    /// Freeze the daemon, kill every terminal host process, then kill the
+    /// daemon. The daemon can observe none of the exits, so the next start
+    /// has to reconcile purely from the journal plus dead-process evidence.
+    fn kill_hosts_and_daemon(&mut self, expected_hosts: usize) {
+        self.signal_daemon(libc::SIGSTOP);
+        let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
+        assert_eq!(records.len(), expected_hosts, "unexpected live terminal host records");
+        for (_, record) in &records {
+            // SAFETY: the record PIDs are harness-owned terminal hosts.
+            let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
+        }
+        for (path, record) in &records {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while terminal_host_record_liveness(path, record).ok()
+                != Some(TerminalHostLiveness::Dead)
+            {
+                assert!(Instant::now() < deadline, "terminal host survived SIGKILL");
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        let mut child = self.child.take().unwrap();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        let _ = fs::remove_file(&self.socket);
+    }
+
+    fn signal_daemon(&self, signal: libc::c_int) {
+        let pid = self.child.as_ref().unwrap().id() as libc::pid_t;
+        // SAFETY: the harness owns this child process and passes a platform
+        // signal constant.
+        assert_eq!(unsafe { libc::kill(pid, signal) }, 0);
+    }
+
+    fn cli(&self, args: &[&str]) -> Value {
+        let output = self.cli_raw(args);
+        assert!(
+            output.status.success(),
+            "cli {args:?} failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "cli {args:?} produced invalid JSON ({error}): {}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        })
+    }
+
+    fn cli_raw(&self, args: &[&str]) -> Output {
+        Command::new(bin())
+            .args(["--json", "--socket"])
+            .arg(&self.socket)
+            .args(args)
+            .env_remove("CMUX_TUI_SOCKET")
+            .output()
+            .unwrap()
+    }
+
+    fn snapshot(&self) -> Value {
+        self.cli(&["session", "current", "snapshot"])
+    }
+}
+
+impl Drop for RestoreHarness {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
+        for (_, record) in &records {
+            // SAFETY: test teardown owns these dedicated host processes.
+            let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
+        }
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn request(path: &Path, value: Value) -> Value {
+    let stream = transport::connect(path).unwrap();
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{value}").unwrap();
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let response: Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "request failed: {response}");
+    response["data"].clone()
+}
+
+fn wait_for_host_records(root: &Path, expected: usize) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let records = load_terminal_host_records(root).unwrap_or_default();
+        if records.len() == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected {expected} terminal host records, found {}",
+            records.len()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_all_terminals_exited(harness: &RestoreHarness, expected: usize) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let snapshot = harness.snapshot();
+        let terminals = snapshot["terminals"].as_array().unwrap();
+        if terminals.len() == expected
+            && terminals.iter().all(|terminal| terminal["lifecycle"] == "exited")
+        {
+            return snapshot;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "terminals did not settle as exited: {}",
+            snapshot["terminals"]
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// The collections that describe durable topology. Focus flags, layout
+/// documents, ratios, names, and ordering all live inside these values.
+const TOPOLOGY_COLLECTIONS: [&str; 4] = ["workspaces", "screens", "panes", "tabs"];
+
+#[test]
+fn server_restart_restores_topology_and_reports_terminals_exited() {
+    let mut harness = RestoreHarness::start("topology");
+
+    // Workspace "One": terminal T1, split right with a default shell (T2),
+    // committed ratio 0.7, and a second tab (T3) beside T1.
+    let first = request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"One","cols":120,"rows":32,
+        }),
+    );
+    let first_pane = first["pane"].as_u64().unwrap();
+    request(&harness.socket, json!({"id":2,"cmd":"split","pane":first_pane,"dir":"right"}));
+    let tree = request(&harness.socket, json!({"id":3,"cmd":"list-workspaces"}));
+    let split = tree["workspaces"][0]["screens"][0]["layout"]["split"]
+        .as_u64()
+        .expect("split id after split-right");
+    request(&harness.socket, json!({"id":4,"cmd":"set-split-ratio","split":split,"ratio":0.7}));
+    request(
+        &harness.socket,
+        json!({"id":5,"cmd":"run","argv":["/bin/cat"],"pane":first_pane,"cols":120,"rows":32}),
+    );
+    // Workspace "Two": one terminal, so restoration must keep workspace
+    // identity, order, and names across more than one workspace.
+    request(
+        &harness.socket,
+        json!({
+            "id":6,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Two","cols":80,"rows":24,
+        }),
+    );
+    wait_for_host_records(&harness.host_root(), 4);
+
+    let before = harness.snapshot();
+    assert_eq!(before["workspaces"].as_array().unwrap().len(), 2);
+    assert_eq!(before["terminals"].as_array().unwrap().len(), 4);
+    let ratio_before = split_ratio(&before);
+    assert!((ratio_before - 0.7).abs() < 1e-6, "committed ratio missing before stop");
+
+    harness.kill_hosts_and_daemon(4);
+    harness.restart();
+    let after = wait_for_all_terminals_exited(&harness, 4);
+
+    // Durable topology survives byte for byte: identity, order, names,
+    // screens, split tree with committed ratio, tab placements.
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(before[collection], after[collection], "{collection} changed across restart");
+    }
+    assert!((split_ratio(&after) - 0.7).abs() < 1e-6, "committed ratio lost across restart");
+    for terminal in after["terminals"].as_array().unwrap() {
+        assert_eq!(terminal["running"], false);
+        assert_eq!(terminal["lifecycle"], "exited");
+        assert_eq!(terminal["exit"]["outcome"]["kind"], "unknown", "{terminal}");
+        assert!(
+            !terminal["tab_ids"].as_array().unwrap().is_empty(),
+            "exited terminal lost its tab placements: {terminal}"
+        );
+    }
+
+    // A second restart replays the preserved state without mutating it.
+    wait_for_host_records(&harness.host_root(), 0);
+    harness.kill_hosts_and_daemon(0);
+    harness.restart();
+    let again = wait_for_all_terminals_exited(&harness, 4);
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(
+            after[collection], again[collection],
+            "{collection} changed across an idle restart"
+        );
+    }
+    assert_eq!(after["terminals"], again["terminals"], "terminals changed across an idle restart");
+}
+
+#[test]
+fn restore_preview_agrees_with_applied_restoration() {
+    let mut harness = RestoreHarness::start("preview");
+
+    let first = request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Preview","cols":100,"rows":30,
+        }),
+    );
+    let first_pane = first["pane"].as_u64().unwrap();
+    request(&harness.socket, json!({"id":2,"cmd":"split","pane":first_pane,"dir":"down"}));
+    let tree = request(&harness.socket, json!({"id":3,"cmd":"list-workspaces"}));
+    let split = tree["workspaces"][0]["screens"][0]["layout"]["split"]
+        .as_u64()
+        .expect("split id after split-down");
+    request(&harness.socket, json!({"id":4,"cmd":"set-split-ratio","split":split,"ratio":0.35}));
+    wait_for_host_records(&harness.host_root(), 2);
+
+    let checkpoint = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "checkpoint",
+        "create",
+        "--idempotency-key",
+        "restore-preview-checkpoint",
+    ]);
+    assert!(checkpoint["value"]["checkpoint_id"].is_string(), "{checkpoint}");
+
+    harness.kill_hosts_and_daemon(2);
+    harness.restart();
+    let live = wait_for_all_terminals_exited(&harness, 2);
+
+    let preview = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "restore",
+        "preview",
+        "--checkpoint",
+        "latest",
+    ]);
+    assert_eq!(preview["fully_reducible"], true, "{preview}");
+    let projected = &preview["state"]["session_snapshot"];
+
+    // The reduced model and the state a fresh server actually serves must
+    // agree on every durable topology collection and on the terminals'
+    // honest not-running representation. The reducer orders collections by
+    // (index, id) while the live projection orders them by topology, so the
+    // comparison is id-keyed; ordering itself is carried by the index fields
+    // and layout documents inside the compared values.
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(
+            sorted_by_id(&projected[collection]),
+            sorted_by_id(&live[collection]),
+            "restore preview and applied restore disagree on {collection}"
+        );
+    }
+    assert_eq!(
+        sorted_by_id(&projected["terminals"]),
+        sorted_by_id(&live["terminals"]),
+        "restore preview and applied restore disagree on terminals"
+    );
+    assert_eq!(
+        projected["cursor"]["revision"], live["cursor"]["revision"],
+        "restore preview and applied restore disagree on the resource cursor"
+    );
+}
+
+fn sorted_by_id(collection: &Value) -> Vec<Value> {
+    let mut values = collection
+        .as_array()
+        .unwrap_or_else(|| panic!("collection is not an array: {collection}"))
+        .clone();
+    values.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+    values
+}
+
+/// Ratio of the single split screen in the snapshot. Screen collection
+/// order is not tied to workspace order, so the split screen is located by
+/// shape instead of by index.
+fn split_ratio(snapshot: &Value) -> f64 {
+    let mut ratios = snapshot["screens"]
+        .as_array()
+        .expect("snapshot screens is an array")
+        .iter()
+        .filter_map(|screen| screen["layout"]["root"]["ratio"].as_f64());
+    let ratio = ratios.next().unwrap_or_else(|| panic!("no split screen: {}", snapshot["screens"]));
+    assert!(ratios.next().is_none(), "more than one split screen: {}", snapshot["screens"]);
+    ratio
+}

--- a/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
@@ -20,6 +20,15 @@ use cmux_tui_core::terminal_host_runtime::{
 };
 use serde_json::{Value, json};
 
+fn test_timeout(timeout: Duration) -> Duration {
+    let scale = std::env::var("CMUX_TEST_TIMEOUT_SCALE")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(1)
+        .clamp(1, 16);
+    timeout.saturating_mul(scale)
+}
+
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_cmux-tui")
 }
@@ -66,7 +75,7 @@ impl RestoreHarness {
             .spawn()
             .unwrap();
         self.child = Some(child);
-        let deadline = Instant::now() + Duration::from_secs(30);
+        let deadline = Instant::now() + test_timeout(Duration::from_secs(30));
         while Instant::now() < deadline {
             if transport::connect(&self.socket).is_ok() {
                 return;
@@ -92,7 +101,7 @@ impl RestoreHarness {
             let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
         }
         for (path, record) in &records {
-            let deadline = Instant::now() + Duration::from_secs(5);
+            let deadline = Instant::now() + test_timeout(Duration::from_secs(5));
             while terminal_host_record_liveness(path, record).ok()
                 != Some(TerminalHostLiveness::Dead)
             {
@@ -172,7 +181,7 @@ fn request(path: &Path, value: Value) -> Value {
 }
 
 fn wait_for_host_records(root: &Path, expected: usize) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + test_timeout(Duration::from_secs(15));
     loop {
         let records = load_terminal_host_records(root).unwrap_or_default();
         if records.len() == expected {
@@ -188,7 +197,7 @@ fn wait_for_host_records(root: &Path, expected: usize) {
 }
 
 fn wait_for_all_terminals_exited(harness: &RestoreHarness, expected: usize) -> Value {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + test_timeout(Duration::from_secs(30));
     loop {
         let snapshot = harness.snapshot();
         let terminals = snapshot["terminals"].as_array().unwrap();

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3013,7 +3013,7 @@ fn running_host_sigkill_detaches_exited_terminal_topology() {
 }
 
 #[test]
-fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal() {
+fn daemon_restart_preserves_dead_host_topology_without_respawn() {
     let mut harness = RecoveryHarness::start("dead-host-restart");
     let created = request(
         &harness.socket,
@@ -3069,16 +3069,20 @@ fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal(
         .iter()
         .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
         .expect("original workspace was not recovered");
-    assert!(first_tab(workspace).is_none(), "Exited terminal was rematerialized after restart");
+    // Restoration keeps the journaled tab placement; the terminal is exited,
+    // not respawned, and its view has no live surface to write to.
+    let tab = first_tab(workspace).expect("exited terminal lost its tab placement after restart");
+    let restored_surface = tab["surface"].as_u64().expect("restored tab has a stable slot");
 
     let write = request_response(
         &harness.socket,
         serde_json::json!({
-            "id":5,"cmd":"send","surface":surface,"text":"must-not-respawn\\n",
+            "id":5,"cmd":"send","surface":restored_surface,"text":"must-not-respawn\\n",
         }),
     );
     assert_eq!(write["ok"], false);
     assert!(write["error"].as_str().unwrap().contains("unknown surface"));
+    let _ = surface;
     request(
         &harness.socket,
         serde_json::json!({
@@ -3086,10 +3090,21 @@ fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal(
             "terminal_incarnation":incarnation,
         }),
     );
+    let closed = request(&harness.socket, serde_json::json!({"id":7,"cmd":"list-workspaces"}));
+    let workspace = closed["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
+        .expect("workspace disappeared after closing its exited terminal");
+    assert!(
+        first_tab(workspace).is_none(),
+        "explicit close did not remove the exited terminal's tab"
+    );
 }
 
 #[test]
-fn daemon_restart_prunes_every_dead_host_behind_one_pane() {
+fn daemon_restart_preserves_every_dead_host_behind_one_pane() {
     let mut harness = RecoveryHarness::start("dead-hosts-restart");
     let first = request(
         &harness.socket,
@@ -3159,7 +3174,15 @@ fn daemon_restart_prunes_every_dead_host_behind_one_pane() {
         .iter()
         .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
         .expect("original workspace was not recovered");
-    assert!(first_tab(workspace).is_none(), "Exited terminals were rematerialized after restart");
+    // Both dead terminals keep their tab placements in the one pane.
+    let tabs = workspace["screens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|screen| screen["panes"].as_array().into_iter().flatten())
+        .flat_map(|pane| pane["tabs"].as_array().into_iter().flatten())
+        .count();
+    assert_eq!(tabs, 2, "exited terminals lost their tab placements after restart");
 }
 
 fn request(path: &Path, value: serde_json::Value) -> serde_json::Value {

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3083,14 +3083,23 @@ fn daemon_restart_preserves_dead_host_topology_without_respawn() {
     assert_eq!(write["ok"], false);
     assert!(write["error"].as_str().unwrap().contains("unknown surface"));
     let _ = surface;
+    let rejected = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":8,"cmd":"close-terminal","terminal_id":terminal_id,
+            "terminal_incarnation":"wrong-incarnation",
+        }),
+    );
+    assert_eq!(rejected["ok"], false);
+    assert!(rejected["error"].as_str().unwrap().contains("incarnation"));
     request(
         &harness.socket,
         serde_json::json!({
-            "id":6,"cmd":"close-terminal","terminal_id":terminal_id,
+            "id":9,"cmd":"close-terminal","terminal_id":terminal_id,
             "terminal_incarnation":incarnation,
         }),
     );
-    let closed = request(&harness.socket, serde_json::json!({"id":7,"cmd":"list-workspaces"}));
+    let closed = request(&harness.socket, serde_json::json!({"id":10,"cmd":"list-workspaces"}));
     let workspace = closed["workspaces"]
         .as_array()
         .unwrap()

--- a/cmux-tui/spec/session-journal.md
+++ b/cmux-tui/spec/session-journal.md
@@ -581,8 +581,8 @@ Server startup applies the restored topology: workspace identity, order, and
 names; screens; split trees with committed ratios and viewport column widths;
 and tab placements. Startup rebuilds it from the transactional projections
 that invariant 2 keeps equal to the journal head, so the applied state and a
-restore preview at the same head agree. A terminal whose process died while
-the daemon was down is latched as exited with the first observed outcome and
+restore preview at the same head agree. A terminal found dead while the daemon
+was down is latched as exited with an unknown exit outcome and
 keeps its journaled placements: restoration never respawns a process, never
 pretends to reattach a dead one, and never discards layout on behalf of a
 process it did not observe exiting. An exit the daemon observes live still
@@ -611,8 +611,7 @@ writer instead of waiting without a limit. The transaction continues to own the
 registry and its atomic idempotency receipt until SQLite returns; a later retry
 therefore observes the committed receipt or performs the request once.
 
-Live restoration will consume this inert complete model. Process adoption,
-fresh process spawning, browser reconnect, and agent resume are explicit
+Process adoption, fresh process spawning, browser reconnect, and agent resume are explicit
 post-replay actions with their own journal outcomes. A partially supported
 record fails with a compatibility error or becomes an explicit degraded
 projection. It is never silently discarded.

--- a/cmux-tui/spec/session-journal.md
+++ b/cmux-tui/spec/session-journal.md
@@ -11,9 +11,11 @@ tab selection; split ratios; viewport column widths; topology; terminal and
 browser lifecycle; continuous terminal output and geometry; frontend focus,
 viewport, and geometry observations; frontend projections; explicit agent
 reports; and normalized native agent-hook observations. A pure restoration
-reducer can preview the state reconstructed from a checkpoint and its tail.
-Verified root ownership leases and live application of a restored model remain
-pending.
+reducer can preview the state reconstructed from a checkpoint and its tail,
+and a restarted server reconstructs the durable topology, representing
+terminals whose processes died while it was down honestly as exited. Verified
+root ownership leases, checkpoint content application, and post-restore
+respawn actions remain pending.
 
 ## Invariants
 
@@ -575,6 +577,19 @@ External effects are not repeated during replay. Their recorded outcomes
 materialize state. Live-process adoption separately verifies process identity
 and incarnation before reconnecting a terminal host.
 
+Server startup applies the restored topology: workspace identity, order, and
+names; screens; split trees with committed ratios and viewport column widths;
+and tab placements. Startup rebuilds it from the transactional projections
+that invariant 2 keeps equal to the journal head, so the applied state and a
+restore preview at the same head agree. A terminal whose process died while
+the daemon was down is latched as exited with the first observed outcome and
+keeps its journaled placements: restoration never respawns a process, never
+pretends to reattach a dead one, and never discards layout on behalf of a
+process it did not observe exiting. An exit the daemon observes live still
+detaches that terminal's views in the same transaction. Explicit close of a
+restored exited terminal, and future respawn actions, are ordinary post-restore
+mutations with their own journal outcomes.
+
 Hosts created before the source-ordered detach protocol remain available in a
 compatibility mode. Their live output is not added to the journal because an
 old host cannot fence output at daemon shutdown. New protocol-v4 hosts use the
@@ -668,7 +683,8 @@ redaction markers are reserved for a later storage version.
 | Hook dispatcher and delivery projections | Implemented in storage v1 |
 | Checkpoint writer and restoration preview reducer | Implemented in storage v1 |
 | Checkpoint-aligned immutable segments | Implemented in storage v1 |
-| Live restoration application | Pending |
+| Restart topology restoration with honest exited terminals | Implemented in storage v1 |
+| Checkpoint content application and post-restore respawn | Pending |
 
 The in-memory `MuxEvent` broadcaster remains a lossy presentation mechanism.
 It may wake consumers after commit, but it is never a journal or restoration


### PR DESCRIPTION
Build-table item 7 slice (journal full restore): after `server stop`, a fresh `server start` on the same session and state root reconstructs the durable topology recorded in the SQLite journal, and `session journal restore preview` agrees with the applied state.

## Gap analysis

Before this PR, restore had two working halves and one destructive gap:

- The pure restore-preview reducer existed (`crates/cmux-tui-core/src/journal_checkpoint.rs`, `RestoreReducer`), exposed as `session journal restore preview`.
- Startup already rebuilt workspaces (identity, order, names), screens, split trees with committed ratios, viewport columns, tabs, and browsers from the transactional projections (`Mux::from_workspace_registry` -> `restore_resource_state` in `crates/cmux-tui-core/src/mux.rs`). Journal invariant 2 keeps those projections equal to the journal head.
- The gap: restart reconciliation of terminals whose host process died while the daemon was down (`mark_terminal_exited_and_detach`, startup `detach_exited_terminal_topology` calls) removed their tabs and collapsed their splits. After a reboot the layout was destroyed, and a preview from the last checkpoint disagreed with what a fresh server actually served. The spec listed live restoration application as pending.

## What this slice does

Restart-window deaths (exit sidecars, proven-dead hosts, missing host records, incarnation mismatches, death during adoption, and the async adoption-retry loop) now commit the durable exit with topology preserved (`commit_terminal_exit` with no detach patch). The restored session keeps every tab placement, split ratio, and ordering; the terminal is projected `lifecycle=exited`, `running=false`, with its first observed outcome, no surface, and no respawn. An exit the daemon observes live still detaches that terminal's views atomically, so interactive close-on-exit is unchanged.

Supporting changes:

- `terminal_exit_snapshot_in_state` uses the same launch-spec grid fallback and canonical tab order as the public projection, so the journaled exit upsert, later restarts, and restore previews agree exactly.
- Explicit close of a restored exited terminal works on both entrypoints: legacy `close-terminal` and protocol-2 `terminal.close` now close retained views without a runtime owner and tombstone the host durably.
- Removed an accidental duplicate `apply_resource_patch` call in `commit_terminal_exit` (merge artifact).
- `spec/session-journal.md`: restoration section documents the retention semantics; the migration table splits restart topology restoration (implemented) from checkpoint content application and respawn (pending).

## Deferred (not in this slice)

- Terminal checkpoints (scrollback restoration into the inert model), item 8.
- Launch specs, respawn, and agent resume, items 9 and 15.
- Building startup state directly from the journal reducer; projections remain the startup source, equal by invariant 2 and enforced by the new agreement test.
- Frontend rendering polish for a surface-less exited tab (the daemon projects the honest state; the TUI shows an empty pane until item 8/9 land).

## Tests

Two commits so CI goes red then green: commit 1 adds the failing tests, commit 2 the behavior.

- New `crates/cmux-tui/tests/journal_restore.rs`:
  - `server_restart_restores_topology_and_reports_terminals_exited`: 2 named workspaces, a split with committed ratio 0.7, a two-tab pane, 4 terminals; SIGSTOP daemon, SIGKILL every host, SIGKILL daemon, restart. Asserts byte-equality of the workspaces/screens/panes/tabs collections across restart, the preserved ratio, and honest exited terminals with retained `tab_ids`; a second idle restart replays identically.
  - `restore_preview_agrees_with_applied_restoration`: checkpoint before the kill, restart, then `journal restore preview --checkpoint latest` must be fully reducible and agree with the live snapshot on all topology collections, terminals, and the resource cursor.
- Updated `crates/cmux-tui/tests/terminal_host_recovery.rs`: `daemon_restart_preserves_dead_host_topology_without_respawn` and `daemon_restart_preserves_every_dead_host_behind_one_pane` encode the retention semantics (tab kept, exited lifecycle, send fails, explicit close removes the tab; no respawn).

Local results (macOS, guarded cargo): all 4 integration tests pass; targeted `cmux-tui-core` unit tests pass, 95 selected (filters: restore, restart, checkpoint, detach, terminal_exit, terminal_close, close_terminal, exited). Three core restart tests that encoded detach-at-restart (`restart_sidecar_restores_exact_wait_exit_and_emits_one_public_event`, `raw_and_resource_agent_reports_share_durable_order_across_restart`, `persistent_mux_restart_restores_auxiliary_resources_and_exact_replay`) were updated to the retention semantics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789719077&installation_model_id=21920&pr_number=10413&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10413&signature=bf4b2509e3d7d1f1d8436e9112499571a2eae488c199fe3e7454758f0243f385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the journaled topology on server restart and preserves layout for terminals that died while the daemon was down. Previously restart detached those terminals and collapsed splits/tabs; now placements are kept and terminals are shown as exited, while live exits still detach.

- Startup reconciliation commits a durable exit with topology preserved: no respawn, lifecycle=exited, running=false, first observed outcome, and no surface.
- Restore preview matches the applied state: exit snapshots use the public projection’s launch-spec size fallback and canonical tab order.
- Explicit close removes retained views for restored exited terminals via both legacy `close-terminal` and protocol-2 `terminal.close`; the router applies `terminal.close` without a runtime by targeting the first placement; hosts are tombstoned and side tables purged; incarnation checks enforce safety; errors are privacy-hardened.
- Removed a duplicate resource patch in the exit commit; updated tests to the retention semantics and added restore coverage; spec documents topology restoration (checkpoint content and respawn remain pending).
- Preallocated the bounded CDP ingress event queue to prevent allocation churn during bursts; no behavior change.

<sup>Written for commit 891544e0ab1f1ab277213b984e7f53078374fb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restored sessions now preserve tabs, panes, split layouts, and exited terminal entries across restarts.
  - Exited terminals can be explicitly closed even when no live terminal process exists.
  - Terminal snapshots retain durable layout and launch dimensions when live surfaces are unavailable.

- **Bug Fixes**
  - Prevented restored exited terminals and their tabs from being removed during recovery.
  - Improved daemon-restart recovery for multiple terminals while avoiding unwanted respawning.

- **Tests**
  - Added comprehensive coverage for journal restoration, topology preservation, terminal recovery, and repeated restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->