### PR TITLE
test: cover the keychain-group mis-bake correction in the TestFlight lanes

### DIFF
--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -184,6 +184,25 @@ if command.startswith("Print "):
         print(value)
     raise SystemExit(0)
 
+if command.startswith("Set "):
+    # Match /usr/libexec/PlistBuddy: Set only updates an existing entry.
+    _, key_path, raw_value = (command.split(" ", 2) + [""])[:3]
+    keys = parts(key_path)
+    current = plist
+    try:
+        for key in keys[:-1]:
+            current = current[int(key)] if isinstance(current, list) else current[key]
+        if isinstance(current, list):
+            current[int(keys[-1])] = raw_value
+        elif keys[-1] in current:
+            current[keys[-1]] = raw_value
+        else:
+            raise KeyError(keys[-1])
+    except (KeyError, IndexError, ValueError):
+        raise SystemExit(1)
+    save(plist_path, plist)
+    raise SystemExit(0)
+
 if command.startswith("Add "):
     _, key_path, value_type, raw_value = (command.split(" ", 3) + [""])[:4]
     if value_type == "dict":
@@ -334,6 +353,11 @@ if "archive" in args:
             "CFBundleVersion": build_number,
             "CFBundleShortVersionString": marketing_version,
             "CMUXCrashReportingEnabled": crash_reporting_enabled,
+            # A manual archive builds with code signing disabled, so
+            # $(AppIdentifierPrefix) expands to "" and the group bakes as the
+            # bare bundle id, the exact mis-bake that made TestFlight builds
+            # keychain-dead. The lane must correct it before codesign.
+            "CMUXKeychainAccessGroup": bundle_id,
         }},
     )
     # upload-testflight.sh refuses archives without dSYM bundles.
@@ -659,6 +683,10 @@ def test_upload_beta_lane_uses_beta_marketing_version(tmp: Path, fakebin: Path) 
     _check(
         info.get("CFBundleIdentifier") == BETA_BUNDLE_ID,
         "final signed beta IPA Info.plist is dev.cmux.app.beta",
+    )
+    _check(
+        info.get("CMUXKeychainAccessGroup") == BETA_APP_ID,
+        "final signed beta IPA Info.plist carries the exact beta keychain group",
     )
     _check(
         info.get("CFBundleShortVersionString") == BETA_MARKETING_VERSION,
@@ -987,6 +1015,10 @@ def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path
     with zipfile.ZipFile(ipa_path) as zf:
         info = plistlib.loads(zf.read("Payload/cmux.app/Info.plist"))
     _check(info.get("CFBundleIdentifier") == APPSTORE_BUNDLE_ID, "final signed IPA Info.plist is com.cmux.app")
+    _check(
+        info.get("CMUXKeychainAccessGroup") == APPSTORE_APP_ID,
+        "final signed App Store IPA Info.plist carries the exact App Store keychain group",
+    )
     _check(
         info.get("CFBundleShortVersionString") == APPSTORE_MARKETING_VERSION,
         "final signed IPA keeps the App Store marketing version",


### PR DESCRIPTION
Follow-up coverage for https://github.com/manaflow-ai/cmux/pull/10435. The lane-identity harness never exercised the `CMUXKeychainAccessGroup` rewrite that PR added: the fake archive's Info.plist did not carry the key, and the fake PlistBuddy did not implement the `Set` command the rewrite uses, so the correction branch ran in zero tests. A regression there would surface only as keychain-dead phones in the field again.

This seeds the fake archive with the bare-bundle-id mis-bake a real unsigned manual archive produces (`AppIdentifierPrefix` expands empty with code signing disabled), teaches the fake PlistBuddy `Set` with real PlistBuddy semantics (only updates an existing entry), and asserts the final signed beta and App Store IPAs carry the exact team-prefixed group.

Verified both directions locally: full suite green as-is; with the script's rewrite line disabled, the seeded mis-bake makes the beta and App Store lanes fail loudly (fail-closed verification plus the new exact-group assertions) instead of passing vacuously.

Salvaged from `fix-ios-internal-auth-persistence` (`b19db347e6`), an independent fix for the same INTERNAL sign-out bug that #10435 superseded; the fix commits there are dropped, only the missing lane coverage moves forward, reworked for the merged script's Set-only rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789793215&installation_model_id=21920&pr_number=10479&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10479&signature=0cadf598a74fc0f397efe153981f7750c2ecf6396da65cc6bce0779b0b3f1998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tests the `CMUXKeychainAccessGroup` rewrite in the TestFlight and App Store lanes to prevent keychain-dead builds. Previously the correction path was untested because the fake archive lacked the key and the fake `PlistBuddy` did not support `Set`.

- Seed the fake archive `Info.plist` with a mis-baked `CMUXKeychainAccessGroup` equal to the bare bundle id (matches unsigned manual archive behavior).
- Add `PlistBuddy` `Set` support in the test harness with real semantics: only updates existing keys; otherwise exits 1.
- Assert the final signed beta and App Store IPAs carry the exact team‑prefixed keychain group.
- Outcome: with the rewrite enabled, suite stays green; if the rewrite regresses or is disabled, the lanes fail closed.

<sup>Written for commit 7998c3f1441be07c4ac384636eb179f13cbad7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected iOS archive signing behavior so keychain access groups use the complete application identifier.
  * Ensured beta and App Store builds include the expected keychain access group in their signed app metadata.

* **Tests**
  * Added coverage validating keychain access groups for beta and App Store uploads.
  * Improved simulated archive tooling to verify plist updates and signing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->