### PR TITLE
feat(tui): powerline separators, chip styles, and sidebar button customization

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -9528,15 +9528,21 @@ impl App {
         let messages = &localization::catalog().sidebar;
         spec.actions
             .iter()
-            .copied()
-            .flat_map(|action| {
+            .flat_map(|action_spec| {
+                let action = action_spec.action;
+                let label_override = action_spec.label.as_deref();
                 if action == Action::NewWorkspace {
                     return self
                         .workspace_creation_modes()
                         .into_iter()
                         .map(|mode| SidebarActionRow {
                             label: match mode {
-                                None => messages.new_workspace.to_string(),
+                                // A configured label renames the plain
+                                // button; the provider-specific isolated and
+                                // shared variants keep their catalog labels.
+                                None => {
+                                    label_override.unwrap_or(messages.new_workspace).to_string()
+                                }
                                 Some(WorkspaceCreationMode::Isolated) => {
                                     messages.new_isolated_workspace.to_string()
                                 }
@@ -9550,13 +9556,32 @@ impl App {
                 }
                 self.action_available(action)
                     .then(|| SidebarActionRow {
-                        label: localization::catalog().action_label(action).to_string(),
+                        label: label_override
+                            .map(str::to_string)
+                            .unwrap_or_else(|| self.action_display_label(action).to_string()),
                         target: SidebarActionTarget::Run(action),
                     })
                     .into_iter()
                     .collect()
             })
             .collect()
+    }
+
+    /// Where the workspace rail's pinned action buttons render.
+    pub(crate) fn workspace_actions_position(&self) -> crate::config::ActionsPosition {
+        self.view_index_for_rail(RailKind::Workspace)
+            .and_then(|index| self.config.sidebar.views.get(index))
+            .map(|spec| spec.actions_position)
+            .unwrap_or_default()
+    }
+
+    /// Expand the configured workspace row label template.
+    pub(crate) fn workspace_button_label(&self, index: usize, name: &str) -> String {
+        let template = &self.config.sidebar.workspace_label;
+        if template == "{name}" {
+            return name.to_string();
+        }
+        template.replace("{index}", &index.to_string()).replace("{name}", name)
     }
 
     pub(crate) fn projection_rail_state_mut(&mut self, index: usize) -> &mut ProjectionRailState {
@@ -24826,7 +24851,8 @@ mod tests {
         let focused = vec![SidebarViewSpec {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
-            actions: vec![Action::NewWorkspace],
+            actions: vec![crate::config::SidebarActionSpec::plain(Action::NewWorkspace)],
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 30,
             max_width: 0,
             collapse_priority: 30,
@@ -38512,6 +38538,7 @@ mod tests {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
             actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,
@@ -38589,6 +38616,7 @@ mod tests {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
             actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,
@@ -38623,6 +38651,7 @@ mod tests {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
             actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,
@@ -38660,6 +38689,7 @@ mod tests {
             id: "agents".into(),
             levels: vec![SidebarResourceKind::Agents],
             actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,
@@ -38809,7 +38839,8 @@ mod tests {
         app.config.sidebar.views = vec![SidebarViewSpec {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
-            actions: vec![Action::NewWorkspace],
+            actions: vec![crate::config::SidebarActionSpec::plain(Action::NewWorkspace)],
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,
@@ -38908,7 +38939,8 @@ mod tests {
         app.config.sidebar.views = vec![SidebarViewSpec {
             id: "workspace-agents".into(),
             levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
-            actions: vec![Action::NewWorkspace],
+            actions: vec![crate::config::SidebarActionSpec::plain(Action::NewWorkspace)],
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 40,
             max_width: 0,
             collapse_priority: 30,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -9622,13 +9622,20 @@ impl App {
             .unwrap_or_default()
     }
 
-    /// Expand the configured workspace row label template.
-    pub(crate) fn workspace_button_label(&self, index: usize, name: &str) -> String {
+    /// Expand the configured workspace row label template. The default
+    /// template borrows the name, so ordinary draws do not allocate.
+    pub(crate) fn workspace_button_label<'a>(
+        &self,
+        index: usize,
+        name: &'a str,
+    ) -> std::borrow::Cow<'a, str> {
         let template = &self.config.sidebar.workspace_label;
         if template == "{name}" {
-            return name.to_string();
+            return std::borrow::Cow::Borrowed(name);
         }
-        template.replace("{index}", &index.to_string()).replace("{name}", name)
+        std::borrow::Cow::Owned(
+            template.replace("{index}", &index.to_string()).replace("{name}", name),
+        )
     }
 
     pub(crate) fn projection_rail_state_mut(&mut self, index: usize) -> &mut ProjectionRailState {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4124,15 +4124,32 @@ pub enum MenuAction {
     SplitDown(PaneId),
     CloseTab(PaneId),
     ClosePane(PaneId),
-    TogglePaneZoom { pane: PaneId, zoomed: bool },
-    ToggleSidebar { visible: bool },
-    ToggleSidebarCompact { compact: bool },
+    TogglePaneZoom {
+        pane: PaneId,
+        zoomed: bool,
+    },
+    ToggleSidebar {
+        visible: bool,
+    },
+    ToggleSidebarCompact {
+        compact: bool,
+    },
     FocusSidebar,
     ActivateSidebarProfile(usize),
-    SetSidebarViewVisible { view: usize, visible: bool },
+    SetSidebarViewVisible {
+        view: usize,
+        visible: bool,
+    },
     ShowShortcuts,
-    SetClientSizing { surface: SurfaceId, client: u64, enabled: bool },
-    UseClientSize { surface: SurfaceId, client: u64 },
+    SetClientSizing {
+        surface: SurfaceId,
+        client: u64,
+        enabled: bool,
+    },
+    UseClientSize {
+        surface: SurfaceId,
+        client: u64,
+    },
     RestoreAllClientSizing(SurfaceId),
     DisconnectClient(u64),
     SelectProviderScope(usize),
@@ -4140,12 +4157,23 @@ pub enum MenuAction {
     CreateMachineFrom(usize),
     ConnectMachineTarget(usize),
     ConnectOtherMachine,
+    /// A configured action from a customizable menu (for example a `+`
+    /// button's right-click menu), targeting an optional pane.
+    RunConfigured {
+        action: Action,
+        pane: Option<PaneId>,
+    },
 }
 
 impl MenuAction {
     pub fn label(&self) -> &'static str {
         let menu = &localization::catalog().menu;
         match self {
+            // Menus always wrap this variant in a labeled item; the catalog
+            // label is the keyboard-help fallback only.
+            MenuAction::RunConfigured { action, .. } => {
+                localization::catalog().action_label(*action)
+            }
             MenuAction::RenameClientMachine(_) | MenuAction::RenameManagedMachine(_) => {
                 localization::catalog().sidebar.rename_machine
             }
@@ -9563,6 +9591,25 @@ impl App {
                     })
                     .into_iter()
                     .collect()
+            })
+            .collect()
+    }
+
+    /// Menu items for a configurable `+` button's right-click menu.
+    fn plus_menu_items(
+        &self,
+        plus: &crate::config::PlusButton,
+        pane: Option<PaneId>,
+    ) -> Vec<MenuItem> {
+        plus.menu
+            .iter()
+            .filter(|spec| self.action_available(spec.action))
+            .map(|spec| MenuItem::LabeledAction {
+                label: spec
+                    .label
+                    .clone()
+                    .unwrap_or_else(|| self.action_display_label(spec.action).to_string()),
+                action: MenuAction::RunConfigured { action: spec.action, pane },
             })
             .collect()
     }
@@ -18415,6 +18462,9 @@ impl App {
                     self.begin_machine_connection(target, MachineConnectRoute::Local);
                 }
             }
+            MenuAction::RunConfigured { action, pane } => {
+                self.run_action_for_pane(action, pane.or_else(|| self.active_pane()))?;
+            }
             MenuAction::ConnectOtherMachine => {
                 let prompt = self.connect_machine_prompt();
                 self.prompt = Some(prompt);
@@ -20496,7 +20546,12 @@ impl App {
                 Hit::CopyStatusMessage => self.copy_status_message(),
                 Hit::NewScreen => {
                     self.focus = FocusTarget::Pane;
-                    self.new_screen(None)?;
+                    if let Some(action) = self.config.status_bar.screens_plus.action {
+                        let pane = self.active_pane();
+                        self.run_action_for_pane(action, pane)?;
+                    } else {
+                        self.new_screen(None)?;
+                    }
                 }
                 Hit::Tab { pane, index } => {
                     if let Some(surface) = self
@@ -20510,7 +20565,9 @@ impl App {
                 }
                 Hit::NewTab { pane } => {
                     self.focus_pane_after_input(pane);
-                    if self.prepare_pty_input_before_mutation() {
+                    if let Some(action) = self.config.tabs.plus.action {
+                        self.run_action_for_pane(action, Some(pane))?;
+                    } else if self.prepare_pty_input_before_mutation() {
                         self.session
                             .new_tab(Some(pane), self.terminal_tab_size_hint(Some(pane)))?;
                     }
@@ -21564,6 +21621,25 @@ impl App {
                 vec![self.menu_group([MenuAction::CopyStatusMessage]), self.global_menu_items()],
             ));
             return;
+        }
+        // Configurable `+` buttons: a right click opens their configured
+        // menu when one exists; without one the generic paths below apply.
+        if let Some(Hit::NewTab { pane }) = hit {
+            let items = self.plus_menu_items(&self.config.tabs.plus, Some(pane));
+            if !items.is_empty() {
+                self.menu =
+                    Some(ContextMenu::with_groups(x, y, vec![items, self.global_menu_items()]));
+                return;
+            }
+        }
+        if matches!(hit, Some(Hit::NewScreen)) {
+            let items =
+                self.plus_menu_items(&self.config.status_bar.screens_plus, self.active_pane());
+            if !items.is_empty() {
+                self.menu =
+                    Some(ContextMenu::with_groups(x, y, vec![items, self.global_menu_items()]));
+                return;
+            }
         }
         if self.total_sidebar_width() > 0 && x < self.total_sidebar_width() {
             let mut groups = Vec::new();

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -227,6 +227,7 @@ struct RawStatusBar {
     left_separator: Option<String>,
     right_separator: Option<String>,
     screens_style: Option<ChipStyle>,
+    screens_plus: Option<RawPlusButton>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -501,6 +502,7 @@ struct RawTabs {
     show_titles: Option<bool>,
     agents: Option<Vec<String>>,
     style: Option<ChipStyle>,
+    plus: Option<RawPlusButton>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -569,6 +571,17 @@ impl RawSidebarAction {
             RawSidebarAction::Detailed { label, .. } => label.as_deref(),
         }
     }
+}
+
+/// Raw form of a configurable `+` button.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPlusButton {
+    label: Option<String>,
+    /// Left-click action override; action name or `command:<id>`.
+    action: Option<String>,
+    /// Right-click menu entries; same grammar as sidebar view actions.
+    menu: Option<Vec<RawSidebarAction>>,
 }
 
 /// Where a view's pinned action buttons render.
@@ -957,6 +970,8 @@ pub struct Tabs {
     pub agents: Vec<String>,
     /// Cap style for solid tab chips.
     pub style: ChipStyle,
+    /// The tab bar's `+` button: label, click override, right-click menu.
+    pub plus: PlusButton,
 }
 
 impl Default for Tabs {
@@ -967,6 +982,7 @@ impl Default for Tabs {
             show_titles: false,
             agents: ["claude", "codex", "opencode", "pi"].map(String::from).to_vec(),
             style: ChipStyle::Block,
+            plus: PlusButton::default(),
         }
     }
 }
@@ -1091,6 +1107,58 @@ impl SidebarActionSpec {
     pub fn plain(action: Action) -> Self {
         Self { action, label: None }
     }
+}
+
+/// A configurable `+` button: its rendered label, an optional left-click
+/// action override, and an optional right-click menu of actions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlusButton {
+    pub label: String,
+    pub action: Option<Action>,
+    pub menu: Vec<SidebarActionSpec>,
+}
+
+impl Default for PlusButton {
+    fn default() -> Self {
+        Self { label: " + ".to_string(), action: None, menu: Vec::new() }
+    }
+}
+
+fn resolve_plus_button(raw: RawPlusButton, command_ids: &[String], owner: &str) -> PlusButton {
+    let mut plus = PlusButton::default();
+    if let Some(label) = raw.label {
+        // Keep at least one visible cell so the button stays clickable.
+        if !label.trim().is_empty() {
+            plus.label = label;
+        }
+    }
+    if let Some(action) = raw.action.as_deref() {
+        match parse_sidebar_action(action.trim(), command_ids) {
+            Ok(action) => plus.action = Some(action),
+            Err(warning) => eprintln!("{warning} in {owner} plus button"),
+        }
+    }
+    if let Some(menu) = raw.menu {
+        let mut seen = HashSet::new();
+        for raw_action in &menu {
+            match parse_sidebar_action(raw_action.action().trim(), command_ids) {
+                Ok(action) if seen.insert(action) => plus.menu.push(SidebarActionSpec {
+                    action,
+                    label: raw_action
+                        .label()
+                        .map(str::trim)
+                        .filter(|label| !label.is_empty())
+                        .map(str::to_string),
+                }),
+                Ok(_) => eprintln!(
+                    "cmux-tui: ignoring duplicate {owner} plus menu action {:?}",
+                    raw_action.action().trim()
+                ),
+                Err(warning) => eprintln!("{warning} in {owner} plus menu"),
+            }
+        }
+    }
+    plus
 }
 
 impl SidebarViewSpec {
@@ -2934,6 +3002,8 @@ pub struct StatusBarOptions {
     pub right_separator: Option<String>,
     /// Cap style for the active screen chip in the screens strip.
     pub screens_style: ChipStyle,
+    /// The screens strip's `+` button.
+    pub screens_plus: PlusButton,
 }
 
 impl Default for StatusBarOptions {
@@ -2947,6 +3017,7 @@ impl Default for StatusBarOptions {
             left_separator: None,
             right_separator: None,
             screens_style: ChipStyle::Block,
+            screens_plus: PlusButton::default(),
         }
     }
 }
@@ -3296,6 +3367,12 @@ pub fn load() -> Config {
     // reference them as `command:<id>`; their chords bind after `keys`.
     let (user_commands, user_command_keys) = resolve_user_command_specs(raw.commands);
     let command_ids: Vec<String> = user_commands.iter().map(|command| command.id.clone()).collect();
+    if let Some(plus) = raw.tabs.plus {
+        config.tabs.plus = resolve_plus_button(plus, &command_ids, "tabs");
+    }
+    if let Some(plus) = raw.status_bar.screens_plus {
+        config.status_bar.screens_plus = resolve_plus_button(plus, &command_ids, "status_bar");
+    }
     if let Some(views) = raw.sidebar.views.as_ref() {
         if raw.sidebar.columns.is_some() {
             eprintln!("cmux-tui: sidebar.views overrides sidebar.columns");
@@ -7988,6 +8065,52 @@ mod tests {
         assert_eq!(raw.sidebar.row_gap, Some(0));
         assert_eq!(raw.sidebar.rail_glyph.as_deref(), Some("none"));
         assert_eq!(raw.sidebar.workspace_label.as_deref(), Some("{index} · {name}"));
+    }
+
+    #[test]
+    fn plus_buttons_parse_labels_actions_and_menus() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "tabs": {"plus": {
+                "label": " new ",
+                "action": "command:top",
+                "menu": [
+                    "new-tab",
+                    {"action": "new-browser-tab", "label": "browser"},
+                    "command:top",
+                    "command:unknown"
+                ]
+            }},
+            "status_bar": {"screens_plus": {"label": " ⊕ "}}
+        }))
+        .unwrap();
+        let command_ids = vec!["top".to_string()];
+        let plus = resolve_plus_button(raw.tabs.plus.unwrap(), &command_ids, "tabs");
+        assert_eq!(plus.label, " new ");
+        assert_eq!(plus.action, Action::user_command(0));
+        assert_eq!(
+            plus.menu,
+            vec![
+                SidebarActionSpec::plain(Action::NewTab),
+                SidebarActionSpec {
+                    action: Action::NewBrowserTab,
+                    label: Some("browser".to_string()),
+                },
+                SidebarActionSpec::plain(Action::user_command(0).unwrap()),
+            ],
+            "unknown command references drop from plus menus"
+        );
+        let screens =
+            resolve_plus_button(raw.status_bar.screens_plus.unwrap(), &command_ids, "status_bar");
+        assert_eq!(screens.label, " ⊕ ");
+        assert_eq!(screens.action, None);
+        assert!(screens.menu.is_empty());
+        // A blank label keeps the clickable default.
+        let blank = resolve_plus_button(
+            RawPlusButton { label: Some("   ".to_string()), action: None, menu: None },
+            &command_ids,
+            "tabs",
+        );
+        assert_eq!(blank.label, " + ");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -148,6 +148,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
+use unicode_width::UnicodeWidthStr;
 use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
@@ -3254,8 +3255,16 @@ pub fn load() -> Config {
         config.sidebar.row_gap = gap.min(2);
     }
     if let Some(glyph) = raw.sidebar.rail_glyph {
-        config.sidebar.rail_glyph =
-            if glyph.eq_ignore_ascii_case("none") { String::new() } else { glyph };
+        if glyph.eq_ignore_ascii_case("none") {
+            config.sidebar.rail_glyph = String::new();
+        } else if glyph.chars().count() == 1 && glyph.width() == 1 {
+            // The renderer reserves exactly one cell for the glyph.
+            config.sidebar.rail_glyph = glyph;
+        } else {
+            eprintln!(
+                "cmux-tui: ignoring sidebar.rail_glyph {glyph:?}: one single-width character or \"none\""
+            );
+        }
     }
     if let Some(template) = raw.sidebar.workspace_label {
         let template = template.trim().to_string();

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -224,6 +224,9 @@ struct RawStatusBar {
     show_session: Option<bool>,
     left: Option<Vec<RawStatusSegment>>,
     right: Option<Vec<RawStatusSegment>>,
+    left_separator: Option<String>,
+    right_separator: Option<String>,
+    screens_style: Option<ChipStyle>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -294,6 +297,8 @@ struct RawTheme {
     border_style: Option<BorderStyle>,
     status_bg: Option<ColorValue>,
     status_fg: Option<ColorValue>,
+    sidebar_fg: Option<ColorValue>,
+    sidebar_selected_fg: Option<ColorValue>,
     dim_inactive: Option<bool>,
 }
 
@@ -495,6 +500,7 @@ struct RawTabs {
     solid_background: Option<bool>,
     show_titles: Option<bool>,
     agents: Option<Vec<String>>,
+    style: Option<ChipStyle>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -509,6 +515,15 @@ struct RawSidebar {
     views: Option<Vec<RawSidebarView>>,
     columns: Option<Vec<RawSidebarColumn>>,
     plugin: Option<RawSidebarPlugin>,
+    /// Rows per rail entry: 2 (default) keeps the subtitle line, 1 is a
+    /// dense name-only list.
+    row_height: Option<u16>,
+    /// Blank rows between rail entries: 1 (default) or 0 for no padding.
+    row_gap: Option<u16>,
+    /// Accent glyph on active rail rows; `"none"` removes it.
+    rail_glyph: Option<String>,
+    /// Workspace row label template with `{index}` and `{name}`.
+    workspace_label: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -524,10 +539,45 @@ struct RawSidebarProfile {
 struct RawSidebarView {
     id: String,
     levels: Vec<String>,
-    actions: Option<Vec<String>>,
+    actions: Option<Vec<RawSidebarAction>>,
+    actions_position: Option<ActionsPosition>,
     width: Option<u16>,
     max_width: Option<u16>,
     collapse_priority: Option<u16>,
+}
+
+/// One pinned action: an action name, or an object that also renames its
+/// button. `"command:<id>"` references a user command from `commands`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawSidebarAction {
+    Name(String),
+    Detailed { action: String, label: Option<String> },
+}
+
+impl RawSidebarAction {
+    fn action(&self) -> &str {
+        match self {
+            RawSidebarAction::Name(name) => name,
+            RawSidebarAction::Detailed { action, .. } => action,
+        }
+    }
+
+    fn label(&self) -> Option<&str> {
+        match self {
+            RawSidebarAction::Name(_) => None,
+            RawSidebarAction::Detailed { label, .. } => label.as_deref(),
+        }
+    }
+}
+
+/// Where a view's pinned action buttons render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActionsPosition {
+    Top,
+    #[default]
+    Bottom,
 }
 
 #[derive(Debug, Deserialize)]
@@ -756,6 +806,30 @@ pub enum BorderStyle {
     None,
 }
 
+/// Chip cap style for tab labels and the active screen chip: `pill` wraps
+/// solid chips in rounded caps, `slant` in angled caps, `block` (default)
+/// keeps the flat rectangle. Cap glyphs come from the Nerd Font powerline
+/// range, the same glyphs tmux and zellij themes use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChipStyle {
+    #[default]
+    Block,
+    Pill,
+    Slant,
+}
+
+impl ChipStyle {
+    /// Left and right cap glyphs, or `None` for the flat block style.
+    pub fn caps(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            ChipStyle::Block => None,
+            ChipStyle::Pill => Some(("\u{e0b6}", "\u{e0b4}")),
+            ChipStyle::Slant => Some(("\u{e0be}", "\u{e0b8}")),
+        }
+    }
+}
+
 /// The six glyphs a pane box is drawn with.
 #[derive(Debug, Clone, Copy)]
 pub struct BorderGlyphs {
@@ -835,6 +909,9 @@ pub struct Theme {
     /// Status bar background/foreground; `None` follows the chrome theme.
     pub status_bg: Option<Color>,
     pub status_fg: Option<Color>,
+    /// Sidebar row foregrounds; `None` follows terminal/chrome defaults.
+    pub sidebar_fg: Option<Color>,
+    pub sidebar_selected_fg: Option<Color>,
     /// Render unfocused terminal panes with the DIM attribute.
     pub dim_inactive: bool,
 }
@@ -858,6 +935,8 @@ impl Default for Theme {
             border_style: BorderStyle::Single,
             status_bg: None,
             status_fg: None,
+            sidebar_fg: None,
+            sidebar_selected_fg: None,
             dim_inactive: false,
         }
     }
@@ -876,6 +955,8 @@ pub struct Tabs {
     /// Program names worth surfacing in the tab label even when
     /// `show_titles` is off (matched as words in the reported title).
     pub agents: Vec<String>,
+    /// Cap style for solid tab chips.
+    pub style: ChipStyle,
 }
 
 impl Default for Tabs {
@@ -885,6 +966,7 @@ impl Default for Tabs {
             solid_background: true,
             show_titles: false,
             agents: ["claude", "codex", "opencode", "pi"].map(String::from).to_vec(),
+            style: ChipStyle::Block,
         }
     }
 }
@@ -910,6 +992,14 @@ pub struct Sidebar {
     pub profiles: Vec<SidebarProfileSpec>,
     pub active_profile: String,
     pub plugin: Option<SidebarPluginOptions>,
+    /// Rows per rail entry: 2 keeps the subtitle line, 1 is name-only.
+    pub row_height: u16,
+    /// Blank rows between rail entries.
+    pub row_gap: u16,
+    /// Accent glyph on active rail rows; empty removes it.
+    pub rail_glyph: String,
+    /// Workspace row label template with `{index}` and `{name}`.
+    pub workspace_label: String,
 }
 
 impl Default for Sidebar {
@@ -937,6 +1027,10 @@ impl Default for Sidebar {
             }],
             active_profile: "default".to_string(),
             plugin: None,
+            row_height: 2,
+            row_gap: 1,
+            rail_glyph: "\u{258e}".to_string(),
+            workspace_label: "{name}".to_string(),
         }
     }
 }
@@ -975,12 +1069,28 @@ pub enum SidebarResourceKind {
 pub struct SidebarViewSpec {
     pub id: String,
     pub levels: Vec<SidebarResourceKind>,
-    /// Canonical native commands pinned below this view's resource rows.
-    pub actions: Vec<Action>,
+    /// Canonical native commands pinned to this view, with optional
+    /// user-facing button labels.
+    pub actions: Vec<SidebarActionSpec>,
+    /// Whether the pinned actions render above or below the resource rows.
+    pub actions_position: ActionsPosition,
     pub width: u16,
     pub max_width: u16,
     /// Lower values collapse first when pane space becomes constrained.
     pub collapse_priority: u16,
+}
+
+/// One pinned sidebar action and its optional label override.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidebarActionSpec {
+    pub action: Action,
+    pub label: Option<String>,
+}
+
+impl SidebarActionSpec {
+    pub fn plain(action: Action) -> Self {
+        Self { action, label: None }
+    }
 }
 
 impl SidebarViewSpec {
@@ -992,7 +1102,15 @@ impl SidebarViewSpec {
         };
         let levels = vec![level];
         let actions = default_sidebar_actions(&levels);
-        Self { id: id.to_string(), levels, actions, width, max_width, collapse_priority }
+        Self {
+            id: id.to_string(),
+            levels,
+            actions,
+            actions_position: ActionsPosition::Bottom,
+            width,
+            max_width,
+            collapse_priority,
+        }
     }
 
     pub fn legacy_kind(&self) -> Option<SidebarColumnKind> {
@@ -1177,15 +1295,26 @@ fn default_sidebar_collapse_priority(levels: &[SidebarResourceKind]) -> u16 {
     }
 }
 
-fn default_sidebar_actions(levels: &[SidebarResourceKind]) -> Vec<Action> {
+fn default_sidebar_actions(levels: &[SidebarResourceKind]) -> Vec<SidebarActionSpec> {
     if levels.first() == Some(&SidebarResourceKind::Workspaces) {
-        vec![Action::NewWorkspace]
+        vec![SidebarActionSpec::plain(Action::NewWorkspace)]
     } else {
         Vec::new()
     }
 }
 
-fn parse_sidebar_action(value: &str) -> Result<Action, String> {
+/// Parse one pinned action name: an action catalog key, or `command:<id>`
+/// referencing a user command from the top-level `commands` section.
+fn parse_sidebar_action(value: &str, command_ids: &[String]) -> Result<Action, String> {
+    if let Some(command_id) = value.strip_prefix("command:") {
+        return command_ids
+            .iter()
+            .position(|id| id == command_id)
+            .and_then(Action::user_command)
+            .ok_or_else(|| {
+                format!("cmux-tui: ignoring sidebar action for unknown command {command_id:?}")
+            });
+    }
     action_definitions()
         .iter()
         .find(|definition| definition.config_key == value)
@@ -1200,6 +1329,7 @@ fn resolve_sidebar_view_specs(
     workspace_width: u16,
     workspace_max_width: u16,
     owner: &str,
+    command_ids: &[String],
 ) -> Vec<SidebarViewSpec> {
     let mut ids = HashSet::new();
     let mut legacy_kinds = HashSet::new();
@@ -1233,6 +1363,7 @@ fn resolve_sidebar_view_specs(
             id: id.to_string(),
             levels: levels.clone(),
             actions: Vec::new(),
+            actions_position: ActionsPosition::Bottom,
             width: 0,
             max_width: 0,
             collapse_priority: 0,
@@ -1261,18 +1392,27 @@ fn resolve_sidebar_view_specs(
             let mut seen = HashSet::new();
             raw_actions
                 .iter()
-                .filter_map(|raw_action| match parse_sidebar_action(raw_action.trim()) {
-                    Ok(action) if seen.insert(action) => Some(action),
-                    Ok(_) => {
-                        eprintln!(
-                            "cmux-tui: ignoring duplicate sidebar action {:?} in {owner} view {id:?}",
-                            raw_action.trim()
-                        );
-                        None
-                    }
-                    Err(warning) => {
-                        eprintln!("{warning} in {owner} view {id:?}");
-                        None
+                .filter_map(|raw_action| {
+                    match parse_sidebar_action(raw_action.action().trim(), command_ids) {
+                        Ok(action) if seen.insert(action) => Some(SidebarActionSpec {
+                            action,
+                            label: raw_action
+                                .label()
+                                .map(str::trim)
+                                .filter(|label| !label.is_empty())
+                                .map(str::to_string),
+                        }),
+                        Ok(_) => {
+                            eprintln!(
+                                "cmux-tui: ignoring duplicate sidebar action {:?} in {owner} view {id:?}",
+                                raw_action.action().trim()
+                            );
+                            None
+                        }
+                        Err(warning) => {
+                            eprintln!("{warning} in {owner} view {id:?}");
+                            None
+                        }
                     }
                 })
                 .collect()
@@ -1286,6 +1426,7 @@ fn resolve_sidebar_view_specs(
                 .unwrap_or_else(|| default_sidebar_collapse_priority(&levels)),
             levels,
             actions,
+            actions_position: view.actions_position.unwrap_or_default(),
             width: view.width.unwrap_or(default_width).clamp(10, 60),
             max_width: view.max_width.unwrap_or(default_max_width),
         });
@@ -2785,6 +2926,14 @@ pub struct StatusBarOptions {
     pub left: Vec<StatusSegment>,
     /// Segments right-aligned before the session label.
     pub right: Vec<StatusSegment>,
+    /// Powerline-style separator drawn between left segments and after the
+    /// last one; its foreground takes the previous segment's background and
+    /// its background the next segment's, tmux `status-left` style.
+    pub left_separator: Option<String>,
+    /// Mirror of `left_separator` for the right-aligned segments.
+    pub right_separator: Option<String>,
+    /// Cap style for the active screen chip in the screens strip.
+    pub screens_style: ChipStyle,
 }
 
 impl Default for StatusBarOptions {
@@ -2795,6 +2944,9 @@ impl Default for StatusBarOptions {
             show_session: true,
             left: Vec::new(),
             right: Vec::new(),
+            left_separator: None,
+            right_separator: None,
+            screens_style: ChipStyle::Block,
         }
     }
 }
@@ -3005,6 +3157,9 @@ pub fn load() -> Config {
     if let Some(agents) = raw.tabs.agents {
         config.tabs.agents = agents.into_iter().map(|a| a.to_lowercase()).collect();
     }
+    if let Some(style) = raw.tabs.style {
+        config.tabs.style = style;
+    }
     if let Some(w) = raw.sidebar.width {
         config.sidebar.width = w.clamp(10, 60);
     }
@@ -3020,6 +3175,22 @@ pub fn load() -> Config {
     }
     if let Some(w) = raw.sidebar.max_width {
         config.sidebar.max_width = w;
+    }
+    if let Some(height) = raw.sidebar.row_height {
+        config.sidebar.row_height = height.clamp(1, 2);
+    }
+    if let Some(gap) = raw.sidebar.row_gap {
+        config.sidebar.row_gap = gap.min(2);
+    }
+    if let Some(glyph) = raw.sidebar.rail_glyph {
+        config.sidebar.rail_glyph =
+            if glyph.eq_ignore_ascii_case("none") { String::new() } else { glyph };
+    }
+    if let Some(template) = raw.sidebar.workspace_label {
+        let template = template.trim().to_string();
+        if !template.is_empty() {
+            config.sidebar.workspace_label = template;
+        }
     }
     if let Some(plugin) = raw.sidebar.plugin {
         let command = plugin
@@ -3121,6 +3292,10 @@ pub fn load() -> Config {
         .map(|column| SidebarViewSpec::legacy(column.kind, column.width, column.max_width))
         .collect();
     config.sidebar.views_explicit = config.sidebar.columns_explicit;
+    // User commands resolve before sidebar views so pinned buttons can
+    // reference them as `command:<id>`; their chords bind after `keys`.
+    let (user_commands, user_command_keys) = resolve_user_command_specs(raw.commands);
+    let command_ids: Vec<String> = user_commands.iter().map(|command| command.id.clone()).collect();
     if let Some(views) = raw.sidebar.views.as_ref() {
         if raw.sidebar.columns.is_some() {
             eprintln!("cmux-tui: sidebar.views overrides sidebar.columns");
@@ -3132,6 +3307,7 @@ pub fn load() -> Config {
             config.sidebar.width,
             config.sidebar.max_width,
             "sidebar",
+            &command_ids,
         );
         if resolved.is_empty() {
             eprintln!("cmux-tui: sidebar.views had no usable entries; keeping defaults");
@@ -3172,6 +3348,7 @@ pub fn load() -> Config {
                 config.sidebar.width,
                 config.sidebar.max_width,
                 &owner,
+                &command_ids,
             );
             if views.is_empty() {
                 eprintln!("cmux-tui: ignoring sidebar profile {id:?} with no usable views");
@@ -3334,6 +3511,12 @@ pub fn load() -> Config {
     if let Some(c) = raw.theme.status_fg.as_ref().and_then(ColorValue::to_color) {
         config.theme.status_fg = Some(c);
     }
+    if let Some(c) = raw.theme.sidebar_fg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.sidebar_fg = Some(c);
+    }
+    if let Some(c) = raw.theme.sidebar_selected_fg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.sidebar_selected_fg = Some(c);
+    }
     if let Some(dim) = raw.theme.dim_inactive {
         config.theme.dim_inactive = dim;
     }
@@ -3355,22 +3538,32 @@ pub fn load() -> Config {
     if let Some(right) = raw.status_bar.right {
         config.status_bar.right = resolve_status_segments(right, "right");
     }
+    config.status_bar.left_separator =
+        raw.status_bar.left_separator.filter(|separator| !separator.is_empty());
+    config.status_bar.right_separator =
+        raw.status_bar.right_separator.filter(|separator| !separator.is_empty());
+    if let Some(style) = raw.status_bar.screens_style {
+        config.status_bar.screens_style = style;
+    }
     if let Some(animation) = raw.viewport.animation {
         config.viewport.animation = animation;
     }
     config.server.ws = raw.server.ws.filter(|value| !value.trim().is_empty());
     config.server.ws_token = raw.server.ws_token.filter(|value| !value.trim().is_empty());
     config.keys.apply(&raw.keys);
-    config.commands = resolve_user_commands(raw.commands, &mut config.keys);
+    bind_user_command_chords(&mut config.keys, &user_commands, &user_command_keys);
+    config.commands = user_commands;
     config
 }
 
-/// Validate the raw `commands` section and bind each command's chords.
-/// Command chords are bound after `keys` overrides, so an explicit command
-/// chord replaces whatever action previously held that chord, matching the
-/// last-write-wins behavior of the `keys` section itself.
-fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserCommandConfig> {
+/// Validate the raw `commands` section into resolved specs plus each
+/// command's raw chord values. Chords bind later, after the `keys` section
+/// applied its overrides, so command chords keep last-write-wins order.
+fn resolve_user_command_specs(
+    raw: Vec<RawUserCommand>,
+) -> (Vec<UserCommandConfig>, Vec<Option<Value>>) {
     let mut commands = Vec::new();
+    let mut key_values = Vec::new();
     let mut ids = HashSet::new();
     for command in raw {
         let id = command.id.as_deref().unwrap_or("").trim().to_string();
@@ -3389,40 +3582,15 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
             eprintln!("cmux-tui: ignoring command {id:?} without a run program");
             continue;
         }
-        let Some(action) = Action::user_command(commands.len()) else {
+        if Action::user_command(commands.len()).is_none() {
             eprintln!(
                 "cmux-tui: ignoring command {id:?} beyond the {MAX_USER_COMMANDS}-command limit"
             );
             continue;
-        };
+        }
         // The id is reserved only after validation, so an ignored invalid
         // entry never blocks a later valid entry with the same id.
         ids.insert(id.clone());
-        if let Some(value) = command.keys.as_ref() {
-            let mut bound = 0usize;
-            for raw_chord in key_values(value) {
-                if raw_chord.eq_ignore_ascii_case("none") {
-                    continue;
-                }
-                if bound >= MAX_USER_COMMAND_CHORDS {
-                    eprintln!(
-                        "cmux-tui: ignoring command {id:?} chords beyond the {MAX_USER_COMMAND_CHORDS}-chord limit"
-                    );
-                    break;
-                }
-                let Some(chord) = parse_chord(raw_chord) else {
-                    eprintln!(
-                        "cmux-tui: ignoring unparseable command binding {id} = {raw_chord:?}"
-                    );
-                    continue;
-                };
-                // Only a successful bind consumes the limit; rejected
-                // chords leave room for the valid ones after them.
-                if keys.bind_user_command_chord(&id, action, chord) {
-                    bound += 1;
-                }
-            }
-        }
         let name = command
             .name
             .map(|name| name.trim().to_string())
@@ -3430,8 +3598,43 @@ fn resolve_user_commands(raw: Vec<RawUserCommand>, keys: &mut Keys) -> Vec<UserC
             .unwrap_or_else(|| id.clone());
         let cwd = command.cwd.map(|cwd| cwd.trim().to_string()).filter(|cwd| !cwd.is_empty());
         commands.push(UserCommandConfig { id, name, run, cwd });
+        key_values.push(command.keys);
     }
-    commands
+    (commands, key_values)
+}
+
+/// Bind every command's chords after `keys` overrides applied.
+fn bind_user_command_chords(
+    keys: &mut Keys,
+    commands: &[UserCommandConfig],
+    chord_values: &[Option<Value>],
+) {
+    for (index, (command, value)) in commands.iter().zip(chord_values).enumerate() {
+        let Some(action) = Action::user_command(index) else { break };
+        let Some(value) = value.as_ref() else { continue };
+        let id = &command.id;
+        let mut bound = 0usize;
+        for raw_chord in key_values(value) {
+            if raw_chord.eq_ignore_ascii_case("none") {
+                continue;
+            }
+            if bound >= MAX_USER_COMMAND_CHORDS {
+                eprintln!(
+                    "cmux-tui: ignoring command {id:?} chords beyond the {MAX_USER_COMMAND_CHORDS}-chord limit"
+                );
+                break;
+            }
+            let Some(chord) = parse_chord(raw_chord) else {
+                eprintln!("cmux-tui: ignoring unparseable command binding {id} = {raw_chord:?}");
+                continue;
+            };
+            // Only a successful bind consumes the limit; rejected chords
+            // leave room for the valid ones after them.
+            if keys.bind_user_command_chord(id, action, chord) {
+                bound += 1;
+            }
+        }
+    }
 }
 
 fn normalize_ssh_machine_port(id: &str, port: Option<u16>) -> Option<u16> {
@@ -7107,7 +7310,13 @@ mod tests {
             vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents]
         );
         assert_eq!(config.sidebar.views[1].collapse_priority, 20);
-        assert_eq!(config.sidebar.views[1].actions, vec![Action::NewWorkspace, Action::NewTab]);
+        assert_eq!(
+            config.sidebar.views[1].actions,
+            vec![
+                SidebarActionSpec::plain(Action::NewWorkspace),
+                SidebarActionSpec::plain(Action::NewTab)
+            ]
+        );
         assert_eq!(
             config.sidebar.views[2].levels,
             vec![
@@ -7181,7 +7390,7 @@ mod tests {
     fn sidebar_resources_are_hidden_when_their_view_is_omitted() {
         let sidebar = Sidebar::default();
         assert!(sidebar.views.iter().all(|view| !view.includes(SidebarResourceKind::Agents)));
-        assert_eq!(sidebar.views[1].actions, vec![Action::NewWorkspace]);
+        assert_eq!(sidebar.views[1].actions, vec![SidebarActionSpec::plain(Action::NewWorkspace)]);
     }
 
     #[test]
@@ -7712,6 +7921,76 @@ mod tests {
     }
 
     #[test]
+    fn chip_styles_and_separators_parse() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "tabs": {"style": "pill"},
+            "status_bar": {
+                "left_separator": "\u{e0b0}",
+                "right_separator": "\u{e0b2}",
+                "screens_style": "slant"
+            }
+        }))
+        .unwrap();
+        assert_eq!(raw.tabs.style, Some(ChipStyle::Pill));
+        assert_eq!(raw.status_bar.screens_style, Some(ChipStyle::Slant));
+        assert_eq!(raw.status_bar.left_separator.as_deref(), Some("\u{e0b0}"));
+        assert!(ChipStyle::Block.caps().is_none());
+        let (left, right) = ChipStyle::Pill.caps().unwrap();
+        assert!(!left.is_empty() && !right.is_empty());
+    }
+
+    #[test]
+    fn sidebar_buttons_accept_labels_positions_and_command_references() {
+        let views = vec![RawSidebarView {
+            id: "ws".to_string(),
+            levels: vec!["workspaces".to_string()],
+            actions: Some(vec![
+                RawSidebarAction::Detailed {
+                    action: "new-workspace".to_string(),
+                    label: Some("new".to_string()),
+                },
+                RawSidebarAction::Name("command:lazygit".to_string()),
+                RawSidebarAction::Name("command:unknown".to_string()),
+                RawSidebarAction::Name("new-tab".to_string()),
+            ]),
+            actions_position: Some(ActionsPosition::Top),
+            width: None,
+            max_width: None,
+            collapse_priority: None,
+        }];
+        let command_ids = vec!["lazygit".to_string()];
+        let resolved = resolve_sidebar_view_specs(&views, 22, 0, 22, 0, "sidebar", &command_ids);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].actions_position, ActionsPosition::Top);
+        assert_eq!(
+            resolved[0].actions,
+            vec![
+                SidebarActionSpec { action: Action::NewWorkspace, label: Some("new".to_string()) },
+                SidebarActionSpec::plain(Action::user_command(0).unwrap()),
+                SidebarActionSpec::plain(Action::NewTab),
+            ],
+            "unknown command references drop, known ones bind by id"
+        );
+    }
+
+    #[test]
+    fn sidebar_row_metrics_glyph_and_label_template_parse() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "sidebar": {
+                "row_height": 1,
+                "row_gap": 0,
+                "rail_glyph": "none",
+                "workspace_label": "{index} · {name}"
+            }
+        }))
+        .unwrap();
+        assert_eq!(raw.sidebar.row_height, Some(1));
+        assert_eq!(raw.sidebar.row_gap, Some(0));
+        assert_eq!(raw.sidebar.rail_glyph.as_deref(), Some("none"));
+        assert_eq!(raw.sidebar.workspace_label.as_deref(), Some("{index} · {name}"));
+    }
+
+    #[test]
     fn raw_config_accepts_commands_section() {
         let raw: RawConfig = serde_json::from_value(json!({
             "commands": [
@@ -7764,7 +8043,8 @@ mod tests {
                 cwd: None,
             },
         ];
-        let commands = resolve_user_commands(raw, &mut keys);
+        let (commands, key_values) = resolve_user_command_specs(raw);
+        bind_user_command_chords(&mut keys, &commands, &key_values);
         assert_eq!(commands.len(), 2);
         assert_eq!(commands[0].id, "lazygit");
         // An ignored invalid entry does not reserve its id: a later valid
@@ -7786,7 +8066,8 @@ mod tests {
                 cwd: Some("   ".to_string()),
             },
         ];
-        let retried = resolve_user_commands(retry, &mut keys_retry);
+        let (retried, retried_keys) = resolve_user_command_specs(retry);
+        bind_user_command_chords(&mut keys_retry, &retried, &retried_keys);
         assert_eq!(retried.len(), 1);
         assert_eq!(retried[0].id, "retry");
         assert_eq!(retried[0].cwd, None, "blank cwd is treated as absent");
@@ -7834,7 +8115,8 @@ mod tests {
                 cwd: None,
             })
             .collect();
-        let commands = resolve_user_commands(raw, &mut keys);
+        let (commands, key_values) = resolve_user_command_specs(raw);
+        bind_user_command_chords(&mut keys, &commands, &key_values);
         assert_eq!(commands.len(), MAX_USER_COMMANDS);
         assert!(Action::user_command(MAX_USER_COMMANDS).is_none());
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -338,6 +338,7 @@ mod tests {
             id: "test".into(),
             levels,
             actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
             width: 22,
             max_width: 0,
             collapse_priority: 20,

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -386,21 +386,52 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
         (start, width)
     };
 
-    for segment in left_segments {
+    let segment_bg = |segment: &crate::app::StatusSegmentView| segment.bg.unwrap_or(status_bg);
+    let left_separator = app.config.status_bar.left_separator.clone();
+    let visible_left: Vec<_> =
+        left_segments.iter().filter(|segment| !segment.text.is_empty()).collect();
+    for (index, segment) in visible_left.iter().enumerate() {
         put(frame, &mut x, &segment.text, segment_style(segment));
+        if let Some(separator) = left_separator.as_deref() {
+            // Powerline transition: the separator's foreground takes this
+            // segment's background and its background the next segment's
+            // (or the bar's own, after the last segment).
+            let next_bg = visible_left.get(index + 1).map(|s| segment_bg(s)).unwrap_or(status_bg);
+            put(frame, &mut x, separator, Style::default().fg(segment_bg(segment)).bg(next_bg));
+        }
     }
     if app.config.status_bar.show_screens
         && let Some(ws) = app.tree.active_workspace().cloned()
     {
         put(frame, &mut x, " screens ", base.fg(chrome.status_dim_fg));
+        let screen_caps = app.config.status_bar.screens_style.caps();
         for (i, screen) in ws.screens.iter().enumerate() {
             let active = i == ws.active_screen;
             let label = format!(" {} ", truncate(&screen.display_name(i), 20));
-            let (start, width) =
-                put(frame, &mut x, &label, if active { active_style } else { base });
-            if width > 0 {
+            let chip_start = x;
+            // Caps wrap only the active chip: inactive screens share the
+            // bar background, so caps there would be invisible anyway.
+            if let (Some((cap_left, _)), true) = (screen_caps, active) {
+                put(
+                    frame,
+                    &mut x,
+                    cap_left,
+                    Style::default().fg(chrome.status_active_bg).bg(status_bg),
+                );
+            }
+            put(frame, &mut x, &label, if active { active_style } else { base });
+            if let (Some((_, cap_right)), true) = (screen_caps, active) {
+                put(
+                    frame,
+                    &mut x,
+                    cap_right,
+                    Style::default().fg(chrome.status_active_bg).bg(status_bg),
+                );
+            }
+            let chip_width = x.saturating_sub(chip_start);
+            if chip_width > 0 {
                 hits.push((
-                    Rect { x: start, y: status_y, width, height: 1 },
+                    Rect { x: chip_start, y: status_y, width: chip_width, height: 1 },
                     Hit::ScreenEntry { index: i, id: screen.id },
                 ));
             }
@@ -444,11 +475,13 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     // Right-aligned custom segments sit left of the label; draw them and
     // shrink the viewport track accordingly.
     let mut right_x = area.width.saturating_sub(label_w);
-    for segment in right_segments.iter().rev() {
-        if segment.text.is_empty() {
-            // Normal before a command's first result; later segments still draw.
-            continue;
-        }
+    let right_separator = app.config.status_bar.right_separator.clone();
+    // Empty texts are normal before a command's first result; later
+    // segments still draw.
+    let visible_right: Vec<_> =
+        right_segments.iter().filter(|segment| !segment.text.is_empty()).collect();
+    for index in (0..visible_right.len()).rev() {
+        let segment = visible_right[index];
         let width = (segment.text.width() as u16).min(right_x.saturating_sub(x));
         if width == 0 {
             break;
@@ -461,6 +494,24 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             width as usize,
             segment_style(segment),
         );
+        if let Some(separator) = right_separator.as_deref() {
+            let separator_width = (separator.width() as u16).min(right_x.saturating_sub(x));
+            if separator_width == 0 {
+                break;
+            }
+            // Mirrored powerline transition: the separator sits left of its
+            // segment, foreground from the segment, background from the
+            // next segment to the left (or the bar itself).
+            let left_bg = if index > 0 { segment_bg(visible_right[index - 1]) } else { status_bg };
+            right_x = right_x.saturating_sub(separator_width);
+            frame.buffer_mut().set_stringn(
+                right_x,
+                status_y,
+                separator,
+                separator_width as usize,
+                Style::default().fg(segment_bg(segment)).bg(left_bg),
+            );
+        }
     }
     let track_end = right_x;
     let track_start = x.saturating_add(1);

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -387,16 +387,23 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     };
 
     let segment_bg = |segment: &crate::app::StatusSegmentView| segment.bg.unwrap_or(status_bg);
-    let left_separator = app.config.status_bar.left_separator.clone();
-    let visible_left: Vec<_> =
-        left_segments.iter().filter(|segment| !segment.text.is_empty()).collect();
-    for (index, segment) in visible_left.iter().enumerate() {
+    // Segment lists are bounded (eight per side), so lookahead scans stay
+    // cheap and the draw path allocates nothing.
+    let left_separator = app.config.status_bar.left_separator.as_deref();
+    for (index, segment) in left_segments.iter().enumerate() {
+        if segment.text.is_empty() {
+            continue;
+        }
         put(frame, &mut x, &segment.text, segment_style(segment));
-        if let Some(separator) = left_separator.as_deref() {
+        if let Some(separator) = left_separator {
             // Powerline transition: the separator's foreground takes this
             // segment's background and its background the next segment's
             // (or the bar's own, after the last segment).
-            let next_bg = visible_left.get(index + 1).map(|s| segment_bg(s)).unwrap_or(status_bg);
+            let next_bg = left_segments[index + 1..]
+                .iter()
+                .find(|next| !next.text.is_empty())
+                .map(segment_bg)
+                .unwrap_or(status_bg);
             put(frame, &mut x, separator, Style::default().fg(segment_bg(segment)).bg(next_bg));
         }
     }
@@ -480,13 +487,14 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     // Right-aligned custom segments sit left of the label; draw them and
     // shrink the viewport track accordingly.
     let mut right_x = area.width.saturating_sub(label_w);
-    let right_separator = app.config.status_bar.right_separator.clone();
+    let right_separator = app.config.status_bar.right_separator.as_deref();
     // Empty texts are normal before a command's first result; later
     // segments still draw.
-    let visible_right: Vec<_> =
-        right_segments.iter().filter(|segment| !segment.text.is_empty()).collect();
-    for index in (0..visible_right.len()).rev() {
-        let segment = visible_right[index];
+    for index in (0..right_segments.len()).rev() {
+        let segment = &right_segments[index];
+        if segment.text.is_empty() {
+            continue;
+        }
         let width = (segment.text.width() as u16).min(right_x.saturating_sub(x));
         if width == 0 {
             break;
@@ -499,7 +507,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             width as usize,
             segment_style(segment),
         );
-        if let Some(separator) = right_separator.as_deref() {
+        if let Some(separator) = right_separator {
             let separator_width = (separator.width() as u16).min(right_x.saturating_sub(x));
             if separator_width == 0 {
                 break;
@@ -507,7 +515,12 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             // Mirrored powerline transition: the separator sits left of its
             // segment, foreground from the segment, background from the
             // next segment to the left (or the bar itself).
-            let left_bg = if index > 0 { segment_bg(visible_right[index - 1]) } else { status_bg };
+            let left_bg = right_segments[..index]
+                .iter()
+                .rev()
+                .find(|previous| !previous.text.is_empty())
+                .map(segment_bg)
+                .unwrap_or(status_bg);
             right_x = right_x.saturating_sub(separator_width);
             frame.buffer_mut().set_stringn(
                 right_x,

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -436,7 +436,12 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
                 ));
             }
         }
-        let (start, width) = put(frame, &mut x, " + ", base.fg(chrome.status_dim_fg));
+        let (start, width) = put(
+            frame,
+            &mut x,
+            &app.config.status_bar.screens_plus.label,
+            base.fg(chrome.status_dim_fg),
+        );
         if width > 0 {
             hits.push((Rect { x: start, y: status_y, width, height: 1 }, Hit::NewScreen));
         }

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -315,7 +315,8 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
     let cap_cells: u16 = if chip_caps.is_some() { 2 } else { 0 };
     let widths: Vec<u16> = labels.iter().map(|label| label.width() as u16 + cap_cells).collect();
     let inner_w = full_width.saturating_sub(2); // between the corners
-    let plus_w: u16 = 3; // " + "
+    let plus_label = app.config.tabs.plus.label.clone();
+    let plus_w: u16 = (plus_label.width() as u16).max(1);
     let arrow_w: u16 = 1;
 
     // Clamp the requested scroll, then bump it until the active tab fits.
@@ -405,7 +406,7 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
     }
     if x + plus_w <= max_x {
         let rect = Rect { x, y: 0, width: plus_w, height: 1 };
-        buf.set_stringn(origin_x + x, origin_y, " + ", plus_w as usize, ctrl_style(rect));
+        buf.set_stringn(origin_x + x, origin_y, &plus_label, plus_w as usize, ctrl_style(rect));
         hits.push((rect, Hit::NewTab { pane: pane_id }));
     }
 

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -309,7 +309,11 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
             format!("{}{}{}", " ".repeat(short / 2), label, " ".repeat(short - short / 2))
         })
         .collect();
-    let widths: Vec<u16> = labels.iter().map(|label| label.width() as u16).collect();
+    // Pill and slant chips wrap solid tabs in cap glyphs, one cell on each
+    // side; the caps take part in layout, scrolling, and hit rects.
+    let chip_caps = tab_cfg.solid_background.then(|| tab_cfg.style.caps()).flatten();
+    let cap_cells: u16 = if chip_caps.is_some() { 2 } else { 0 };
+    let widths: Vec<u16> = labels.iter().map(|label| label.width() as u16 + cap_cells).collect();
     let inner_w = full_width.saturating_sub(2); // between the corners
     let plus_w: u16 = 3; // " + "
     let arrow_w: u16 = 1;
@@ -360,9 +364,25 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         if tab_drag.is_some_and(|drag| pane.tabs[i].surface == drag.surface) {
             style = style.add_modifier(Modifier::DIM);
         }
-        buf.set_stringn(origin_x + x, origin_y, label, w as usize, style);
-        if tab_cfg.solid_background && is_active {
-            buf[(origin_x + x, origin_y)].set_symbol("▎").set_style(style.fg(theme.tab_rail));
+        if let Some((cap_left, cap_right)) = chip_caps {
+            // Caps take the chip's background as their foreground and float
+            // over the border row, so every chip reads as a pill or slant.
+            let chip_bg = style.bg.unwrap_or(theme.tab_bg);
+            let cap_style = Style::default().fg(chip_bg);
+            buf.set_stringn(origin_x + x, origin_y, cap_left, 1, cap_style);
+            buf.set_stringn(
+                origin_x + x + 1,
+                origin_y,
+                label,
+                w.saturating_sub(cap_cells) as usize,
+                style,
+            );
+            buf.set_stringn(origin_x + x + w.saturating_sub(1), origin_y, cap_right, 1, cap_style);
+        } else {
+            buf.set_stringn(origin_x + x, origin_y, label, w as usize, style);
+            if tab_cfg.solid_background && is_active {
+                buf[(origin_x + x, origin_y)].set_symbol("▎").set_style(style.fg(theme.tab_rail));
+            }
         }
         if drop_index == Some(i) && x < max_x {
             buf[(origin_x + x, origin_y)]

--- a/cmux-tui/crates/cmux-tui/src/ui/rail.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/rail.rs
@@ -6,9 +6,22 @@ use ratatui::style::{Color, Modifier, Style};
 
 use super::truncate;
 use crate::app::App;
+use crate::config::ActionsPosition;
 
-pub const ENTRY_HEIGHT: usize = 2;
-pub const ENTRY_STRIDE: usize = 3;
+/// Configurable rail row geometry: `height` rows of content per entry and
+/// `stride` rows from one entry's start to the next (height plus gap).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RailMetrics {
+    pub height: usize,
+    pub stride: usize,
+}
+
+impl RailMetrics {
+    pub fn for_app(app: &App) -> Self {
+        let height = app.config.sidebar.row_height.max(1) as usize;
+        Self { height, stride: height + app.config.sidebar.row_gap as usize }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RowSpan {
@@ -52,17 +65,46 @@ pub fn viewport(
     selected_body: Option<RowSpan>,
     selected_footer: Option<RowSpan>,
 ) -> Viewport {
+    viewport_positioned(
+        area,
+        body_rows,
+        footer_rows,
+        body_offset,
+        footer_offset,
+        selected_body,
+        selected_footer,
+        ActionsPosition::Bottom,
+    )
+}
+
+/// `viewport` with a configurable action-row position: `Bottom` pins the
+/// action rows to the rail's bottom edge, `Top` mounts them directly under
+/// the header with the scrollable body below.
+#[allow(clippy::too_many_arguments)]
+pub fn viewport_positioned(
+    area: Rect,
+    body_rows: usize,
+    footer_rows: usize,
+    body_offset: &mut usize,
+    footer_offset: &mut usize,
+    selected_body: Option<RowSpan>,
+    selected_footer: Option<RowSpan>,
+    position: ActionsPosition,
+) -> Viewport {
     let available = area.height.saturating_sub(2);
     let footer_height = footer_rows.min(available as usize) as u16;
     let body_height = available.saturating_sub(footer_height);
-    let body =
-        Rect { x: area.x, y: area.y.saturating_add(2), width: area.width, height: body_height };
-    let footer = Rect {
-        x: area.x,
-        y: area.y.saturating_add(area.height).saturating_sub(footer_height),
-        width: area.width,
-        height: footer_height,
+    let (body_y, footer_y) = match position {
+        ActionsPosition::Bottom => (
+            area.y.saturating_add(2),
+            area.y.saturating_add(area.height).saturating_sub(footer_height),
+        ),
+        ActionsPosition::Top => {
+            (area.y.saturating_add(2).saturating_add(footer_height), area.y.saturating_add(2))
+        }
     };
+    let body = Rect { x: area.x, y: body_y, width: area.width, height: body_height };
+    let footer = Rect { x: area.x, y: footer_y, width: area.width, height: footer_height };
     reveal(body_rows, body_height as usize, body_offset, selected_body);
     reveal(footer_rows, footer_height as usize, footer_offset, selected_footer);
     Viewport { body, footer, body_offset: *body_offset, footer_offset: *footer_offset }
@@ -102,6 +144,9 @@ pub struct RailPalette {
     pub border: Style,
     pub border_symbol: &'static str,
     pub rail: Color,
+    /// Accent glyph on active rows; `None` draws none. A single character
+    /// keeps the palette `Copy`, so drawing never borrows the app config.
+    pub rail_glyph: Option<char>,
 }
 
 impl RailPalette {
@@ -112,14 +157,16 @@ impl RailPalette {
         } else {
             chrome.sidebar_selected_bg
         };
-        let base = Style::default();
+        let selected_fg =
+            app.config.theme.sidebar_selected_fg.unwrap_or(chrome.sidebar_selected_fg);
+        let base = match app.config.theme.sidebar_fg {
+            Some(fg) => Style::default().fg(fg),
+            None => Style::default(),
+        };
         Self {
             base,
             dim: base.fg(chrome.sidebar_dim_fg),
-            active: Style::default()
-                .bg(selected_bg)
-                .fg(chrome.sidebar_selected_fg)
-                .add_modifier(Modifier::BOLD),
+            active: Style::default().bg(selected_bg).fg(selected_fg).add_modifier(Modifier::BOLD),
             header: if focused {
                 Style::default()
                     .bg(chrome.status_active_bg)
@@ -133,6 +180,7 @@ impl RailPalette {
                 .add_modifier(if focused { Modifier::BOLD } else { Modifier::empty() }),
             border_symbol: if focused { "┃" } else { "│" },
             rail: app.config.theme.sidebar_rail,
+            rail_glyph: app.config.sidebar.rail_glyph.chars().next(),
         }
     }
 }
@@ -179,8 +227,16 @@ pub struct Entry<'a> {
     pub dimmed: bool,
 }
 
-pub fn entry(frame: &mut Frame, area: Rect, y: u16, entry: Entry<'_>, palette: RailPalette) {
-    if area.width < 3 || y + 1 >= area.y + area.height {
+pub fn entry(
+    frame: &mut Frame,
+    area: Rect,
+    y: u16,
+    entry: Entry<'_>,
+    palette: RailPalette,
+    metrics: RailMetrics,
+) {
+    let rows = metrics.height.max(1) as u16;
+    if area.width < 3 || y + rows > area.y + area.height {
         return;
     }
     let content_width = area.width.saturating_sub(1);
@@ -193,14 +249,20 @@ pub fn entry(frame: &mut Frame, area: Rect, y: u16, entry: Entry<'_>, palette: R
         if entry.highlighted { palette.active.add_modifier(Modifier::DIM) } else { palette.dim };
     let buf = frame.buffer_mut();
     if entry.highlighted {
-        for x in area.x..area.x + content_width {
-            buf[(x, y)].set_style(palette.active);
-            buf[(x, y + 1)].set_style(palette.active);
+        for row in 0..rows {
+            for x in area.x..area.x + content_width {
+                buf[(x, y + row)].set_style(palette.active);
+            }
         }
-        if entry.active {
+        if entry.active
+            && let Some(glyph) = palette.rail_glyph
+        {
+            let mut encoded = [0u8; 4];
+            let symbol: &str = glyph.encode_utf8(&mut encoded);
             let rail_style = palette.active.fg(palette.rail);
-            buf[(area.x, y)].set_symbol("▎").set_style(rail_style);
-            buf[(area.x, y + 1)].set_symbol("▎").set_style(rail_style);
+            for row in 0..rows {
+                buf[(area.x, y + row)].set_symbol(symbol).set_style(rail_style);
+            }
         }
     }
     let indicator = entry.indicator.filter(|_| content_w > 3);
@@ -219,7 +281,7 @@ pub fn entry(frame: &mut Frame, area: Rect, y: u16, entry: Entry<'_>, palette: R
             style,
         );
     }
-    if content_w > 1 {
+    if rows >= 2 && content_w > 1 {
         buf.set_stringn(
             area.x + 1,
             y + 1,
@@ -306,8 +368,11 @@ pub fn tree_row(
             buf[(x, y)].set_symbol(" ").set_style(style);
         }
     }
-    if active {
-        buf[(area.x, y)].set_symbol("▎").set_style(style.fg(palette.rail));
+    if active && let Some(glyph) = palette.rail_glyph {
+        let mut encoded = [0u8; 4];
+        buf[(area.x, y)]
+            .set_symbol(glyph.encode_utf8(&mut encoded))
+            .set_style(style.fg(palette.rail));
     }
     let disclosure_x = area
         .x
@@ -352,6 +417,7 @@ mod tests {
             border: Style::default(),
             border_symbol: "│",
             rail: Color::Cyan,
+            rail_glyph: Some('▎'),
         };
         terminal
             .draw(|frame| {
@@ -368,6 +434,7 @@ mod tests {
                         dimmed: false,
                     },
                     palette,
+                    RailMetrics { height: 2, stride: 3 },
                 );
             })
             .unwrap();
@@ -406,7 +473,7 @@ mod tests {
     fn resizing_clamps_scroll_without_forgetting_a_visible_selection() {
         let mut body_offset = 12;
         let mut footer_offset = 0;
-        let selected = RowSpan::new(15, ENTRY_HEIGHT);
+        let selected = RowSpan::new(15, 2);
         let small = viewport(
             Rect { x: 0, y: 0, width: 20, height: 8 },
             30,

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -97,6 +97,7 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
     let provider = machine_ui.provider.clone();
     let rail_selection = machine_ui.rail_selection;
     let palette = rail::RailPalette::for_app(app, app.machine_sidebar_focused());
+    let metrics = rail::RailMetrics::for_app(app);
     let messages = &localization::catalog().sidebar;
     rail::prepare(frame, area, palette);
     let header = rail::header(frame, area, messages.machines, palette);
@@ -119,7 +120,7 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
     if machines.is_empty() {
         body_rows += 1;
     } else {
-        body_rows += machines.len() * rail::ENTRY_STRIDE;
+        body_rows += machines.len() * metrics.stride;
     }
     let create_footer = capabilities.create.then_some(0);
     let connect_footer = capabilities.connect.then_some(usize::from(capabilities.create));
@@ -129,8 +130,8 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
             MachineRailSelection::Scope => scope_row.map(|row| rail::RowSpan::new(row, 1)),
             MachineRailSelection::Actions => actions_row.map(|row| rail::RowSpan::new(row, 1)),
             MachineRailSelection::Machine => (!machines.is_empty()).then_some(rail::RowSpan::new(
-                machine_start + selection * rail::ENTRY_STRIDE,
-                rail::ENTRY_HEIGHT,
+                machine_start + selection * metrics.stride,
+                metrics.height,
             )),
             MachineRailSelection::NewVm | MachineRailSelection::ConnectMachine => None,
         }
@@ -209,8 +210,7 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
         );
     }
     for (index, machine) in machines.iter().enumerate() {
-        let span =
-            rail::RowSpan::new(machine_start + index * rail::ENTRY_STRIDE, rail::ENTRY_HEIGHT);
+        let span = rail::RowSpan::new(machine_start + index * metrics.stride, metrics.height);
         let Some(y) = viewport.body_y(span) else { continue };
         let is_active = Some(machine.key) == active;
         let focused = app.machine_sidebar_focused()
@@ -276,9 +276,12 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
                 dimmed: recoverable,
             },
             palette,
+            metrics,
         );
         hits.push((rail::row(area, y), Hit::Machine { index, key: machine.key }));
-        hits.push((rail::row(area, y + 1), Hit::Machine { index, key: machine.key }));
+        if metrics.height >= 2 {
+            hits.push((rail::row(area, y + 1), Hit::Machine { index, key: machine.key }));
+        }
     }
 
     if let Some(y) = create_footer.and_then(|row| viewport.footer_y(rail::RowSpan::new(row, 1))) {
@@ -314,17 +317,16 @@ pub fn draw_tabs(app: &mut App, frame: &mut Frame) {
     let targets = app.sidebar_tab_targets();
     app.tabs_rail_selection = app.tabs_rail_selection.min(targets.len().saturating_sub(1));
     let palette = rail::RailPalette::for_app(app, app.tabs_sidebar_focused());
+    let metrics = rail::RailMetrics::for_app(app);
     let messages = &localization::catalog().sidebar;
     rail::prepare(frame, area, palette);
     let header = rail::header(frame, area, messages.tabs, palette);
 
-    let body_rows = if targets.is_empty() { 1 } else { targets.len() * rail::ENTRY_STRIDE };
-    let selected =
-        (!targets.is_empty() && app.tabs_sidebar_focused() && app.tabs_rail_follow_selection)
-            .then_some(rail::RowSpan::new(
-                app.tabs_rail_selection * rail::ENTRY_STRIDE,
-                rail::ENTRY_HEIGHT,
-            ));
+    let body_rows = if targets.is_empty() { 1 } else { targets.len() * metrics.stride };
+    let selected = (!targets.is_empty()
+        && app.tabs_sidebar_focused()
+        && app.tabs_rail_follow_selection)
+        .then_some(rail::RowSpan::new(app.tabs_rail_selection * metrics.stride, metrics.height));
     let viewport = rail::viewport(
         area,
         body_rows,
@@ -341,7 +343,7 @@ pub fn draw_tabs(app: &mut App, frame: &mut Frame) {
         }
     } else {
         for (target_index, target) in targets.iter().enumerate() {
-            let span = rail::RowSpan::new(target_index * rail::ENTRY_STRIDE, rail::ENTRY_HEIGHT);
+            let span = rail::RowSpan::new(target_index * metrics.stride, metrics.height);
             let Some(y) = viewport.body_y(span) else { continue };
             let selected = app.tabs_sidebar_focused()
                 && app.tabs_rail_selection == target_index
@@ -359,6 +361,7 @@ pub fn draw_tabs(app: &mut App, frame: &mut Frame) {
                     dimmed: false,
                 },
                 palette,
+                metrics,
             );
             let hit = Hit::SidebarTab {
                 workspace: target.workspace,
@@ -368,7 +371,9 @@ pub fn draw_tabs(app: &mut App, frame: &mut Frame) {
                 surface: target.surface,
             };
             app.hits.push((rail::row(area, y), hit));
-            app.hits.push((rail::row(area, y + 1), hit));
+            if metrics.height >= 2 {
+                app.hits.push((rail::row(area, y + 1), hit));
+            }
         }
     }
     app.hits.push((header, Hit::RailHeader(RailKind::Tabs)));
@@ -544,6 +549,7 @@ fn draw_plugin(app: &mut App, frame: &mut Frame) {
 fn draw_workspaces(app: &mut App, frame: &mut Frame) {
     let Some(area) = app.workspace_sidebar_area(frame.area().height) else { return };
     let palette = rail::RailPalette::for_app(app, app.workspace_sidebar_focused());
+    let metrics = rail::RailMetrics::for_app(app);
     let workspace_drag = app.workspace_drag();
     let messages = &localization::catalog().sidebar;
     rail::prepare(frame, area, palette);
@@ -556,15 +562,15 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
         .as_ref()
         .map(|ui| ui.recoverable_workspaces().into_iter().cloned().collect::<Vec<_>>())
         .unwrap_or_default();
-    let body_rows = (app.tree.workspaces.len() + recoverable.len()) * rail::ENTRY_STRIDE;
+    let body_rows = (app.tree.workspaces.len() + recoverable.len()) * metrics.stride;
     let selected_body = (app.workspace_sidebar_focused() && app.workspace_rail_follow_selection)
         .then(|| match app.workspace_rail_selection {
             WorkspaceRailSelection::Workspace
                 if app.sidebar_workspace_selection < app.tree.workspaces.len() =>
             {
                 Some(rail::RowSpan::new(
-                    app.sidebar_workspace_selection * rail::ENTRY_STRIDE,
-                    rail::ENTRY_HEIGHT,
+                    app.sidebar_workspace_selection * metrics.stride,
+                    metrics.height,
                 ))
             }
             WorkspaceRailSelection::Recoverable
@@ -572,8 +578,8 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
             {
                 Some(rail::RowSpan::new(
                     (app.tree.workspaces.len() + app.sidebar_recoverable_workspace_selection)
-                        * rail::ENTRY_STRIDE,
-                    rail::ENTRY_HEIGHT,
+                        * metrics.stride,
+                    metrics.height,
                 ))
             }
             _ => None,
@@ -588,7 +594,8 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
     } else {
         None
     };
-    let viewport = rail::viewport(
+    let actions_position = app.workspace_actions_position();
+    let viewport = rail::viewport_positioned(
         area,
         body_rows,
         actions.len(),
@@ -596,6 +603,7 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
         &mut app.workspace_footer_scroll,
         selected_body,
         selected_footer,
+        actions_position,
     );
     let mut hits = Vec::new();
     let scrollbar_track = if viewport.body.height > 0 && body_rows > viewport.body.height as usize {
@@ -619,7 +627,7 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
         ));
     }
     for (i, ws) in app.tree.workspaces.iter().enumerate() {
-        let span = rail::RowSpan::new(i * rail::ENTRY_STRIDE, rail::ENTRY_HEIGHT);
+        let span = rail::RowSpan::new(i * metrics.stride, metrics.height);
         let Some(y) = viewport.body_y(span) else { continue };
         let active = i == app.tree.active_workspace;
         let focused_selection = app.workspace_sidebar_focused()
@@ -635,12 +643,13 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
         } else {
             title.to_string()
         };
+        let label = app.workspace_button_label(i, &ws.name);
         rail::entry(
             frame,
             area,
             y,
             rail::Entry {
-                name: &ws.name,
+                name: &label,
                 subtitle: &subtitle,
                 highlighted,
                 active,
@@ -648,14 +657,17 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
                 dimmed: workspace_drag.is_some_and(|(id, _)| id == ws.id),
             },
             palette,
+            metrics,
         );
         hits.push((rail::row(area, y), Hit::Workspace { index: i, id: ws.id }));
-        hits.push((rail::row(area, y + 1), Hit::Workspace { index: i, id: ws.id }));
+        if metrics.height >= 2 {
+            hits.push((rail::row(area, y + 1), Hit::Workspace { index: i, id: ws.id }));
+        }
     }
 
     for (index, workspace) in recoverable.iter().enumerate() {
         let row = app.tree.workspaces.len() + index;
-        let span = rail::RowSpan::new(row * rail::ENTRY_STRIDE, rail::ENTRY_HEIGHT);
+        let span = rail::RowSpan::new(row * metrics.stride, metrics.height);
         let Some(y) = viewport.body_y(span) else { continue };
         let selected = app.workspace_sidebar_focused()
             && app.workspace_rail_selection == WorkspaceRailSelection::Recoverable
@@ -677,13 +689,16 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
                 dimmed: true,
             },
             palette,
+            metrics,
         );
         hits.push((rail::row(area, y), Hit::RecoverableWorkspace { index }));
-        hits.push((rail::row(area, y + 1), Hit::RecoverableWorkspace { index }));
+        if metrics.height >= 2 {
+            hits.push((rail::row(area, y + 1), Hit::RecoverableWorkspace { index }));
+        }
     }
 
     if let Some((_, Some(index))) = workspace_drag {
-        let marker_row = index.saturating_mul(rail::ENTRY_STRIDE).saturating_sub(1);
+        let marker_row = index.saturating_mul(metrics.stride).saturating_sub(1);
         if let Some(marker_y) = viewport.body_y(rail::RowSpan::new(marker_row, 1)) {
             let buf = frame.buffer_mut();
             for x in area.x..area.x + area.width.saturating_sub(1) {

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -25,6 +25,8 @@ Selection colors are resolved in this order: explicit cmux-tui config, Ghostty c
 | `theme.border_style` | `"single"`, `"rounded"`, `"thick"`, `"double"`, or `"none"` | `"single"` | Pane border glyph set; `"none"` leaves the border cells blank so panes separate by empty space |
 | `theme.status_bg` | color | chrome default | Status bar background |
 | `theme.status_fg` | color | chrome default | Status bar foreground |
+| `theme.sidebar_fg` | color | terminal default | Sidebar row foreground |
+| `theme.sidebar_selected_fg` | color | chrome default | Selected sidebar row foreground |
 | `theme.dim_inactive` | boolean | `false` | Renders unfocused terminal panes with the DIM attribute |
 
 ## Tabs
@@ -35,6 +37,7 @@ Selection colors are resolved in this order: explicit cmux-tui config, Ghostty c
 | `tabs.solid_background` | boolean | `true` | Renders tab chips with solid backgrounds |
 | `tabs.show_titles` | boolean | `false` | Shows full process titles after tab numbers |
 | `tabs.agents` | string array | `["claude","codex","opencode","pi"]` | Agent names surfaced in tab labels when `show_titles` is false |
+| `tabs.style` | `"block"`, `"pill"`, or `"slant"` | `"block"` | Cap glyphs around solid tab chips (Nerd Font powerline glyphs, catppuccin-tmux style) |
 
 Tabs are numbered by default. A recognized agent program can appear after the number. A user-assigned tab name replaces the generated label.
 
@@ -46,7 +49,7 @@ The built-in sidebar defaults to the workspace list. Set `"sidebar": {"view": "f
 
 `sidebar.profiles` names multiple view lists, and `sidebar.profile` selects the startup layout. Right-click anywhere and open **Sidebar → Layouts** to switch profiles without reconnecting machines. The same menu can hide or restore an individual view for the current session. Runtime visibility changes are keyed by profile and view ID, so switching away and back restores that profile's session-local choices.
 
-Actions use the same stable IDs and execution path as keyboard commands, including `new-workspace`, `new-tab`, and `new-pane-smart`. A view rooted at `workspaces` inherits `new-workspace`, including provider-specific isolated and shared choices. Set `"actions": []` to hide every pinned action, or provide an ordered list to replace the preset. Machine creation and connection actions remain capability-driven by the selected provider.
+Actions use the same stable IDs and execution path as keyboard commands, including `new-workspace`, `new-tab`, and `new-pane-smart`. An entry may also be an object `{"action": "new-workspace", "label": "new"}` to rename its button, and `"command:<id>"` pins a user command from the top-level `commands` section as a button. `actions_position: "top"` mounts the buttons directly under the view header instead of the bottom edge. A view rooted at `workspaces` inherits `new-workspace`, including provider-specific isolated and shared choices. Set `"actions": []` to hide every pinned action, or provide an ordered list to replace the preset. Machine creation and connection actions remain capability-driven by the selected provider.
 
 Every view has an independent width and drag handle. Lower `collapse_priority` values hide first when the terminal must preserve 40 pane columns. A hidden view needs four additional columns before it returns, which prevents resize-boundary flicker. `sidebar.columns` remains a compatibility alias for one-level machine, workspace, and tab views; `sidebar.views` wins when both are present.
 
@@ -68,6 +71,11 @@ Every view has an independent width and drag handle. Lower `collapse_priority` v
 | `sidebar.views[].width` | integer | resource default | Initial width, clamped to 10 through 60 |
 | `sidebar.views[].max_width` | integer | `0` | Maximum live drag width; `0` means no configured maximum |
 | `sidebar.views[].collapse_priority` | integer | resource default | Lower priorities hide first on narrow terminals |
+| `sidebar.views[].actions_position` | `"top"` or `"bottom"` | `"bottom"` | Where the view's pinned action buttons render |
+| `sidebar.row_height` | `1` or `2` | `2` | Rows per rail entry; `1` drops the subtitle line |
+| `sidebar.row_gap` | integer | `1` | Blank rows between rail entries, `0` through `2` |
+| `sidebar.rail_glyph` | string | `"▎"` | Accent glyph on active rail rows; `"none"` removes it |
+| `sidebar.workspace_label` | string | `"{name}"` | Workspace row template with `{index}` and `{name}` |
 | `sidebar.columns` | array of column objects | unset | Compatibility form for one-level `machines`, `workspaces`, and `tabs` views |
 | `sidebar.plugin.command` | array of strings | unset | External sidebar plugin argv; when set, the sidebar hosts this program in a PTY instead of the built-in list |
 | `sidebar.plugin.cwd` | string | unset | Working directory for the sidebar plugin process |
@@ -232,6 +240,9 @@ Padding shrinks the PTY size accordingly and never pads a pane below one content
 | `status_bar.left[].run` | string array | one of text/run | Argv run on an interval; the last nonempty stdout line becomes the segment text, escape sequences stripped, capped at 200 characters |
 | `status_bar.left[].interval` | integer seconds | `5` | Refresh interval for `run` segments, clamped to 1 through 3600 |
 | `status_bar.left[].fg` / `bg` | color | bar colors | Segment colors |
+| `status_bar.left_separator` | string | unset | Powerline separator between left segments; its foreground takes the previous segment's background and its background the next one's (e.g. `"\ue0b0"`) |
+| `status_bar.right_separator` | string | unset | Mirrored separator drawn left of each right segment (e.g. `"\ue0b2"`) |
+| `status_bar.screens_style` | `"block"`, `"pill"`, or `"slant"` | `"block"` | Cap glyphs around the active screen chip |
 
 Text segments interpolate `{session}`, `{workspace}`, `{screen}`, `{screens}`, `{title}`, and `{user}`; unknown braces stay literal. `run` segments are the tmux `#()` equivalent: each is executed on its own interval with a five-second runtime bound, so a battery, git, or clock widget is one script. At most 8 segments per side. Transient status messages keep priority over the session label.
 

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -38,6 +38,9 @@ Selection colors are resolved in this order: explicit cmux-tui config, Ghostty c
 | `tabs.show_titles` | boolean | `false` | Shows full process titles after tab numbers |
 | `tabs.agents` | string array | `["claude","codex","opencode","pi"]` | Agent names surfaced in tab labels when `show_titles` is false |
 | `tabs.style` | `"block"`, `"pill"`, or `"slant"` | `"block"` | Cap glyphs around solid tab chips (Nerd Font powerline glyphs, catppuccin-tmux style) |
+| `tabs.plus.label` | string | `" + "` | Text of the tab bar's `+` button |
+| `tabs.plus.action` | action name or `command:<id>` | new tab | Left-click override for the `+` button |
+| `tabs.plus.menu` | action array | `[]` | Right-click menu on the `+` button; entries use the sidebar action grammar including labels and `command:<id>` |
 
 Tabs are numbered by default. A recognized agent program can appear after the number. A user-assigned tab name replaces the generated label.
 
@@ -243,6 +246,7 @@ Padding shrinks the PTY size accordingly and never pads a pane below one content
 | `status_bar.left_separator` | string | unset | Powerline separator between left segments; its foreground takes the previous segment's background and its background the next one's (e.g. `"\ue0b0"`) |
 | `status_bar.right_separator` | string | unset | Mirrored separator drawn left of each right segment (e.g. `"\ue0b2"`) |
 | `status_bar.screens_style` | `"block"`, `"pill"`, or `"slant"` | `"block"` | Cap glyphs around the active screen chip |
+| `status_bar.screens_plus.label` / `.action` / `.menu` | as `tabs.plus` | `" + "` / new screen / `[]` | The screens strip's `+` button |
 
 Text segments interpolate `{session}`, `{workspace}`, `{screen}`, `{screens}`, `{title}`, and `{user}`; unknown braces stay literal. `run` segments are the tmux `#()` equivalent: each is executed on its own interval with a five-second runtime bound, so a battery, git, or clock widget is one script. At most 8 segments per side. Transient status messages keep priority over the session label.
 

--- a/cmux-tui/scripts/check-spec-inventory.py
+++ b/cmux-tui/scripts/check-spec-inventory.py
@@ -744,6 +744,10 @@ def menu_action_variants() -> set[str]:
 
 
 MENU_ONLY_METADATA: dict[str, dict[str, str]] = {
+    "RunConfigured": {
+        "classification": "composite",
+        "route": "frontend configured menu + the referenced action's own route",
+    },
     "RenameClientMachine": {
         "classification": "composite",
         "route": "frontend prompt + client-local machine catalog",

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -418,7 +418,8 @@
     {"variant": "InvokeProviderAction", "classification": "external-protocol", "route": "machine-provider invoke_action"},
     {"variant": "CreateMachineFrom", "classification": "composite", "route": "native source picker + client-local machine catalog"},
     {"variant": "ConnectMachineTarget", "classification": "composite", "route": "SSH config picker + client-local machine connector"},
-    {"variant": "ConnectOtherMachine", "classification": "composite", "route": "frontend prompt + client-local machine connector"}
+    {"variant": "ConnectOtherMachine", "classification": "composite", "route": "frontend prompt + client-local machine connector"},
+    {"variant": "RunConfigured", "classification": "composite", "route": "frontend configured menu + the referenced action's own route"}
   ],
   "feature_families": [
     {"id": "topology-layout-focus", "wire_status": "implemented", "programmability": "partial", "route": "control commands and tree snapshots/events; SDK and conformance parity remain incomplete"},


### PR DESCRIPTION
Closes the visual gap to tmux/zellij status-bar and tab theming, and makes the vertical workspace buttons configurable, building on #10383.

**Status bar**: `status_bar.left_separator` / `right_separator` draw powerline transitions between segments — separator foreground from the previous segment's background, background from the next (the zjstatus/tmux-powerline scheme, mirrored on the right side). `status_bar.screens_style` (`block`/`pill`/`slant`) wraps the active screen chip in Nerd Font cap glyphs.

**Tabs**: `tabs.style` (`block`/`pill`/`slant`) gives solid tab chips catppuccin-style caps; cap cells participate in layout, scrolling, and click hit rects, and replace the `▎` rail accent when active.

**Sidebar (vertical workspace buttons)**:
- Pinned view actions accept `{"action": "new-workspace", "label": "new"}` objects to rename buttons, and `"command:<id>"` entries that pin a user command from `commands` as a button (labels resolve to the command's display name).
- `sidebar.views[].actions_position: "top"` mounts the buttons directly under the view header instead of the bottom edge.
- `sidebar.row_height: 1` drops the subtitle line for dense one-line rows; `sidebar.row_gap: 0` removes the padding row between entries (hit rects follow).
- `sidebar.rail_glyph` replaces or removes (`"none"`) the active-row accent; `sidebar.workspace_label` templates rows with `{index}`/`{name}`; `theme.sidebar_fg`/`sidebar_selected_fg` recolor rows.

Implementation notes: user commands now resolve before sidebar views so buttons can reference them by id, while chord binding still happens after `keys` overrides; `RailPalette` stays `Copy` (the rail glyph is a single `char`), so rendering never borrows the config; `rail::viewport_positioned` generalizes the existing bottom-pinned footer.

Docs: `docs/configuration.md` rows for every key. Tests: chip style and separator parsing, sidebar action objects with labels/positions/command references (including unknown-command rejection), row metrics and template parsing; suite green (1501 tests), fmt and clippy clean, hosted verification passed on Linux and macOS.

Dogfooded in tmux on the hosted binary: powerline bar with paired-color separators and pill screen chip, pill and slant tab caps rendered per chip, dense one-line numbered sidebar with top-mounted `new`/`tab` buttons plus a user-command button, all combined with rounded borders and dim-inactive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789790689&installation_model_id=21920&pr_number=10469&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10469&signature=53cd561d6c772c7706fe0dc3f3620c5a316cd8241a6cdc8288110b3e3424be0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds powerline separators, chip-cap styles, configurable “+” buttons (with right‑click menus), and sidebar button/layout customization. Improves status‑bar draw performance and validates the sidebar rail glyph to a single‑width character.

- Status bar: `status_bar.left_separator`/`right_separator` render powerline transitions; `status_bar.screens_style` adds `block`/`pill`/`slant` caps to the active screen chip; `status_bar.screens_plus` sets the “+” label, optional left‑click action (`action` or `command:<id>`), and optional right‑click menu. Right‑click menus dispatch via a new `MenuAction::RunConfigured` into the existing `run_action_for_pane`.
- Tabs: `tabs.style` adds `block`/`pill`/`slant` caps; cap cells participate in layout/scrolling/hit‑rects and replace the active `▎` rail; `tabs.plus` customizes the tab “+” label/left‑click action and adds an optional right‑click menu.
- Sidebar: `sidebar.views[].actions` now accept `{"action":"...","label":"..."}` to rename buttons and `"command:<id>"` to pin user commands; `sidebar.views[].actions_position` can be `"top"` or `"bottom"`. `sidebar.row_height` (1–2), `sidebar.row_gap` (0–2), `sidebar.workspace_label` supports `{index}`/`{name}`, and new `theme.sidebar_fg`/`theme.sidebar_selected_fg` recolor rows. Migration: `sidebar.rail_glyph` must be exactly one single‑width character or `"none"` (invalid values are ignored).
- Ordering and perf: user commands resolve before sidebar views and plus menus so `command:<id>` can bind; command chords still bind after `keys`. The status bar draws without per‑frame allocations; the default workspace label path borrows without allocation. Caps, separators, and configurable labels/menus affect layout, scrolling, and click targets. Docs updated in `docs/configuration.md`.

<sup>Written for commit 09ab74a5b943322263c735f61b5518f182d48c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable sidebar row height, spacing, active-row glyphs, workspace labels, and action placement.
  * Added labeled sidebar actions, configurable action menus, plus-button actions, and pane-specific actions.
  * Added configurable tab and screen chip styles, plus-button labels, and status-bar separators.
  * Expanded sidebar, tab, screen, and workspace labeling and color customization.
* **Documentation**
  * Documented the new configuration options.
* **Bug Fixes**
  * Improved sidebar hit areas and rendering for variable-height rows and subtitles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Plus buttons**: `tabs.plus` and `status_bar.screens_plus` customize the two `+` buttons — `label` (any text), `action` (left-click override: any action name or `command:<id>`), and `menu` (a right-click context menu using the sidebar action grammar with per-entry labels). Menu entries dispatch through the new `MenuAction::RunConfigured` variant into the shared `run_action_for_pane` path, registered in the menu inventory as `composite`. Dogfooded in tmux: a `+ ▾` tab-bar button and `⊕ screen` strip button rendered, right-click opened the configured three-entry menu, and clicking the user-command entry spawned its tab.
