### PR TITLE
Add Cortex Code agent hook integration

### DIFF
--- a/CLI/CMUXCLI+AgentHookCatalog.swift
+++ b/CLI/CMUXCLI+AgentHookCatalog.swift
@@ -230,6 +230,22 @@ extension CMUXCLI {
             feedHookEvents: ["PreToolUse"]
         ),
         AgentHookDef(
+            name: "cortex", displayName: "Cortex Code", statusKey: "cortex",
+            configDir: ".snowflake/cortex", configFile: "hooks.json",
+            configDirEnvOverride: "CORTEX_HOME",
+            createConfigDirIfMissing: true,
+            sessionStoreSuffix: "cortex", disableEnvVar: "CMUX_CORTEX_HOOKS_DISABLED",
+            hookMarker: "cmux hooks cortex", format: .nested(timeoutMs: 10_000),
+            events: [
+                .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start"),
+                .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit"),
+                .init(agentEvent: "Stop", cmuxSubcommand: "stop"),
+                .init(agentEvent: "Notification", cmuxSubcommand: "notification"),
+                .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
+            ],
+            feedHookEvents: ["PreToolUse"]
+        ),
+        AgentHookDef(
             name: "kimi", displayName: "Kimi Code", statusKey: "kimi",
             configDir: ".kimi", configFile: "config.toml", configDirEnvOverride: "KIMI_SHARE_DIR",
             createConfigDirIfMissing: true, binaryName: "kimi",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16288,7 +16288,7 @@ struct CMUXCLI {
             agent. Claude Code hooks are injected automatically by the cmux Claude wrapper.
 
             Agents:
-              codex, grok, opencode, pi, omp, campfire, amp, cursor, gemini, kiro, antigravity (alias: agy), rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder
+              codex, grok, opencode, pi, omp, campfire, amp, cursor, gemini, kiro, antigravity (alias: agy), rovodev (alias: rovo), hermes-agent, copilot, codebuddy, factory, qoder, cortex
 
             Hook targets:
               setup              Install hooks for all supported agents on PATH
@@ -29356,12 +29356,12 @@ struct CMUXCLI {
     }
 
     private func nestedHookTimeout(_ timeoutMs: Int, for def: AgentHookDef) -> Int {
-        guard def.name == "grok" else { return max(timeoutMs, 1) }
+        guard def.name == "grok" || def.name == "cortex" else { return max(timeoutMs, 1) }
         return Self.timeoutSecondsFromMilliseconds(timeoutMs)
     }
 
     private func nestedFeedHookTimeout(_ timeoutMs: Int, for def: AgentHookDef) -> Int {
-        guard def.name == "codex" || def.name == "grok" else { return max(timeoutMs, 1) }
+        guard def.name == "codex" || def.name == "grok" || def.name == "cortex" else { return max(timeoutMs, 1) }
         return Self.timeoutSecondsFromMilliseconds(timeoutMs)
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
@@ -25,6 +25,7 @@ public enum AgentLaunchCaptureTrust {
         "codex": ["codex"],
         "codebuddy": ["codebuddy"],
         "copilot": ["copilot"],
+        "cortex": ["cortex", "coco"],
         "cursor": ["cursor-agent", "cursor"],
         "factory": ["droid", "factory"],
         "gemini": ["gemini"],

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -195,6 +195,8 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: qoderPolicy)
         case "kimi":
             return preserveOptions(args, policy: kimiPolicy)
+        case "cortex":
+            return preserveOptions(args, policy: cortexPolicy)
         case "ollama":
             return OllamaLaunchArgumentsPreserver().preservedArguments(args)
         default:

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
@@ -506,4 +506,143 @@ extension AgentLaunchSanitizer {
             "--list-toolsets"
         ]
     )
+
+    /// Cortex Code (`cortex`). Preserves the Snowflake connection, model, sandbox, and
+    /// config selection so a resumed session lands on the same account and workspace.
+    /// Drops session selectors (cmux appends its own `--resume <id>`), `--goal` /
+    /// `--worktree` payloads that would restart work rather than continue it, and rejects
+    /// the headless shapes (`--print`, stream-json IO) that never resume interactively.
+    static let cortexPolicy = Policy(
+        valueOptions: [
+            "--agent",
+            "--allowed-tools",
+            "-c",
+            "--cloud",
+            "--config",
+            "--config-file",
+            "--connection",
+            "--disallowed-tools",
+            "--effort",
+            "--fork",
+            "--github",
+            "--goal",
+            "--input-format",
+            "-m",
+            "--max-turns",
+            "--mcp-config",
+            "--mode",
+            "--model",
+            "--mount",
+            "-o",
+            "--output-format",
+            "--output-last-message",
+            "-p",
+            "--plugin-dir",
+            "--print",
+            "--profile",
+            "-r",
+            "--resume",
+            "--resume-session-at",
+            "--session-id",
+            "--session-name",
+            "--setting-sources",
+            "--shell",
+            "--skills",
+            "-w",
+            "--with-restricted-session-scope",
+            "--workdir",
+            "--worktree"
+        ],
+        optionalValueOptions: [
+            "--cloud",
+            "-r",
+            "--resume"
+        ],
+        booleanOptions: [
+            "--auto-accept-plans",
+            "--auto-update",
+            "--bypass",
+            "--continue",
+            "--dangerously-allow-all-tool-calls",
+            "--enable-fips",
+            "--fips-status",
+            "--fork-session",
+            "--include-partial-messages",
+            "--index",
+            "--mcp",
+            "--no-auto-update",
+            "--no-enable-fips",
+            "--no-mcp",
+            "--only-explicit-mcp-servers",
+            "--plan",
+            "--private",
+            "--snowflake-sandbox",
+            "--sql-read-only",
+            "--swarm",
+            "--team"
+        ],
+        variadicOptions: [
+            "--allowed-tools",
+            "--disallowed-tools",
+            "--mount",
+            "--plugin-dir"
+        ],
+        nonRestorableCommands: [
+            "acp",
+            "agent-studio",
+            "agents",
+            "airflow",
+            "analyst",
+            "artifact",
+            "automation",
+            "completion",
+            "connections",
+            "conversations",
+            "ctx",
+            "exec",
+            "lineage",
+            "mcp",
+            "profile",
+            "resume",
+            "search",
+            "skill",
+            "swarm",
+            "update",
+            "versions",
+            "worktree"
+        ],
+        droppedOptions: [
+            "--continue",
+            "--fork",
+            "--fork-session",
+            "--goal",
+            "-r",
+            "--resume",
+            "--resume-session-at",
+            "--session-id",
+            "--session-name",
+            "--worktree"
+        ],
+        droppedOptionPrefixes: [
+            "--fork=",
+            "--goal=",
+            "-r=",
+            "--resume=",
+            "--resume-session-at=",
+            "--session-id=",
+            "--session-name=",
+            "--worktree="
+        ],
+        rejectOptions: [
+            "--fips-status",
+            "--include-partial-messages",
+            "--input-format",
+            "-o",
+            "--output-format",
+            "--output-last-message",
+            "-p",
+            "--print",
+            "--swarm"
+        ]
+    )
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -393,6 +393,8 @@ public struct AgentResumeArgv: Sendable, Equatable {
             return withOption("qoder", executable: "qodercli", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "kimi":
             return withOption("kimi", executable: "kimi", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
+        case "cortex":
+            return withOption("cortex", executable: "cortex", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         default:
             return nil
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamSource.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamSource.swift
@@ -17,6 +17,7 @@ public enum WorkstreamSource: String, Codable, Sendable, CaseIterable, Equatable
     case codebuddy
     case factory
     case qoder
+    case cortex
 
     /// Parses a wire-frame `_source` string. Unknown sources fall back to
     /// `nil`; callers should persist the raw string separately when they want

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -243,6 +243,50 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
+    @Test("Preserves Cortex Code connection and sandbox selection while dropping session selectors")
+    func preservesCortexConnectionAndSandboxSelection() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "cortex",
+                    "--connection",
+                    "PROD",
+                    "--model",
+                    "claude-opus-5",
+                    "--cloud",
+                    "DB.SCHEMA.STAGE",
+                    "--resume",
+                    "old-session",
+                    "--session-name",
+                    "old run",
+                    "--goal",
+                    "ship the thing",
+                ],
+                launcher: "cortex",
+                fallbackKind: "cortex"
+            ) == [
+                "cortex",
+                "--connection",
+                "PROD",
+                "--model",
+                "claude-opus-5",
+                "--cloud",
+                "DB.SCHEMA.STAGE",
+            ]
+        )
+    }
+
+    @Test("Rejects headless Cortex Code launches")
+    func rejectsHeadlessCortexLaunches() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["cortex", "--print", "summarize the repo"],
+                launcher: "cortex",
+                fallbackKind: "cortex"
+            ) == nil
+        )
+    }
+
     @Test("Drops Antigravity conversation selectors without replaying prompts")
     func dropsAntigravityConversationSelectorsWithoutReplayingPrompts() {
         #expect(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -16,6 +16,7 @@ struct AgentResumeArgvTests {
         ("codebuddy", "codebuddy", ["codebuddy", "--resume", "SID"]),
         ("factory", "droid", ["droid", "--resume", "SID"]),
         ("qoder", "qodercli", ["qodercli", "--resume", "SID"]),
+        ("cortex", "cortex", ["cortex", "--resume", "SID"]),
     ])
     func builtInWithOptionKinds(kind: String, executable: String, expected: [String]) {
         #expect(

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ cmux hooks setup --agent opencode
 `cmux hooks setup` installs supported agents it can find and prints a summary
 for skipped agents. Supported resume integrations include Claude Code, Codex,
 Grok, OpenCode, Pi, Amp, Cursor CLI, Gemini, Rovo Dev, Copilot, CodeBuddy,
-Factory, and Qoder. Claude Code is handled by the cmux Claude wrapper when Claude
+Factory, Qoder, and Cortex Code. Claude Code is handled by the cmux Claude wrapper when Claude
 integration is enabled in Settings.
 
 Advanced users and integrations can attach a custom resume command to the

--- a/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
+++ b/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
@@ -64,6 +64,7 @@ enum AgentHibernationLifecycleStatusKeys {
         "codebuddy",
         "codex",
         "copilot",
+        "cortex",
         "cursor",
         "factory",
         "gemini",

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -43,6 +43,8 @@ extension CmuxTaskManagerCodingAgentDefinition {
               launchKinds: ["copilot"], directBasenames: ["copilot"], argumentNeedles: ["copilot"]),
         .init(id: "codebuddy", displayName: "CodeBuddy", assetName: nil,
               launchKinds: ["codebuddy"], directBasenames: ["codebuddy"], argumentNeedles: ["codebuddy"]),
+        .init(id: "cortex", displayName: "Cortex Code", assetName: nil,
+              launchKinds: ["cortex"], directBasenames: ["cortex"], argumentNeedles: ["cortex"]),
         .init(id: "factory", displayName: "Factory", assetName: nil,
               launchKinds: ["factory"], directBasenames: ["droid", "factory"], argumentNeedles: ["factory"]),
         .init(id: "qoder", displayName: "Qoder", assetName: nil,

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -19,6 +19,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
     case factory
     case qoder
     case kimi
+    case cortex
     case ollama
     case custom(String)
 
@@ -40,6 +41,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .codebuddy,
         .factory,
         .qoder,
+        .cortex,
         // Kimi and Ollama are registry-owned like Pi/Grok/Antigravity: leaving them
         // out keeps their ids available to pre-existing custom Vault registrations
         // while direct native values still encode.
@@ -65,6 +67,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case "factory": self = .factory
         case "qoder": self = .qoder
         case "kimi": self = .kimi
+        case "cortex": self = .cortex
         case "ollama": self = .ollama
         default:
             guard CmuxVaultAgentRegistration.isValidID(value) else { return nil }
@@ -102,6 +105,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .factory: return "factory"
         case .qoder: return "qoder"
         case .kimi: return "kimi"
+        case .cortex: return "cortex"
         case .ollama: return "ollama"
         case .custom(let id): return id
         }
@@ -132,6 +136,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .codebuddy: return "CodeBuddy"
         case .factory: return "Factory"
         case .qoder: return "Qoder"
+        case .cortex: return "Cortex Code"
         case .kimi:
             return String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code")
         case .ollama:

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -11,7 +11,7 @@ cmux hooks setup --agent <agent>
 cmux hooks uninstall <agent>
 ```
 
-Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, `amp`, `cursor`, `gemini`, `kimi`, `kiro`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, `amp`, `cursor`, `gemini`, `kimi`, `kiro`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, `qoder`, and `cortex`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
 ## Integrations
 
@@ -34,6 +34,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 | Kimi Code | `kimi` | `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
+| Cortex Code | `cortex` | `~/.snowflake/cortex/hooks.json` | `cortex --resume <id>` | PreToolUse |
 
 OpenCode also supports project-local Feed installation:
 
@@ -55,7 +56,7 @@ Grok uses its `Notification` hook for user-facing completion messages. cmux reco
 
 ## Workspace auto-naming
 
-When the opt-in `automation.workspaceAutoNaming` setting is enabled, turn-end hooks also drive AI naming of workspaces and tabs. Supported adapters are Claude Code, Codex, Grok, OpenCode, Pi, and OMP; each adapter gates on the live setting over the socket, reuses the session store above for throttle state, summarizes with that agent's own CLI in a no-tools or isolated headless mode, and never overwrites a name the user set. Gemini, Amp, Cursor, Antigravity, Kiro, Rovo Dev, Hermes Agent, Copilot, CodeBuddy, Factory, and Qoder are skipped until they have both a verified conversation source and a safe cheap non-interactive summarizer runner. See [workspace-auto-naming.md](workspace-auto-naming.md).
+When the opt-in `automation.workspaceAutoNaming` setting is enabled, turn-end hooks also drive AI naming of workspaces and tabs. Supported adapters are Claude Code, Codex, Grok, OpenCode, Pi, and OMP; each adapter gates on the live setting over the socket, reuses the session store above for throttle state, summarizes with that agent's own CLI in a no-tools or isolated headless mode, and never overwrites a name the user set. Gemini, Amp, Cursor, Antigravity, Kiro, Rovo Dev, Hermes Agent, Copilot, CodeBuddy, Factory, Qoder, and Cortex Code are skipped until they have both a verified conversation source and a safe cheap non-interactive summarizer runner. See [workspace-auto-naming.md](workspace-auto-naming.md).
 
 ## Agent Hibernation
 
@@ -155,6 +156,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
 | Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
+| Cortex Code | `CORTEX_HOME` | `CMUX_CORTEX_HOOKS_DISABLED=1` |
 
 Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
 
@@ -163,6 +165,8 @@ OMP uses OMP's native extension system. OMP native extension discovery scans `${
 Campfire ships this integration natively: current campfire versions include a built-in cmux bridge, so no install step is needed (like Claude Code via the cmux wrapper) — `cmux hooks campfire install` exists for older campfire versions, and the installed extension defers to the native bridge when both are present. Campfire embeds vanilla Pi under a `.campfire` white-label, so its extension discovery scans `${CAMPFIRE_CODING_AGENT_DIR:-~/.campfire/agent}/extensions/`. The cmux extension records only the HOST role (`CAMPFIRE_SESSION_ROLE=host`); a joiner is an ephemeral view whose argv carries the invite URL — a capability token that is never persisted or replayed. The extension also subscribes to campfire's in-process observer bridge and surfaces driver-actionable collaborative moments (a joiner waiting in the lobby, a capability ask) as cmux notifications.
 
 Kiro stores hooks inside agent configuration files. The cmux installer creates or updates a `cmux` agent config with lifecycle, tool, and completion hooks; merge the generated `hooks` block into another Kiro agent config if you want the same cmux notifications on that agent.
+
+Cortex Code reads hooks from `~/.snowflake/cortex/hooks.json` (or `$CORTEX_HOME/hooks.json`), whose schema matches Claude Code's, so no launch wrapper is needed — `cortex` picks up the installed hooks on its own. Its `timeout` values are seconds, not milliseconds. Cortex Code runs `Notification` hooks regardless of its own `enableDesktopNotifications` setting, so cmux notifications arrive without a duplicate native banner; on older Cortex Code builds that gate hooks behind that setting, enable **Desktop Notifications** in Cortex Code for the notification hooks to fire.
 
 Kiro Feed verbosity follows **Settings > Automation > Kiro Notification Level** or `automation.kiroNotificationLevel` in `cmux.json`. `minimal` keeps actionable approval cards only, `standard` also keeps mutating tool events, and `verbose` keeps every Kiro tool event.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,6 @@
 # Notifications
 
-cmux provides a notification panel for AI agents like Claude Code, Codex, and OpenCode. Notifications appear in a dedicated panel and trigger macOS system notifications.
+cmux provides a notification panel for AI agents like Claude Code, Codex, Cortex Code, and OpenCode. Notifications appear in a dedicated panel and trigger macOS system notifications.
 
 > For inline permission / plan / question approvals directly from the sidebar (Vibe Island-style), see **[Feed](feed.md)**. `cmux hooks setup` installs the Feed bridge alongside the notification hooks covered below.
 


### PR DESCRIPTION
## Summary

Adds Cortex Code (Snowflake's coding agent CLI, `cortex`) to the agent hook catalog.

Cortex Code reads hooks from `~/.snowflake/cortex/hooks.json` using Claude Code's schema, so it needs no launch wrapper and no bespoke hook subcommand — a single `AgentHookDef` entry wires up notifications, tab status, Feed approvals, and session restore.

Supersedes #752 (prior art by @blackary), which predates the `AgentHookDef` catalog: it added a `Resources/bin/cortex` wrapper plus a `cortex-hook` subcommand and refactored the `ClaudeHook*` internals into generic equivalents. With the catalog in place none of that is needed, and that branch no longer merges cleanly. This version adds no wrapper binary and no new CLI subcommand.

## Details

- **Catalog entry** — `configDir: .snowflake/cortex`, `configFile: hooks.json`, `CORTEX_HOME` override, `CMUX_CORTEX_HOOKS_DISABLED`, `.nested` format. Events: `SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `SessionEnd`.
- **Timeout units** — Cortex Code's hook `timeout` is seconds, not milliseconds, so `cortex` joins `grok` in `nestedHookTimeout` / `nestedFeedHookTimeout`.
- **Feed bridge on `PreToolUse`** — Cortex Code implements Claude's `hookSpecificOutput.permissionDecision` / `permissionDecisionReason` contract for `PreToolUse`, which is exactly what `nonClaudePreToolDecision` already emits, so the existing default path works unmodified. (It also implements the `hookSpecificOutput.decision.behavior` shape on `PermissionRequest`, so moving the bridge to that event later is possible and would fire only on real permission prompts.)
- **Session restore** — `cortex --resume <id>`, plus `RestorableAgentKind.cortex`, the hibernation status key, and a task-manager agent definition.
- **Sanitizer policy** — preserves the Snowflake connection, model, sandbox, and config selection so a resumed session lands on the same account and workspace; drops session selectors and the `--goal` / `--worktree` payloads that would start new work rather than continue it; rejects headless shapes (`--print`, stream-json IO).

## Notes

Current Cortex Code builds run `Notification` hooks independently of their own desktop-notification setting, so cmux notifications arrive without a duplicate native banner. `docs/agent-hooks.md` documents the caveat for older builds that gate hooks behind that setting.

Workspace auto-naming deliberately skips Cortex Code for now, consistent with the existing rule that an adapter needs both a verified conversation source and a safe, cheap non-interactive summarizer.

## Test plan

- [x] `swift test` in `Packages/macOS/CMUXAgentLaunch` — 332 tests pass, including 3 new cases (resume argv, plus two sanitizer cases covering preserved connection/sandbox flags and rejected headless launches)
- [x] `swiftc -parse` on every edited Swift file
- [x] Audited `RestorableAgentKind` switch exhaustiveness — only `RestorableAgentTypes.swift` enumerates its cases, and every arm there is updated
- [x] Verified the emitted config actually loads in Cortex Code: with a `hooks.json` of the shape this installer writes, its loader logs `Loaded hooks from global settings at ~/.snowflake/cortex/hooks.json` and `Loaded hooks (deduplicated): {"UserPromptSubmit":1,"Notification":1}`
- [ ] Full `xcodebuild` not run locally — no Xcode.app on this machine, so the app-target compile is unverified here and I am relying on CI
- [ ] Not yet exercised against a running cmux build: `cmux hooks cortex install`, live notification delivery, a Feed approval round-trip, and quit/relaunch session restore. Happy to iterate on review feedback, or to hand these to someone with a working build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789747750&installation_model_id=21920&pr_number=10433&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10433&signature=1988d271d3c37ffeb199ac7af9fe6741e912147dc1368e812a8cb60b8e2d0938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cortex Code (`cortex`) to the agent hook catalog, enabling notifications, Feed approvals, tab status, and session restore. Cortex reads Claude-compatible hooks from `~/.snowflake/cortex/hooks.json`, so no wrapper or bespoke subcommand is needed.

- Hook catalog: `configDir: .snowflake/cortex`, `configFile: hooks.json`, `CORTEX_HOME` override, disable via `CMUX_CORTEX_HOOKS_DISABLED`; events `SessionStart`, `UserPromptSubmit`, `Stop`, `Notification`, `SessionEnd`; Feed on `PreToolUse`.
- Timeout semantics: treat Cortex hook `timeout` values as seconds in nested hook and Feed paths.
- Session restore: `cortex --resume <id>` wired via `RestorableAgentKind.cortex`, task-manager definition, and resume argv builder.
- Launch sanitizer: preserve connection/model/sandbox selectors; drop session selectors and `--goal`/`--worktree`; reject headless modes (e.g., `--print`).
- CLI/docs: add `cortex` to `cmux hooks` help; docs updated; workspace auto-naming intentionally excluded for Cortex for now.
- Tests: new sanitizer cases (preserve Snowflake context, reject headless) and resume argv case; no changes to other agents.

<sup>Written for commit 868b7886802b32f28c0a5819e078f837e8e7a6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cortex Code as a supported agent.
  * Enabled Cortex Code session resume with preserved launch options.
  * Added Cortex Code lifecycle hooks, notifications, and tool-use event support.
  * Added handling for Cortex Code configuration and environment overrides.
* **Documentation**
  * Updated supported-agent, notification, and hook documentation to include Cortex Code.
* **Bug Fixes**
  * Improved launch argument handling and validation for Cortex Code, including rejection of unsupported headless modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->