### PR TITLE
cmux-tui: a failed reconnect checkpoint must not tear down the host

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -7428,10 +7428,10 @@ mod tests {
         loop {
             let text =
                 surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            if let Some(start) = text.find("CT=[") {
-                if let Some(len) = text[start..].find(']') {
-                    return text[start..=start + len].to_string();
-                }
+            if let Some(start) = text.find("CT=[")
+                && let Some(len) = text[start..].find(']')
+            {
+                return text[start..=start + len].to_string();
             }
             assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
             std::thread::sleep(Duration::from_millis(5));

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -3541,33 +3541,35 @@ impl Surface {
                                 identity.incarnation,
                                 replacement_sequence_boundary
                             );
-                            if let Err(error) = reconnect_mux.create_journal_checkpoint(
+                            // The checkpoint is a journal-replay optimization:
+                            // failing to capture one only means the next replay
+                            // starts from an older boundary. Capture races with
+                            // every other terminal's concurrent reconnect
+                            // appends, so retry it in place a few times - and
+                            // never tear down the freshly reconnected, healthy
+                            // host over it. The old path disconnected and re-ran
+                            // the full reconnect up to 16 times per terminal,
+                            // each attempt's journal writes re-poisoning the
+                            // other terminals' captures.
+                            let mut checkpoint = reconnect_mux.create_journal_checkpoint(
                                 "terminal_host_reconnect",
                                 &checkpoint_key,
-                            ) {
+                            );
+                            for attempt in 1u32..4 {
+                                if checkpoint.is_ok() {
+                                    break;
+                                }
+                                std::thread::sleep(Duration::from_millis(25 << attempt));
+                                checkpoint = reconnect_mux.create_journal_checkpoint(
+                                    "terminal_host_reconnect",
+                                    &checkpoint_key,
+                                );
+                            }
+                            if let Err(error) = checkpoint {
                                 reconnect_mux.emit(MuxEvent::Status(format!(
-                                    "could not checkpoint terminal {} reconnect: {error:#}",
+                                    "skipped terminal {} reconnect checkpoint (replay starts from the previous boundary): {error:#}",
                                     identity.terminal_id
                                 )));
-                                replacement_control_responses.fail_all();
-                                if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
-                                    && host.identity() == identity
-                                {
-                                    host.disconnect();
-                                }
-                                pty.host_connection_state.store(
-                                    TerminalHostConnectionState::Reconnecting as u8,
-                                    Ordering::Release,
-                                );
-                                if !reconnect_mux
-                                    .terminal_host_connection_lost(surface.id, &identity)
-                                {
-                                    return;
-                                }
-                                if !retry.wait_or_fail(pty) {
-                                    return;
-                                }
-                                continue;
                             }
                         }
                         reconnect_mux.reconcile_deferred_cell_pixel_ack(


### PR DESCRIPTION
After a successful terminal-host reconnect, a journal checkpoint whose whole-session consistency fence raced with concurrent session activity was treated as a connection failure: the freshly reconnected healthy host was disconnected and the full reconnect re-ran, up to 16 attempts per terminal. With N terminals reconnecting at once (a machine resume), each attempt's journal appends re-poisoned every other terminal's capture window - storms of `could not checkpoint terminal ... session changed during checkpoint capture` (68 then 145 occurrences in one field log).

A checkpoint is a replay optimization; missing one only means the next replay starts from the previous boundary. Capture now retries in place with a short bounded backoff and otherwise skips with a single status line; the connection is never torn down over it. Field-verified: the storm ended once this ran.

Extracted from the machine-rail branch stack so it can land on main independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794880&installation_model_id=21920&pr_number=10484&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10484&signature=49f530ade4a59913b20b9562a78e5aae48a61db473b48ba3868621cc123dfce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating a failed post-reconnect journal checkpoint as a connection failure. Previously we disconnected a healthy host and re-ran full reconnects; now we retry locally and, if it still fails, skip the checkpoint so replay starts from the previous boundary.

- Retries the reconnect checkpoint up to 3 times with short bounded backoff; on final failure, emits a single status line and continues without disconnecting.
- Removes the disconnect/reconnect loop, state flip, and control-response failures on checkpoint errors, preventing repeated journal appends and log storms. Behavior change only affects the replay optimization; replay may start from an older boundary.
- Test maintenance: collapse a nested if in `surface` test to satisfy current toolchain clippy; no behavior change.

<sup>Written for commit 3b5976b5844ff80a530d6a103a41168c553e7bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal host reconnection reliability by retrying checkpoint creation up to three times with increasing delays.
  * Prevented checkpoint failures from unnecessarily disconnecting a healthy replacement connection or restarting reconnection.
  * Preserved connection state and resumed replay from the previous checkpoint boundary when checkpoint creation remains unavailable.
  * Added clearer status messaging when replay continues from the previous boundary after a checkpoint failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->