### PR TITLE
cmux-tui: self-spawns survive in-place binary upgrades

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -132,6 +132,23 @@ pub mod transport {
     }
 }
 
+/// The path to exec THIS running build again (terminal hosts, headless
+/// daemons). On Linux this is the open inode via `/proc/self/exe`, so an
+/// in-place binary upgrade can never break a running process's self-spawns:
+/// `std::env::current_exe()` resolves to "<path> (deleted)" after the file
+/// is replaced and exec then fails, which broke every new tab on a
+/// long-lived daemon. Elsewhere it is the resolved executable path.
+pub fn self_exe_for_spawn() -> io::Result<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        Ok(PathBuf::from("/proc/self/exe"))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::env::current_exe()
+    }
+}
+
 /// Runtime socket/pidfile directory for the current user.
 pub fn runtime_dir() -> PathBuf {
     runtime_base_dir().join(format!("cmux-tui-{}", user_id_component()))

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -7426,10 +7426,10 @@ mod tests {
         loop {
             let text =
                 surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            if let Some(start) = text.find("CT=[") {
-                if let Some(len) = text[start..].find(']') {
-                    return text[start..=start + len].to_string();
-                }
+            if let Some(start) = text.find("CT=[")
+                && let Some(len) = text[start..].find(']')
+            {
+                return text[start..=start + len].to_string();
             }
             assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
             std::thread::sleep(Duration::from_millis(5));

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1776,7 +1776,13 @@ mod unix {
             kitty_graphics_limits,
         };
 
-        let binary = std::env::current_exe().context("resolve cmux-tui terminal-host binary")?;
+        // Exec the daemon's own running build (open inode on Linux): after an
+        // in-place binary upgrade, resolving the executable path yields
+        // "<path> (deleted)" and exec fails, which broke every new tab/split
+        // on a long-lived daemon. This also guarantees daemon and host can
+        // never run skewed builds.
+        let binary = crate::platform::self_exe_for_spawn()
+            .context("resolve cmux-tui terminal-host binary")?;
         let mut command = Command::new(binary);
         command
             .args(["__terminal-host", "--bootstrap-stdio"])

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -2112,7 +2112,10 @@ fn ensure_daemon(
         return Ok(());
     }
 
-    let executable = std::env::current_exe()?;
+    // Spawn the daemon from this client's own running build (open inode on
+    // Linux) so an in-place binary upgrade cannot leave a long-lived client
+    // exec'ing a "(deleted)" path, and daemon/client builds never skew.
+    let executable = cmux_tui_core::platform::self_exe_for_spawn()?;
     let log_path = session_state.join("daemon.log");
     let mux_socket = mux_socket_override
         .map(Path::to_path_buf)


### PR DESCRIPTION
New tabs and splits failed with `remote command rejected: spawn terminal-host process` on any daemon whose binary had been replaced on disk: `std::env::current_exe()` resolves to `<path> (deleted)` after the swap and exec then fails. Hit in production on a Linux VM after upgrading the binary under a running daemon.

Terminal-host and headless-daemon spawns now go through `platform::self_exe_for_spawn()`, which on Linux execs `/proc/self/exe` (the open inode), so a running process always re-execs its own build and daemon, host, and client can never run skewed builds. The remaining `current_exe` call sites are test-only.

Extracted from the machine-rail branch stack so it can land on main independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794877&installation_model_id=21920&pr_number=10483&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10483&signature=b200f912b682d6c923536a4a3050dde18638c8966c97af4c2ff9b02861684c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-spawns now re-exec the running build so in-place binary upgrades don’t break new tabs/splits or create build skew. Previously on Linux, `std::env::current_exe()` resolved to "<path> (deleted)" after a swap and exec failed.

- Adds `cmux-tui-core::platform::self_exe_for_spawn()` which returns `/proc/self/exe` on Linux, else falls back to `std::env::current_exe()`.
- Uses it for terminal-host and headless-daemon spawns in `cmux-tui-core::terminal_host_runtime` and `cmux-tui::remote_cli`, ensuring daemon/host/client always run the same build.
- Collapses a nested `if` in `cmux-tui-core::surface` tests to satisfy clippy; no behavior change.
- Remaining `current_exe()` usages are test-only. No migration or config changes.

<sup>Written for commit d0a5d83f06ea08022ac760a39041057f12ad87e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching terminal hosts and remote daemon processes after an in-place application upgrade.
  * Ensured newly spawned processes continue using the currently running application build, preventing failures caused by replaced or deleted executable paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->