### PR TITLE
iOS: always show New Task, warn in composer when no Mac is connected

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -119,9 +119,36 @@ extension MobileShellComposite {
         supportedHostCapabilities.contains(Self.workspaceGroupCreateCapability)
             && discoversMacScopedWorkspaceMutations
     }
-    /// Whether the Mac supports creating task-composer workspaces.
+    /// Whether the New Task composer entrypoint is available. A connected
+    /// Mac's capability snapshot is authoritative for that Mac: any connected
+    /// Mac advertising task creation shows the entrypoint, and a fleet of
+    /// connected Macs that all lack it (remote flag off, or older builds)
+    /// hides it. With zero connected Macs there is no snapshot to consult, so
+    /// the entrypoint stays visible and the composer warns that no Mac is
+    /// connected instead of the button silently disappearing while offline.
     public var supportsTaskComposer: Bool {
-        supportedHostCapabilities.contains(Self.taskCreateCapability)
+        var sawConnectedMac = false
+        if connectionState == .connected {
+            if supportedHostCapabilities.contains(Self.taskCreateCapability) {
+                return true
+            }
+            sawConnectedMac = true
+        }
+        for (_, subscription) in secondaryMacSubscriptions {
+            if subscription.supportedHostCapabilities.contains(Self.taskCreateCapability) {
+                return true
+            }
+            sawConnectedMac = true
+        }
+        return !sawConnectedMac
+    }
+
+    /// True while at least one Mac session is live: the foreground connection
+    /// or any control-role secondary. The task composer keys its "No Mac is
+    /// connected" warning off this so the warning clears the moment any Mac
+    /// comes up, not only the foreground one.
+    public var hasAnyConnectedMac: Bool {
+        connectionState == .connected || !secondaryMacSubscriptions.isEmpty
     }
     /// Whether the Mac supports dogfood feedback submission.
     public var supportsDogfoodFeedback: Bool { supportedHostCapabilities.contains(Self.dogfoodFeedbackCapability) }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileRPC
 import CmuxMobileShellModel
 import Foundation
 import Testing
@@ -257,6 +258,62 @@ import Testing
             "terminal.replay.v1",
         ])
         #expect(!incapable.store.supportsTaskComposer)
+    }
+
+    @Test func taskComposerEntrypointFollowsSecondaryMacCapability() throws {
+        let clock = TestClock()
+        let runtime = LivenessTestRuntime(
+            transportFactory: LivenessTransportFactory(
+                router: LivenessHostRouter(),
+                box: TransportBox()
+            ),
+            now: { clock.now }
+        )
+        let store = MobileShellComposite.preview(runtime: runtime)
+        let ticket = try ticket(
+            clock: clock,
+            workspaceID: "live-workspace",
+            terminalID: "live-terminal"
+        )
+        let route = try #require(ticket.routes.first)
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+        let key = MacPairingKey(macDeviceID: "test-mac", instanceTag: nil)
+
+        // A connected control secondary without task creation is the only
+        // live Mac, and its snapshot is authoritative: the entrypoint hides.
+        let incapable = SecondaryMacSubscription(
+            macDeviceID: "test-mac",
+            client: client,
+            route: route,
+            ticket: ticket,
+            supportedHostCapabilities: ["terminal.render_grid.v1"],
+            actionCapabilities: .none
+        )
+        store.secondaryMacSubscriptions[key] = incapable
+        #expect(store.hasAnyConnectedMac)
+        #expect(!store.supportsTaskComposer)
+        store.secondaryMacSubscriptions[key] = nil
+        incapable.cancel()
+
+        // A capable secondary shows the entrypoint even though the
+        // foreground connection is down.
+        let capable = SecondaryMacSubscription(
+            macDeviceID: "test-mac",
+            client: client,
+            route: route,
+            ticket: ticket,
+            supportedHostCapabilities: ["workspace.task_create.v1"],
+            actionCapabilities: .none
+        )
+        store.secondaryMacSubscriptions[key] = capable
+        #expect(store.supportsTaskComposer)
+        store.secondaryMacSubscriptions[key] = nil
+        capable.cancel()
     }
 
     @Test func hasAnyConnectedMacTracksForegroundSession() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
@@ -231,6 +231,34 @@ import Testing
         #expect(authorization.first?.stackAccessToken == "test-stack-token")
     }
 
+    @Test func taskComposerEntrypointStaysAvailableWithNoConnectedMac() {
+        let store = MobileShellComposite.preview()
+        // With no Mac connected there is no capability snapshot to consult, so
+        // the New Task entrypoint must stay visible; the composer itself warns
+        // that no Mac is connected. Hiding here made the button vanish whenever
+        // the phone was offline or between reconnects.
+        #expect(store.supportsTaskComposer)
+    }
+
+    @Test func taskComposerEntrypointFollowsConnectedMacCapability() async throws {
+        let capable = try await connectedStore(capabilities: [
+            "events.v1",
+            "terminal.render_grid.v1",
+            "terminal.replay.v1",
+            "workspace.task_create.v1",
+        ])
+        #expect(capable.store.supportsTaskComposer)
+
+        // A connected Mac that does not advertise task creation (remote flag
+        // off or an older build) is authoritative: the entrypoint hides.
+        let incapable = try await connectedStore(capabilities: [
+            "events.v1",
+            "terminal.render_grid.v1",
+            "terminal.replay.v1",
+        ])
+        #expect(!incapable.store.supportsTaskComposer)
+    }
+
     @Test func macScopedMutationsSurviveTicketExpiryOnAccountAuthHosts() async throws {
         let connected = try await connectedStore(
             capabilities: [

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
@@ -259,6 +259,18 @@ import Testing
         #expect(!incapable.store.supportsTaskComposer)
     }
 
+    @Test func hasAnyConnectedMacTracksForegroundSession() async throws {
+        let offline = MobileShellComposite.preview()
+        #expect(!offline.hasAnyConnectedMac)
+
+        let connected = try await connectedStore(capabilities: [
+            "events.v1",
+            "terminal.render_grid.v1",
+            "terminal.replay.v1",
+        ])
+        #expect(connected.store.hasAnyConnectedMac)
+    }
+
     @Test func macScopedMutationsSurviveTicketExpiryOnAccountAuthHosts() async throws {
         let connected = try await connectedStore(
             capabilities: [

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerConnectionWarningBanner.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerConnectionWarningBanner.swift
@@ -1,0 +1,28 @@
+#if os(iOS)
+import SwiftUI
+
+/// Non-blocking notice shown while no Mac connection is live. The composer
+/// stays usable for drafting; submission needs a connected Mac, so the banner
+/// explains the missing connection instead of the entrypoint hiding itself.
+struct TaskComposerConnectionWarningBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.subheadline.weight(.semibold))
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(.footnote.weight(.medium))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(.orange)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("MobileTaskComposerConnectionWarning")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
@@ -25,6 +25,9 @@ struct TaskComposerLayout: View {
     let isModelLoading: Bool
     let isSubmitting: Bool
     let isSubmitEnabled: Bool
+    /// Rendered as a non-blocking orange banner when no Mac connection is
+    /// live; `nil` while at least one Mac is connected.
+    let connectionWarningText: String?
     let failureTitle: String
     let failureText: String?
     let completedOperationRecovery: TaskComposerCompletedOperationRecovery?
@@ -116,6 +119,11 @@ struct TaskComposerLayout: View {
 
     private var accessoryBar: some View {
         VStack(spacing: 10) {
+            if let connectionWarningText {
+                TaskComposerConnectionWarningBanner(message: connectionWarningText)
+                    .padding(.horizontal, 16)
+            }
+
             if failureText != nil || completedOperationRecovery != nil {
                 TaskComposerFailureRecoveryContent(
                     isSubmitting: isSubmitting,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -458,6 +458,7 @@ struct TaskComposerSheet: View {
                 && !workspaceGroupSelectionNeedsInventory
                 && !workspaceGroupSelectionRequiresResolution
                 && blockingCompletedOperationRecovery == nil,
+            connectionWarningText: connectionWarningText,
             failureTitle: failureTitleStyle.title,
             failureText: failureText,
             completedOperationRecovery: blockingCompletedOperationRecovery,
@@ -549,6 +550,18 @@ struct TaskComposerSheet: View {
 
     private var machines: [MobilePairedMac] {
         availableMachines ?? store.displayPairedMacs
+    }
+
+    /// The "No Mac is connected" notice. The entrypoint no longer hides while
+    /// offline, so the composer itself must say why a task cannot start yet.
+    /// The accessibility harness injects deterministic machines without live
+    /// sessions, so injected machines suppress the warning.
+    private var connectionWarningText: String? {
+        guard availableMachines == nil, !store.hasAnyConnectedMac else { return nil }
+        return L10n.string(
+            "mobile.taskComposer.warning.noConnectedMac",
+            defaultValue: "No Mac is connected. Open cmux on a Mac to start this task."
+        )
     }
 
     private var workspaceGroups: [MobileWorkspaceGroupPreview] {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -13294,6 +13294,23 @@
         }
       }
     },
+    "mobile.taskComposer.warning.noConnectedMac": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Mac is connected. Open cmux on a Mac to start this task."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続されているMacがありません。タスクを開始するには、Macでcmuxを開いてください。"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.workspace": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
The Compose Task button was gated on `supportsTaskComposer`, which only read the foreground Mac's live capability snapshot. That snapshot is empty whenever no Mac connection is live, so the button disappeared while offline or between reconnects, and a capable secondary Mac could not show it either.

Now any connected Mac (foreground or control secondary) advertising `workspace.task_create.v1` shows the entrypoint. A fleet of connected Macs that all lack the capability still hides it, so the `mobile-task-composer-enabled-release` remote kill switch keeps working. With zero connected Macs the entrypoint stays visible and the composer shows a non-blocking orange "No Mac is connected. Open cmux on a Mac to start this task." banner (new `hasAnyConnectedMac` store signal). Submission to an offline Mac keeps its existing failure path.

Commit 1 adds the failing regression test (fresh store must keep the entrypoint visible), commit 2 the fix. Localization audit: one new key `mobile.taskComposer.warning.noConnectedMac` added to `ios/cmux/Resources/Localizable.xcstrings` with en and ja; no other user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789792603&installation_model_id=21920&pr_number=10476&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10476&signature=caeaf79a7406813426a3af434205bc0b72ad758bedebfb11a7beed1c5247aff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show New Task on iOS and explain when no Mac is connected. Previously the button hid when no Mac was live because `supportsTaskComposer` only consulted the foreground Mac; now any connected Mac with `workspace.task_create.v1` enables it, and with zero Macs the button stays visible and the composer shows a non-blocking warning.

- Logic: `MobileShellComposite.supportsTaskComposer` returns true if any connected Mac (foreground or control secondary) advertises `workspace.task_create.v1`; returns false only when at least one Mac is connected and none advertise; returns true when zero Macs are connected. New `hasAnyConnectedMac` tracks any live Mac session.
- UI: new `TaskComposerConnectionWarningBanner`; `TaskComposerLayout` renders it; `TaskComposerSheet` supplies the localized message and exposes accessibility id "MobileTaskComposerConnectionWarning".
- Kill switch: behavior of the `mobile-task-composer-enabled-release` remote flag is preserved—if all connected Macs lack the capability, the entrypoint hides.
- Tests: added coverage for entrypoint visibility with no Macs, capability-driven visibility across foreground and secondary Macs, and `hasAnyConnectedMac`. New localization key `mobile.taskComposer.warning.noConnectedMac` (en, ja). No migrations required.

<sup>Written for commit d0f8e3cee62a5af8539af30bfe7ab12be7342076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task Composer now accounts for task-creation capabilities across connected Macs.
  * Added a warning banner when no Mac is connected, with English and Japanese localization.
  * Task Composer remains available offline while explaining how to connect a Mac.

* **Bug Fixes**
  * Improved composer visibility and connection-state handling for multiple connected Macs.

* **Tests**
  * Added coverage for connection states and capability-based composer availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->