### PR TITLE
iOS: preserve workspace-list scroll position across workspace enter/exit

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -58,9 +58,15 @@ extension WorkspaceListView {
         filterMachines: [WorkspaceFilterMachine]
     ) -> some View {
         #if os(iOS)
-            if showsNavigationToolbar {
-                content
-                    .toolbar {
+            // The toolbar-visibility flip (off while a workspace is pushed on
+            // the compact stack, back on at exit) must stay inside the toolbar
+            // content builder. Branching the whole subtree on it changes the
+            // list's structural identity on every workspace enter/exit, which
+            // dismantles the represented workspace table and resets its scroll
+            // position to the top (issue #10481).
+            content
+                .toolbar {
+                    if showsNavigationToolbar {
                         if !usesExternalSharedToolbar {
                             ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
                                 settingsMenu
@@ -89,9 +95,7 @@ extension WorkspaceListView {
                             }
                         }
                     }
-            } else {
-                content
-            }
+                }
         #else
             content
                 .toolbar {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollPreservationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollPreservationTests.swift
@@ -1,0 +1,150 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import SwiftUI
+import Testing
+import UIKit
+@testable import CmuxMobileShellUI
+
+/// Entering a workspace on the compact stack flips the list's
+/// `showsNavigationToolbar` off, and exiting flips it back on. The list's
+/// structural identity must not depend on that flag: an identity change
+/// dismantles the represented workspace table, so the freshly created table
+/// comes back scrolled to the top (issue #10481).
+@MainActor
+@Suite struct WorkspaceListScrollPreservationTests {
+    @Test func workspaceTableSurvivesNavigationToolbarRoundTrip() async throws {
+        let fixture = Fixture(workspaceCount: 40)
+        defer { fixture.tearDown() }
+        await fixture.render(showsNavigationToolbar: true)
+
+        let table = try #require(fixture.currentTable())
+        let offset = CGPoint(x: 0, y: 240)
+        table.setContentOffset(offset, animated: false)
+
+        // Enter a workspace (list covered, toolbar hidden), then exit back.
+        await fixture.render(showsNavigationToolbar: false)
+        await fixture.render(showsNavigationToolbar: true)
+
+        let tableAfter = try #require(fixture.currentTable())
+        #expect(
+            tableAfter === table,
+            "Toolbar visibility must not change the list's structural identity; a rebuilt table loses the scroll position."
+        )
+        #expect(tableAfter.contentOffset == offset)
+    }
+
+    @Test func workspaceTableKeepsOffsetWhenContentRefreshesWhileCovered() async throws {
+        let fixture = Fixture(workspaceCount: 40)
+        defer { fixture.tearDown() }
+        await fixture.render(showsNavigationToolbar: true)
+
+        let table = try #require(fixture.currentTable())
+        let offset = CGPoint(x: 0, y: 240)
+        table.setContentOffset(offset, animated: false)
+
+        // While the workspace is open, the Mac appends new rows to the list.
+        await fixture.render(showsNavigationToolbar: false)
+        await fixture.render(showsNavigationToolbar: false, workspaceCount: 44)
+        await fixture.render(showsNavigationToolbar: true, workspaceCount: 44)
+
+        let tableAfter = try #require(fixture.currentTable())
+        #expect(tableAfter === table)
+        #expect(tableAfter.contentOffset == offset)
+        #expect(tableAfter.numberOfRows(inSection: 0) >= 44)
+    }
+
+    /// Hosts the real `WorkspaceListView` the way the compact shell does: at
+    /// the root of a `NavigationStack`, re-rendered with a new
+    /// `showsNavigationToolbar` value on every push/pop.
+    @MainActor
+    private final class Fixture {
+        private let window: UIWindow
+        private let host: UIHostingController<Harness>
+        private let filterState = WorkspaceListFilterState()
+
+        init(workspaceCount: Int) {
+            host = UIHostingController(
+                rootView: Harness(
+                    workspaces: Self.workspaces(count: workspaceCount),
+                    showsNavigationToolbar: true,
+                    filterState: filterState
+                )
+            )
+            window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+        }
+
+        func render(showsNavigationToolbar: Bool, workspaceCount: Int? = nil) async {
+            host.rootView = Harness(
+                workspaces: Self.workspaces(
+                    count: workspaceCount ?? host.rootView.workspaces.count
+                ),
+                showsNavigationToolbar: showsNavigationToolbar,
+                filterState: filterState
+            )
+            window.layoutIfNeeded()
+            host.view.layoutIfNeeded()
+            // Let SwiftUI commit deferred hierarchy updates (representable
+            // dismantles land on a later main-queue turn).
+            for _ in 0..<20 {
+                await Task.yield()
+            }
+            window.layoutIfNeeded()
+        }
+
+        func currentTable() -> WorkspaceListUITableView? {
+            Self.findTable(in: window)
+        }
+
+        func tearDown() {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        private static func findTable(in view: UIView) -> WorkspaceListUITableView? {
+            if let table = view as? WorkspaceListUITableView { return table }
+            for subview in view.subviews {
+                if let table = findTable(in: subview) { return table }
+            }
+            return nil
+        }
+
+        private static func workspaces(count: Int) -> [MobileWorkspacePreview] {
+            (1...count).map { index in
+                MobileWorkspacePreview(
+                    id: .init(rawValue: "workspace-\(index)"),
+                    name: "Workspace \(index)",
+                    previewText: "Agent activity \(index)",
+                    terminals: []
+                )
+            }
+        }
+    }
+
+    private struct Harness: View {
+        let workspaces: [MobileWorkspacePreview]
+        let showsNavigationToolbar: Bool
+        let filterState: WorkspaceListFilterState
+
+        var body: some View {
+            NavigationStack {
+                WorkspaceListView(
+                    workspaces: workspaces,
+                    selectedWorkspaceID: nil,
+                    host: "Test Mac",
+                    connectionStatus: .connected,
+                    navigationStyle: .push,
+                    showsNavigationToolbar: showsNavigationToolbar,
+                    usesExternalSharedToolbar: true,
+                    wrapWorkspaceTitles: false,
+                    selectWorkspace: { _ in },
+                    createWorkspace: {},
+                    macSelection: .constant(.automatic),
+                    filterState: filterState
+                )
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #10481

## Bug

On iPhone, exiting a workspace back to the main menu (the workspace list) always snapped the list back to the very top instead of staying where the user had scrolled.

## Root cause

`WorkspaceListView.workspaceListWithToolbar` branched the **entire list subtree** on `showsNavigationToolbar`:

```swift
if showsNavigationToolbar {
    content.toolbar { ...items... }
} else {
    content
}
```

On the compact stack, `showsNavigationToolbar` is `compactNavigationPath.isEmpty`, so it flips **off** when a workspace is pushed and **on** again when the user exits. A ViewBuilder `if/else` is `_ConditionalContent`; switching branches changes the structural identity of everything inside, so SwiftUI dismantled the `WorkspaceListTable` `UIViewControllerRepresentable` and built a fresh `UITableView` — at content offset zero — on every workspace enter/exit round trip.

## Fix

Keep one stable view tree: always apply `.toolbar` and move the visibility condition **inside** the `ToolbarContentBuilder` (the same pattern `WorkspaceShellView` already uses for its root toolbar). The toolbar items still only render while the list is topmost, but the list's identity — and therefore the table and its scroll position — survives the round trip. Content refreshes that arrive while a workspace is open flow through the existing `WorkspaceListTableCoordinator` diff path, which preserves the offset (anchoring behavior is unchanged and already covered by the apply-route tests).

## Regression test (red → green in CI)

Commit 1 adds `WorkspaceListScrollPreservationTests` only; commit 2 adds the fix. The test hosts the real `WorkspaceListView` at the root of a `NavigationStack` and flips `showsNavigationToolbar` exactly as the shell does on enter/exit:

- `workspaceTableSurvivesNavigationToolbarRoundTrip` — same `WorkspaceListUITableView` instance and content offset after the flip round trip.
- `workspaceTableKeepsOffsetWhenContentRefreshesWhileCovered` — rows appended while the workspace is "open" still land through the coordinator without losing the offset.

Dispatched `test-ios.yml` runs on both SHAs to demonstrate red on the test-only commit and green on the fix (links in comments once complete).

## Localization audit

No user-facing strings added or changed: the toolbar items are byte-for-byte the same views, only their position in the builder moved; the new file is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789795522&installation_model_id=21920&pr_number=10488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10488&signature=175216330f24e92e824c70b0417e94eefe3ea3e7a86b2810c64e6f566fe12e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the workspace list scroll position on iPhone when returning from a workspace. Previously the list reset to the top because the entire list subtree was branched on `showsNavigationToolbar`, changing view identity; now `.toolbar` is always applied and items are gated inside the builder, so the table instance and offset survive the round trip.

- Moves the `showsNavigationToolbar` check inside `.toolbar {}` in `WorkspaceListView+Toolbar.swift`; toolbar items still render only when the list is topmost, but the list’s structural identity stays stable.
- Adds `WorkspaceListScrollPreservationTests` that host the real list in a `NavigationStack` and assert the same `WorkspaceListUITableView` instance and content offset after a toolbar-visibility round trip, including during a content refresh while covered.

<sup>Written for commit a52ec57fa4d273cc4d20b594e4b817e4e406ac03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

