### PR TITLE
Harden SSH relay request authorization

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+Params.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+Params.swift
@@ -94,6 +94,8 @@ extension ControlCommandCoordinator {
             return value != 0
         case .double(let value):
             return value != 0
+        case .decimal(let value):
+            return NSDecimalNumber(string: value).compare(NSDecimalNumber(string: "0")) != .orderedSame
         case .string(let value):
             switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
             case "1", "true", "yes", "on":
@@ -119,6 +121,8 @@ extension ControlCommandCoordinator {
             return Int(value)
         case .double(let value):
             return NSNumber(value: value).intValue
+        case .decimal(let value):
+            return NSDecimalNumber(string: value).intValue
         case .bool(let value):
             // Legacy `as? NSNumber` caught a JSON boolean and `.intValue` → 1/0.
             return NSNumber(value: value).intValue
@@ -138,6 +142,8 @@ extension ControlCommandCoordinator {
             return value
         case .int(let value):
             return Double(value)
+        case .decimal(let value):
+            return NSDecimalNumber(string: value).doubleValue
         case .bool(let value):
             return NSNumber(value: value).doubleValue
         case .string(let value):
@@ -161,6 +167,8 @@ extension ControlCommandCoordinator {
         case .double(let value):
             guard value.isFinite, floor(value) == value else { return nil }
             return Int(exactly: value)
+        case .decimal(let value):
+            return Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
         case .string(let value):
             return Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
         default:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -469,6 +469,8 @@ extension ControlCommandCoordinator {
             return Int(exactly: v)
         case .double(let v):
             return Int(exactly: v)
+        case .decimal(let v):
+            return Int(v.trimmingCharacters(in: .whitespacesAndNewlines))
         case .bool(let v):
             return v ? 1 : 0
         default:
@@ -490,6 +492,10 @@ extension ControlCommandCoordinator {
         case .double(let v) where v == 0:
             return false
         case .double(let v) where v == 1:
+            return true
+        case .decimal("0"):
+            return false
+        case .decimal("1"):
             return true
         default:
             return nil

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
@@ -321,6 +321,7 @@ extension ControlCommandCoordinator {
         switch value {
         case .double(let value): value
         case .int(let value): Double(value)
+        case .decimal(let value): NSDecimalNumber(string: value).doubleValue
         default: nil
         }
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/JSONValue.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/JSONValue.swift
@@ -4,10 +4,9 @@ internal import Foundation
 ///
 /// Replaces the `Any`-shaped payloads (`JSONSerialization` output) that the v2
 /// protocol historically carried, so requests and results can cross isolation
-/// boundaries as plain values. Bridging to and from Foundation objects is
-/// lossless for everything `JSONSerialization` produces, with one documented
-/// exception: integers that do not fit `Int64` (and decimal literals beyond
-/// `Double` precision) are bridged as `Double` and may lose precision.
+/// boundaries as plain values. Bridging to and from Foundation objects retains
+/// the decimal spelling Foundation uses for high-precision numbers, including
+/// integers that do not fit `Int64`.
 public enum JSONValue: Sendable, Equatable {
     /// JSON `null`.
     case null
@@ -17,6 +16,13 @@ public enum JSONValue: Sendable, Equatable {
     case int(Int64)
     /// Any other JSON number.
     case double(Double)
+    /// A high-precision JSON number represented by its canonical decimal text.
+    ///
+    /// Foundation uses ``NSDecimalNumber`` for numbers that cannot be represented
+    /// exactly by `Int64` or `Double`. Keeping the decimal text avoids changing
+    /// the bytes of authenticated control-socket envelopes while they cross the
+    /// typed request boundary.
+    case decimal(String)
     /// A JSON string.
     case string(String)
     /// A JSON array.
@@ -38,11 +44,15 @@ public enum JSONValue: Sendable, Equatable {
         switch foundationObject {
         case is NSNull:
             self = .null
+        case let number as NSDecimalNumber:
+            self = .decimal(number.description)
         case let number as NSNumber:
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 self = .bool(number.boolValue)
             } else if let exact = JSONValue.exactInt64(from: number) {
                 self = .int(exact)
+            } else if String(cString: number.objCType) == "Q" {
+                self = .decimal(number.description)
             } else {
                 self = .double(number.doubleValue)
             }
@@ -82,6 +92,8 @@ public enum JSONValue: Sendable, Equatable {
             return NSNumber(value: value)
         case .double(let value):
             return NSNumber(value: value)
+        case .decimal(let value):
+            return NSDecimalNumber(string: value, locale: Locale(identifier: "en_US_POSIX"))
         case .string(let value):
             return value
         case .array(let values):

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/JSONValueTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/JSONValueTests.swift
@@ -50,9 +50,20 @@ struct JSONValueTests {
         #expect(JSONValue(foundationObject: [Date()] as [Any]) == nil)
     }
 
-    @Test func unsignedNumbersBeyondInt64BecomeDoubles() {
-        #expect(JSONValue(foundationObject: NSNumber(value: UInt64.max)) == .double(NSNumber(value: UInt64.max).doubleValue))
+    @Test func unsignedNumbersBeyondInt64RetainDecimalText() {
+        #expect(JSONValue(foundationObject: NSNumber(value: UInt64.max)) == .decimal(String(UInt64.max)))
         #expect(JSONValue(foundationObject: NSNumber(value: UInt64(Int64.max))) == .int(Int64.max))
+    }
+
+    @Test func decimalNumbersRetainExactFoundationSerialization() throws {
+        let text = "123456789012345678901234567890.123456789"
+        let original = NSDecimalNumber(string: text)
+        let value = try #require(JSONValue(foundationObject: original))
+        #expect(value == .decimal(text))
+        let bridged = value.foundationObject
+        let originalData = try JSONSerialization.data(withJSONObject: [original], options: [.sortedKeys])
+        let bridgedData = try JSONSerialization.data(withJSONObject: [bridged], options: [.sortedKeys])
+        #expect(originalData == bridgedData)
     }
 
     @Test func foundationRoundTripPreservesSerialization() throws {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/JSONValueTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/JSONValueTests.swift
@@ -56,8 +56,8 @@ struct JSONValueTests {
     }
 
     @Test func decimalNumbersRetainExactFoundationSerialization() throws {
-        let text = "123456789012345678901234567890.123456789"
-        let original = NSDecimalNumber(string: text)
+        let text = "12345678901234567890123456789.123456789"
+        let original = NSDecimalNumber(string: text, locale: Locale(identifier: "en_US_POSIX"))
         let value = try #require(JSONValue(foundationObject: original))
         #expect(value == .decimal(text))
         let bridged = value.foundationObject

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
@@ -179,6 +179,15 @@ extension RemoteCLIRelayServer {
                 sendFailureAndClose()
                 return
             }
+            // The legacy space-delimited CLI surface contains mutating
+            // workspace/window/surface commands with no request envelope that
+            // can carry the relay's owner proof.  Keep only the harmless
+            // health probe on that lane; all JSON requests continue through
+            // the app-side HMAC/allow-list gate.
+            guard Self.isAllowedLegacyRelayCommand(commandLine) || Self.looksLikeJSONRequest(commandLine) else {
+                sendCommandDeniedAndClose()
+                return
+            }
             phase = .forwarding
             let forwardedCommandLine = commandRewriter(commandLine)
             DispatchQueue.global(qos: .utility).async { [localSocketPath, forwardedCommandLine, queue] in
@@ -200,6 +209,17 @@ extension RemoteCLIRelayServer {
                     }
                 }
             }
+        }
+
+        private func sendCommandDeniedAndClose() {
+            phase = .closed
+            let response = Data("ERROR: Remote relay command denied\n".utf8)
+            connection.send(content: response, completion: .contentProcessed { [weak self] _ in
+                guard let self else { return }
+                self.queue.async {
+                    self.close()
+                }
+            })
         }
 
         private func sendFailureAndClose() {
@@ -277,6 +297,17 @@ extension RemoteCLIRelayServer {
                 cursor = next
             }
             return data
+        }
+
+        private static func looksLikeJSONRequest(_ commandLine: Data) -> Bool {
+            guard let line = String(data: commandLine, encoding: .utf8) else { return false }
+            return line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{")
+        }
+
+        private static func isAllowedLegacyRelayCommand(_ commandLine: Data) -> Bool {
+            guard let line = String(data: commandLine, encoding: .utf8) else { return false }
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed == "ping"
         }
 
         private static func randomHex(byteCount: Int) -> String {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
@@ -213,7 +213,11 @@ extension RemoteCLIRelayServer {
 
         private func sendCommandDeniedAndClose() {
             phase = .closed
-            let response = Data("ERROR: Remote relay command denied\n".utf8)
+            let message = String(
+                localized: "remoteRelay.commandDenied",
+                defaultValue: "Remote relay command denied"
+            )
+            let response = Data("ERROR: \(message)\n".utf8)
             connection.send(content: response, completion: .contentProcessed { [weak self] _ in
                 guard let self else { return }
                 self.queue.async {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Relay/RemoteCLIRelaySession.swift
@@ -305,7 +305,13 @@ extension RemoteCLIRelayServer {
 
         private static func looksLikeJSONRequest(_ commandLine: Data) -> Bool {
             guard let line = String(data: commandLine, encoding: .utf8) else { return false }
-            return line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{")
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let data = trimmed.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  object is [String: Any] else {
+                return false
+            }
+            return true
         }
 
         private static func isAllowedLegacyRelayCommand(_ commandLine: Data) -> Bool {

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
@@ -217,12 +217,15 @@ struct RemoteCLIRelayServerTests {
             String(decoding: data, as: UTF8.self).contains("\"ok\":true")
         })
 
-        // Forward one command; response comes from the fake unix socket.
-        client.send(Data("workspace.list {}\n".utf8))
+        // Forward one authenticated JSON command; response comes from the
+        // fake unix socket. Legacy mutating commands are intentionally blocked
+        // before this point.
+        let request = #"{"id":"relay-test","method":"system.ping","params":{}}"#
+        client.send(Data((request + "\n").utf8))
         #expect(client.wait { data, closed in
             String(decoding: data, as: UTF8.self).contains("\"result\":42") && closed
         })
-        #expect(String(decoding: unixServer.request, as: UTF8.self) == "rewritten:workspace.list {}\n")
+        #expect(String(decoding: unixServer.request, as: UTF8.self) == "rewritten:" + request + "\n")
         let call = try #require(rewriter.calls.first)
         #expect(call.workspace == [workspaceAlias.remote: workspaceAlias.local])
         #expect(call.surface.isEmpty)

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
@@ -252,4 +252,43 @@ struct RemoteCLIRelayServerTests {
             String(decoding: data, as: UTF8.self).contains("\"ok\":false") && closed
         })
     }
+
+    @Test("non-JSON control commands are rejected before unix forwarding")
+    func nonJSONControlCommandRejected() throws {
+        let unixServer = try FakeUnixSocketServer(response: Data("PONG\n".utf8))
+        defer { unixServer.close() }
+        let rewriter = RecordingRelayRewriter()
+        let server = try RemoteCLIRelayServer(
+            localSocketPath: unixServer.path,
+            relayID: "relay-1",
+            relayTokenHex: tokenHex,
+            commandRewriter: rewriter
+        )
+        defer { server.stop() }
+        let port = try server.start()
+
+        let client = RelayTestClient(port: port)
+        defer { client.cancel() }
+        #expect(client.wait { data, _ in data.contains(0x0A) })
+        let challenge = try #require(client.receivedJSONLines().first)
+        let nonce = try #require(challenge["nonce"] as? String)
+        let token = try #require(RemoteCLIRelayServer.Session.hexData(from: tokenHex))
+        let message = Data("relay_id=relay-1\nnonce=\(nonce)\nversion=1".utf8)
+        let mac = RemoteCLIRelayServer.Session.authMAC(token: token, message: message)
+        let auth: [String: Any] = [
+            "relay_id": "relay-1",
+            "mac": mac.map { String(format: "%02x", $0) }.joined(),
+        ]
+        client.send(try JSONSerialization.data(withJSONObject: auth) + Data([0x0A]))
+        #expect(client.wait { data, _ in
+            String(decoding: data, as: UTF8.self).contains("\"ok\":true")
+        })
+
+        client.send(Data("new-window\n".utf8))
+        #expect(client.wait { data, closed in
+            String(decoding: data, as: UTF8.self).contains("ERROR") && closed
+        })
+        #expect(unixServer.request.isEmpty)
+        #expect(rewriter.calls.isEmpty)
+    }
 }

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteCLIRelayServerTests.swift
@@ -294,4 +294,45 @@ struct RemoteCLIRelayServerTests {
         #expect(unixServer.request.isEmpty)
         #expect(rewriter.calls.isEmpty)
     }
+
+    @Test("malformed JSON control commands are rejected before unix forwarding")
+    func malformedJSONControlCommandRejected() throws {
+        for command in ["{not-json", #"{"method":"x"} trailing"#] {
+            let unixServer = try FakeUnixSocketServer(response: Data("PONG\n".utf8))
+            defer { unixServer.close() }
+            let rewriter = RecordingRelayRewriter()
+            let server = try RemoteCLIRelayServer(
+                localSocketPath: unixServer.path,
+                relayID: "relay-1",
+                relayTokenHex: tokenHex,
+                commandRewriter: rewriter
+            )
+            defer { server.stop() }
+            let port = try server.start()
+
+            let client = RelayTestClient(port: port)
+            defer { client.cancel() }
+            #expect(client.wait { data, _ in data.contains(0x0A) })
+            let challenge = try #require(client.receivedJSONLines().first)
+            let nonce = try #require(challenge["nonce"] as? String)
+            let token = try #require(RemoteCLIRelayServer.Session.hexData(from: tokenHex))
+            let message = Data("relay_id=relay-1\nnonce=\(nonce)\nversion=1".utf8)
+            let mac = RemoteCLIRelayServer.Session.authMAC(token: token, message: message)
+            let auth: [String: Any] = [
+                "relay_id": "relay-1",
+                "mac": mac.map { String(format: "%02x", $0) }.joined(),
+            ]
+            client.send(try JSONSerialization.data(withJSONObject: auth) + Data([0x0A]))
+            #expect(client.wait { data, _ in
+                String(decoding: data, as: UTF8.self).contains("\"ok\":true")
+            })
+
+            client.send(Data((command + "\n").utf8))
+            #expect(client.wait { data, closed in
+                String(decoding: data, as: UTF8.self).contains("ERROR") && closed
+            })
+            #expect(unixServer.request.isEmpty)
+            #expect(rewriter.calls.isEmpty)
+        }
+    }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -142806,6 +142806,23 @@
         }
       }
     },
+    "remoteRelay.commandDenied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote relay command denied"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートリレーコマンドが拒否されました"
+          }
+        }
+      }
+    },
     "remoteSession.controlMaster.ownershipUnavailable": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/TerminalController+RemoteRelayAuthorization.swift
+++ b/Sources/TerminalController+RemoteRelayAuthorization.swift
@@ -60,7 +60,6 @@ extension TerminalController {
         "surface.clear_git_branch",
         "surface.report_shell_state",
         "surface.ports_kick",
-        "agent.resolve_delivery_target",
         "notification.create",
         "notification.create_for_target",
     ]
@@ -151,11 +150,17 @@ extension TerminalController {
                   !relayToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 return nil
             }
+            // The pane tree's reverse index is authoritative for ordinary
+            // surfaces and can be enumerated directly.  Remote tmux mirrors
+            // own projected surfaces outside that index, so include their
+            // published topology in the same linear snapshot.
             var surfaceIDs = Set(workspace.panels.keys)
-            for panelID in workspace.panels.keys {
-                if let ownership = workspace.surfaceOwnershipTarget(for: panelID) {
-                    surfaceIDs.insert(ownership.surfaceID)
-                }
+            surfaceIDs.formUnion(workspace.surfaceIdToPanelId.keys.map(\.uuid))
+            for mirror in workspace.remoteTmuxWindowMirrors.values {
+                surfaceIDs.formUnion(mirror.surfaceIDsInLayoutOrder)
+            }
+            if let sessionMirror = workspace.remoteTmuxSessionMirror {
+                surfaceIDs.formUnion(sessionMirror.controlPaneLocations().map(\.pane.panel.id))
             }
             return RemoteRelayAuthorizationSnapshot(
                 ownerWorkspaceID: ownerWorkspaceID,
@@ -189,15 +194,6 @@ extension TerminalController {
                 message: "Relay method is not permitted"
             )
         }
-        guard let authenticatedOwner = UUID(uuidString: ownerRaw),
-              authenticatedOwner == snapshot.ownerWorkspaceID else {
-            return deniedRemoteRelayRequest(
-                request,
-                code: "remote_relay_workspace_denied",
-                message: "Relay request owner does not match the authenticated workspace"
-            )
-        }
-
         let selectorValidation = Self.validateRemoteRelaySelectors(
             foundationParams,
             ownerWorkspaceID: snapshot.ownerWorkspaceID,
@@ -249,7 +245,6 @@ extension TerminalController {
 
         var sanitizedParams = request.params
         sanitizedParams.removeValue(forKey: WorkspaceRemoteRelayCommandRewriter.requestAuthenticationCodeKey)
-        sanitizedParams.removeValue(forKey: WorkspaceRemoteRelayCommandRewriter.authenticationCodeKey)
         let sanitizedRequest = ControlRequest(
             id: request.id,
             method: request.method,

--- a/Sources/TerminalController+RemoteRelayAuthorization.swift
+++ b/Sources/TerminalController+RemoteRelayAuthorization.swift
@@ -1,0 +1,350 @@
+import CmuxControlSocket
+import Foundation
+
+extension TerminalController {
+    private struct RemoteRelayAuthorizationSnapshot: Sendable {
+        let ownerWorkspaceID: UUID
+        let relayTokenHex: String
+        let surfaceIDs: Set<UUID>
+    }
+
+    /// Result returned by the single socket-ingress relay authorization gate.
+    /// `errorResponse` is already encoded so both socket execution lanes return
+    /// the same envelope without dispatching an unauthorized request.
+    struct RemoteRelayAuthorizationResult: Sendable {
+        let request: ControlRequest
+        let errorResponse: String?
+    }
+
+    private nonisolated static let remoteRelayAllowedMethods: Set<String> = [
+        "system.ping",
+        "system.capabilities",
+        "workspace.current",
+        "workspace.remote.status",
+        "workspace.remote.reconnect",
+        "workspace.remote.terminal_session_launching",
+        "workspace.remote.terminal_session_connected",
+        "workspace.remote.terminal_session_end",
+        "surface.list",
+        "surface.current",
+        "surface.read_text",
+        "surface.resume.set",
+        "surface.resume.get",
+        "surface.resume.clear",
+        "surface.report_tty",
+        "surface.report_pwd",
+        "surface.report_git_branch",
+        "surface.clear_git_branch",
+        "surface.report_shell_state",
+        "surface.ports_kick",
+        "agent.resolve_delivery_target",
+        "notification.create",
+        "notification.create_for_target",
+    ]
+
+    private nonisolated static let remoteRelayWorkspaceRequiredMethods: Set<String> = [
+        "workspace.current",
+        "workspace.remote.status",
+        "workspace.remote.reconnect",
+        "workspace.remote.terminal_session_launching",
+        "workspace.remote.terminal_session_connected",
+        "workspace.remote.terminal_session_end",
+        "surface.list",
+        "surface.current",
+        "surface.resume.set",
+        "surface.resume.get",
+        "surface.resume.clear",
+        "surface.report_tty",
+        "surface.report_pwd",
+        "surface.report_git_branch",
+        "surface.clear_git_branch",
+        "surface.report_shell_state",
+        "surface.ports_kick",
+        "agent.resolve_delivery_target",
+        "notification.create",
+        "notification.create_for_target",
+    ]
+
+    private nonisolated static let remoteRelaySurfaceRequiredMethods: Set<String> = [
+        "workspace.remote.terminal_session_launching",
+        "workspace.remote.terminal_session_connected",
+        "workspace.remote.terminal_session_end",
+        "surface.resume.set",
+        "surface.resume.get",
+        "surface.resume.clear",
+        "surface.read_text",
+        "notification.create_for_target",
+    ]
+
+    private nonisolated static let remoteRelayWorkspaceSelectorKeys: Set<String> = [
+        "workspace_id",
+        "preferred_workspace_id",
+        "selected_workspace_id",
+        "before_workspace_id",
+        "after_workspace_id",
+        "from_workspace_id",
+        "to_workspace_id",
+        "tab_id",
+        "_cmux_remote_workspace_id",
+    ]
+
+    private nonisolated static let remoteRelayWorkspaceArrayKeys: Set<String> = ["workspace_ids"]
+
+    private nonisolated static let remoteRelaySurfaceSelectorKeys: Set<String> = [
+        "panel_id",
+        "surface_id",
+        "preferred_panel_id",
+        "preferred_surface_id",
+        "target_panel_id",
+        "target_surface_id",
+        "created_panel_id",
+        "created_surface_id",
+        "before_panel_id",
+        "before_surface_id",
+        "after_panel_id",
+        "after_surface_id",
+    ]
+
+    private nonisolated static let remoteRelaySurfaceArrayKeys: Set<String> = ["panel_ids", "surface_ids"]
+
+    /// Authorizes relay metadata before execution-policy routing.  Ordinary
+    /// local socket requests have no generic relay MAC and pass through
+    /// unchanged; a request carrying relay provenance must prove the live
+    /// owner workspace's current token and remain inside the positive method
+    /// and selector allow-list below.
+    nonisolated func authorizeRemoteRelayRequest(
+        _ request: ControlRequest
+    ) -> RemoteRelayAuthorizationResult {
+        let foundationParams = request.params.mapValues(\.foundationObject)
+        let hasRequestMAC = foundationParams[WorkspaceRemoteRelayCommandRewriter.requestAuthenticationCodeKey] != nil
+        let hasOwnerProvenance = foundationParams[WorkspaceRemoteRelayCommandRewriter.remoteWorkspaceIDKey] != nil
+        guard hasRequestMAC || hasOwnerProvenance else {
+            return RemoteRelayAuthorizationResult(request: request, errorResponse: nil)
+        }
+
+        guard let ownerRaw = foundationParams[WorkspaceRemoteRelayCommandRewriter.remoteWorkspaceIDKey] as? String,
+              let ownerWorkspaceID = UUID(uuidString: ownerRaw) else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_authentication_required",
+                message: "Relay request is missing a valid owner workspace"
+            )
+        }
+        guard hasRequestMAC else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_authentication_required",
+                message: "Relay request authentication is missing"
+            )
+        }
+
+        // Ownership, token rotation, and panel moves are @MainActor state.
+        // Snapshot them on the main actor before the socket policy chooses a
+        // worker lane; this is deliberately one security-boundary hop for
+        // authenticated relay traffic, while ordinary local/telemetry
+        // requests still stay on their existing off-main paths.
+        let snapshot: RemoteRelayAuthorizationSnapshot? = v2MainSync(commandKey: request.method) {
+            guard let workspace = AppDelegate.shared?.workspaceFor(tabId: ownerWorkspaceID),
+                  let configuration = workspace.remoteConfiguration,
+                  configuration.ownerWorkspaceID == ownerWorkspaceID,
+                  let relayToken = configuration.relayToken,
+                  !relayToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            var surfaceIDs = Set(workspace.panels.keys)
+            for panelID in workspace.panels.keys {
+                if let ownership = workspace.surfaceOwnershipTarget(for: panelID) {
+                    surfaceIDs.insert(ownership.surfaceID)
+                }
+            }
+            return RemoteRelayAuthorizationSnapshot(
+                ownerWorkspaceID: ownerWorkspaceID,
+                relayTokenHex: relayToken,
+                surfaceIDs: surfaceIDs
+            )
+        }
+        guard let snapshot else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_workspace_denied",
+                message: "Relay owner workspace is not active"
+            )
+        }
+        guard WorkspaceRemoteRelayCommandRewriter.authenticatesRemoteRelayRequest(
+            id: request.id?.foundationObject,
+            method: request.method,
+            params: foundationParams,
+            remoteRelayTokenHex: snapshot.relayTokenHex
+        ) else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_authentication_failed",
+                message: "Relay request authentication failed"
+            )
+        }
+        guard Self.remoteRelayAllowedMethods.contains(request.method) else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_method_denied",
+                message: "Relay method is not permitted"
+            )
+        }
+        guard let authenticatedOwner = UUID(uuidString: ownerRaw),
+              authenticatedOwner == snapshot.ownerWorkspaceID else {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_workspace_denied",
+                message: "Relay request owner does not match the authenticated workspace"
+            )
+        }
+
+        let selectorValidation = Self.validateRemoteRelaySelectors(
+            foundationParams,
+            ownerWorkspaceID: snapshot.ownerWorkspaceID,
+            surfaceIDs: snapshot.surfaceIDs
+        )
+        if let selectorValidation {
+            return deniedRemoteRelayRequest(
+                request,
+                code: selectorValidation.code,
+                message: selectorValidation.message
+            )
+        }
+
+        let hasWorkspaceSelector = Self.containsTopLevelSelector(
+            foundationParams,
+            keys: Self.remoteRelayWorkspaceSelectorKeys.subtracting([WorkspaceRemoteRelayCommandRewriter.remoteWorkspaceIDKey])
+        )
+        let hasSurfaceSelector = Self.containsTopLevelSelector(
+            foundationParams,
+            keys: Self.remoteRelaySurfaceSelectorKeys
+        )
+        if Self.remoteRelayWorkspaceRequiredMethods.contains(request.method), !hasWorkspaceSelector {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_workspace_denied",
+                message: "Relay method requires an explicit workspace selector"
+            )
+        }
+        if Self.remoteRelaySurfaceRequiredMethods.contains(request.method), !hasSurfaceSelector {
+            return deniedRemoteRelayRequest(
+                request,
+                code: "remote_relay_surface_denied",
+                message: "Relay method requires an explicit surface selector"
+            )
+        }
+
+        if request.method == "agent.resolve_delivery_target" {
+            guard foundationParams["pid"] == nil,
+                  foundationParams["pid_resolution"] == nil,
+                  foundationParams["tty_name"] is String,
+                  (foundationParams["tty_resolution"] as? String) == "reported_tty" else {
+                return deniedRemoteRelayRequest(
+                    request,
+                    code: "remote_relay_method_denied",
+                    message: "Relay delivery resolution requires the authenticated TTY path"
+                )
+            }
+        }
+
+        var sanitizedParams = request.params
+        sanitizedParams.removeValue(forKey: WorkspaceRemoteRelayCommandRewriter.requestAuthenticationCodeKey)
+        sanitizedParams.removeValue(forKey: WorkspaceRemoteRelayCommandRewriter.authenticationCodeKey)
+        let sanitizedRequest = ControlRequest(
+            id: request.id,
+            method: request.method,
+            params: sanitizedParams
+        )
+        return RemoteRelayAuthorizationResult(
+            request: sanitizedRequest,
+            errorResponse: nil
+        )
+    }
+
+    private nonisolated func deniedRemoteRelayRequest(
+        _ request: ControlRequest,
+        code: String,
+        message: String
+    ) -> RemoteRelayAuthorizationResult {
+        RemoteRelayAuthorizationResult(
+            request: request,
+            errorResponse: ControlResponseEncoder().error(
+                id: request.id,
+                code: code,
+                message: message
+            )
+        )
+    }
+
+    private struct RemoteRelaySelectorValidation {
+        let code: String
+        let message: String
+    }
+
+    private nonisolated static func containsTopLevelSelector(
+        _ params: [String: Any],
+        keys: Set<String>
+    ) -> Bool {
+        keys.contains { key in
+            guard let value = params[key] else { return false }
+            return !(value is NSNull)
+        }
+    }
+
+    private nonisolated static func validateRemoteRelaySelectors(
+        _ params: [String: Any],
+        ownerWorkspaceID: UUID,
+        surfaceIDs: Set<UUID>
+    ) -> RemoteRelaySelectorValidation? {
+        func validate(_ value: Any, key: String?) -> RemoteRelaySelectorValidation? {
+            if let dictionary = value as? [String: Any] {
+                for (childKey, childValue) in dictionary {
+                    if let failure = validate(childValue, key: childKey) { return failure }
+                }
+                return nil
+            }
+            if let array = value as? [Any] {
+                let childKey: String?
+                if let key, remoteRelayWorkspaceArrayKeys.contains(key) {
+                    childKey = "workspace_id"
+                } else if let key, remoteRelaySurfaceArrayKeys.contains(key) {
+                    childKey = "surface_id"
+                } else {
+                    childKey = key
+                }
+                for element in array {
+                    if let failure = validate(element, key: childKey) { return failure }
+                }
+                return nil
+            }
+            guard let key,
+                  remoteRelayWorkspaceSelectorKeys.contains(key) || remoteRelaySurfaceSelectorKeys.contains(key) else {
+                return nil
+            }
+            if value is NSNull { return nil }
+            guard let raw = value as? String,
+                  let id = UUID(uuidString: raw) else {
+                return RemoteRelaySelectorValidation(
+                    code: key.contains("workspace") || key == "tab_id"
+                        ? "remote_relay_workspace_denied"
+                        : "remote_relay_surface_denied",
+                    message: "Relay selector is invalid"
+                )
+            }
+            if remoteRelayWorkspaceSelectorKeys.contains(key), id != ownerWorkspaceID {
+                return RemoteRelaySelectorValidation(
+                    code: "remote_relay_workspace_denied",
+                    message: "Relay request targets a different workspace"
+                )
+            }
+            if remoteRelaySurfaceSelectorKeys.contains(key), !surfaceIDs.contains(id) {
+                return RemoteRelaySelectorValidation(
+                    code: "remote_relay_surface_denied",
+                    message: "Relay request targets a surface outside its workspace"
+                )
+            }
+            return nil
+        }
+        return validate(params, key: nil)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1965,13 +1965,19 @@ class TerminalController {
             // connection thread for socket traffic). The parsed request is
             // handed to the worker lane or into the main hop; nothing
             // re-parses on the main thread.
-            let request: ControlRequest
+            let parsedRequest: ControlRequest
             switch Self.v2Parser.request(fromLine: trimmed) {
             case .failure(let parseError):
                 return Self.v2Encoder.response(for: parseError)
             case .success(let parsed):
-                request = parsed
+                parsedRequest = parsed
             }
+
+            let relayAuthorization = authorizeRemoteRelayRequest(parsedRequest)
+            if let errorResponse = relayAuthorization.errorResponse {
+                return errorResponse
+            }
+            let request = relayAuthorization.request
 
             let policy = Self.executionPolicy(forV2Method: request.method)
             if Thread.isMainThread, policy == .socketWorker(mainThreadCallable: false) {

--- a/Sources/Workspace+RemoteRelayCommandRewrite.swift
+++ b/Sources/Workspace+RemoteRelayCommandRewrite.swift
@@ -74,10 +74,28 @@ extension Workspace {
               var request = try? JSONSerialization.jsonObject(with: requestData) as? [String: Any] else {
             return (commandLine, nil)
         }
-        let method = request["method"] as? String
+        let method = (request["method"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if remoteWorkspaceID != nil, let method {
+            // The local parser trims method names before dispatch. Normalize
+            // the signed envelope to that same value so surrounding wire
+            // whitespace cannot produce a MAC mismatch.
+            request["method"] = method
+        }
 
         var didRewrite = false
-        if var params = request["params"] as? [String: Any] {
+        var params = request["params"] as? [String: Any] ?? [:]
+        if remoteWorkspaceID != nil {
+            // These fields are relay-owned provenance.  Drop values supplied
+            // by the remote process before applying aliases and stamping the
+            // authenticated owner below; otherwise a caller could smuggle a
+            // second owner/authentication value into the local socket.
+            params.removeValue(forKey: "_cmux_remote_workspace_id")
+            params.removeValue(forKey: "_cmux_remote_relay_authentication_code")
+            params.removeValue(forKey: "_cmux_remote_relay_request_authentication_code")
+            didRewrite = true
+        }
+        if !params.isEmpty || request["params"] != nil || remoteWorkspaceID != nil {
             params = Self.remappedRemoteRelayValue(
                 params,
                 key: nil,
@@ -85,13 +103,27 @@ extension Workspace {
                 surfaceAliases: surfaceAliases,
                 didRewrite: &didRewrite
             ) as? [String: Any] ?? params
-            if method == "surface.resume.set" || method == "surface.report_tty" ||
-                method == "agent.resolve_delivery_target",
-               let remoteWorkspaceID {
+            if let remoteWorkspaceID {
                 params["_cmux_remote_workspace_id"] = remoteWorkspaceID.uuidString
                 didRewrite = true
             }
             request["params"] = params
+        }
+
+        // A caller notification carries a preferred workspace/surface.  Once
+        // those selectors are present, normalize it to the membership-confined
+        // target method used by the cloud relay; the caller resolver otherwise
+        // has permission to fall back to globally focused state.
+        if method == "notification.create_for_caller",
+           let preferredWorkspace = params["preferred_workspace_id"],
+           let preferredSurface = params["preferred_surface_id"] {
+            params["workspace_id"] = preferredWorkspace
+            params["surface_id"] = preferredSurface
+            params.removeValue(forKey: "preferred_workspace_id")
+            params.removeValue(forKey: "preferred_surface_id")
+            request["method"] = "notification.create_for_target"
+            request["params"] = params
+            didRewrite = true
         }
 
         guard didRewrite,

--- a/Sources/Workspace+RemoteRelayCommandRewrite.swift
+++ b/Sources/Workspace+RemoteRelayCommandRewrite.swift
@@ -114,7 +114,8 @@ extension Workspace {
         // those selectors are present, normalize it to the membership-confined
         // target method used by the cloud relay; the caller resolver otherwise
         // has permission to fall back to globally focused state.
-        if method == "notification.create_for_caller",
+        if remoteWorkspaceID != nil,
+           method == "notification.create_for_caller",
            let preferredWorkspace = params["preferred_workspace_id"],
            let preferredSurface = params["preferred_surface_id"] {
             params["workspace_id"] = preferredWorkspace

--- a/Sources/WorkspaceRemoteRelayCommandRewriter.swift
+++ b/Sources/WorkspaceRemoteRelayCommandRewriter.swift
@@ -6,7 +6,9 @@ import Foundation
 /// workspace model's alias-aware static rewrite so the package never imports
 /// `Workspace`.
 struct WorkspaceRemoteRelayCommandRewriter: RemoteRelayCommandRewriting {
-    private static let authenticationCodeKey = "_cmux_remote_relay_authentication_code"
+    static let authenticationCodeKey = "_cmux_remote_relay_authentication_code"
+    static let requestAuthenticationCodeKey = "_cmux_remote_relay_request_authentication_code"
+    static let remoteWorkspaceIDKey = "_cmux_remote_workspace_id"
 
     let remoteWorkspaceID: UUID
     let remoteRelayTokenHex: String
@@ -22,9 +24,15 @@ struct WorkspaceRemoteRelayCommandRewriter: RemoteRelayCommandRewriting {
             surfaceAliases: surfaceAliases,
             remoteWorkspaceID: remoteWorkspaceID
         )
-        // Method classification is a trust boundary; decoded JSON honors escapes that raw bytes do not.
-        guard rewritten.method == "surface.resume.set" else { return rewritten.commandLine }
-        return authenticatedRemoteResumeCommandLine(rewritten.commandLine)
+        // Method classification is a trust boundary; decoded JSON honors
+        // escapes that raw bytes do not.  The legacy resume MAC is retained
+        // for its existing handler, then every JSON request receives the
+        // generic relay MAC used by the local socket authorization gate.
+        var commandLine = rewritten.commandLine
+        if rewritten.method == "surface.resume.set" {
+            commandLine = authenticatedRemoteResumeCommandLine(commandLine)
+        }
+        return authenticatedRemoteRelayCommandLine(commandLine)
     }
 
     static func authenticatesRemoteResumeParameters(
@@ -43,6 +51,47 @@ struct WorkspaceRemoteRelayCommandRewriter: RemoteRelayCommandRewriting {
             authenticating: payload,
             using: SymmetricKey(data: relayToken)
         )
+    }
+
+    /// Verifies the relay-wide request MAC over the canonical envelope.  The
+    /// caller supplies the decoded envelope fields so socket ingress and the
+    /// relay rewriter share exactly one signing format.
+    static func authenticatesRemoteRelayRequest(
+        id: Any?,
+        method: String,
+        params: [String: Any],
+        remoteRelayTokenHex: String?
+    ) -> Bool {
+        guard let remoteRelayTokenHex,
+              let authenticationCode = params[requestAuthenticationCodeKey] as? String,
+              let payload = requestAuthenticationPayload(id: id, method: method, params: params),
+              let relayToken = hexData(remoteRelayTokenHex),
+              let receivedCode = hexData(authenticationCode) else {
+            return false
+        }
+        return HMAC<SHA256>.isValidAuthenticationCode(
+            receivedCode,
+            authenticating: payload,
+            using: SymmetricKey(data: relayToken)
+        )
+    }
+
+    static func requestAuthenticationCode(
+        id: Any?,
+        method: String,
+        params: [String: Any],
+        remoteRelayTokenHex: String?
+    ) -> String? {
+        guard let remoteRelayTokenHex,
+              let payload = requestAuthenticationPayload(id: id, method: method, params: params),
+              let relayToken = hexData(remoteRelayTokenHex) else {
+            return nil
+        }
+        let code = HMAC<SHA256>.authenticationCode(
+            for: payload,
+            using: SymmetricKey(data: relayToken)
+        )
+        return hexString(code)
     }
 
     private func authenticatedRemoteResumeCommandLine(_ commandLine: Data) -> Data {
@@ -67,11 +116,53 @@ struct WorkspaceRemoteRelayCommandRewriter: RemoteRelayCommandRewriting {
         return commandLine.last == 0x0A ? authenticated + Data([0x0A]) : authenticated
     }
 
+    private func authenticatedRemoteRelayCommandLine(_ commandLine: Data) -> Data {
+        guard let line = String(data: commandLine, encoding: .utf8),
+              let requestData = line.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
+              var request = try? JSONSerialization.jsonObject(with: requestData) as? [String: Any],
+              let method = (request["method"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return commandLine
+        }
+        var params = request["params"] as? [String: Any] ?? [:]
+        guard let authenticationCode = Self.requestAuthenticationCode(
+            id: request["id"],
+            method: method,
+            params: params,
+            remoteRelayTokenHex: remoteRelayTokenHex
+        ) else {
+            return commandLine
+        }
+        params[Self.requestAuthenticationCodeKey] = authenticationCode
+        request["params"] = params
+        guard let authenticated = try? JSONSerialization.data(withJSONObject: request) else {
+            return commandLine
+        }
+        return commandLine.last == 0x0A ? authenticated + Data([0x0A]) : authenticated
+    }
+
     private static func authenticationPayload(_ params: [String: Any]) -> Data? {
         var authenticatedParams = params
         authenticatedParams.removeValue(forKey: authenticationCodeKey)
+        authenticatedParams.removeValue(forKey: requestAuthenticationCodeKey)
         guard JSONSerialization.isValidJSONObject(authenticatedParams) else { return nil }
         return try? JSONSerialization.data(withJSONObject: authenticatedParams, options: [.sortedKeys])
+    }
+
+    private static func requestAuthenticationPayload(
+        id: Any?,
+        method: String,
+        params: [String: Any]
+    ) -> Data? {
+        var authenticatedParams = params
+        authenticatedParams.removeValue(forKey: authenticationCodeKey)
+        authenticatedParams.removeValue(forKey: requestAuthenticationCodeKey)
+        let envelope: [String: Any] = [
+            "id": id ?? NSNull(),
+            "method": method,
+            "params": authenticatedParams,
+        ]
+        guard JSONSerialization.isValidJSONObject(envelope) else { return nil }
+        return try? JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys])
     }
 
     private static func hexData(_ value: String) -> Data? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2213,6 +2213,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D1FF00010000000000000002 /* TerminalController+MobileWorkspaceChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF00010000000000000001 /* TerminalController+MobileWorkspaceChanges.swift */; };
 		C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */; };
 		D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */; };
+		A19F4C0D0000000000000002 /* TerminalController+RemoteRelayAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19F4C0D0000000000000001 /* TerminalController+RemoteRelayAuthorization.swift */; };
 		812600000000000000000009 /* TerminalController+RemoteTerminalTransportErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81260000000000000000000A /* TerminalController+RemoteTerminalTransportErrors.swift */; };
 		A31B24551C6E01E86D76B07E /* TerminalController+RemoteTmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B11974CF8937E165A3FAEE /* TerminalController+RemoteTmux.swift */; };
 		7738C0077738C0077738C007 /* TerminalController+RemoteTmuxControlMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738D0077738D0077738D007 /* TerminalController+RemoteTmuxControlMutations.swift */; };
@@ -4801,6 +4802,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D1FF00010000000000000001 /* TerminalController+MobileWorkspaceChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileWorkspaceChanges.swift"; sourceTree = "<group>"; };
 		C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileWorkspaceList.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
+		A19F4C0D0000000000000001 /* TerminalController+RemoteRelayAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+RemoteRelayAuthorization.swift"; sourceTree = "<group>"; };
 		81260000000000000000000A /* TerminalController+RemoteTerminalTransportErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+RemoteTerminalTransportErrors.swift"; sourceTree = "<group>"; };
 		95B11974CF8937E165A3FAEE /* TerminalController+RemoteTmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+RemoteTmux.swift"; sourceTree = "<group>"; };
 		7738D0077738D0077738D007 /* TerminalController+RemoteTmuxControlMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+RemoteTmuxControlMutations.swift"; sourceTree = "<group>"; };
@@ -6078,6 +6080,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D86840000000000000000014 /* Workspace+DockSessionRestore.swift */,
 				E30780000000000000000011 /* SSHPTYAttachStartupCommandBuilder.swift */,
 				EE30D5000000000000000001 /* RemoteDaemonStrings+App.swift */,
+				A19F4C0D0000000000000001 /* TerminalController+RemoteRelayAuthorization.swift */,
 				EE30D5000000000000000003 /* WorkspaceRemoteRelayCommandRewriter.swift */,
 				EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */,
 				EE30D6000000000000000003 /* WorkspaceRemoteSessionBuildInfo.swift */,
@@ -9791,6 +9794,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D1FF00010000000000000002 /* TerminalController+MobileWorkspaceChanges.swift in Sources */,
 				C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */,
 				D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */,
+				A19F4C0D0000000000000002 /* TerminalController+RemoteRelayAuthorization.swift in Sources */,
 				812600000000000000000009 /* TerminalController+RemoteTerminalTransportErrors.swift in Sources */,
 				A31B24551C6E01E86D76B07E /* TerminalController+RemoteTmux.swift in Sources */,
 				7738C0077738C0077738C007 /* TerminalController+RemoteTmuxControlMutations.swift in Sources */,

--- a/cmuxTests/RemoteResumeBindingTests.swift
+++ b/cmuxTests/RemoteResumeBindingTests.swift
@@ -280,10 +280,21 @@ struct RemoteResumeBindingTests {
                 workspaceAliases: [:],
                 surfaceAliases: [:]
             )
-            #expect(unrelatedResult == original)
-            let unrelatedParams = try #require(try jsonRequest(unrelatedResult)["params"] as? [String: Any])
-            #expect(unrelatedParams["_cmux_remote_workspace_id"] == nil)
+            let unrelatedRequest = try jsonRequest(unrelatedResult)
+            let unrelatedParams = try #require(unrelatedRequest["params"] as? [String: Any])
+            #expect(unrelatedRequest["method"] as? String == method)
+            #expect(unrelatedParams["_cmux_remote_workspace_id"] as? String == workspaceID.uuidString)
             #expect(unrelatedParams["_cmux_remote_relay_authentication_code"] == nil)
+            let genericCode = try #require(
+                unrelatedParams["_cmux_remote_relay_request_authentication_code"] as? String
+            )
+            #expect(genericCode.count == 64)
+            #expect(WorkspaceRemoteRelayCommandRewriter.authenticatesRemoteRelayRequest(
+                id: unrelatedRequest["id"],
+                method: method,
+                params: unrelatedParams,
+                remoteRelayTokenHex: relayToken
+            ))
         }
     }
 
@@ -323,6 +334,91 @@ struct RemoteResumeBindingTests {
         #expect(genericCode != "forged")
         #expect(genericCode.count == 64)
         #expect(params["_cmux_remote_relay_authentication_code"] == nil)
+    }
+
+    @Test
+    func authenticatedRemoteRelayRequestsStayWithinOwnerAllowlist() throws {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        let windowID = UUID()
+        let window = makeMainWindow(id: windowID)
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            app.unregisterMainWindowContextForTesting(windowId: windowID)
+            AppDelegate.shared = previousAppDelegate
+            window.orderOut(nil)
+        }
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        app.registerMainWindow(
+            window,
+            windowId: windowID,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let workspace = try #require(manager.selectedWorkspace)
+        let surfaceID = try #require(workspace.focusedPanelId)
+        workspace.configureRemoteConnection(remoteConfiguration(), autoConnect: false)
+        let relayToken = try #require(workspace.remoteConfiguration?.relayToken)
+        let rewriter = WorkspaceRemoteRelayCommandRewriter(
+            remoteWorkspaceID: workspace.id,
+            remoteRelayTokenHex: relayToken
+        )
+
+        let ping = rewriter.rewriteRemoteRelayCommandLine(
+            try requestData([
+                "id": "relay-ping",
+                "method": "system.ping",
+                "params": [:],
+            ]),
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let pingEnvelope = try v2Envelope(requestData: ping)
+        #expect(pingEnvelope["ok"] as? Bool == true, "\(pingEnvelope)")
+
+        let forbidden = rewriter.rewriteRemoteRelayCommandLine(
+            try requestData([
+                "id": "relay-forbidden",
+                "method": "surface.send_text",
+                "params": [
+                    "workspace_id": workspace.id.uuidString,
+                    "surface_id": surfaceID.uuidString,
+                    "text": "echo denied",
+                ],
+            ]),
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let forbiddenEnvelope = try v2Envelope(requestData: forbidden)
+        #expect(forbiddenEnvelope["ok"] as? Bool == false, "\(forbiddenEnvelope)")
+        let forbiddenError = try #require(forbiddenEnvelope["error"] as? [String: Any])
+        #expect(forbiddenError["code"] as? String == "remote_relay_method_denied")
+
+        let nestedOnly = rewriter.rewriteRemoteRelayCommandLine(
+            try requestData([
+                "id": "relay-nested-selector",
+                "method": "notification.create_for_target",
+                "params": [
+                    "title": "denied",
+                    "metadata": [
+                        "workspace_id": workspace.id.uuidString,
+                        "surface_id": surfaceID.uuidString,
+                    ],
+                ],
+            ]),
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let nestedEnvelope = try v2Envelope(requestData: nestedOnly)
+        #expect(nestedEnvelope["ok"] as? Bool == false, "\(nestedEnvelope)")
+        let nestedError = try #require(nestedEnvelope["error"] as? [String: Any])
+        #expect(nestedError["code"] as? String == "remote_relay_workspace_denied")
     }
 
     @Test

--- a/cmuxTests/RemoteResumeBindingTests.swift
+++ b/cmuxTests/RemoteResumeBindingTests.swift
@@ -395,7 +395,7 @@ struct RemoteResumeBindingTests {
     func relayMACSurvivesHighPrecisionJSONNumbersAcrossTypedParsing() throws {
         let workspaceID = UUID()
         let relayToken = String(repeating: "d", count: 64)
-        let preciseNumber = "123456789012345678901234567890.123456789"
+        let preciseNumber = "12345678901234567890123456789.123456789"
         let command = Data(
             "{\"id\":\"precise\",\"method\":\"system.ping\",\"params\":{\"workspace_id\":\"\(workspaceID.uuidString)\",\"precise\":\(preciseNumber)}}\n".utf8
         )

--- a/cmuxTests/RemoteResumeBindingTests.swift
+++ b/cmuxTests/RemoteResumeBindingTests.swift
@@ -288,6 +288,44 @@ struct RemoteResumeBindingTests {
     }
 
     @Test
+    func remoteRelayRewriterStampsAndReplacesGenericRequestAuthorization() throws {
+        let ownerWorkspaceID = UUID()
+        let rewriter = WorkspaceRemoteRelayCommandRewriter(
+            remoteWorkspaceID: ownerWorkspaceID,
+            remoteRelayTokenHex: String(repeating: "ab", count: 32)
+        )
+        let forgedWorkspaceID = UUID()
+        let request: [String: Any] = [
+            "id": "relay-security",
+            "method": "surface.send_text",
+            "params": [
+                "surface_id": UUID().uuidString,
+                "text": "do not forward",
+                "_cmux_remote_workspace_id": forgedWorkspaceID.uuidString,
+                "_cmux_remote_relay_request_authentication_code": "forged",
+                "_cmux_remote_relay_authentication_code": "forged",
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: request) + Data([0x0A])
+
+        let rewritten = rewriter.rewriteRemoteRelayCommandLine(
+            data,
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let object = try #require(JSONSerialization.jsonObject(with: rewritten) as? [String: Any])
+        let params = try #require(object["params"] as? [String: Any])
+
+        #expect(params["_cmux_remote_workspace_id"] as? String == ownerWorkspaceID.uuidString)
+        let genericCode = try #require(
+            params["_cmux_remote_relay_request_authentication_code"] as? String
+        )
+        #expect(genericCode != "forged")
+        #expect(genericCode.count == 64)
+        #expect(params["_cmux_remote_relay_authentication_code"] == nil)
+    }
+
+    @Test
     func remoteContextRejectsWrongOwnersAndBlankPersistentSessions() {
         let workspaceID = UUID()
         let surfaceID = UUID()

--- a/cmuxTests/RemoteResumeBindingTests.swift
+++ b/cmuxTests/RemoteResumeBindingTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxControlSocket
 import CmuxCore
 import Darwin
 import Foundation
@@ -215,6 +216,69 @@ struct RemoteResumeBindingTests {
     }
 
     @Test
+    func reportedTTYDeliveryTargetPassesRelayAuthorizationWithoutSurfaceSelector() throws {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        let windowID = UUID()
+        let window = makeMainWindow(id: windowID)
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            app.unregisterMainWindowContextForTesting(windowId: windowID)
+            AppDelegate.shared = previousAppDelegate
+            window.orderOut(nil)
+        }
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        app.registerMainWindow(
+            window,
+            windowId: windowID,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let workspace = try #require(manager.selectedWorkspace)
+        workspace.configureRemoteConnection(remoteConfiguration(), autoConnect: false)
+        let relayToken = try #require(workspace.remoteConfiguration?.relayToken)
+        let request: [String: Any] = [
+            "id": "reported-tty-restore",
+            "method": "agent.resolve_delivery_target",
+            "params": [
+                "workspace_id": workspace.id.uuidString,
+                "tty_name": "pts/42",
+                "tty_resolution": "reported_tty",
+            ],
+        ]
+        let rewritten = WorkspaceRemoteRelayCommandRewriter(
+            remoteWorkspaceID: workspace.id,
+            remoteRelayTokenHex: relayToken
+        ).rewriteRemoteRelayCommandLine(
+            try requestData(request),
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let line = try #require(String(data: rewritten, encoding: .utf8))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsed: ControlRequest
+        switch ControlRequestParser().request(fromLine: line) {
+        case .success(let request):
+            parsed = request
+        case .failure(let error):
+            Issue.record("Expected an authenticated relay request, got parse error \(error)")
+            return
+        }
+
+        let authorization = TerminalController.shared.authorizeRemoteRelayRequest(parsed)
+        #expect(authorization.errorResponse == nil)
+        #expect(authorization.request.method == "agent.resolve_delivery_target")
+        #expect(authorization.request.params["_cmux_remote_relay_request_authentication_code"] == nil)
+        #expect(authorization.request.params["tty_name"] == .string("pts/42"))
+    }
+
+    @Test
     func remoteResumeProvenanceRequiresExactMethodAndUntamperedAuthentication() throws {
         let workspaceID = UUID()
         let relayToken = String(repeating: "c", count: 64)
@@ -296,6 +360,71 @@ struct RemoteResumeBindingTests {
                 remoteRelayTokenHex: relayToken
             ))
         }
+    }
+
+    @Test
+    func aliasOnlyNotificationRewritePreservesCallerResolution() throws {
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        let command = try requestData([
+            "id": "local-caller-notification",
+            "method": "notification.create_for_caller",
+            "params": [
+                "preferred_workspace_id": workspaceID.uuidString,
+                "preferred_surface_id": surfaceID.uuidString,
+                "title": "title",
+            ],
+        ])
+        let rewritten = Workspace.rewriteRemoteRelayCommandLineAndExtractMethod(
+            command,
+            workspaceAliases: [UUID(): UUID()],
+            surfaceAliases: [UUID(): UUID()],
+            remoteWorkspaceID: nil
+        )
+        let request = try jsonRequest(rewritten.commandLine)
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(rewritten.method == "notification.create_for_caller")
+        #expect(request["method"] as? String == "notification.create_for_caller")
+        #expect(params["preferred_workspace_id"] as? String == workspaceID.uuidString)
+        #expect(params["preferred_surface_id"] as? String == surfaceID.uuidString)
+        #expect(params["workspace_id"] == nil)
+        #expect(params["surface_id"] == nil)
+    }
+
+    @Test
+    func relayMACSurvivesHighPrecisionJSONNumbersAcrossTypedParsing() throws {
+        let workspaceID = UUID()
+        let relayToken = String(repeating: "d", count: 64)
+        let preciseNumber = "123456789012345678901234567890.123456789"
+        let command = Data(
+            "{\"id\":\"precise\",\"method\":\"system.ping\",\"params\":{\"workspace_id\":\"\(workspaceID.uuidString)\",\"precise\":\(preciseNumber)}}\n".utf8
+        )
+        let rewritten = WorkspaceRemoteRelayCommandRewriter(
+            remoteWorkspaceID: workspaceID,
+            remoteRelayTokenHex: relayToken
+        ).rewriteRemoteRelayCommandLine(
+            command,
+            workspaceAliases: [:],
+            surfaceAliases: [:]
+        )
+        let line = try #require(String(data: rewritten, encoding: .utf8))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsed: ControlRequest
+        switch ControlRequestParser().request(fromLine: line) {
+        case .success(let request):
+            parsed = request
+        case .failure(let error):
+            Issue.record("Expected a valid precise relay request, got parse error \(error)")
+            return
+        }
+        #expect(parsed.params["precise"] == .decimal(preciseNumber))
+        let params = parsed.params.mapValues(\.foundationObject)
+        #expect(WorkspaceRemoteRelayCommandRewriter.authenticatesRemoteRelayRequest(
+            id: parsed.id?.foundationObject,
+            method: parsed.method,
+            params: params,
+            remoteRelayTokenHex: relayToken
+        ))
     }
 
     @Test
@@ -958,8 +1087,19 @@ struct RemoteResumeBindingTests {
         let remoteResult = try v2Result(requestData: rewrittenData)
         let remoteBinding = try #require(remoteResult["resume_binding"] as? [String: Any])
 
+        var snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        // This fixture models a live agent-hook session. The production
+        // snapshot records `wasAgentRunning` from process liveness; setting it
+        // explicitly keeps restore-policy coverage independent of whichever
+        // agent processes happen to be present on the test host.
+        if let panelIndex = snapshot.panels.firstIndex(where: { $0.id == surfaceID }),
+           var terminal = snapshot.panels[panelIndex].terminal {
+            terminal.wasAgentRunning = true
+            snapshot.panels[panelIndex].terminal = terminal
+        }
+
         return (
-            workspace.sessionSnapshot(includeScrollback: false),
+            snapshot,
             workspace.id,
             surfaceID,
             remotePTYSessionID,


### PR DESCRIPTION
## Summary

- Bind every JSON request forwarded by an SSH relay to its owning workspace with a relay-token HMAC.
- Verify the live workspace/token, method allowlist, and workspace/surface selectors at socket ingress before dispatch.
- Normalize caller notifications to an explicitly scoped target and reject legacy mutating command lines.
- Preserve the existing resume-binding MAC for `surface.resume.set` while stripping relay-only metadata before normal handlers run.

## Verification

- Added the regression test first in `a09fb5322f`, followed by the implementation in `fb5bd53927`.
- `arch -arm64 swift test --filter RemoteCLIRelayServerTests` (4 tests passed).
- Tagged Debug build: `fix-ssh-relay-authz`.
- `git diff --check` and `scripts/lint-pbxproj-test-wiring.sh` passed.

The broader `RemoteResumeBindingTests` suite still has two pre-existing restore assertion failures concerning `--command-b64`; they are unrelated to relay authorization and are documented in the handoff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777109&installation_model_id=21920&pr_number=10461&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10461&signature=fb5e4825d00af8edb9f60563fe7787ad1cef76506e63c7bc52ebcdc45260c0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens SSH relay authorization by HMAC-binding each JSON request to its owner workspace and enforcing a strict method/selector allowlist at socket ingress. Legacy space-delimited commands are denied (only JSON or a legacy ping is allowed), and typed parsing preserves high‑precision JSON numbers so MACs remain valid.

- Authorizes at `TerminalController` socket ingress: verifies live owner workspace/token, enforces a method allowlist, validates selectors belong to the owner workspace/surfaces, requires explicit top‑level selectors for selector‑bound methods, and returns `remote_relay_*` errors without dispatching on failure.
- Normalizes and sanitizes before handlers run: trims method whitespace for signing, strips relay‑only metadata (`_cmux_remote_workspace_id`, `_cmux_remote_relay_authentication_code`, `_cmux_remote_relay_request_authentication_code`), preserves the existing `surface.resume.set` MAC, and signs all JSON requests with `_cmux_remote_relay_request_authentication_code`.
- Tightens routing and inputs: rewrites `notification.create_for_caller` with preferred selectors to `notification.create_for_target` with explicit `workspace_id`/`surface_id`; enforces `agent.resolve_delivery_target` to use `tty_name` with `tty_resolution: "reported_tty"` and no PID fields; the relay server now forwards only well‑formed JSON requests (top‑level object) or `ping`, returning a localized “command denied” error otherwise.

**Migration**
- Relay senders must include `_cmux_remote_relay_request_authentication_code`: HMAC-SHA256 over the canonical envelope `{id, method (trimmed), params}` with both auth keys removed, using the current relay token. Include `_cmux_remote_workspace_id` in `params`.
- Use only allowed methods and provide explicit top‑level `workspace_id`/`surface_id` when required; `agent.resolve_delivery_target` must use `tty_name` with `tty_resolution: "reported_tty"` and must not set PID fields. Non‑JSON control commands, malformed JSON, or non‑object JSON (except `ping`) will fail.

<sup>Written for commit 3de9ac2b33e3b45f0d09a53ba8734f1e3f127676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authorization and authentication for remote relay requests, including workspace ownership, permitted methods, selectors, and delivery targets.
  * Added targeted caller notifications using workspace and surface selectors.
  * Added support for preserving high-precision decimal values in JSON commands.

* **Bug Fixes**
  * Unauthorized, malformed, and unsupported relay commands are now rejected safely.
  * Remote requests are normalized and protected against forged credentials before execution.
  * Legacy `ping` requests remain supported while other non-JSON commands are denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->