### PR TITLE
fix(browser): default toolbar actions to overflow menu

### DIFF
--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -614,6 +614,23 @@ final class BrowserDesignModeController {
         )
     }
 
+    /// Evaluates page-owned JavaScript through the same cancellable, bounded
+    /// evaluator used by Design Mode. React Grab lives in the page world, so
+    /// lifecycle teardown can release this await even if WebKit drops its
+    /// completion callback while the web view is being removed.
+    func evaluatePageJavaScript(
+        _ body: String,
+        arguments: [String: Any] = [:],
+        in webView: WKWebView
+    ) async throws -> Any? {
+        try await javaScriptEvaluator.call(
+            body,
+            arguments: arguments,
+            in: webView,
+            contentWorld: .page
+        )
+    }
+
     private func receiveSnapshotData(_ data: Data) {
         guard phase.isEnabled || phase == .activating else { return }
         guard let next = try? JSONDecoder().decode(BrowserDesignModeSnapshot.self, from: data) else { return }

--- a/Sources/Panels/BrowserPanel+ElementPicker.swift
+++ b/Sources/Panels/BrowserPanel+ElementPicker.swift
@@ -57,7 +57,10 @@ extension BrowserPanel {
     private func deactivateReactGrabForDesignMode(reason: String) async -> Bool {
         guard isReactGrabActive else { return true }
         do {
-            _ = try await evaluateJavaScript("window.__REACT_GRAB__?.deactivate(); true")
+            _ = try await designModeController.evaluatePageJavaScript(
+                "window.__REACT_GRAB__?.deactivate(); true",
+                in: webView
+            )
             isReactGrabActive = false
             clearReactGrabRoundTrip(reason: "\(reason).deactivateReactGrab")
             return true

--- a/Sources/Panels/BrowserPanel+ElementPicker.swift
+++ b/Sources/Panels/BrowserPanel+ElementPicker.swift
@@ -1,18 +1,20 @@
 import Foundation
 
 extension BrowserPanel {
-    /// Starts the toolbar's Design Mode transition on the panel-owned task.
-    /// Keeping the operation here lets lifecycle teardown cancel it without
-    /// leaving an unstructured task attached to a transient SwiftUI view.
-    func toggleDesignModeFromToolbar() {
-        guard designModeToolbarToggleTask == nil else { return }
+    /// Starts a browser-chrome Design Mode transition on the panel-owned task.
+    /// Keeping the operation here lets lifecycle teardown cancel either the
+    /// active chip or overflow-menu action without separate unstructured tasks.
+    @discardableResult
+    func toggleDesignModeFromBrowserChrome(reason: String) -> Bool {
+        guard designModeToolbarToggleTask == nil else { return false }
         designModeToolbarToggleTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            _ = await self.toggleDesignMode(reason: "toolbar")
+            _ = await self.toggleDesignMode(reason: reason)
             if !Task.isCancelled {
                 self.designModeToolbarToggleTask = nil
             }
         }
+        return true
     }
 
     /// Cancels a toolbar-triggered Design Mode transition during view teardown.

--- a/Sources/Panels/BrowserPanel+ElementPicker.swift
+++ b/Sources/Panels/BrowserPanel+ElementPicker.swift
@@ -9,18 +9,18 @@ extension BrowserPanel {
         guard designModeToolbarToggleTask == nil else { return false }
         designModeToolbarToggleTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer { self.designModeToolbarToggleTask = nil }
+            guard !Task.isCancelled else { return }
             _ = await self.toggleDesignMode(reason: reason)
-            if !Task.isCancelled {
-                self.designModeToolbarToggleTask = nil
-            }
         }
         return true
     }
 
     /// Cancels a toolbar-triggered Design Mode transition during view teardown.
     func cancelDesignModeToolbarToggle() {
+        // Keep the handle until the task's defer runs so cancellation cannot
+        // overlap a still-unwinding transition with a later toolbar action.
         designModeToolbarToggleTask?.cancel()
-        designModeToolbarToggleTask = nil
     }
 
     @discardableResult

--- a/Sources/Panels/BrowserPanel+ElementPicker.swift
+++ b/Sources/Panels/BrowserPanel+ElementPicker.swift
@@ -1,6 +1,26 @@
 import Foundation
 
 extension BrowserPanel {
+    /// Starts the toolbar's Design Mode transition on the panel-owned task.
+    /// Keeping the operation here lets lifecycle teardown cancel it without
+    /// leaving an unstructured task attached to a transient SwiftUI view.
+    func toggleDesignModeFromToolbar() {
+        guard designModeToolbarToggleTask == nil else { return }
+        designModeToolbarToggleTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            _ = await self.toggleDesignMode(reason: "toolbar")
+            if !Task.isCancelled {
+                self.designModeToolbarToggleTask = nil
+            }
+        }
+    }
+
+    /// Cancels a toolbar-triggered Design Mode transition during view teardown.
+    func cancelDesignModeToolbarToggle() {
+        designModeToolbarToggleTask?.cancel()
+        designModeToolbarToggleTask = nil
+    }
+
     @discardableResult
     func toggleDesignMode(reason: String) async -> Bool {
         await setDesignModeEnabled(!designModeController.isActive, reason: reason)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2313,6 +2313,9 @@ final class BrowserPanel: Panel, ObservableObject {
             reevaluateHiddenWebViewDiscardScheduling(reason: "react_grab_changed")
         }
     }
+    /// Owns the toolbar-triggered Design Mode transition so a disappearing
+    /// browser surface can cancel the in-flight operation.
+    var designModeToolbarToggleTask: Task<Void, Never>?
     lazy var designModeController = BrowserDesignModeController(
         surfaceID: id,
         script: BrowserDesignModeScript(),
@@ -4926,6 +4929,7 @@ final class BrowserPanel: Panel, ObservableObject {
         openAppLinkInBrowserSplit = nil
         detachWebViewObservers()
         faviconTask?.cancel(); faviconTask = nil
+        designModeToolbarToggleTask?.cancel(); designModeToolbarToggleTask = nil
     }
 
     // MARK: - Popup window management
@@ -5709,6 +5713,7 @@ final class BrowserPanel: Panel, ObservableObject {
         if let detachedDeveloperToolsWindowCloseObserver {
             NotificationCenter.default.removeObserver(detachedDeveloperToolsWindowCloseObserver)
         }
+        designModeToolbarToggleTask?.cancel()
         // `deinit` is nonisolated, so tear observers down inline.
         webViewObservers.removeAll()
         webViewCancellables.removeAll()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4929,7 +4929,7 @@ final class BrowserPanel: Panel, ObservableObject {
         openAppLinkInBrowserSplit = nil
         detachWebViewObservers()
         faviconTask?.cancel(); faviconTask = nil
-        designModeToolbarToggleTask?.cancel(); designModeToolbarToggleTask = nil
+        designModeToolbarToggleTask?.cancel()
     }
 
     // MARK: - Popup window management

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5713,7 +5713,6 @@ final class BrowserPanel: Panel, ObservableObject {
         if let detachedDeveloperToolsWindowCloseObserver {
             NotificationCenter.default.removeObserver(detachedDeveloperToolsWindowCloseObserver)
         }
-        designModeToolbarToggleTask?.cancel()
         // `deinit` is nonisolated, so tear observers down inline.
         webViewObservers.removeAll()
         webViewCancellables.removeAll()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2190,6 +2190,9 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Browser focus mode gives the focused WKWebView first ownership of page/app shortcuts.
     @Published private(set) var isBrowserFocusModeActive: Bool = false
 
+    /// Bumped after any browser screenshot reaches the general pasteboard.
+    @Published private(set) var screenshotCopiedToken: UInt64 = 0
+
     /// A first plain Escape in browser focus mode is forwarded to the page and arms exit.
     @Published private(set) var isBrowserFocusModeExitArmed: Bool = false
 
@@ -3035,6 +3038,9 @@ final class BrowserPanel: Panel, ObservableObject {
                     "event": event
                 ]
             )
+        }
+        webView.onScreenshotCopied = { [weak self] in
+            self?.screenshotCopiedToken &+= 1
         }
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
@@ -4865,7 +4871,18 @@ final class BrowserPanel: Panel, ObservableObject {
             return true
         }
 
-        guard window.makeFirstResponder(webView) else { return false }
+        let didBecomeFirstResponder: Bool
+        if let cmuxWebView = webView as? CmuxWebView {
+            // Toolbar/menu activation is an explicit user gesture. Temporarily
+            // bypass the background-pane acquisition guard while handing focus
+            // back from the menu window to this browser surface.
+            didBecomeFirstResponder = cmuxWebView.withPointerFocusAllowance {
+                window.makeFirstResponder(webView)
+            }
+        } else {
+            didBecomeFirstResponder = window.makeFirstResponder(webView)
+        }
+        guard didBecomeFirstResponder else { return false }
         // Prevent omnibar auto-focus from immediately stealing first responder back.
         suppressOmnibarAutofocus(for: 1.5)
         noteWebViewFocused()
@@ -4873,8 +4890,19 @@ final class BrowserPanel: Panel, ObservableObject {
         DispatchQueue.main.async { [weak self, weak window, weak webView] in
             guard let self, let window, let webView else { return }
             guard webView.window === window else { return }
-            if !Self.responderChainContains(window.firstResponder, target: webView),
-               window.makeFirstResponder(webView) {
+            let didBecomeFirstResponder: Bool
+            if !Self.responderChainContains(window.firstResponder, target: webView) {
+                if let cmuxWebView = webView as? CmuxWebView {
+                    didBecomeFirstResponder = cmuxWebView.withPointerFocusAllowance {
+                        window.makeFirstResponder(webView)
+                    }
+                } else {
+                    didBecomeFirstResponder = window.makeFirstResponder(webView)
+                }
+            } else {
+                didBecomeFirstResponder = false
+            }
+            if didBecomeFirstResponder {
                 self.suppressOmnibarAutofocus(for: 1.5)
                 self.noteWebViewFocused()
             }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1180,8 +1180,12 @@ struct BrowserPanelView: View {
                 browserProfileButton
                 browserThemeModeButton
                 Spacer(minLength: 0)
-                developerToolsButton
-                browserOverflowMenu
+                HStack(spacing: browserToolbarAccessorySpacing) {
+                    developerToolsButton
+                    browserOverflowMenu
+                }
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1183,6 +1183,7 @@ struct BrowserPanelView: View {
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
+            .layoutPriority(1)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, addressBarVerticalPadding)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1502,7 +1502,8 @@ struct BrowserPanelView: View {
     }
 
     /// Low-frequency browser actions that do not need dedicated toolbar space.
-    /// Design Mode and DevTools stay visible because they are persistent tools.
+    /// In compact panes, the persistent tools join this menu so the omnibar
+    /// keeps its profile/theme anchors without clipping.
     private var browserOverflowMenu: some View {
         Menu {
             Button(action: handleBrowserFocusModeButtonAction) {
@@ -1552,9 +1553,15 @@ struct BrowserPanelView: View {
     }
 
     private var browserVerticalMoreIcon: some View {
-        Text(verbatim: "⋮")
-            .cmuxFont(size: devToolsButtonIconSize, weight: .medium)
+        // macOS does not expose `ellipsis.vertical`; rotate the native
+        // template symbol so the dots share the other accessories' tint/weight.
+        CmuxSystemSymbolImage(
+            systemName: "ellipsis",
+            pointSize: devToolsButtonIconSize + 2,
+            weight: .medium
+        )
             .foregroundStyle(devToolsColorOption.color)
+            .rotationEffect(.degrees(90))
             .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .accessibilityHidden(true)
     }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1161,16 +1161,13 @@ struct BrowserPanelView: View {
                 // mutually exclusive, so a second standalone icon would only
                 // recreate the crowded cluster this layout removes.
                 browserActiveModeButtonWithShortcutHint
+                browserScreenshotCopiedIndicator
                 browserOverflowMenu
                 browserProfileButton
                 browserThemeModeButton
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
-            .overlay(alignment: .topTrailing) {
-                browserScreenshotCopiedIndicator
-                    .offset(y: -24)
-            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, addressBarVerticalPadding)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1524,9 +1524,9 @@ struct BrowserPanelView: View {
         return ZStack {
             CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
-                .rotationEffect(.degrees(90))
         }
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .rotationEffect(.degrees(90))
         .accessibilityHidden(true)
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1547,21 +1547,23 @@ struct BrowserPanelView: View {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .tint(devToolsColorOption.color)
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .safeHelp(String(localized: "browser.moreActions", defaultValue: "More Actions"))
         .accessibilityIdentifier("BrowserOverflowMenu")
     }
 
     private var browserVerticalMoreIcon: some View {
-        // macOS does not expose `ellipsis.vertical`; rotate the native
-        // template symbol so the dots share the other accessories' tint/weight.
-        CmuxSystemSymbolImage(
-            systemName: "ellipsis",
-            pointSize: devToolsButtonIconSize + 2,
-            weight: .medium
-        )
-            .foregroundStyle(devToolsColorOption.color)
-            .rotationEffect(.degrees(90))
+        // Menu labels flatten SwiftUI transforms on macOS, so draw the
+        // vertical affordance directly instead of rotating a horizontal glyph.
+        let dotDiameter = max(3, devToolsButtonIconSize * 0.34)
+        let dotSpacing = max(1.5, devToolsButtonIconSize * 0.18)
+        return VStack(spacing: dotSpacing) {
+            Circle().fill(devToolsColorOption.color)
+            Circle().fill(devToolsColorOption.color)
+            Circle().fill(devToolsColorOption.color)
+        }
+            .frame(width: dotDiameter, height: dotDiameter * 3 + dotSpacing * 2)
             .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .accessibilityHidden(true)
     }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -310,15 +310,6 @@ struct BrowserPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @State private var omnibarPillFrame: CGRect = .zero
     @State private var addressBarHeight: CGFloat = 0
-    @State private var addressBarWidth: CGFloat = 0
-
-    /// Below this chrome width the full accessory row would crowd out the
-    /// omnibar, so the plain-action buttons collapse into an overflow menu.
-    private static let compactChromeWidthThreshold: CGFloat = 420
-
-    private var isChromeCompact: Bool {
-        addressBarWidth > 0 && addressBarWidth < Self.compactChromeWidthThreshold
-    }
     @State private var isBrowserImportHintPopoverPresented = false
     @State private var focusModeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @State private var lastHandledAddressBarFocusRequestId: UUID?
@@ -1055,9 +1046,6 @@ struct BrowserPanelView: View {
         .onPreferenceChange(BrowserAddressBarHeightPreferenceKey.self) { height in
             addressBarHeight = height
         }
-        .onPreferenceChange(BrowserAddressBarWidthPreferenceKey.self) { width in
-            addressBarWidth = width
-        }
         .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveClick)) { notification in
             handleBrowserWebViewClickIntent(notification)
         }
@@ -1152,16 +1140,14 @@ struct BrowserPanelView: View {
                 if shouldShowToolbarImportHintChip {
                     browserImportHintToolbarChip
                 }
-                if isChromeCompact {
-                    // Narrow panes can't fit the full accessory row without
-                    // clipping the omnibar; collapse the plain-action buttons
-                    // into an overflow menu and keep the popover-anchored
-                    // profile/theme controls present.
-                    browserOverflowMenu
-                    browserProfileButton
-                    browserThemeModeButton
-                } else {
+                // Plain actions stay in the overflow menu so the browser
+                // chrome remains quiet at every width. Mode controls are the
+                // exception: while active, their state must remain visible
+                // without asking the user to reopen the menu.
+                if panel.isBrowserFocusModeActive {
                     browserFocusModeButtonWithShortcutHint
+                }
+                if panel.designModeController.isActive {
                     BrowserDesignModeToolbarButton(
                         controller: panel.designModeController,
                         iconPointSize: devToolsButtonIconSize,
@@ -1169,25 +1155,21 @@ struct BrowserPanelView: View {
                         inactiveColor: devToolsColorOption.color,
                         onToggle: { await panel.toggleDesignMode(reason: "toolbar") }
                     )
-                    screenshotPageButton
-                    // reactGrabButton  // Hidden for now; design mode covers element grabbing.
-                    browserProfileButton
-                    browserThemeModeButton
-                    developerToolsButton
                 }
+                // Screenshot feedback is transiently promoted beside the
+                // overflow trigger so the existing Copied chip remains
+                // visible after the menu item closes.
+                if screenshotPageCopied {
+                    screenshotPageButton
+                }
+                browserOverflowMenu
+                browserProfileButton
+                browserThemeModeButton
             }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, addressBarVerticalPadding)
         .background(browserChromeBackground)
-        .background {
-            GeometryReader { geo in
-                Color.clear.preference(
-                    key: BrowserAddressBarWidthPreferenceKey.self,
-                    value: geo.size.width
-                )
-            }
-        }
         .background(
             WindowAccessor(refreshID: showModifierHoldHints) { window in
                 focusModeShortcutHintMonitor.setHostWindow(showModifierHoldHints ? window : nil)
@@ -3610,14 +3592,6 @@ private struct OmnibarPillFramePreferenceKey: PreferenceKey {
 }
 
 private struct BrowserAddressBarHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-private struct BrowserAddressBarWidthPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1505,8 +1505,11 @@ struct BrowserPanelView: View {
             .disabled(!panel.shouldRenderWebView)
             .accessibilityIdentifier("BrowserScreenshotSectionButton")
         } label: {
-            CmuxSystemSymbolImage(systemName: "ellipsis.vertical", pointSize: devToolsButtonIconSize, weight: .medium)
+            // macOS does not provide `ellipsis.vertical`; rotate the
+            // supported horizontal symbol to keep the More affordance vertical.
+            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
+                .rotationEffect(.degrees(90))
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
         .menuStyle(.borderlessButton)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1505,18 +1505,30 @@ struct BrowserPanelView: View {
             .disabled(!panel.shouldRenderWebView)
             .accessibilityIdentifier("BrowserScreenshotSectionButton")
         } label: {
-            // macOS does not provide `ellipsis.vertical`; rotate the
-            // supported horizontal symbol to keep the More affordance vertical.
-            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
-                .foregroundStyle(devToolsColorOption.color)
-                .rotationEffect(.degrees(90))
-                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            browserVerticalMoreIcon
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .safeHelp(String(localized: "browser.moreActions", defaultValue: "More Actions"))
         .accessibilityIdentifier("BrowserOverflowMenu")
+    }
+
+    private var browserVerticalMoreIcon: some View {
+        let dotSize = max(2, devToolsButtonIconSize * 0.2)
+        return VStack(spacing: dotSize * 0.55) {
+            Circle()
+                .fill(devToolsColorOption.color)
+                .frame(width: dotSize, height: dotSize)
+            Circle()
+                .fill(devToolsColorOption.color)
+                .frame(width: dotSize, height: dotSize)
+            Circle()
+                .fill(devToolsColorOption.color)
+                .frame(width: dotSize, height: dotSize)
+        }
+        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .accessibilityHidden(true)
     }
 
     private var browserThemeModeButton: some View {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1521,12 +1521,23 @@ struct BrowserPanelView: View {
     }
 
     private var browserVerticalMoreIcon: some View {
+        let dotSize = max(2, devToolsButtonIconSize * 0.2)
         return ZStack {
-            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
-                .foregroundStyle(devToolsColorOption.color)
+            Color.clear
+                .frame(width: devToolsButtonIconSize, height: devToolsButtonIconSize)
+            VStack(spacing: dotSize * 0.55) {
+                Circle()
+                    .fill(devToolsColorOption.color)
+                    .frame(width: dotSize, height: dotSize)
+                Circle()
+                    .fill(devToolsColorOption.color)
+                    .frame(width: dotSize, height: dotSize)
+                Circle()
+                    .fill(devToolsColorOption.color)
+                    .frame(width: dotSize, height: dotSize)
+            }
         }
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        .rotationEffect(.degrees(90))
         .accessibilityHidden(true)
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -651,9 +651,7 @@ struct BrowserPanelView: View {
             defer {
                 screenshotPageCaptureInProgress = false
             }
-            let didCopy = await panel.captureScreenshotPageToClipboard()
-            guard didCopy else { return }
-            showScreenshotPageCopiedIndicator()
+            _ = await panel.captureScreenshotPageToClipboard()
         }
     }
 
@@ -1093,6 +1091,9 @@ struct BrowserPanelView: View {
         }
         .onChange(of: panel.focusFlashToken) { _, _ in
             triggerFocusFlashAnimation()
+        }
+        .onChange(of: panel.screenshotCopiedToken) { _, _ in
+            showScreenshotPageCopiedIndicator()
         }
         .onChange(of: panel.currentURL) { _, _ in
             handleCurrentURLChange()
@@ -1554,16 +1555,11 @@ struct BrowserPanelView: View {
     }
 
     private var browserVerticalMoreIcon: some View {
-        // Menu labels flatten SwiftUI transforms on macOS, so draw the
-        // vertical affordance directly instead of rotating a horizontal glyph.
-        let dotDiameter = max(3, devToolsButtonIconSize * 0.34)
-        let dotSpacing = max(1.5, devToolsButtonIconSize * 0.18)
-        return VStack(spacing: dotSpacing) {
-            Circle().fill(devToolsColorOption.color)
-            Circle().fill(devToolsColorOption.color)
-            Circle().fill(devToolsColorOption.color)
-        }
-            .frame(width: dotDiameter, height: dotDiameter * 3 + dotSpacing * 2)
+        // Menu labels preserve text glyphs (but flatten view transforms), so
+        // use the native vertical-ellipsis character for a stable label.
+        Text(verbatim: "⋮")
+            .font(.system(size: devToolsButtonIconSize + 4, weight: .medium))
+            .foregroundStyle(devToolsColorOption.color)
             .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .accessibilityHidden(true)
     }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -318,6 +318,16 @@ struct BrowserPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @State private var omnibarPillFrame: CGRect = .zero
     @State private var addressBarHeight: CGFloat = 0
+    @State private var addressBarWidth: CGFloat = 0
+
+    /// Below this chrome width the full accessory row would crowd out the
+    /// omnibar, so the toolbar tools collapse into More.
+    private static let compactChromeWidthThreshold: CGFloat = 420
+
+    private var isChromeCompact: Bool {
+        addressBarWidth > 0 && addressBarWidth < Self.compactChromeWidthThreshold
+    }
+
     @State private var isBrowserImportHintPopoverPresented = false
     @State private var focusModeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @State private var lastHandledAddressBarFocusRequestId: UUID?
@@ -1066,6 +1076,9 @@ struct BrowserPanelView: View {
         .onPreferenceChange(BrowserAddressBarHeightPreferenceKey.self) { height in
             addressBarHeight = height
         }
+        .onPreferenceChange(BrowserAddressBarWidthPreferenceKey.self) { width in
+            addressBarWidth = width
+        }
         .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveClick)) { notification in
             handleBrowserWebViewClickIntent(notification)
         }
@@ -1155,45 +1168,51 @@ struct BrowserPanelView: View {
             omnibarField
                 .accessibilityIdentifier("BrowserOmnibarPill")
                 .accessibilityLabel("Browser omnibar")
-                .frame(minWidth: 0, maxWidth: .infinity)
 
             HStack(spacing: browserToolbarAccessorySpacing) {
                 if shouldShowToolbarImportHintChip {
                     browserImportHintToolbarChip
                 }
-                // Focus and Design Mode share one transient text chip while
-                // active. Design Mode and DevTools stay reachable without
-                // opening the menu; lower-frequency screenshot actions remain
-                // in the overflow menu. Keep More at the far right so the
-                // popover/menu affordance has a stable trailing anchor.
-                browserActiveModeButtonWithShortcutHint
-                browserScreenshotCopiedIndicator
-                if activeToolbarMode != .design {
-                    BrowserDesignModeToolbarButton(
-                        controller: panel.designModeController,
-                        iconPointSize: devToolsButtonIconSize,
-                        hitSize: addressBarButtonSize,
-                        inactiveColor: devToolsColorOption.color,
-                        onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "toolbar") }
-                    )
-                }
-                browserProfileButton
-                browserThemeModeButton
-                Spacer(minLength: 0)
-                HStack(spacing: browserToolbarAccessorySpacing) {
+                if isChromeCompact {
+                    browserActiveModeButtonWithShortcutHint
+                    browserScreenshotCopiedIndicator
+                    browserProfileButton
+                    browserThemeModeButton
+                    browserOverflowMenu
+                } else {
+                    // Keep the stable wide-row sizing and place Inspect/DevTools
+                    // immediately before the trailing More affordance.
+                    browserActiveModeButtonWithShortcutHint
+                    browserScreenshotCopiedIndicator
+                    if activeToolbarMode != .design {
+                        BrowserDesignModeToolbarButton(
+                            controller: panel.designModeController,
+                            iconPointSize: devToolsButtonIconSize,
+                            hitSize: addressBarButtonSize,
+                            inactiveColor: devToolsColorOption.color,
+                            onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "toolbar") }
+                        )
+                    }
+                    browserProfileButton
+                    browserThemeModeButton
                     developerToolsButton
                     browserOverflowMenu
                 }
-                .fixedSize(horizontal: true, vertical: false)
-                .layoutPriority(1)
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
-            .layoutPriority(1)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, addressBarVerticalPadding)
         .background(browserChromeBackground)
+        .background {
+            GeometryReader { geo in
+                Color.clear.preference(
+                    key: BrowserAddressBarWidthPreferenceKey.self,
+                    value: geo.size.width
+                )
+            }
+        }
         .background(
             WindowAccessor(refreshID: showModifierHoldHints) { window in
                 focusModeShortcutHintMonitor.setHostWindow(showModifierHoldHints ? window : nil)
@@ -1510,6 +1529,18 @@ struct BrowserPanelView: View {
             }
             .disabled(!panel.shouldRenderWebView)
             .accessibilityIdentifier("BrowserScreenshotSectionButton")
+            if isChromeCompact {
+                Divider()
+                BrowserDesignModeOverflowMenuButton(
+                    controller: panel.designModeController,
+                    onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "overflowMenu") }
+                )
+                .accessibilityIdentifier("BrowserOverflowDesignModeButton")
+                Button(action: openDevTools) {
+                    Label(developerToolsButtonHelp, systemImage: devToolsIconOption.rawValue)
+                }
+                .accessibilityIdentifier("BrowserToggleDevToolsButton")
+            }
         } label: {
             browserVerticalMoreIcon
         }
@@ -1521,24 +1552,11 @@ struct BrowserPanelView: View {
     }
 
     private var browserVerticalMoreIcon: some View {
-        let dotSize = max(2, devToolsButtonIconSize * 0.2)
-        return ZStack {
-            Color.clear
-                .frame(width: devToolsButtonIconSize, height: devToolsButtonIconSize)
-            VStack(spacing: dotSize * 0.55) {
-                Circle()
-                    .fill(devToolsColorOption.color)
-                    .frame(width: dotSize, height: dotSize)
-                Circle()
-                    .fill(devToolsColorOption.color)
-                    .frame(width: dotSize, height: dotSize)
-                Circle()
-                    .fill(devToolsColorOption.color)
-                    .frame(width: dotSize, height: dotSize)
-            }
-        }
-        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        .accessibilityHidden(true)
+        Text(verbatim: "⋮")
+            .cmuxFont(size: devToolsButtonIconSize, weight: .medium)
+            .foregroundStyle(devToolsColorOption.color)
+            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            .accessibilityHidden(true)
     }
 
     private var browserThemeModeButton: some View {
@@ -3664,6 +3682,14 @@ private struct OmnibarPillFramePreferenceKey: PreferenceKey {
         if next != .zero {
             value = next
         }
+    }
+}
+
+private struct BrowserAddressBarWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1155,14 +1155,23 @@ struct BrowserPanelView: View {
                 if shouldShowToolbarImportHintChip {
                     browserImportHintToolbarChip
                 }
-                // Plain actions stay in the overflow menu so the browser
-                // chrome remains quiet at every width. Focus and Design Mode
-                // share one transient text chip while active; the modes are
-                // mutually exclusive, so a second standalone icon would only
-                // recreate the crowded cluster this layout removes.
+                // Focus and Design Mode share one transient text chip while
+                // active. Design Mode and DevTools stay reachable without
+                // opening the menu; lower-frequency Focus and Screenshot
+                // actions remain in the overflow menu.
                 browserActiveModeButtonWithShortcutHint
                 browserScreenshotCopiedIndicator
                 browserOverflowMenu
+                if activeToolbarMode != .design {
+                    BrowserDesignModeToolbarButton(
+                        controller: panel.designModeController,
+                        iconPointSize: devToolsButtonIconSize,
+                        hitSize: addressBarButtonSize,
+                        inactiveColor: devToolsColorOption.color,
+                        onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "toolbar") }
+                    )
+                }
+                developerToolsButton
                 browserProfileButton
                 browserThemeModeButton
             }
@@ -1421,21 +1430,6 @@ struct BrowserPanelView: View {
         }
     }
 
-    private var reactGrabButton: some View {
-        Button(action: {
-            panel.clearReactGrabRoundTrip(reason: "toolbarButton.manualStart")
-            Task { await panel.toggleOrInjectReactGrab() }
-        }) {
-            CmuxSystemSymbolImage(systemName: "cursorarrow.click.2", pointSize: devToolsButtonIconSize, weight: .medium)
-                .foregroundStyle(panel.isReactGrabActive ? Color.accentColor : Color.secondary)
-                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        }
-        .buttonStyle(OmnibarAddressButtonStyle())
-        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        .safeHelp(String(localized: "browser.reactGrab", defaultValue: "Inject React Grab"))
-        .accessibilityIdentifier("BrowserReactGrabButton")
-    }
-
     private var developerToolsButton: some View {
         Button(action: {
             openDevTools()
@@ -1475,8 +1469,8 @@ struct BrowserPanelView: View {
         .accessibilityIdentifier("BrowserProfileButton")
     }
 
-    /// Compact-chrome actions that do not need dedicated toolbar space.
-    /// Profile and theme stay as visible buttons since they anchor popovers.
+    /// Low-frequency browser actions that do not need dedicated toolbar space.
+    /// Design Mode and DevTools stay visible because they are persistent tools.
     private var browserOverflowMenu: some View {
         Menu {
             Button(action: handleBrowserFocusModeButtonAction) {
@@ -1494,26 +1488,6 @@ struct BrowserPanelView: View {
             }
             .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
             .accessibilityIdentifier("BrowserScreenshotPageButton")
-            BrowserDesignModeOverflowMenuButton(
-                controller: panel.designModeController,
-                onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "overflowMenu") }
-            )
-            .accessibilityIdentifier("BrowserOverflowDesignModeButton")
-            Button {
-                panel.clearReactGrabRoundTrip(reason: "overflowMenu.manualStart")
-                Task { await panel.toggleOrInjectReactGrab() }
-            } label: {
-                Label(
-                    String(localized: "browser.reactGrab", defaultValue: "Inject React Grab"),
-                    systemImage: "cursorarrow.click.2"
-                )
-            }
-            .accessibilityIdentifier("BrowserOverflowReactGrabButton")
-
-            Button(action: { openDevTools() }) {
-                Label(developerToolsButtonHelp, systemImage: devToolsIconOption.rawValue)
-            }
-            .accessibilityIdentifier("BrowserToggleDevToolsButton")
         } label: {
             CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1485,10 +1485,7 @@ struct BrowserPanelView: View {
             }
             .disabled(!panel.canToggleBrowserFocusMode)
             Button(action: handleScreenshotPageButtonAction) {
-                Label(
-                    String(localized: "browser.screenshotPage.copy.help", defaultValue: "Screenshot Page to Clipboard"),
-                    systemImage: "camera"
-                )
+                Text(String(localized: "browser.screenshotPage.copy.help", defaultValue: "Screenshot Page to Clipboard"))
             }
             .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
             .accessibilityIdentifier("BrowserScreenshotPageButton")

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1415,7 +1415,7 @@ struct BrowserPanelView: View {
         case .focus:
             handleBrowserFocusModeButtonAction()
         case .design:
-            panel.toggleDesignModeFromToolbar()
+            _ = panel.toggleDesignModeFromBrowserChrome(reason: "toolbar")
         case nil:
             break
         }
@@ -1496,7 +1496,7 @@ struct BrowserPanelView: View {
             .accessibilityIdentifier("BrowserScreenshotPageButton")
             BrowserDesignModeOverflowMenuButton(
                 controller: panel.designModeController,
-                onToggle: { await panel.toggleDesignMode(reason: "overflowMenu") }
+                onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "overflowMenu") }
             )
             .accessibilityIdentifier("BrowserOverflowDesignModeButton")
             Button {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -757,6 +757,7 @@ struct BrowserPanelView: View {
     private func handleBrowserPanelDisappear() {
         stopOmnibarSuggestionRefreshConsumer()
         cancelPendingOmnibarSuggestionWork()
+        panel.cancelDesignModeToolbarToggle()
         focusModeShortcutHintMonitor.stop()
         screenshotPageCopiedScheduler.cancel()
         screenshotPageCopied = false
@@ -1164,6 +1165,8 @@ struct BrowserPanelView: View {
                 browserProfileButton
                 browserThemeModeButton
             }
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("BrowserToolbarAccessoryRow")
             .overlay(alignment: .topTrailing) {
                 browserScreenshotCopiedIndicator
                     .offset(y: -24)
@@ -1283,6 +1286,12 @@ struct BrowserPanelView: View {
                 )
                 .fixedSize()
                 .allowsHitTesting(false)
+                .accessibilityRepresentation {
+                    Label(
+                        String(localized: "browser.screenshotPage.copied", defaultValue: "Copied"),
+                        systemImage: "checkmark"
+                    )
+                }
                 .accessibilityIdentifier("BrowserScreenshotPageCopied")
                 .transition(.opacity)
                 .animation(.easeOut(duration: 0.12), value: screenshotPageCopied)
@@ -1409,9 +1418,7 @@ struct BrowserPanelView: View {
         case .focus:
             handleBrowserFocusModeButtonAction()
         case .design:
-            Task { @MainActor in
-                _ = await panel.toggleDesignMode(reason: "toolbar")
-            }
+            panel.toggleDesignModeFromToolbar()
         case nil:
             break
         }
@@ -1484,6 +1491,7 @@ struct BrowserPanelView: View {
                 )
             }
             .disabled(!panel.canToggleBrowserFocusMode)
+            .accessibilityIdentifier("BrowserOverflowFocusModeButton")
             Button(action: handleScreenshotPageButtonAction) {
                 Text(String(localized: "browser.screenshotPage.copy.help", defaultValue: "Screenshot Page to Clipboard"))
             }
@@ -1493,6 +1501,7 @@ struct BrowserPanelView: View {
                 controller: panel.designModeController,
                 onToggle: { await panel.toggleDesignMode(reason: "overflowMenu") }
             )
+            .accessibilityIdentifier("BrowserOverflowDesignModeButton")
             Button {
                 panel.clearReactGrabRoundTrip(reason: "overflowMenu.manualStart")
                 Task { await panel.toggleOrInjectReactGrab() }
@@ -1502,10 +1511,12 @@ struct BrowserPanelView: View {
                     systemImage: "cursorarrow.click.2"
                 )
             }
+            .accessibilityIdentifier("BrowserOverflowReactGrabButton")
 
             Button(action: { openDevTools() }) {
                 Label(developerToolsButtonHelp, systemImage: devToolsIconOption.rawValue)
             }
+            .accessibilityIdentifier("BrowserToggleDevToolsButton")
         } label: {
             CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -249,6 +249,14 @@ struct BrowserPanelView: View {
         case suggestion
     }
 
+    /// The one transient mode state that may be promoted into the toolbar.
+    /// Focus and Design Mode are mutually exclusive, so showing one shared
+    /// status chip keeps the accessory row from growing a second icon cluster.
+    private enum ActiveToolbarMode: Equatable {
+        case focus
+        case design
+    }
+
     @ObservedObject var panel: BrowserPanel
     @ObservedObject private var browserProfileStore = BrowserProfileStore.shared
     private let chromeState: BrowserChromeState
@@ -340,6 +348,12 @@ struct BrowserPanelView: View {
     private var addressBarButtonSize: CGFloat { chromeMetrics.buttonIconSize }
     private var addressBarButtonHitSize: CGFloat { chromeMetrics.buttonHitSize }
     private var devToolsButtonIconSize: CGFloat { chromeMetrics.accessoryIconFontSize }
+
+    private var activeToolbarMode: ActiveToolbarMode? {
+        if panel.isBrowserFocusModeActive { return .focus }
+        if panel.designModeController.isActive { return .design }
+        return nil
+    }
 
     private var resolvedThemeBackgroundIdentity: String {
         resolvedThemeBackgroundColor.hexString(includeAlpha: true)
@@ -1141,30 +1155,18 @@ struct BrowserPanelView: View {
                     browserImportHintToolbarChip
                 }
                 // Plain actions stay in the overflow menu so the browser
-                // chrome remains quiet at every width. Mode controls are the
-                // exception: while active, their state must remain visible
-                // without asking the user to reopen the menu.
-                if panel.isBrowserFocusModeActive {
-                    browserFocusModeButtonWithShortcutHint
-                }
-                if panel.designModeController.isActive {
-                    BrowserDesignModeToolbarButton(
-                        controller: panel.designModeController,
-                        iconPointSize: devToolsButtonIconSize,
-                        hitSize: addressBarButtonSize,
-                        inactiveColor: devToolsColorOption.color,
-                        onToggle: { await panel.toggleDesignMode(reason: "toolbar") }
-                    )
-                }
-                // Screenshot feedback is transiently promoted beside the
-                // overflow trigger so the existing Copied chip remains
-                // visible after the menu item closes.
-                if screenshotPageCopied {
-                    screenshotPageButton
-                }
+                // chrome remains quiet at every width. Focus and Design Mode
+                // share one transient text chip while active; the modes are
+                // mutually exclusive, so a second standalone icon would only
+                // recreate the crowded cluster this layout removes.
+                browserActiveModeButtonWithShortcutHint
                 browserOverflowMenu
                 browserProfileButton
                 browserThemeModeButton
+            }
+            .overlay(alignment: .topTrailing) {
+                browserScreenshotCopiedIndicator
+                    .offset(y: -24)
             }
         }
         .padding(.horizontal, 8)
@@ -1267,99 +1269,152 @@ struct BrowserPanelView: View {
         return panel.recentDownloads
     }
 
-    private var screenshotPageButton: some View {
-        Button(action: handleScreenshotPageButtonAction) {
-            CmuxSystemSymbolImage(systemName: screenshotPageCopied ? "checkmark" : "camera", pointSize: devToolsButtonIconSize, weight: .medium)
-                .foregroundStyle(screenshotPageButtonColor)
-                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+    @ViewBuilder
+    private var browserScreenshotCopiedIndicator: some View {
+        if screenshotPageCopied {
+            Text(String(localized: "browser.screenshotPage.copied", defaultValue: "Copied"))
+                .cmuxFont(size: 11, weight: .medium)
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.thinMaterial, in: Capsule())
+                .overlay(
+                    Capsule().stroke(Color.white.opacity(0.14), lineWidth: 1)
+                )
+                .fixedSize()
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("BrowserScreenshotPageCopied")
+                .transition(.opacity)
+                .animation(.easeOut(duration: 0.12), value: screenshotPageCopied)
         }
-        .buttonStyle(OmnibarAddressButtonStyle())
-        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
-        .opacity(panel.shouldRenderWebView ? 1.0 : 0.4)
-        .safeHelp(
-            screenshotPageCopied
-                ? String(localized: "browser.screenshotPage.copied.help", defaultValue: "Screenshot copied to clipboard")
-                : String(localized: "browser.screenshotPage.copy.help", defaultValue: "Screenshot Page to Clipboard")
-        )
-        .accessibilityIdentifier("BrowserScreenshotPageButton")
-        .overlay(alignment: .top) {
-            if screenshotPageCopied {
-                Label(String(localized: "browser.screenshotPage.copied", defaultValue: "Copied"), systemImage: "checkmark")
-                    .cmuxFont(size: 11, weight: .medium)
-                    .labelStyle(.titleAndIcon)
-                    .foregroundStyle(.primary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(.thinMaterial, in: Capsule())
-                    .overlay(
-                        Capsule().stroke(Color.white.opacity(0.14), lineWidth: 1)
-                    )
-                    .fixedSize()
-                    .offset(y: -28)
-                    .allowsHitTesting(false)
-                    .transition(.opacity)
-            }
-        }
-        .animation(.easeOut(duration: 0.12), value: screenshotPageCopied)
     }
 
-    private var browserFocusModeButtonWithShortcutHint: some View {
-        ZStack(alignment: .top) {
-            browserFocusModeButton
-            if shouldShowBrowserFocusModeShortcutHint {
-                ShortcutHintPill(text: browserFocusModeShortcutHint, fontSize: 9, emphasis: 1.05)
-                    .offset(y: -22)
-                    .shortcutHintTransition()
-                    .accessibilityIdentifier("BrowserFocusModeShortcutHint")
-                    .allowsHitTesting(false)
-                    .zIndex(10)
-            }
-        }
-        .shortcutHintVisibilityAnimation(value: shouldShowBrowserFocusModeShortcutHint)
-    }
-
-    private var browserFocusModeButton: some View {
-        Button(action: handleBrowserFocusModeButtonAction) {
-            HStack(spacing: 5) {
-                CmuxSystemSymbolImage(systemName: "keyboard", pointSize: devToolsButtonIconSize, weight: .medium)
-                    .scaleEffect(panel.isBrowserFocusModeActive ? 1.08 : 1.0)
-                    .animation(.spring(response: 0.18, dampingFraction: 0.82), value: panel.isBrowserFocusModeActive)
-                if panel.isBrowserFocusModeActive {
-                    Text(
-                        panel.isBrowserFocusModeExitArmed
-                            ? String(localized: "browser.focusMode.armed", defaultValue: "Esc again to exit")
-                            : String(localized: "browser.focusMode.active", defaultValue: "Focus Mode")
-                    )
-                    .cmuxFont(size: 11, weight: .semibold)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+    @ViewBuilder
+    private var browserActiveModeButtonWithShortcutHint: some View {
+        if activeToolbarMode != nil {
+            ZStack(alignment: .top) {
+                browserActiveModeButton
+                if shouldShowBrowserFocusModeShortcutHint {
+                    ShortcutHintPill(text: browserFocusModeShortcutHint, fontSize: 9, emphasis: 1.05)
+                        .offset(y: -22)
+                        .shortcutHintTransition()
+                        .accessibilityIdentifier("BrowserFocusModeShortcutHint")
+                        .allowsHitTesting(false)
+                        .zIndex(10)
                 }
             }
-            .foregroundStyle(panel.isBrowserFocusModeActive ? Color.orange : devToolsColorOption.color)
-            .padding(.horizontal, panel.isBrowserFocusModeActive ? 7 : 0)
-            .frame(
-                minWidth: panel.isBrowserFocusModeActive ? 0 : addressBarButtonSize,
-                minHeight: addressBarButtonSize,
-                alignment: .center
-            )
-            .animation(.easeOut(duration: 0.14), value: panel.isBrowserFocusModeActive)
-            .animation(.easeOut(duration: 0.12), value: panel.isBrowserFocusModeExitArmed)
+            .shortcutHintVisibilityAnimation(value: shouldShowBrowserFocusModeShortcutHint)
         }
-        .buttonStyle(OmnibarAddressButtonStyle())
-        .frame(height: addressBarButtonSize, alignment: .center)
-        .disabled(!panel.canToggleBrowserFocusMode)
-        .opacity(panel.canToggleBrowserFocusMode ? 1.0 : 0.4)
-        .safeHelp(browserFocusModeButtonHelp)
-        .accessibilityIdentifier("BrowserFocusModeButton")
     }
 
-    private var screenshotPageButtonColor: Color {
-        if screenshotPageCopied {
-            return .green
+    private var browserActiveModeButton: some View {
+        Button(action: handleActiveToolbarModeButtonAction) {
+            Text(activeToolbarModeTitle)
+                .cmuxFont(size: 11, weight: .semibold)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .foregroundStyle(activeToolbarModeColor)
+                .padding(.horizontal, 8)
+                .frame(minHeight: addressBarButtonSize, alignment: .center)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(activeToolbarModeColor.opacity(0.12))
+                )
         }
-        return panel.shouldRenderWebView ? devToolsColorOption.color : Color.secondary
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .frame(minHeight: addressBarButtonSize, alignment: .center)
+        .disabled(!activeToolbarModeCanToggle)
+        .opacity(activeToolbarModeCanToggle ? 1.0 : 0.4)
+        .safeHelp(activeToolbarModeHelp)
+        .accessibilityLabel(activeToolbarModeAccessibilityLabel)
+        .accessibilityIdentifier(activeToolbarModeAccessibilityIdentifier)
+    }
+
+    private var activeToolbarModeTitle: String {
+        switch activeToolbarMode {
+        case .focus:
+            return panel.isBrowserFocusModeExitArmed
+                ? String(localized: "browser.focusMode.armed", defaultValue: "Esc again to exit")
+                : String(localized: "browser.focusMode.active", defaultValue: "Focus Mode")
+        case .design:
+            return String(localized: "browser.designMode.title", defaultValue: "Design Mode")
+        case nil:
+            return ""
+        }
+    }
+
+    private var activeToolbarModeColor: Color {
+        switch activeToolbarMode {
+        case .focus:
+            return .orange
+        case .design:
+            return cmuxAccentColor()
+        case nil:
+            return devToolsColorOption.color
+        }
+    }
+
+    private var activeToolbarModeCanToggle: Bool {
+        switch activeToolbarMode {
+        case .focus:
+            return panel.canToggleBrowserFocusMode
+        case .design:
+            return panel.designModeController.canToggle
+        case nil:
+            return false
+        }
+    }
+
+    private var activeToolbarModeHelp: String {
+        switch activeToolbarMode {
+        case .focus:
+            return browserFocusModeButtonHelp
+        case .design:
+            return panel.designModeController.unavailableMessage ?? String(
+                format: String(
+                    localized: "browser.designMode.buttonHelpFormat",
+                    defaultValue: "Design Mode (%@)"
+                ),
+                KeyboardShortcutSettings.shortcut(for: .toggleBrowserDesignMode).displayString
+            )
+        case nil:
+            return ""
+        }
+    }
+
+    private var activeToolbarModeAccessibilityLabel: String {
+        switch activeToolbarMode {
+        case .focus:
+            return activeToolbarModeTitle
+        case .design:
+            return String(localized: "browser.designMode.title", defaultValue: "Design Mode")
+        case nil:
+            return ""
+        }
+    }
+
+    private var activeToolbarModeAccessibilityIdentifier: String {
+        switch activeToolbarMode {
+        case .focus:
+            return "BrowserFocusModeButton"
+        case .design:
+            return "BrowserDesignModeButton"
+        case nil:
+            return "BrowserActiveModeButton"
+        }
+    }
+
+    private func handleActiveToolbarModeButtonAction() {
+        switch activeToolbarMode {
+        case .focus:
+            handleBrowserFocusModeButtonAction()
+        case .design:
+            Task { @MainActor in
+                _ = await panel.toggleDesignMode(reason: "toolbar")
+            }
+        case nil:
+            break
+        }
     }
 
     private var reactGrabButton: some View {
@@ -1435,7 +1490,8 @@ struct BrowserPanelView: View {
                     systemImage: "camera"
                 )
             }
-            .disabled(!panel.shouldRenderWebView)
+            .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
+            .accessibilityIdentifier("BrowserScreenshotPageButton")
             BrowserDesignModeOverflowMenuButton(
                 controller: panel.designModeController,
                 onToggle: { await panel.toggleDesignMode(reason: "overflowMenu") }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1179,12 +1179,12 @@ struct BrowserPanelView: View {
                 }
                 browserProfileButton
                 browserThemeModeButton
+                Spacer(minLength: 0)
                 developerToolsButton
                 browserOverflowMenu
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
-            .fixedSize(horizontal: true, vertical: false)
             .layoutPriority(1)
         }
         .padding(.horizontal, 8)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1521,17 +1521,10 @@ struct BrowserPanelView: View {
     }
 
     private var browserVerticalMoreIcon: some View {
-        let dotSize = max(2, devToolsButtonIconSize * 0.2)
-        return VStack(spacing: dotSize * 0.55) {
-            Circle()
-                .fill(devToolsColorOption.color)
-                .frame(width: dotSize, height: dotSize)
-            Circle()
-                .fill(devToolsColorOption.color)
-                .frame(width: dotSize, height: dotSize)
-            Circle()
-                .fill(devToolsColorOption.color)
-                .frame(width: dotSize, height: dotSize)
+        return ZStack {
+            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
+                .foregroundStyle(devToolsColorOption.color)
+                .rotationEffect(.degrees(90))
         }
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .accessibilityHidden(true)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1357,17 +1357,28 @@ struct BrowserPanelView: View {
 
     private var browserActiveModeButton: some View {
         Button(action: handleActiveToolbarModeButtonAction) {
-            Text(activeToolbarModeTitle)
-                .cmuxFont(size: 11, weight: .semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .foregroundStyle(activeToolbarModeColor)
-                .padding(.horizontal, 8)
-                .frame(minHeight: addressBarButtonSize, alignment: .center)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(activeToolbarModeColor.opacity(0.12))
-                )
+            HStack(spacing: 5) {
+                if let activeToolbarModeIconName {
+                    CmuxSystemSymbolImage(
+                        systemName: activeToolbarModeIconName,
+                        pointSize: devToolsButtonIconSize,
+                        weight: .medium
+                    )
+                    .foregroundStyle(activeToolbarModeColor)
+                    .accessibilityHidden(true)
+                }
+                Text(activeToolbarModeTitle)
+                    .cmuxFont(size: 11, weight: .semibold)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .foregroundStyle(activeToolbarModeColor)
+            .padding(.horizontal, 8)
+            .frame(minHeight: addressBarButtonSize, alignment: .center)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(activeToolbarModeColor.opacity(0.12))
+            )
         }
         .buttonStyle(OmnibarAddressButtonStyle())
         .frame(minHeight: addressBarButtonSize, alignment: .center)
@@ -1388,6 +1399,17 @@ struct BrowserPanelView: View {
             return String(localized: "browser.designMode.title", defaultValue: "Design Mode")
         case nil:
             return ""
+        }
+    }
+
+    private var activeToolbarModeIconName: String? {
+        switch activeToolbarMode {
+        case .focus:
+            return "keyboard"
+        case .design:
+            return "paintbrush.pointed.fill"
+        case nil:
+            return nil
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1176,9 +1176,9 @@ struct BrowserPanelView: View {
                         onToggle: { panel.toggleDesignModeFromBrowserChrome(reason: "toolbar") }
                     )
                 }
-                developerToolsButton
                 browserProfileButton
                 browserThemeModeButton
+                developerToolsButton
                 browserOverflowMenu
             }
             .accessibilityElement(children: .contain)
@@ -1504,7 +1504,7 @@ struct BrowserPanelView: View {
             .disabled(!panel.shouldRenderWebView)
             .accessibilityIdentifier("BrowserScreenshotSectionButton")
         } label: {
-            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(systemName: "ellipsis.vertical", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1475,16 +1475,17 @@ struct BrowserPanelView: View {
         Menu {
             Button(action: handleBrowserFocusModeButtonAction) {
                 Label(
-                    panel.isBrowserFocusModeActive
-                        ? String(localized: "browser.focusMode.active", defaultValue: "Focus Mode")
-                        : String(localized: "browser.focusMode.enter", defaultValue: "Enter Focus Mode"),
+                    String(localized: "browser.focusMode.active", defaultValue: "Focus Mode"),
                     systemImage: "keyboard"
                 )
             }
             .disabled(!panel.canToggleBrowserFocusMode)
             .accessibilityIdentifier("BrowserOverflowFocusModeButton")
             Button(action: handleScreenshotPageButtonAction) {
-                Text(String(localized: "browser.screenshotPage.copy.help", defaultValue: "Screenshot Page to Clipboard"))
+                Label(
+                    String(localized: "browser.contextMenu.screenshotPage", defaultValue: "Screenshot Page"),
+                    systemImage: "camera"
+                )
             }
             .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
             .accessibilityIdentifier("BrowserScreenshotPageButton")

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1155,6 +1155,7 @@ struct BrowserPanelView: View {
             omnibarField
                 .accessibilityIdentifier("BrowserOmnibarPill")
                 .accessibilityLabel("Browser omnibar")
+                .frame(minWidth: 0, maxWidth: .infinity)
 
             HStack(spacing: browserToolbarAccessorySpacing) {
                 if shouldShowToolbarImportHintChip {
@@ -1183,6 +1184,7 @@ struct BrowserPanelView: View {
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
+            .fixedSize(horizontal: true, vertical: false)
             .layoutPriority(1)
         }
         .padding(.horizontal, 8)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -647,6 +647,11 @@ struct BrowserPanelView: View {
         }
     }
 
+    private func handleScreenshotSectionButtonAction() {
+        guard panel.shouldRenderWebView else { return }
+        panel.beginScreenshotSectionSelectionFromBrowserChrome()
+    }
+
     private func showScreenshotPageCopiedIndicator() {
         screenshotPageCopiedScheduler.cancel()
         screenshotPageCopied = true
@@ -1157,11 +1162,11 @@ struct BrowserPanelView: View {
                 }
                 // Focus and Design Mode share one transient text chip while
                 // active. Design Mode and DevTools stay reachable without
-                // opening the menu; lower-frequency Focus and Screenshot
-                // actions remain in the overflow menu.
+                // opening the menu; lower-frequency screenshot actions remain
+                // in the overflow menu. Keep More at the far right so the
+                // popover/menu affordance has a stable trailing anchor.
                 browserActiveModeButtonWithShortcutHint
                 browserScreenshotCopiedIndicator
-                browserOverflowMenu
                 if activeToolbarMode != .design {
                     BrowserDesignModeToolbarButton(
                         controller: panel.designModeController,
@@ -1174,6 +1179,7 @@ struct BrowserPanelView: View {
                 developerToolsButton
                 browserProfileButton
                 browserThemeModeButton
+                browserOverflowMenu
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("BrowserToolbarAccessoryRow")
@@ -1489,6 +1495,14 @@ struct BrowserPanelView: View {
             }
             .disabled(!panel.shouldRenderWebView || screenshotPageCaptureInProgress)
             .accessibilityIdentifier("BrowserScreenshotPageButton")
+            Button(action: handleScreenshotSectionButtonAction) {
+                Label(
+                    String(localized: "browser.contextMenu.screenshotSection", defaultValue: "Screenshot Section"),
+                    systemImage: "viewfinder"
+                )
+            }
+            .disabled(!panel.shouldRenderWebView)
+            .accessibilityIdentifier("BrowserScreenshotSectionButton")
         } label: {
             CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)

--- a/Sources/Panels/BrowserScreenshot.swift
+++ b/Sources/Panels/BrowserScreenshot.swift
@@ -372,6 +372,7 @@ extension CmuxWebView {
                 return false
             }
             BrowserScreenshotFlash.show(over: self)
+            onScreenshotCopied?()
             return true
         } catch {
             #if DEBUG
@@ -421,6 +422,7 @@ extension CmuxWebView {
                         return
                     }
                     BrowserScreenshotFlash.show(over: self)
+                    onScreenshotCopied?()
                 } catch {
                     #if DEBUG
                     cmuxDebugLog("browser.screenshot.section.failed error=\(error.localizedDescription)")

--- a/Sources/Panels/BrowserScreenshot.swift
+++ b/Sources/Panels/BrowserScreenshot.swift
@@ -394,6 +394,10 @@ extension CmuxWebView {
         beginScreenshotSectionSelection()
     }
 
+    func beginScreenshotSectionSelectionFromBrowserChrome() {
+        beginScreenshotSectionSelection()
+    }
+
     private func beginScreenshotSectionSelection() {
         screenshotSelectionOverlay?.removeFromSuperview()
 
@@ -439,5 +443,10 @@ extension BrowserPanel {
             return false
         }
         return await webView.captureScreenshotPageToClipboard()
+    }
+
+    func beginScreenshotSectionSelectionFromBrowserChrome() {
+        guard let webView = webView as? CmuxWebView else { return }
+        webView.beginScreenshotSectionSelectionFromBrowserChrome()
     }
 }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -270,6 +270,8 @@ final class CmuxWebView: WKWebView {
     private static let pasteAsPlainTextKeyCode: UInt16 = 9 // V key (hardware position, layout-independent)
     var onContextMenuDownloadStateChanged: ((Bool) -> Void)?
     var onSessionDownloadEvent: (([String: Any]) -> Void)?
+    /// Called after a page or section screenshot is written to the pasteboard.
+    var onScreenshotCopied: (() -> Void)?
     private lazy var sessionDownloadSaver = BrowserSessionDownloadSaver(
         parentWindow: { [weak self] in self?.window },
         notifyDownloadState: { [weak self] in self?.notifyContextMenuDownloadState($0) },

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -322,6 +322,16 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             toolbarElement(app, identifier: "BrowserThemeModeButton").frame.maxX,
             "More should be the rightmost accessory control"
         )
+        XCTAssertGreaterThan(
+            toolbarElement(app, identifier: "BrowserToggleDevToolsButton").frame.minX,
+            toolbarElement(app, identifier: "BrowserThemeModeButton").frame.maxX,
+            "Inspect/DevTools should sit immediately before More"
+        )
+        XCTAssertGreaterThan(
+            toolbarElement(app, identifier: "BrowserOverflowMenu").frame.minX,
+            toolbarElement(app, identifier: "BrowserToggleDevToolsButton").frame.maxX,
+            "More should trail the Inspect/DevTools control"
+        )
 
         let inlineOverflowActionIdentifiers = [
             "BrowserFocusModeButton",

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -219,18 +219,22 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             "Expected the focus-mode test page to finish loading. data=\(loadGotoSplit() ?? [:])"
         )
 
-        let focusModeButton = app.buttons["BrowserFocusModeButton"].firstMatch
+        // Focus mode is a plain action in the overflow menu while inactive.
+        // Use its configured shortcut to enter it, then verify the active chip
+        // is promoted back into the inline accessory row.
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [.command, .option])
+
+        let focusModeButton = toolbarElement(app, identifier: "BrowserFocusModeButton")
         XCTAssertTrue(
             focusModeButton.waitForExistence(timeout: 5.0),
-            "Expected browser focus-mode toolbar button to exist"
+            "Expected the active browser focus-mode chip to be promoted inline"
         )
-        focusModeButton.click()
 
         XCTAssertTrue(
             waitForGotoSplitMatch(timeout: 5.0) { data in
                 data["browserFocusModeActive"] == "true"
             },
-            "Expected toolbar button to enter browser focus mode. data=\(loadGotoSplit() ?? [:])"
+            "Expected the configured focus-mode shortcut to enter browser focus mode. data=\(loadGotoSplit() ?? [:])"
         )
 
         app.typeKey("f", modifierFlags: [.command])
@@ -277,12 +281,53 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             "Expected second Escape to exit focus mode without reaching the page. data=\(loadGotoSplit() ?? [:])"
         )
 
+        XCTAssertFalse(
+            focusModeButton.exists,
+            "The inactive focus-mode action should return to the overflow menu"
+        )
+
         let baselineAddTabInvocations = loadKeyequiv()["addTabInvocations"].flatMap(Int.init) ?? 0
         app.typeKey("n", modifierFlags: [.command])
         XCTAssertTrue(
             waitForKeyequivInt(key: "addTabInvocations", toBeAtLeast: baselineAddTabInvocations + 1, timeout: 5.0),
             "Expected Cmd+N to resume normal cmux routing after focus mode exit. data=\(loadKeyequiv())"
         )
+    }
+
+    func testWideBrowserToolbarUsesOverflowForPlainActions() {
+        let app = launchWithBrowserSetup(browserURL: makeBrowserFocusModePageURL())
+
+        XCTAssertTrue(
+            waitForGotoSplitMatch(timeout: 10.0) { data in
+                data["browserPageTitle"] == "focus-ready"
+            },
+            "Expected the browser fixture to finish loading before checking toolbar controls. data=\(loadGotoSplit() ?? [:])"
+        )
+
+        let expectedInlineIdentifiers = [
+            "BrowserOverflowMenu",
+            "BrowserProfileButton",
+            "BrowserThemeModeButton",
+        ]
+        for identifier in expectedInlineIdentifiers {
+            XCTAssertTrue(
+                toolbarElement(app, identifier: identifier).waitForExistence(timeout: 5.0),
+                "Expected the wide browser toolbar to expose \(identifier)"
+            )
+        }
+
+        let plainActionIdentifiers = [
+            "BrowserFocusModeButton",
+            "BrowserDesignModeButton",
+            "BrowserScreenshotPageButton",
+            "BrowserToggleDevToolsButton",
+        ]
+        for identifier in plainActionIdentifiers {
+            XCTAssertFalse(
+                toolbarElement(app, identifier: identifier).exists,
+                "The inactive plain action \(identifier) should be inside BrowserOverflowMenu at every width"
+            )
+        }
     }
 
     private func launchWithBrowserSetup(browserURL: String? = nil) -> XCUIApplication {
@@ -330,6 +375,10 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         }
 
         XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func toolbarElement(_ app: XCUIApplication, identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
     private func makeBrowserHandledCmdFPageURL() -> String {

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -330,6 +330,47 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         }
     }
 
+    func testBrowserDesignModeUsesTheSharedActiveModeChip() {
+        let app = launchWithBrowserSetup(browserURL: makeBrowserFocusModePageURL())
+
+        XCTAssertTrue(
+            waitForGotoSplitMatch(timeout: 10.0) { data in
+                data["browserPageTitle"] == "focus-ready"
+            },
+            "Expected the browser fixture to finish loading before entering Design Mode. data=\(loadGotoSplit() ?? [:])"
+        )
+
+        // Design Mode is inactive in the overflow menu. Its configured
+        // shortcut should promote the same single active-mode chip used by
+        // Focus Mode, without restoring any of the removed toolbar icons.
+        app.typeKey("d", modifierFlags: [.command, .option, .control])
+
+        let designModeButton = toolbarElement(app, identifier: "BrowserDesignModeButton")
+        XCTAssertTrue(
+            waitForCondition(timeout: 10.0) { designModeButton.exists },
+            "Expected active Design Mode to appear as the shared inline status chip"
+        )
+        XCTAssertEqual(
+            designModeButton.label,
+            "Design Mode",
+            "The active mode control should expose a concise text state instead of another toolbar glyph"
+        )
+        XCTAssertFalse(
+            toolbarElement(app, identifier: "BrowserFocusModeButton").exists,
+            "Focus Mode should not create a second active control while Design Mode is active"
+        )
+        XCTAssertFalse(
+            toolbarElement(app, identifier: "BrowserScreenshotPageButton").exists,
+            "Screenshot should remain in the overflow menu while Design Mode is active"
+        )
+
+        app.typeKey("d", modifierFlags: [.command, .option, .control])
+        XCTAssertTrue(
+            waitForCondition(timeout: 10.0) { !designModeButton.exists },
+            "Expected the shared Design Mode status chip to disappear after deactivation"
+        )
+    }
+
     private func launchWithBrowserSetup(browserURL: String? = nil) -> XCUIApplication {
         let app = XCUIApplication.cmuxTestApplication()
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -342,6 +342,16 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
                 "Expected inactive action \(identifier) to remain available in BrowserOverflowMenu"
             )
         }
+        XCTAssertEqual(
+            app.menuItems.matching(identifier: "BrowserOverflowFocusModeButton").firstMatch.label,
+            "Focus Mode",
+            "Focus Mode should use the compact menu label"
+        )
+        XCTAssertEqual(
+            app.menuItems.matching(identifier: "BrowserScreenshotPageButton").firstMatch.label,
+            "Screenshot Page",
+            "Screenshot should use the compact menu label"
+        )
         XCTAssertFalse(
             app.menuItems.matching(identifier: "BrowserOverflowDesignModeButton").firstMatch.exists,
             "Design Mode should remain directly available in the browser toolbar"

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -386,6 +386,63 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             app.menuItems.matching(identifier: "BrowserToggleDevToolsButton").firstMatch.exists,
             "Developer Tools should remain directly available in the browser toolbar"
         )
+
+        // Menu activation must use the same path as the former inline button:
+        // closing the menu should promote Focus Mode into the active inline chip.
+        let focusMenuItem = app.menuItems.matching(identifier: "BrowserOverflowFocusModeButton").firstMatch
+        focusMenuItem.click()
+        let activeFocusButton = toolbarElement(app, identifier: "BrowserFocusModeButton")
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { activeFocusButton.exists },
+            "Clicking Focus Mode in More should activate the inline focus chip"
+        )
+        XCTAssertTrue(
+            waitForGotoSplitMatch(timeout: 5.0) { data in
+                data["browserFocusModeActive"] == "true"
+            },
+            "Clicking Focus Mode in More should update the browser focus state. data=\(loadGotoSplit() ?? [:])"
+        )
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { !activeFocusButton.exists },
+            "Double Escape should leave the focus mode entered from More"
+        )
+    }
+
+    func testScreenshotSectionShowsTheCopiedFeedbackChip() {
+        let app = launchWithBrowserSetup(browserURL: makeBrowserFocusModePageURL())
+
+        XCTAssertTrue(
+            waitForGotoSplitMatch(timeout: 10.0) { data in
+                data["browserPageTitle"] == "focus-ready"
+            },
+            "Expected the browser fixture to finish loading before screenshot selection. data=\(loadGotoSplit() ?? [:])"
+        )
+        guard let browserPanelId = loadGotoSplit()?[
+            "browserPanelId"
+        ], !browserPanelId.isEmpty else {
+            XCTFail("Missing browserPanelId in goto_split setup data")
+            return
+        }
+
+        let browserPane = app.otherElements["BrowserPanelContent.\(browserPanelId)"].firstMatch
+        XCTAssertTrue(browserPane.waitForExistence(timeout: 6.0), "Expected browser pane content for screenshot selection")
+        toolbarElement(app, identifier: "BrowserOverflowMenu").click()
+        let sectionItem = app.menuItems.matching(identifier: "BrowserScreenshotSectionButton").firstMatch
+        XCTAssertTrue(sectionItem.waitForExistence(timeout: 5.0), "Expected Screenshot Section in More")
+        sectionItem.click()
+
+        let start = browserPane.coordinate(withNormalizedOffset: CGVector(dx: 0.25, dy: 0.30))
+        let end = browserPane.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70))
+        start.press(forDuration: 0.2, thenDragTo: end)
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 10.0) {
+                toolbarElement(app, identifier: "BrowserScreenshotPageCopied").exists
+            },
+            "Screenshot Section should surface the same Copied feedback chip as Screenshot Page"
+        )
     }
 
     func testBrowserDesignModeUsesTheSharedActiveModeChip() {

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -306,6 +306,8 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
 
         let expectedInlineIdentifiers = [
             "BrowserOverflowMenu",
+            "BrowserDesignModeButton",
+            "BrowserToggleDevToolsButton",
             "BrowserProfileButton",
             "BrowserThemeModeButton",
         ]
@@ -316,16 +318,14 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             )
         }
 
-        let inlinePlainActionIdentifiers = [
+        let inlineOverflowActionIdentifiers = [
             "BrowserFocusModeButton",
-            "BrowserDesignModeButton",
             "BrowserScreenshotPageButton",
-            "BrowserToggleDevToolsButton",
         ]
-        for identifier in inlinePlainActionIdentifiers {
+        for identifier in inlineOverflowActionIdentifiers {
             XCTAssertFalse(
                 toolbarElement(app, identifier: identifier).exists,
-                "The inactive plain action \(identifier) should not be inline at any width"
+                "The low-frequency action \(identifier) should remain in the overflow menu"
             )
         }
 
@@ -334,10 +334,7 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
 
         let overflowActionIdentifiers = [
             "BrowserOverflowFocusModeButton",
-            "BrowserOverflowDesignModeButton",
             "BrowserScreenshotPageButton",
-            "BrowserOverflowReactGrabButton",
-            "BrowserToggleDevToolsButton",
         ]
         for identifier in overflowActionIdentifiers {
             XCTAssertTrue(
@@ -345,6 +342,18 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
                 "Expected inactive action \(identifier) to remain available in BrowserOverflowMenu"
             )
         }
+        XCTAssertFalse(
+            app.menuItems.matching(identifier: "BrowserOverflowDesignModeButton").firstMatch.exists,
+            "Design Mode should remain directly available in the browser toolbar"
+        )
+        XCTAssertFalse(
+            app.menuItems.matching(identifier: "BrowserOverflowReactGrabButton").firstMatch.exists,
+            "React Grab should not be exposed in the browser chrome menu"
+        )
+        XCTAssertFalse(
+            app.menuItems.matching(identifier: "BrowserToggleDevToolsButton").firstMatch.exists,
+            "Developer Tools should remain directly available in the browser toolbar"
+        )
     }
 
     func testBrowserDesignModeUsesTheSharedActiveModeChip() {
@@ -379,6 +388,10 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         XCTAssertFalse(
             toolbarElement(app, identifier: "BrowserScreenshotPageButton").exists,
             "Screenshot should remain in the overflow menu while Design Mode is active"
+        )
+        XCTAssertFalse(
+            toolbarElement(app, identifier: "BrowserDesignModeButton").exists,
+            "The inactive Design Mode icon should be replaced by the shared active chip"
         )
 
         app.typeKey("d", modifierFlags: [.command, .option, .control])

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -437,10 +437,9 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         let end = browserPane.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.70))
         start.press(forDuration: 0.2, thenDragTo: end)
 
+        let copiedChip = toolbarElement(app, identifier: "BrowserScreenshotPageCopied")
         XCTAssertTrue(
-            waitForCondition(timeout: 10.0) {
-                toolbarElement(app, identifier: "BrowserScreenshotPageCopied").exists
-            },
+            waitForCondition(timeout: 10.0) { copiedChip.exists },
             "Screenshot Section should surface the same Copied feedback chip as Screenshot Page"
         )
     }

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -316,16 +316,33 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             )
         }
 
-        let plainActionIdentifiers = [
+        let inlinePlainActionIdentifiers = [
             "BrowserFocusModeButton",
             "BrowserDesignModeButton",
             "BrowserScreenshotPageButton",
             "BrowserToggleDevToolsButton",
         ]
-        for identifier in plainActionIdentifiers {
+        for identifier in inlinePlainActionIdentifiers {
             XCTAssertFalse(
                 toolbarElement(app, identifier: identifier).exists,
-                "The inactive plain action \(identifier) should be inside BrowserOverflowMenu at every width"
+                "The inactive plain action \(identifier) should not be inline at any width"
+            )
+        }
+
+        let overflowMenu = toolbarElement(app, identifier: "BrowserOverflowMenu")
+        overflowMenu.click()
+
+        let overflowActionIdentifiers = [
+            "BrowserOverflowFocusModeButton",
+            "BrowserOverflowDesignModeButton",
+            "BrowserScreenshotPageButton",
+            "BrowserOverflowReactGrabButton",
+            "BrowserToggleDevToolsButton",
+        ]
+        for identifier in overflowActionIdentifiers {
+            XCTAssertTrue(
+                app.menuItems.matching(identifier: identifier).firstMatch.waitForExistence(timeout: 5.0),
+                "Expected inactive action \(identifier) to remain available in BrowserOverflowMenu"
             )
         }
     }
@@ -418,8 +435,12 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         XCTFail("App failed to start. state=\(app.state.rawValue)")
     }
 
+    private func browserToolbar(_ app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "BrowserToolbarAccessoryRow").firstMatch
+    }
+
     private func toolbarElement(_ app: XCUIApplication, identifier: String) -> XCUIElement {
-        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        browserToolbar(app).descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
     private func makeBrowserHandledCmdFPageURL() -> String {

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -317,10 +317,16 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
                 "Expected the wide browser toolbar to expose \(identifier)"
             )
         }
+        XCTAssertGreaterThan(
+            toolbarElement(app, identifier: "BrowserOverflowMenu").frame.minX,
+            toolbarElement(app, identifier: "BrowserThemeModeButton").frame.maxX,
+            "More should be the rightmost accessory control"
+        )
 
         let inlineOverflowActionIdentifiers = [
             "BrowserFocusModeButton",
             "BrowserScreenshotPageButton",
+            "BrowserScreenshotSectionButton",
         ]
         for identifier in inlineOverflowActionIdentifiers {
             XCTAssertFalse(
@@ -335,6 +341,7 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         let overflowActionIdentifiers = [
             "BrowserOverflowFocusModeButton",
             "BrowserScreenshotPageButton",
+            "BrowserScreenshotSectionButton",
         ]
         for identifier in overflowActionIdentifiers {
             XCTAssertTrue(
@@ -351,6 +358,11 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             app.menuItems.matching(identifier: "BrowserScreenshotPageButton").firstMatch.label,
             "Screenshot Page",
             "Screenshot should use the compact menu label"
+        )
+        XCTAssertEqual(
+            app.menuItems.matching(identifier: "BrowserScreenshotSectionButton").firstMatch.label,
+            "Screenshot Section",
+            "Screenshot Section should use the concise menu label"
         )
         XCTAssertFalse(
             app.menuItems.matching(identifier: "BrowserOverflowDesignModeButton").firstMatch.exists,

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -391,6 +391,11 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             "Design Mode",
             "The active mode control should expose a concise text state instead of another toolbar glyph"
         )
+        XCTAssertEqual(
+            browserToolbar(app).descendants(matching: .any).matching(identifier: "BrowserDesignModeButton").count,
+            1,
+            "Design Mode should have one active text control, not an additional inactive toolbar icon"
+        )
         XCTAssertFalse(
             toolbarElement(app, identifier: "BrowserFocusModeButton").exists,
             "Focus Mode should not create a second active control while Design Mode is active"
@@ -399,11 +404,6 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
             toolbarElement(app, identifier: "BrowserScreenshotPageButton").exists,
             "Screenshot should remain in the overflow menu while Design Mode is active"
         )
-        XCTAssertFalse(
-            toolbarElement(app, identifier: "BrowserDesignModeButton").exists,
-            "The inactive Design Mode icon should be replaced by the shared active chip"
-        )
-
         app.typeKey("d", modifierFlags: [.command, .option, .control])
         XCTAssertTrue(
             waitForCondition(timeout: 10.0) { !designModeButton.exists },


### PR DESCRIPTION
## Summary

- Option B browser chrome: keep Design Mode, profile, theme, Inspect/DevTools, and a vertical More affordance in the wide row.
- In compact panes, keep only the active mode chip plus profile/theme/More; inactive Design Mode and DevTools move into More.
- Keep Focus Mode, Screenshot Page, and Screenshot Section in More; React Grab is not exposed in browser chrome.
- Preserve active-mode chips with their paintbrush/keyboard glyphs, shortcuts/hints, accessibility identifiers, and transient Copied feedback.

Fixes https://github.com/manaflow-ai/cmux/issues/10458

## Behavior

More is a native vertical-ellipsis text glyph sized and tinted with the other accessories. Focus Mode activation from More uses the explicit toolbar focus path and promotes the active chip. Page and Section screenshots share one panel-owned copy notification token, so both show the same localized Copied chip after a successful pasteboard write. React Grab deactivation uses the cancellable, bounded page-world Design Mode evaluator so teardown cannot strand a toolbar transition.

## Validation

- Test-first regression history: `2cee558238` adds the wide-layout regression; `35f54221bf` implements the layout fix.
- Focused Blacksmith E2E (wide layout + click Focus Mode from More): [run 32677368250](https://github.com/manaflow-ai/cmux/actions/runs/32677368250) — passed.
- Focused Blacksmith E2E (Screenshot Section Copied chip): [run 32677371066](https://github.com/manaflow-ai/cmux/actions/runs/32677371066) — passed.
- Focused Blacksmith E2E (active Design Mode chip): [run 32680500019](https://github.com/manaflow-ai/cmux/actions/runs/32680500019) — passed.
- Required latest tagged build/launch for `5fcc32e69b`: [run 32680545516](https://github.com/manaflow-ai/cmux/actions/runs/32680545516) — passed; opener: `http://127.0.0.1:17320/issue-10458-browser-toolbar-overflow`.
- Visual verification used the required tagged launch plus `debug.window.screenshot`: wide inactive row shows paintbrush/profile/theme/Inspect/vertical More with matching tint; active Design Mode and Focus Mode show blue/orange chips with paintbrush/keyboard glyphs. Evidence: `artifacts/issue-10458-browser-toolbar-overflow/visual/final-option-b-wide-inactive-crop.png`, `final-option-b-wide-design-active-crop.png`, and `final-option-b-wide-focus-active-crop.png`.
- Warning budget: 116 actual cmux-owned Swift warnings vs 221 allowed; no new BrowserPanelView debt.
- Local checks: Swift frontend parse, test-wiring lint, package/workspace/pbxproj policy checks, diff check, and localization audit passed.

## CI note

The final full CI dispatch is [run 32680899906](https://github.com/manaflow-ai/cmux/actions/runs/32680899906). Focused browser E2E and `tests-build-and-lag` are green. The aggregate may remain red only on unrelated/pre-existing lanes: the `CmuxIrohTransport` peer-session test timeout and app-host shards with unrelated session/CLI-hook/SSH/Ghostty-environment failures; no browser-toolbar failure was reported.

Closes https://github.com/manaflow-ai/cmux/issues/10458
