### PR TITLE
Fix Cmd-click URL double routing to Finder

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickPathResolutionSource.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickPathResolutionSource.swift
@@ -1,0 +1,7 @@
+/// Identifies the terminal-text source used to resolve a local path candidate.
+public enum TerminalCommandClickPathResolutionSource: Equatable, Sendable {
+    /// Ghostty's quick-look word supplied the candidate.
+    case quicklook
+    /// cmux's pointer-anchored terminal snapshot supplied the candidate.
+    case snapshot
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
@@ -2,50 +2,16 @@
 /// has processed the mouse event.
 public struct TerminalCommandClickReleaseRouter: Sendable {
     /// The terminal runtime's primary handling outcome for the release.
-    public enum RuntimeOutcome: Equatable, Sendable {
-        /// The runtime did not consume the release.
-        case unhandled
-        /// The runtime consumed the release without dispatching an open-URL action.
-        case consumed
-        /// The runtime dispatched an open-URL action for the release.
-        case openURL
-    }
+    public typealias RuntimeOutcome = TerminalCommandClickRuntimeOutcome
 
     /// How cmux resolved a local path candidate under the pointer.
-    public enum PathResolutionSource: Equatable, Sendable {
-        /// Ghostty's quick-look word supplied the candidate.
-        case quicklook
-        /// cmux's pointer-anchored terminal snapshot supplied the candidate.
-        case snapshot
-    }
+    public typealias PathResolutionSource = TerminalCommandClickPathResolutionSource
 
     /// An existing local path resolved under the pointer.
-    public struct ResolvedPath: Equatable, Sendable {
-        /// The absolute path to open.
-        public let path: String
-        /// The terminal-text source that produced the path.
-        public let source: PathResolutionSource
-
-        /// Creates a resolved local-path candidate.
-        ///
-        /// - Parameters:
-        ///   - path: The absolute path to open.
-        ///   - source: The terminal-text source that produced the path.
-        public init(path: String, source: PathResolutionSource) {
-            self.path = path
-            self.source = source
-        }
-    }
+    public typealias ResolvedPath = TerminalCommandClickResolvedPath
 
     /// The exclusive action selected for one command-click release.
-    public enum Route: Equatable, Sendable {
-        /// Keep the open-URL action already dispatched by the terminal runtime.
-        case runtimeOpenURL
-        /// Open the resolved local path through cmux's fallback path.
-        case pathFallback(ResolvedPath)
-        /// Perform no cmux fallback action.
-        case none
-    }
+    public typealias Route = TerminalCommandClickRoute
 
     /// Creates a command-click release router.
     public init() {}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
@@ -68,16 +68,19 @@ public struct TerminalCommandClickReleaseRouter: Sendable {
         resolvePath: () -> ResolvedPath?
     ) -> Route {
         guard commandHeld, !pathFallbackSuppressed else { return .none }
-        guard let resolution = resolvePath() else { return .none }
 
         switch runtimeOutcome {
         case .unhandled:
+            guard let resolution = resolvePath() else { return .none }
             return .pathFallback(resolution)
-        case .consumed, .openURL:
-            // Preserve the legacy pointer-snapshot exception while extracting
-            // the routing decision. The regression test proves that an explicit
-            // open-URL outcome must become the exclusive owner in the fix.
+        case .consumed:
+            guard let resolution = resolvePath() else { return .none }
+            // Preserve the legacy pointer-snapshot exception for consumed
+            // non-URL clicks. An explicit open-URL action is handled below and
+            // never reaches local path resolution.
             return resolution.source == .snapshot ? .pathFallback(resolution) : .none
+        case .openURL:
+            return .runtimeOpenURL
         }
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickReleaseRouter.swift
@@ -1,0 +1,83 @@
+/// Chooses the one owner of a command-click release after the terminal runtime
+/// has processed the mouse event.
+public struct TerminalCommandClickReleaseRouter: Sendable {
+    /// The terminal runtime's primary handling outcome for the release.
+    public enum RuntimeOutcome: Equatable, Sendable {
+        /// The runtime did not consume the release.
+        case unhandled
+        /// The runtime consumed the release without dispatching an open-URL action.
+        case consumed
+        /// The runtime dispatched an open-URL action for the release.
+        case openURL
+    }
+
+    /// How cmux resolved a local path candidate under the pointer.
+    public enum PathResolutionSource: Equatable, Sendable {
+        /// Ghostty's quick-look word supplied the candidate.
+        case quicklook
+        /// cmux's pointer-anchored terminal snapshot supplied the candidate.
+        case snapshot
+    }
+
+    /// An existing local path resolved under the pointer.
+    public struct ResolvedPath: Equatable, Sendable {
+        /// The absolute path to open.
+        public let path: String
+        /// The terminal-text source that produced the path.
+        public let source: PathResolutionSource
+
+        /// Creates a resolved local-path candidate.
+        ///
+        /// - Parameters:
+        ///   - path: The absolute path to open.
+        ///   - source: The terminal-text source that produced the path.
+        public init(path: String, source: PathResolutionSource) {
+            self.path = path
+            self.source = source
+        }
+    }
+
+    /// The exclusive action selected for one command-click release.
+    public enum Route: Equatable, Sendable {
+        /// Keep the open-URL action already dispatched by the terminal runtime.
+        case runtimeOpenURL
+        /// Open the resolved local path through cmux's fallback path.
+        case pathFallback(ResolvedPath)
+        /// Perform no cmux fallback action.
+        case none
+    }
+
+    /// Creates a command-click release router.
+    public init() {}
+
+    /// Resolves one release to exactly one action.
+    ///
+    /// Path resolution is lazy so primary runtime actions can exclude local
+    /// filesystem probing altogether.
+    ///
+    /// - Parameters:
+    ///   - commandHeld: Whether Command was held for the release.
+    ///   - pathFallbackSuppressed: Whether selection state suppresses path fallback.
+    ///   - runtimeOutcome: The terminal runtime's primary handling outcome.
+    ///   - resolvePath: Resolves the local path candidate only when eligible.
+    /// - Returns: The exclusive action for the release.
+    public func route(
+        commandHeld: Bool,
+        pathFallbackSuppressed: Bool,
+        runtimeOutcome: RuntimeOutcome,
+        resolvePath: () -> ResolvedPath?
+    ) -> Route {
+        guard commandHeld, !pathFallbackSuppressed else { return .none }
+        guard let resolution = resolvePath() else { return .none }
+
+        switch runtimeOutcome {
+        case .unhandled:
+            return .pathFallback(resolution)
+        case .consumed, .openURL:
+            // Preserve the legacy pointer-snapshot exception while extracting
+            // the routing decision. The regression test proves that an explicit
+            // open-URL outcome must become the exclusive owner in the fix.
+            return resolution.source == .snapshot ? .pathFallback(resolution) : .none
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickResolvedPath.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickResolvedPath.swift
@@ -1,0 +1,17 @@
+/// Represents an existing local path resolved under the pointer.
+public struct TerminalCommandClickResolvedPath: Equatable, Sendable {
+    /// The absolute path to open.
+    public let path: String
+    /// The terminal-text source that produced the path.
+    public let source: TerminalCommandClickPathResolutionSource
+
+    /// Creates a resolved local-path candidate.
+    ///
+    /// - Parameters:
+    ///   - path: The absolute path to open.
+    ///   - source: The terminal-text source that produced the path.
+    public init(path: String, source: TerminalCommandClickPathResolutionSource) {
+        self.path = path
+        self.source = source
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickRoute.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickRoute.swift
@@ -1,0 +1,9 @@
+/// Selects the exclusive action for one command-click release.
+public enum TerminalCommandClickRoute: Equatable, Sendable {
+    /// Keep the open-URL action already dispatched by the terminal runtime.
+    case runtimeOpenURL
+    /// Open the resolved local path through cmux's fallback path.
+    case pathFallback(TerminalCommandClickResolvedPath)
+    /// Perform no cmux fallback action.
+    case none
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickRuntimeOutcome.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalCommandClickRuntimeOutcome.swift
@@ -1,0 +1,9 @@
+/// Describes how the terminal runtime handled one command-click release.
+public enum TerminalCommandClickRuntimeOutcome: Equatable, Sendable {
+    /// The runtime did not consume the release.
+    case unhandled
+    /// The runtime consumed the release without dispatching an open-URL action.
+    case consumed
+    /// The runtime dispatched an open-URL action for the release.
+    case openURL
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommandClickReleaseRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommandClickReleaseRouterTests.swift
@@ -1,0 +1,70 @@
+import CmuxTerminalCore
+import Testing
+
+@Suite struct TerminalCommandClickReleaseRouterTests {
+    private let router = TerminalCommandClickReleaseRouter()
+
+    @Test func runtimeOpenURLExcludesLocalPathFallback() {
+        var pathResolutionAttempted = false
+
+        let route = router.route(
+            commandHeld: true,
+            pathFallbackSuppressed: false,
+            runtimeOutcome: .openURL
+        ) {
+            pathResolutionAttempted = true
+            return .init(path: "/Users/dev/repo", source: .snapshot)
+        }
+
+        #expect(route == .runtimeOpenURL)
+        #expect(!pathResolutionAttempted)
+    }
+
+    @Test func unhandledReleaseUsesResolvedPathFallback() {
+        let resolution = TerminalCommandClickReleaseRouter.ResolvedPath(
+            path: "/Users/dev/repo/README.md",
+            source: .quicklook
+        )
+
+        let route = router.route(
+            commandHeld: true,
+            pathFallbackSuppressed: false,
+            runtimeOutcome: .unhandled,
+            resolvePath: { resolution }
+        )
+
+        #expect(route == .pathFallback(resolution))
+    }
+
+    @Test func consumedReleasePreservesPointerSnapshotFallback() {
+        let resolution = TerminalCommandClickReleaseRouter.ResolvedPath(
+            path: "/Users/dev/repo/README.md",
+            source: .snapshot
+        )
+
+        let route = router.route(
+            commandHeld: true,
+            pathFallbackSuppressed: false,
+            runtimeOutcome: .consumed,
+            resolvePath: { resolution }
+        )
+
+        #expect(route == .pathFallback(resolution))
+    }
+
+    @Test func ineligibleReleaseDoesNotProbeForPath() {
+        var pathResolutionAttempted = false
+
+        let route = router.route(
+            commandHeld: false,
+            pathFallbackSuppressed: false,
+            runtimeOutcome: .unhandled
+        ) {
+            pathResolutionAttempted = true
+            return .init(path: "/Users/dev/repo", source: .snapshot)
+        }
+
+        #expect(route == .none)
+        #expect(!pathResolutionAttempted)
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommandClickReleaseRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommandClickReleaseRouterTests.swift
@@ -52,6 +52,38 @@ import Testing
         #expect(route == .pathFallback(resolution))
     }
 
+    @Test func consumedQuickLookReleaseDoesNotUsePathFallback() {
+        let resolution = TerminalCommandClickReleaseRouter.ResolvedPath(
+            path: "/Users/dev/repo/README.md",
+            source: .quicklook
+        )
+
+        let route = router.route(
+            commandHeld: true,
+            pathFallbackSuppressed: false,
+            runtimeOutcome: .consumed,
+            resolvePath: { resolution }
+        )
+
+        #expect(route == .none)
+    }
+
+    @Test func suppressedPathFallbackDoesNotProbeForPath() {
+        var pathResolutionAttempted = false
+
+        let route = router.route(
+            commandHeld: true,
+            pathFallbackSuppressed: true,
+            runtimeOutcome: .unhandled
+        ) {
+            pathResolutionAttempted = true
+            return .init(path: "/Users/dev/repo", source: .snapshot)
+        }
+
+        #expect(route == .none)
+        #expect(!pathResolutionAttempted)
+    }
+
     @Test func ineligibleReleaseDoesNotProbeForPath() {
         var pathResolutionAttempted = false
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3537,13 +3537,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case snapshot
     }
 
-    /// Tracks the primary owner of one left-button release while Ghostty
-    /// synchronously emits any actions caused by that release.
-    private enum CommandClickReleaseRoutingState {
-        case idle
-        case awaitingRuntimeOutcome(TerminalCommandClickReleaseRouter.RuntimeOutcome?)
-    }
-
     private struct WordPathResolution {
         let path: String
         let source: WordPathResolutionSource
@@ -3599,7 +3592,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var cellSize: CGSize = .zero
     private var lastKnownMousePointInView: NSPoint?
     private let commandClickReleaseRouter = TerminalCommandClickReleaseRouter()
-    private var commandClickReleaseRoutingState: CommandClickReleaseRoutingState = .idle
+    private var commandClickReleaseRoutingActive = false
+    private var commandClickReleaseRuntimeOutcome: TerminalCommandClickReleaseRouter.RuntimeOutcome?
     private var ghosttyMouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
     private static func ghosttyMouseCursor(for shape: ghostty_action_mouse_shape_e) -> NSCursor {
         switch shape {
@@ -6510,7 +6504,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func beginCommandClickReleaseRouting() {
-        commandClickReleaseRoutingState = .awaitingRuntimeOutcome(nil)
+        commandClickReleaseRoutingActive = true
+        commandClickReleaseRuntimeOutcome = nil
     }
 
     /// Records a URL action only while its originating mouse release is active.
@@ -6518,18 +6513,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate func recordCommandClickReleaseRuntimeOutcome(
         _ outcome: TerminalCommandClickReleaseRouter.RuntimeOutcome
     ) {
-        guard case .awaitingRuntimeOutcome = commandClickReleaseRoutingState else { return }
-        commandClickReleaseRoutingState = .awaitingRuntimeOutcome(outcome)
+        guard commandClickReleaseRoutingActive else { return }
+        commandClickReleaseRuntimeOutcome = outcome
     }
 
     private func finishCommandClickReleaseRouting(
         ghosttyConsumed: Bool
     ) -> TerminalCommandClickReleaseRouter.RuntimeOutcome {
-        defer { commandClickReleaseRoutingState = .idle }
-        guard case let .awaitingRuntimeOutcome(runtimeOutcome) = commandClickReleaseRoutingState else {
+        defer {
+            commandClickReleaseRoutingActive = false
+            commandClickReleaseRuntimeOutcome = nil
+        }
+        guard commandClickReleaseRoutingActive else {
             return ghosttyConsumed ? .consumed : .unhandled
         }
-        return runtimeOutcome ?? (ghosttyConsumed ? .consumed : .unhandled)
+        return commandClickReleaseRuntimeOutcome ?? (ghosttyConsumed ? .consumed : .unhandled)
     }
 
     @discardableResult

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3385,11 +3385,7 @@ class GhosttyApp {
                 workingDirectory: surfaceView.currentDirectoryActionDispatcher.directorySnapshot()
             )
             return performOnMain {
-                // Mark the dispatch before routing: this action fires
-                // synchronously inside `ghostty_surface_mouse_button`, and the
-                // release path must see it even when routing returns false
-                // (Ghostty then opens the URL with its own fallback).
-                surfaceView.noteGhosttyOpenURLActionDispatched()
+                surfaceView.recordCommandClickReleaseRuntimeOutcome(.openURL)
                 return TerminalLinkOpenCoordinator().open(request)
             }
         default:
@@ -3541,6 +3537,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case snapshot
     }
 
+    /// Tracks the primary owner of one left-button release while Ghostty
+    /// synchronously emits any actions caused by that release.
+    private enum CommandClickReleaseRoutingState {
+        case idle
+        case awaitingRuntimeOutcome(TerminalCommandClickReleaseRouter.RuntimeOutcome?)
+    }
+
     private struct WordPathResolution {
         let path: String
         let source: WordPathResolutionSource
@@ -3595,6 +3598,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var selectionAccessibilityNotifier: TerminalSelectionAccessibilityNotifier?
     var cellSize: CGSize = .zero
     private var lastKnownMousePointInView: NSPoint?
+    private let commandClickReleaseRouter = TerminalCommandClickReleaseRouter()
+    private var commandClickReleaseRoutingState: CommandClickReleaseRoutingState = .idle
     private var ghosttyMouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
     private static func ghosttyMouseCursor(for shape: ghostty_action_mouse_shape_e) -> NSCursor {
         switch shape {
@@ -3793,14 +3798,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var lastDrawableSize: CGSize = .zero
     private var isFindEscapeSuppressionArmed = false
     private var hasPendingLeftMouseRelease = false
-    /// Monotonic count of Ghostty `open_url` actions dispatched for this
-    /// surface. Ghostty fires that action synchronously inside
-    /// `ghostty_surface_mouse_button` when a release lands on a link, so the
-    /// release path snapshots this counter around the call: an advance means
-    /// Ghostty already routed the clicked link through
-    /// `TerminalLinkOpenCoordinator`, and the cmd-click word-path fallback
-    /// must not deliver the same click to a second handler (#10222).
-    private var ghosttyOpenURLDispatchCount: UInt64 = 0
     let imageTransferPreparation: TerminalImageTransferPreparationService?
 #if DEBUG
     private var lastSizeSkipSignature: String?
@@ -6496,13 +6493,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return true
     }
 
-    /// Records that Ghostty dispatched an `open_url` action for this surface.
-    /// Called by the runtime action handler so the in-flight mouse release can
-    /// tell that Ghostty owns the clicked link, whatever the routing outcome.
-    func noteGhosttyOpenURLActionDispatched() {
-        ghosttyOpenURLDispatchCount += 1
-    }
-
     @discardableResult
     func completePendingLeftMouseRelease(with event: NSEvent) -> Bool {
         if routeInputDuringClipboardRead(event) { return true }
@@ -6510,20 +6500,63 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         hasPendingLeftMouseRelease = false
         guard let surface else { return false }
         let point = convert(event.locationInWindow, from: nil)
-        let openURLCountBeforeRelease = ghosttyOpenURLDispatchCount
+        _ = dispatchCommandClickRelease(
+            surface: surface,
+            at: point,
+            modifierFlags: event.modifierFlags,
+            mouseMods: mouseModsFromEvent(event)
+        )
+        return true
+    }
+
+    private func beginCommandClickReleaseRouting() {
+        commandClickReleaseRoutingState = .awaitingRuntimeOutcome(nil)
+    }
+
+    /// Records a URL action only while its originating mouse release is active.
+    /// Other Ghostty URL actions must not affect a later path fallback.
+    fileprivate func recordCommandClickReleaseRuntimeOutcome(
+        _ outcome: TerminalCommandClickReleaseRouter.RuntimeOutcome
+    ) {
+        guard case .awaitingRuntimeOutcome = commandClickReleaseRoutingState else { return }
+        commandClickReleaseRoutingState = .awaitingRuntimeOutcome(outcome)
+    }
+
+    private func finishCommandClickReleaseRouting(
+        ghosttyConsumed: Bool
+    ) -> TerminalCommandClickReleaseRouter.RuntimeOutcome {
+        defer { commandClickReleaseRoutingState = .idle }
+        guard case let .awaitingRuntimeOutcome(runtimeOutcome) = commandClickReleaseRoutingState else {
+            return ghosttyConsumed ? .consumed : .unhandled
+        }
+        return runtimeOutcome ?? (ghosttyConsumed ? .consumed : .unhandled)
+    }
+
+    @discardableResult
+    private func dispatchCommandClickRelease(
+        surface: ghostty_surface_t,
+        at point: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags,
+        mouseMods: ghostty_input_mods_e
+    ) -> (
+        consumed: Bool,
+        runtimeOutcome: TerminalCommandClickReleaseRouter.RuntimeOutcome,
+        resolution: WordPathResolution?
+    ) {
+        beginCommandClickReleaseRouting()
         let consumed = sendGhosttyMouseButton(
             surface,
             state: GHOSTTY_MOUSE_RELEASE,
             button: GHOSTTY_MOUSE_LEFT,
-            mods: mouseModsFromEvent(event)
+            mods: mouseMods
         )
-        _ = handleCommandClickRelease(
+        let runtimeOutcome = finishCommandClickReleaseRouting(ghosttyConsumed: consumed)
+        let resolution = handleCommandClickRelease(
             at: point,
-            modifierFlags: event.modifierFlags,
-            ghosttyConsumed: consumed,
-            ghosttyDispatchedOpenURL: ghosttyOpenURLDispatchCount != openURLCountBeforeRelease
+            modifierFlags: modifierFlags,
+            runtimeOutcome: runtimeOutcome
         )
-        return true
+        return (consumed, runtimeOutcome, resolution)
     }
 
     /// Attempt to open the word under the mouse cursor as a file path, resolved
@@ -6874,26 +6907,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func handleCommandClickRelease(
         at point: NSPoint,
         modifierFlags: NSEvent.ModifierFlags,
-        ghosttyConsumed: Bool,
-        ghosttyDispatchedOpenURL: Bool
+        runtimeOutcome: TerminalCommandClickReleaseRouter.RuntimeOutcome
     ) -> WordPathResolution? {
         guard let surface else { return nil }
-        // Ghostty dispatched its open-url action for this release, so the
-        // clicked link is already being routed through
-        // TerminalLinkOpenCoordinator. Resolving and opening the word under
-        // the pointer as well would deliver the same click to two handlers —
-        // e.g. an image opening in both Preview and the preferred editor
-        // (#10222). `ghosttyConsumed` alone cannot gate this: Ghostty also
-        // consumes releases for mouse reporting and prompt clicks, where the
-        // snapshot fallback must keep working.
-        guard !ghosttyDispatchedOpenURL else {
-#if DEBUG
-            cmuxDebugLog("link.wordFallback skipped reason=ghostty_open_url_dispatched")
-#endif
-            return nil
-        }
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: modifierFlags)
         let cmdHeld = modifierFlags.contains(.command)
+        let ghosttyConsumed = runtimeOutcome != .unhandled
         let resolvedPoint = preferredPointerPoint(from: point)
         guard cmdHeld, !suppressCommandPathHover else {
 #if DEBUG
@@ -6929,49 +6948,82 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
         }
 
-        guard let resolution = resolveWordUnderCursorPath(at: resolvedPoint) else {
+        var resolvedPath: WordPathResolution?
+        let route = commandClickReleaseRouter.route(
+            commandHeld: cmdHeld,
+            pathFallbackSuppressed: suppressCommandPathHover,
+            runtimeOutcome: runtimeOutcome
+        ) { [self] in
+            guard let resolution = resolveWordUnderCursorPath(at: resolvedPoint) else { return nil }
+            resolvedPath = resolution
+            return TerminalCommandClickReleaseRouter.ResolvedPath(
+                path: resolution.path,
+                source: resolution.source == .snapshot ? .snapshot : .quicklook
+            )
+        }
+
+        switch route {
+        case .runtimeOpenURL:
 #if DEBUG
             runtimeDebugLog(
-                hypothesisID: "h2",
+                hypothesisID: "h3",
                 name: "command_click_release",
-                expected: "cmd-click should resolve the token under the pointer",
-                actual: "no_resolution",
+                expected: "a runtime URL action exclusively owns the release",
+                actual: "runtime_open_url_owned",
                 data: [
+                    "flags": debugModifierString(modifierFlags),
+                    "ghostty_consumed": ghosttyConsumed,
+                    "point_x": point.x,
+                    "point_y": point.y
+                ]
+            )
+#endif
+            return nil
+        case .none:
+#if DEBUG
+            if let resolution = resolvedPath {
+                var payload: [String: Any] = [
                     "flags": debugModifierString(modifierFlags),
                     "ghostty_consumed": ghosttyConsumed,
                     "point_x": point.x,
                     "point_y": point.y,
                     "resolved_point_x": resolvedPoint?.x ?? -1,
-                    "resolved_point_y": resolvedPoint?.y ?? -1
+                    "resolved_point_y": resolvedPoint?.y ?? -1,
+                    "suppress_path_hover": suppressCommandPathHover
                 ]
-            )
-#endif
-            return nil
-        }
-        guard !ghosttyConsumed || resolution.source == .snapshot else {
-#if DEBUG
-            var payload: [String: Any] = [
-                "flags": debugModifierString(modifierFlags),
-                "ghostty_consumed": ghosttyConsumed,
-                "point_x": point.x,
-                "point_y": point.y,
-                "resolved_point_x": resolvedPoint?.x ?? -1,
-                "resolved_point_y": resolvedPoint?.y ?? -1,
-                "suppress_path_hover": suppressCommandPathHover
-            ]
-            for (key, value) in runtimeDebugResolutionPayload(resolution) {
-                payload[key] = value
+                for (key, value) in runtimeDebugResolutionPayload(resolution) {
+                    payload[key] = value
+                }
+                runtimeDebugLog(
+                    hypothesisID: "h3",
+                    name: "command_click_release",
+                    expected: "ghostty-consumed clicks should only skip fallback for real ghostty targets",
+                    actual: "consumed_quicklook_resolution_skipped",
+                    data: payload
+                )
+            } else {
+                runtimeDebugLog(
+                    hypothesisID: "h2",
+                    name: "command_click_release",
+                    expected: "cmd-click should resolve the token under the pointer",
+                    actual: "no_resolution",
+                    data: [
+                        "flags": debugModifierString(modifierFlags),
+                        "ghostty_consumed": ghosttyConsumed,
+                        "point_x": point.x,
+                        "point_y": point.y,
+                        "resolved_point_x": resolvedPoint?.x ?? -1,
+                        "resolved_point_y": resolvedPoint?.y ?? -1
+                    ]
+                )
             }
-            runtimeDebugLog(
-                hypothesisID: "h3",
-                name: "command_click_release",
-                expected: "ghostty-consumed clicks should only skip fallback for real ghostty targets",
-                actual: "consumed_quicklook_resolution_skipped",
-                data: payload
-            )
 #endif
             return nil
+        case .pathFallback:
+            break
         }
+
+        guard let resolution = resolvedPath else { return nil }
 
         #if DEBUG
         cmuxDebugLog(
@@ -7145,26 +7197,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             button: GHOSTTY_MOUSE_LEFT,
             mods: mods
         )
-        let openURLCountBeforeRelease = ghosttyOpenURLDispatchCount
-        let releaseConsumed = sendGhosttyMouseButton(
-            surface,
-            state: GHOSTTY_MOUSE_RELEASE,
-            button: GHOSTTY_MOUSE_LEFT,
-            mods: mods
-        )
-        let dispatchedOpenURL = ghosttyOpenURLDispatchCount != openURLCountBeforeRelease
-        let resolution = handleCommandClickRelease(
+        let release = dispatchCommandClickRelease(
+            surface: surface,
             at: clampedPoint,
             modifierFlags: flags,
-            ghosttyConsumed: releaseConsumed,
-            ghosttyDispatchedOpenURL: dispatchedOpenURL
+            mouseMods: mods
         )
 
         var payload: [String: Any] = [
             "pressHandled": pressHandled ? "1" : "0",
-            "releaseConsumed": releaseConsumed ? "1" : "0",
+            "releaseConsumed": release.consumed ? "1" : "0",
         ]
-        if let resolution {
+        if let resolution = release.resolution {
             payload["openedPath"] = resolution.path
             payload["resolutionSource"] = resolution.source.rawValue
             payload["rawToken"] = resolution.rawToken
@@ -7202,17 +7246,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             button: GHOSTTY_MOUSE_LEFT,
             mods: commandMods
         )
-        let releaseConsumed = sendGhosttyMouseButton(
-            surface,
-            state: GHOSTTY_MOUSE_RELEASE,
-            button: GHOSTTY_MOUSE_LEFT,
-            mods: commandMods
+        let release = dispatchCommandClickRelease(
+            surface: surface,
+            at: clampedPoint,
+            modifierFlags: flags,
+            mouseMods: commandMods
         )
         flagsChanged(with: cmdUp)
 
         return [
             "pressHandled": pressHandled ? "1" : "0",
-            "releaseConsumed": releaseConsumed ? "1" : "0",
+            "releaseConsumed": release.consumed ? "1" : "0",
         ]
     }
 


### PR DESCRIPTION
## Summary

Closes #9120.

A terminal left-button release could dispatch two independent handlers: Ghostty emitted `GHOSTTY_ACTION_OPEN_URL` and opened the embedded browser, then cmux ran the command-click path fallback against the same text. For GitHub PR/issue URLs that second resolution could look filesystem-like and reveal the repository in Finder.

This fix makes the release routing mutually exclusive. An event-scoped runtime phase records an open-URL action, and `TerminalCommandClickReleaseRouter` chooses exactly one owner before lazily probing for a local path. URL-owned releases never invoke path resolution; unhandled releases still use the path fallback, and the legacy pointer-snapshot exception for non-URL consumed clicks is preserved. This is scheme/host-independent and does not special-case `github.com`.

The Claude `PreToolUse` Finder-reveal behavior from #7125 is unrelated and unchanged.

## Testing

- Commit `2390c92f9b` adds the regression suite first (the router remains intentionally buggy in that commit).
- Commit `43013c6502` applies the exclusive-routing fix.
- `swift test --filter TerminalCommandClickReleaseRouterTests` — 4 tests passed.
- `./scripts/reload.sh --tag issue-9120-cmdclick-finder-reveal` — succeeded.
- `python3 scripts/swift_warning_budget.py --log /tmp/cmux-reload-issue-9120-cmdclick-finder-reveal.log` — 132 actual warnings within the existing 221-warning budget; no new warnings from this change.
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (644 test files).
- `python3 scripts/check-package-resolved-policy.py` and `git diff --check` — passed.
- Local Xcode tests/XCUITests were not run per the repository safety constraint; the focused package behavior tests provide the deterministic regression coverage. A cloud Mac visual recording was unavailable because this environment has no macfleet lease token, so no interactive video is claimed.

## Demo Video

No video claimed: the cloud-mac visual path is blocked by missing macfleet authentication, and local app launch is intentionally deferred.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no user-facing strings or release notes changed)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789764424&installation_model_id=21920&pr_number=10454&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10454&signature=d374a7038baf684395b45077d64713f76d03d0bb642815c25add5bce5a478639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Cmd-click on terminal URLs from also triggering a local path fallback that could reveal Finder. Previously the release could open the URL and also probe the path; now exactly one owner is chosen per release, URL-owned releases skip filesystem probing, and Ghostty-consumed non-URL clicks still allow the legacy snapshot fallback.

- Adds `TerminalCommandClickReleaseRouter` in `CmuxTerminalCore` to select a single action and preserve the snapshot exception.
- Replaces the open-URL counter with a release-scoped `TerminalCommandClickRuntimeOutcome`; centralizes routing and makes path resolution lazy.
- Isolates routing value types in `CmuxTerminalCore`: `TerminalCommandClickRoute`, `TerminalCommandClickResolvedPath`, and `TerminalCommandClickPathResolutionSource`.
- Adds `TerminalCommandClickReleaseRouterTests` covering exclusive routing, laziness, and suppression; no config/migration changes and no host-specific behavior.

<sup>Written for commit ed288fa76a8fc2daa41073fbeada82338c89b509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Command-click handling for terminal links and local file paths.
  * Runtime URL actions now take priority over local path fallbacks.
  * Eligible local paths can open through snapshot or Quick Look resolution.

* **Bug Fixes**
  * Prevented unintended fallback actions when Command-click handling is suppressed.
  * Improved consistency for debug and stationary-click simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->