### PR TITLE
cmux-tui: advertise COLORTERM=truecolor to child PTYs

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/workspace/process.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/process.rs
@@ -1391,6 +1391,10 @@ impl ProcessManager {
         command.cwd(&cwd);
         #[cfg(unix)]
         command.cwd_descriptor(cwd_directory.try_clone_file()?);
+        // Remote workspace children get the same truecolor guarantee as local
+        // surfaces (see Surface spawn in cmux-tui-core); explicit caller env
+        // below can override it.
+        command.env("COLORTERM", "truecolor");
         for (key, value) in env {
             command.env(key, value);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2248,6 +2248,12 @@ impl Surface {
         let mut cmd = PtyCommand::new(&argv[0]);
         cmd.args(argv[1..].iter().cloned());
         cmd.env("TERM", &opts.term);
+        // The embedded ghostty-vt terminal always parses 24-bit SGR and every
+        // frontend forwards RGB cells losslessly, so children can rely on
+        // truecolor regardless of where the session server was started
+        // (launchd, ssh, cron strip COLORTERM). Set before extra_env so a
+        // caller can still override it.
+        cmd.env("COLORTERM", "truecolor");
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -7399,6 +7399,61 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    fn spawn_and_read_colorterm(id: SurfaceId, extra_env: Vec<(String, String)>) -> String {
+        let mux = Mux::new_for_test("colorterm-env", SurfaceOptions::default());
+        let surface = Surface::spawn(
+            id,
+            SurfaceOptions {
+                command: Some(vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf 'CT=[%s]' \"$COLORTERM\"".into(),
+                ]),
+                extra_env,
+                ..SurfaceOptions::default()
+            },
+            Arc::downgrade(&mux),
+        )
+        .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let text =
+                surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
+            if let Some(start) = text.find("CT=[") {
+                if let Some(len) = text[start..].find(']') {
+                    return text[start..=start + len].to_string();
+                }
+            }
+            assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    /// The embedded ghostty-vt terminal always parses 24-bit SGR and the
+    /// frontends forward RGB cells losslessly, so children must be able to
+    /// rely on truecolor even when the session server itself was started from
+    /// an environment without COLORTERM (launchd, ssh, cron). Without the
+    /// guarantee, truecolor-capable programs quantize to the 256-color cube
+    /// and render visibly different colors than the same program run directly
+    /// in the host terminal.
+    #[cfg(unix)]
+    #[test]
+    fn child_env_advertises_truecolor_colorterm() {
+        assert_eq!(spawn_and_read_colorterm(151, Vec::new()), "CT=[truecolor]");
+    }
+
+    /// extra_env stays authoritative: a caller that sets COLORTERM explicitly
+    /// wins over the built-in truecolor advertisement.
+    #[cfg(unix)]
+    #[test]
+    fn child_env_colorterm_yields_to_extra_env() {
+        assert_eq!(
+            spawn_and_read_colorterm(152, vec![("COLORTERM".into(), "24bit".into())]),
+            "CT=[24bit]"
+        );
+    }
+
     #[test]
     fn terminal_color_override_delta_sets_and_resets_sparse_state() {
         let mut colors = TerminalColorOverrides {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -4836,6 +4836,9 @@ mod unix {
         let mut command = PtyCommand::new(&launch.command[0]);
         command.args(launch.command[1..].iter().cloned());
         command.env("TERM", &launch.term);
+        // Terminal-host children get the same truecolor guarantee as directly
+        // spawned surfaces (see Surface spawn in surface.rs); extra_env wins.
+        command.env("COLORTERM", "truecolor");
         for (key, value) in &launch.extra_env {
             command.env(key, value);
         }


### PR DESCRIPTION
Child PTYs only inherited COLORTERM from wherever the session server happened to start. A server started by launchd, ssh, or cron has no COLORTERM, so truecolor-capable programs (btop, bat, delta, claude-code, vim with termguicolors autodetect) inside cmux-tui quantize to the 256-color cube and render visibly different colors than the same program run directly in the host terminal.

The embedded ghostty-vt terminal always parses 24-bit SGR and the frontends forward RGB cells losslessly, so truecolor is unconditionally safe to advertise. This sets COLORTERM=truecolor at all three spawn sites (local surfaces, terminal-host runtime, remote workspace processes), before caller-supplied env so explicit overrides still win. Same convention as Ghostty itself and tmux with RGB-capable outer terminals.

Two commits: the first adds the failing tests (child sees truecolor; extra_env override wins), the second adds the fix.

Found while investigating a report that cmux-tui colors differ from raw Ghostty. The dominant cause of that report is separate and already fixed on main since 24b7582c5c (basic ANSI colors 0-15 were resolved against the built-in Monokai theme and re-emitted as explicit RGB; pre-Jul-18 binaries in the wild still do this). This PR closes the remaining daemon-session gap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789732023&installation_model_id=21920&pr_number=10429&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10429&signature=7ce812878c0960e06c30d6d8e429b319795a1b699ab05675e366037c808a6eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advertises COLORTERM=truecolor to all child PTYs so truecolor apps render correctly regardless of how the session server started. Previously children inherited COLORTERM (often unset under launchd/ssh/cron) and downgraded to 256 colors; now they see truecolor by default, and caller-provided `extra_env` can still override.

- Applies at all spawn sites: local surfaces, terminal-host runtime, and remote workspace processes.
- Sets COLORTERM before `extra_env`; tests cover the default truecolor guarantee and that `extra_env` wins (e.g., COLORTERM=24bit).
- Safe with the embedded ghostty-vt (24-bit SGR, RGB forwarded losslessly) and matches Ghostty/tmux conventions; no migration required. To disable or change, set COLORTERM via `extra_env`.

<sup>Written for commit c9755fd101ba5afffc9f2356563b53072fe0670e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Terminal sessions now advertise truecolor support by default.
  * Custom environment settings can override the default truecolor configuration.
* **Tests**
  * Added coverage to verify default truecolor support and custom override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->