### PR TITLE
Fix Option-only shortcut bindings for arrows and text

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -47,22 +47,25 @@ func browserOmnibarNormalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NS
         .subtracting([.numericPad, .function, .capsLock])
 }
 
-/// Returns whether a key-down event has Option as its only primary modifier.
-/// Shift may still be present; Command and Control opt the event out of the
-/// Option-text routing policy.
-func shortcutRoutingIsOptionOnly(_ event: NSEvent) -> Bool {
-    guard event.type == .keyDown else { return false }
-    let normalizedFlags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
-    return normalizedFlags.contains(.option)
-        && !normalizedFlags.contains(.command)
-        && !normalizedFlags.contains(.control)
+/// Policy decisions shared by the window and text-input shortcut routers.
+enum ShortcutRoutingPolicy {
+    /// Returns whether a key-down event has Option as its only primary modifier.
+    /// Shift may still be present; Command and Control opt the event out of the
+    /// Option-text routing policy.
+    static func isOptionOnly(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+        let normalizedFlags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
+        return normalizedFlags.contains(.option)
+            && !normalizedFlags.contains(.command)
+            && !normalizedFlags.contains(.control)
+    }
 }
 
 func shortcutRoutingShouldBypassForPrintableOptionText(
     event: NSEvent,
     textInputCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.textInputCharacter(forKeyCode:modifierFlags:)
 ) -> Bool {
-    guard shortcutRoutingIsOptionOnly(event) else { return false }
+    guard ShortcutRoutingPolicy.isOptionOnly(event) else { return false }
 
     if shortcutRoutingTextIsPrintable(event.characters) {
         return true

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -47,17 +47,22 @@ func browserOmnibarNormalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NS
         .subtracting([.numericPad, .function, .capsLock])
 }
 
+/// Returns whether a key-down event has Option as its only primary modifier.
+/// Shift may still be present; Command and Control opt the event out of the
+/// Option-text routing policy.
+func shortcutRoutingIsOptionOnly(_ event: NSEvent) -> Bool {
+    guard event.type == .keyDown else { return false }
+    let normalizedFlags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
+    return normalizedFlags.contains(.option)
+        && !normalizedFlags.contains(.command)
+        && !normalizedFlags.contains(.control)
+}
+
 func shortcutRoutingShouldBypassForPrintableOptionText(
     event: NSEvent,
     textInputCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.textInputCharacter(forKeyCode:modifierFlags:)
 ) -> Bool {
-    guard event.type == .keyDown else { return false }
-    let normalizedFlags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
-    guard normalizedFlags.contains(.option),
-          !normalizedFlags.contains(.command),
-          !normalizedFlags.contains(.control) else {
-        return false
-    }
+    guard shortcutRoutingIsOptionOnly(event) else { return false }
 
     if shortcutRoutingTextIsPrintable(event.characters) {
         return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -18082,12 +18082,20 @@ private extension NSWindow {
             return true
         }
         let browserWebKitKeyDownReentry = firstResponderWebView != nil && cmuxBrowserWebKitKeyDownDispatchIsActive()
-        if shortcutRoutingShouldBypassForPrintableOptionText(event: event) {
+        let shouldBypassPrintableOptionText = shortcutRoutingShouldBypassForPrintableOptionText(event: event)
+        // AppKit can send Option-only keys through a text/terminal fast path
+        // before the normal menu route. Give the shared configured-shortcut
+        // dispatcher first ownership for every Option-only event; an unmatched
+        // printable event still takes the text-input branch below.
+        if shortcutRoutingIsOptionOnly(event),
+           !browserWebKitKeyDownReentry,
+           !firstResponderHasMarkedText,
+           !(firstResponderGhosttyView?.hasMarkedText() ?? false),
+           AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
+            return true
+        }
+        if shouldBypassPrintableOptionText {
             if browserWebKitKeyDownReentry { return false }
-            if !firstResponderHasMarkedText,
-               AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
-                return true
-            }
             let textInputTarget: NSResponder? = firstResponderGhosttyView
                 ?? firstResponderWebView
                 ?? self.firstResponder

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -18087,7 +18087,7 @@ private extension NSWindow {
         // before the normal menu route. Give the shared configured-shortcut
         // dispatcher first ownership for every Option-only event; an unmatched
         // printable event still takes the text-input branch below.
-        if shortcutRoutingIsOptionOnly(event),
+        if ShortcutRoutingPolicy.isOptionOnly(event),
            !browserWebKitKeyDownReentry,
            !firstResponderHasMarkedText,
            !(firstResponderGhosttyView?.hasMarkedText() ?? false),

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1659,7 +1659,7 @@ struct ShortcutStroke: Equatable, Hashable {
         }
 
         let shortcutKey = key.lowercased()
-        if Self.usesDirectKeyCodeMatching(shortcutKey) {
+        if Self.usesPhysicalKeyCodeMatching(shortcutKey) {
             guard let expectedKeyCode = self.keyCode ?? Self.keyCodeForShortcutKey(shortcutKey) else {
                 return false
             }
@@ -1978,6 +1978,18 @@ struct ShortcutStroke: Equatable, Hashable {
 
     private static func usesDirectKeyCodeMatching(_ key: String) -> Bool {
         key == "\t" || key == "space" || functionKeyDisplayString(for: key) != nil || key.hasPrefix("media.")
+    }
+
+    /// Arrow glyphs are persisted by name in hand-written config, but AppKit
+    /// reports them as private-use function-key characters. Match their stable
+    /// physical key codes without changing the bare-key recording policy.
+    private static func usesPhysicalKeyCodeMatching(_ key: String) -> Bool {
+        switch key {
+        case "←", "→", "↓", "↑":
+            return true
+        default:
+            return usesDirectKeyCodeMatching(key)
+        }
     }
 
     private static func functionKeyDisplayString(for key: String) -> String? {

--- a/cmuxTests/AppDelegateOptionDigitShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateOptionDigitShortcutRoutingTests.swift
@@ -35,6 +35,146 @@ private final class MarkedOptionTextView: NSTextView {
 struct AppDelegateOptionDigitShortcutRoutingTests {
 #if DEBUG
     @Test
+    func fileConfiguredOptionOnlyArrowBindingsRouteBeforeTerminalFallback() throws {
+        try withIsolatedShortcutRoutingState {
+            let appDelegate = try #require(AppDelegate.shared)
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
+
+            let testWindow = try #require(self.window(withId: windowId))
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            let firstWorkspace = try #require(manager.selectedWorkspace)
+            let secondWorkspace = manager.addTab(select: false)
+            manager.selectTab(at: 0)
+
+            let terminalPanelId = try #require(firstWorkspace.focusedPanelId)
+            let terminalPanel = try #require(firstWorkspace.terminalPanel(for: terminalPanelId))
+            terminalPanel.hostedView.setVisibleInUI(true)
+            terminalPanel.hostedView.setActive(true)
+            terminalPanel.hostedView.moveFocus()
+            testWindow.makeKeyAndOrderFront(nil)
+            testWindow.displayIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            #expect(terminalPanel.hostedView.isSurfaceViewFirstResponder())
+
+            let settingsFileURL = try writeShortcutSettingsFile(bindings: [
+                "nextSidebarTab": "opt+↓",
+                "prevSidebarTab": "opt+↑",
+            ])
+            defer { try? FileManager.default.removeItem(at: settingsFileURL) }
+            KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+            appDelegate.debugResetShortcutRoutingStateForTesting()
+
+            let nextEvent = try #require(makeKeyEvent(
+                modifierFlags: [.option],
+                characters: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+                charactersIgnoringModifiers: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+                keyCode: 125,
+                windowNumber: testWindow.windowNumber
+            ))
+            let previousEvent = try #require(makeKeyEvent(
+                modifierFlags: [.option],
+                characters: String(UnicodeScalar(NSUpArrowFunctionKey)!),
+                charactersIgnoringModifiers: String(UnicodeScalar(NSUpArrowFunctionKey)!),
+                keyCode: 126,
+                windowNumber: testWindow.windowNumber
+            ))
+
+            #expect(appDelegate.debugMatchesConfiguredShortcut(event: nextEvent, action: .nextSidebarTab))
+            #expect(
+                testWindow.performKeyEquivalent(with: nextEvent),
+                "An explicit Option+Down binding should route before the terminal arrow fallback"
+            )
+            #expect(manager.selectedTabId == secondWorkspace.id)
+
+            #expect(appDelegate.debugMatchesConfiguredShortcut(event: previousEvent, action: .prevSidebarTab))
+            #expect(
+                testWindow.performKeyEquivalent(with: previousEvent),
+                "An explicit Option+Up binding should route before the terminal arrow fallback"
+            )
+            #expect(manager.selectedTabId == firstWorkspace.id)
+        }
+    }
+
+    @Test
+    func fileConfiguredOptionOnlyPrintableBindingWinsBeforeTextInput() throws {
+        try withIsolatedShortcutRoutingState {
+            let appDelegate = try #require(AppDelegate.shared)
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
+
+            let testWindow = try #require(self.window(withId: windowId))
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            let initialWorkspaceCount = manager.tabs.count
+            let settingsFileURL = try writeShortcutSettingsFile(bindings: [
+                "newTab": "opt+q",
+            ])
+            defer { try? FileManager.default.removeItem(at: settingsFileURL) }
+            KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+            appDelegate.debugResetShortcutRoutingStateForTesting()
+
+            let event = try #require(makeKeyEvent(
+                modifierFlags: [.option],
+                characters: "@",
+                charactersIgnoringModifiers: "q",
+                keyCode: 12,
+                windowNumber: testWindow.windowNumber
+            ))
+
+            #expect(shortcutRoutingShouldBypassForPrintableOptionText(event: event))
+            #expect(
+                appDelegate.debugHandleCustomShortcut(event: event),
+                "An explicitly configured Option+Q binding should win over printable Option text"
+            )
+            #expect(manager.tabs.count == initialWorkspaceCount + 1)
+        }
+    }
+
+    @Test
+    func unboundOptionOnlyPrintableTextReachesFirstResponder() throws {
+        try withIsolatedShortcutRoutingState {
+            let appDelegate = try #require(AppDelegate.shared)
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
+
+            let testWindow = try #require(self.window(withId: windowId))
+            let focusableView = OptionDigitFocusableTestView(
+                frame: NSRect(x: 0, y: 0, width: 120, height: 24)
+            )
+            testWindow.contentView?.addSubview(focusableView)
+            defer { focusableView.removeFromSuperview() }
+            testWindow.makeKeyAndOrderFront(nil)
+            #expect(testWindow.makeFirstResponder(focusableView))
+
+            let event = try #require(makeKeyEvent(
+                modifierFlags: [.option],
+                characters: "@",
+                charactersIgnoringModifiers: "q",
+                keyCode: 12,
+                windowNumber: testWindow.windowNumber
+            ))
+
+            #expect(shortcutRoutingShouldBypassForPrintableOptionText(event: event))
+            #expect(
+                testWindow.performKeyEquivalent(with: event),
+                "An unbound Option+Q should be forwarded as text input"
+            )
+            #expect(focusableView.keyDownCallCount == 1)
+            #expect(focusableView.lastKeyDownCharactersIgnoringModifiers == "q")
+        }
+    }
+
+    @Test
     func optionDigitWorkspaceNumberShortcutBeatsPrintableOptionTextBypass() throws {
         try withIsolatedShortcutRoutingState {
             let appDelegate = try #require(AppDelegate.shared)
@@ -609,6 +749,27 @@ struct AppDelegateOptionDigitShortcutRoutingTests {
             option: true,
             control: false
         )
+    }
+
+    private func writeShortcutSettingsFile(bindings: [String: String]) throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        let bindingsObject = bindings
+            .sorted { $0.key < $1.key }
+            .map { "\"\($0.key)\": \"\($0.value)\"" }
+            .joined(separator: ",\n        ")
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              \(bindingsObject)
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+        return settingsFileURL
     }
 
     private func optionTwoEvent(windowNumber: Int) -> NSEvent? {


### PR DESCRIPTION
## Summary

- Route configured Option-only shortcuts before the terminal/text fast paths at the shared `NSWindow` key-equivalent chokepoint.
- Match hand-written arrow bindings by their stable physical key codes even though AppKit delivers private-use function-key characters.
- Preserve unmatched printable Option input for text entry, including Turkish-Q-style Option+Q.

## Regression coverage

- File-managed `opt+↓` / `opt+↑` workspace bindings route through a focused terminal.
- File-managed printable `opt+q` wins over text-input routing.
- An unbound printable `opt+q` is forwarded to the first responder.

The failing regression-test commit is separate from the fix commit so CI demonstrates the red-to-green behavior. No local Xcode build or test was run per task instructions; static parsing and repository policy checks passed.

Closes https://github.com/manaflow-ai/cmux/issues/10436
Closes https://github.com/manaflow-ai/cmux/issues/5361

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763367&installation_model_id=21920&pr_number=10452&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10452&signature=b4cd94d2bf6f46aacda7ede061bba992a5248d3ec98d5255d4af6299612124f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Option-only shortcut routing so configured bindings run before text/terminal fallbacks, and arrow glyph bindings match reliably. Previously, Option-only keys could bypass the dispatcher; now unmatched printable Option-only input still reaches text input.

- Route Option-only events first at the `NSWindow` key-equivalent chokepoint; skip when WebKit re-enters keyDown or the first responder has marked text. Unmatched printable Option-only events then go to text input.
- Match arrow glyph bindings by stable physical key codes so configs using "←", "→", "↓", "↑" work even when AppKit reports private-use function-key characters.
- Centralize detection in `ShortcutRoutingPolicy.isOptionOnly` and reuse it across window and text-input routers.
- Add tests for Option-only arrow routing precedence, printable Option-only binding winning over text, and unbound printable Option-only forwarding.

<sup>Written for commit 142b8ba963ffed0069314a1a5d6692a7c47809af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

