### PR TITLE
Fix Codex Teams app-server process leaks

### DIFF
--- a/CLI/CodexTeamsAppServerProcess.swift
+++ b/CLI/CodexTeamsAppServerProcess.swift
@@ -1,103 +1,323 @@
 import Darwin
 import Foundation
 
-/// Owns the app-server process launched for one `cmux codex-teams` session.
+/// Owns the app-server process launched for one Codex Teams session.
 ///
-/// The lifetime handle is deliberately separate from the process object. The
-/// app-server is often a Node launcher whose native child can outlive the
-/// launcher when the launcher receives a fatal signal, so the second commit in
-/// this change replaces the direct `Process` launch with a process-group
-/// supervisor while keeping this ownership seam stable.
+/// Codex is commonly installed through a Node launcher. Killing that launcher
+/// alone does not reliably kill its native child, so the app-server is started
+/// in a private process group with two parent-lifetime watchdogs. One channel
+/// belongs to the launching CLI and one belongs to the watcher; either process
+/// disappearing sends SIGTERM to the complete group, allowing the Node launcher
+/// to forward the signal and the native app-server to shut down cleanly.
 final class CodexTeamsAppServerProcess {
-    private let process: Process
+    private let processIdentifierValue: pid_t
     private let lifetimePipe: Pipe
+    private let watcherLifetimePipe: Pipe
+    private var watcherLifetimeTransferred = false
+    private var cachedTerminationStatus: Int32? = nil
     private var didCloseLifetime = false
 
     init(
+        supervisorExecutablePath: String,
         executablePath: String,
         arguments: [String],
         environment: [String: String]?,
         logURL: URL?
     ) throws {
-        let process = Process()
-        if executablePath.hasPrefix("/") {
-            process.executableURL = URL(fileURLWithPath: executablePath)
-            process.arguments = arguments
-        } else {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [executablePath] + arguments
-        }
-        process.currentDirectoryURL = URL(
-            fileURLWithPath: FileManager.default.currentDirectoryPath,
-            isDirectory: true
-        )
-        process.environment = environment
-
         let lifetimePipe = Pipe()
-        process.standardInput = lifetimePipe.fileHandleForReading
-        if let logURL {
-            let descriptor = Darwin.open(
-                logURL.path,
-                O_WRONLY | O_CREAT | O_TRUNC | O_APPEND,
-                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+        let readFD = lifetimePipe.fileHandleForReading.fileDescriptor
+        let writeFD = lifetimePipe.fileHandleForWriting.fileDescriptor
+        let watcherLifetimePipe = Pipe()
+        let watcherReadFD = watcherLifetimePipe.fileHandleForReading.fileDescriptor
+        let watcherWriteFD = watcherLifetimePipe.fileHandleForWriting.fileDescriptor
+        var fileActions: posix_spawn_file_actions_t?
+        let fileActionsStatus = posix_spawn_file_actions_init(&fileActions)
+        guard fileActionsStatus == 0 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "initialize Codex Teams process actions", code: fileActionsStatus)
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawn_file_actions_adddup2(&fileActions, readFD, STDIN_FILENO),
+            operation: "connect Codex Teams lifetime pipe"
+        )
+        if readFD != STDIN_FILENO {
+            try CodexTeamsPOSIXSupport.require(
+                posix_spawn_file_actions_addclose(&fileActions, readFD),
+                operation: "close Codex Teams lifetime read end"
             )
-            guard descriptor >= 0 else {
-                throw NSError(
-                    domain: "CodexTeamsAppServerProcess",
-                    code: Int(errno),
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Failed to open Codex Teams log "
-                            + logURL.path
-                            + ": "
-                            + String(cString: strerror(errno))
-                    ]
-                )
-            }
-            let logHandle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
-            process.standardOutput = logHandle
-            process.standardError = logHandle
-        } else {
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
+        }
+        if writeFD > STDERR_FILENO {
+            try CodexTeamsPOSIXSupport.require(
+                posix_spawn_file_actions_addclose(&fileActions, writeFD),
+                operation: "close Codex Teams lifetime write end"
+            )
+        }
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawn_file_actions_adddup2(
+                &fileActions,
+                watcherReadFD,
+                CodexTeamsPOSIXSupport.watcherLifetimeFileDescriptor
+            ),
+            operation: "connect Codex Teams watcher lifetime pipe"
+        )
+        if watcherReadFD != CodexTeamsPOSIXSupport.watcherLifetimeFileDescriptor {
+            try CodexTeamsPOSIXSupport.require(
+                posix_spawn_file_actions_addclose(&fileActions, watcherReadFD),
+                operation: "close Codex Teams watcher lifetime read end"
+            )
+        }
+        if watcherWriteFD > STDERR_FILENO,
+           watcherWriteFD != CodexTeamsPOSIXSupport.watcherLifetimeFileDescriptor {
+            try CodexTeamsPOSIXSupport.require(
+                posix_spawn_file_actions_addclose(&fileActions, watcherWriteFD),
+                operation: "close Codex Teams watcher lifetime write end"
+            )
         }
 
-        try process.run()
+        if let logURL {
+            try CodexTeamsPOSIXSupport.require(
+                logURL.path.withCString {
+                    posix_spawn_file_actions_addopen(
+                        &fileActions,
+                        STDOUT_FILENO,
+                        $0,
+                        O_WRONLY | O_CREAT | O_TRUNC | O_APPEND,
+                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+                    )
+                },
+                operation: "redirect Codex Teams stdout"
+            )
+            try CodexTeamsPOSIXSupport.require(
+                logURL.path.withCString {
+                    posix_spawn_file_actions_addopen(
+                        &fileActions,
+                        STDERR_FILENO,
+                        $0,
+                        O_WRONLY | O_CREAT | O_APPEND,
+                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+                    )
+                },
+                operation: "redirect Codex Teams stderr"
+            )
+        } else {
+            try CodexTeamsPOSIXSupport.require(
+                "/dev/null".withCString {
+                    posix_spawn_file_actions_addopen(
+                        &fileActions,
+                        STDOUT_FILENO,
+                        $0,
+                        O_WRONLY,
+                        0
+                    )
+                },
+                operation: "redirect Codex Teams stdout"
+            )
+            try CodexTeamsPOSIXSupport.require(
+                "/dev/null".withCString {
+                    posix_spawn_file_actions_addopen(
+                        &fileActions,
+                        STDERR_FILENO,
+                        $0,
+                        O_WRONLY,
+                        0
+                    )
+                },
+                operation: "redirect Codex Teams stderr"
+            )
+        }
+
+        var attributes: posix_spawnattr_t?
+        let attributesStatus = posix_spawnattr_init(&attributes)
+        guard attributesStatus == 0 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "initialize Codex Teams process attributes", code: attributesStatus)
+        }
+        defer { posix_spawnattr_destroy(&attributes) }
+        let flags = Int16(
+            POSIX_SPAWN_CLOEXEC_DEFAULT
+                | POSIX_SPAWN_SETPGROUP
+                | POSIX_SPAWN_START_SUSPENDED
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawnattr_setflags(&attributes, flags),
+            operation: "configure Codex Teams process group"
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawnattr_setpgroup(&attributes, 0),
+            operation: "configure Codex Teams process group leader"
+        )
+
+        let targetExecutable = executablePath.hasPrefix("/") ? executablePath : "/usr/bin/env"
+        let targetArguments = executablePath.hasPrefix("/")
+            ? arguments
+            : [executablePath] + arguments
+        let supervisorExecutable = supervisorExecutablePath.hasPrefix("/")
+            ? supervisorExecutablePath
+            : "/usr/bin/env"
+        let supervisorArguments = supervisorExecutablePath.hasPrefix("/")
+            ? ["__codex-teams-app-server-supervisor", targetExecutable] + targetArguments
+            : [
+                supervisorExecutablePath,
+                "__codex-teams-app-server-supervisor",
+                targetExecutable
+            ] + targetArguments
+        let argv = [supervisorExecutable] + supervisorArguments
+        var mergedEnvironment = ProcessInfo.processInfo.environment
+        for (key, value) in environment ?? [:] {
+            mergedEnvironment[key] = value
+        }
+        let environmentStrings = mergedEnvironment
+            .map { "\($0.key)=\($0.value)" }
+            .sorted()
+
+        var processIdentifier: pid_t = 0
+        let spawnStatus = try CodexTeamsPOSIXSupport.withCStringArray(argv) { argvPointer in
+            try CodexTeamsPOSIXSupport.withCStringArray(environmentStrings) { environmentPointer in
+                supervisorExecutable.withCString { executablePointer in
+                    posix_spawn(
+                        &processIdentifier,
+                        executablePointer,
+                        &fileActions,
+                        &attributes,
+                        argvPointer,
+                        environmentPointer
+                    )
+                }
+            }
+        }
+        guard spawnStatus == 0 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "launch Codex Teams app-server", code: spawnStatus)
+        }
+        guard processIdentifier > 1 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "launch Codex Teams app-server", code: EINVAL)
+        }
+        guard getpgid(processIdentifier) == processIdentifier else {
+            _ = Darwin.kill(processIdentifier, SIGKILL)
+            _ = waitpid(processIdentifier, nil, 0)
+            throw CodexTeamsPOSIXSupport.error(
+                operation: "isolate Codex Teams app-server process group",
+                code: EPERM
+            )
+        }
+
         try? lifetimePipe.fileHandleForReading.close()
-        self.process = process
+        try? watcherLifetimePipe.fileHandleForReading.close()
+        guard Darwin.kill(processIdentifier, SIGCONT) == 0 else {
+            _ = Darwin.kill(-processIdentifier, SIGKILL)
+            _ = waitpid(processIdentifier, nil, 0)
+            throw CodexTeamsPOSIXSupport.error(
+                operation: "resume Codex Teams app-server",
+                code: errno
+            )
+        }
+        self.processIdentifierValue = processIdentifier
         self.lifetimePipe = lifetimePipe
+        self.watcherLifetimePipe = watcherLifetimePipe
     }
 
     var processIdentifier: pid_t {
-        process.processIdentifier
+        processIdentifierValue
     }
 
-    var isRunning: Bool {
-        process.isRunning
-    }
-
-    var terminationStatus: Int32 {
-        process.terminationStatus
-    }
-
-    /// Closes the parent-owned lifetime signal without otherwise touching the
-    /// child. This is the boundary exercised when the launching CLI dies.
+    /// Closes the launcher-owned lifetime signal.
     func closeParentLifetimeForTesting() {
         closeParentLifetime()
     }
 
-    func terminate() {
-        closeParentLifetime()
-        guard process.isRunning else { return }
-        process.terminate()
+    /// Closes the watcher-owned lifetime signal.
+    func closeWatcherLifetimeForTesting() {
+        closeWatcherLifetime()
     }
 
-    func waitUntilExit() {
-        process.waitUntilExit()
+    /// Transfers the watcher lifetime endpoint to the watcher process.
+    func takeWatcherLifetimeWriteHandle() -> FileHandle {
+        watcherLifetimeTransferred = true
+        return watcherLifetimePipe.fileHandleForWriting
+    }
+
+    var isRunning: Bool {
+        guard cachedTerminationStatus == nil else { return false }
+        var status: Int32 = 0
+        let result = waitpid(processIdentifierValue, &status, WNOHANG)
+        if result == processIdentifierValue {
+            cachedTerminationStatus = Self.decodedTerminationStatus(status)
+            return false
+        }
+        if result == -1, errno == ECHILD {
+            cachedTerminationStatus = -1
+            return false
+        }
+        return true
+    }
+
+    func terminate() {
+        closeParentLifetime()
+        closeWatcherLifetime()
+    }
+
+    @discardableResult
+    func waitUntilExit(timeout: TimeInterval = 2) -> Bool {
+        guard cachedTerminationStatus == nil else { return true }
+        let queue = kqueue()
+        guard queue >= 0 else { return false }
+        defer { close(queue) }
+        var registration = kevent(
+            ident: UInt(processIdentifierValue),
+            filter: Int16(EVFILT_PROC),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_ONESHOT),
+            fflags: UInt32(NOTE_EXIT),
+            data: 0,
+            udata: nil
+        )
+        guard kevent(queue, &registration, 1, nil, 0, nil) == 0 else {
+            if errno != ESRCH { return false }
+            return reapBlocking()
+        }
+        let deadline = ProcessInfo.processInfo.systemUptime + max(0, timeout)
+        while true {
+            let remaining = deadline - ProcessInfo.processInfo.systemUptime
+            guard remaining > 0 else { return false }
+            var timeoutSpec = timespec(
+                tv_sec: Int(remaining),
+                tv_nsec: Int((remaining - floor(remaining)) * 1_000_000_000)
+            )
+            var event = kevent()
+            let result = kevent(queue, nil, 0, &event, 1, &timeoutSpec)
+            if result > 0 {
+                return reapBlocking()
+            }
+            if result == 0 { return false }
+            if errno == EINTR { continue }
+            return false
+        }
+    }
+
+    func forceTerminate() {
+        closeParentLifetime()
+        closeWatcherLifetime()
+        guard cachedTerminationStatus == nil else { return }
+        _ = Darwin.kill(-processIdentifierValue, SIGKILL)
+        _ = waitUntilExit(timeout: 2)
+    }
+
+    private func reapBlocking() -> Bool {
+        var status: Int32 = 0
+        while true {
+            let result = waitpid(processIdentifierValue, &status, 0)
+            if result == processIdentifierValue {
+                cachedTerminationStatus = Self.decodedTerminationStatus(status)
+                return true
+            }
+            if result == -1, errno == EINTR {
+                continue
+            }
+            cachedTerminationStatus = -1
+            return false
+        }
     }
 
     deinit {
-        terminate()
+        forceTerminate()
     }
 
     private func closeParentLifetime() {
@@ -105,4 +325,18 @@ final class CodexTeamsAppServerProcess {
         didCloseLifetime = true
         try? lifetimePipe.fileHandleForWriting.close()
     }
+
+    private func closeWatcherLifetime() {
+        guard !watcherLifetimeTransferred else { return }
+        try? watcherLifetimePipe.fileHandleForWriting.close()
+    }
+
+    private static func decodedTerminationStatus(_ rawStatus: Int32) -> Int32 {
+        let signal = rawStatus & 0x7f
+        if signal == 0 {
+            return (rawStatus >> 8) & 0xff
+        }
+        return 128 + signal
+    }
+
 }

--- a/CLI/CodexTeamsAppServerProcess.swift
+++ b/CLI/CodexTeamsAppServerProcess.swift
@@ -1,0 +1,108 @@
+import Darwin
+import Foundation
+
+/// Owns the app-server process launched for one `cmux codex-teams` session.
+///
+/// The lifetime handle is deliberately separate from the process object. The
+/// app-server is often a Node launcher whose native child can outlive the
+/// launcher when the launcher receives a fatal signal, so the second commit in
+/// this change replaces the direct `Process` launch with a process-group
+/// supervisor while keeping this ownership seam stable.
+final class CodexTeamsAppServerProcess {
+    private let process: Process
+    private let lifetimePipe: Pipe
+    private var didCloseLifetime = false
+
+    init(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String]?,
+        logURL: URL?
+    ) throws {
+        let process = Process()
+        if executablePath.hasPrefix("/") {
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [executablePath] + arguments
+        }
+        process.currentDirectoryURL = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath,
+            isDirectory: true
+        )
+        process.environment = environment
+
+        let lifetimePipe = Pipe()
+        process.standardInput = lifetimePipe.fileHandleForReading
+        if let logURL {
+            let descriptor = Darwin.open(
+                logURL.path,
+                O_WRONLY | O_CREAT | O_TRUNC | O_APPEND,
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
+            )
+            guard descriptor >= 0 else {
+                throw NSError(
+                    domain: "CodexTeamsAppServerProcess",
+                    code: Int(errno),
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Failed to open Codex Teams log "
+                            + logURL.path
+                            + ": "
+                            + String(cString: strerror(errno))
+                    ]
+                )
+            }
+            let logHandle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+            process.standardOutput = logHandle
+            process.standardError = logHandle
+        } else {
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+        }
+
+        try process.run()
+        try? lifetimePipe.fileHandleForReading.close()
+        self.process = process
+        self.lifetimePipe = lifetimePipe
+    }
+
+    var processIdentifier: pid_t {
+        process.processIdentifier
+    }
+
+    var isRunning: Bool {
+        process.isRunning
+    }
+
+    var terminationStatus: Int32 {
+        process.terminationStatus
+    }
+
+    /// Closes the parent-owned lifetime signal without otherwise touching the
+    /// child. This is the boundary exercised when the launching CLI dies.
+    func closeParentLifetimeForTesting() {
+        closeParentLifetime()
+    }
+
+    func terminate() {
+        closeParentLifetime()
+        guard process.isRunning else { return }
+        process.terminate()
+    }
+
+    func waitUntilExit() {
+        process.waitUntilExit()
+    }
+
+    deinit {
+        terminate()
+    }
+
+    private func closeParentLifetime() {
+        guard !didCloseLifetime else { return }
+        didCloseLifetime = true
+        try? lifetimePipe.fileHandleForWriting.close()
+    }
+}

--- a/CLI/CodexTeamsAppServerSupervisor.swift
+++ b/CLI/CodexTeamsAppServerSupervisor.swift
@@ -1,0 +1,283 @@
+import Darwin
+import Foundation
+
+/// Runs one Codex app-server in an isolated process group until either owner disappears.
+struct CodexTeamsAppServerSupervisor {
+    private static let graceTimerIdentifier: UInt = 1
+    /// Genuine shutdown grace deadline, delivered by EVFILT_TIMER rather than polling.
+    private static let gracefulTerminationMilliseconds: Int = 1_000
+
+    private let executablePath: String
+    private let arguments: [String]
+
+    init(arguments: [String]) throws {
+        guard let executablePath = arguments.first, !executablePath.isEmpty else {
+            throw CodexTeamsPOSIXSupport.error(operation: "missing target executable", code: EINVAL)
+        }
+        self.executablePath = executablePath
+        self.arguments = Array(arguments.dropFirst())
+    }
+
+    func run() throws -> Int32 {
+        let processIdentifier = try spawnTarget()
+        let queue = kqueue()
+        guard queue >= 0 else {
+            Self.forceTerminateAndReap(processIdentifier)
+            throw CodexTeamsPOSIXSupport.error(operation: "create event queue", code: errno)
+        }
+        defer { close(queue) }
+
+        do {
+            try Self.registerLifetime(
+                fileDescriptor: STDIN_FILENO,
+                queue: queue
+            )
+            try Self.registerLifetime(
+                fileDescriptor: CodexTeamsPOSIXSupport.watcherLifetimeFileDescriptor,
+                queue: queue
+            )
+            try Self.registerExit(
+                processIdentifier: processIdentifier,
+                queue: queue
+            )
+            guard Darwin.kill(processIdentifier, SIGCONT) == 0 else {
+                throw CodexTeamsPOSIXSupport.error(operation: "resume target", code: errno)
+            }
+            let rawStatus = try Self.observe(
+                processIdentifier: processIdentifier,
+                queue: queue
+            )
+            return Self.decodedTerminationStatus(rawStatus)
+        } catch {
+            Self.forceTerminateAndReap(processIdentifier)
+            throw error
+        }
+    }
+
+    private func spawnTarget() throws -> pid_t {
+        var fileActions: posix_spawn_file_actions_t?
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawn_file_actions_init(&fileActions),
+            operation: "initialize target file actions"
+        )
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        try CodexTeamsPOSIXSupport.require(
+            "/dev/null".withCString {
+                posix_spawn_file_actions_addopen(
+                    &fileActions,
+                    STDIN_FILENO,
+                    $0,
+                    O_RDONLY,
+                    0
+                )
+            },
+            operation: "redirect target stdin"
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawn_file_actions_addinherit_np(
+                &fileActions,
+                STDOUT_FILENO
+            ),
+            operation: "inherit target stdout"
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawn_file_actions_addinherit_np(
+                &fileActions,
+                STDERR_FILENO
+            ),
+            operation: "inherit target stderr"
+        )
+
+        var attributes: posix_spawnattr_t?
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawnattr_init(&attributes),
+            operation: "initialize target attributes"
+        )
+        defer { posix_spawnattr_destroy(&attributes) }
+        let flags = Int16(
+            POSIX_SPAWN_CLOEXEC_DEFAULT
+                | POSIX_SPAWN_SETPGROUP
+                | POSIX_SPAWN_START_SUSPENDED
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawnattr_setflags(&attributes, flags),
+            operation: "configure target process group"
+        )
+        try CodexTeamsPOSIXSupport.require(
+            posix_spawnattr_setpgroup(&attributes, 0),
+            operation: "configure target group leader"
+        )
+
+        let argv = [executablePath] + arguments
+        let environment = ProcessInfo.processInfo.environment
+            .map { "\($0.key)=\($0.value)" }
+            .sorted()
+        var processIdentifier: pid_t = 0
+        let spawnStatus = try CodexTeamsPOSIXSupport.withCStringArray(argv) { argvPointer in
+            try CodexTeamsPOSIXSupport.withCStringArray(environment) { environmentPointer in
+                executablePath.withCString { executablePointer in
+                    posix_spawn(
+                        &processIdentifier,
+                        executablePointer,
+                        &fileActions,
+                        &attributes,
+                        argvPointer,
+                        environmentPointer
+                    )
+                }
+            }
+        }
+        guard spawnStatus == 0 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "launch target", code: spawnStatus)
+        }
+        guard processIdentifier > 1 else {
+            throw CodexTeamsPOSIXSupport.error(operation: "launch target", code: EINVAL)
+        }
+        guard getpgid(processIdentifier) == processIdentifier else {
+            _ = Darwin.kill(processIdentifier, SIGKILL)
+            _ = Self.reap(processIdentifier)
+            throw CodexTeamsPOSIXSupport.error(operation: "isolate target process group", code: EPERM)
+        }
+        return processIdentifier
+    }
+
+    private static func observe(
+        processIdentifier: pid_t,
+        queue: Int32
+    ) throws -> Int32 {
+        var terminationStarted = false
+        var exitObserved = false
+        var forceKillSent = false
+
+        while true {
+            var event = kevent()
+            let count = kevent(queue, nil, 0, &event, 1, nil)
+            if count < 0 {
+                if errno == EINTR { continue }
+                throw CodexTeamsPOSIXSupport.error(operation: "wait for supervisor event", code: errno)
+            }
+            guard count == 1 else { continue }
+            if (event.flags & UInt16(EV_ERROR)) != 0 {
+                throw CodexTeamsPOSIXSupport.error(
+                    operation: "receive supervisor event",
+                    code: event.data == 0 ? EIO : Int32(event.data)
+                )
+            }
+
+            switch Int32(event.filter) {
+            case EVFILT_READ:
+                if !terminationStarted {
+                    var byte: UInt8 = 0
+                    let readResult = Darwin.read(Int32(event.ident), &byte, 1)
+                    let didReachEOF = (event.flags & UInt16(EV_EOF)) != 0 || readResult == 0
+                    guard didReachEOF else { continue }
+                    terminationStarted = true
+                    _ = Darwin.close(Int32(event.ident))
+                    _ = Darwin.kill(-processIdentifier, SIGTERM)
+                    try registerGraceTimer(queue: queue)
+                }
+            case EVFILT_PROC:
+                exitObserved = true
+                if !terminationStarted {
+                    terminationStarted = true
+                    _ = Darwin.kill(-processIdentifier, SIGTERM)
+                    try registerGraceTimer(queue: queue)
+                }
+            case EVFILT_TIMER:
+                // Keep the leader unreaped until this deadline so its process
+                // group id cannot be reused while descendants are cleaned up.
+                forceKillSent = true
+                _ = Darwin.kill(-processIdentifier, SIGKILL)
+            default:
+                continue
+            }
+
+            if exitObserved, !forceKillSent,
+               Darwin.kill(-processIdentifier, 0) != 0,
+               errno == ESRCH {
+                return reap(processIdentifier)
+            }
+            if exitObserved, forceKillSent {
+                return reap(processIdentifier)
+            }
+        }
+    }
+
+    private static func registerLifetime(
+        fileDescriptor: Int32,
+        queue: Int32
+    ) throws {
+        var event = kevent(
+            ident: UInt(fileDescriptor),
+            filter: Int16(EVFILT_READ),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_CLEAR),
+            fflags: 0,
+            data: 0,
+            udata: nil
+        )
+        try register(event: &event, queue: queue, operation: "register lifetime")
+    }
+
+    private static func registerExit(
+        processIdentifier: pid_t,
+        queue: Int32
+    ) throws {
+        var event = kevent(
+            ident: UInt(processIdentifier),
+            filter: Int16(EVFILT_PROC),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_ONESHOT),
+            fflags: UInt32(NOTE_EXIT),
+            data: 0,
+            udata: nil
+        )
+        try register(event: &event, queue: queue, operation: "register target exit")
+    }
+
+    private static func registerGraceTimer(queue: Int32) throws {
+        var event = kevent(
+            ident: graceTimerIdentifier,
+            filter: Int16(EVFILT_TIMER),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_ONESHOT),
+            fflags: 0,
+            data: gracefulTerminationMilliseconds,
+            udata: nil
+        )
+        try register(event: &event, queue: queue, operation: "register termination deadline")
+    }
+
+    private static func register(
+        event: inout kevent,
+        queue: Int32,
+        operation: String
+    ) throws {
+        while kevent(queue, &event, 1, nil, 0, nil) != 0 {
+            if errno == EINTR { continue }
+            throw CodexTeamsPOSIXSupport.error(operation: operation, code: errno)
+        }
+    }
+
+    private static func forceTerminateAndReap(_ processIdentifier: pid_t) {
+        guard processIdentifier > 1 else { return }
+        _ = Darwin.kill(-processIdentifier, SIGKILL)
+        _ = reap(processIdentifier)
+    }
+
+    private static func reap(_ processIdentifier: pid_t) -> Int32 {
+        var status: Int32 = 0
+        while true {
+            let result = waitpid(processIdentifier, &status, 0)
+            if result == processIdentifier { return status }
+            if result == -1, errno == EINTR { continue }
+            return -1
+        }
+    }
+
+    private static func decodedTerminationStatus(_ rawStatus: Int32) -> Int32 {
+        let signal = rawStatus & 0x7f
+        if signal == 0 {
+            return (rawStatus >> 8) & 0xff
+        }
+        return 128 + signal
+    }
+
+}

--- a/CLI/CodexTeamsPOSIXSupport.swift
+++ b/CLI/CodexTeamsPOSIXSupport.swift
@@ -1,0 +1,51 @@
+import Darwin
+import Foundation
+
+/// Shared POSIX plumbing for the Codex Teams launcher and supervisor.
+struct CodexTeamsPOSIXSupport {
+    static let watcherLifetimeFileDescriptor: Int32 = 9
+
+    static func require(
+        _ status: Int32,
+        operation: String
+    ) throws {
+        guard status == 0 else {
+            throw error(operation: operation, code: status)
+        }
+    }
+
+    /// Returns a system-localized POSIX error; operation labels stay out of CLI
+    /// output so internal process topology is not disclosed to callers.
+    static func error(operation: String, code: Int32) -> POSIXError {
+        _ = operation
+        return POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+    }
+
+    static func withCStringArray<Result>(
+        _ strings: [String],
+        _ body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> Result
+    ) throws -> Result {
+        var pointers: [UnsafeMutablePointer<CChar>?] = []
+        pointers.reserveCapacity(strings.count + 1)
+        defer {
+            for pointer in pointers {
+                if let pointer {
+                    free(pointer)
+                }
+            }
+        }
+        for string in strings {
+            guard !string.utf8.contains(0), let pointer = strdup(string) else {
+                throw error(operation: "encode process arguments", code: EINVAL)
+            }
+            pointers.append(pointer)
+        }
+        pointers.append(nil)
+        return try pointers.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                throw error(operation: "encode process arguments", code: EINVAL)
+            }
+            return try body(baseAddress)
+        }
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22450,7 +22450,7 @@ struct CMUXCLI {
 
         let appServerLogURL = codexTeamsLogURL(port: appServerPort, name: "app-server")
         let watcherLogURL = codexTeamsLogURL(port: appServerPort, name: "watcher")
-        let appServer = try startCodexTeamsProcess(
+        let appServer = try CodexTeamsAppServerProcess(
             executablePath: codexExecutablePath,
             arguments: ["app-server", "--listen", appServerURL],
             environment: launcherEnvironment,
@@ -22565,6 +22565,7 @@ struct CMUXCLI {
         restoreRootCodexForegroundIfNeeded()
         codexTeamsTerminateProcess(watcher)
         codexTeamsTerminateProcess(appServer)
+        appServer.waitUntilExit()
         exit(status)
     }
 
@@ -22838,6 +22839,10 @@ struct CMUXCLI {
     private func codexTeamsTerminateProcess(_ process: Process?) {
         guard let process, process.isRunning else { return }
         process.terminate()
+    }
+
+    private func codexTeamsTerminateProcess(_ process: CodexTeamsAppServerProcess?) {
+        process?.terminate()
     }
 
     private func runCodexTeamsWatcher(commandArgs: [String], client: SocketClient, socketPassword: String?) throws {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3689,6 +3689,10 @@ struct CMUXCLI {
 
         let command = args[index]
         let rawCommandArgs = Array(args[(index + 1)...])
+        if command == "__codex-teams-app-server-supervisor" {
+            let status = try CodexTeamsAppServerSupervisor(arguments: rawCommandArgs).run()
+            exit(status)
+        }
         if command == "coderouter" || command == "cr" {
             try runCoderouterAlias(commandArgs: rawCommandArgs)
             return
@@ -22450,7 +22454,9 @@ struct CMUXCLI {
 
         let appServerLogURL = codexTeamsLogURL(port: appServerPort, name: "app-server")
         let watcherLogURL = codexTeamsLogURL(port: appServerPort, name: "watcher")
+        let launchExecutable = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
         let appServer = try CodexTeamsAppServerProcess(
+            supervisorExecutablePath: launchExecutable,
             executablePath: codexExecutablePath,
             arguments: ["app-server", "--listen", appServerURL],
             environment: launcherEnvironment,
@@ -22486,7 +22492,6 @@ struct CMUXCLI {
         }
         setenv("CMUX_CODEX_TEAMS_APP_SERVER_URL", appServerURL, 1)
         setenv("CMUX_CODEX_TEAMS_MAX_AUTO_DEPTH", String(Self.codexTeamsMaxAutoDepth), 1)
-        let launchExecutable = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
         let launchArguments = [launchExecutable, "codex-teams"] + commandArgs
         exportAgentLaunchCommandEnvironment(
             launcher: "codexTeams",
@@ -22551,21 +22556,26 @@ struct CMUXCLI {
         if let rootPid = rootCodex?.processIdentifier {
             watcherArguments += ["--owner-pid", String(rootPid)]
         }
-        watcherArguments += ["--app-server-pid", String(appServer.processIdentifier)]
-
-        watcher = try startCodexTeamsProcess(
-            executablePath: executablePath,
-            arguments: watcherArguments,
-            environment: launcherEnvironment,
-            logURL: watcherLogURL
-        )
+        let watcherLifetime = appServer.takeWatcherLifetimeWriteHandle()
+        do {
+            watcher = try startCodexTeamsProcess(
+                executablePath: executablePath,
+                arguments: watcherArguments,
+                environment: launcherEnvironment,
+                logURL: watcherLogURL,
+                standardInput: watcherLifetime
+            )
+        } catch {
+            try? watcherLifetime.close()
+            throw error
+        }
+        try? watcherLifetime.close()
 
         rootCodex?.waitUntilExit()
         let status = rootCodex?.terminationStatus ?? 0
         restoreRootCodexForegroundIfNeeded()
         codexTeamsTerminateProcess(watcher)
         codexTeamsTerminateProcess(appServer)
-        appServer.waitUntilExit()
         exit(status)
     }
 
@@ -22842,7 +22852,11 @@ struct CMUXCLI {
     }
 
     private func codexTeamsTerminateProcess(_ process: CodexTeamsAppServerProcess?) {
-        process?.terminate()
+        guard let process else { return }
+        process.terminate()
+        if !process.waitUntilExit(timeout: 2) {
+            process.forceTerminate()
+        }
     }
 
     private func runCodexTeamsWatcher(commandArgs: [String], client: SocketClient, socketPassword: String?) throws {
@@ -22852,8 +22866,7 @@ struct CMUXCLI {
         let (codexPath, rem3) = parseOption(rem2, name: "--codex-path")
         let (launchPath, rem4) = parseOption(rem3, name: "--launch-path")
         let (maxDepthRaw, rem5a) = parseOption(rem4, name: "--max-auto-depth")
-        let (ownerPidRaw, rem5) = parseOption(rem5a, name: "--owner-pid")
-        let (appServerPidRaw, remaining) = parseOption(rem5, name: "--app-server-pid")
+        let (ownerPidRaw, remaining) = parseOption(rem5a, name: "--owner-pid")
         if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
             throw CLIError(message: "__codex-teams-watch: unknown flag '\(unknown)'")
         }
@@ -22869,12 +22882,10 @@ struct CMUXCLI {
         let codexExecutable = codexPath?.trimmingCharacters(in: .whitespacesAndNewlines)
         let maxDepth = Int(maxDepthRaw ?? "") ?? Self.codexTeamsMaxAutoDepth
         let ownerPid = ownerPidRaw.flatMap { Int32($0) } ?? 0
-        let appServerPid = appServerPidRaw.flatMap { Int32($0) } ?? 0
 
         var ownerSource: DispatchSourceProcess?
         if ownerPid > 0 {
             if !codexTeamsProcessExists(ownerPid) {
-                if appServerPid > 0 { kill(appServerPid, SIGTERM) }
                 return
             }
             let source = DispatchSource.makeProcessSource(
@@ -22883,9 +22894,6 @@ struct CMUXCLI {
                 queue: DispatchQueue.global(qos: .utility)
             )
             source.setEventHandler {
-                if appServerPid > 0 {
-                    kill(appServerPid, SIGTERM)
-                }
                 exit(0)
             }
             source.resume()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -909,6 +909,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DEBACC0000000000000001 /* CodexTeamsAppServerFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBACC0000000000000004 /* CodexTeamsAppServerFixture.swift */; };
+		A10240010000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */; };
+		A10240030000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */; };
+		A10240040000000000000001 /* CodexTeamsAppServerProcessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240050000000000000001 /* CodexTeamsAppServerProcessTests.swift */; };
 		C0DEBACC0000000000000003 /* CodexTeamsResumedBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */; };
 		C0DEBACC0000000000000002 /* CodexTeamsSocketFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */; };
 		C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */; };
@@ -3698,6 +3701,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexRolloutIdentityResolver.swift; sourceTree = "<group>"; };
 		C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsApprovalBridge.swift; sourceTree = "<group>"; };
 		C0DEBACC0000000000000004 /* CodexTeamsAppServerFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerFixture.swift; sourceTree = "<group>"; };
+		A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerProcess.swift; sourceTree = "<group>"; };
+		A10240050000000000000001 /* CodexTeamsAppServerProcessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerProcessTests.swift; sourceTree = "<group>"; };
 		C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsResumedBackfillTests.swift; sourceTree = "<group>"; };
 		C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsSocketFixture.swift; sourceTree = "<group>"; };
 		C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalErrorNotificationTests.swift; sourceTree = "<group>"; };
@@ -7758,7 +7763,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B900002CA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift */,
 					B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */,
 					B9000065A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */,
-					B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */,
+				B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */,
+				A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */,
 					C0DE64950000000000000002 /* CMUXCLI+SessionsList.swift */,
 					C0DE64960000000000000006 /* CMUXCLI+SessionsListClaudeWorkflow.swift */,
 					C0DE64950000000000000008 /* CMUXCLI+SessionsListForkDiagnostics.swift */,
@@ -8135,6 +8141,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */,
 				A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */,
 				C0DEBACC0000000000000004 /* CodexTeamsAppServerFixture.swift */,
+				A10240050000000000000001 /* CodexTeamsAppServerProcessTests.swift */,
 				C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */,
 				C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */,
 				773600000000000000000002 /* CLIWindowCommandMockServer.swift */,
@@ -9436,6 +9443,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */,
 					C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */,
 					C8711D000000000000000002 /* CodexRolloutIdentityResolver.swift in Sources */,
+				A10240030000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */,
 				C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */,
 				C0DE86060000000000000001 /* CommandPaletteFocusRestoreCoordinator.swift in Sources */,
 				C0DEFF200000000000000001 /* CommandPaletteOverlay.swift in Sources */,
@@ -10831,7 +10839,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C08672010000000000000001 /* CMUXCLI+PiExtensionSourceDispatch.swift in Sources */,
 						C05555010000000000000005 /* CMUXCLI+PiExtensionSourcePart1.swift in Sources */,
 						C05555010000000000000007 /* CMUXCLI+PiExtensionSourcePart2.swift in Sources */,
-						B9000054A1B2C3D4E5F60719 /* CMUXCLI+Process.swift in Sources */,
+					B9000054A1B2C3D4E5F60719 /* CMUXCLI+Process.swift in Sources */,
 				C73660010000000000000001 /* CMUXCLI+RemotePTYErrors.swift in Sources */,
 					REE0CA0000000000000000C2 /* CMUXCLI+Remotes.swift in Sources */,
 				925800000000000000000002 /* CMUXCLI+Restore.swift in Sources */,
@@ -10876,6 +10884,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				918100000000000000000061 /* CodexHookUserInputCandidate.swift in Sources */,
 				918100000000000000000091 /* CodexMonitorOwnerState.swift in Sources */,
 				C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */,
+					A10240010000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */,
 				918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */,
 				918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */,
 				918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */,
@@ -11200,6 +11209,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D96290010000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
 				C0DEBACC0000000000000001 /* CodexTeamsAppServerFixture.swift in Sources */,
+				A10240040000000000000001 /* CodexTeamsAppServerProcessTests.swift in Sources */,
 				C0DEBACC0000000000000003 /* CodexTeamsResumedBackfillTests.swift in Sources */,
 				C0DEBACC0000000000000002 /* CodexTeamsSocketFixture.swift in Sources */,
 				C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -912,6 +912,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A10240010000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */; };
 		A10240030000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */; };
 		A10240040000000000000001 /* CodexTeamsAppServerProcessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240050000000000000001 /* CodexTeamsAppServerProcessTests.swift */; };
+		A10240060000000000000001 /* CodexTeamsAppServerSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240070000000000000001 /* CodexTeamsAppServerSupervisor.swift */; };
+		A10240080000000000000001 /* CodexTeamsPOSIXSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240090000000000000001 /* CodexTeamsPOSIXSupport.swift */; };
+		A10240100000000000000001 /* CodexTeamsPOSIXSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10240090000000000000001 /* CodexTeamsPOSIXSupport.swift */; };
 		C0DEBACC0000000000000003 /* CodexTeamsResumedBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */; };
 		C0DEBACC0000000000000002 /* CodexTeamsSocketFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */; };
 		C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */; };
@@ -3703,6 +3706,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DEBACC0000000000000004 /* CodexTeamsAppServerFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerFixture.swift; sourceTree = "<group>"; };
 		A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerProcess.swift; sourceTree = "<group>"; };
 		A10240050000000000000001 /* CodexTeamsAppServerProcessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerProcessTests.swift; sourceTree = "<group>"; };
+		A10240070000000000000001 /* CodexTeamsAppServerSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsAppServerSupervisor.swift; sourceTree = "<group>"; };
+		A10240090000000000000001 /* CodexTeamsPOSIXSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsPOSIXSupport.swift; sourceTree = "<group>"; };
 		C0DEBACC0000000000000006 /* CodexTeamsResumedBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsResumedBackfillTests.swift; sourceTree = "<group>"; };
 		C0DEBACC0000000000000005 /* CodexTeamsSocketFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsSocketFixture.swift; sourceTree = "<group>"; };
 		C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalErrorNotificationTests.swift; sourceTree = "<group>"; };
@@ -7765,6 +7770,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					B9000065A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */,
 				B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */,
 				A10240020000000000000001 /* CodexTeamsAppServerProcess.swift */,
+				A10240070000000000000001 /* CodexTeamsAppServerSupervisor.swift */,
+				A10240090000000000000001 /* CodexTeamsPOSIXSupport.swift */,
 					C0DE64950000000000000002 /* CMUXCLI+SessionsList.swift */,
 					C0DE64960000000000000006 /* CMUXCLI+SessionsListClaudeWorkflow.swift */,
 					C0DE64950000000000000008 /* CMUXCLI+SessionsListForkDiagnostics.swift */,
@@ -9444,6 +9451,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */,
 					C8711D000000000000000002 /* CodexRolloutIdentityResolver.swift in Sources */,
 				A10240030000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */,
+				A10240100000000000000001 /* CodexTeamsPOSIXSupport.swift in Sources */,
 				C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */,
 				C0DE86060000000000000001 /* CommandPaletteFocusRestoreCoordinator.swift in Sources */,
 				C0DEFF200000000000000001 /* CommandPaletteOverlay.swift in Sources */,
@@ -10885,6 +10893,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				918100000000000000000091 /* CodexMonitorOwnerState.swift in Sources */,
 				C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */,
 					A10240010000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */,
+					A10240060000000000000001 /* CodexTeamsAppServerSupervisor.swift in Sources */,
+					A10240080000000000000001 /* CodexTeamsPOSIXSupport.swift in Sources */,
 				918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */,
 				918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */,
 				918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */,

--- a/cmuxTests/CodexTeamsAppServerProcessTests.swift
+++ b/cmuxTests/CodexTeamsAppServerProcessTests.swift
@@ -1,0 +1,95 @@
+import Darwin
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct CodexTeamsAppServerProcessTests {
+    @Test("closing the launcher lifetime terminates the app-server process tree")
+    func closingLauncherLifetimeTerminatesProcessTree() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "cmux-codex-teams-process-" + UUID().uuidString,
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parentMarker = root.appendingPathComponent("parent")
+        let childMarker = root.appendingPathComponent("child")
+        let childPIDMarker = root.appendingPathComponent("child-pid")
+        let script = """
+        echo \"$$\" > \"$CMUX_CODEX_PARENT_MARKER\"
+        /bin/sh -c 'echo \"$$\" > \"$CMUX_CODEX_CHILD_MARKER\"; while :; do /bin/sleep 1; done' &
+        child=$!
+        echo \"$child\" > \"$CMUX_CODEX_CHILD_PID_MARKER\"
+        wait \"$child\"
+        """
+        let process = try CodexTeamsAppServerProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", script],
+            environment: [
+                "CMUX_CODEX_PARENT_MARKER": parentMarker.path,
+                "CMUX_CODEX_CHILD_MARKER": childMarker.path,
+                "CMUX_CODEX_CHILD_PID_MARKER": childPIDMarker.path,
+                "PATH": "/usr/bin:/bin",
+            ],
+            logURL: nil
+        )
+        defer {
+            process.terminate()
+            process.waitUntilExit()
+            if let childPID = Self.readPID(from: childPIDMarker) {
+                _ = Darwin.kill(childPID, SIGKILL)
+            }
+        }
+
+        _ = try await Self.waitForPIDMarker(parentMarker)
+        let childPID = try #require(await Self.waitForPIDMarker(childPIDMarker))
+        _ = try await Self.waitForPIDMarker(childMarker)
+
+        process.closeParentLifetimeForTesting()
+
+        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        while ContinuousClock().now < deadline,
+              process.isRunning || Self.processExists(childPID) {
+            try await ContinuousClock().sleep(for: .milliseconds(20))
+        }
+
+        #expect(!process.isRunning)
+        #expect(!Self.processExists(childPID))
+    }
+
+    private static func waitForPIDMarker(_ url: URL) async throws -> Int32? {
+        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        while ContinuousClock().now < deadline {
+            if let pid = readPID(from: url) {
+                return pid
+            }
+            try await ContinuousClock().sleep(for: .milliseconds(20))
+        }
+        return nil
+    }
+
+    private static func readPID(from url: URL) -> Int32? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8),
+              let pid = Int32(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+              pid > 1 else {
+            return nil
+        }
+        return pid
+    }
+
+    private static func processExists(_ pid: Int32) -> Bool {
+        guard pid > 1 else { return false }
+        if Darwin.kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+}

--- a/cmuxTests/CodexTeamsAppServerProcessTests.swift
+++ b/cmuxTests/CodexTeamsAppServerProcessTests.swift
@@ -31,6 +31,7 @@ struct CodexTeamsAppServerProcessTests {
         wait \"$child\"
         """
         let process = try CodexTeamsAppServerProcess(
+            supervisorExecutablePath: try bundledCLIPath(),
             executablePath: "/bin/sh",
             arguments: ["-c", script],
             environment: [
@@ -43,15 +44,14 @@ struct CodexTeamsAppServerProcessTests {
         )
         defer {
             process.terminate()
-            process.waitUntilExit()
-            if let childPID = Self.readPID(from: childPIDMarker) {
-                _ = Darwin.kill(childPID, SIGKILL)
+            if !process.waitUntilExit() {
+                process.forceTerminate()
             }
         }
 
-        _ = try await Self.waitForPIDMarker(parentMarker)
+        _ = try #require(await Self.waitForPIDMarker(parentMarker))
         let childPID = try #require(await Self.waitForPIDMarker(childPIDMarker))
-        _ = try await Self.waitForPIDMarker(childMarker)
+        _ = try #require(await Self.waitForPIDMarker(childMarker))
 
         process.closeParentLifetimeForTesting()
 
@@ -92,4 +92,30 @@ struct CodexTeamsAppServerProcessTests {
         }
         return errno == EPERM
     }
+
+    private func bundledCLIPath() throws -> String {
+        let appBundleURL = Bundle(for: BundleToken.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let cliURL = appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux", isDirectory: false)
+        guard FileManager.default.isExecutableFile(atPath: cliURL.path) else {
+            throw NSError(
+                domain: "CodexTeamsAppServerProcessTests",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Bundled cmux CLI not found at \(cliURL.path)"
+                ]
+            )
+        }
+        return cliURL.path
+    }
+
+    private final class BundleToken {}
 }


### PR DESCRIPTION
Closes #10240

## Summary

`cmux codex-teams` previously launched the app-server through a Node wrapper using a plain `Foundation.Process`. If the launcher or workspace terminal disappeared, the wrapper could die while the native Codex child remained reparented to launchd. The watcher also signaled only a numeric wrapper PID.

This change:
- starts each Codex Teams app-server through a dedicated internal cmux supervisor and a private POSIX process group
- gives the supervisor separate launcher and watcher lifetime pipes; either owner disappearing triggers EOF-driven cleanup, with kqueue SIGTERM grace and bounded SIGKILL fallback/reaping
- transfers watcher ownership through its stdin, eliminating watcher PID-reuse races
- bounds the launcher-side wait and preserves target exit status
- adds shared POSIX spawn plumbing and a behavior regression test that launches a parent/child process tree and verifies lifetime closure removes both processes

## Verification

- Hosted macOS `test-e2e.yml`: `cmuxTests/CodexTeamsAppServerProcessTests` passed (1 test, 1 suite) on the final SHA
- `swiftc -typecheck CLI/CodexTeamsPOSIXSupport.swift CLI/CodexTeamsAppServerProcess.swift CLI/CodexTeamsAppServerSupervisor.swift`
- `swiftc -parse CLI/cmux.swift` and the regression test
- `scripts/check-pbxproj.sh`
- `python3 scripts/normalize-pbxproj.py --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- standalone POSIX supervisor smoke checks for launcher and watcher lifetime closure

The unrelated pre-existing `vendor/bonsplit` worktree modification was not included in the commits.