### PR TITLE
fix(ios): bake the team-prefixed keychain access group into re-signed TestFlight builds

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -384,14 +384,9 @@ public struct MobileAuthComposition {
     }
 
     private static func keychainAccessGroup(in bundle: Bundle) -> String? {
-        let value = bundle.object(
-            forInfoDictionaryKey: "CMUXKeychainAccessGroup"
-        ) as? String
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let trimmed, !trimmed.isEmpty, !trimmed.contains("$(") else {
-            return nil
-        }
-        return trimmed
+        MobileKeychainAccessGroupPolicy.resolve(
+            bundle.object(forInfoDictionaryKey: "CMUXKeychainAccessGroup") as? String
+        )
     }
 
     /// Parse optional string overrides from a bundled `LocalConfig.plist`.

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2261,7 +2261,7 @@ public final class MobileIrohRuntimeComposition:
         #endif
     }
 
-    private static func keychainAccessGroup(
+    static func keychainAccessGroup(
         infoDictionary: [String: Any]?
     ) -> String? {
         let raw = infoDictionary?["CMUXKeychainAccessGroup"] as? String

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2264,12 +2264,9 @@ public final class MobileIrohRuntimeComposition:
     static func keychainAccessGroup(
         infoDictionary: [String: Any]?
     ) -> String? {
-        let raw = infoDictionary?["CMUXKeychainAccessGroup"] as? String
-        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let trimmed, !trimmed.isEmpty, !trimmed.contains("$(") else {
-            return nil
-        }
-        return trimmed
+        MobileKeychainAccessGroupPolicy.resolve(
+            infoDictionary?["CMUXKeychainAccessGroup"] as? String
+        )
     }
 
     static func initialTransportVerificationMode(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileKeychainAccessGroupPolicy.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileKeychainAccessGroupPolicy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Resolves the keychain access group baked into Info.plist as
+/// `CMUXKeychainAccessGroup` from `$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)`.
+///
+/// An archive built with code signing disabled expands `$(AppIdentifierPrefix)`
+/// to an empty string, baking a team-prefix-less group. The signed
+/// entitlements grant only `TEAMID.bundle-id`, so requesting the prefix-less
+/// group makes every SecItem call fail with errSecMissingEntitlement before a
+/// single broker fetch. Resolving such a value to nil leaves
+/// kSecAttrAccessGroup unset, and SecItem then uses the app's default
+/// entitlement access group, which is the group the signature actually grants.
+enum MobileKeychainAccessGroupPolicy {
+    static func resolve(_ raw: String?) -> String? {
+        guard
+            let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty,
+            !value.contains("$(")
+        else { return nil }
+        let components = value.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+        guard
+            components.count > 1,
+            let team = components.first,
+            team.count == 10,
+            team.allSatisfy({ $0.isASCII && ($0.isUppercase || $0.isNumber) }),
+            components.dropFirst().contains(where: { !$0.isEmpty })
+        else { return nil }
+        return value
+    }
+}

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileKeychainAccessGroupPolicy.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileKeychainAccessGroupPolicy.swift
@@ -26,7 +26,7 @@ enum MobileKeychainAccessGroupPolicy {
             let team = components.first,
             team.count == 10,
             team.allSatisfy({ $0.isASCII && ($0.isUppercase || $0.isNumber) }),
-            components.dropFirst().contains(where: { !$0.isEmpty })
+            components.dropFirst().allSatisfy({ !$0.isEmpty })
         else { return nil }
         return value
     }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
@@ -64,3 +64,36 @@ struct MobileKeychainAccessGroupResolutionTests {
         ) == nil)
     }
 }
+
+/// The auth composition shares the same policy, so both keychain consumers
+/// accept and reject identically.
+@Suite
+struct MobileKeychainAccessGroupPolicyTests {
+    @Test
+    func acceptsDevTagAndProductionGroups() {
+        #expect(MobileKeychainAccessGroupPolicy.resolve(
+            "7WLXT3NR37.dev.cmux.ios.tflex"
+        ) == "7WLXT3NR37.dev.cmux.ios.tflex")
+        #expect(MobileKeychainAccessGroupPolicy.resolve(
+            "7WLXT3NR37.com.cmux.app"
+        ) == "7WLXT3NR37.com.cmux.app")
+    }
+
+    @Test
+    func trimsWhitespaceAroundAValidGroup() {
+        #expect(MobileKeychainAccessGroupPolicy.resolve(
+            " 7WLXT3NR37.dev.cmux.app.beta\n"
+        ) == "7WLXT3NR37.dev.cmux.app.beta")
+    }
+
+    @Test
+    func rejectsPrefixLessNilAndMalformedValues() {
+        #expect(MobileKeychainAccessGroupPolicy.resolve("dev.cmux.app.beta") == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve(nil) == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve("") == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve(".dev.cmux.app.beta") == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve(
+            "$(AppIdentifierPrefix)dev.cmux.app.beta"
+        ) == nil)
+    }
+}

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
@@ -96,4 +96,15 @@ struct MobileKeychainAccessGroupPolicyTests {
             "$(AppIdentifierPrefix)dev.cmux.app.beta"
         ) == nil)
     }
+
+    @Test
+    func rejectsEmptyBundleComponentsAfterTheTeamIdentifier() {
+        // An empty interior or trailing component is a bake gone wrong, not a
+        // grantable group; it must fall back rather than resolve.
+        #expect(MobileKeychainAccessGroupPolicy.resolve("7WLXT3NR37..dev") == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve("7WLXT3NR37.dev.") == nil)
+        #expect(MobileKeychainAccessGroupPolicy.resolve(
+            "7WLXT3NR37.dev..cmux.app.beta"
+        ) == nil)
+    }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileKeychainAccessGroupResolutionTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import cmuxFeature
+
+/// `CMUXKeychainAccessGroup` is baked from
+/// `$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)`. An unsigned archive
+/// build expands the prefix to an empty string, and the signed entitlements
+/// never grant that prefix-less group, so requesting it makes every SecItem
+/// call fail with errSecMissingEntitlement and the transport dies before any
+/// broker fetch. A value without a `TEAMID.` prefix must resolve to nil so
+/// SecItem falls back to the app's default entitlement access group, which is
+/// the exact group the re-signed entitlements grant.
+@MainActor
+@Suite
+struct MobileKeychainAccessGroupResolutionTests {
+    @Test
+    func acceptsTeamPrefixedGroup() {
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: [
+                "CMUXKeychainAccessGroup": "7WLXT3NR37.dev.cmux.app.internal",
+            ]
+        ) == "7WLXT3NR37.dev.cmux.app.internal")
+    }
+
+    @Test
+    func rejectsPrefixLessGroupFromUnsignedArchiveBake() {
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: [
+                "CMUXKeychainAccessGroup": "dev.cmux.app.internal",
+            ]
+        ) == nil)
+    }
+
+    @Test
+    func rejectsUnexpandedEmptyAndAbsentValues() {
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: [
+                "CMUXKeychainAccessGroup": "$(AppIdentifierPrefix)dev.cmux.app.internal",
+            ]
+        ) == nil)
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: ["CMUXKeychainAccessGroup": "  "]
+        ) == nil)
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: nil
+        ) == nil)
+    }
+
+    @Test
+    func rejectsGroupWhoseFirstComponentIsNotATeamIdentifier() {
+        // A ten-character first component must be uppercase alphanumeric to be
+        // a team identifier; lowercase bundle-id-shaped values are bakes gone
+        // wrong, not real groups.
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: [
+                "CMUXKeychainAccessGroup": "abcdefghij.dev.cmux.app.internal",
+            ]
+        ) == nil)
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: ["CMUXKeychainAccessGroup": "7WLXT3NR37."]
+        ) == nil)
+        #expect(MobileIrohRuntimeComposition.keychainAccessGroup(
+            infoDictionary: ["CMUXKeychainAccessGroup": "7WLXT3NR37"]
+        ) == nil)
+    }
+}

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -152,6 +152,16 @@ PY
     rm -rf "$workdir"
     return 1
   fi
+  # The runtime reads CMUXKeychainAccessGroup verbatim for kSecAttrAccessGroup.
+  # An unsigned archive bakes it without the $(AppIdentifierPrefix) team prefix,
+  # a group the signature never grants, which kills every SecItem call at
+  # runtime (silent dead transport). Fail the upload instead of shipping it.
+  plist_keychain_group="$("$PLISTBUDDY" -c 'Print :CMUXKeychainAccessGroup' "$app/Info.plist" 2>/dev/null || true)"
+  if [[ -n "$plist_keychain_group" && "$plist_keychain_group" != "$expected_app_id" ]]; then
+    echo "error: Info.plist CMUXKeychainAccessGroup is '$plist_keychain_group', expected '$expected_app_id' (unsigned-archive AppIdentifierPrefix bake); refusing to upload a keychain-broken build: $app" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
 
   rm -rf "$workdir"
   return 0
@@ -1220,6 +1230,19 @@ PY
     -json "[\"$DEVELOPMENT_TEAM.$PRODUCT_BUNDLE_IDENTIFIER\"]" \
     "$MERGED_ENTITLEMENTS"
   plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
+
+  # The archive is built unsigned, so $(AppIdentifierPrefix) in Info.plist
+  # expanded to an empty string and CMUXKeychainAccessGroup baked as the bare
+  # bundle id. The runtime reads that key verbatim for kSecAttrAccessGroup, and
+  # the entitlements above never grant a prefix-less group, so every SecItem
+  # call fails with errSecMissingEntitlement and the iroh transport dies before
+  # any broker fetch. Rewrite the key to the exact group the entitlements
+  # grant, then sign, so the signature covers the corrected plist.
+  if "$PLISTBUDDY" -c 'Print :CMUXKeychainAccessGroup' "$RESIGN_APP/Info.plist" >/dev/null 2>&1; then
+    "$PLISTBUDDY" -c "Set :CMUXKeychainAccessGroup $DEVELOPMENT_TEAM.$PRODUCT_BUNDLE_IDENTIFIER" \
+      "$RESIGN_APP/Info.plist"
+    echo "Patched CMUXKeychainAccessGroup -> $DEVELOPMENT_TEAM.$PRODUCT_BUNDLE_IDENTIFIER"
+  fi
 
   codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"
 


### PR DESCRIPTION
## Problem

Every iOS TestFlight build cut from main since https://github.com/manaflow-ai/cmux/pull/9183 is keychain-dead on physical devices. #9183 set `CMUXKeychainAccessGroup = $(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)`, but the TestFlight lane archives unsigned (`ios/scripts/upload-testflight.sh` re-signs after export), so the prefix expands empty and the plist bakes the bare bundle id. The re-sign grants `keychain-access-groups = [7WLXT3NR37.<bundle-id>]` while the runtime requests the prefix-less group verbatim, so every SecItem call fails with errSecMissingEntitlement: the iroh identity store dies, the endpoint never starts, and the phone loops `Credentials unavailable` in 0-12 ms with zero broker fetches. Simulators ignore access groups, which is why CI and sim verification never caught it.

Field impact: cmux INTERNAL (auto-built from main) broke for dogfooders the evening #9183 landed; cmux BETA still works only because its shipped build predates the change. Same mechanism as the cloud dev-install fix in https://github.com/manaflow-ai/cmuxterm-hq/pull/310.

## Fix

One policy, three layers:
- `upload-testflight.sh` rewrites `CMUXKeychainAccessGroup` to `$DEVELOPMENT_TEAM.$PRODUCT_BUNDLE_IDENTIFIER` in the exported app before codesign, so the signature covers the corrected plist. `upload-app-store.sh` delegates here, so internal, beta, demo, and App Store lanes are all covered.
- The shared IPA verification fails the upload when the plist group does not equal the signed entitlement group, closing the `--signing automatic` path fail-closed.
- New `MobileKeychainAccessGroupPolicy` rejects any group without a `TEAMID.` prefix at runtime; both the iroh and auth compositions then leave `kSecAttrAccessGroup` unset, and SecItem falls back to the app's default entitlement group, which is the same physical group a correctly-signed build names. Already-shipped mis-baked binaries self-heal on next app update without waiting for a perfect pipeline.

Backwards compatibility: no keychain data moves in any path. Pre-#9183 builds stored items in the default entitlement group (`TEAM.bundle-id`); corrected builds name that group explicitly and hardened runtimes fall back to it, so endpoint identities, bindings, and pairings survive the update with no re-pairing.

## Tests

Two commits so CI proves the tests catch the bug: commit 1 adds failing policy tests (a prefix-less group must resolve to nil; the visibility of one helper changes private→internal for testability only), commit 2 adds the fix. Policy logic additionally verified standalone against all vectors; `bash -n` clean on the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789759841&installation_model_id=21920&pr_number=10435&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10435&signature=7740bf688544f05b418e30695b184c62c724d3b77a2c87bee113e8763a1a4b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS TestFlight builds that lost keychain access by enforcing a team‑prefixed, well‑formed `CMUXKeychainAccessGroup`. Previously, unsigned archives baked a prefix‑less or malformed group, so the app requested an entitlement it didn’t have and every SecItem call failed; now the lane rewrites and verifies the group, and the runtime uses only valid values or falls back safely.

- `ios/scripts/upload-testflight.sh`: rewrites `CMUXKeychainAccessGroup` to `DEVELOPMENT_TEAM.PRODUCT_BUNDLE_IDENTIFIER` before codesign, and hard‑fails upload if the plist group doesn’t match the signed entitlement group. `upload-app-store.sh` already delegates here, so all lanes are covered.
- New `MobileKeychainAccessGroupPolicy.resolve`: accepts only `TEAMID.bundle-id` groups with a 10‑char uppercase alphanumeric team id and all suffix components non‑empty; otherwise returns nil so `kSecAttrAccessGroup` is unset and SecItem uses the app’s default entitlement group. `MobileAuthComposition` and `MobileIrohRuntimeComposition` now use this policy.
- Tests: add acceptance/rejection cases, including empty‑component regressions.
- No migration: keychain items remain in the default entitlement group; existing identities and pairings persist. Mis‑baked installs self‑heal on update.

<sup>Written for commit fe8406c19f3e0a7decbb974248294f0af0281ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of iOS keychain access groups, rejecting missing, malformed, unresolved, empty, or incorrectly prefixed values.
  * Ensured authentication and runtime components resolve valid keychain groups consistently.
  * Prevented TestFlight uploads when the app’s keychain group does not match its expected application identifier.
  * Updated manual signing to apply the entitlement-approved keychain group automatically.
* **Tests**
  * Added coverage for valid, invalid, development, and production keychain group configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->