### PR TITLE
CmuxIrohTransport: unify duplicated host/client runtime lifecycle

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Lifecycle.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Lifecycle.swift
@@ -1,4 +1,4 @@
-public import Foundation
+import Foundation
 
 extension CmxIrohClientRuntime {
     func performSignOut(
@@ -6,61 +6,18 @@ extension CmxIrohClientRuntime {
         bindingAuthorization: CmxIrohBindingRequestAuthorization?,
         revision: UInt64
     ) async -> CmxIrohClientSignOutPreparation {
-        async let wasPersisted = Self.persist(pendingRevocation, to: pendingRevocations)
-        async let networkTeardown: Void = tearDownNetwork(preserveBinding: true)
-        let (persisted, _) = await (wasPersisted, networkTeardown)
-        let preparation = CmxIrohClientSignOutPreparation(
+        await performSignOutFlow(
             pendingRevocation: pendingRevocation,
-            wasPersisted: persisted,
-            bindingAuthorization: bindingAuthorization
+            bindingAuthorization: bindingAuthorization,
+            revision: revision,
+            tearDownNetwork: {
+                await self.tearDownNetwork(preserveBinding: true)
+            },
+            deactivateLocalState: { [offlinePolicyCache, handleLocalDeactivation] in
+                try? await offlinePolicyCache?.deactivate()
+                await handleLocalDeactivation()
+            }
         )
-
-        guard lifecyclePhase == .signingOut,
-              lifecycleRevision == revision else {
-            signOutOperation = nil
-            return preparation
-        }
-        guard persisted else {
-            lifecyclePhase = .quarantined
-            currentSnapshot = CmxIrohClientRuntimeSnapshot(
-                state: .quarantined,
-                endpointID: nil,
-                bindingID: pendingRevocation?.bindingID
-            )
-            signOutOperation = nil
-            return preparation
-        }
-
-        try? await offlinePolicyCache?.deactivate()
-        await handleLocalDeactivation()
-        guard lifecyclePhase == .signingOut,
-              lifecycleRevision == revision else {
-            signOutOperation = nil
-            return preparation
-        }
-        localBinding = nil
-        lastRegistrationRefreshState = nil
-        lifecyclePhase = .inactive
-        currentSnapshot = CmxIrohClientRuntimeSnapshot(
-            state: .inactive,
-            endpointID: nil,
-            bindingID: nil
-        )
-        signOutOperation = nil
-        return preparation
-    }
-
-    nonisolated static func persist(
-        _ revocation: CmxIrohPendingRevocation?,
-        to pendingRevocations: CmxIrohPendingRevocationOutbox
-    ) async -> Bool {
-        guard let revocation else { return true }
-        do {
-            try await pendingRevocations.enqueue(revocation)
-            return true
-        } catch {
-            return false
-        }
     }
 
     func tearDownNetwork(preserveBinding: Bool = false) async {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -39,53 +39,23 @@ extension CmxIrohClientRuntime {
             || profile.allowedRelayURLs.isSubset(of: replacementManagedURLs) else {
             throw CmxIrohClientRuntimeError.relayFleetMismatch
         }
-        let revision = lifecycleRevision
 
-        await relayCoordinator?.deactivate()
-        relayCoordinator = nil
-        if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
-            let refreshSchedule = CmxIrohRelayRefreshSchedule(
-                role: .client,
-                endpointIdentity: binding.endpointID
-            )
-            let coordinator = CmxIrohRelayCredentialCoordinator(
-                supervisor: connectivityEngine,
-                broker: broker,
-                managedRelayURLs: replacementManagedURLs,
-                selectedRelayURLs: profile.allowedRelayURLs,
-                jitter: { now, refreshAfter in
-                    refreshSchedule.deadline(now: now, refreshAfter: refreshAfter)
-                },
-                retrySchedule: .foregroundClient,
-                automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
-                credentialDidInstall: { [handleRelayCredential] response in
-                    await handleRelayCredential(response, binding)
-                }
-            )
-            relayCoordinator = coordinator
-            do {
-                try await coordinator.activateManagedPolicy(
-                    bindingID: binding.bindingID,
-                    endpointIdentity: binding.endpointID,
-                    profile: profile,
-                    bootstrap: relayBootstrap
-                )
-            } catch {
-                await coordinator.deactivate()
-                if relayCoordinator === coordinator {
-                    relayCoordinator = nil
-                }
-                throw error
+        let revision = try await swapRelayCoordinator(
+            profile: profile,
+            replacementManagedURLs: replacementManagedURLs,
+            relayBootstrap: relayBootstrap,
+            role: .client,
+            bindingID: binding.bindingID,
+            endpointIdentity: binding.endpointID,
+            connectivityEngine: connectivityEngine,
+            broker: broker,
+            retrySchedule: .foregroundClient,
+            automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
+            credentialDidInstall: { [handleRelayCredential] response in
+                await handleRelayCredential(response, binding)
             }
-        } else {
-            try await connectivityEngine.replaceRelayProfile(
-                profile,
-                expectedIdentity: binding.endpointID
-            )
-        }
-        try requireCurrent(revision)
+        )
 
-        managedRelayURLs = replacementManagedURLs
         endpointRelayProfile = profile
         let expectation = try CmxIrohLocalBindingExpectation(
             deviceID: binding.deviceID,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayReachability.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayReachability.swift
@@ -1,13 +1,6 @@
 public extension CmxIrohClientRuntime {
     /// Returns whether the live authenticated endpoint currently advertises an allowed relay.
     func hasReachableRelay(in allowedRelayURLs: Set<String>) async -> Bool? {
-        guard !allowedRelayURLs.isEmpty,
-              lifecyclePhase == .active,
-              let address = try? await connectivityEngine.endpointAddress() else {
-            return nil
-        }
-        return address.pathHints.contains {
-            $0.kind == .relayURL && allowedRelayURLs.contains($0.value)
-        }
+        await activeRelayReachability(in: allowedRelayURLs, connectivityEngine: connectivityEngine)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -47,23 +47,7 @@ public actor CmxIrohClientRuntime {
         let task: Task<CmxIrohLiveDiscoveryRefreshOutcome, Never>
     }
 
-    enum LifecyclePhase: Equatable, Sendable {
-        case inactive
-        case starting
-        case active
-        case stopping
-        case signingOut
-        case quarantined
-        case failed
-
-        var allowsStart: Bool {
-            self == .inactive || self == .failed
-        }
-
-        var ownsNetworkOperation: Bool {
-            self == .starting || self == .active
-        }
-    }
+    typealias LifecyclePhase = CmxIrohRuntimeLifecyclePhase
 
     /// The route-aware factory registered by the iOS app before fallback transports.
     public nonisolated let transportFactory: CmxConnectivityByteTransportFactory

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
@@ -41,53 +41,23 @@ extension CmxIrohHostRuntime {
             || profile.allowedRelayURLs.isSubset(of: replacementManagedURLs) else {
             throw CmxIrohHostRuntimeError.relayFleetMismatch
         }
-        let revision = lifecycleRevision
 
         relayActivationTask?.cancel()
         relayActivationTask = nil
-        await relayCoordinator?.deactivate()
-        relayCoordinator = nil
-        if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
-            let refreshSchedule = CmxIrohRelayRefreshSchedule(
-                role: .host,
-                endpointIdentity: binding.endpointID
-            )
-            let coordinator = CmxIrohRelayCredentialCoordinator(
-                supervisor: connectivityEngine,
-                broker: broker,
-                managedRelayURLs: replacementManagedURLs,
-                selectedRelayURLs: profile.allowedRelayURLs,
-                jitter: { now, refreshAfter in
-                    refreshSchedule.deadline(now: now, refreshAfter: refreshAfter)
-                },
-                credentialDidInstall: { [handleRelayCredential] response in
-                    await handleRelayCredential(response, binding)
-                }
-            )
-            relayCoordinator = coordinator
-            do {
-                try await coordinator.activateManagedPolicy(
-                    bindingID: binding.bindingID,
-                    endpointIdentity: binding.endpointID,
-                    profile: profile,
-                    bootstrap: relayBootstrap
-                )
-            } catch {
-                await coordinator.deactivate()
-                if relayCoordinator === coordinator {
-                    relayCoordinator = nil
-                }
-                throw error
+        let revision = try await swapRelayCoordinator(
+            profile: profile,
+            replacementManagedURLs: replacementManagedURLs,
+            relayBootstrap: relayBootstrap,
+            role: .host,
+            bindingID: binding.bindingID,
+            endpointIdentity: binding.endpointID,
+            connectivityEngine: connectivityEngine,
+            broker: broker,
+            credentialDidInstall: { [handleRelayCredential] response in
+                await handleRelayCredential(response, binding)
             }
-        } else {
-            try await connectivityEngine.replaceRelayProfile(
-                profile,
-                expectedIdentity: binding.endpointID
-            )
-        }
-        try requireCurrent(revision)
+        )
 
-        managedRelayURLs = replacementManagedURLs
         currentEndpointRelayProfile = profile
         await admissionController?.updateManagedRelayURLs(replacementManagedURLs)
         try requireCurrent(revision)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayReachability.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayReachability.swift
@@ -1,14 +1,6 @@
 public extension CmxIrohHostRuntime {
     /// Returns whether the live authenticated endpoint currently advertises an allowed relay.
     func hasReachableRelay(in allowedRelayURLs: Set<String>) async -> Bool? {
-        guard !allowedRelayURLs.isEmpty,
-              lifecyclePhase == .active,
-              let connectivityEngine,
-              let address = try? await connectivityEngine.endpointAddress() else {
-            return nil
-        }
-        return address.pathHints.contains {
-            $0.kind == .relayURL && allowedRelayURLs.contains($0.value)
-        }
+        await activeRelayReachability(in: allowedRelayURLs, connectivityEngine: connectivityEngine)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
@@ -1,5 +1,3 @@
-public import Foundation
-
 extension CmxIrohHostRuntime {
     func performSignOut(
         pendingRevocation: CmxIrohPendingRevocation?,
@@ -7,60 +5,17 @@ extension CmxIrohHostRuntime {
         requiresNetworkDeactivation: Bool,
         revision: UInt64
     ) async -> CmxIrohHostSignOutPreparation {
-        async let wasPersisted = Self.persist(
-            pendingRevocation,
-            to: pendingRevocations
-        )
-        async let networkTeardown: Void = deactivateNetworkForSignOut(
-            bindingID: pendingRevocation?.bindingID,
-            required: requiresNetworkDeactivation
-        )
-        let (persisted, _) = await (wasPersisted, networkTeardown)
-        let preparation = CmxIrohHostSignOutPreparation(
+        await performSignOutFlow(
             pendingRevocation: pendingRevocation,
-            wasPersisted: persisted,
-            bindingAuthorization: bindingAuthorization
+            bindingAuthorization: bindingAuthorization,
+            revision: revision,
+            tearDownNetwork: {
+                await self.deactivateNetworkForSignOut(
+                    bindingID: pendingRevocation?.bindingID,
+                    required: requiresNetworkDeactivation
+                )
+            }
         )
-
-        guard lifecyclePhase == .signingOut,
-              lifecycleRevision == revision else {
-            signOutOperation = nil
-            return preparation
-        }
-        guard persisted else {
-            lifecyclePhase = .quarantined
-            currentSnapshot = CmxIrohHostRuntimeSnapshot(
-                state: .quarantined,
-                endpointID: nil,
-                bindingID: pendingRevocation?.bindingID
-            )
-            signOutOperation = nil
-            return preparation
-        }
-
-        localBinding = nil
-        lastRegistrationRefreshState = nil
-        lifecyclePhase = .inactive
-        currentSnapshot = CmxIrohHostRuntimeSnapshot(
-            state: .inactive,
-            endpointID: nil,
-            bindingID: nil
-        )
-        signOutOperation = nil
-        return preparation
-    }
-
-    nonisolated static func persist(
-        _ revocation: CmxIrohPendingRevocation?,
-        to pendingRevocations: CmxIrohPendingRevocationOutbox
-    ) async -> Bool {
-        guard let revocation else { return true }
-        do {
-            try await pendingRevocations.enqueue(revocation)
-            return true
-        } catch {
-            return false
-        }
     }
 
     func deactivateNetworkForSignOut(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -46,23 +46,7 @@ public actor CmxIrohHostRuntime {
         let registrationRetryAfterSeconds: Int?
     }
 
-    enum LifecyclePhase: Equatable, Sendable {
-        case inactive
-        case starting
-        case active
-        case stopping
-        case signingOut
-        case quarantined
-        case failed
-
-        var allowsStart: Bool {
-            self == .inactive || self == .failed
-        }
-
-        var ownsNetworkOperation: Bool {
-            self == .starting || self == .active
-        }
-    }
+    typealias LifecyclePhase = CmxIrohRuntimeLifecyclePhase
 
     let factory: any CmxIrohEndpointFactory
     let broker: any CmxIrohHostBrokerServing

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeLifecycle.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeLifecycle.swift
@@ -1,0 +1,190 @@
+import CMUXMobileCore
+import Foundation
+
+/// One lifecycle phase machine shared by the host and client runtimes.
+enum CmxIrohRuntimeLifecyclePhase: Equatable, Sendable {
+    case inactive, starting, active, stopping, signingOut, quarantined, failed
+
+    var allowsStart: Bool { self == .inactive || self == .failed }
+
+    var ownsNetworkOperation: Bool { self == .starting || self == .active }
+}
+
+/// Builds the terminal snapshots the shared sign-out flow settles into.
+protocol CmxIrohRuntimeSnapshotRepresenting: Sendable {
+    static func quarantined(bindingID: String?) -> Self
+    static var inactive: Self { get }
+}
+
+extension CmxIrohHostRuntimeSnapshot: CmxIrohRuntimeSnapshotRepresenting {
+    static func quarantined(bindingID: String?) -> Self {
+        Self(state: .quarantined, endpointID: nil, bindingID: bindingID)
+    }
+
+    static var inactive: Self { Self(state: .inactive, endpointID: nil, bindingID: nil) }
+}
+
+extension CmxIrohClientRuntimeSnapshot: CmxIrohRuntimeSnapshotRepresenting {
+    static func quarantined(bindingID: String?) -> Self {
+        Self(state: .quarantined, endpointID: nil, bindingID: bindingID)
+    }
+
+    static var inactive: Self { Self(state: .inactive, endpointID: nil, bindingID: nil) }
+}
+
+/// Actor state both runtimes expose to the shared lifecycle helpers.
+protocol CmxIrohRuntimeLifecycleManaging: Actor {
+    associatedtype Binding
+    associatedtype Snapshot: CmxIrohRuntimeSnapshotRepresenting
+
+    var lifecyclePhase: CmxIrohRuntimeLifecyclePhase { get set }
+    var lifecycleRevision: UInt64 { get }
+    var localBinding: Binding? { get set }
+    var lastRegistrationRefreshState: CmxIrohRegistrationPublicationState? { get set }
+    var currentSnapshot: Snapshot { get set }
+    var signOutOperation: Task<CmxIrohSignOutPreparation, Never>? { get set }
+    var relayCoordinator: CmxIrohRelayCredentialCoordinator? { get set }
+    var managedRelayURLs: Set<String> { get set }
+    var pendingRevocations: CmxIrohPendingRevocationOutbox { get }
+    func requireCurrent(_ revision: UInt64) throws
+}
+
+/// Queues one revocation device-side, reporting false only on outbox failure.
+func cmxIrohPersistSignOutRevocation(
+    _ revocation: CmxIrohPendingRevocation?,
+    to pendingRevocations: CmxIrohPendingRevocationOutbox
+) async -> Bool {
+    guard let revocation else { return true }
+    return (try? await pendingRevocations.enqueue(revocation)) != nil
+}
+
+extension CmxIrohRuntimeLifecycleManaging {
+    /// Persists the revocation and tears down concurrently, then settles the phase.
+    func performSignOutFlow(
+        pendingRevocation: CmxIrohPendingRevocation?,
+        bindingAuthorization: CmxIrohBindingRequestAuthorization?,
+        revision: UInt64,
+        tearDownNetwork: @escaping @Sendable () async -> Void,
+        deactivateLocalState: (@Sendable () async -> Void)? = nil
+    ) async -> CmxIrohSignOutPreparation {
+        async let wasPersisted = cmxIrohPersistSignOutRevocation(
+            pendingRevocation,
+            to: pendingRevocations
+        )
+        async let networkTeardown: Void = tearDownNetwork()
+        let (persisted, _) = await (wasPersisted, networkTeardown)
+        let preparation = CmxIrohSignOutPreparation(
+            pendingRevocation: pendingRevocation,
+            wasPersisted: persisted,
+            bindingAuthorization: bindingAuthorization
+        )
+
+        guard lifecyclePhase == .signingOut, lifecycleRevision == revision else {
+            signOutOperation = nil
+            return preparation
+        }
+        guard persisted else {
+            lifecyclePhase = .quarantined
+            currentSnapshot = .quarantined(bindingID: pendingRevocation?.bindingID)
+            signOutOperation = nil
+            return preparation
+        }
+
+        if let deactivateLocalState {
+            await deactivateLocalState()
+            guard lifecyclePhase == .signingOut, lifecycleRevision == revision else {
+                signOutOperation = nil
+                return preparation
+            }
+        }
+
+        localBinding = nil
+        lastRegistrationRefreshState = nil
+        lifecyclePhase = .inactive
+        currentSnapshot = .inactive
+        signOutOperation = nil
+        return preparation
+    }
+
+    /// Swaps the relay coordinator or installs a custom profile; the caller
+    /// validates the fleet first and appends its role-specific tail.
+    func swapRelayCoordinator(
+        profile: CmxIrohEndpointRelayProfile,
+        replacementManagedURLs: Set<String>,
+        relayBootstrap: CmxIrohRelayTokenResponse?,
+        role: CmxIrohRelayRefreshSchedule.Role,
+        bindingID: String,
+        endpointIdentity: CmxIrohPeerIdentity,
+        connectivityEngine: CmxConnectivityEngine,
+        broker: any CmxIrohRelayTokenServing,
+        retrySchedule: CmxIrohRetrySchedule = CmxIrohRetrySchedule(),
+        automaticRefreshEnabled: Bool = true,
+        credentialDidInstall: @escaping @Sendable (CmxIrohRelayTokenResponse) async -> Void
+    ) async throws -> UInt64 {
+        let revision = lifecycleRevision
+
+        await relayCoordinator?.deactivate()
+        relayCoordinator = nil
+        if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
+            let refreshSchedule = CmxIrohRelayRefreshSchedule(
+                role: role,
+                endpointIdentity: endpointIdentity
+            )
+            let coordinator = CmxIrohRelayCredentialCoordinator(
+                supervisor: connectivityEngine,
+                broker: broker,
+                managedRelayURLs: replacementManagedURLs,
+                selectedRelayURLs: profile.allowedRelayURLs,
+                jitter: { now, refreshAfter in
+                    refreshSchedule.deadline(now: now, refreshAfter: refreshAfter)
+                },
+                retrySchedule: retrySchedule,
+                automaticRefreshEnabled: automaticRefreshEnabled,
+                credentialDidInstall: credentialDidInstall
+            )
+            relayCoordinator = coordinator
+            do {
+                try await coordinator.activateManagedPolicy(
+                    bindingID: bindingID,
+                    endpointIdentity: endpointIdentity,
+                    profile: profile,
+                    bootstrap: relayBootstrap
+                )
+            } catch {
+                await coordinator.deactivate()
+                if relayCoordinator === coordinator {
+                    relayCoordinator = nil
+                }
+                throw error
+            }
+        } else {
+            try await connectivityEngine.replaceRelayProfile(
+                profile,
+                expectedIdentity: endpointIdentity
+            )
+        }
+        try requireCurrent(revision)
+
+        managedRelayURLs = replacementManagedURLs
+        return revision
+    }
+
+    /// Returns whether the live authenticated endpoint advertises an allowed relay.
+    func activeRelayReachability(
+        in allowedRelayURLs: Set<String>,
+        connectivityEngine: CmxConnectivityEngine?
+    ) async -> Bool? {
+        guard !allowedRelayURLs.isEmpty,
+              lifecyclePhase == .active,
+              let connectivityEngine,
+              let address = try? await connectivityEngine.endpointAddress() else {
+            return nil
+        }
+        return address.pathHints.contains {
+            $0.kind == .relayURL && allowedRelayURLs.contains($0.value)
+        }
+    }
+}
+
+extension CmxIrohHostRuntime: CmxIrohRuntimeLifecycleManaging {}
+extension CmxIrohClientRuntime: CmxIrohRuntimeLifecycleManaging {}


### PR DESCRIPTION
CmxIrohHostRuntime and CmxIrohClientRuntime carried verbatim copies of the same lifecycle machinery. This moves the shared phase enum, snapshot terminal states, sign-out persistence helper, and the performSignOut skeleton into CmxIrohRuntimeLifecycle.swift behind an internal actor protocol, with typealiases keeping every call site and test unchanged. Net delta is 240 insertions against 245 deletions across 9 files, all inside the package, with no behavior change. Part of the mobile-sync rip-out wave 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729348&installation_model_id=21920&pr_number=10425&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10425&signature=2e3f9a3b2f551b68c9b7d236effd5828d85727adbe03137c151d9ae3e69f79ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies duplicated lifecycle logic for `CmxIrohHostRuntime` and `CmxIrohClientRuntime` into shared helpers in `CmxIrohRuntimeLifecycle.swift`. This removes drift without changing runtime behavior or public API.

- Introduces `CmxIrohRuntimeLifecyclePhase` (with `typealias` on each runtime) and the internal actor protocol `CmxIrohRuntimeLifecycleManaging`; snapshots unify via `CmxIrohRuntimeSnapshotRepresenting`.
- Extracts shared helpers:
  - `performSignOutFlow` and `cmxIrohPersistSignOutRevocation` replace duplicated sign-out code; client passes a deactivation closure for its offline cache.
  - `swapRelayCoordinator` consolidates relay policy swaps; client passes retry/automatic-refresh options, host uses defaults.
  - `activeRelayReachability` deduplicates relay reachability checks.
- Call sites and tests remain unchanged; error enums, admission, endpoint server, peer session, and codecs are untouched.

**Review notes**
- Verify sign-out transitions (quarantined → inactive) and relay coordinator swaps on both runtimes.
- Confirm actor isolation and revision checks still guard against superseded operations.
- No migration required.

<sup>Written for commit f858bc37e43e865894cb8b43353a87cd6282967f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out handling, including revocation persistence, network cleanup, and safer lifecycle transitions.
  * Improved relay profile replacement and activation for more consistent connectivity behavior.
  * Improved relay reachability checks across host and client runtimes.

* **Refactor**
  * Unified lifecycle management for host and client runtimes, providing more consistent state handling and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->