### PR TITLE
Fix stale connected computer status after teardown

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9817,17 +9817,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // just-disconnected Mac would keep showing a green connected dot. Downgrade
         // it to `.unavailable` to match the global connection state.
         let offlineDeviceID = offlineForegroundKey.canonicalMacDeviceID
-        let offlineTag = offlineForegroundKey.normalizedInstanceTag
-        for key in Array(workspacesByMac.keys) where
+        let keysToDowngrade = workspacesByMac.keys.filter { key in
             key == offlineForegroundKey
-            || (offlineForegroundKey != .anonymousForeground
-                && key.canonicalMacDeviceID == offlineDeviceID
-                && macInstanceTagAuthority.sameStoredAuthority(key.normalizedInstanceTag, offlineTag)) {
-            guard var offline = workspacesByMac[key] else { continue }
+                || (!preservingOtherMacWorkspaceState
+                    && offlineForegroundKey != .anonymousForeground
+                    && key.canonicalMacDeviceID == offlineDeviceID)
+        }
+        var updatedWorkspacesByMac = workspacesByMac
+        for key in keysToDowngrade {
+            guard var offline = updatedWorkspacesByMac[key] else { continue }
             offline.status = .unavailable
             offline.workspaceGroupsAreAuthoritative = false
-            workspacesByMac[key] = offline
+            updatedWorkspacesByMac[key] = offline
         }
+        workspacesByMac = updatedWorkspacesByMac
         rawTerminalInputBuffer.clear()
         terminalInputRPCPipeline.clear()
         resumeRawTerminalInputDrainWaiters()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9816,10 +9816,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // per-Mac dots) derives from these per-Mac states, so without this the
         // just-disconnected Mac would keep showing a green connected dot. Downgrade
         // it to `.unavailable` to match the global connection state.
-        if var offline = workspacesByMac[offlineForegroundKey] {
+        let offlineDeviceID = offlineForegroundKey.canonicalMacDeviceID
+        let offlineTag = offlineForegroundKey.normalizedInstanceTag
+        for key in Array(workspacesByMac.keys) where
+            key == offlineForegroundKey
+            || (offlineForegroundKey != .anonymousForeground
+                && key.canonicalMacDeviceID == offlineDeviceID
+                && macInstanceTagAuthority.sameStoredAuthority(key.normalizedInstanceTag, offlineTag)) {
+            guard var offline = workspacesByMac[key] else { continue }
             offline.status = .unavailable
             offline.workspaceGroupsAreAuthoritative = false
-            workspacesByMac[offlineForegroundKey] = offline
+            workspacesByMac[key] = offline
         }
         rawTerminalInputBuffer.clear()
         terminalInputRPCPipeline.clear()


### PR DESCRIPTION
The Computers screen derives its green dot from retained per-pairing workspace state. Teardown only downgraded one exact key, so identity adoption or tag normalization could leave a retained key marked connected while the focused workspace shell was already disconnected.

Downgrade all retained states matching the disconnected foreground pairing identity, preserving sibling build connections.

Tested with `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellCompositePairingScopeTests`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789757113&installation_model_id=21920&pr_number=10434&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10434&signature=23bb9dc0061154909913c63e68182435e4e7c3c726281856312d45ce4a99b474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale green dots on the Computers screen after teardown by downgrading all retained workspace entries for the disconnected Mac. Previously only the exact foreground key was downgraded, so other entries sharing the same canonical device ID could stay “connected”.

- In `CmuxMobileShell` teardown, downgrades the exact key and—unless `preservingOtherMacWorkspaceState` is set or the key is `.anonymousForeground`—all `workspacesByMac` entries with the same `canonicalMacDeviceID`; sets status to `.unavailable` and clears authority for each.
- Leaves unrelated Macs and sibling build connections untouched when preservation is enabled.
- Tested with `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellCompositePairingScopeTests`.

<sup>Written for commit 8d2dfaf5799b7e01869f4c056a6f265b6cb77ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline connection handling by consistently marking all matching workspace entries as unavailable when clearing a remote connection.
  * Prevented stale workspace authority information from remaining after an offline connection is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->