### PR TITLE
Clamp the freestyle attach reconnect budget through a shared policy

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11567,9 +11567,10 @@ struct CMUXCLI {
     private func defaultFreestyleCloudSSHAttachLoopCommand(vmID: String, executablePath: String) -> String {
         let quotedCLI = shellQuote(executablePath)
         let quotedVMID = shellQuote(vmID)
+        let reconnectBudget = SSHReconnectBudgetShellPolicy()
         let lines = [
             "cmux_freestyle_cli=\(quotedCLI)",
-        ] + SSHReconnectBudgetShellPolicy.configurationLines + [
+        ] + reconnectBudget.configurationLines + [
             "CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT=\"${CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT:-$CMUX_SSH_RECONNECT_LIMIT}\"",
             "CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_DELAY_SECONDS=\"${CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_DELAY_SECONDS:-$CMUX_SSH_RECONNECT_DELAY_SECONDS}\"",
             "export CMUX_SSH_RECONNECT_LIMIT CMUX_SSH_RECONNECT_DELAY_SECONDS",
@@ -11591,9 +11592,9 @@ struct CMUXCLI {
             "  cmux_freestyle_attach",
             "  cmux_freestyle_status=$?",
             "  case \"$cmux_freestyle_status\" in 254|255) ;; *) exit \"$cmux_freestyle_status\" ;; esac",
-            "  \(SSHReconnectBudgetShellPolicy.limitReachedCommand(retryCountVariable: "cmux_freestyle_retry", statusVariable: "cmux_freestyle_status"))",
+            "  \(reconnectBudget.limitReachedCommand(retryCountVariable: "cmux_freestyle_retry", statusVariable: "cmux_freestyle_status"))",
             "  cmux_freestyle_retry=$((cmux_freestyle_retry + 1))",
-            "  \(SSHReconnectBudgetShellPolicy.delayCommand)",
+            "  \(reconnectBudget.delayCommand)",
             "done",
         ]
         return "/bin/sh -c \(shellQuote(lines.joined(separator: "\n")))"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11569,8 +11569,7 @@ struct CMUXCLI {
         let quotedVMID = shellQuote(vmID)
         let lines = [
             "cmux_freestyle_cli=\(quotedCLI)",
-            "CMUX_SSH_RECONNECT_LIMIT=\"${CMUX_SSH_RECONNECT_LIMIT:-86400}\"",
-            "CMUX_SSH_RECONNECT_DELAY_SECONDS=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
+        ] + SSHReconnectBudgetShellPolicy.configurationLines + [
             "CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT=\"${CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT:-$CMUX_SSH_RECONNECT_LIMIT}\"",
             "CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_DELAY_SECONDS=\"${CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_DELAY_SECONDS:-$CMUX_SSH_RECONNECT_DELAY_SECONDS}\"",
             "export CMUX_SSH_RECONNECT_LIMIT CMUX_SSH_RECONNECT_DELAY_SECONDS",
@@ -11592,9 +11591,9 @@ struct CMUXCLI {
             "  cmux_freestyle_attach",
             "  cmux_freestyle_status=$?",
             "  case \"$cmux_freestyle_status\" in 254|255) ;; *) exit \"$cmux_freestyle_status\" ;; esac",
-            "  if [ \"$cmux_freestyle_retry\" -ge \"$CMUX_SSH_RECONNECT_LIMIT\" ]; then exit \"$cmux_freestyle_status\"; fi",
+            "  \(SSHReconnectBudgetShellPolicy.limitReachedCommand(retryCountVariable: "cmux_freestyle_retry", statusVariable: "cmux_freestyle_status"))",
             "  cmux_freestyle_retry=$((cmux_freestyle_retry + 1))",
-            "  sleep \"$CMUX_SSH_RECONNECT_DELAY_SECONDS\"",
+            "  \(SSHReconnectBudgetShellPolicy.delayCommand)",
             "done",
         ]
         return "/bin/sh -c \(shellQuote(lines.joined(separator: "\n")))"

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
@@ -36,15 +36,40 @@ public enum SSHReconnectBudgetShellPolicy {
     /// The environment variable holding the delay between attempts.
     public static let delaySecondsVariable = "CMUX_SSH_RECONNECT_DELAY_SECONDS"
 
-    /// Shell lines that resolve both variables before the loop runs.
+    /// Shell lines that resolve and normalize both variables before the loop runs.
     ///
-    /// The values are assigned back to their own variables, so a loop that
-    /// exports them hands the resolved values to the processes it starts.
+    /// Each value is rejected when it is not a number, capped when it is larger
+    /// than the loop can act on, and assigned back to its own variable, so a
+    /// loop that exports them hands the normalized values to the processes it
+    /// starts as well.
     public static var configurationLines: [String] {
         [
             "\(retryLimitVariable)=\"${\(retryLimitVariable):-\(defaultRetryLimit)}\"",
+            // Padding comes off before anything counts digits, because "0000002"
+            // is a budget of two retries, not of a seven-digit number of them.
+            paddingStrippingLine(variable: retryLimitVariable),
+            // A digit count is the only test for "too large" that a shell can run
+            // without first turning the value into a number it may not be able to
+            // represent, which is the failure being prevented.
+            "case \"$\(retryLimitVariable)\" in ''|*[!0-9]*) \(retryLimitVariable)=\(defaultRetryLimit) ;; \(digitPattern(minimumDigits: 7))) \(retryLimitVariable)=\(maximumConfigurableRetryLimit) ;; esac",
             "\(delaySecondsVariable)=\"${\(delaySecondsVariable):-\(defaultDelaySeconds)}\"",
+            paddingStrippingLine(variable: delaySecondsVariable),
+            "case \"$\(delaySecondsVariable)\" in ''|*[!0-9]*) \(delaySecondsVariable)=\(defaultDelaySeconds) ;; \(digitPattern(minimumDigits: 6))) \(delaySecondsVariable)=\(maximumConfigurableDelaySeconds) ;; esac",
+            // The ceiling is five digits, so the values the case above lets
+            // through still need comparing, and by now they are small enough to
+            // compare safely.
+            "if [ \"$\(delaySecondsVariable)\" -gt \(maximumConfigurableDelaySeconds) ]; then \(delaySecondsVariable)=\(maximumConfigurableDelaySeconds); fi",
         ]
+    }
+
+    /// A line that drops the leading zeros of `variable`, keeping a bare `0`.
+    private static func paddingStrippingLine(variable: String) -> String {
+        "while :; do case \"$\(variable)\" in 0?*) \(variable)=\"${\(variable)#0}\" ;; *) break ;; esac; done"
+    }
+
+    /// A `case` pattern matching values of at least `minimumDigits` characters.
+    private static func digitPattern(minimumDigits: Int) -> String {
+        String(repeating: "?", count: minimumDigits) + "*"
     }
 
     /// The shell command that ends a loop once its retry budget is spent.

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The reconnect budget a generated attach loop reads from the environment.
+///
+/// `CMUX_SSH_RECONNECT_LIMIT` and `CMUX_SSH_RECONNECT_DELAY_SECONDS` are shared
+/// by every persistent attach entry point, so a value a user sets for one loop
+/// reaches the others too. This type owns how those two variables are read and
+/// how the loop that reads them compares and waits, so the handling cannot drift
+/// between the loops that inherit it.
+public enum SSHReconnectBudgetShellPolicy {
+    /// The retries a loop takes when the environment does not set a limit.
+    public static let defaultRetryLimit = 86_400
+
+    /// The seconds a loop waits between attempts when the environment does not
+    /// set a delay.
+    public static let defaultDelaySeconds = 2
+
+    /// The largest retry budget the generated comparison can answer.
+    ///
+    /// `CMUX_SSH_RECONNECT_LIMIT` is free-form text, and a value too large for
+    /// shell arithmetic makes `-ge` fail with `integer expression expected`
+    /// instead of answering, which leaves the loop unbounded. The ceiling is a
+    /// number of retries no outage reaches before the host comes back.
+    public static let maximumConfigurableRetryLimit = 1_000_000
+
+    /// The longest wait between two attempts, in seconds.
+    ///
+    /// `sleep` rejects an interval it cannot represent, so an oversized delay
+    /// makes the loop retry with no wait at all. A day between attempts is
+    /// already indistinguishable from never.
+    public static let maximumConfigurableDelaySeconds = 86_400
+
+    /// The environment variable holding the retry budget.
+    public static let retryLimitVariable = "CMUX_SSH_RECONNECT_LIMIT"
+
+    /// The environment variable holding the delay between attempts.
+    public static let delaySecondsVariable = "CMUX_SSH_RECONNECT_DELAY_SECONDS"
+
+    /// Shell lines that resolve both variables before the loop runs.
+    ///
+    /// The values are assigned back to their own variables, so a loop that
+    /// exports them hands the resolved values to the processes it starts.
+    public static var configurationLines: [String] {
+        [
+            "\(retryLimitVariable)=\"${\(retryLimitVariable):-\(defaultRetryLimit)}\"",
+            "\(delaySecondsVariable)=\"${\(delaySecondsVariable):-\(defaultDelaySeconds)}\"",
+        ]
+    }
+
+    /// The shell command that ends a loop once its retry budget is spent.
+    ///
+    /// - Parameters:
+    ///   - retryCountVariable: The loop's shell variable holding retries taken.
+    ///   - statusVariable: The loop's shell variable holding the last attach status.
+    /// - Returns: A command that exits with the last status at the budget.
+    public static func limitReachedCommand(
+        retryCountVariable: String,
+        statusVariable: String
+    ) -> String {
+        "if [ \"$\(retryCountVariable)\" -ge \"$\(retryLimitVariable)\" ]; then exit \"$\(statusVariable)\"; fi"
+    }
+
+    /// The shell command that waits between two attempts.
+    public static var delayCommand: String {
+        "sleep \"$\(delaySecondsVariable)\""
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift
@@ -1,21 +1,14 @@
-import Foundation
-
 /// The reconnect budget a generated attach loop reads from the environment.
 ///
 /// `CMUX_SSH_RECONNECT_LIMIT` and `CMUX_SSH_RECONNECT_DELAY_SECONDS` are shared
 /// by every persistent attach entry point, so a value a user sets for one loop
-/// reaches the others too. This type owns how those two variables are read and
+/// reaches the others too. An instance owns how those two variables are read and
 /// how the loop that reads them compares and waits, so the handling cannot drift
-/// between the loops that inherit it.
-public enum SSHReconnectBudgetShellPolicy {
-    /// The retries a loop takes when the environment does not set a limit.
-    public static let defaultRetryLimit = 86_400
-
-    /// The seconds a loop waits between attempts when the environment does not
-    /// set a delay.
-    public static let defaultDelaySeconds = 2
-
-    /// The largest retry budget the generated comparison can answer.
+/// between the loops that inherit it, and a loop with its own idea of a sensible
+/// default constructs the policy with that default rather than restating the
+/// reading of the value.
+public struct SSHReconnectBudgetShellPolicy: Sendable, Equatable {
+    /// The largest retry budget a generated comparison can answer.
     ///
     /// `CMUX_SSH_RECONNECT_LIMIT` is free-form text, and a value too large for
     /// shell arithmetic makes `-ge` fail with `integer expression expected`
@@ -36,40 +29,53 @@ public enum SSHReconnectBudgetShellPolicy {
     /// The environment variable holding the delay between attempts.
     public static let delaySecondsVariable = "CMUX_SSH_RECONNECT_DELAY_SECONDS"
 
+    /// The retries the loop takes when the environment does not set a limit.
+    public let defaultRetryLimit: Int
+
+    /// The seconds the loop waits between attempts when the environment does
+    /// not set a delay.
+    public let defaultDelaySeconds: Int
+
+    /// Creates a budget, holding its own defaults to the same ceilings it
+    /// holds a configured value to.
+    ///
+    /// - Parameters:
+    ///   - defaultRetryLimit: Retries allowed when the environment is silent.
+    ///   - defaultDelaySeconds: Seconds waited when the environment is silent.
+    public init(
+        defaultRetryLimit: Int = 86_400,
+        defaultDelaySeconds: Int = 2
+    ) {
+        self.defaultRetryLimit = min(max(0, defaultRetryLimit), Self.maximumConfigurableRetryLimit)
+        self.defaultDelaySeconds = min(max(0, defaultDelaySeconds), Self.maximumConfigurableDelaySeconds)
+    }
+
     /// Shell lines that resolve and normalize both variables before the loop runs.
     ///
     /// Each value is rejected when it is not a number, capped when it is larger
     /// than the loop can act on, and assigned back to its own variable, so a
     /// loop that exports them hands the normalized values to the processes it
     /// starts as well.
-    public static var configurationLines: [String] {
-        [
-            "\(retryLimitVariable)=\"${\(retryLimitVariable):-\(defaultRetryLimit)}\"",
+    public var configurationLines: [String] {
+        let retryLimit = Self.retryLimitVariable
+        let delaySeconds = Self.delaySecondsVariable
+        return [
+            "\(retryLimit)=\"${\(retryLimit):-\(defaultRetryLimit)}\"",
             // Padding comes off before anything counts digits, because "0000002"
             // is a budget of two retries, not of a seven-digit number of them.
-            paddingStrippingLine(variable: retryLimitVariable),
+            paddingStrippingLine(variable: retryLimit),
             // A digit count is the only test for "too large" that a shell can run
             // without first turning the value into a number it may not be able to
             // represent, which is the failure being prevented.
-            "case \"$\(retryLimitVariable)\" in ''|*[!0-9]*) \(retryLimitVariable)=\(defaultRetryLimit) ;; \(digitPattern(minimumDigits: 7))) \(retryLimitVariable)=\(maximumConfigurableRetryLimit) ;; esac",
-            "\(delaySecondsVariable)=\"${\(delaySecondsVariable):-\(defaultDelaySeconds)}\"",
-            paddingStrippingLine(variable: delaySecondsVariable),
-            "case \"$\(delaySecondsVariable)\" in ''|*[!0-9]*) \(delaySecondsVariable)=\(defaultDelaySeconds) ;; \(digitPattern(minimumDigits: 6))) \(delaySecondsVariable)=\(maximumConfigurableDelaySeconds) ;; esac",
+            "case \"$\(retryLimit)\" in ''|*[!0-9]*) \(retryLimit)=\(defaultRetryLimit) ;; \(digitPattern(minimumDigits: 7))) \(retryLimit)=\(Self.maximumConfigurableRetryLimit) ;; esac",
+            "\(delaySeconds)=\"${\(delaySeconds):-\(defaultDelaySeconds)}\"",
+            paddingStrippingLine(variable: delaySeconds),
+            "case \"$\(delaySeconds)\" in ''|*[!0-9]*) \(delaySeconds)=\(defaultDelaySeconds) ;; \(digitPattern(minimumDigits: 6))) \(delaySeconds)=\(Self.maximumConfigurableDelaySeconds) ;; esac",
             // The ceiling is five digits, so the values the case above lets
             // through still need comparing, and by now they are small enough to
             // compare safely.
-            "if [ \"$\(delaySecondsVariable)\" -gt \(maximumConfigurableDelaySeconds) ]; then \(delaySecondsVariable)=\(maximumConfigurableDelaySeconds); fi",
+            "if [ \"$\(delaySeconds)\" -gt \(Self.maximumConfigurableDelaySeconds) ]; then \(delaySeconds)=\(Self.maximumConfigurableDelaySeconds); fi",
         ]
-    }
-
-    /// A line that drops the leading zeros of `variable`, keeping a bare `0`.
-    private static func paddingStrippingLine(variable: String) -> String {
-        "while :; do case \"$\(variable)\" in 0?*) \(variable)=\"${\(variable)#0}\" ;; *) break ;; esac; done"
-    }
-
-    /// A `case` pattern matching values of at least `minimumDigits` characters.
-    private static func digitPattern(minimumDigits: Int) -> String {
-        String(repeating: "?", count: minimumDigits) + "*"
     }
 
     /// The shell command that ends a loop once its retry budget is spent.
@@ -78,15 +84,25 @@ public enum SSHReconnectBudgetShellPolicy {
     ///   - retryCountVariable: The loop's shell variable holding retries taken.
     ///   - statusVariable: The loop's shell variable holding the last attach status.
     /// - Returns: A command that exits with the last status at the budget.
-    public static func limitReachedCommand(
+    public func limitReachedCommand(
         retryCountVariable: String,
         statusVariable: String
     ) -> String {
-        "if [ \"$\(retryCountVariable)\" -ge \"$\(retryLimitVariable)\" ]; then exit \"$\(statusVariable)\"; fi"
+        "if [ \"$\(retryCountVariable)\" -ge \"$\(Self.retryLimitVariable)\" ]; then exit \"$\(statusVariable)\"; fi"
     }
 
     /// The shell command that waits between two attempts.
-    public static var delayCommand: String {
-        "sleep \"$\(delaySecondsVariable)\""
+    public var delayCommand: String {
+        "sleep \"$\(Self.delaySecondsVariable)\""
+    }
+
+    /// A line that drops the leading zeros of `variable`, keeping a bare `0`.
+    private func paddingStrippingLine(variable: String) -> String {
+        "while :; do case \"$\(variable)\" in 0?*) \(variable)=\"${\(variable)#0}\" ;; *) break ;; esac; done"
+    }
+
+    /// A `case` pattern matching values of at least `minimumDigits` characters.
+    private func digitPattern(minimumDigits: Int) -> String {
+        String(repeating: "?", count: minimumDigits) + "*"
     }
 }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
@@ -6,6 +6,8 @@ import Testing
 struct SSHReconnectBudgetShellPolicyTests {
     private static let oversizedValue = "99999999999999999999"
 
+    private let policy = SSHReconnectBudgetShellPolicy()
+
     @Test func retryLimitEndsTheLoopWhenTheBudgetIsSpent() throws {
         let result = try runBudgetCheck(retriesTaken: 5, limit: "5")
 
@@ -54,11 +56,11 @@ struct SSHReconnectBudgetShellPolicyTests {
 
     @Test func nonNumericRetryLimitFallsBackToTheDefaultBudget() throws {
         let spent = try runBudgetCheck(
-            retriesTaken: SSHReconnectBudgetShellPolicy.defaultRetryLimit,
+            retriesTaken: policy.defaultRetryLimit,
             limit: "not-a-number"
         )
         let remaining = try runBudgetCheck(
-            retriesTaken: SSHReconnectBudgetShellPolicy.defaultRetryLimit - 1,
+            retriesTaken: policy.defaultRetryLimit - 1,
             limit: "not-a-number"
         )
 
@@ -77,11 +79,13 @@ struct SSHReconnectBudgetShellPolicyTests {
     @Test func nonNumericDelayFallsBackToTheDefaultInterval() throws {
         let waited = try runDelay(delaySeconds: "half a minute")
 
-        #expect(waited == "\(SSHReconnectBudgetShellPolicy.defaultDelaySeconds)")
+        #expect(waited == "\(policy.defaultDelaySeconds)")
     }
 
     @Test func configuredDelayIsWaitedAsWritten() throws {
         #expect(try runDelay(delaySeconds: "7") == "7")
+        // Padding is dropped rather than counted toward the ceiling.
+        #expect(try runDelay(delaySeconds: "0000007") == "7")
         // An explicit zero asks for no wait at all, which the loop honors.
         #expect(try runDelay(delaySeconds: "0") == "0")
     }
@@ -94,10 +98,10 @@ struct SSHReconnectBudgetShellPolicyTests {
         retriesTaken: Int,
         limit: String
     ) throws -> (status: Int32, stderr: String) {
-        let script = (SSHReconnectBudgetShellPolicy.configurationLines + [
+        let script = (policy.configurationLines + [
             "cmux_test_retry=\(retriesTaken)",
             "cmux_test_status=255",
-            SSHReconnectBudgetShellPolicy.limitReachedCommand(
+            policy.limitReachedCommand(
                 retryCountVariable: "cmux_test_retry",
                 statusVariable: "cmux_test_status"
             ),
@@ -118,8 +122,8 @@ struct SSHReconnectBudgetShellPolicyTests {
 
         let script = ([
             "sleep() { printf '%s' \"$1\" > \"$CMUX_TEST_LOG\"; }",
-        ] + SSHReconnectBudgetShellPolicy.configurationLines + [
-            SSHReconnectBudgetShellPolicy.delayCommand,
+        ] + policy.configurationLines + [
+            policy.delayCommand,
         ]).joined(separator: "\n")
 
         let result = try run(

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
@@ -71,9 +71,14 @@ struct SSHReconnectBudgetShellPolicyTests {
     }
 
     @Test func oversizedDelayIsClampedToAnIntervalSleepAccepts() throws {
-        let waited = try runDelay(delaySeconds: Self.oversizedValue)
+        let ceiling = "\(SSHReconnectBudgetShellPolicy.maximumConfigurableDelaySeconds)"
 
-        #expect(waited == "\(SSHReconnectBudgetShellPolicy.maximumConfigurableDelaySeconds)")
+        #expect(try runDelay(delaySeconds: Self.oversizedValue) == ceiling)
+        // A value the shell can still compare is capped by the comparison
+        // rather than by its digit count, which is the branch below the one
+        // above it.
+        #expect(try runDelay(delaySeconds: "86401") == ceiling)
+        #expect(try runDelay(delaySeconds: "86400") == ceiling)
     }
 
     @Test func nonNumericDelayFallsBackToTheDefaultInterval() throws {

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHReconnectBudgetShellPolicyTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+
+@testable import CmuxFoundation
+
+struct SSHReconnectBudgetShellPolicyTests {
+    private static let oversizedValue = "99999999999999999999"
+
+    @Test func retryLimitEndsTheLoopWhenTheBudgetIsSpent() throws {
+        let result = try runBudgetCheck(retriesTaken: 5, limit: "5")
+
+        #expect(result.status == 255)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func retryLimitKeepsTheLoopRunningBelowTheBudget() throws {
+        let result = try runBudgetCheck(retriesTaken: 4, limit: "5")
+
+        #expect(result.status == 0)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func oversizedRetryLimitStillAnswersTheBudgetComparison() throws {
+        let result = try runBudgetCheck(
+            retriesTaken: SSHReconnectBudgetShellPolicy.maximumConfigurableRetryLimit,
+            limit: Self.oversizedValue
+        )
+
+        // Without a ceiling the comparison errors instead of answering, and a
+        // budget that never answers stops bounding the loop it belongs to.
+        #expect(result.status == 255)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func oversizedRetryLimitDoesNotEndTheLoopEarly() throws {
+        let result = try runBudgetCheck(retriesTaken: 5, limit: Self.oversizedValue)
+
+        #expect(result.status == 0)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func zeroPaddedRetryLimitIsReadAsItsDigits() throws {
+        // The ceiling is applied by counting digits, so padding has to come off
+        // first: "0000002" is a budget of two retries, not of a seven-digit
+        // number of them.
+        let spent = try runBudgetCheck(retriesTaken: 2, limit: "0000002")
+        let remaining = try runBudgetCheck(retriesTaken: 1, limit: "0000002")
+
+        #expect(spent.status == 255)
+        #expect(remaining.status == 0)
+        #expect(spent.stderr.isEmpty)
+        #expect(remaining.stderr.isEmpty)
+    }
+
+    @Test func nonNumericRetryLimitFallsBackToTheDefaultBudget() throws {
+        let spent = try runBudgetCheck(
+            retriesTaken: SSHReconnectBudgetShellPolicy.defaultRetryLimit,
+            limit: "not-a-number"
+        )
+        let remaining = try runBudgetCheck(
+            retriesTaken: SSHReconnectBudgetShellPolicy.defaultRetryLimit - 1,
+            limit: "not-a-number"
+        )
+
+        #expect(spent.status == 255)
+        #expect(remaining.status == 0)
+        #expect(spent.stderr.isEmpty)
+        #expect(remaining.stderr.isEmpty)
+    }
+
+    @Test func oversizedDelayIsClampedToAnIntervalSleepAccepts() throws {
+        let waited = try runDelay(delaySeconds: Self.oversizedValue)
+
+        #expect(waited == "\(SSHReconnectBudgetShellPolicy.maximumConfigurableDelaySeconds)")
+    }
+
+    @Test func nonNumericDelayFallsBackToTheDefaultInterval() throws {
+        let waited = try runDelay(delaySeconds: "half a minute")
+
+        #expect(waited == "\(SSHReconnectBudgetShellPolicy.defaultDelaySeconds)")
+    }
+
+    @Test func configuredDelayIsWaitedAsWritten() throws {
+        #expect(try runDelay(delaySeconds: "7") == "7")
+        // An explicit zero asks for no wait at all, which the loop honors.
+        #expect(try runDelay(delaySeconds: "0") == "0")
+    }
+
+    /// Runs the policy's budget check with a retry count and returns its outcome.
+    ///
+    /// The check exits with the attach status once the budget is spent, so a
+    /// script that reaches its final line still had budget left.
+    private func runBudgetCheck(
+        retriesTaken: Int,
+        limit: String
+    ) throws -> (status: Int32, stderr: String) {
+        let script = (SSHReconnectBudgetShellPolicy.configurationLines + [
+            "cmux_test_retry=\(retriesTaken)",
+            "cmux_test_status=255",
+            SSHReconnectBudgetShellPolicy.limitReachedCommand(
+                retryCountVariable: "cmux_test_retry",
+                statusVariable: "cmux_test_status"
+            ),
+            "exit 0",
+        ]).joined(separator: "\n")
+
+        return try run(
+            script,
+            environment: [SSHReconnectBudgetShellPolicy.retryLimitVariable: limit]
+        )
+    }
+
+    /// Returns the interval the policy's delay command hands to `sleep`.
+    private func runDelay(delaySeconds: String) throws -> String {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-reconnect-delay-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        let script = ([
+            "sleep() { printf '%s' \"$1\" > \"$CMUX_TEST_LOG\"; }",
+        ] + SSHReconnectBudgetShellPolicy.configurationLines + [
+            SSHReconnectBudgetShellPolicy.delayCommand,
+        ]).joined(separator: "\n")
+
+        let result = try run(
+            script,
+            environment: [
+                "CMUX_TEST_LOG": logURL.path,
+                SSHReconnectBudgetShellPolicy.delaySecondsVariable: delaySeconds,
+            ]
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stderr.isEmpty)
+        return (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+    }
+
+    private func run(
+        _ script: String,
+        environment overrides: [String: String]
+    ) throws -> (status: Int32, stderr: String) {
+        let process = Process()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        process.environment = ProcessInfo.processInfo.environment.merging(overrides) { _, override in override }
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderrPipe
+
+        try process.run()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(data: stderrData, encoding: .utf8) ?? ""
+        )
+    }
+}


### PR DESCRIPTION
The freestyle attach loop reads the two reconnect settings straight out of the environment and hands them to `[` and to `sleep` verbatim (`CLI/cmux.swift:11572-11597` before this change):

```sh
CMUX_SSH_RECONNECT_LIMIT="${CMUX_SSH_RECONNECT_LIMIT:-86400}"
CMUX_SSH_RECONNECT_DELAY_SECONDS="${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}"
…
  if [ "$cmux_freestyle_retry" -ge "$CMUX_SSH_RECONNECT_LIMIT" ]; then exit "$cmux_freestyle_status"; fi
  cmux_freestyle_retry=$((cmux_freestyle_retry + 1))
  sleep "$CMUX_SSH_RECONNECT_DELAY_SECONDS"
```

Both reads fail on a value the shell cannot turn into a number, and both fail open. The headline symptom is the delay: **an absurd delay setting removes the delay entirely**, because `sleep` rejects the interval, returns immediately, and the loop reconnects as fast as it can fail — a hot reconnect loop against the host, not the long wait one might expect. The limit fails the same way: the comparison errors instead of answering, and a budget that never answers bounds nothing.

## Verified before fixing

Driving the loop above, lifted verbatim into `/bin/sh` (bash 3.2.57, macOS) with a stub attach that returns 255:

- `CMUX_SSH_RECONNECT_LIMIT=99999999999999999999` — every iteration prints

  ```
  ./run-oversized.sh: line 24: [: 99999999999999999999: integer expression expected
  ```

  and the comparison never answers, so the retry budget stops ending the loop. The run only terminated because the stub gave up.

- `CMUX_SSH_RECONNECT_DELAY_SECONDS=99999999999999999999` — `sleep` rejects the interval

  ```
  usage: sleep number[unit] [...]
  Unit can be 's' (seconds, the default), m (minutes), h (hours), or d (days).
  ```

  and returns 1, so the wait is skipped: measured `elapsed=0s` across three attempts, i.e. a reconnect loop that hammers the host as fast as it can fail.

One correction to the issue text, checked rather than assumed: zero padding alone does **not** break the comparison here. `[` in bash parses base 10, so `[ 1 -ge 0000002 ]` answers correctly today. Padding still has to be stripped, because the ceiling below is applied by counting digits and would otherwise read `0000002` as an oversized value. There is a test pinning that.

## The fix

`SSHReconnectBudgetShellPolicy` (`Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHReconnectBudgetShellPolicy.swift`) owns how the two variables are read, how the budget comparison is written and how the wait is written. The freestyle loop now inherits all three instead of spelling them out. Normalization happens once, where the values enter the script: reject a non-number, drop padding zeros, then cap by digit count — the only size test a shell can run without first turning the value into a number it may not be able to represent — and assign back to the same variables, so the loop's `export` hands the normalized values to the CLI it starts as well.

**Why this is a shared policy and not a third copy of the guard.** #10350's clamp is still in flight and lives inline in `SSHPTYAttachRetryScriptBuilder.lines`, not behind a reusable API, so there is nothing on `main` for this path to call. The shape the issue asks for — `SSHPTYAttachExitCode.noProgressShellPolicy()`, shared lines both callers inherit — is what this PR adds for the reconnect budget, in the same module and the same shape. The ssh-pty-attach path is deliberately left alone: editing the exact lines #10350 rewrites would conflict with it, and that path is better moved onto this policy on top of #10350 than in parallel with it. The ceilings match the ones #10350 chose (1,000,000 retries, 86,400s) so the two paths do not disagree once they meet.

Behavior for values that already worked is unchanged, including an explicit `CMUX_SSH_RECONNECT_DELAY_SECONDS=0`, which still means "no wait".

## Converging on one policy

This PR must not leave two implementations of one rule behind. The map:

1. **After #10350 merges, its inline clamp moves onto this policy.** It currently lives in `SSHPTYAttachRetryScriptBuilder.lines(command:reauthenticates:)` (`Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift`), written out line by line rather than behind an API. Once it lands, that builder should read `SSHReconnectBudgetShellPolicy` instead, and so should the same pair of reads in `SSHPTYAttachExitCode.retryLoopLines(command:reauthenticates:)`, which carries them on `main` today. Doing it here instead would edit the exact lines #10350 rewrites and conflict with it.
2. **The two app-side copies of this loop are tracked in #10422** — `Sources/Workspace.swift` and `Sources/SessionRemoteWorkspaceSnapshot+Restore.swift` — and inherit the same policy in that issue rather than widening this PR.

Three call sites, one file.

### Considered during review and deliberately not done

Review suggested that the child attach path read the normalized `CMUX_SSH_RECONNECT_*` values instead of `CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT` / `_DELAY_SECONDS`. That would be a behavior change, not a fix, so it is not in this PR: those two variables are a deliberate per-child override. They bound the CLI's own retry of the Freestyle SSH-info fetch — read in `defaultFreestyleAttachRetryLimit()` (`CLI/cmux.swift:11673`) and `defaultFreestyleAttachRetryDelaySeconds()` (`CLI/cmux.swift:11684`), which also accept `CMUX_CLOUD_ATTACH_RETRY_*` ahead of them — while `CMUX_SSH_RECONNECT_*` bound the shell loop that retries the attach itself. The generated line already takes the normalized value as the *default* (`"${CMUX_DEFAULT_FREESTYLE_ATTACH_RETRY_LIMIT:-$CMUX_SSH_RECONNECT_LIMIT}"`), so a caller who sets nothing inherits the clamp; overriding an explicitly set value would discard the override silently. The reviewer agreed and withdrew the finding.

Those two variables also cannot reproduce the defect fixed here: they never reach `[` or `sleep`, they are parsed in Swift. **There is one genuine remainder there, out of scope for this PR and tracked in #10422:** `Int("99999999999999999999")` is `nil`, so the retry limit falls back to its built-in 120 and fails closed, but `Double("99999999999999999999")` is `1e+20`, so an absurd value for the child's delay becomes an effectively unbounded Swift wait.

## Red, then green

Commit 1 moves the two reads, the comparison and the wait into the policy unchanged — a behavior-preserving move, needed because nothing could reach them inside `CLI/cmux.swift` — and adds the tests, which drive those production fragments under `/bin/sh`. On that commit, 5 of 9 fail, quoting the shell:

```
✘ oversizedRetryLimitStillAnswersTheBudgetComparison
    Expectation failed: (result.status → 0) == 255
    Expectation failed: (result.stderr → "/bin/sh: line 4: [: 99999999999999999999: integer expression expected
    ").isEmpty → false
✘ oversizedRetryLimitDoesNotEndTheLoopEarly
    Expectation failed: (result.stderr → "/bin/sh: line 4: [: 99999999999999999999: integer expression expected
    ").isEmpty → false
✘ nonNumericRetryLimitFallsBackToTheDefaultBudget
    Expectation failed: (spent.status → 0) == 255
    Expectation failed: (spent.stderr → "/bin/sh: line 4: [: not-a-number: integer expression expected
    ").isEmpty → false
✘ oversizedDelayIsClampedToAnIntervalSleepAccepts
    Expectation failed: (waited → "99999999999999999999") == ("86400")
✘ nonNumericDelayFallsBackToTheDefaultInterval
    Expectation failed: (waited → "half a minute") == ("2")
```

Commit 2 adds the normalization; the same nine tests pass untouched.

Commit 3 is review-driven and behavior-neutral: the policy was a caseless enum of static members, which the repository's `no-ambient-global-state` rule rejects, so its defaults are instance state now and the freestyle generator constructs it — the shape `SSHPTYAttachRetryScriptBuilder()` already uses at its call sites. It also adds the zero-padded delay case CodeRabbit asked for.

The whole loop was also driven end to end with the generated policy lines in place: an oversized limit and delay now produce no shell error and a 86,400s wait, `CMUX_SSH_RECONNECT_LIMIT=0000002` exits at its budget of two retries after three attempts, and an unset environment still waits 2s.

## Validation

```
swift test --package-path Packages/macOS/CmuxFoundation
  → 224 tests in 38 suites passed (of which 9 are new)
xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -derivedDataPath /tmp/cmux-freestyle build
  → BUILD SUCCEEDED
./scripts/lint-pbxproj-test-wiring.sh
  → ok (checked 693 test files)
```

One earlier full run had `CommandRunnerDescriptorLifecycleTests` fail on an unrelated pipe-lifecycle expectation; it passes in isolation across repeated runs and in later full runs, and touches nothing in this change.

No app build: `GhosttyKit.xcframework` is built from the submodule and is not part of this change.

Fixes #10419

---

Workflows show as `action_required` — this is a pull request from a fork, so the runs need a maintainer to approve them before they start.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789727951&installation_model_id=21920&pr_number=10421&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10421&signature=e02b906cef69525c68ef3c5dfd24587cf81d65709958b3073585db7199a128b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp and centralize the freestyle attach reconnect budget via a shared shell policy so bad environment values no longer disable the budget or skip the wait. Old behavior read `CMUX_SSH_RECONNECT_LIMIT`/`CMUX_SSH_RECONNECT_DELAY_SECONDS` verbatim and failed open on non-numeric or oversized values; new behavior normalizes, strips padding, caps to safe maxima, and exports normalized values to the child CLI.

- Introduces `SSHReconnectBudgetShellPolicy` in `CmuxFoundation`; `CLI/cmux.swift` now uses its `configurationLines`, `limitReachedCommand`, and `delayCommand`.
- Normalizes both env vars: non-numeric → defaults (limit 86,400; delay 2s), leading zeros stripped, then capped (max 1,000,000 retries; 86,400s). Explicit delay 0 still means no wait.
- Policy is constructable (instance defaults), avoiding ambient static state; normalized values are reassigned to the same variables and exported.
- Adds shell-driven tests for oversized, non-numeric, and zero-padded values, plus delay ceiling boundaries (86,401 capped to 86,400; 86,400 preserved).
- ssh-pty-attach path remains unchanged while #10350 lands; ceilings match that path to avoid divergence and ease follow-up consolidation onto this policy.

<sup>Written for commit 9a77d5aaf450ea119dc4130126ba918d712da829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SSH reconnect retry limits and delays.
  * Reconnect settings can be configured through environment variables with sensible defaults.
  * Values are validated, normalized, and capped at supported limits.
  * Delays can be disabled by setting the delay value to zero.

* **Bug Fixes**
  * Reconnect attempts now stop reliably when the configured retry budget is exhausted.
  * Improved delay handling between attempts, including safe fallback behavior for invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

