### PR TITLE
Expose per-account session counts and cooldowns in account listing

### DIFF
--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -151,22 +151,56 @@ export async function deleteAccount(input: {
 export async function listAccounts(
   teamId: string,
 ): Promise<readonly CodeRouterAccountSummary[]> {
-  return await cloudDb()
-    .select({
-      id: coderouterAccounts.id,
-      provider: coderouterAccounts.provider,
-      providerAccountId: coderouterAccounts.providerAccountId,
-      label: coderouterAccounts.label,
-      state: coderouterAccounts.state,
-      credentialExpiresAt: coderouterAccounts.credentialExpiresAt,
-      lastFailureCode: coderouterAccounts.lastFailureCode,
-    })
-    .from(coderouterAccounts)
-    .where(eq(coderouterAccounts.teamId, teamId))
-    .then((rows) => rows.map((row) => ({
-      ...row,
-      credentialExpiresAt: row.credentialExpiresAt?.toISOString() ?? null,
-    })));
+  const [rows, sessionCounts] = await Promise.all([
+    cloudDb()
+      .select({
+        id: coderouterAccounts.id,
+        provider: coderouterAccounts.provider,
+        providerAccountId: coderouterAccounts.providerAccountId,
+        label: coderouterAccounts.label,
+        state: coderouterAccounts.state,
+        credentialExpiresAt: coderouterAccounts.credentialExpiresAt,
+        lastFailureCode: coderouterAccounts.lastFailureCode,
+        cooldownUntil: coderouterAccounts.cooldownUntil,
+      })
+      .from(coderouterAccounts)
+      .where(eq(coderouterAccounts.teamId, teamId)),
+    countActiveSessionsByAccount(teamId),
+  ]);
+  return rows.map((row) => ({
+    ...row,
+    credentialExpiresAt: row.credentialExpiresAt?.toISOString() ?? null,
+    cooldownUntil: row.cooldownUntil?.toISOString() ?? null,
+    activeSessions: sessionCounts.get(row.id) ?? 0,
+  }));
+}
+
+/**
+ * Sessions bound per account with traffic inside the load window. Display
+ * only: a failure here must never take the status endpoint down.
+ */
+async function countActiveSessionsByAccount(
+  teamId: string,
+): Promise<ReadonlyMap<string, number>> {
+  try {
+    const rows = await cloudDb()
+      .select({
+        accountId: coderouterSessionAccounts.accountId,
+        sessions: sql<number>`count(*)::int`,
+      })
+      .from(coderouterSessionAccounts)
+      .where(and(
+        eq(coderouterSessionAccounts.teamId, teamId),
+        gt(
+          coderouterSessionAccounts.lastSeenAt,
+          sql`now() - interval '${sql.raw(SESSION_BINDING_LOAD_WINDOW)}'`,
+        ),
+      ))
+      .groupBy(coderouterSessionAccounts.accountId);
+    return new Map(rows.map((row) => [row.accountId, Number(row.sessions)]));
+  } catch {
+    return new Map();
+  }
 }
 
 export async function listCoderouterTeamIds(): Promise<readonly string[]> {

--- a/web/services/coderouter/types.ts
+++ b/web/services/coderouter/types.ts
@@ -41,4 +41,7 @@ export type CodeRouterAccountSummary = {
   readonly state: "active" | "refreshing" | "expired" | "broken";
   readonly credentialExpiresAt: string | null;
   readonly lastFailureCode: string | null;
+  readonly cooldownUntil: string | null;
+  /** Sessions bound to this account with traffic in the recent window. */
+  readonly activeSessions: number;
 };

--- a/web/tests/coderouter-routing-db-behavior.test.ts
+++ b/web/tests/coderouter-routing-db-behavior.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import { randomUUID } from "node:crypto";
 import postgres, { type Sql } from "postgres";
 import { closeCloudDbForTests } from "../db/client";
+import { listAccounts } from "../services/coderouter/repository";
 import {
   bindSessionAccount,
   claimAccountForPlacement,
@@ -211,6 +212,27 @@ describe("coderouter routing db behavior", () => {
     });
     expect(during?.id).toBe(first?.id ?? "");
     expect(during?.sticky).toBe(true);
+  });
+
+  dbTest("account listing reports active session counts and cooldowns", async () => {
+    if (!sql) throw new Error("no sql client");
+    const accounts = await insertAccounts(2);
+    await bindSessionAccount(TEAM, "codex", "fresh-session-1", accounts[0] ?? "");
+    await bindSessionAccount(TEAM, "codex", "fresh-session-2", accounts[0] ?? "");
+    await bindSessionAccount(TEAM, "codex", "stale-session", accounts[1] ?? "");
+    await sql`
+      update coderouter_session_accounts
+      set last_seen_at = now() - interval '7 hours'
+      where session_key = 'stale-session'
+    `;
+    await markAccountCooldown(accounts[1] ?? "", 60_000);
+    const listed = await listAccounts(TEAM);
+    const byId = new Map(listed.map((account) => [account.id, account]));
+    expect(byId.get(accounts[0] ?? "")?.activeSessions).toBe(2);
+    expect(byId.get(accounts[0] ?? "")?.cooldownUntil).toBeNull();
+    // A binding idle beyond the load window no longer counts.
+    expect(byId.get(accounts[1] ?? "")?.activeSessions).toBe(0);
+    expect(byId.get(accounts[1] ?? "")?.cooldownUntil).not.toBeNull();
   });
 
   dbTest("routes without stickiness while the session table is missing", async () => {


### PR DESCRIPTION
The coderouter status endpoint (`GET /api/coderouter/accounts`) now includes two display fields per account:

- `activeSessions` — sessions bound to the account with traffic inside the routing load window (6h), from the `coderouter_session_accounts` table added in #10387. Makes sticky routing visible in `cr`.
- `cooldownUntil` — the account's rate-limit cooldown deadline, previously stored but never exposed.

The session-count read fails to an empty map so a problem with it can never take the status endpoint down. Covered by a CMUX_DB_TEST behavior test (fresh binding counts, stale binding beyond the window does not, cooldown surfaces). Full web suite: 1503 tests, 0 fail.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729198&installation_model_id=21920&pr_number=10424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10424&signature=7ff833813cb3abb06af0457f007cb922f960866520ac4cabb033b66f79aa9395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose per-account session counts and cooldowns in `GET /api/coderouter/accounts` so sticky routing visibility and rate-limit cooldowns are clear. Previously, the endpoint omitted these; now it returns `activeSessions` and `cooldownUntil` per account.

**Review notes**
- Adds `activeSessions` (count of sessions with traffic in the last 6h) and `cooldownUntil` (ISO string or null) to the response.
- Session counts come from `coderouter_session_accounts`; stale bindings outside the 6h window do not count.
- Session-count read is best effort and fails to zero; the status endpoint never fails due to this query.
- Fetches accounts and session counts in parallel; dates are returned as ISO strings.
- Tests verify fresh vs. stale session behavior and cooldown exposure.
- No migrations or client changes required; added fields are backward compatible.

<sup>Written for commit 34f0e1eecae2a983fddfa9cc4ab7378e35ecbcae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account listings now show cooldown status and the number of active sessions.
  * Active sessions reflect activity within the last six hours, excluding idle connections.

* **Bug Fixes**
  * Account status information remains available even if session activity data cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->