### PR TITLE
Mobile host: merge duplicate connection initializers and alias dispatch table

### DIFF
--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -2002,36 +2002,27 @@ actor MobileHostConnection {
     private var usableEventSubscription: UsableEventSubscription?
     private var didPublishUsableSession = false
 
+    /// Wraps an accepted `NWConnection` in the network byte transport and delegates.
     init(
         id: UUID,
         connection: NWConnection,
-        eventQueue: MobileHostConnectionEventQueue = MobileHostConnectionEventQueue(),
         firstFrameTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultFirstFrameTimeoutNanoseconds,
         idleTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultIdleTimeoutNanoseconds,
-        eventSendStallTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultEventSendStallTimeoutNanoseconds,
-        independentEventWriter: (any MobileHostIndependentEventWriting)? = nil,
         authorizeRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult?,
         onAuthorizedRequest: @escaping @Sendable (MobileHostRPCRequest) async -> Void,
-        onUsableSession: @escaping @Sendable () async -> Bool = { true },
         handleRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult,
-        onClose: @escaping @Sendable (UUID) async -> Void,
-        requestSimulatorFrameReplay: @escaping @Sendable (UUID, Set<String>) async -> Void = { _, _ in }
+        onClose: @escaping @Sendable (UUID) async -> Void
     ) {
-        let transport = CmxNetworkByteTransport(acceptedConnection: connection)
-        self.id = id
-        self.transport = transport
-        self.writer = MobileHostSerializedTransportWriter(transport: transport)
-        self.independentEventWriter = independentEventWriter
-        self.firstFrameTimeoutNanoseconds = firstFrameTimeoutNanoseconds
-        self.idleTimeoutNanoseconds = idleTimeoutNanoseconds
-        self.eventSendStallTimeoutNanoseconds = eventSendStallTimeoutNanoseconds
-        self.authorizeRequest = authorizeRequest
-        self.onAuthorizedRequest = onAuthorizedRequest
-        self.onUsableSession = onUsableSession
-        self.handleRequest = handleRequest
-        self.onClose = onClose
-        self.requestSimulatorFrameReplay = requestSimulatorFrameReplay
-        self.eventQueue = eventQueue
+        self.init(
+            id: id,
+            transport: CmxNetworkByteTransport(acceptedConnection: connection),
+            firstFrameTimeoutNanoseconds: firstFrameTimeoutNanoseconds,
+            idleTimeoutNanoseconds: idleTimeoutNanoseconds,
+            authorizeRequest: authorizeRequest,
+            onAuthorizedRequest: onAuthorizedRequest,
+            handleRequest: handleRequest,
+            onClose: onClose
+        )
     }
 
     init(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -14398,6 +14398,11 @@ class TerminalController {
 
     // MARK: - Mobile Host V2 Methods
 
+    private static let bareMobileTerminalAliases: Set<String> = [
+        "terminal.create", "terminal.input", "terminal.paste", "terminal.paste_image",
+        "terminal.replay", "terminal.viewport", "terminal.scroll", "terminal.mouse",
+    ]
+
     @MainActor
     func mobileHostHandleRPC(
         _ request: MobileHostRPCRequest,
@@ -14413,7 +14418,10 @@ class TerminalController {
         // control socket shares the same bodies through `handleMobileHost`, so the
         // wire bytes stay identical across both entrypoints without a bridge here.
         let result: V2CallResult
-        switch request.method {
+        // Bare "terminal.<verb>" aliases (still pinned in irohReleaseGateRPCMethods) normalize to "mobile.terminal.<verb>".
+        let method = Self.bareMobileTerminalAliases.contains(request.method)
+            ? "mobile." + request.method : request.method
+        switch method {
         case "mobile.host.status":
             result = v2MobileHostStatus(params: request.params, includePrivateMetadata: false)
 #if DEBUG
@@ -14449,21 +14457,21 @@ class TerminalController {
             result = v2MobileTaskAttachmentUpload(params: request.params)
         case "mobile.task.models.list":
             result = await v2MobileTaskModelsList(params: request.params)
-        case "mobile.terminal.create", "terminal.create":
+        case "mobile.terminal.create":
             result = v2MobileTerminalCreate(params: request.params)
-        case "mobile.terminal.input", "terminal.input":
+        case "mobile.terminal.input":
             result = v2MobileTerminalInput(params: request.params)
-        case "mobile.terminal.paste", "terminal.paste":
+        case "mobile.terminal.paste":
             result = v2MobileTerminalPaste(params: request.params)
-        case "mobile.terminal.paste_image", "terminal.paste_image":
+        case "mobile.terminal.paste_image":
             result = v2MobileTerminalPasteImage(params: request.params)
-        case "mobile.terminal.replay", "terminal.replay":
+        case "mobile.terminal.replay":
             result = v2MobileTerminalReplay(params: request.params)
-        case "mobile.terminal.viewport", "terminal.viewport":
+        case "mobile.terminal.viewport":
             result = v2MobileTerminalViewport(params: request.params)
-        case "mobile.terminal.scroll", "terminal.scroll":
+        case "mobile.terminal.scroll":
             result = v2MobileTerminalScroll(params: request.params)
-        case "mobile.terminal.mouse", "terminal.mouse":
+        case "mobile.terminal.mouse":
             result = v2MobileTerminalMouse(params: request.params)
         case let method where method.hasPrefix("mobile.terminal.artifact."):
             result = await v2MobileTerminalArtifactDispatch(


### PR DESCRIPTION
MobileHostConnection now has one designated initializer that both call sites use, and the bare terminal.* RPC aliases are normalized through a single lookup table before dispatch instead of duplicated case arms. Wire formats, event topic names, and JSON keys are unchanged. Net delta from git diff origin/main...HEAD --shortstat: 2 files changed, 29 insertions(+), 30 deletions(-).

Part of the mobile-sync rip-out wave 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789721122&installation_model_id=21920&pr_number=10416&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10416&signature=b1ccf32b2d00c867835712573c45a64dc4acb12c721f4d67201291c035dc8306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates MobileHostConnection initialization and normalizes bare terminal RPC aliases. Previously we had two initializers and duplicate switch cases; now a single designated initializer handles setup, and bare `terminal.*` methods map to `mobile.terminal.*` before dispatch. Accepted method names, wire bytes, event topics, and JSON keys are unchanged.

- Review notes:
  - The `NWConnection` initializer now delegates to the designated transport-based initializer; verify timeouts and auth hooks remain identical.
  - The alias set covers exactly these verbs: create, input, paste, paste_image, replay, viewport, scroll, mouse; confirm `irohReleaseGateRPCMethods` remains unchanged.
  - If any external code used the removed `NWConnection`-init parameters, update to the transport initializer or drop unused args.

<sup>Written for commit b0e810e0b2ed6f2cb35887688928f38dc592974b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile host connection setup for more consistent communication.
  * Terminal commands using either supported naming format now route correctly.
  * Removed duplicate handling while preserving existing terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->