### PR TITLE
cmux-tui web: present the terminal in Display P3 like desktop Ghostty

### DIFF
--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -22,7 +22,7 @@ import {
   colorsToSelectionThemePatch,
 } from "../lib/terminalColors";
 import { terminalTheme } from "../lib/terminalTheme";
-import { tryLoadWebglRenderer } from "../lib/webglRenderer";
+import { retagWebglDisplayP3, tryLoadWebglRenderer } from "../lib/webglRenderer";
 
 interface AttachedTerminalOptions {
   client: CmuxClient | null;
@@ -59,6 +59,9 @@ export function useAttachedTerminal({
     terminal.loadAddon(fit);
     terminal.open(host);
     const webgl = tryLoadWebglRenderer(terminal);
+    // Match desktop Ghostty's Display P3 presentation; no-op where the
+    // browser (or the DOM fallback renderer) cannot retag the buffer.
+    if (webgl !== null) retagWebglDisplayP3(host);
 
     const handleFocusIn = () => setFocused(true);
     const handleFocusOut = () => {

--- a/cmux-tui/frontends/web/src/lib/webglRenderer.ts
+++ b/cmux-tui/frontends/web/src/lib/webglRenderer.ts
@@ -5,6 +5,41 @@ interface AddonHost {
   loadAddon(addon: ITerminalAddon): void;
 }
 
+/**
+ * Retag xterm's WebGL drawing buffer as Display P3.
+ *
+ * Desktop Ghostty writes terminal color bytes into a Display P3 surface with
+ * no conversion, so the same bytes look more saturated there than in an sRGB
+ * canvas. Retagging the buffer (same bytes, P3 interpretation) reproduces the
+ * desktop rendering on wide-gamut displays. `getContext` on a canvas that
+ * already has a context returns that existing context, which is how we reach
+ * the addon's private WebGL2 context. Browsers without
+ * `drawingBufferColorSpace` (Firefox) keep sRGB; per spec an unsupported
+ * assignment leaves the value unchanged, so we report what the buffer
+ * actually is.
+ */
+export function retagWebglDisplayP3(
+  host: HTMLElement,
+  getCanvas: (root: HTMLElement) => HTMLCanvasElement | null = (root) =>
+    root.querySelector<HTMLCanvasElement>(".xterm-screen canvas"),
+): "display-p3" | "srgb" | null {
+  const canvas = getCanvas(host);
+  if (canvas === null) return null;
+  let gl: (WebGL2RenderingContext & { drawingBufferColorSpace?: string }) | null = null;
+  try {
+    gl = canvas.getContext("webgl2") as typeof gl;
+  } catch {
+    return null;
+  }
+  if (gl === null || !("drawingBufferColorSpace" in gl)) return null;
+  try {
+    gl.drawingBufferColorSpace = "display-p3";
+  } catch {
+    return "srgb";
+  }
+  return gl.drawingBufferColorSpace === "display-p3" ? "display-p3" : "srgb";
+}
+
 /** Prefer xterm's WebGL renderer, but keep its built-in renderer on failure. */
 export function tryLoadWebglRenderer(
   terminal: AddonHost,

--- a/cmux-tui/frontends/web/test/webgl-renderer.test.ts
+++ b/cmux-tui/frontends/web/test/webgl-renderer.test.ts
@@ -34,3 +34,42 @@ describe("xterm WebGL renderer", () => {
     expect(terminal.loadAddon).not.toHaveBeenCalled();
   });
 });
+
+describe("retagWebglDisplayP3", () => {
+  const hostWith = (canvas: HTMLCanvasElement | null) => document.createElement("div");
+
+  const fakeCanvas = (gl: object | null) =>
+    ({ getContext: vi.fn(() => gl) }) as unknown as HTMLCanvasElement;
+
+  it("returns null when the addon rendered no canvas (DOM fallback)", async () => {
+    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+    expect(retagWebglDisplayP3(hostWith(null), () => null)).toBeNull();
+  });
+
+  it("returns null when the browser has no drawingBufferColorSpace", async () => {
+    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+    const canvas = fakeCanvas({});
+    expect(retagWebglDisplayP3(hostWith(canvas), () => canvas)).toBeNull();
+  });
+
+  it("retags the existing context and reports the ACTUAL buffer color space", async () => {
+    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+    const gl = { drawingBufferColorSpace: "srgb" };
+    const canvas = fakeCanvas(gl);
+    expect(retagWebglDisplayP3(hostWith(canvas), () => canvas)).toBe("display-p3");
+    expect(gl.drawingBufferColorSpace).toBe("display-p3");
+  });
+
+  it("reports srgb when the assignment is silently ignored (unsupported space)", async () => {
+    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+    // Per spec, assigning an unsupported color space leaves the value unchanged.
+    const gl = {
+      get drawingBufferColorSpace() {
+        return "srgb";
+      },
+      set drawingBufferColorSpace(_v: string) {},
+    };
+    const canvas = fakeCanvas(gl);
+    expect(retagWebglDisplayP3(hostWith(canvas), () => canvas)).toBe("srgb");
+  });
+});

--- a/cmux-tui/frontends/web/test/webgl-renderer.test.ts
+++ b/cmux-tui/frontends/web/test/webgl-renderer.test.ts
@@ -1,6 +1,6 @@
 import type { ITerminalAddon } from "@xterm/xterm";
 import { describe, expect, it, vi } from "vitest";
-import { tryLoadWebglRenderer } from "../src/lib/webglRenderer";
+import { retagWebglDisplayP3, tryLoadWebglRenderer } from "../src/lib/webglRenderer";
 
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: class {
@@ -41,27 +41,23 @@ describe("retagWebglDisplayP3", () => {
   const fakeCanvas = (gl: object | null) =>
     ({ getContext: vi.fn(() => gl) }) as unknown as HTMLCanvasElement;
 
-  it("returns null when the addon rendered no canvas (DOM fallback)", async () => {
-    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+  it("returns null when the addon rendered no canvas (DOM fallback)", () => {
     expect(retagWebglDisplayP3(hostWith(null), () => null)).toBeNull();
   });
 
-  it("returns null when the browser has no drawingBufferColorSpace", async () => {
-    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+  it("returns null when the browser has no drawingBufferColorSpace", () => {
     const canvas = fakeCanvas({});
     expect(retagWebglDisplayP3(hostWith(canvas), () => canvas)).toBeNull();
   });
 
-  it("retags the existing context and reports the ACTUAL buffer color space", async () => {
-    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+  it("retags the existing context and reports the ACTUAL buffer color space", () => {
     const gl = { drawingBufferColorSpace: "srgb" };
     const canvas = fakeCanvas(gl);
     expect(retagWebglDisplayP3(hostWith(canvas), () => canvas)).toBe("display-p3");
     expect(gl.drawingBufferColorSpace).toBe("display-p3");
   });
 
-  it("reports srgb when the assignment is silently ignored (unsupported space)", async () => {
-    const { retagWebglDisplayP3 } = await import("../src/lib/webglRenderer");
+  it("reports srgb when the assignment is silently ignored (unsupported space)", () => {
     // Per spec, assigning an unsupported color space leaves the value unchanged.
     const gl = {
       get drawingBufferColorSpace() {


### PR DESCRIPTION
The web frontend renders the terminal into an sRGB WebGL buffer while desktop Ghostty writes the same color bytes into a Display P3 surface unconverted (proven byte-exact in the ghostty-web parity work, docs/ghostty-web-parity.md in cmuxterm-hq). On a wide-gamut Mac display the web TUI therefore looks visibly desaturated next to the same session in the terminal app.

Fix: after the xterm WebGL addon loads, retag its drawing buffer as display-p3. Same bytes, P3 interpretation, exactly matching the desktop presentation. This is the cmux-tui analog of manaflow-ai/ghostty-web@9b912881 (derive the ACTUAL canvas color space, keep the byte path conversion-free): getContext on the already-contexted canvas returns the addon's own WebGL2 context, and per spec an unsupported drawingBufferColorSpace assignment leaves the value unchanged, so Firefox and the DOM fallback renderer keep today's sRGB rendering unchanged.

Two commits: red (tests pin the retag contract) then green. frontends/web vitest suite: 214/214 pass.

Residual: the DOM fallback renderer (no WebGL) stays sRGB, and a highly saturated theme background could differ slightly from the surrounding CSS page background (grays are identical in both spaces, so default themes show no seam).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789770150&installation_model_id=21920&pr_number=10459&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10459&signature=7862ea18845583aeb737490935995be623f711eea287828abb8ca3d81c205f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the web TUI in Display P3 to match desktop Ghostty on wide‑gamut displays. Previously the terminal rendered into an sRGB WebGL buffer; now we retag the existing WebGL drawing buffer as Display P3 without changing bytes.

- After the WebGL renderer loads, `retagWebglDisplayP3(host)` sets `drawingBufferColorSpace = 'display-p3'` on the existing context.
- Browsers without `drawingBufferColorSpace` (e.g., Firefox) and the DOM fallback renderer stay sRGB; unsupported assignments are no-ops by spec.
- No color pipeline changes; on P3 displays the web TUI now matches desktop saturation.
- Tests cover DOM fallback, missing API, successful retag, and ignored-assignments; the web frontend suite passes.
- Known limitation: the DOM fallback remains sRGB, so highly saturated theme backgrounds may differ slightly from surrounding CSS backgrounds.

<sup>Written for commit 691718f5deb6008f7817b5a8abe2b64847a0bf47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved terminal color rendering by enabling Display-P3 presentation when supported by the browser and graphics hardware.
  * Automatically falls back to standard sRGB rendering when Display-P3 is unavailable or unsupported.

* **Bug Fixes**
  * Prevented unsupported color-space settings from disrupting terminal display rendering.

* **Tests**
  * Added coverage for supported, unavailable, and fallback color-rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->