### PR TITLE
cmux-tui: a missed Kitty limits ack degrades graphics, not the connection

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -9269,7 +9269,7 @@ impl Mux {
                         Err(error) => {
                             failed_operations.insert(pending.surface_id);
                             failed_surface_ids.insert(pending.surface_id);
-                            failures.push(format!("surface {}: {error}", pending.surface_id));
+                            failures.push(format!("surface {}: {error:#}", pending.surface_id));
                         }
                     }
                 }
@@ -9393,7 +9393,7 @@ impl Mux {
                         DeadlineMapResult::Complete(Err(error)) => {
                             retry_expansion |= *expanding;
                             failed_surface_ids.insert(*id);
-                            failures.push(format!("surface {id}: {error}"));
+                            failures.push(format!("surface {id}: {error:#}"));
                         }
                         DeadlineMapResult::Pending(result) => {
                             pending_operations.push(PendingKittyImageBudgetOperation {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -7426,10 +7426,10 @@ mod tests {
         loop {
             let text =
                 surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            if let Some(start) = text.find("CT=[") {
-                if let Some(len) = text[start..].find(']') {
-                    return text[start..=start + len].to_string();
-                }
+            if let Some(start) = text.find("CT=[")
+                && let Some(len) = text[start..].find(']')
+            {
+                return text[start..=start + len].to_string();
             }
             assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
             std::thread::sleep(Duration::from_millis(5));

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1132,11 +1132,14 @@ mod unix {
             let mut payload = Vec::with_capacity(KITTY_GRAPHICS_LIMITS_ENCODED_LEN);
             encode_kitty_graphics_limits(&mut payload, limits)?;
             let response = self
-                .send_control_request_until(
+                .send_control_request_with_policy(
                     MessageKind::SetKittyGraphicsLimits,
                     MessageKind::KittyGraphicsLimitsAck,
                     payload,
                     deadline,
+                    // Advisory control: a missed ack must degrade graphics for
+                    // this surface, not tear down a healthy host connection.
+                    false,
                 )
                 .map_err(ClearHistoryFailure::into_error)
                 .context("terminal host did not acknowledge Kitty graphics limits")?;
@@ -1541,6 +1544,29 @@ mod unix {
             payload: Vec<u8>,
             deadline: Instant,
         ) -> Result<Vec<u8>, ClearHistoryFailure> {
+            self.send_control_request_with_policy(
+                request_kind,
+                response_kind,
+                payload,
+                deadline,
+                true,
+            )
+        }
+
+        /// `disconnect_on_timeout` = false keeps the channel alive when the
+        /// ack misses the deadline. Responses are matched by request id and
+        /// an unknown id is dropped on arrival, so a late ack is harmless.
+        /// Advisory controls (Kitty graphics limits) use this: tearing down
+        /// a healthy host over a slow ack forced a full terminal reconnect,
+        /// which reset the budget blocklist and re-armed the retry storm.
+        fn send_control_request_with_policy(
+            &self,
+            request_kind: MessageKind,
+            response_kind: MessageKind,
+            payload: Vec<u8>,
+            deadline: Instant,
+            disconnect_on_timeout: bool,
+        ) -> Result<Vec<u8>, ClearHistoryFailure> {
             let request_id = self.next_request.fetch_add(1, Ordering::Relaxed);
             if request_id == 0 {
                 return Err(ClearHistoryFailure::known_not_delivered(anyhow::anyhow!(
@@ -1585,7 +1611,9 @@ mod unix {
                 Ok(frame) => Ok(frame.payload),
                 Err(error) => {
                     self.control_responses.waiters.lock().unwrap().remove(&request_id);
-                    self.disconnect();
+                    if disconnect_on_timeout {
+                        self.disconnect();
+                    }
                     Err(ClearHistoryFailure::ambiguous(anyhow::anyhow!(
                         "terminal host did not acknowledge {request_kind:?}: {error}"
                     )))


### PR DESCRIPTION
The Kitty image budget worker already has bounded retries and a per-surface blocklist, but a limits ack that missed its 2s deadline disconnected the host channel. That forced a full terminal reconnect, which cleared the surface's blocked state and re-armed the whole retry sequence - a self-sustaining storm (128 then 172 occurrences in one field log, chronic on hosts frozen past the deadline by VM pause/resume).

Control requests are matched by request id and an unknown id is dropped on arrival, so a late ack is harmless: the limits request now uses a no-disconnect timeout policy, and a missed ack degrades graphics for that surface while the existing bounded retries and blocklist handle persistence. Budget failure summaries also print the full error chain (`{error:#}`); the Display-only formatting hid the root cause behind the generic context line.

Extracted from the machine-rail branch stack so it can land on main independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794882&installation_model_id=21920&pr_number=10485&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10485&signature=dfbe3b8567bb9be17e74f9c219a08ee65a6709103a0290af8b120421c7e89efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the host connection alive when the Kitty graphics limits ack misses its 2s deadline; only that surface’s graphics degrade. Previously a timeout disconnected the channel, forced a terminal reconnect, and re-armed image budget retries.

- Adds send_control_request_with_policy(disconnect_on_timeout) and uses it with disconnect_on_timeout = false for Kitty graphics limits; other control requests keep the existing disconnect-on-timeout behavior.
- Late acks are safe: responses match by request id and unknown ids are dropped.
- Relies on existing bounded retries and the per-surface blocklist; only that surface degrades.
- Prints full error chains in budget failure summaries with {error:#}.
- Collapses a nested if in the `surface` test to satisfy current clippy; no runtime behavior change.

<sup>Written for commit 0c07c7c00217fb52a27c11d543353cfb370b7c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now include more detailed diagnostic information when multiple operations fail.
  * Kitty graphics requests that time out no longer disconnect the terminal host, improving connection stability.
  * Other control requests retain their existing disconnect behavior when acknowledgements time out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->