### PR TITLE
cmux-tui: machine_provider.command config key (CLI parity)

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -7426,10 +7426,10 @@ mod tests {
         loop {
             let text =
                 surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            if let Some(start) = text.find("CT=[") {
-                if let Some(len) = text[start..].find(']') {
-                    return text[start..=start + len].to_string();
-                }
+            if let Some(start) = text.find("CT=[")
+                && let Some(len) = text[start..].find(']')
+            {
+                return text[start..=start + len].to_string();
             }
             assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
             std::thread::sleep(Duration::from_millis(5));

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -6811,7 +6811,9 @@ mod tests {
         .unwrap();
         assert_eq!(
             raw.machine_provider.command.as_deref(),
-            Some(["/opt/provider/run.sh".to_string(), "--profile".into(), "prod".into()].as_slice())
+            Some(
+                ["/opt/provider/run.sh".to_string(), "--profile".into(), "prod".into()].as_slice()
+            )
         );
 
         // An empty argv or blank program is ignored at apply time.
@@ -6820,9 +6822,7 @@ mod tests {
         assert!(raw.machine_provider.command.as_deref().is_some_and(|c| c.is_empty()));
         let raw: RawConfig =
             serde_json::from_str(r#"{"machine_provider":{"command":["  "]}}"#).unwrap();
-        assert!(
-            raw.machine_provider.command.as_deref().is_some_and(|c| c[0].trim().is_empty())
-        );
+        assert!(raw.machine_provider.command.as_deref().is_some_and(|c| c[0].trim().is_empty()));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -259,6 +259,11 @@ struct RawUserCommand {
 struct RawMachineProvider {
     #[serde(default)]
     cloud: RawCloudProvider,
+    /// Config parity with `--machine-provider-command`: the argv of a
+    /// provider process to spawn, no shell. The CLI flag wins when both are
+    /// given.
+    #[serde(default)]
+    command: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1031,6 +1036,10 @@ pub struct MachineCreationSourceConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MachineProviderConfig {
     pub cloud: CloudProviderConfig,
+    /// Argv of a machine-provider process to spawn, exactly like
+    /// `--machine-provider-command program arg -- `. CLI provider modes
+    /// override it.
+    pub command: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3221,6 +3230,15 @@ pub fn load() -> Config {
         }
     } else if raw.sidebar.profile.is_some() {
         eprintln!("cmux-tui: ignoring sidebar.profile without sidebar.profiles");
+    }
+    match raw.machine_provider.command {
+        Some(command) if command.first().is_some_and(|program| !program.trim().is_empty()) => {
+            config.machine_provider.command = Some(command);
+        }
+        Some(_) => {
+            eprintln!("cmux-tui: ignoring machine_provider.command without a program");
+        }
+        None => {}
     }
     let cloud = raw.machine_provider.cloud;
     if let Some(enabled) = cloud.enabled {
@@ -6783,6 +6801,28 @@ mod tests {
         ] {
             assert!(serde_json::from_str::<RawConfig>(invalid).is_err(), "accepted {invalid}");
         }
+    }
+
+    #[test]
+    fn machine_provider_command_parses_and_requires_a_program() {
+        let raw: RawConfig = serde_json::from_str(
+            r#"{"machine_provider":{"command":["/opt/provider/run.sh","--profile","prod"]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            raw.machine_provider.command.as_deref(),
+            Some(["/opt/provider/run.sh".to_string(), "--profile".into(), "prod".into()].as_slice())
+        );
+
+        // An empty argv or blank program is ignored at apply time.
+        let raw: RawConfig =
+            serde_json::from_str(r#"{"machine_provider":{"command":[]}}"#).unwrap();
+        assert!(raw.machine_provider.command.as_deref().is_some_and(|c| c.is_empty()));
+        let raw: RawConfig =
+            serde_json::from_str(r#"{"machine_provider":{"command":["  "]}}"#).unwrap();
+        assert!(
+            raw.machine_provider.command.as_deref().is_some_and(|c| c[0].trim().is_empty())
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1059,7 +1059,11 @@ fn resolve_provider_launch(
         // Config parity with --machine-provider-command. Any explicit CLI
         // provider mode above wins; an explicit --cloud also wins below, so
         // the config command only applies when the CLI chose nothing.
-        config.machine_provider.command.as_ref().filter(|_| !args.cloud_cli_requested())
+        config
+            .machine_provider
+            .command
+            .as_ref()
+            .filter(|_| !args.cloud_cli_requested())
     {
         Some(ProviderLaunch::Command(command.iter().map(OsString::from).collect()))
     } else if args.cloud_cli_requested() || config.machine_provider.cloud.enabled {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1055,6 +1055,13 @@ fn resolve_provider_launch(
         Some(ProviderLaunch::Unix(socket.clone()))
     } else if let Some(command) = &args.machine_provider_command {
         Some(ProviderLaunch::Command(command.iter().map(OsString::from).collect()))
+    } else if let Some(command) =
+        // Config parity with --machine-provider-command. Any explicit CLI
+        // provider mode above wins; an explicit --cloud also wins below, so
+        // the config command only applies when the CLI chose nothing.
+        config.machine_provider.command.as_ref().filter(|_| !args.cloud_cli_requested())
+    {
+        Some(ProviderLaunch::Command(command.iter().map(OsString::from).collect()))
     } else if args.cloud_cli_requested() || config.machine_provider.cloud.enabled {
         let cloud = &config.machine_provider.cloud;
         Some(ProviderLaunch::Cloud(CloudLaunch {

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -177,6 +177,7 @@ Dynamic provider startup is disabled by default. Persistent configuration curren
 
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
+| `machine_provider.command` | array of strings or null | `null` | Argv of a provider process to spawn, like `--machine-provider-command program arg --` (no shell). Explicit CLI provider modes override it |
 | `machine_provider.cloud.enabled` | boolean | `false` | Starts the dynamic provider through SSH |
 | `machine_provider.cloud.host` | string | `"cmux.cloud"` | SSH host |
 | `machine_provider.cloud.user` | string or null | `null` | Optional SSH user |


### PR DESCRIPTION
`--machine-provider-command` existed only as a CLI flag, so a user config that set `machine_provider.command` was rejected as an unknown field - and because typed config sections are strict, that one field silently discarded the user's ENTIRE config on every launch (36 warnings in one field log).

The key is now real config: the argv of a provider process to spawn, identical semantics to the CLI flag (no shell; cmux appends `control`/`stream`). Precedence is CLI-first: any explicit CLI provider mode, including `--cloud`, overrides it; the config command otherwise beats config `cloud.enabled`. Empty argv or a blank program is ignored with a warning. Static machines remain incompatible with command providers, same as the CLI path. Documented in configuration.md; parse and validation covered by a config test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794904&installation_model_id=21920&pr_number=10487&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10487&signature=b816ded4c09bb25687d13e3c56a334569c768b992dae691ceb1541ab6e12fdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `machine_provider.command` to `cmux-tui` config to match the `--machine-provider-command` flag, fixing prior behavior where the unknown key caused the entire config to be discarded. Now the command is parsed and used when no explicit CLI provider mode is selected.

- Semantics match the CLI flag: argv only (no shell); the app appends `control`/`stream`.
- Precedence: any explicit CLI provider mode (including `--cloud`) wins; otherwise the config command applies and overrides config `cloud.enabled`.
- Empty argv or a blank program is ignored with a warning. Static machines remain incompatible with command providers.
- Added parsing/validation test and documented the key in `configuration.md`.
- Lint-only change: collapsed a nested `if` in a `cmux-tui-core` surface test to satisfy current Clippy; no behavior change.

<sup>Written for commit badcdc7ee676297c12296fc93cfc19a81e2b9d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

