### PR TITLE
Fix blank Markdown viewers after pane/window resize

### DIFF
--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -77,6 +77,7 @@ struct MarkdownPanelView: View {
                 markdown: panel.content,
                 theme: MarkdownWebTheme.resolve(backgroundColor: themeBackgroundColor),
                 backgroundColor: appearance.contentBackgroundColor,
+                isVisibleInUI: isVisibleInUI && panel.displayMode == .preview,
                 panelId: panel.id,
                 workspaceId: panel.workspaceId,
                 filePath: panel.filePath,

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -9,6 +9,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
     let markdown: String
     let theme: MarkdownWebTheme
     let backgroundColor: NSColor
+    let isVisibleInUI: Bool
     let panelId: UUID
     let workspaceId: UUID
     let filePath: String
@@ -32,6 +33,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                 webView.removeFromSuperview()
             }
             webView.onPointerDown = onRequestPanelFocus
+            webView.setVisibleInUI(isVisibleInUI)
             webView.onLeaveWindow = { [weak coordinator = context.coordinator] in
                 coordinator?.handleViewLeftWindow()
             }
@@ -64,6 +66,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         )
         let webView = MarkdownWebView(frame: .zero, configuration: config)
         webView.onPointerDown = onRequestPanelFocus
+        webView.setVisibleInUI(isVisibleInUI)
         webView.onLeaveWindow = { [weak coordinator = context.coordinator] in
             coordinator?.handleViewLeftWindow()
         }
@@ -98,6 +101,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         // the panel-owned renderer session kept the same coordinator.
         context.coordinator.bind(panelId: panelId, workspaceId: workspaceId, filePath: filePath)
         (nsView as? MarkdownWebView)?.onPointerDown = onRequestPanelFocus
+        (nsView as? MarkdownWebView)?.setVisibleInUI(isVisibleInUI)
         applyBackground(to: nsView)
         applyAppearance(to: nsView, isDark: theme.isDark)
         context.coordinator.setFontSize(fontSize)

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -81,9 +81,16 @@ final class MarkdownWebRenderingCoordinator {
     /// Records an exact geometry change. Fractional-point divider movement is
     /// meaningful to WebKit, so no epsilon is applied here.
     func layoutDidChange(to boundsSize: CGSize) {
-        guard lastObservedBoundsSize != boundsSize else { return }
+        let sizeChanged = lastObservedBoundsSize != boundsSize
         lastObservedBoundsSize = boundsSize
-        schedule(reason: "boundsChanged", forceLifecycleRefresh: false)
+        if sizeChanged {
+            schedule(reason: "boundsChanged", forceLifecycleRefresh: false)
+        } else if needsRenderingReattach, desiredVisibility, attachedToWindow {
+            // SwiftUI can finish an opacity/hidden transition without changing
+            // the view's size. A settled layout callback is the platform signal
+            // that lets a previously hidden repair try again.
+            schedule(reason: "visibilitySettled", forceLifecycleRefresh: true)
+        }
     }
 
     /// Requests a lifecycle-aware repaint after an AppKit live resize ends.
@@ -93,11 +100,13 @@ final class MarkdownWebRenderingCoordinator {
 
     /// Records whether SwiftUI intends this keep-alive viewer to be visible.
     func setVisibleInUI(_ visible: Bool) {
-        guard desiredVisibility != visible else { return }
+        let changed = desiredVisibility != visible
         desiredVisibility = visible
         if visible {
-            schedule(reason: "visibility.visible", forceLifecycleRefresh: true)
-        } else {
+            if changed || needsRenderingReattach || renderingStateIsHidden || pendingWindowReentryNotification {
+                schedule(reason: "visibility.visible", forceLifecycleRefresh: true)
+            }
+        } else if changed {
             needsRenderingReattach = true
             schedule(reason: "visibility.hidden", forceLifecycleRefresh: false)
         }
@@ -335,27 +344,13 @@ final class MarkdownWebView: WKWebView {
                 callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
             }
 
-            // WKWebView's backing layer is hosted below an internal scroll view.
-            // Mark and flush that WebKit-owned subtree as well as the web view;
-            // never ask an ancestor NSHostingView or the whole window to draw.
-            if let scrollView = enclosingScrollView {
-                scrollView.needsLayout = true
-                scrollView.needsDisplay = true
-                scrollView.setNeedsDisplay(scrollView.bounds)
-                scrollView.contentView.needsLayout = true
-                scrollView.contentView.needsDisplay = true
-            }
             needsLayout = true
             needsDisplay = true
             setNeedsDisplay(bounds)
-            if let scrollView = enclosingScrollView {
-                scrollView.layoutSubtreeIfNeeded()
-                scrollView.contentView.layoutSubtreeIfNeeded()
-                scrollView.displayIfNeeded()
-            }
             // This is deliberately below the deferred scheduler boundary. It
-            // flushes only the WebKit-owned subtree after SwiftUI/AppKit has
-            // unwound, so no NSHostingView ancestor is synchronously re-entered.
+            // flushes only the Markdown WebKit view after SwiftUI/AppKit has
+            // unwound, so no enclosing scroll view or NSHostingView is
+            // synchronously re-entered.
             layoutSubtreeIfNeeded()
             displayIfNeeded()
         }

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -28,6 +28,7 @@ final class WeakMarkdownScriptMessageHandler: NSObject, WKScriptMessageHandler {
 /// testable without relying on WebKit's pixel output.
 @MainActor
 final class MarkdownWebRenderingCoordinator {
+    /// The one deferred platform action emitted by the lifecycle state machine.
     enum Action: Equatable {
         case hide(reason: String)
         case refresh(reason: String, forceLifecycleRefresh: Bool)
@@ -47,6 +48,7 @@ final class MarkdownWebRenderingCoordinator {
     private var pendingForceLifecycleRefresh = false
     private var pendingWindowReentryNotification = false
 
+    /// Creates a coordinator with an injectable action sink for transition tests.
     init(
         initialBoundsSize: CGSize,
         scheduler: MainActorDeferredActionScheduler = MainActorDeferredActionScheduler(),
@@ -101,11 +103,7 @@ final class MarkdownWebRenderingCoordinator {
         }
     }
 
-    /// Cancels a pending repair when the host view is being torn down.
-    func cancel() {
-        scheduler.cancel()
-    }
-
+    /// Replaces the pending action so a resize burst produces one settled pass.
     private func schedule(reason: String, forceLifecycleRefresh: Bool) {
         pendingRefreshReason = reason
         pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
@@ -114,6 +112,7 @@ final class MarkdownWebRenderingCoordinator {
         }
     }
 
+    /// Applies the latest state snapshot after the host layout callback returns.
     private func performPendingAction() {
         let forceLifecycleRefresh = pendingForceLifecycleRefresh
         pendingForceLifecycleRefresh = false
@@ -146,6 +145,7 @@ final class MarkdownWebRenderingCoordinator {
         }
     }
 
+    /// Moves WebKit out of its in-window lifecycle exactly once per hide period.
     private func applyHiddenAction(reason: String) {
         guard !renderingStateIsHidden else { return }
         renderingStateIsHidden = true

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -31,6 +31,14 @@ final class MarkdownWebView: WKWebView {
     /// out of the window (e.g. a pane drag re-parented the hosting views).
     var onReenterWindow: (() -> Void)?
 
+#if DEBUG
+    /// Test-only observation point for the WebKit repaint pass. The callback
+    /// is intentionally attached to the actual subtree refresh rather than to
+    /// a scheduler so tests can distinguish an inline host re-entry flush from
+    /// the deferred repair turn.
+    var renderingRefreshProbeForTesting: (() -> Void)?
+#endif
+
     private var needsRenderingReattach = false
     private var editableFocusStateConfirmed = false
     private var editableElementFocused = false
@@ -167,6 +175,9 @@ final class MarkdownWebView: WKWebView {
         needsLayout = true
         needsDisplay = true
         setNeedsDisplay(bounds)
+#if DEBUG
+        renderingRefreshProbeForTesting?()
+#endif
         layoutSubtreeIfNeeded()
         displayIfNeeded()
     }

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -85,7 +85,10 @@ final class MarkdownWebRenderingCoordinator {
         lastObservedBoundsSize = boundsSize
         if sizeChanged {
             schedule(reason: "boundsChanged", forceLifecycleRefresh: false)
-        } else if needsRenderingReattach, desiredVisibility, attachedToWindow {
+        } else if needsRenderingReattach,
+                  desiredVisibility,
+                  attachedToWindow,
+                  isActuallyVisible() {
             // SwiftUI can finish an opacity/hidden transition without changing
             // the view's size. A settled layout callback is the platform signal
             // that lets a previously hidden repair try again.
@@ -103,7 +106,10 @@ final class MarkdownWebRenderingCoordinator {
         let changed = desiredVisibility != visible
         desiredVisibility = visible
         if visible {
-            if changed || needsRenderingReattach || renderingStateIsHidden || pendingWindowReentryNotification {
+            if changed ||
+                needsRenderingReattach ||
+                renderingStateIsHidden ||
+                pendingWindowReentryNotification {
                 schedule(reason: "visibility.visible", forceLifecycleRefresh: true)
             }
         } else if changed {

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -51,12 +51,12 @@ final class MarkdownWebRenderingCoordinator {
     /// Creates a coordinator with an injectable action sink for transition tests.
     init(
         initialBoundsSize: CGSize,
-        scheduler: MainActorDeferredActionScheduler = MainActorDeferredActionScheduler(),
+        scheduler: MainActorDeferredActionScheduler? = nil,
         isActuallyVisible: @escaping @MainActor () -> Bool,
         applyAction: @escaping @MainActor (Action) -> Void,
         onReenterWindow: @escaping @MainActor () -> Void = {}
     ) {
-        self.scheduler = scheduler
+        self.scheduler = scheduler ?? MainActorDeferredActionScheduler()
         self.isActuallyVisible = isActuallyVisible
         self.applyAction = applyAction
         self.onReenterWindow = onReenterWindow

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -18,6 +18,142 @@ final class WeakMarkdownScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 }
 
+/// Owns the Markdown viewer's AppKit/WebKit lifecycle state.
+///
+/// `NSView` callbacks can arrive while SwiftUI is laying out an ancestor. The
+/// coordinator records those callbacks synchronously, then coalesces the one
+/// WebKit action that is safe to perform after the host transaction unwinds.
+/// Keeping the state machine here gives window, geometry, and tab-visibility
+/// transitions one owner and makes the transition contract independently
+/// testable without relying on WebKit's pixel output.
+@MainActor
+final class MarkdownWebRenderingCoordinator {
+    enum Action: Equatable {
+        case hide(reason: String)
+        case refresh(reason: String, forceLifecycleRefresh: Bool)
+    }
+
+    private let scheduler: MainActorDeferredActionScheduler
+    private let isActuallyVisible: @MainActor () -> Bool
+    private let applyAction: @MainActor (Action) -> Void
+    private let onReenterWindow: @MainActor () -> Void
+
+    private var attachedToWindow = false
+    private var desiredVisibility = true
+    private var needsRenderingReattach = false
+    private var renderingStateIsHidden = false
+    private var lastObservedBoundsSize: CGSize
+    private var pendingRefreshReason = "initial"
+    private var pendingForceLifecycleRefresh = false
+    private var pendingWindowReentryNotification = false
+
+    init(
+        initialBoundsSize: CGSize,
+        scheduler: MainActorDeferredActionScheduler = MainActorDeferredActionScheduler(),
+        isActuallyVisible: @escaping @MainActor () -> Bool,
+        applyAction: @escaping @MainActor (Action) -> Void,
+        onReenterWindow: @escaping @MainActor () -> Void = {}
+    ) {
+        self.scheduler = scheduler
+        self.isActuallyVisible = isActuallyVisible
+        self.applyAction = applyAction
+        self.onReenterWindow = onReenterWindow
+        lastObservedBoundsSize = initialBoundsSize
+    }
+
+    /// Records a view-to-window transition without entering WebKit inline.
+    func viewDidMoveToWindow(isAttached: Bool) {
+        attachedToWindow = isAttached
+        if isAttached {
+            // Reparenting can preserve SwiftUI identity while WebKit loses its
+            // in-window layer state. Always repair on the deferred turn.
+            pendingWindowReentryNotification = true
+            schedule(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)
+        } else {
+            needsRenderingReattach = true
+            pendingWindowReentryNotification = false
+            schedule(reason: "viewDidMoveToWindow.hidden", forceLifecycleRefresh: false)
+        }
+    }
+
+    /// Records an exact geometry change. Fractional-point divider movement is
+    /// meaningful to WebKit, so no epsilon is applied here.
+    func layoutDidChange(to boundsSize: CGSize) {
+        guard lastObservedBoundsSize != boundsSize else { return }
+        lastObservedBoundsSize = boundsSize
+        schedule(reason: "boundsChanged", forceLifecycleRefresh: false)
+    }
+
+    /// Requests a lifecycle-aware repaint after an AppKit live resize ends.
+    func viewDidEndLiveResize() {
+        schedule(reason: "viewDidEndLiveResize", forceLifecycleRefresh: true)
+    }
+
+    /// Records whether SwiftUI intends this keep-alive viewer to be visible.
+    func setVisibleInUI(_ visible: Bool) {
+        guard desiredVisibility != visible else { return }
+        desiredVisibility = visible
+        if visible {
+            schedule(reason: "visibility.visible", forceLifecycleRefresh: true)
+        } else {
+            needsRenderingReattach = true
+            schedule(reason: "visibility.hidden", forceLifecycleRefresh: false)
+        }
+    }
+
+    /// Cancels a pending repair when the host view is being torn down.
+    func cancel() {
+        scheduler.cancel()
+    }
+
+    private func schedule(reason: String, forceLifecycleRefresh: Bool) {
+        pendingRefreshReason = reason
+        pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
+        scheduler.schedule { [weak self] in
+            self?.performPendingAction()
+        }
+    }
+
+    private func performPendingAction() {
+        let forceLifecycleRefresh = pendingForceLifecycleRefresh
+        pendingForceLifecycleRefresh = false
+        let reason = pendingRefreshReason
+
+        guard desiredVisibility, attachedToWindow else {
+            applyHiddenAction(reason: reason)
+            return
+        }
+
+        guard isActuallyVisible() else {
+            // AppKit may still be completing the hide/unhide transaction. Keep
+            // the reattach intent; the next settled geometry/visibility callback
+            // will run this same state transition again.
+            needsRenderingReattach = true
+            pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
+            return
+        }
+
+        let shouldReenter = forceLifecycleRefresh || needsRenderingReattach || renderingStateIsHidden
+        if shouldReenter {
+            needsRenderingReattach = false
+            renderingStateIsHidden = false
+        }
+        applyAction(.refresh(reason: reason, forceLifecycleRefresh: shouldReenter))
+
+        if pendingWindowReentryNotification {
+            pendingWindowReentryNotification = false
+            onReenterWindow()
+        }
+    }
+
+    private func applyHiddenAction(reason: String) {
+        guard !renderingStateIsHidden else { return }
+        renderingStateIsHidden = true
+        needsRenderingReattach = true
+        applyAction(.hide(reason: reason))
+    }
+}
+
 @MainActor
 final class MarkdownWebView: WKWebView {
     var onPointerDown: (() -> Void)?
@@ -31,27 +167,8 @@ final class MarkdownWebView: WKWebView {
     /// out of the window (e.g. a pane drag re-parented the hosting views).
     var onReenterWindow: (() -> Void)?
 
-#if DEBUG
-    /// Test-only observation point for the WebKit repaint pass. The callback
-    /// is intentionally attached to the actual subtree refresh rather than to
-    /// a scheduler so tests can distinguish an inline host re-entry flush from
-    /// the deferred repair turn.
-    var renderingRefreshProbeForTesting: (() -> Void)?
-#endif
-
-    /// AppKit/SwiftUI can invoke layout and move-to-window callbacks while an
-    /// ancestor `NSHostingView` is still rendering. Keep WebKit lifecycle and
-    /// subtree flushes behind this scheduler so those callbacks only invalidate
-    /// state and never synchronously re-enter the host hierarchy.
-    private let renderingRefreshScheduler = MainActorDeferredActionScheduler()
-    private var needsRenderingReattach = false
-    private var desiredVisibility = true
-    private var webKitRenderingStateIsHidden = false
-    private var lastObservedBoundsSize: CGSize = .zero
-    private var pendingRefreshReason = "initial"
-    private var pendingForceLifecycleRefresh = false
-    private var pendingWindowReentryNotification = false
-    private var windowResizeObserver: NSObjectProtocol?
+    /// The coordinator is the only owner of deferred WebKit lifecycle work.
+    private var renderingCoordinator: MarkdownWebRenderingCoordinator?
     private var editableFocusStateConfirmed = false
     private var editableElementFocused = false
     private let viewerNavigationKeyRouter = ViewerNavigationKeyRouter(actions: [
@@ -64,20 +181,13 @@ final class MarkdownWebView: WKWebView {
     override init(frame: CGRect, configuration: WKWebViewConfiguration) {
         Self.installEditableFocusTracking(on: configuration.userContentController)
         super.init(frame: frame, configuration: configuration)
-        lastObservedBoundsSize = bounds.size
+        renderingCoordinator = makeRenderingCoordinator(initialBoundsSize: bounds.size)
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         Self.installEditableFocusTracking(on: configuration.userContentController)
-        lastObservedBoundsSize = bounds.size
-    }
-
-    deinit {
-        if let windowResizeObserver {
-            NotificationCenter.default.removeObserver(windowResizeObserver)
-        }
-        renderingRefreshScheduler.cancel()
+        renderingCoordinator = makeRenderingCoordinator(initialBoundsSize: bounds.size)
     }
 
     private static func installEditableFocusTracking(on controller: WKUserContentController) {
@@ -168,41 +278,25 @@ final class MarkdownWebView: WKWebView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        removeWindowResizeObserver()
+        renderingCoordinator?.viewDidMoveToWindow(isAttached: window != nil)
         if window == nil {
-            // Leaving the window (the detach half of a pane re-parent) is only
-            // a state transition here. Calling WebKit's private lifecycle
-            // selectors inline can re-enter the surrounding NSHostingView.
-            needsRenderingReattach = true
-            pendingWindowReentryNotification = false
-            scheduleRenderingRefresh(reason: "viewDidMoveToWindow.hidden", forceLifecycleRefresh: false)
+            // This callback only records renderer health. All WebKit lifecycle
+            // selectors and layout/display work stay on the deferred path.
             onLeaveWindow?()
-        } else {
-            installWindowResizeObserver(for: window)
-            // A view can be reparented without changing its SwiftUI identity.
-            // Re-entering must therefore always get a deferred WebKit refresh;
-            // the coordinator callback is delivered in that same safe turn.
-            pendingWindowReentryNotification = true
-            scheduleRenderingRefresh(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)
         }
     }
 
     override func layout() {
-        let previousSize = lastObservedBoundsSize
-        let currentSize = bounds.size
-        lastObservedBoundsSize = currentSize
         super.layout()
-
-        guard !Self.isApproximatelyEqual(previousSize, currentSize) else { return }
         // A divider/window resize can leave a live WKWebView with valid scroll
         // geometry but stale backing tiles. Invalidate and repair after this
         // layout callback returns; never flush the SwiftUI-owned ancestor here.
-        scheduleRenderingRefresh(reason: "boundsChanged", forceLifecycleRefresh: false)
+        renderingCoordinator?.layoutDidChange(to: bounds.size)
     }
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
-        scheduleRenderingRefresh(reason: "viewDidEndLiveResize", forceLifecycleRefresh: true)
+        renderingCoordinator?.viewDidEndLiveResize()
     }
 
     /// Updates the SwiftUI visibility intent for this viewer. Workspace panes
@@ -210,104 +304,61 @@ final class MarkdownWebView: WKWebView {
     /// WebKit's in-window lifecycle or ProcessThrottler may park its process;
     /// the selected tab gets a deferred enter/paint pass on reveal.
     func setVisibleInUI(_ visible: Bool) {
-        guard desiredVisibility != visible else { return }
-        desiredVisibility = visible
-        if visible {
-            scheduleRenderingRefresh(reason: "visibility.visible", forceLifecycleRefresh: true)
-        } else {
-            needsRenderingReattach = true
-            scheduleRenderingRefresh(reason: "visibility.hidden", forceLifecycleRefresh: false)
-        }
+        renderingCoordinator?.setVisibleInUI(visible)
     }
 
-    private func scheduleRenderingRefresh(
-        reason: String,
-        forceLifecycleRefresh: Bool
-    ) {
-        pendingRefreshReason = reason
-        pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
-        renderingRefreshScheduler.schedule { [weak self] in
-            guard let self else { return }
-            let forceLifecycleRefresh = self.pendingForceLifecycleRefresh
-            let reason = self.pendingRefreshReason
-            self.pendingForceLifecycleRefresh = false
-            self.performRenderingRefresh(
-                reason: reason,
-                forceLifecycleRefresh: forceLifecycleRefresh
-            )
-            if self.pendingWindowReentryNotification {
-                self.pendingWindowReentryNotification = false
-                self.onReenterWindow?()
+    private func makeRenderingCoordinator(initialBoundsSize: CGSize) -> MarkdownWebRenderingCoordinator {
+        MarkdownWebRenderingCoordinator(
+            initialBoundsSize: initialBoundsSize,
+            isActuallyVisible: { [weak self] in
+                guard let self else { return false }
+                return self.window != nil && !self.isHiddenOrHasHiddenAncestor
+            },
+            applyAction: { [weak self] action in
+                self?.applyRenderingAction(action)
+            },
+            onReenterWindow: { [weak self] in
+                self?.onReenterWindow?()
             }
-        }
+        )
     }
 
-    private func performRenderingRefresh(reason: String, forceLifecycleRefresh: Bool) {
-        guard desiredVisibility, window != nil else {
-            applyHiddenRenderingState(reason: reason)
-            return
-        }
-        guard !isHiddenOrHasHiddenAncestor else {
-            // `viewDidUnhide`/the next visibility update will retry once the
-            // SwiftUI opacity/hidden transition has completed.
-            needsRenderingReattach = true
-            return
-        }
-
-        let shouldReenter = forceLifecycleRefresh || needsRenderingReattach || webKitRenderingStateIsHidden
-        if shouldReenter {
-            callVoidSelectorIfAvailable("viewDidUnhide")
-            callVoidSelectorIfAvailable("_enterInWindow")
-            callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
-            needsRenderingReattach = false
-            webKitRenderingStateIsHidden = false
-        }
-
-        needsLayout = true
-        needsDisplay = true
-        setNeedsDisplay(bounds)
-#if DEBUG
-        renderingRefreshProbeForTesting?()
-#endif
-        // This is deliberately below the deferred scheduler boundary. It
-        // flushes only the WebKit-owned subtree after SwiftUI/AppKit has
-        // unwound, so no NSHostingView ancestor is synchronously re-entered.
-        layoutSubtreeIfNeeded()
-        displayIfNeeded()
-    }
-
-    private func applyHiddenRenderingState(reason _: String) {
-        guard !webKitRenderingStateIsHidden else { return }
-        callVoidSelectorIfAvailable("viewDidHide")
-        callVoidSelectorIfAvailable("_exitInWindow")
-        needsRenderingReattach = true
-        webKitRenderingStateIsHidden = true
-    }
-
-    private func installWindowResizeObserver(for window: NSWindow?) {
-        guard let window else { return }
-        windowResizeObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didEndLiveResizeNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.scheduleRenderingRefresh(
-                    reason: "windowDidEndLiveResize",
-                    forceLifecycleRefresh: true
-                )
+    private func applyRenderingAction(_ action: MarkdownWebRenderingCoordinator.Action) {
+        switch action {
+        case .hide:
+            callVoidSelectorIfAvailable("viewDidHide")
+            callVoidSelectorIfAvailable("_exitInWindow")
+        case let .refresh(_, forceLifecycleRefresh):
+            if forceLifecycleRefresh {
+                callVoidSelectorIfAvailable("viewDidUnhide")
+                callVoidSelectorIfAvailable("_enterInWindow")
+                callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
             }
+
+            // WKWebView's backing layer is hosted below an internal scroll view.
+            // Mark and flush that WebKit-owned subtree as well as the web view;
+            // never ask an ancestor NSHostingView or the whole window to draw.
+            if let scrollView = enclosingScrollView {
+                scrollView.needsLayout = true
+                scrollView.needsDisplay = true
+                scrollView.setNeedsDisplay(scrollView.bounds)
+                scrollView.contentView.needsLayout = true
+                scrollView.contentView.needsDisplay = true
+            }
+            needsLayout = true
+            needsDisplay = true
+            setNeedsDisplay(bounds)
+            if let scrollView = enclosingScrollView {
+                scrollView.layoutSubtreeIfNeeded()
+                scrollView.contentView.layoutSubtreeIfNeeded()
+                scrollView.displayIfNeeded()
+            }
+            // This is deliberately below the deferred scheduler boundary. It
+            // flushes only the WebKit-owned subtree after SwiftUI/AppKit has
+            // unwound, so no NSHostingView ancestor is synchronously re-entered.
+            layoutSubtreeIfNeeded()
+            displayIfNeeded()
         }
-    }
-
-    private func removeWindowResizeObserver() {
-        guard let windowResizeObserver else { return }
-        NotificationCenter.default.removeObserver(windowResizeObserver)
-        self.windowResizeObserver = nil
-    }
-
-    private static func isApproximatelyEqual(_ lhs: CGSize, _ rhs: CGSize, epsilon: CGFloat = 0.5) -> Bool {
-        abs(lhs.width - rhs.width) <= epsilon && abs(lhs.height - rhs.height) <= epsilon
     }
 
     /// Calls a private WKWebView lifecycle selector when present. Guarded by

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -39,7 +39,19 @@ final class MarkdownWebView: WKWebView {
     var renderingRefreshProbeForTesting: (() -> Void)?
 #endif
 
+    /// AppKit/SwiftUI can invoke layout and move-to-window callbacks while an
+    /// ancestor `NSHostingView` is still rendering. Keep WebKit lifecycle and
+    /// subtree flushes behind this scheduler so those callbacks only invalidate
+    /// state and never synchronously re-enter the host hierarchy.
+    private let renderingRefreshScheduler = MainActorDeferredActionScheduler()
     private var needsRenderingReattach = false
+    private var desiredVisibility = true
+    private var webKitRenderingStateIsHidden = false
+    private var lastObservedBoundsSize: CGSize = .zero
+    private var pendingRefreshReason = "initial"
+    private var pendingForceLifecycleRefresh = false
+    private var pendingWindowReentryNotification = false
+    private var windowResizeObserver: NSObjectProtocol?
     private var editableFocusStateConfirmed = false
     private var editableElementFocused = false
     private let viewerNavigationKeyRouter = ViewerNavigationKeyRouter(actions: [
@@ -52,11 +64,20 @@ final class MarkdownWebView: WKWebView {
     override init(frame: CGRect, configuration: WKWebViewConfiguration) {
         Self.installEditableFocusTracking(on: configuration.userContentController)
         super.init(frame: frame, configuration: configuration)
+        lastObservedBoundsSize = bounds.size
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         Self.installEditableFocusTracking(on: configuration.userContentController)
+        lastObservedBoundsSize = bounds.size
+    }
+
+    deinit {
+        if let windowResizeObserver {
+            NotificationCenter.default.removeObserver(windowResizeObserver)
+        }
+        renderingRefreshScheduler.cancel()
     }
 
     private static func installEditableFocusTracking(on controller: WKUserContentController) {
@@ -147,39 +168,146 @@ final class MarkdownWebView: WKWebView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        removeWindowResizeObserver()
         if window == nil {
-            // Leaving the window (the detach half of a pane re-parent). Drive
-            // WebKit's in-window lifecycle out so the matching re-entry below
-            // resumes rendering, mirroring the browser panel's recovery path.
+            // Leaving the window (the detach half of a pane re-parent) is only
+            // a state transition here. Calling WebKit's private lifecycle
+            // selectors inline can re-enter the surrounding NSHostingView.
             needsRenderingReattach = true
-            callVoidSelectorIfAvailable("viewDidHide")
-            callVoidSelectorIfAvailable("_exitInWindow")
+            pendingWindowReentryNotification = false
+            scheduleRenderingRefresh(reason: "viewDidMoveToWindow.hidden", forceLifecycleRefresh: false)
             onLeaveWindow?()
         } else {
-            reattachRenderingState()
-            onReenterWindow?()
+            installWindowResizeObserver(for: window)
+            // A view can be reparented without changing its SwiftUI identity.
+            // Re-entering must therefore always get a deferred WebKit refresh;
+            // the coordinator callback is delivered in that same safe turn.
+            pendingWindowReentryNotification = true
+            scheduleRenderingRefresh(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)
         }
     }
 
-    /// Resume WebKit's rendering after the view re-enters a window. WebKit can
-    /// suspend painting (or reclaim the WebContent process) while a WKWebView
-    /// is detached during a pane drag, which previously left the Markdown
-    /// viewer permanently blank. This nudges the in-window lifecycle back on
-    /// and forces a layout/display pass so the live document repaints.
-    private func reattachRenderingState() {
-        guard needsRenderingReattach else { return }
-        needsRenderingReattach = false
-        callVoidSelectorIfAvailable("viewDidUnhide")
-        callVoidSelectorIfAvailable("_enterInWindow")
-        callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
+    override func layout() {
+        let previousSize = lastObservedBoundsSize
+        let currentSize = bounds.size
+        lastObservedBoundsSize = currentSize
+        super.layout()
+
+        guard !Self.isApproximatelyEqual(previousSize, currentSize) else { return }
+        // A divider/window resize can leave a live WKWebView with valid scroll
+        // geometry but stale backing tiles. Invalidate and repair after this
+        // layout callback returns; never flush the SwiftUI-owned ancestor here.
+        scheduleRenderingRefresh(reason: "boundsChanged", forceLifecycleRefresh: false)
+    }
+
+    override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+        scheduleRenderingRefresh(reason: "viewDidEndLiveResize", forceLifecycleRefresh: true)
+    }
+
+    /// Updates the SwiftUI visibility intent for this viewer. Workspace panes
+    /// keep all tabs alive, so an opacity-hidden tab must explicitly leave
+    /// WebKit's in-window lifecycle or ProcessThrottler may park its process;
+    /// the selected tab gets a deferred enter/paint pass on reveal.
+    func setVisibleInUI(_ visible: Bool) {
+        guard desiredVisibility != visible else { return }
+        desiredVisibility = visible
+        if visible {
+            scheduleRenderingRefresh(reason: "visibility.visible", forceLifecycleRefresh: true)
+        } else {
+            needsRenderingReattach = true
+            scheduleRenderingRefresh(reason: "visibility.hidden", forceLifecycleRefresh: false)
+        }
+    }
+
+    private func scheduleRenderingRefresh(
+        reason: String,
+        forceLifecycleRefresh: Bool
+    ) {
+        pendingRefreshReason = reason
+        pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
+        renderingRefreshScheduler.schedule { [weak self] in
+            guard let self else { return }
+            let forceLifecycleRefresh = self.pendingForceLifecycleRefresh
+            let reason = self.pendingRefreshReason
+            self.pendingForceLifecycleRefresh = false
+            self.performRenderingRefresh(
+                reason: reason,
+                forceLifecycleRefresh: forceLifecycleRefresh
+            )
+            if self.pendingWindowReentryNotification {
+                self.pendingWindowReentryNotification = false
+                self.onReenterWindow?()
+            }
+        }
+    }
+
+    private func performRenderingRefresh(reason: String, forceLifecycleRefresh: Bool) {
+        guard desiredVisibility, window != nil else {
+            applyHiddenRenderingState(reason: reason)
+            return
+        }
+        guard !isHiddenOrHasHiddenAncestor else {
+            // `viewDidUnhide`/the next visibility update will retry once the
+            // SwiftUI opacity/hidden transition has completed.
+            needsRenderingReattach = true
+            return
+        }
+
+        let shouldReenter = forceLifecycleRefresh || needsRenderingReattach || webKitRenderingStateIsHidden
+        if shouldReenter {
+            callVoidSelectorIfAvailable("viewDidUnhide")
+            callVoidSelectorIfAvailable("_enterInWindow")
+            callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
+            needsRenderingReattach = false
+            webKitRenderingStateIsHidden = false
+        }
+
         needsLayout = true
         needsDisplay = true
         setNeedsDisplay(bounds)
 #if DEBUG
         renderingRefreshProbeForTesting?()
 #endif
+        // This is deliberately below the deferred scheduler boundary. It
+        // flushes only the WebKit-owned subtree after SwiftUI/AppKit has
+        // unwound, so no NSHostingView ancestor is synchronously re-entered.
         layoutSubtreeIfNeeded()
         displayIfNeeded()
+    }
+
+    private func applyHiddenRenderingState(reason _: String) {
+        guard !webKitRenderingStateIsHidden else { return }
+        callVoidSelectorIfAvailable("viewDidHide")
+        callVoidSelectorIfAvailable("_exitInWindow")
+        needsRenderingReattach = true
+        webKitRenderingStateIsHidden = true
+    }
+
+    private func installWindowResizeObserver(for window: NSWindow?) {
+        guard let window else { return }
+        windowResizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didEndLiveResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.scheduleRenderingRefresh(
+                    reason: "windowDidEndLiveResize",
+                    forceLifecycleRefresh: true
+                )
+            }
+        }
+    }
+
+    private func removeWindowResizeObserver() {
+        guard let windowResizeObserver else { return }
+        NotificationCenter.default.removeObserver(windowResizeObserver)
+        self.windowResizeObserver = nil
+    }
+
+    private static func isApproximatelyEqual(_ lhs: CGSize, _ rhs: CGSize, epsilon: CGFloat = 0.5) -> Bool {
+        abs(lhs.width - rhs.width) <= epsilon && abs(lhs.height - rhs.height) <= epsilon
     }
 
     /// Calls a private WKWebView lifecycle selector when present. Guarded by

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -122,6 +122,10 @@ final class MarkdownWebRenderingCoordinator {
     private func schedule(reason: String, forceLifecycleRefresh: Bool) {
         pendingRefreshReason = reason
         pendingForceLifecycleRefresh = pendingForceLifecycleRefresh || forceLifecycleRefresh
+        // The queued action reads the latest state when it runs. Keep one
+        // scheduler task for a resize/visibility burst instead of repeatedly
+        // cancelling and recreating MainActor tasks while AppKit is laying out.
+        guard !scheduler.isScheduled else { return }
         scheduler.schedule { [weak self] in
             self?.performPendingAction()
         }

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -427,41 +427,28 @@ final class MarkdownPanelTests: XCTestCase {
     }
 
     func testMarkdownWebViewReattachDoesNotRefreshInsideHostCallback() async {
-        let frame = NSRect(x: 0, y: 0, width: 640, height: 360)
-        let window = NSWindow(
-            contentRect: frame,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
+        var isActuallyVisible = true
+        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        var reentryCount = 0
+        let coordinator = MarkdownWebRenderingCoordinator(
+            initialBoundsSize: CGSize(width: 640, height: 360),
+            isActuallyVisible: { isActuallyVisible },
+            applyAction: { action in actions.append(action) },
+            onReenterWindow: { reentryCount += 1 }
         )
-        let webView = MarkdownWebView(
-            frame: frame,
-            configuration: WKWebViewConfiguration()
-        )
-        var refreshCount = 0
-        webView.renderingRefreshProbeForTesting = {
-            refreshCount += 1
-        }
-        window.contentView = webView
-        window.orderFrontRegardless()
+
+        // Establish the attached state, then model Bonsplit's remove/add
+        // transition before the deferred action gets a chance to run.
+        coordinator.viewDidMoveToWindow(isAttached: true)
         await Self.drainMainRunLoopTurn()
-        defer {
-            webView.renderingRefreshProbeForTesting = nil
-            webView.removeFromSuperview()
-            window.close()
-        }
+        actions.removeAll()
+        isActuallyVisible = false
+        coordinator.viewDidMoveToWindow(isAttached: false)
+        isActuallyVisible = true
+        coordinator.viewDidMoveToWindow(isAttached: true)
 
-        // Reparenting the view is the same lifecycle transition that occurs
-        // when Bonsplit moves a tab between columns. The host callback must
-        // not synchronously enter WebKit's layout/display subtree: doing so
-        // re-enters the surrounding NSHostingView layout pass on macOS 15.
-        webView.removeFromSuperview()
-        refreshCount = 0
-        window.contentView = webView
-
-        XCTAssertEqual(
-            refreshCount,
-            0,
+        XCTAssertTrue(
+            actions.isEmpty,
             "A markdown viewer re-entry must not flush WebKit while the host layout callback is active"
         )
 
@@ -469,92 +456,64 @@ final class MarkdownPanelTests: XCTestCase {
         // returned. A run-loop turn is the production scheduling boundary; no
         // wall-clock delay is needed.
         await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(actions.count, 1)
         XCTAssertEqual(
-            refreshCount,
-            1,
-            "A reattached markdown viewer must repaint on the deferred turn"
+            actions.first,
+            .refresh(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)
         )
+        XCTAssertEqual(reentryCount, 2, "The initial attach and reattach each complete once")
     }
 
     func testMarkdownWebViewResizeRefreshCoalescesOutsideLayoutCallback() async {
-        let initialFrame = NSRect(x: 0, y: 0, width: 640, height: 360)
-        let window = NSWindow(
-            contentRect: initialFrame,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
+        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let coordinator = MarkdownWebRenderingCoordinator(
+            initialBoundsSize: CGSize(width: 640, height: 360),
+            isActuallyVisible: { true },
+            applyAction: { action in actions.append(action) }
         )
-        let webView = MarkdownWebView(
-            frame: initialFrame,
-            configuration: WKWebViewConfiguration()
-        )
-        var refreshCount = 0
-        webView.renderingRefreshProbeForTesting = {
-            refreshCount += 1
-        }
-        window.contentView = webView
-        window.orderFrontRegardless()
+        coordinator.viewDidMoveToWindow(isAttached: true)
         await Self.drainMainRunLoopTurn()
-        defer {
-            webView.renderingRefreshProbeForTesting = nil
-            webView.removeFromSuperview()
-            window.close()
-        }
+        actions.removeAll()
+        coordinator.layoutDidChange(to: CGSize(width: 500.25, height: 320.25))
+        coordinator.layoutDidChange(to: CGSize(width: 460, height: 300))
 
-        refreshCount = 0
-        webView.setFrameSize(NSSize(width: 500, height: 320))
-        window.contentView?.layoutSubtreeIfNeeded()
-        webView.setFrameSize(NSSize(width: 460, height: 300))
-        window.contentView?.layoutSubtreeIfNeeded()
-
-        XCTAssertEqual(
-            refreshCount,
-            0,
+        XCTAssertTrue(
+            actions.isEmpty,
             "A markdown resize must not flush WebKit synchronously from AppKit layout"
         )
 
         await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(actions.count, 1)
         XCTAssertEqual(
-            refreshCount,
-            1,
+            actions.first,
+            .refresh(reason: "boundsChanged", forceLifecycleRefresh: false),
             "Repeated geometry callbacks should coalesce into one deferred repaint"
         )
     }
 
     func testMarkdownWebViewVisibilityRevealRepairsAfterHiddenTabLifecycle() async {
-        let frame = NSRect(x: 0, y: 0, width: 640, height: 360)
-        let window = NSWindow(
-            contentRect: frame,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
+        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let coordinator = MarkdownWebRenderingCoordinator(
+            initialBoundsSize: CGSize(width: 640, height: 360),
+            isActuallyVisible: { true },
+            applyAction: { action in actions.append(action) }
         )
-        let webView = MarkdownWebView(
-            frame: frame,
-            configuration: WKWebViewConfiguration()
+        coordinator.viewDidMoveToWindow(isAttached: true)
+        await Self.drainMainRunLoopTurn()
+        actions.removeAll()
+        coordinator.setVisibleInUI(false)
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(actions, [.hide(reason: "visibility.hidden")])
+
+        actions.removeAll()
+        coordinator.setVisibleInUI(true)
+        XCTAssertTrue(actions.isEmpty, "A visibility reveal must cross the deferred boundary")
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(
+            actions,
+            [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)],
+            "A revealed markdown tab must receive a repaint pass"
         )
-        var refreshCount = 0
-        webView.renderingRefreshProbeForTesting = {
-            refreshCount += 1
-        }
-        window.contentView = webView
-        window.orderFrontRegardless()
-        await Self.drainMainRunLoopTurn()
-        defer {
-            webView.renderingRefreshProbeForTesting = nil
-            webView.removeFromSuperview()
-            window.close()
-        }
-
-        refreshCount = 0
-        webView.setVisibleInUI(false)
-        await Self.drainMainRunLoopTurn()
-        XCTAssertEqual(refreshCount, 0, "A hidden markdown tab must not be repainted")
-
-        webView.setVisibleInUI(true)
-        XCTAssertEqual(refreshCount, 0, "A visibility reveal must cross the deferred boundary")
-        await Self.drainMainRunLoopTurn()
-        XCTAssertEqual(refreshCount, 1, "A revealed markdown tab must receive a repaint pass")
     }
 
     func testMarkdownRendererKeepsRecoveryBudgetAfterShellReload() {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -514,9 +514,19 @@ final class MarkdownPanelTests: XCTestCase {
     func testMarkdownWebViewVisibilityRevealRepairsAfterHiddenTabLifecycle() async {
         let recorder = RenderingActionRecorder()
         var events = recorder.stream.makeAsyncIterator()
+        var isActuallyVisible = true
+        let visibilityGateReached = expectation(description: "hidden reveal reaches visibility gate")
+        visibilityGateReached.assertForOverFulfill = false
+        var didObserveHiddenVisibilityGate = false
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
-            isActuallyVisible: { true },
+            isActuallyVisible: {
+                if !isActuallyVisible, !didObserveHiddenVisibilityGate {
+                    didObserveHiddenVisibilityGate = true
+                    visibilityGateReached.fulfill()
+                }
+                return isActuallyVisible
+            },
             applyAction: recorder.record
         )
         coordinator.viewDidMoveToWindow(isAttached: true)
@@ -527,12 +537,23 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(recorder.actions, [.hide(reason: "visibility.hidden")])
 
         recorder.reset()
+        isActuallyVisible = false
         coordinator.setVisibleInUI(true)
         XCTAssertTrue(recorder.actions.isEmpty, "A visibility reveal must cross the deferred boundary")
+        await fulfillment(of: [visibilityGateReached], timeout: 1)
+        XCTAssertTrue(
+            didObserveHiddenVisibilityGate,
+            "A hidden reveal must wait for the actual AppKit visibility boundary"
+        )
+        XCTAssertTrue(recorder.actions.isEmpty, "A hidden reveal must not paint while its ancestor is hidden")
+
+        isActuallyVisible = true
+        coordinator.viewDidMoveToWindow(isAttached: true)
+        XCTAssertTrue(recorder.actions.isEmpty, "The visibility retry remains deferred")
         _ = await events.next()
         XCTAssertEqual(
             recorder.actions,
-            [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)],
+            [.refresh(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)],
             "A revealed markdown tab must receive a repaint pass"
         )
     }
@@ -541,16 +562,25 @@ final class MarkdownPanelTests: XCTestCase {
         var isActuallyVisible = false
         let recorder = RenderingActionRecorder()
         var events = recorder.stream.makeAsyncIterator()
+        let visibilityGateReached = expectation(description: "visibility settle reaches visibility gate")
+        visibilityGateReached.assertForOverFulfill = false
+        var didObserveHiddenVisibilityGate = false
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
-            isActuallyVisible: { isActuallyVisible },
+            isActuallyVisible: {
+                if !isActuallyVisible, !didObserveHiddenVisibilityGate {
+                    didObserveHiddenVisibilityGate = true
+                    visibilityGateReached.fulfill()
+                }
+                return isActuallyVisible
+            },
             applyAction: recorder.record
         )
 
         coordinator.viewDidMoveToWindow(isAttached: true)
-        // Let the scheduled attempt run; it must stop at the visibility gate.
-        await Task.yield()
-        await Task.yield()
+        // Await the scheduler's actual visibility gate rather than guessing
+        // how many executor turns its queued task needs.
+        await fulfillment(of: [visibilityGateReached], timeout: 1)
         XCTAssertTrue(recorder.actions.isEmpty, "A hidden ancestor must defer the first paint")
 
         // SwiftUI can call updateNSView with the same visible value after the

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -11,6 +11,14 @@ import XCTest
 
 @MainActor
 final class MarkdownPanelTests: XCTestCase {
+    private static func drainMainRunLoopTurn() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) {
+                continuation.resume()
+            }
+        }
+    }
+
     func testMarkdownThemeUsesTransparentPageAndOverlayTintsForTranslucentBackgrounds() throws {
         let theme = MarkdownWebTheme.resolve(
             backgroundColor: NSColor(
@@ -414,6 +422,55 @@ final class MarkdownPanelTests: XCTestCase {
         discardedWebView.onPointerDown?()
 
         XCTAssertEqual(discardedPointerDownCount, 0)
+    }
+
+    func testMarkdownWebViewReattachDoesNotRefreshInsideHostCallback() async {
+        let frame = NSRect(x: 0, y: 0, width: 640, height: 360)
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let webView = MarkdownWebView(
+            frame: frame,
+            configuration: WKWebViewConfiguration()
+        )
+        var refreshCount = 0
+        webView.renderingRefreshProbeForTesting = {
+            refreshCount += 1
+        }
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.renderingRefreshProbeForTesting = nil
+            webView.removeFromSuperview()
+            window.close()
+        }
+
+        // Reparenting the view is the same lifecycle transition that occurs
+        // when Bonsplit moves a tab between columns. The host callback must
+        // not synchronously enter WebKit's layout/display subtree: doing so
+        // re-enters the surrounding NSHostingView layout pass on macOS 15.
+        webView.removeFromSuperview()
+        refreshCount = 0
+        window.contentView = webView
+
+        XCTAssertEqual(
+            refreshCount,
+            0,
+            "A markdown viewer re-entry must not flush WebKit while the host layout callback is active"
+        )
+
+        // The repair still has to happen once the originating callback has
+        // returned. A run-loop turn is the production scheduling boundary; no
+        // wall-clock delay is needed.
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(
+            refreshCount,
+            1,
+            "A reattached markdown viewer must repaint on the deferred turn"
+        )
     }
 
     func testMarkdownRendererKeepsRecoveryBudgetAfterShellReload() {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -11,12 +11,28 @@ import XCTest
 
 @MainActor
 final class MarkdownPanelTests: XCTestCase {
-    private static func drainDeferredSchedulerTurn() async {
-        // MainActorDeferredActionScheduler enqueues a zero-delay MainActor
-        // task. Yield on that same executor so assertions observe the queued
-        // action, rather than relying on RunLoop ordering.
-        await Task.yield()
-        await Task.yield()
+    @MainActor
+    private final class RenderingActionRecorder {
+        typealias Action = MarkdownWebRenderingCoordinator.Action
+
+        let stream: AsyncStream<Action>
+        private let continuation: AsyncStream<Action>.Continuation
+        private(set) var actions: [Action] = []
+
+        init() {
+            let events = AsyncStream<Action>.makeStream()
+            stream = events.stream
+            continuation = events.continuation
+        }
+
+        func record(_ action: Action) {
+            actions.append(action)
+            continuation.yield(action)
+        }
+
+        func reset() {
+            actions.removeAll()
+        }
     }
 
     func testMarkdownThemeUsesTransparentPageAndOverlayTintsForTranslucentBackgrounds() throws {
@@ -428,91 +444,94 @@ final class MarkdownPanelTests: XCTestCase {
 
     func testMarkdownWebViewReattachDoesNotRefreshInsideHostCallback() async {
         var isActuallyVisible = true
-        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let recorder = RenderingActionRecorder()
+        var events = recorder.stream.makeAsyncIterator()
         var reentryCount = 0
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
             isActuallyVisible: { isActuallyVisible },
-            applyAction: { action in actions.append(action) },
+            applyAction: recorder.record,
             onReenterWindow: { reentryCount += 1 }
         )
 
         // Establish the attached state, then model Bonsplit's remove/add
         // transition before the deferred action gets a chance to run.
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainDeferredSchedulerTurn()
-        actions.removeAll()
+        _ = await events.next()
+        recorder.reset()
         isActuallyVisible = false
         coordinator.viewDidMoveToWindow(isAttached: false)
         isActuallyVisible = true
         coordinator.viewDidMoveToWindow(isAttached: true)
 
         XCTAssertTrue(
-            actions.isEmpty,
+            recorder.actions.isEmpty,
             "A markdown viewer re-entry must not flush WebKit while the host layout callback is active"
         )
 
         // The repair still has to happen once the originating callback has
         // returned. A MainActor yield is the production scheduling boundary;
         // no wall-clock delay is needed.
-        await Self.drainDeferredSchedulerTurn()
-        XCTAssertEqual(actions.count, 1)
+        _ = await events.next()
+        XCTAssertEqual(recorder.actions.count, 1)
         XCTAssertEqual(
-            actions.first,
+            recorder.actions.first,
             .refresh(reason: "viewDidMoveToWindow.visible", forceLifecycleRefresh: true)
         )
         XCTAssertEqual(reentryCount, 2, "The initial attach and reattach each complete once")
     }
 
     func testMarkdownWebViewResizeRefreshCoalescesOutsideLayoutCallback() async {
-        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let recorder = RenderingActionRecorder()
+        var events = recorder.stream.makeAsyncIterator()
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
             isActuallyVisible: { true },
-            applyAction: { action in actions.append(action) }
+            applyAction: recorder.record
         )
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainDeferredSchedulerTurn()
-        actions.removeAll()
+        _ = await events.next()
+        recorder.reset()
         // Both changes are smaller than the old half-point tolerance. Each is
         // still real divider geometry and must leave a deferred repair queued.
         coordinator.layoutDidChange(to: CGSize(width: 639.75, height: 359.75))
         coordinator.layoutDidChange(to: CGSize(width: 639.5, height: 359.5))
 
         XCTAssertTrue(
-            actions.isEmpty,
+            recorder.actions.isEmpty,
             "A markdown resize must not flush WebKit synchronously from AppKit layout"
         )
 
-        await Self.drainDeferredSchedulerTurn()
-        XCTAssertEqual(actions.count, 1)
+        _ = await events.next()
+        XCTAssertEqual(recorder.actions.count, 1)
         XCTAssertEqual(
-            actions.first,
+            recorder.actions.first,
             .refresh(reason: "boundsChanged", forceLifecycleRefresh: false),
             "Repeated geometry callbacks should coalesce into one deferred repaint"
         )
     }
 
     func testMarkdownWebViewVisibilityRevealRepairsAfterHiddenTabLifecycle() async {
-        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let recorder = RenderingActionRecorder()
+        var events = recorder.stream.makeAsyncIterator()
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
             isActuallyVisible: { true },
-            applyAction: { action in actions.append(action) }
+            applyAction: recorder.record
         )
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainDeferredSchedulerTurn()
-        actions.removeAll()
+        _ = await events.next()
+        recorder.reset()
         coordinator.setVisibleInUI(false)
-        await Self.drainDeferredSchedulerTurn()
-        XCTAssertEqual(actions, [.hide(reason: "visibility.hidden")])
+        _ = await events.next()
+        XCTAssertEqual(recorder.actions, [.hide(reason: "visibility.hidden")])
 
-        actions.removeAll()
+        recorder.reset()
         coordinator.setVisibleInUI(true)
-        XCTAssertTrue(actions.isEmpty, "A visibility reveal must cross the deferred boundary")
-        await Self.drainDeferredSchedulerTurn()
+        XCTAssertTrue(recorder.actions.isEmpty, "A visibility reveal must cross the deferred boundary")
+        _ = await events.next()
         XCTAssertEqual(
-            actions,
+            recorder.actions,
             [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)],
             "A revealed markdown tab must receive a repaint pass"
         )
@@ -520,25 +539,28 @@ final class MarkdownPanelTests: XCTestCase {
 
     func testMarkdownRenderingCoordinatorRetriesWhenVisibilitySettles() async {
         var isActuallyVisible = false
-        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let recorder = RenderingActionRecorder()
+        var events = recorder.stream.makeAsyncIterator()
         let coordinator = MarkdownWebRenderingCoordinator(
             initialBoundsSize: CGSize(width: 640, height: 360),
             isActuallyVisible: { isActuallyVisible },
-            applyAction: { action in actions.append(action) }
+            applyAction: recorder.record
         )
 
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainDeferredSchedulerTurn()
-        XCTAssertTrue(actions.isEmpty, "A hidden ancestor must defer the first paint")
+        // Let the scheduled attempt run; it must stop at the visibility gate.
+        await Task.yield()
+        await Task.yield()
+        XCTAssertTrue(recorder.actions.isEmpty, "A hidden ancestor must defer the first paint")
 
         // SwiftUI can call updateNSView with the same visible value after the
         // ancestor becomes visible. That callback must retry pending work.
         isActuallyVisible = true
         coordinator.setVisibleInUI(true)
-        XCTAssertTrue(actions.isEmpty, "The visibility retry remains deferred")
-        await Self.drainDeferredSchedulerTurn()
+        XCTAssertTrue(recorder.actions.isEmpty, "The visibility retry remains deferred")
+        _ = await events.next()
         XCTAssertEqual(
-            actions,
+            recorder.actions,
             [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)]
         )
     }

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -361,6 +361,7 @@ final class MarkdownPanelTests: XCTestCase {
             markdown: "# Existing\n",
             theme: theme,
             backgroundColor: .windowBackgroundColor,
+            isVisibleInUI: true,
             panelId: panelId,
             workspaceId: workspaceId,
             filePath: filePath,
@@ -376,6 +377,7 @@ final class MarkdownPanelTests: XCTestCase {
             markdown: "# Existing\n",
             theme: theme,
             backgroundColor: .windowBackgroundColor,
+            isVisibleInUI: true,
             panelId: panelId,
             workspaceId: workspaceId,
             filePath: filePath,
@@ -442,6 +444,7 @@ final class MarkdownPanelTests: XCTestCase {
         }
         window.contentView = webView
         window.orderFrontRegardless()
+        await Self.drainMainRunLoopTurn()
         defer {
             webView.renderingRefreshProbeForTesting = nil
             webView.removeFromSuperview()
@@ -471,6 +474,87 @@ final class MarkdownPanelTests: XCTestCase {
             1,
             "A reattached markdown viewer must repaint on the deferred turn"
         )
+    }
+
+    func testMarkdownWebViewResizeRefreshCoalescesOutsideLayoutCallback() async {
+        let initialFrame = NSRect(x: 0, y: 0, width: 640, height: 360)
+        let window = NSWindow(
+            contentRect: initialFrame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let webView = MarkdownWebView(
+            frame: initialFrame,
+            configuration: WKWebViewConfiguration()
+        )
+        var refreshCount = 0
+        webView.renderingRefreshProbeForTesting = {
+            refreshCount += 1
+        }
+        window.contentView = webView
+        window.orderFrontRegardless()
+        await Self.drainMainRunLoopTurn()
+        defer {
+            webView.renderingRefreshProbeForTesting = nil
+            webView.removeFromSuperview()
+            window.close()
+        }
+
+        refreshCount = 0
+        webView.setFrameSize(NSSize(width: 500, height: 320))
+        window.contentView?.layoutSubtreeIfNeeded()
+        webView.setFrameSize(NSSize(width: 460, height: 300))
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(
+            refreshCount,
+            0,
+            "A markdown resize must not flush WebKit synchronously from AppKit layout"
+        )
+
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(
+            refreshCount,
+            1,
+            "Repeated geometry callbacks should coalesce into one deferred repaint"
+        )
+    }
+
+    func testMarkdownWebViewVisibilityRevealRepairsAfterHiddenTabLifecycle() async {
+        let frame = NSRect(x: 0, y: 0, width: 640, height: 360)
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let webView = MarkdownWebView(
+            frame: frame,
+            configuration: WKWebViewConfiguration()
+        )
+        var refreshCount = 0
+        webView.renderingRefreshProbeForTesting = {
+            refreshCount += 1
+        }
+        window.contentView = webView
+        window.orderFrontRegardless()
+        await Self.drainMainRunLoopTurn()
+        defer {
+            webView.renderingRefreshProbeForTesting = nil
+            webView.removeFromSuperview()
+            window.close()
+        }
+
+        refreshCount = 0
+        webView.setVisibleInUI(false)
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(refreshCount, 0, "A hidden markdown tab must not be repainted")
+
+        webView.setVisibleInUI(true)
+        XCTAssertEqual(refreshCount, 0, "A visibility reveal must cross the deferred boundary")
+        await Self.drainMainRunLoopTurn()
+        XCTAssertEqual(refreshCount, 1, "A revealed markdown tab must receive a repaint pass")
     }
 
     func testMarkdownRendererKeepsRecoveryBudgetAfterShellReload() {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -11,12 +11,12 @@ import XCTest
 
 @MainActor
 final class MarkdownPanelTests: XCTestCase {
-    private static func drainMainRunLoopTurn() async {
-        await withCheckedContinuation { continuation in
-            RunLoop.main.perform(inModes: [.common]) {
-                continuation.resume()
-            }
-        }
+    private static func drainDeferredSchedulerTurn() async {
+        // MainActorDeferredActionScheduler enqueues a zero-delay MainActor
+        // task. Yield on that same executor so assertions observe the queued
+        // action, rather than relying on RunLoop ordering.
+        await Task.yield()
+        await Task.yield()
     }
 
     func testMarkdownThemeUsesTransparentPageAndOverlayTintsForTranslucentBackgrounds() throws {
@@ -440,7 +440,7 @@ final class MarkdownPanelTests: XCTestCase {
         // Establish the attached state, then model Bonsplit's remove/add
         // transition before the deferred action gets a chance to run.
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         actions.removeAll()
         isActuallyVisible = false
         coordinator.viewDidMoveToWindow(isAttached: false)
@@ -453,9 +453,9 @@ final class MarkdownPanelTests: XCTestCase {
         )
 
         // The repair still has to happen once the originating callback has
-        // returned. A run-loop turn is the production scheduling boundary; no
-        // wall-clock delay is needed.
-        await Self.drainMainRunLoopTurn()
+        // returned. A MainActor yield is the production scheduling boundary;
+        // no wall-clock delay is needed.
+        await Self.drainDeferredSchedulerTurn()
         XCTAssertEqual(actions.count, 1)
         XCTAssertEqual(
             actions.first,
@@ -472,7 +472,7 @@ final class MarkdownPanelTests: XCTestCase {
             applyAction: { action in actions.append(action) }
         )
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         actions.removeAll()
         // Both changes are smaller than the old half-point tolerance. Each is
         // still real divider geometry and must leave a deferred repair queued.
@@ -484,7 +484,7 @@ final class MarkdownPanelTests: XCTestCase {
             "A markdown resize must not flush WebKit synchronously from AppKit layout"
         )
 
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         XCTAssertEqual(actions.count, 1)
         XCTAssertEqual(
             actions.first,
@@ -501,20 +501,45 @@ final class MarkdownPanelTests: XCTestCase {
             applyAction: { action in actions.append(action) }
         )
         coordinator.viewDidMoveToWindow(isAttached: true)
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         actions.removeAll()
         coordinator.setVisibleInUI(false)
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         XCTAssertEqual(actions, [.hide(reason: "visibility.hidden")])
 
         actions.removeAll()
         coordinator.setVisibleInUI(true)
         XCTAssertTrue(actions.isEmpty, "A visibility reveal must cross the deferred boundary")
-        await Self.drainMainRunLoopTurn()
+        await Self.drainDeferredSchedulerTurn()
         XCTAssertEqual(
             actions,
             [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)],
             "A revealed markdown tab must receive a repaint pass"
+        )
+    }
+
+    func testMarkdownRenderingCoordinatorRetriesWhenVisibilitySettles() async {
+        var isActuallyVisible = false
+        var actions: [MarkdownWebRenderingCoordinator.Action] = []
+        let coordinator = MarkdownWebRenderingCoordinator(
+            initialBoundsSize: CGSize(width: 640, height: 360),
+            isActuallyVisible: { isActuallyVisible },
+            applyAction: { action in actions.append(action) }
+        )
+
+        coordinator.viewDidMoveToWindow(isAttached: true)
+        await Self.drainDeferredSchedulerTurn()
+        XCTAssertTrue(actions.isEmpty, "A hidden ancestor must defer the first paint")
+
+        // SwiftUI can call updateNSView with the same visible value after the
+        // ancestor becomes visible. That callback must retry pending work.
+        isActuallyVisible = true
+        coordinator.setVisibleInUI(true)
+        XCTAssertTrue(actions.isEmpty, "The visibility retry remains deferred")
+        await Self.drainDeferredSchedulerTurn()
+        XCTAssertEqual(
+            actions,
+            [.refresh(reason: "visibility.visible", forceLifecycleRefresh: true)]
         )
     }
 

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -474,8 +474,10 @@ final class MarkdownPanelTests: XCTestCase {
         coordinator.viewDidMoveToWindow(isAttached: true)
         await Self.drainMainRunLoopTurn()
         actions.removeAll()
-        coordinator.layoutDidChange(to: CGSize(width: 500.25, height: 320.25))
-        coordinator.layoutDidChange(to: CGSize(width: 460, height: 300))
+        // Both changes are smaller than the old half-point tolerance. Each is
+        // still real divider geometry and must leave a deferred repair queued.
+        coordinator.layoutDidChange(to: CGSize(width: 639.75, height: 359.75))
+        coordinator.layoutDidChange(to: CGSize(width: 639.5, height: 359.5))
 
         XCTAssertTrue(
             actions.isEmpty,


### PR DESCRIPTION
Closes #10470

## Root cause

`MarkdownWebView.viewDidMoveToWindow()` synchronously called WebKit's in-window lifecycle selectors and then `layoutSubtreeIfNeeded()`/`displayIfNeeded()`. Bonsplit hosts markdown panels below nested `NSHostingView`s, so pane reparenting and resize callbacks could enter that path while SwiftUI was rendering. The skipped reentrant layout left a live, scrollable WKWebView with stale backing tiles; WebKit could also keep an opacity-hidden keep-alive tab's WebContent process throttled.

## Fix

- Coalesce lifecycle and WebKit subtree refreshes onto a deferred main-actor turn. Host callbacks now only record state/invalidate; the synchronous flush happens only after the SwiftUI/AppKit callback unwinds and is limited to the WKWebView subtree.
- Track bounds changes and live-resize completion so pane/window resizes trigger a deferred repaint and lifecycle re-entry.
- Propagate pane/display-mode visibility into markdown WebViews, explicitly leaving hidden keep-alive viewers and re-entering/refreshing the active viewer on reveal.
- Preserve the existing detach/crash-loop recovery budget semantics.

## Coverage

The MarkdownPanel regression tests cover deferred re-entry, resize coalescing, and hidden-tab reveal behavior. Paint output itself is WebKit/OS-rendered and is not asserted pixel-for-pixel; the tests observe the actual deferred refresh boundary and lifecycle behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789792334&installation_model_id=21920&pr_number=10474&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10474&signature=42e5de3e6e65991d858ff17ac4040269d0191a43425a4f877e7cbd6c352473e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank Markdown viewers after pane reparent, resize, or hidden-tab reveal by deferring WebKit lifecycle and repaint to a single coordinator. Old behavior flushed inside AppKit/SwiftUI callbacks and left a live `WKWebView` with stale tiles; new behavior defers, coalesces, and repaints once when visibility settles, keeping one scheduled refresh per burst.

- Introduces `MarkdownWebRenderingCoordinator` to record window/geometry/visibility and emit one deferred action (hide or refresh). Applies lifecycle enter/exit and repaint only to the `WKWebView` subtree after host callbacks unwind.
- Coalesces geometry changes (including fractional divider moves). Forces a lifecycle refresh at live-resize end and after reparent; suppresses retries while an ancestor is hidden and retries once visibility settles; maintains a single deferred task across resize/visibility bursts.
- Propagates UI visibility via `isVisibleInUI` (only `.preview` tabs are visible). Hidden tabs leave WebKit’s lifecycle; reveal re-enters and repaints once actually visible.
- Tests await deferred actions, synchronize the hidden-visibility gate, cover fractional geometry, and assert no synchronous flushes during host layout.

- Migration: callers constructing `MarkdownWebRenderer` must pass `isVisibleInUI`.

<sup>Written for commit 98d8ce367bbf12406e4460638ea4456b8104aa64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown preview rendering when panels are hidden, revealed, resized, or reattached.
  * Deferred rendering updates to reduce unnecessary refreshes during layout and window changes.
  * Coalesced resize-related updates for smoother performance.
  * Ensured hidden previews remain inactive until they become visible again.
  * Improved reliability when previews transition between hidden and visible states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->