### PR TITLE
fix: validate ssh-session-attach IDs and owning workspace

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13077,24 +13077,49 @@ struct CMUXCLI {
         if paneOpt != nil, splitOpt != nil {
             throw CLIError(message: "ssh-session-attach: --pane cannot be combined with --split")
         }
-        let workspaceRaw = workspaceOpt ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
-        let workspaceID = try normalizeWorkspaceHandle(workspaceRaw, client: client)
+
+        // Ownership is resolved by the control socket before any surface
+        // mutation. The CLI only forwards the explicit workspace selector and
+        // consumes the authoritative workspace returned by that read.
+        let requestedWorkspaceID = try normalizeWorkspaceHandle(workspaceOpt, client: client)
+        var resolutionParams: [String: Any] = ["session_id": sessionID]
+        if let requestedWorkspaceID {
+            resolutionParams["workspace_id"] = requestedWorkspaceID
+        }
+        let resolution = try client.sendV2(
+            method: "surface.ssh_session_attach.resolve",
+            params: resolutionParams
+        )
+        guard let workspaceID = Self.normalizedEnvValue(resolution["workspace_id"] as? String) else {
+            throw CLIError(message: "ssh-session-attach: control socket returned no owning workspace")
+        }
+        let workspaceRef = Self.normalizedEnvValue(resolution["workspace_ref"] as? String)
+
         let initialCommand = sshSessionAttachStartupCommand(sessionID: sessionID)
         var params: [String: Any] = [
             "initial_command": initialCommand,
             "remote_pty_session_id": sessionID,
+            "workspace_id": workspaceID,
         ]
-        if let workspaceID {
-            params["workspace_id"] = workspaceID
-        }
         try applyFocusOption(focusOpt, defaultValue: true, to: &params)
 
         let payload: [String: Any]
         if let split = splitOpt?.trimmingCharacters(in: .whitespacesAndNewlines),
            !split.isEmpty {
             params["direction"] = split
+            let inheritedSurfaceAnchor: String? = {
+                guard surfaceOpt == nil, workspaceOpt == nil,
+                      let callerWorkspaceID = Self.normalizedEnvValue(
+                          ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
+                      ),
+                      handlesMatch(callerWorkspaceID, workspaceID) ||
+                          (workspaceRef.map { handlesMatch(callerWorkspaceID, $0) } ?? false) else {
+                    return nil
+                }
+                return ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+            }()
             let surfaceID = try normalizeSurfaceHandle(
-                surfaceOpt ?? (workspaceOpt == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil),
+                surfaceOpt ?? inheritedSurfaceAnchor,
                 client: client,
                 workspaceHandle: workspaceID
             )

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -127,6 +127,10 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         // never runs inline on the main thread, and no in-process main-thread
         // caller needs it.
         "surface.read_text",
+        // SSH-session attach resolves ownership and reads the remote PTY
+        // registry before any surface mutation; keep the bounded remote query
+        // off the main actor.
+        "surface.ssh_session_attach.resolve",
         // `workspace.env` is a read that resolves a workspace and copies its
         // env dictionary behind a `v2MainSync` hop, so it runs on the worker
         // lane like the other workspace reads below.

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -38121,13 +38121,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "ssh-session-attach: persisted SSH PTY session state is unavailable"
+            "value": "ssh-session-attach: persisted SSH PTY session state is unavailable. Run 'cmux ssh-session-list --all-workspaces' and retry."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ssh-session-attach: 永続 SSH PTY セッションの状態を利用できません"
+            "value": "ssh-session-attach: 永続 SSH PTY セッションの状態を利用できません。'cmux ssh-session-list --all-workspaces' を実行してから再試行してください。"
           }
         }
       }
@@ -38145,6 +38145,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "ssh-session-attach: セッション '%1$@' はワークスペース %2$@ に属していますが、--workspace では別のワークスペースが指定されました"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachWorkspaceAmbiguous": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: session '%1$@' exists in multiple workspaces (%2$@). Pass --workspace <workspace> to choose one."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: セッション '%1$@' は複数のワークスペース (%2$@) に存在します。--workspace <workspace> で指定してください。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -38098,6 +38098,57 @@
         }
       }
     },
+    "cli.error.sshSessionAttachSessionNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: no persisted SSH PTY session with id '%@'. Run 'cmux ssh-session-list --all-workspaces' to see valid session ids."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: ID '%@' の永続 SSH PTY セッションが見つかりません。有効なセッション ID を確認するには 'cmux ssh-session-list --all-workspaces' を実行してください。"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachStateUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: persisted SSH PTY session state is unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: 永続 SSH PTY セッションの状態を利用できません"
+          }
+        }
+      }
+    },
+    "cli.error.sshSessionAttachWorkspaceMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: session '%1$@' belongs to workspace %2$@, but --workspace requested a different workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ssh-session-attach: セッション '%1$@' はワークスペース %2$@ に属していますが、--workspace では別のワークスペースが指定されました"
+          }
+        }
+      }
+    },
     "cli.error.workspaceLoadingInvalidId": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/TerminalController+SSHSessionAttachContext.swift
+++ b/Sources/TerminalController+SSHSessionAttachContext.swift
@@ -1,0 +1,135 @@
+import CmuxControlSocket
+import Foundation
+
+/// Resolves SSH PTY attach ownership through the same persisted-session payload
+/// used by `workspace.remote.pty_sessions`.
+extension TerminalController {
+    nonisolated func v2SSHSessionAttachResolve(params: [String: Any]) -> V2CallResult {
+        guard let sessionID = (params["session_id"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty else {
+            return .err(
+                code: "invalid_params",
+                message: "ssh-session-attach requires --session-id <id>",
+                data: nil
+            )
+        }
+        let workspaceSelection = v2RequestedRemotePTYWorkspaceID(params: params)
+        if let error = workspaceSelection.error { return error }
+        let registryResult = v2WorkspaceRemotePTYSessions(params: ["all_workspaces": true])
+        return sshSessionAttachV2Result(
+            sessionID: sessionID,
+            requestedWorkspaceID: workspaceSelection.workspaceId,
+            registryResult: registryResult
+        )
+    }
+
+    private nonisolated func sshSessionAttachV2Result(
+        sessionID: String,
+        requestedWorkspaceID: UUID?,
+        registryResult: V2CallResult
+    ) -> V2CallResult {
+        guard case .ok(let rawPayload) = registryResult,
+              let payload = rawPayload as? [String: Any] else {
+            return .err(
+                code: "unavailable",
+                message: sshSessionAttachStateUnavailableMessage(),
+                data: ["session_id": sessionID]
+            )
+        }
+
+        let matchingWorkspaceIDs = matchingSSHSessionWorkspaceIDs(
+            sessionID: sessionID,
+            payload: payload
+        )
+        guard !matchingWorkspaceIDs.isEmpty else {
+            // An absent session is still an invalid attach target even when a
+            // different remote workspace was unavailable during the inventory
+            // read. Keep the error actionable and point callers to the complete
+            // cross-workspace listing command.
+            return .err(
+                code: "not_found",
+                message: sshSessionAttachNotFoundMessage(sessionID: sessionID),
+                data: ["session_id": sessionID]
+            )
+        }
+
+        if let requestedWorkspaceID,
+           !matchingWorkspaceIDs.contains(requestedWorkspaceID) {
+            let owningWorkspaceID = matchingWorkspaceIDs.sorted { $0.uuidString < $1.uuidString }[0]
+            return .err(
+                code: "invalid_params",
+                message: sshSessionAttachWorkspaceMismatchMessage(
+                    sessionID: sessionID,
+                    owningWorkspaceID: owningWorkspaceID
+                ),
+                data: [
+                    "session_id": sessionID,
+                    "owning_workspace_id": owningWorkspaceID.uuidString,
+                ]
+            )
+        }
+
+        guard matchingWorkspaceIDs.count == 1,
+              let workspaceID = matchingWorkspaceIDs.first else {
+            return .err(
+                code: "unavailable",
+                message: sshSessionAttachStateUnavailableMessage(),
+                data: ["session_id": sessionID]
+            )
+        }
+        return .ok([
+            "workspace_id": workspaceID.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceID),
+        ])
+    }
+
+    private nonisolated func matchingSSHSessionWorkspaceIDs(
+        sessionID: String,
+        payload: [String: Any]
+    ) -> Set<UUID> {
+        let sessions = payload["sessions"] as? [[String: Any]] ?? []
+        return Set(
+            sessions.compactMap { session -> UUID? in
+                guard let candidate = (session["session_id"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      candidate == sessionID,
+                      let rawWorkspaceID = session["workspace_id"] as? String else {
+                    return nil
+                }
+                return UUID(uuidString: rawWorkspaceID)
+            }
+        )
+    }
+
+    private nonisolated func sshSessionAttachNotFoundMessage(sessionID: String) -> String {
+        String.localizedStringWithFormat(
+            String(
+                localized: "cli.error.sshSessionAttachSessionNotFound",
+                defaultValue: "ssh-session-attach: no persisted SSH PTY session with id '%@'. Run 'cmux ssh-session-list --all-workspaces' to see valid session ids."
+            ),
+            sessionID
+        )
+    }
+
+    private nonisolated func sshSessionAttachWorkspaceMismatchMessage(
+        sessionID: String,
+        owningWorkspaceID: UUID
+    ) -> String {
+        String.localizedStringWithFormat(
+            String(
+                localized: "cli.error.sshSessionAttachWorkspaceMismatch",
+                defaultValue: "ssh-session-attach: session '%1$@' belongs to workspace %2$@, but --workspace requested a different workspace"
+            ),
+            sessionID,
+            owningWorkspaceID.uuidString
+        )
+    }
+
+    private nonisolated func sshSessionAttachStateUnavailableMessage() -> String {
+        String(
+            localized: "cli.error.sshSessionAttachStateUnavailable",
+            defaultValue: "ssh-session-attach: persisted SSH PTY session state is unavailable"
+        )
+    }
+}

--- a/Sources/TerminalController+SSHSessionAttachContext.swift
+++ b/Sources/TerminalController+SSHSessionAttachContext.swift
@@ -43,20 +43,57 @@ extension TerminalController {
             payload: payload
         )
         guard !matchingWorkspaceIDs.isEmpty else {
-            // An absent session is still an invalid attach target even when a
-            // different remote workspace was unavailable during the inventory
-            // read. Keep the error actionable and point callers to the complete
-            // cross-workspace listing command.
-            return .err(
-                code: "not_found",
-                message: sshSessionAttachNotFoundMessage(sessionID: sessionID),
-                data: ["session_id": sessionID]
-            )
+            let inventoryErrors = payload["errors"] as? [[String: Any]] ?? []
+            if !inventoryErrors.isEmpty,
+               let inferredWorkspaceID = Workspace.parsedDefaultSSHPTYSessionID(sessionID)?.workspaceId,
+               case .ok(let scopedRawPayload) = v2WorkspaceRemotePTYSessions(
+                   params: ["workspace_id": inferredWorkspaceID.uuidString]
+               ),
+               let scopedPayload = scopedRawPayload as? [String: Any] {
+                let scopedMatches = matchingSSHSessionWorkspaceIDs(
+                    sessionID: sessionID,
+                    payload: scopedPayload
+                )
+                if !scopedMatches.isEmpty {
+                    return sshSessionAttachOwnerResult(
+                        sessionID: sessionID,
+                        requestedWorkspaceID: requestedWorkspaceID,
+                        owningWorkspaceIDs: scopedMatches
+                    )
+                }
+            }
+
+            // A partial inventory cannot prove that the session is unknown.
+            // Report unavailable so callers can retry after the remote
+            // workspace reconnects; a complete empty inventory is definitive.
+            return inventoryErrors.isEmpty
+                ? .err(
+                    code: "not_found",
+                    message: sshSessionAttachNotFoundMessage(sessionID: sessionID),
+                    data: ["session_id": sessionID]
+                )
+                : .err(
+                    code: "unavailable",
+                    message: sshSessionAttachStateUnavailableMessage(),
+                    data: ["session_id": sessionID]
+                )
         }
 
+        return sshSessionAttachOwnerResult(
+            sessionID: sessionID,
+            requestedWorkspaceID: requestedWorkspaceID,
+            owningWorkspaceIDs: matchingWorkspaceIDs
+        )
+    }
+
+    private nonisolated func sshSessionAttachOwnerResult(
+        sessionID: String,
+        requestedWorkspaceID: UUID?,
+        owningWorkspaceIDs: Set<UUID>
+    ) -> V2CallResult {
         if let requestedWorkspaceID,
-           !matchingWorkspaceIDs.contains(requestedWorkspaceID) {
-            let owningWorkspaceID = matchingWorkspaceIDs.sorted { $0.uuidString < $1.uuidString }[0]
+           !owningWorkspaceIDs.contains(requestedWorkspaceID) {
+            let owningWorkspaceID = owningWorkspaceIDs.sorted { $0.uuidString < $1.uuidString }[0]
             return .err(
                 code: "invalid_params",
                 message: sshSessionAttachWorkspaceMismatchMessage(
@@ -70,12 +107,27 @@ extension TerminalController {
             )
         }
 
-        guard matchingWorkspaceIDs.count == 1,
-              let workspaceID = matchingWorkspaceIDs.first else {
+        if let requestedWorkspaceID {
+            return .ok([
+                "workspace_id": requestedWorkspaceID.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: requestedWorkspaceID),
+            ])
+        }
+
+        guard owningWorkspaceIDs.count == 1,
+              let workspaceID = owningWorkspaceIDs.first else {
             return .err(
-                code: "unavailable",
-                message: sshSessionAttachStateUnavailableMessage(),
-                data: ["session_id": sessionID]
+                code: "invalid_params",
+                message: sshSessionAttachAmbiguousMessage(
+                    sessionID: sessionID,
+                    owningWorkspaceIDs: owningWorkspaceIDs
+                ),
+                data: [
+                    "session_id": sessionID,
+                    "owning_workspace_ids": owningWorkspaceIDs
+                        .sorted { $0.uuidString < $1.uuidString }
+                        .map(\.uuidString),
+                ]
             )
         }
         return .ok([
@@ -130,6 +182,23 @@ extension TerminalController {
         String(
             localized: "cli.error.sshSessionAttachStateUnavailable",
             defaultValue: "ssh-session-attach: persisted SSH PTY session state is unavailable"
+        )
+    }
+
+    private nonisolated func sshSessionAttachAmbiguousMessage(
+        sessionID: String,
+        owningWorkspaceIDs: Set<UUID>
+    ) -> String {
+        String.localizedStringWithFormat(
+            String(
+                localized: "cli.error.sshSessionAttachWorkspaceAmbiguous",
+                defaultValue: "ssh-session-attach: session '%1$@' exists in multiple workspaces (%2$@). Pass --workspace <workspace> to choose one."
+            ),
+            sessionID,
+            owningWorkspaceIDs
+                .sorted { $0.uuidString < $1.uuidString }
+                .map(\.uuidString)
+                .joined(separator: ", ")
         )
     }
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1503,6 +1503,8 @@ class TerminalController {
             return v2Result(id: request.id, v2SystemMemory(params: request.params))
         case "surface.read_text":
             return v2Result(id: request.id, v2SurfaceReadText(params: request.params))
+        case "surface.ssh_session_attach.resolve":
+            return v2Result(id: request.id, v2SSHSessionAttachResolve(params: request.params))
         case "workspace.env":
             return v2Result(id: request.id, v2WorkspaceEnv(params: request.params))
         case "workspace.remote.pty_sessions":
@@ -4123,7 +4125,7 @@ class TerminalController {
         ])
     }
 
-    private nonisolated func v2RequestedRemotePTYWorkspaceID(params: [String: Any]) -> (
+    nonisolated func v2RequestedRemotePTYWorkspaceID(params: [String: Any]) -> (
         workspaceId: UUID?,
         error: V2CallResult?
     ) {
@@ -4403,7 +4405,7 @@ class TerminalController {
         }
     }
 
-    private nonisolated func v2WorkspaceRemotePTYSessions(params: [String: Any]) -> V2CallResult {
+    nonisolated func v2WorkspaceRemotePTYSessions(params: [String: Any]) -> V2CallResult {
         if v2HasNonNullParam(params, "all_workspaces"), v2Bool(params, "all_workspaces") == nil {
             return .err(code: "invalid_params", message: "Missing or invalid all_workspaces", data: nil)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6397,7 +6397,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
     nonisolated static let remotePTYSessionEnvironmentKey = "CMUX_REMOTE_PTY_SESSION_ID"
 
-    private nonisolated static func parsedDefaultSSHPTYSessionID(_ value: String) -> (workspaceId: UUID, panelId: UUID)? {
+    nonisolated static func parsedDefaultSSHPTYSessionID(_ value: String) -> (workspaceId: UUID, panelId: UUID)? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.hasPrefix("ssh-") else { return nil }
         let suffix = String(trimmed.dropFirst(4))

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2340,6 +2340,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C79470010000000000000003 /* TerminalController+SocketClientCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79470010000000000000004 /* TerminalController+SocketClientCapability.swift */; };
 		A79840030000000000000002 /* TerminalController+SocketConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79840030000000000000001 /* TerminalController+SocketConfiguration.swift */; };
 		C79470020000000000000001 /* TerminalController+SocketListenerRearm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79470020000000000000002 /* TerminalController+SocketListenerRearm.swift */; };
+		C0DE00000000000000000F01 /* TerminalController+SSHSessionAttachContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000F02 /* TerminalController+SSHSessionAttachContext.swift */; };
 		D6212D0C00000000000000D3 /* TerminalController+WindowDockBrowserRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */; };
 		9065A0010000000000000001 /* TerminalController+WindowScreenshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9065A0010000000000000002 /* TerminalController+WindowScreenshotCapture.swift */; };
 		C0DE00000000000000000C84 /* TerminalController+WorkspaceCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C83 /* TerminalController+WorkspaceCreate.swift */; };
@@ -5111,6 +5112,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C79470010000000000000004 /* TerminalController+SocketClientCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketClientCapability.swift"; sourceTree = "<group>"; };
 		A79840030000000000000001 /* TerminalController+SocketConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketConfiguration.swift"; sourceTree = "<group>"; };
 		C79470020000000000000002 /* TerminalController+SocketListenerRearm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketListenerRearm.swift"; sourceTree = "<group>"; };
+		C0DE00000000000000000F02 /* TerminalController+SSHSessionAttachContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SSHSessionAttachContext.swift"; sourceTree = "<group>"; };
 		D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WindowDockBrowserRouting.swift"; sourceTree = "<group>"; };
 		9065A0010000000000000002 /* TerminalController+WindowScreenshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WindowScreenshotCapture.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C83 /* TerminalController+WorkspaceCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WorkspaceCreate.swift"; sourceTree = "<group>"; };
@@ -6747,6 +6749,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C51A73000000000000000302 /* TerminalController+ControlSurfacePanelType.swift */,
 				C0DE00000000000000000C67 /* TerminalController+ControlSurfaceContext3.swift */,
 				C0DE00000000000000000C69 /* TerminalController+ControlSurfaceContext4.swift */,
+				C0DE00000000000000000F02 /* TerminalController+SSHSessionAttachContext.swift */,
 				8126BEEF0000000000000002 /* TerminalController+ControlSurfaceGitContext.swift */,
 				C0DE00000000000000000C85 /* TerminalController+ControlSurfaceDock.swift */,
 				C0DE00000000000000000C51 /* TerminalController+ControlMobileHostContext.swift */,
@@ -10422,6 +10425,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C79470010000000000000003 /* TerminalController+SocketClientCapability.swift in Sources */,
 				A79840030000000000000002 /* TerminalController+SocketConfiguration.swift in Sources */,
 				C79470020000000000000001 /* TerminalController+SocketListenerRearm.swift in Sources */,
+				C0DE00000000000000000F01 /* TerminalController+SSHSessionAttachContext.swift in Sources */,
 				D6212D0C00000000000000D3 /* TerminalController+WindowDockBrowserRouting.swift in Sources */,
 				9065A0010000000000000001 /* TerminalController+WindowScreenshotCapture.swift in Sources */,
 				C0DE00000000000000000C84 /* TerminalController+WorkspaceCreate.swift in Sources */,

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -9,6 +9,60 @@ import Testing
 /// reporting "(0 unexpected)", so a failing test there cannot red the shard.
 @Suite(.serialized)
 struct CLISSHSessionAttachAnchorTests {
+    @Test func unknownSessionIDFailsBeforeCreatingSurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "10",
+                "--focus", "false",
+            ],
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionResolution: .notFound
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(result.stderr.contains("ssh-session-list --all-workspaces"), Comment(rawValue: result.stderr))
+    }
+
+    @Test func knownSessionIDCreatesInOwningWorkspace() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "ssh-test",
+                "--focus", "false",
+            ],
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionResolution: .owner(Self.targetWorkspaceId)
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        let create = try #require(requests.first(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
+        #expect(params["remote_pty_session_id"] as? String == "ssh-test")
+    }
+
+    @Test func explicitWorkspaceThatDoesNotOwnSessionFailsBeforeCreatingSurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "ssh-test",
+                "--workspace", Self.callerWorkspaceId,
+                "--focus", "false",
+            ],
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionResolution: .workspaceMismatch
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
     @Test func splitWithExplicitWorkspaceOmitsCallerEnvSurfaceAnchor() throws {
         let (requests, result) = try runSSHSessionAttach(
             arguments: [
@@ -92,7 +146,8 @@ struct CLISSHSessionAttachAnchorTests {
 
     private func runSSHSessionAttach(
         arguments: [String],
-        responseWorkspaceId: String
+        responseWorkspaceId: String,
+        sessionResolution: SessionResolution = .owner(targetWorkspaceId)
     ) throws -> ([[String: Any]], ProcessRunResult) {
         let socketPath = Self.makeSocketPath("ssh-anchor")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -109,7 +164,34 @@ struct CLISSHSessionAttachAnchorTests {
                 return Self.malformedRequestResponse(raw: line)
             }
             switch method {
-            case "surface.split":
+            case "surface.ssh_session_attach.resolve":
+                switch sessionResolution {
+                case .owner(let workspaceID):
+                    return Self.v2Response(
+                        id: id,
+                        ok: true,
+                        result: ["workspace_id": workspaceID, "workspace_ref": "workspace:4"]
+                    )
+                case .notFound:
+                    return Self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: [
+                            "code": "not_found",
+                            "message": "ssh-session-attach: no persisted SSH PTY session with id '10'. Run 'cmux ssh-session-list --all-workspaces' to see valid session ids.",
+                        ]
+                    )
+                case .workspaceMismatch:
+                    return Self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: [
+                            "code": "invalid_params",
+                            "message": "ssh-session-attach: session 'ssh-test' belongs to another workspace",
+                        ]
+                    )
+                }
+            case "surface.create", "surface.split":
                 return Self.v2Response(
                     id: id,
                     ok: true,
@@ -142,6 +224,12 @@ struct CLISSHSessionAttachAnchorTests {
         #expect(!result.timedOut, Comment(rawValue: result.stderr))
 
         return (try state.requestObjects(), result)
+    }
+
+    private enum SessionResolution: Sendable {
+        case owner(String)
+        case notFound
+        case workspaceMismatch
     }
 
     private func cliEnvironment(socketPath: String) -> [String: String] {

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -63,6 +63,41 @@ struct CLISSHSessionAttachAnchorTests {
         #expect(!methods.contains("surface.split"), Comment(rawValue: methods.joined(separator: ",")))
     }
 
+    @Test func explicitWorkspaceDisambiguatesDuplicateSessionOwnership() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "ssh-test",
+                "--workspace", Self.targetWorkspaceId,
+                "--focus", "false",
+            ],
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionResolution: .duplicate
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stdout + result.stderr))
+        let create = try #require(requests.last(where: { $0["method"] as? String == "surface.create" }))
+        let params = try #require(create["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
+    }
+
+    @Test func partialInventoryFailsAsUnavailableWithoutCreatingSurface() throws {
+        let (requests, result) = try runSSHSessionAttach(
+            arguments: [
+                "ssh-session-attach",
+                "--session-id", "ssh-test",
+                "--focus", "false",
+            ],
+            responseWorkspaceId: Self.targetWorkspaceId,
+            sessionResolution: .partialInventory
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stdout + result.stderr))
+        #expect(result.stderr.contains("ssh-session-list --all-workspaces"), Comment(rawValue: result.stderr))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("surface.create"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
     @Test func splitWithExplicitWorkspaceOmitsCallerEnvSurfaceAnchor() throws {
         let (requests, result) = try runSSHSessionAttach(
             arguments: [
@@ -172,6 +207,7 @@ struct CLISSHSessionAttachAnchorTests {
                   let method = payload["method"] as? String else {
                 return Self.malformedRequestResponse(raw: line)
             }
+            let params = payload["params"] as? [String: Any] ?? [:]
             switch method {
             case "surface.ssh_session_attach.resolve":
                 switch sessionResolution ?? .owner(responseWorkspaceId) {
@@ -197,6 +233,31 @@ struct CLISSHSessionAttachAnchorTests {
                         error: [
                             "code": "invalid_params",
                             "message": "ssh-session-attach: session 'ssh-test' belongs to another workspace",
+                        ]
+                    )
+                case .duplicate:
+                    if params["workspace_id"] as? String == Self.targetWorkspaceId {
+                        return Self.v2Response(
+                            id: id,
+                            ok: true,
+                            result: ["workspace_id": Self.targetWorkspaceId, "workspace_ref": "workspace:4"]
+                        )
+                    }
+                    return Self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: [
+                            "code": "invalid_params",
+                            "message": "ssh-session-attach: session 'ssh-test' exists in multiple workspaces; pass --workspace",
+                        ]
+                    )
+                case .partialInventory:
+                    return Self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: [
+                            "code": "unavailable",
+                            "message": "ssh-session-attach: persisted SSH PTY session state is unavailable. Run 'cmux ssh-session-list --all-workspaces' and retry.",
                         ]
                     )
                 }
@@ -239,6 +300,8 @@ struct CLISSHSessionAttachAnchorTests {
         case owner(String)
         case notFound
         case workspaceMismatch
+        case duplicate
+        case partialInventory
     }
 
     private func cliEnvironment(socketPath: String) -> [String: String] {

--- a/cmuxTests/CLISSHSessionAttachAnchorTests.swift
+++ b/cmuxTests/CLISSHSessionAttachAnchorTests.swift
@@ -77,9 +77,12 @@ struct CLISSHSessionAttachAnchorTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(
+            methods == ["surface.ssh_session_attach.resolve", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
         #expect(params["direction"] as? String == "right")
         #expect(params["remote_pty_session_id"] as? String == "ssh-test")
@@ -101,9 +104,12 @@ struct CLISSHSessionAttachAnchorTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(
+            methods == ["surface.ssh_session_attach.resolve", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.targetWorkspaceId)
         #expect(params["surface_id"] as? String == Self.targetSurfaceId)
     }
@@ -121,9 +127,12 @@ struct CLISSHSessionAttachAnchorTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["surface.split"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(
+            methods == ["surface.ssh_session_attach.resolve", "surface.split"],
+            Comment(rawValue: methods.joined(separator: ","))
+        )
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
+        let params = try #require(requests.last?["params"] as? [String: Any])
         #expect(params["workspace_id"] as? String == Self.callerWorkspaceId)
         #expect(params["surface_id"] as? String == Self.callerSurfaceId)
     }
@@ -147,7 +156,7 @@ struct CLISSHSessionAttachAnchorTests {
     private func runSSHSessionAttach(
         arguments: [String],
         responseWorkspaceId: String,
-        sessionResolution: SessionResolution = .owner(targetWorkspaceId)
+        sessionResolution: SessionResolution? = nil
     ) throws -> ([[String: Any]], ProcessRunResult) {
         let socketPath = Self.makeSocketPath("ssh-anchor")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -165,7 +174,7 @@ struct CLISSHSessionAttachAnchorTests {
             }
             switch method {
             case "surface.ssh_session_attach.resolve":
-                switch sessionResolution {
+                switch sessionResolution ?? .owner(responseWorkspaceId) {
                 case .owner(let workspaceID):
                     return Self.v2Response(
                         id: id,


### PR DESCRIPTION
## Summary

- Resolve `ssh-session-attach` session ownership in the control-socket worker before creating or splitting a surface.
- Reject unknown session IDs with an actionable `cmux ssh-session-list --all-workspaces` hint and no surface side effect.
- Route valid attaches to the owning workspace and reject explicit workspace mismatches.
- Preserve split focus/anchor behavior, while ignoring an inherited caller anchor when the session belongs elsewhere.
- Add regression coverage in a tests-first commit, wire the new app extension, and localize the new English/Japanese error messages.

Closes https://github.com/manaflow-ai/cmux/issues/10323

## Validation

- `swiftc -parse` on changed Swift files
- `swift test --package-path Packages/macOS/CmuxControlSocket --filter ControlCommandExecutionPolicyTests`
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 tests/test_ci_cmux_unit_test_shard.py`
- `Resources/Localizable.xcstrings` JSON parse
- No local Xcode build or app launch (per issue instructions)
