### PR TITLE
Dial discovered secondary Macs concurrently

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -1,3 +1,4 @@
+internal import CmuxMobileDiagnostics
 import CmuxMobilePairedMac
 import Foundation
 
@@ -133,6 +134,9 @@ extension MobileShellComposite {
         // `maximumLiveMacConnectionCount`.
         let admissionWidth = Self.maximumLiveMacConnectionCount
             - liveMacConnections.count
+        MobileDebugLog.anchormux(
+            "CMUX_CONNECT zero_touch_admission_start candidates=\(candidates.count) width=\(max(0, admissionWidth))"
+        )
         let admissionResults = await withTaskGroup(
             of: SecondaryMacReconciliationResult.self,
             returning: [SecondaryMacReconciliationResult].self
@@ -182,6 +186,9 @@ extension MobileShellComposite {
             where result.establishmentOutcome == .transientFailure {
             transientFailureMacIDs.insert(result.macDeviceID)
         }
+        MobileDebugLog.anchormux(
+            "CMUX_CONNECT zero_touch_admission_end attempted=\(admissionResults.count(where: { $0.establishmentOutcome != nil })) transient=\(transientFailureMacIDs.count)"
+        )
         guard attemptedCandidate, await isScopeCurrent(scope) else { return }
         // Some authenticated rows can persist even if their first workspace
         // snapshot fails. Reload once after the bounded pass so every proven
@@ -212,6 +219,9 @@ extension MobileShellComposite {
               await isScopeCurrent(scope),
               connectionState == .connected,
               remoteClient != nil else {
+            MobileDebugLog.anchormux(
+                "CMUX_CONNECT secondary_admission_skipped mac=\(candidate.macDeviceID) tag=\(candidate.instanceTag ?? "-")"
+            )
             return SecondaryMacReconciliationResult(
                 macDeviceID: candidate.macDeviceID,
                 establishmentOutcome: nil

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -220,7 +220,7 @@ extension MobileShellComposite {
               connectionState == .connected,
               remoteClient != nil else {
             MobileDebugLog.anchormux(
-                "CMUX_CONNECT secondary_admission_skipped mac=\(candidate.macDeviceID) tag=\(candidate.instanceTag ?? "-")"
+                "CMUX_CONNECT secondary_admission_skipped mac=\(candidate.macDeviceID.prefix(8)) tag=\(candidate.instanceTag ?? "-")"
             )
             return SecondaryMacReconciliationResult(
                 macDeviceID: candidate.macDeviceID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -124,26 +124,63 @@ extension MobileShellComposite {
               connectionState == .connected,
               remoteClient != nil else { return }
 
-        var attemptedCandidate = false
-        var transientFailureMacIDs: Set<String> = []
-        for candidate in candidates {
-            guard liveMacConnections.count
-                    < Self.maximumLiveMacConnectionCount,
-                  await isScopeCurrent(scope),
-                  connectionState == .connected,
-                  remoteClient != nil else { break }
-            attemptedCandidate = true
-            switch await establishSecondaryMacSubscription(
-                for: candidate,
-                scope: scope,
-                authorityValidation: .store,
-                persistAuthenticatedDiscovery: true
-            ) {
-            case .connected, .permanentFailure, .superseded:
-                break
-            case .transientFailure:
-                transientFailureMacIDs.insert(candidate.macDeviceID)
+        // Admit discovered peers concurrently: each candidate is an
+        // independent Mac, so one slow or unreachable peer must not delay the
+        // others. The initial group width is the live-capacity headroom at
+        // admission time; each dial re-checks capacity, scope, and foreground
+        // health before it starts, and establishment re-checks the cap at
+        // commit, so concurrent winners stay inside
+        // `maximumLiveMacConnectionCount`.
+        let admissionWidth = Self.maximumLiveMacConnectionCount
+            - liveMacConnections.count
+        let admissionResults = await withTaskGroup(
+            of: SecondaryMacReconciliationResult.self,
+            returning: [SecondaryMacReconciliationResult].self
+        ) { group in
+            var pending = candidates.makeIterator()
+            var results: [SecondaryMacReconciliationResult] = []
+            results.reserveCapacity(candidates.count)
+
+            for _ in 0 ..< max(0, admissionWidth) {
+                guard let candidate = pending.next() else { break }
+                group.addTask { [weak self] in
+                    guard let self else {
+                        return SecondaryMacReconciliationResult(
+                            macDeviceID: candidate.macDeviceID,
+                            establishmentOutcome: nil
+                        )
+                    }
+                    return await self.admitDiscoveredSecondaryIrohMac(
+                        candidate,
+                        scope: scope
+                    )
+                }
             }
+            while let result = await group.next() {
+                results.append(result)
+                guard let candidate = pending.next() else { continue }
+                group.addTask { [weak self] in
+                    guard let self else {
+                        return SecondaryMacReconciliationResult(
+                            macDeviceID: candidate.macDeviceID,
+                            establishmentOutcome: nil
+                        )
+                    }
+                    return await self.admitDiscoveredSecondaryIrohMac(
+                        candidate,
+                        scope: scope
+                    )
+                }
+            }
+            return results
+        }
+        let attemptedCandidate = admissionResults.contains {
+            $0.establishmentOutcome != nil
+        }
+        var transientFailureMacIDs: Set<String> = []
+        for result in admissionResults
+            where result.establishmentOutcome == .transientFailure {
+            transientFailureMacIDs.insert(result.macDeviceID)
         }
         guard attemptedCandidate, await isScopeCurrent(scope) else { return }
         // Some authenticated rows can persist even if their first workspace
@@ -160,5 +197,35 @@ extension MobileShellComposite {
                 needsFullRefresh: true
             )
         }
+    }
+
+    /// One bounded zero-touch admission dial. Re-checks live capacity, scope,
+    /// and foreground health immediately before dialing so a concurrent winner
+    /// (foreground attach, warm-pool dial, or another admission) stops a
+    /// queued candidate instead of oversubscribing the pool. A `nil` outcome
+    /// means the dial never started.
+    private func admitDiscoveredSecondaryIrohMac(
+        _ candidate: MobilePairedMac,
+        scope: MobileShellScopeSnapshot
+    ) async -> SecondaryMacReconciliationResult {
+        guard liveMacConnections.count < Self.maximumLiveMacConnectionCount,
+              await isScopeCurrent(scope),
+              connectionState == .connected,
+              remoteClient != nil else {
+            return SecondaryMacReconciliationResult(
+                macDeviceID: candidate.macDeviceID,
+                establishmentOutcome: nil
+            )
+        }
+        let outcome = await establishSecondaryMacSubscription(
+            for: candidate,
+            scope: scope,
+            authorityValidation: .store,
+            persistAuthenticatedDiscovery: true
+        )
+        return SecondaryMacReconciliationResult(
+            macDeviceID: candidate.macDeviceID,
+            establishmentOutcome: outcome
+        )
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5855,8 +5855,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) async -> SecondaryMacEstablishmentOutcome {
         let flightKey = MacPairingKey(mac)
         if let existing = secondaryMacEstablishmentFlights[flightKey] {
+            MobileDebugLog.anchormux(
+                "CMUX_CONNECT secondary_dial_join mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-")"
+            )
             return await existing.task.value
         }
+        let dialStart = ContinuousClock.now
+        MobileDebugLog.anchormux(
+            "CMUX_CONNECT secondary_dial_start mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-") name=\(mac.displayName ?? "-")"
+        )
         let flightID = UUID()
         let task = Task { @MainActor [weak self] in
             defer {
@@ -5885,7 +5892,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 mac: mac,
                 task: task
             )
-        return await task.value
+        let outcome = await task.value
+        let elapsed = dialStart.duration(to: .now)
+        // attoseconds (1e-18 s) -> milliseconds (1e-3 s): divide by 1e15.
+        let elapsedMilliseconds = elapsed.components.seconds * 1000
+            + elapsed.components.attoseconds / 1_000_000_000_000_000
+        MobileDebugLog.anchormux(
+            "CMUX_CONNECT secondary_dial_end mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-") outcome=\(String(describing: outcome)) elapsed_ms=\(elapsedMilliseconds)"
+        )
+        return outcome
     }
 
     private func performSecondaryMacSubscriptionEstablishment(
@@ -5932,6 +5947,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return .permanentFailure
         }
         let client = handle.client
+        MobileDebugLog.anchormux(
+            "CMUX_CONNECT secondary_client_connected mac=\(macID) tag=\(mac.instanceTag ?? "-")"
+        )
         // Re-check after the async client build so a concurrent refresh cannot
         // open a duplicate connection, AND so a sign-out / account/team switch
         // during the connect does not leave an old-scope connection live or write

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5856,13 +5856,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let flightKey = MacPairingKey(mac)
         if let existing = secondaryMacEstablishmentFlights[flightKey] {
             MobileDebugLog.anchormux(
-                "CMUX_CONNECT secondary_dial_join mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-")"
+                "CMUX_CONNECT secondary_dial_join mac=\(mac.macDeviceID.prefix(8)) tag=\(mac.instanceTag ?? "-")"
             )
             return await existing.task.value
         }
         let dialStart = ContinuousClock.now
         MobileDebugLog.anchormux(
-            "CMUX_CONNECT secondary_dial_start mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-") name=\(mac.displayName ?? "-")"
+            "CMUX_CONNECT secondary_dial_start mac=\(mac.macDeviceID.prefix(8)) tag=\(mac.instanceTag ?? "-")"
         )
         let flightID = UUID()
         let task = Task { @MainActor [weak self] in
@@ -5898,7 +5898,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let elapsedMilliseconds = elapsed.components.seconds * 1000
             + elapsed.components.attoseconds / 1_000_000_000_000_000
         MobileDebugLog.anchormux(
-            "CMUX_CONNECT secondary_dial_end mac=\(mac.macDeviceID) tag=\(mac.instanceTag ?? "-") outcome=\(String(describing: outcome)) elapsed_ms=\(elapsedMilliseconds)"
+            "CMUX_CONNECT secondary_dial_end mac=\(mac.macDeviceID.prefix(8)) tag=\(mac.instanceTag ?? "-") outcome=\(String(describing: outcome)) elapsed_ms=\(elapsedMilliseconds)"
         )
         return outcome
     }
@@ -5948,7 +5948,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         let client = handle.client
         MobileDebugLog.anchormux(
-            "CMUX_CONNECT secondary_client_connected mac=\(macID) tag=\(mac.instanceTag ?? "-")"
+            "CMUX_CONNECT secondary_client_connected mac=\(macID.prefix(8)) tag=\(mac.instanceTag ?? "-")"
         )
         // Re-check after the async client build so a concurrent refresh cannot
         // open a duplicate connection, AND so a sign-out / account/team switch

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -331,6 +331,120 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func discoveredSecondaryCandidatesDialConcurrently() async throws {
+        let candidates = [
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "a",
+                instanceTag: "phand1",
+                routeID: "iroh-phand1"
+            ),
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "b",
+                instanceTag: "phand2",
+                routeID: "iroh-phand2"
+            ),
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "c",
+                instanceTag: "phand3",
+                routeID: "iroh-phand3"
+            ),
+        ]
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        var routers: [String: LivenessHostRouter] = [:]
+        for candidate in candidates {
+            let router = LivenessHostRouter()
+            await router.setHostIdentity(
+                deviceID: candidate.deviceID,
+                instanceTag: candidate.instanceTag,
+                displayName: candidate.displayName
+            )
+            routers[candidate.routes[0].id] = router
+        }
+        let secondRouter = try #require(routers["iroh-phand2"])
+        let thirdRouter = try #require(routers["iroh-phand3"])
+        // Park each discovered peer's dial at its first host-status exchange
+        // until released. The 30s pairing timeout is far beyond the poll
+        // window below, so a parked dial cannot time out and fake an
+        // overlapping second dial.
+        await secondRouter.delayHostStatusRequest(number: 1)
+        await thirdRouter.delayHostStatusRequest(number: 1)
+        let factory = RoutedZeroTouchFactory(routers: routers)
+        let defaults = UserDefaults(
+            suiteName: "iroh-concurrent-admission-\(UUID().uuidString)"
+        )!
+        defaults.set(true, forKey: "multiMacAggregation")
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Self.fixedNow },
+                supportedRouteKinds: [.iroh]
+            ),
+            isSignedIn: true,
+            pairedMacStore: store,
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "phand1",
+                additionalInstanceTags: ["phand2", "phand3"]
+            ),
+            personalIrohDiscovery: ScriptedIrohDiscovery(
+                snapshots: [candidates]
+            ),
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: defaults,
+            multiMacAggregationDefaults: defaults
+        )
+        defer {
+            for (_, subscription) in shell.secondaryMacSubscriptions {
+                subscription.cancel()
+            }
+            Task { await shell.remoteClient?.disconnect() }
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let foreground = candidates[0]
+        try await store.upsert(
+            macDeviceID: foreground.deviceID,
+            displayName: foreground.displayName,
+            routes: foreground.routes,
+            instanceTag: foreground.instanceTag,
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: foreground.lastSeenAt
+        )
+        await shell.loadPairedMacs()
+
+        #expect(await shell.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        // Serial admission never dials the third peer while the second one's
+        // host-status exchange is held; both dials held at once is the
+        // concurrency proof.
+        #expect(
+            try await pollUntil {
+                let secondHeld = await secondRouter.heldRequestCount()
+                let thirdHeld = await thirdRouter.heldRequestCount()
+                return secondHeld == 1 && thirdHeld == 1
+            },
+            "discovered candidates should dial concurrently"
+        )
+        await secondRouter.releaseAllHeld()
+        await thirdRouter.releaseAllHeld()
+        #expect(try await pollUntil {
+            shell.liveMacConnections.count == 3
+                && shell.pairedMacs.count == 3
+        })
+    }
+
+    @Test
     func signOutWhileDiscoveryIsSuspendedPreventsDialAndPersistence() async throws {
         let live = try candidate(deviceID: "mac-a", endpointByte: "a")
         let discovery = SuspendedIrohDiscovery(candidates: [live])


### PR DESCRIPTION
Zero-touch iroh admission dialed one discovered peer at a time, so a slow or unreachable candidate delayed every peer behind it by up to a full dial timeout before it appeared in the Connections list. The warm-pool reconciliation pass has fanned out since a028ba24e1; this closes the same gap for discovered peers.

The admission loop now uses the same bounded task-group shape as warm-pool reconciliation: the initial width is the live-capacity headroom at admission time, every dial re-checks capacity, scope, and foreground health immediately before starting, and establishment keeps re-checking the cap at commit, so concurrent winners stay inside `maximumLiveMacConnectionCount`. Within-Mac route fallback stays serial on purpose: those routes are alternatives to one Mac, not independent work.

Commit 1 adds the regression test only (red): each discovered peer's first host-status exchange parks on its own router, and serial admission never starts the second dial while the first is parked. Commit 2 fans out the dials (green). `swift test` on CmuxMobileShell passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789788079&installation_model_id=21920&pr_number=10466&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10466&signature=4e9af14b71144120933ed812b9c080f40dd1985cfd7251e62d66f0c1b923273b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits discovered secondary Macs concurrently instead of serially, so a slow or unreachable peer no longer blocks others. Adds CMUX_CONNECT debug logs for admission and dial lifecycles; logs now show only an 8‑char device‑id prefix and instance tag to avoid leaking full identifiers.

- Uses a bounded task group: initial width = `maximumLiveMacConnectionCount - liveMacConnections.count`; each task re-checks capacity, scope, and foreground health before dialing; establishment re-checks the cap at commit. Cap enforcement and failure handling are unchanged; within‑Mac route fallback remains serial.
- Introduces private `admitDiscoveredSecondaryIrohMac` to perform a guarded dial; a nil outcome means the dial never started.
- Adds CMUX_CONNECT logs: zero_touch_admission_start/end, secondary_dial_start/join/end (with outcome and elapsed_ms), secondary_client_connected, and secondary_admission_skipped; truncates device ids to 8 chars and omits display names.
- Adds a concurrency test that holds host-status on two candidates simultaneously to prove both dials start in parallel.

<sup>Written for commit 9e1be68085473980d587768f45b94a254a168faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Secondary device connections are now established concurrently, reducing the time required to connect multiple discovered devices.

- **Reliability**
  - Connection attempts recheck availability and capacity before dialing, helping prevent invalid or unnecessary attempts.
  - Transient connection failures continue to support retrying eligible devices.
  - Improved tracking of connection attempts and outcomes provides more consistent pairing results during automatic discovery.

- **Diagnostics**
  - Added connection progress details, including active attempts, completion results, timing, and successful secondary-device connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->