### PR TITLE
Journal-backed sidebar agent lifecycle: semantic event log + deterministic reducer + startup replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1469,6 +1469,7 @@ jobs:
             CmuxTerminalCore
             CmuxUpdater
             CMUXAgentLaunch
+            CmuxAgentJournal
           )
           # SwiftPM emits an error-severity diagnostic while planning the
           # GhosttyKit binaryTarget (the xcframework's static archive is not

--- a/CLI/AgentHookFailureStage.swift
+++ b/CLI/AgentHookFailureStage.swift
@@ -2,4 +2,5 @@
 enum AgentHookFailureStage: String, Sendable {
     case targetResolution = "target-resolution"
     case notificationDelivery = "notification-delivery"
+    case journalAppend = "journal-append"
 }

--- a/CLI/AgentHookNotificationPolicy.swift
+++ b/CLI/AgentHookNotificationPolicy.swift
@@ -132,14 +132,15 @@ enum AgentHookNotificationClassifier {
                 notifyCategory: .idleReminder
             )
         }
-        let body = String.localizedStringWithFormat(
-            String(localized: "agent.generic.notification.body.needsAttention", defaultValue: "%@ needs your attention"),
-            displayName
-        )
+        // No usable message and no matching cue: nothing is fabricated. The
+        // empty body tells callers to reuse a stored summary or skip the
+        // banner, and the nil status makes no lifecycle claim — the old
+        // "%@ needs your attention" needs-input fallback is deliberately
+        // gone (semantic journal events carry state now).
         return AgentHookNotificationSummary(
             subtitle: String(localized: "agent.generic.notification.subtitle.attention", defaultValue: "Attention"),
-            body: body,
-            status: .needsInput,
+            body: "",
+            status: nil,
             isFallback: true,
             notifyCategory: .idleReminder
         )

--- a/CLI/CMUXCLI+AgentJournalEmission.swift
+++ b/CLI/CMUXCLI+AgentJournalEmission.swift
@@ -31,15 +31,29 @@ extension CMUXCLI {
         store: ClaudeHookSessionStore? = nil,
         telemetry: CLISocketSentryTelemetry? = nil
     ) {
+        // A malformed or partial target (empty string, non-UUID, missing
+        // half) is never trusted: the event is journaled as an explicit
+        // diagnostic instead of being rejected at admission or guessed.
+        let validWorkspaceId = workspaceId.flatMap { UUID(uuidString: $0) != nil ? $0 : nil }
+        let validSurfaceId = surfaceId.flatMap { UUID(uuidString: $0) != nil ? $0 : nil }
+        let hasCompleteTarget = validWorkspaceId != nil && validSurfaceId != nil
+        let resolvedReason: String?
+        if let unattributedReason {
+            resolvedReason = unattributedReason
+        } else if !hasCompleteTarget {
+            resolvedReason = "malformed-target"
+        } else {
+            resolvedReason = nil
+        }
         let draft = AgentJournalEventDraft(
             kind: kind,
             occurredAtMs: Int64(Date().timeIntervalSince1970 * 1000),
             source: source,
             agentKey: agentKey,
             sessionId: sessionId,
-            workspaceId: unattributedReason == nil ? workspaceId : nil,
-            surfaceId: unattributedReason == nil ? surfaceId : nil,
-            unattributedReason: unattributedReason,
+            workspaceId: resolvedReason == nil ? validWorkspaceId : nil,
+            surfaceId: resolvedReason == nil ? validSurfaceId : nil,
+            unattributedReason: resolvedReason,
             isSubagent: isSubagent,
             pendingWork: pendingWork,
             nativeEvent: nativeEvent,
@@ -178,13 +192,13 @@ extension CMUXCLI {
             let lineData = try JSONSerialization.data(withJSONObject: record)
             guard var line = String(data: lineData, encoding: .utf8) else { return }
             line += "\n"
-            if fileManager.fileExists(atPath: url.path) {
-                let handle = try FileHandle(forWritingTo: url)
-                defer { try? handle.close() }
-                try handle.seekToEnd()
-                try handle.write(contentsOf: Data(line.utf8))
-            } else {
-                try line.write(to: url, atomically: true, encoding: .utf8)
+            // O_APPEND with one write(2) call keeps concurrent hook
+            // processes' records intact (no read-modify-write interleaving).
+            let descriptor = open(url.path, O_WRONLY | O_CREAT | O_APPEND, 0o600)
+            guard descriptor >= 0 else { return }
+            defer { close(descriptor) }
+            _ = Array(line.utf8).withUnsafeBufferPointer { buffer in
+                write(descriptor, buffer.baseAddress, buffer.count)
             }
         } catch {
             // stderr warning above already made the failure visible.

--- a/CLI/CMUXCLI+AgentJournalEmission.swift
+++ b/CLI/CMUXCLI+AgentJournalEmission.swift
@@ -1,0 +1,193 @@
+import CmuxAgentJournal
+import Foundation
+
+extension CMUXCLI {
+    /// Emits one semantic agent event into the app's append-only agent
+    /// journal and blocks until the app acknowledges the durable commit.
+    ///
+    /// This is the structured replacement for the fire-and-forget
+    /// `set_agent_lifecycle` verb: sidebar lifecycle is now a reduction over
+    /// these events. Attribution is decided by the caller — an event that
+    /// could not be attributed carries `unattributedReason` (and no target)
+    /// so the app surfaces it as a diagnostic instead of guessing a pane.
+    ///
+    /// Delivery failures are never silent: they land in the dead-letter file
+    /// and, when a session store and telemetry are provided, in the throttled
+    /// hook-failure report channel.
+    func emitAgentJournalEvent(
+        client: SocketClient,
+        kind: AgentJournalEventKind,
+        source: String,
+        agentKey: String,
+        sessionId: String?,
+        workspaceId: String?,
+        surfaceId: String?,
+        unattributedReason: String? = nil,
+        isSubagent: Bool = false,
+        pendingWork: Bool = false,
+        nativeEvent: String?,
+        declaredPhase: AgentLifecyclePhase? = nil,
+        detail: String? = nil,
+        store: ClaudeHookSessionStore? = nil,
+        telemetry: CLISocketSentryTelemetry? = nil
+    ) {
+        let draft = AgentJournalEventDraft(
+            kind: kind,
+            occurredAtMs: Int64(Date().timeIntervalSince1970 * 1000),
+            source: source,
+            agentKey: agentKey,
+            sessionId: sessionId,
+            workspaceId: unattributedReason == nil ? workspaceId : nil,
+            surfaceId: unattributedReason == nil ? surfaceId : nil,
+            unattributedReason: unattributedReason,
+            isSubagent: isSubagent,
+            pendingWork: pendingWork,
+            nativeEvent: nativeEvent,
+            declaredPhase: declaredPhase,
+            detail: detail
+        )
+        if let problem = draft.validationProblem() {
+            recordAgentJournalDeliveryFailure(
+                draft: draft,
+                message: "invalid draft: \(problem)",
+                store: store,
+                telemetry: telemetry
+            )
+            return
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(draft),
+              let json = String(data: data, encoding: .utf8) else {
+            recordAgentJournalDeliveryFailure(
+                draft: draft,
+                message: "encode failed",
+                store: store,
+                telemetry: telemetry
+            )
+            return
+        }
+        do {
+            let response = try sendV1Command("agent_journal_append \(json)", client: client)
+            guard response.hasPrefix("OK") else {
+                recordAgentJournalDeliveryFailure(
+                    draft: draft,
+                    message: response,
+                    store: store,
+                    telemetry: telemetry
+                )
+                return
+            }
+        } catch {
+            recordAgentJournalDeliveryFailure(
+                draft: draft,
+                message: String(describing: error),
+                store: store,
+                telemetry: telemetry
+            )
+        }
+    }
+
+    /// Resolves the semantic kind for a generic agent hook's `notification`
+    /// action: the native event name maps first (`StopFailure`,
+    /// `pre_approval_request`, …); only when the mapper has nothing stronger
+    /// than an observation does the prose classifier's verdict fill in, as a
+    /// last-resort adapter detail.
+    func agentJournalNotificationKind(
+        def: AgentHookDef,
+        nativeEvent: String?,
+        toolName: String?,
+        summary: AgentHookNotificationSummary
+    ) -> AgentJournalEventKind {
+        let mapper = AgentSemanticEventMapper()
+        if let nativeEvent, !nativeEvent.isEmpty {
+            let mapped = mapper.kind(source: def.name, nativeEvent: nativeEvent, toolName: toolName)
+            if mapped != .stateChanged {
+                return mapped
+            }
+        }
+        switch summary.status {
+        case .needsInput?:
+            return summary.notifyCategory == .needsPermission ? .approvalRequested : .questionRequested
+        case .error?:
+            return .errorReported
+        case .idle?:
+            return .turnCompleted
+        case nil:
+            return .stateChanged
+        }
+    }
+
+    /// Records a failed journal emission: appended to the bounded dead-letter
+    /// file, warned on stderr, and (when possible) reported through the
+    /// throttled hook-failure channel. Never silent.
+    func recordAgentJournalDeliveryFailure(
+        draft: AgentJournalEventDraft,
+        message: String,
+        store: ClaudeHookSessionStore?,
+        telemetry: CLISocketSentryTelemetry?
+    ) {
+        appendAgentJournalDeadLetter(draft: draft, message: message)
+        cliWriteStderr("Warning: agent journal append failed (\(draft.kind.rawValue)): \(message)\n")
+        if let store, let telemetry {
+            reportAgentHookFailure(
+                stage: .journalAppend,
+                agentName: draft.source,
+                sessionId: draft.sessionId ?? "",
+                event: draft.nativeEvent ?? draft.kind.rawValue,
+                error: nil,
+                store: store,
+                telemetry: telemetry
+            )
+        }
+    }
+
+    /// Dead-letter location: one JSON line per failed emission, bounded by
+    /// truncation so an unreachable app cannot grow it without limit.
+    static func agentJournalDeadLetterURL(env: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        if let override = env["CMUX_AGENT_JOURNAL_DEAD_LETTER_PATH"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("agent-journal-dead-letter.jsonl", isDirectory: false)
+    }
+
+    private func appendAgentJournalDeadLetter(draft: AgentJournalEventDraft, message: String) {
+        let url = Self.agentJournalDeadLetterURL()
+        let maximumBytes: UInt64 = 1_048_576
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if let size = (try? fileManager.attributesOfItem(atPath: url.path)[.size]) as? UInt64,
+               size > maximumBytes {
+                try? fileManager.removeItem(at: url)
+            }
+            var record: [String: Any] = [
+                "at_ms": Int64(Date().timeIntervalSince1970 * 1000),
+                "error": message,
+            ]
+            if let draftData = try? JSONEncoder().encode(draft),
+               let draftObject = try? JSONSerialization.jsonObject(with: draftData) {
+                record["event"] = draftObject
+            }
+            let lineData = try JSONSerialization.data(withJSONObject: record)
+            guard var line = String(data: lineData, encoding: .utf8) else { return }
+            line += "\n"
+            if fileManager.fileExists(atPath: url.path) {
+                let handle = try FileHandle(forWritingTo: url)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: Data(line.utf8))
+            } else {
+                try line.write(to: url, atomically: true, encoding: .utf8)
+            }
+        } catch {
+            // stderr warning above already made the failure visible.
+        }
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31729,6 +31729,23 @@ export default CMUXSessionRestore;
 #endif
                 return target
             }
+            // The ambient workspace claim existed but failed validation
+            // (foreign cmux instance, deleted workspace) and no live TTY or
+            // process evidence repaired it above. The persisted session
+            // record is not ground truth for a caller whose own claim
+            // contradicts it — falling back to it here is exactly the stale
+            // repaint the foreign-env guard exists to prevent. The event
+            // stays journaled as an unattributed diagnostic instead.
+            if hookWsFlag == nil, directWorkspaceArg != nil, resolvedDirectWorkspaceArg == nil {
+#if DEBUG
+                agentHookDebugLog(
+                    "agentHook.target.nil agent=\(def.name) subcommand=\(subcommand) session=\(agentHookDebugShort(sessionId)) reason=uncorroboratedForeignEnv mapped=\(mapped == nil ? 0 : 1)",
+                    socketPath: client.socketPath,
+                    env: env
+                )
+#endif
+                return nil
+            }
             guard let workspaceId = resolveAccessibleWorkspaceId(mapped?.workspaceId) else {
 #if DEBUG
                 agentHookDebugLog(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CMUXAgentLaunch
+import CmuxAgentJournal
 import CmuxFoundation
 import CmuxSettings
 import CmuxSimulator
@@ -3177,13 +3178,6 @@ struct CMUXCLI {
     private static let persistentCloudVMSlotID = "cmux-default-freestyle-sshd-v1"
     private static let persistentCloudVMWorkspaceName = "sshd"
     private static let claudeCodeStatusKey = "claude_code"
-
-    private static var allowedAgentLifecycleStatusKeys: Set<String> {
-        var keys = Set(agentDefs.map(\.statusKey))
-        keys.formUnion(AgentHibernationLifecycleStatusKeys.allowedStatusKeys)
-        keys.insert(claudeCodeStatusKey)
-        return keys
-    }
 
     init(
         args: [String],
@@ -25249,6 +25243,19 @@ struct CMUXCLI {
             ), resolvedTarget.isAuthoritative else {
                 didSendFeedTelemetry = true
                 telemetry.breadcrumb("claude-hook.session-start.unresolved")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .sessionStarted,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "SessionStart",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
@@ -25299,6 +25306,20 @@ struct CMUXCLI {
                 launchCommand: launchCommand,
                 observedPermissionMode: observedHookPermissionMode
             )
+            emitAgentJournalEvent(
+                client: client,
+                kind: .sessionStarted,
+                source: "claude",
+                agentKey: Self.claudeCodeStatusKey,
+                sessionId: acceptedSessionId,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                isSubagent: suppressVisibleMutations,
+                nativeEvent: reportedHookEventName(from: parsedInput) ?? "SessionStart",
+                detail: isClearSessionStart ? "clear-session-start" : nil,
+                store: sessionStore,
+                telemetry: telemetry
+            )
             // SessionStart itself is the process-running signal. Keep ordinary
             // startup/resume visually quiet, but register the PID immediately so
             // later hooks and terminal state are attached to this exact surface.
@@ -25310,13 +25331,6 @@ struct CMUXCLI {
             }
             if isClearSessionStart, !suppressVisibleMutations {
                 _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)\(socketPanelOption(surfaceId))", client: client)
-                setAgentLifecycle(
-                    client: client,
-                    key: Self.claudeCodeStatusKey,
-                    lifecycle: .running,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
                 try setClaudeStatus(
                     client: client,
                     workspaceId: workspaceId,
@@ -25342,6 +25356,19 @@ struct CMUXCLI {
                 ), resolvedTarget.isAuthoritative else {
                     didSendFeedTelemetry = true
                     telemetry.breadcrumb("claude-hook.stop.unresolved")
+                    emitAgentJournalEvent(
+                        client: client,
+                        kind: .turnCompleted,
+                        source: "claude",
+                        agentKey: Self.claudeCodeStatusKey,
+                        sessionId: parsedInput.sessionId,
+                        workspaceId: nil,
+                        surfaceId: nil,
+                        unattributedReason: "target-unresolved",
+                        nativeEvent: reportedHookEventName(from: parsedInput) ?? "Stop",
+                        store: sessionStore,
+                        telemetry: telemetry
+                    )
                     printClaudeHookAck()
                     return
                 }
@@ -25384,12 +25411,42 @@ struct CMUXCLI {
                     telemetry: telemetry
                 ) else {
                     telemetry.breadcrumb("claude-hook.stop.stale")
+                    // A stop from a session that is no longer the pane's
+                    // active session: journal the supersession so the stale
+                    // session stops contributing to the reduced lifecycle.
+                    emitAgentJournalEvent(
+                        client: client,
+                        kind: .sessionEnded,
+                        source: "claude",
+                        agentKey: Self.claudeCodeStatusKey,
+                        sessionId: parsedInput.sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        nativeEvent: reportedHookEventName(from: parsedInput) ?? "Stop",
+                        detail: "superseded-stale",
+                        store: sessionStore,
+                        telemetry: telemetry
+                    )
                     printClaudeHookAck()
                     return
                 }
 
                 guard !suppressVisibleMutations else {
                     telemetry.breadcrumb("claude-hook.stop.nested-suppressed")
+                    emitAgentJournalEvent(
+                        client: client,
+                        kind: .turnCompleted,
+                        source: "claude",
+                        agentKey: Self.claudeCodeStatusKey,
+                        sessionId: parsedInput.sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        isSubagent: true,
+                        pendingWork: hasActiveClaudeBackgroundWork(parsedInput),
+                        nativeEvent: reportedHookEventName(from: parsedInput) ?? "Stop",
+                        store: sessionStore,
+                        telemetry: telemetry
+                    )
                     printClaudeHookAck()
                     return
                 }
@@ -25437,12 +25494,19 @@ struct CMUXCLI {
                     )
                 }
 
-                setAgentLifecycle(
+                emitAgentJournalEvent(
                     client: client,
-                    key: Self.claudeCodeStatusKey,
-                    lifecycle: hasPendingBackgroundWork ? .running : .idle,
+                    kind: .turnCompleted,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
                     workspaceId: workspaceId,
-                    surfaceId: surfaceId
+                    surfaceId: surfaceId,
+                    isSubagent: isNestedAgentSession,
+                    pendingWork: hasPendingBackgroundWork,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "Stop",
+                    store: sessionStore,
+                    telemetry: telemetry
                 )
                 if hasPendingBackgroundWork {
                     // The turn ended but a background task or scheduled wakeup is
@@ -25504,6 +25568,19 @@ struct CMUXCLI {
             ), resolvedTarget.isAuthoritative else {
                 didSendFeedTelemetry = true
                 telemetry.breadcrumb("claude-hook.prompt-submit.unresolved")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .turnStarted,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "UserPromptSubmit",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
@@ -25533,11 +25610,37 @@ struct CMUXCLI {
                 )
             guard shouldApplyPromptSubmit else {
                 telemetry.breadcrumb("claude-hook.prompt-submit.stale")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .sessionEnded,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "UserPromptSubmit",
+                    detail: "superseded-stale",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
             guard !suppressVisibleMutations else {
                 telemetry.breadcrumb("claude-hook.prompt-submit.nested-suppressed")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .turnStarted,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    isSubagent: true,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "UserPromptSubmit",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
@@ -25580,12 +25683,17 @@ struct CMUXCLI {
                 )
             }
             _ = try sendV1Command("clear_notifications --tab=\(workspaceId)\(socketPanelOption(surfaceId))", client: client)
-            setAgentLifecycle(
+            emitAgentJournalEvent(
                 client: client,
-                key: Self.claudeCodeStatusKey,
-                lifecycle: .running,
+                kind: .turnStarted,
+                source: "claude",
+                agentKey: Self.claudeCodeStatusKey,
+                sessionId: parsedInput.sessionId,
                 workspaceId: workspaceId,
-                surfaceId: surfaceId
+                surfaceId: surfaceId,
+                nativeEvent: reportedHookEventName(from: parsedInput) ?? "UserPromptSubmit",
+                store: sessionStore,
+                telemetry: telemetry
             )
             try setClaudeStatus(
                 client: client,
@@ -25655,6 +25763,19 @@ struct CMUXCLI {
             ), resolvedTarget.isAuthoritative else {
                 didSendFeedTelemetry = true
                 telemetry.breadcrumb("claude-hook.notification.unresolved")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .stateChanged,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "Notification",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
@@ -25682,17 +25803,47 @@ struct CMUXCLI {
                 telemetry: telemetry
             ) else {
                 telemetry.breadcrumb("claude-hook.notification.stale")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .sessionEnded,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "Notification",
+                    detail: "superseded-stale",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
             guard !suppressVisibleMutations else {
                 telemetry.breadcrumb("claude-hook.notification.nested-suppressed")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .stateChanged,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    isSubagent: true,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "Notification",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
-            if let mappedSession,
-               let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
-               summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
+            // A payload with no usable message reuses the summary the session
+            // saved at its last meaningful event (question text, plan summary,
+            // stop completion) instead of fabricating a body. The empty-body
+            // marker replaces the old localized-string comparison.
+            if summary.body.isEmpty,
+               let mappedSession,
+               let savedBody = mappedSession.lastBody, !savedBody.isEmpty {
                 summary = (subtitle: mappedSession.lastSubtitle ?? summary.subtitle, body: savedBody)
             }
 
@@ -25766,7 +25917,47 @@ struct CMUXCLI {
                 )
             )
 
-            if let sessionId = parsedInput.sessionId, !suppressNeedsInputState {
+            // Semantic kind for the journal: the structured notification_type
+            // decides first; the prose classifier's verdict is only the
+            // adapter fallback for older clients; nothing ever fabricates a
+            // needs-input state out of an unparseable message.
+            let journalKind: AgentJournalEventKind
+            switch notificationType {
+            case "permission_prompt":
+                journalKind = .approvalRequested
+            case "idle_prompt":
+                journalKind = suppressNeedsInputState ? .stateChanged : .questionRequested
+            default:
+                switch classifiedSubtitle {
+                case "Permission":
+                    journalKind = .approvalRequested
+                case "Waiting":
+                    journalKind = suppressNeedsInputState ? .stateChanged : .questionRequested
+                case "Completed":
+                    journalKind = .turnCompleted
+                case "Error":
+                    journalKind = .errorReported
+                default:
+                    journalKind = summary.body.isEmpty ? .stateChanged : .questionRequested
+                }
+            }
+            emitAgentJournalEvent(
+                client: client,
+                kind: journalKind,
+                source: "claude",
+                agentKey: Self.claudeCodeStatusKey,
+                sessionId: parsedInput.sessionId,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                isSubagent: isNestedAgentSession,
+                pendingWork: notifyPending,
+                nativeEvent: reportedHookEventName(from: parsedInput) ?? "Notification",
+                store: sessionStore,
+                telemetry: telemetry
+            )
+            let recordsNeedsInput = journalKind == .approvalRequested
+                || journalKind == .questionRequested
+            if let sessionId = parsedInput.sessionId, recordsNeedsInput, !summary.body.isEmpty {
                 _ = try? sessionStore.upsert(
                     sessionId: sessionId,
                     workspaceId: workspaceId,
@@ -25779,14 +25970,7 @@ struct CMUXCLI {
                 )
             }
 
-            if !suppressNeedsInputState {
-                setAgentLifecycle(
-                    client: client,
-                    key: Self.claudeCodeStatusKey,
-                    lifecycle: .needsInput,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
+            if recordsNeedsInput {
                 _ = try? setClaudeStatus(
                     client: client,
                     workspaceId: workspaceId,
@@ -25796,7 +25980,11 @@ struct CMUXCLI {
                     color: "#4C8DFF", pid: claudePid
                 )
             }
-            _ = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
+            // A notification with nothing to show is state signal only: the
+            // journal recorded it; no banner is fabricated for it.
+            if !summary.body.isEmpty {
+                _ = try sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
+            }
             printClaudeHookAck()
         case "push-notification": try runClaudePushNotificationHook(client: client, telemetry: telemetry, parsedInput: parsedInput, sessionStore: sessionStore, routing: hookRouting, markFeedTelemetryHandled: { didSendFeedTelemetry = true }, sendFeedTelemetry: sendClaudeFeedTelemetry)
         case "session-end":
@@ -25822,6 +26010,19 @@ struct CMUXCLI {
                 // can still clear the visible state this attempt could not.
                 didSendFeedTelemetry = true
                 telemetry.breadcrumb("claude-hook.session-end.unresolved")
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .sessionEnded,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: parsedInput.sessionId,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "SessionEnd",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 printClaudeHookAck()
                 return
             }
@@ -25848,6 +26049,18 @@ struct CMUXCLI {
                     workspaceId = consumedSession.workspaceId
                     cleanupSurfaceId = consumedSession.surfaceId
                 }
+                emitAgentJournalEvent(
+                    client: client,
+                    kind: .sessionEnded,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: consumedSession.sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: cleanupSurfaceId,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "SessionEnd",
+                    store: sessionStore,
+                    telemetry: telemetry
+                )
                 if !clearAgentSurfaceResumeBinding(
                     client: client,
                     workspaceId: workspaceId,
@@ -26017,12 +26230,18 @@ struct CMUXCLI {
                     lastSubtitle: waitingSubtitle,
                     lastBody: needsInputBody
                 )
-                setAgentLifecycle(
+                emitAgentJournalEvent(
                     client: client,
-                    key: Self.claudeCodeStatusKey,
-                    lifecycle: .needsInput,
+                    kind: toolName == "AskUserQuestion" ? .questionRequested : .planReviewRequested,
+                    source: "claude",
+                    agentKey: Self.claudeCodeStatusKey,
+                    sessionId: sessionId,
                     workspaceId: workspaceId,
-                    surfaceId: existingSurfaceId
+                    surfaceId: existingSurfaceId,
+                    isSubagent: isNestedAgentSession,
+                    nativeEvent: reportedHookEventName(from: parsedInput) ?? "PreToolUse",
+                    store: sessionStore,
+                    telemetry: telemetry
                 )
                 // In bypassPermissions (--dangerously-skip-permissions) mode no
                 // PermissionRequest or Notification hook follows, so this handler must
@@ -26086,12 +26305,18 @@ struct CMUXCLI {
                 )
             }
             _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)\(socketPanelOption(surfaceId))", client: client)
-            setAgentLifecycle(
+            emitAgentJournalEvent(
                 client: client,
-                key: Self.claudeCodeStatusKey,
-                lifecycle: .running,
+                kind: .turnStarted,
+                source: "claude",
+                agentKey: Self.claudeCodeStatusKey,
+                sessionId: parsedInput.sessionId,
                 workspaceId: workspaceId,
-                surfaceId: surfaceId
+                surfaceId: surfaceId,
+                isSubagent: isNestedAgentSession,
+                nativeEvent: reportedHookEventName(from: parsedInput) ?? "PreToolUse",
+                store: sessionStore,
+                telemetry: telemetry
             )
 
             let statusValue: String
@@ -26174,27 +26399,6 @@ struct CMUXCLI {
             cmd += " --pid=\(pid)"
         }
         _ = try client.send(command: cmd)
-    }
-
-    private func setAgentLifecycle(
-        client: SocketClient,
-        key: String,
-        lifecycle: AgentHibernationLifecycleState,
-        workspaceId: String,
-        surfaceId: String?
-    ) {
-        guard Self.allowedAgentLifecycleStatusKeys.contains(key) else {
-            cliWriteStderr("Warning: unsupported agent lifecycle key\n")
-            return
-        }
-        do {
-            _ = try sendV1Command(
-                "set_agent_lifecycle \(key) \(lifecycle.rawValue) --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
-                client: client
-            )
-        } catch {
-            cliWriteStderr("Warning: failed to set agent lifecycle\n")
-        }
     }
 
     private func runAgentHibernation(
@@ -28181,7 +28385,10 @@ struct CMUXCLI {
             if let fallback = parsedInput.rawFallback, !fallback.isEmpty {
                 return classifyClaudeNotification(signal: fallback, message: fallback)
             }
-            return ("Waiting", "Claude is waiting for your input")
+            // No payload at all: nothing to say. An empty body tells the
+            // caller to reuse the stored session summary or skip the banner —
+            // never to fabricate a needs-attention message.
+            return ("Waiting", "")
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
@@ -28194,7 +28401,7 @@ struct CMUXCLI {
             firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
             firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
         ]
-        let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
+        let message = messageCandidates.compactMap { $0 }.first ?? ""
         let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
         var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
@@ -28219,11 +28426,9 @@ struct CMUXCLI {
                     isFallback: false
                 )
             }
-            let body = String.localizedStringWithFormat(
-                String(localized: "agent.generic.notification.body.sentNotification", defaultValue: "%@ sent a notification"),
-                def.displayName
-            )
-            return classifyAgentHookNotification(def: def, signal: "", message: body, isFallback: true)
+            // No payload: an empty body tells the caller to reuse the stored
+            // session summary or skip the banner — never to fabricate one.
+            return classifyAgentHookNotification(def: def, signal: "", message: "", isFallback: true)
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
@@ -28238,11 +28443,7 @@ struct CMUXCLI {
             firstString(in: nested, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
             firstString(in: extra, keys: ["message", "body", "text", "prompt", "summary", "description", "error", "title"]),
         ]
-        let fallbackBody = String.localizedStringWithFormat(
-            String(localized: "agent.generic.notification.body.sentNotification", defaultValue: "%@ sent a notification"),
-            def.displayName
-        )
-        let message = messageCandidates.compactMap { $0 }.first ?? fallbackBody
+        let message = messageCandidates.compactMap { $0 }.first ?? ""
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
         let normalizedMessage = normalizedSingleLine(message)
         if let hermesApprovalMessage = hermesAgentApprovalNotificationMessage(def: def, object: object) {
@@ -28277,7 +28478,7 @@ struct CMUXCLI {
             def: def,
             signal: signal,
             message: normalizedMessage,
-            isFallback: message == fallbackBody
+            isFallback: normalizedMessage.isEmpty
         )
     }
 
@@ -28524,11 +28725,15 @@ struct CMUXCLI {
             let body = message.isEmpty ? "Waiting for input" : message
             return ("Waiting", body)
         }
-        // Use the message directly if it's meaningful (not a generic placeholder).
-        if !message.isEmpty, message != "Claude needs your input" {
+        // Use the message directly when there is one. A payload with no
+        // usable message yields an empty body: callers reuse the stored
+        // session summary or skip the banner. The old "Claude needs your
+        // attention" fabrication (and the needs-input state it implied) is
+        // deliberately gone — an unparseable message is not a signal.
+        if !message.isEmpty {
             return ("Attention", message)
         }
-        return ("Attention", "Claude needs your attention")
+        return ("Attention", "")
     }
 
     private func sanitizeNotificationField(_ value: String) -> String {
@@ -31223,6 +31428,38 @@ export default CMUXSessionRestore;
         }
         let pidKey = "\(def.statusKey).\(sessionId.isEmpty ? "default" : sessionId)"
         var didSendFeedTelemetry = false
+        // One structured semantic event per hook invocation: the append-only
+        // agent journal is what the sidebar reduces lifecycle state from, so
+        // every action lane below emits exactly one of these (attributed to
+        // the resolved target, or explicitly unattributed as a diagnostic).
+        func emitJournal(
+            _ kind: AgentJournalEventKind,
+            workspaceId: String?,
+            surfaceId: String?,
+            unattributedReason: String? = nil,
+            isSubagent: Bool = false,
+            pendingWork: Bool = false,
+            declaredPhase: AgentLifecyclePhase? = nil,
+            detail: String? = nil
+        ) {
+            emitAgentJournalEvent(
+                client: client,
+                kind: kind,
+                source: def.name,
+                agentKey: def.statusKey,
+                sessionId: sessionId.isEmpty ? nil : sessionId,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                unattributedReason: unattributedReason,
+                isSubagent: isSubagent,
+                pendingWork: pendingWork,
+                nativeEvent: reportedHookEventName(from: input) ?? subcommand,
+                declaredPhase: declaredPhase,
+                detail: detail,
+                store: store,
+                telemetry: telemetry
+            )
+        }
         // Destructive session teardown shared by a genuine (non-turn-boundary)
         // `session-end` and the dedicated `session-finalize` action: consume the
         // restore record, clear the surface resume binding, and clear PID routing.
@@ -31523,6 +31760,7 @@ export default CMUXSessionRestore;
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
+                emitJournal(.sessionStarted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true
                 print("{}")
                 return
@@ -31651,12 +31889,11 @@ export default CMUXSessionRestore;
                     client: client
                 )
             }
-            setAgentLifecycle(
-                client: client,
-                key: def.statusKey,
-                lifecycle: .unknown,
+            emitJournal(
+                .sessionStarted,
                 workspaceId: workspaceId,
-                surfaceId: surfaceId
+                surfaceId: surfaceId,
+                isSubagent: suppressVisibleMutations
             )
             if !suppressVisibleMutations {
                 if let owner = try? store.lookup(sessionId: sessionId) {
@@ -31674,6 +31911,7 @@ export default CMUXSessionRestore;
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
+                emitJournal(.turnStarted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true
                 print("{}")
                 return
@@ -31726,48 +31964,44 @@ export default CMUXSessionRestore;
                     transcriptPath: latest.transcriptPath,
                     telemetry: telemetry
                 )
-                if let lifecycle = latest.agentLifecycle {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: lifecycle,
+                // A stale prompt-submit may have journaled a spurious
+                // turn-started before the turn was recognized as terminal.
+                // Assert the store's known-good phase explicitly so the
+                // reduced lifecycle converges back.
+                let correctedPhase: AgentLifecyclePhase?
+                switch latest.runtimeStatus {
+                case .running?: correctedPhase = .running
+                case .idle?: correctedPhase = .idle
+                case .needsInput?: correctedPhase = .needsInput
+                case .error?: correctedPhase = .error
+                case nil:
+                    switch latest.agentLifecycle {
+                    case .running?: correctedPhase = .running
+                    case .idle?: correctedPhase = .idle
+                    case .needsInput?: correctedPhase = .needsInput
+                    case .unknown?: correctedPhase = .unknown
+                    case nil: correctedPhase = nil
+                    }
+                }
+                if let correctedPhase {
+                    emitJournal(
+                        .stateChanged,
                         workspaceId: workspaceId,
-                        surfaceId: surfaceId
+                        surfaceId: surfaceId,
+                        declaredPhase: correctedPhase,
+                        detail: "stale-turn-corrected"
                     )
                 }
                 switch latest.runtimeStatus {
                 case .running?:
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .running,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     let runningStatus = String(localized: "agent.generic.status.running", defaultValue: "Running")
                     _ = try? sendV1Command(
                         "set_status \(def.statusKey) \(runningStatus) --icon=bolt.fill --color=#4C8DFF --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
                         client: client
                     )
                 case .idle?:
-                    if !hasNewerRunningSession(workspaceId: workspaceId, surfaceId: surfaceId) {
-                        setAgentLifecycle(
-                            client: client,
-                            key: def.statusKey,
-                            lifecycle: .idle,
-                            workspaceId: workspaceId,
-                            surfaceId: surfaceId
-                        )
-                    }
                     setIdleStatusUnlessAnotherSessionIsRunning(workspaceId: workspaceId, surfaceId: surfaceId)
                 case .needsInput?:
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .needsInput,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     let statusValue = String.localizedStringWithFormat(
                         String(localized: "agent.generic.notification.status.needsInput", defaultValue: "%@ needs input"),
                         def.displayName
@@ -31777,13 +32011,6 @@ export default CMUXSessionRestore;
                         client: client
                     )
                 case .error?:
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .needsInput,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     let statusValue = String.localizedStringWithFormat(
                         String(localized: "agent.generic.notification.status.error", defaultValue: "%@ error"),
                         def.displayName
@@ -31952,13 +32179,7 @@ export default CMUXSessionRestore;
                     stopStaleCodexPromptSubmit()
                     return
                 }
-                setAgentLifecycle(
-                    client: client,
-                    key: def.statusKey,
-                    lifecycle: .running,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
+                emitJournal(.turnStarted, workspaceId: workspaceId, surfaceId: surfaceId)
                 if codexPromptTurnWentTerminal() {
                     stopStaleCodexPromptSubmit(restoreVisibleState: true)
                     return
@@ -31978,6 +32199,12 @@ export default CMUXSessionRestore;
                 }
             } else {
                 telemetry.breadcrumb("\(def.name)-hook.prompt-submit.nested-suppressed")
+                emitJournal(
+                    .turnStarted,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    isSubagent: true
+                )
             }
             if def.name == "codex", !sessionId.isEmpty, !suppressVisibleMutations {
                 if codexPromptTurnWentTerminal() {
@@ -32027,6 +32254,7 @@ export default CMUXSessionRestore;
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
+                emitJournal(.turnCompleted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true
                 print("{}")
                 return
@@ -32199,6 +32427,20 @@ export default CMUXSessionRestore;
             let suppressCompletionNotification = suppressVisibleMutations
                 || codexSubagentSignals.hasSubagentNotificationRelay
 
+            // The journal records the turn boundary unconditionally: the
+            // reducer's per-session fold handles stale sessions (a newer
+            // running session outranks this one) and subagent tagging keeps
+            // nested sessions off the pane badge — no emit-side guessing.
+            let stopHadFailure = codexFailure != nil || antigravityFailure != nil
+            emitJournal(
+                stopHadFailure ? .errorReported : .turnCompleted,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                isSubagent: isNestedAgentSession,
+                pendingWork: antigravityHasActiveBackgroundWork,
+                detail: stopHadFailure ? body : nil
+            )
+
             if !sessionId.isEmpty, !suppressVisibleMutations {
                 _ = try? store.upsert(sessionId: sessionId, workspaceId: workspaceId, surfaceId: surfaceId, cwd: cwd,
                                   transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
@@ -32316,25 +32558,11 @@ export default CMUXSessionRestore;
             }
             if !suppressVisibleMutations {
                 if let codexFailure {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .needsInput,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     _ = try? sendV1Command(
                         "set_status \(def.statusKey) \(codexFailure.statusValue) --icon=exclamationmark.triangle.fill --color=#FF453A --priority=100 --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
                         client: client
                     )
                 } else if antigravityFailure != nil {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .needsInput,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     let statusValue = String.localizedStringWithFormat(
                         String(localized: "agent.generic.notification.status.error", defaultValue: "%@ error"),
                         def.displayName
@@ -32344,26 +32572,12 @@ export default CMUXSessionRestore;
                         client: client
                     )
                 } else if antigravityHasActiveBackgroundWork {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .running,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     let runningStatus = String(localized: "agent.generic.status.running", defaultValue: "Running")
                     _ = try? sendV1Command(
                         "set_status \(def.statusKey) \(runningStatus) --icon=bolt.fill --color=#4C8DFF --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
                         client: client
                     )
                 } else {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .idle,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
                     setIdleStatusUnlessAnotherSessionIsRunning(workspaceId: workspaceId, surfaceId: surfaceId)
                 }
             }
@@ -32396,6 +32610,13 @@ export default CMUXSessionRestore;
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
+                emitJournal(
+                    .turnStarted,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    detail: "approval-response"
+                )
                 didSendFeedTelemetry = true
                 print("{}")
                 return
@@ -32446,14 +32667,16 @@ export default CMUXSessionRestore;
                     client: client
                 )
             }
+            // An approval response resumes the blocked turn: journal it as the
+            // turn running again.
+            emitJournal(
+                .turnStarted,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                isSubagent: suppressVisibleMutations,
+                detail: "approval-response"
+            )
             if !suppressVisibleMutations {
-                setAgentLifecycle(
-                    client: client,
-                    key: def.statusKey,
-                    lifecycle: .running,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
                 _ = try? sendV1Command(
                     "clear_notifications --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
                     client: client
@@ -32471,6 +32694,7 @@ export default CMUXSessionRestore;
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
+                emitJournal(.stateChanged, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true
                 print("{}")
                 return
@@ -32496,6 +32720,12 @@ export default CMUXSessionRestore;
                         env: env
                     )
 #endif
+                    emitJournal(
+                        .stateChanged,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        detail: "grok-internal-notification"
+                    )
                     print("{}")
                     return
                 }
@@ -32508,18 +32738,18 @@ export default CMUXSessionRestore;
                 env: env,
                 sessionId: input.sessionId ?? sessionId
             )
-            if summary.isFallback, let savedBody = mapped?.lastBody, !savedBody.isEmpty {
-                // Rebuilt from the stored session record: a stale .idle status is
-                // still a completion re-notification, so keep it under the
-                // "Agent Finished" gate. A stale non-idle status cannot
-                // distinguish permission from waiting; the fresh permission
-                // alert already delivered, so re-notifications gate as waiting.
+            if summary.body.isEmpty, let savedBody = mapped?.lastBody, !savedBody.isEmpty {
+                // A notification with no usable message reuses the stored
+                // session summary for DISPLAY only: no lifecycle status is
+                // adopted from stale disk state (the journal event decides
+                // state), and when there is no stored summary either the
+                // banner is skipped rather than fabricated.
                 summary = AgentHookNotificationSummary(
                     subtitle: mapped?.lastSubtitle ?? summary.subtitle,
                     body: savedBody,
-                    status: mapped?.lastNotificationStatus,
+                    status: nil,
                     isFallback: false,
-                    notifyCategory: mapped?.lastNotificationStatus == .idle ? .turnComplete : .idleReminder
+                    notifyCategory: .idleReminder
                 )
             }
             let antigravitySuppressDuplicateIdleWhileBackgroundWork = def.name == "antigravity"
@@ -32563,6 +32793,12 @@ export default CMUXSessionRestore;
                     env: env
                 )
 #endif
+                emitJournal(
+                    .turnCompleted,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    pendingWork: true
+                )
                 sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
                 print("{}")
                 return
@@ -32581,6 +32817,12 @@ export default CMUXSessionRestore;
                     env: env
                 )
 #endif
+                emitJournal(
+                    .turnCompleted,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    pendingWork: true
+                )
                 sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
                 print("{}")
                 return
@@ -32596,6 +32838,14 @@ export default CMUXSessionRestore;
                     env: env
                 )
 #endif
+                // The stale session's completion is still a fact; the
+                // reducer's per-session combine keeps the newer running
+                // session in charge of the pane badge.
+                emitJournal(
+                    .turnCompleted,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
                 sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
                 print("{}")
                 return
@@ -32657,12 +32907,35 @@ export default CMUXSessionRestore;
                 }
             }
 
+            // Journal the semantic event: the native hook event name maps
+            // first; the prose classifier's verdict is only the adapter
+            // fallback, and a pending waiting-nag never claims needs-input.
+            let mappedJournalKind = agentJournalNotificationKind(
+                def: def,
+                nativeEvent: reportedHookEventName(from: input),
+                toolName: nil,
+                summary: summary
+            )
+            let notificationJournalKind: AgentJournalEventKind =
+                suppressPendingWaitingState
+                    && (mappedJournalKind == .approvalRequested || mappedJournalKind == .questionRequested)
+                    ? .stateChanged
+                    : mappedJournalKind
+            emitJournal(
+                notificationJournalKind,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                pendingWork: (summary.notifyCategory == .turnComplete || summary.notifyCategory == .idleReminder)
+                    && hasActiveAntigravityBackgroundWork(),
+                detail: notificationJournalKind == .errorReported ? summary.body : nil
+            )
+
             let notificationFingerprint = notificationDedupeFingerprint(
                 status: summary.status,
                 category: summary.notifyCategory,
                 body: summary.body
             )
-            if shouldSendNotification(fingerprint: notificationFingerprint) {
+            if !summary.body.isEmpty, shouldSendNotification(fingerprint: notificationFingerprint) {
                 // One ancestry walk per delivered notification, feeding the
                 // notify payload's subagent tag below.
                 let notificationEventPID = preferredAgentHookEventPID(
@@ -32734,17 +33007,10 @@ export default CMUXSessionRestore;
 
             switch summary.status {
             case .needsInput? where suppressPendingWaitingState:
-                // Suppressed pending waiting cue: leave the Running pill and
-                // lifecycle in place; the fullyIdle turn boundary reconciles.
+                // Suppressed pending waiting cue: leave the Running pill in
+                // place; the fullyIdle turn boundary reconciles.
                 break
             case .needsInput?:
-                setAgentLifecycle(
-                    client: client,
-                    key: def.statusKey,
-                    lifecycle: .needsInput,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
                 let statusValue = String.localizedStringWithFormat(
                     String(localized: "agent.generic.notification.status.needsInput", defaultValue: "%@ needs input"),
                     def.displayName
@@ -32754,13 +33020,6 @@ export default CMUXSessionRestore;
                     client: client
                 )
             case .error?:
-                setAgentLifecycle(
-                    client: client,
-                    key: def.statusKey,
-                    lifecycle: .needsInput,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId
-                )
                 let statusValue = String.localizedStringWithFormat(
                     String(localized: "agent.generic.notification.status.error", defaultValue: "%@ error"),
                     def.displayName
@@ -32770,15 +33029,6 @@ export default CMUXSessionRestore;
                     client: client
                 )
             case .idle?:
-                if !hasNewerRunningSession(workspaceId: workspaceId, surfaceId: surfaceId) {
-                    setAgentLifecycle(
-                        client: client,
-                        key: def.statusKey,
-                        lifecycle: .idle,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId
-                    )
-                }
                 setIdleStatusUnlessAnotherSessionIsRunning(workspaceId: workspaceId, surfaceId: surfaceId)
             case nil:
                 break
@@ -32791,6 +33041,15 @@ export default CMUXSessionRestore;
             }
             if def.sessionEndIsTurnBoundary {
                 if let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId)) {
+                    // These providers use session-end as their per-turn
+                    // boundary (the cmux-tui mapping table's antigravity /
+                    // hermes special case), so it journals as a completed
+                    // turn, not a session teardown.
+                    emitJournal(
+                        .turnCompleted,
+                        workspaceId: mapped.workspaceId,
+                        surfaceId: mapped.surfaceId
+                    )
                     sendAgentFeedTelemetry(workspaceId: mapped.workspaceId, surfaceId: mapped.surfaceId)
                     _ = try? store.recordPromptStop(
                         sessionId: sessionId,
@@ -32820,9 +33079,19 @@ export default CMUXSessionRestore;
                 break
             }
             // A non-turn-boundary session-end is a genuine teardown.
+            if let ending = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId)) {
+                emitJournal(.sessionEnded, workspaceId: ending.workspaceId, surfaceId: ending.surfaceId)
+            } else {
+                emitJournal(.sessionEnded, workspaceId: nil, surfaceId: nil, unattributedReason: "session-unknown")
+            }
             performAgentSessionTeardown()
 
         case .sessionFinalize:
+            if let ending = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId)) {
+                emitJournal(.sessionEnded, workspaceId: ending.workspaceId, surfaceId: ending.surfaceId)
+            } else {
+                emitJournal(.sessionEnded, workspaceId: nil, surfaceId: nil, unattributedReason: "session-unknown")
+            }
             performAgentSessionTeardown()
 
         case .noop:

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32738,6 +32738,7 @@ export default CMUXSessionRestore;
                 env: env,
                 sessionId: input.sessionId ?? sessionId
             )
+            var rebuiltFromStoredSummary = false
             if summary.body.isEmpty, let savedBody = mapped?.lastBody, !savedBody.isEmpty {
                 // A notification with no usable message reuses the stored
                 // session summary for DISPLAY only: no lifecycle status is
@@ -32751,6 +32752,7 @@ export default CMUXSessionRestore;
                     isFallback: false,
                     notifyCategory: .idleReminder
                 )
+                rebuiltFromStoredSummary = true
             }
             let antigravitySuppressDuplicateIdleWhileBackgroundWork = def.name == "antigravity"
                 && summary.status == .idle
@@ -32773,7 +32775,10 @@ export default CMUXSessionRestore;
             )
 #endif
 
-            if def.name == "grok", summary.status == nil {
+            // A rebuilt stored summary is an intentional re-notification, not
+            // grok notification noise: it bypasses the nil-status filter (the
+            // rebuilt summary deliberately claims no lifecycle status).
+            if def.name == "grok", summary.status == nil, !rebuiltFromStoredSummary {
 #if DEBUG
                 agentHookDebugLog(
                     "agentHook.notification.skip agent=\(def.name) session=\(agentHookDebugShort(sessionId)) reason=nonTerminalNotification subtitleLen=\(summary.subtitle.count) bodyLen=\(summary.body.count)",

--- a/Packages/macOS/CmuxAgentJournal/Package.swift
+++ b/Packages/macOS/CmuxAgentJournal/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CmuxAgentJournal",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxAgentJournal",
+            targets: ["CmuxAgentJournal"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxAgentJournal",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxAgentJournalTests",
+            dependencies: ["CmuxAgentJournal"]
+        ),
+    ]
+)

--- a/Packages/macOS/CmuxAgentJournal/README.md
+++ b/Packages/macOS/CmuxAgentJournal/README.md
@@ -1,0 +1,49 @@
+# CmuxAgentJournal
+
+Journal-backed sidebar agent lifecycle: an append-only, replayable log of
+semantic agent events, plus the deterministic reducer that derives
+Running / NeedsInput / Idle / Error for the sidebar from it.
+
+The design is a Swift port of the cmux-tui session journal
+(`cmux-tui/crates/cmux-tui-core/`): the same 12 `agent.*` semantic kinds, the
+same normalized-key native-event mapping, an append-only SQLite table with a
+monotonic sequence and immutability triggers, and idempotent appends keyed by
+event id so producer retries replay the original receipt.
+
+## Pieces
+
+- `AgentJournalEventKind` — the 12 semantic `agent.*` kinds.
+- `AgentSemanticEventMapper` — native hook event name → semantic kind
+  (normalized-key matching; per-source special cases for antigravity,
+  hermes-agent, opencode, and the copilot/codebuddy/factory trio).
+- `AgentJournalEventDraft` / `AgentJournalEvent` — the wire draft (the
+  `agent_journal_append` socket verb payload) and the committed record.
+- `AgentJournalStore` — append-only SQLite store with durable append
+  receipts, sequence-ordered reads, restore-time identity alias tables, and
+  bounded open-time retention.
+- `AgentLifecycleReducer` / `AgentLifecycleReducerState` — the deterministic
+  fold: per-session newest-event-wins (drop duplicates and stale
+  out-of-order arrivals), surface phase = precedence combine over live
+  sessions. Unattributed events become bounded diagnostics, never guessed
+  state.
+- `AgentLifecycleSnapshot` / `AgentLifecycleAssignment` — the combined view
+  and the diff the app applies to `Workspace.setAgentLifecycle`.
+- `AgentJournalReplayPolicy` — what a relaunch may repaint from history
+  (needsInput/error survive; running/idle/unknown wait for live evidence).
+
+## Testing
+
+Everything is constructor-injected and runs headless:
+
+```swift
+let store = try AgentJournalStore(databaseURL: temporaryURL)
+let outcome = try store.append(draft)          // durable receipt
+var state = AgentLifecycleReducerState()
+let reducer = AgentLifecycleReducer()
+for event in try store.events(afterSequence: 0, limit: 1024) {
+    reducer.apply(event, to: &state)
+}
+let assignments = state.snapshot().assignments(since: previousSnapshot)
+```
+
+`swift test --package-path Packages/macOS/CmuxAgentJournal`

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalAliasResolver.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalAliasResolver.swift
@@ -1,0 +1,61 @@
+/// In-memory alias-chain resolver over the journal's restore identity maps.
+///
+/// A replay fold canonicalizes every event's workspace/surface identity; doing
+/// that through per-event SQL lookups costs two round-trips per event, so the
+/// consumer loads the (tiny) alias tables once and resolves chains here.
+/// Semantics match ``AgentJournalStore/resolvedSurfaceId(_:)``: chains are
+/// followed up to ``AgentJournalStore/maximumAliasChainLength`` hops, and a
+/// recorded cycle fails closed with `nil`.
+public struct AgentJournalAliasResolver: Sendable, Equatable {
+    /// Old workspace UUID string → new workspace UUID string.
+    public private(set) var workspaces: [String: String]
+    /// Old surface UUID string → new surface UUID string.
+    public private(set) var surfaces: [String: String]
+
+    /// Creates a resolver over the given maps.
+    ///
+    /// - Parameters:
+    ///   - workspaces: Old workspace UUID string → new workspace UUID string.
+    ///   - surfaces: Old surface UUID string → new surface UUID string.
+    public init(workspaces: [String: String] = [:], surfaces: [String: String] = [:]) {
+        self.workspaces = workspaces
+        self.surfaces = surfaces
+    }
+
+    /// Merges freshly recorded aliases into the resolver.
+    ///
+    /// - Parameters:
+    ///   - workspaces: Newly recorded workspace aliases.
+    ///   - surfaces: Newly recorded surface aliases.
+    public mutating func merge(workspaces: [String: String], surfaces: [String: String]) {
+        self.workspaces.merge(workspaces) { _, new in new }
+        self.surfaces.merge(surfaces) { _, new in new }
+    }
+
+    /// Resolves a surface identity through the chain.
+    ///
+    /// - Parameter surfaceId: The (possibly stale) surface UUID string.
+    /// - Returns: The current identity, or `nil` on a recorded cycle.
+    public func resolvedSurfaceId(_ surfaceId: String) -> String? {
+        Self.resolve(surfaceId, in: surfaces)
+    }
+
+    /// Resolves a workspace identity through the chain.
+    ///
+    /// - Parameter workspaceId: The (possibly stale) workspace UUID string.
+    /// - Returns: The current identity, or `nil` on a recorded cycle.
+    public func resolvedWorkspaceId(_ workspaceId: String) -> String? {
+        Self.resolve(workspaceId, in: workspaces)
+    }
+
+    private static func resolve(_ identifier: String, in map: [String: String]) -> String? {
+        var current = identifier
+        var hops = 0
+        while hops < AgentJournalStore.maximumAliasChainLength {
+            guard let next = map[current], next != current else { return current }
+            current = next
+            hops += 1
+        }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalAppendOutcome.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalAppendOutcome.swift
@@ -1,0 +1,25 @@
+/// Durable acknowledgement returned by ``AgentJournalStore/append(_:committedAt:)``.
+///
+/// Mirrors the cmux-tui journal's commit receipt: a replayed append (same
+/// `event_id` seen before) returns the original sequence instead of writing a
+/// second record, so producer retries are idempotent.
+public struct AgentJournalAppendOutcome: Sendable, Equatable {
+    /// The committed (or previously committed) journal sequence.
+    public let sequence: Int64
+    /// Commit timestamp of the (original) record, ms since the Unix epoch.
+    public let committedAtMs: Int64
+    /// Whether this append deduplicated against an existing record.
+    public let replayed: Bool
+
+    /// Creates an outcome.
+    ///
+    /// - Parameters:
+    ///   - sequence: The committed journal sequence.
+    ///   - committedAtMs: Commit timestamp of the (original) record.
+    ///   - replayed: Whether the append deduplicated against an existing record.
+    public init(sequence: Int64, committedAtMs: Int64, replayed: Bool) {
+        self.sequence = sequence
+        self.committedAtMs = committedAtMs
+        self.replayed = replayed
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalDatabase.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalDatabase.swift
@@ -1,0 +1,139 @@
+internal import Foundation
+internal import SQLite3
+
+/// Thin owner of one raw `sqlite3` connection plus prepared-statement helpers
+/// (mirrors `CmuxSyncStore`'s `SyncDatabase` binder).
+///
+/// The raw `OpaquePointer` handle is private to this file, so the store's
+/// serialization invariant cannot be violated by a stray helper.
+/// `AgentJournalStore` guards every call with its own lock and additionally
+/// opens the connection `SQLITE_OPEN_FULLMUTEX`; this type is therefore
+/// `@unchecked Sendable`: it is only ever touched under the owning store's
+/// lock (and the owner's `close()` tears it down), never shared concurrently.
+final class AgentJournalDatabase: @unchecked Sendable {
+    enum BindValue {
+        case text(String)
+        case int(Int64)
+        case null
+
+        static func optionalText(_ value: String?) -> BindValue {
+            value.map { .text($0) } ?? .null
+        }
+    }
+
+    private let handle: OpaquePointer
+
+    init(path: String) throws {
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let rc = sqlite3_open_v2(path, &handle, flags, nil)
+        guard rc == SQLITE_OK, let handle else {
+            if let handle { sqlite3_close_v2(handle) }
+            throw AgentJournalStoreError.openFailed(rc)
+        }
+        // WAL for concurrent-reader friendliness; FULL synchronous so the
+        // append acknowledgement returned to the hook emitter is durable.
+        for pragma in [
+            "PRAGMA busy_timeout = 5000;",
+            "PRAGMA foreign_keys = ON;",
+            "PRAGMA journal_mode = WAL;",
+            "PRAGMA synchronous = FULL;",
+        ] {
+            let prc = sqlite3_exec(handle, pragma, nil, nil, nil)
+            guard prc == SQLITE_OK else {
+                sqlite3_close_v2(handle)
+                throw AgentJournalStoreError.stepFailed(prc, "")
+            }
+        }
+        self.handle = handle
+    }
+
+    func close() {
+        sqlite3_close_v2(handle)
+    }
+
+    /// Prepare a statement, throwing `.prepareFailed` on error. The caller
+    /// owns finalizing it (`defer { sqlite3_finalize(stmt) }`).
+    func prepare(_ sql: String) throws -> OpaquePointer? {
+        var statement: OpaquePointer?
+        let rc = sqlite3_prepare_v2(handle, sql, -1, &statement, nil)
+        guard rc == SQLITE_OK else {
+            throw AgentJournalStoreError.prepareFailed(rc, lastErrorMessage())
+        }
+        return statement
+    }
+
+    func exec(_ sql: String, binding parameters: [BindValue] = []) throws {
+        if parameters.isEmpty {
+            let rc = sqlite3_exec(handle, sql, nil, nil, nil)
+            guard rc == SQLITE_OK else {
+                throw AgentJournalStoreError.stepFailed(rc, lastErrorMessage())
+            }
+            return
+        }
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        statement = try prepare(sql)
+        try bind(statement: statement, parameters: parameters)
+        let step = sqlite3_step(statement)
+        guard step == SQLITE_DONE || step == SQLITE_ROW else {
+            throw AgentJournalStoreError.stepFailed(step, lastErrorMessage())
+        }
+    }
+
+    func bind(statement: OpaquePointer?, parameters: [BindValue]) throws {
+        for (index, value) in parameters.enumerated() {
+            let position = Int32(index + 1)
+            let rc: Int32
+            switch value {
+            case .text(let string):
+                rc = string.withCString { pointer in
+                    sqlite3_bind_text(
+                        statement,
+                        position,
+                        pointer,
+                        -1,
+                        unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+                    )
+                }
+            case .int(let integer):
+                rc = sqlite3_bind_int64(statement, position, integer)
+            case .null:
+                rc = sqlite3_bind_null(statement, position)
+            }
+            guard rc == SQLITE_OK else {
+                throw AgentJournalStoreError.stepFailed(rc, lastErrorMessage())
+            }
+        }
+    }
+
+    func transaction<Result>(_ block: () throws -> Result) throws -> Result {
+        try exec("BEGIN IMMEDIATE;")
+        do {
+            let result = try block()
+            try exec("COMMIT;")
+            return result
+        } catch {
+            _ = sqlite3_exec(handle, "ROLLBACK;", nil, nil, nil)
+            throw error
+        }
+    }
+
+    func columnText(_ statement: OpaquePointer?, _ index: Int32) -> String? {
+        guard let cString = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: cString)
+    }
+
+    func columnInt64(_ statement: OpaquePointer?, _ index: Int32) -> Int64 {
+        sqlite3_column_int64(statement, index)
+    }
+
+    func step(_ statement: OpaquePointer?) -> Int32 {
+        sqlite3_step(statement)
+    }
+
+    func lastErrorMessage() -> String {
+        guard let cString = sqlite3_errmsg(handle) else { return "" }
+        return String(cString: cString)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalDatabase.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalDatabase.swift
@@ -41,8 +41,9 @@ final class AgentJournalDatabase: @unchecked Sendable {
         ] {
             let prc = sqlite3_exec(handle, pragma, nil, nil, nil)
             guard prc == SQLITE_OK else {
+                let message = sqlite3_errmsg(handle).map { String(cString: $0) } ?? ""
                 sqlite3_close_v2(handle)
-                throw AgentJournalStoreError.stepFailed(prc, "")
+                throw AgentJournalStoreError.stepFailed(prc, "\(pragma) failed: \(message)")
             }
         }
         self.handle = handle

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEvent.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEvent.swift
@@ -1,0 +1,39 @@
+/// One committed journal record: a draft plus the identity the journal
+/// assigned at commit time.
+///
+/// `sequence` is a strictly monotonic per-journal ordinal (SQLite
+/// AUTOINCREMENT, never reused); the reducer's determinism contract is defined
+/// over it.
+public struct AgentJournalEvent: Sendable, Equatable {
+    /// Monotonic journal ordinal assigned at commit.
+    public let sequence: Int64
+    /// Journal wall-clock commit timestamp in ms since the Unix epoch.
+    public let committedAtMs: Int64
+    /// The event as the producer emitted it.
+    public let draft: AgentJournalEventDraft
+
+    /// Creates a committed record.
+    ///
+    /// - Parameters:
+    ///   - sequence: Monotonic journal ordinal.
+    ///   - committedAtMs: Commit timestamp in ms since the Unix epoch.
+    ///   - draft: The producer's event.
+    public init(sequence: Int64, committedAtMs: Int64, draft: AgentJournalEventDraft) {
+        self.sequence = sequence
+        self.committedAtMs = committedAtMs
+        self.draft = draft
+    }
+
+    /// Semantic kind of the event.
+    public var kind: AgentJournalEventKind { draft.kind }
+    /// Attributed surface UUID, if attribution succeeded.
+    public var surfaceId: String? { draft.surfaceId }
+    /// Attributed workspace UUID, if attribution succeeded.
+    public var workspaceId: String? { draft.workspaceId }
+    /// Sidebar lifecycle status key the event applies to.
+    public var agentKey: String { draft.agentKey }
+    /// Whether the event carries a trusted target and may drive lifecycle.
+    public var isAttributed: Bool {
+        draft.unattributedReason == nil && draft.surfaceId != nil && draft.workspaceId != nil
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventDraft.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventDraft.swift
@@ -12,7 +12,8 @@ public struct AgentJournalEventDraft: Codable, Sendable, Equatable {
     /// Wire schema version; bump when the draft shape changes incompatibly.
     public static let currentSchemaVersion = 1
 
-    /// Longest accepted ``detail`` in UTF-8 form; longer values are truncated.
+    /// Longest accepted ``detail`` in UTF-8 bytes; longer values are
+    /// truncated on a character boundary.
     public static let maximumDetailLength = 500
 
     /// Schema version of this draft (``currentSchemaVersion`` for new events).
@@ -123,11 +124,7 @@ public struct AgentJournalEventDraft: Codable, Sendable, Equatable {
         self.pendingWork = pendingWork
         self.nativeEvent = nativeEvent
         self.declaredPhase = declaredPhase
-        self.detail = detail.map { value in
-            value.count > Self.maximumDetailLength
-                ? String(value.prefix(Self.maximumDetailLength))
-                : value
-        }
+        self.detail = detail.map(Self.boundedDetail)
     }
 
     /// Validates the draft for journal admission.
@@ -145,13 +142,37 @@ public struct AgentJournalEventDraft: Codable, Sendable, Equatable {
         if unattributedReason != nil, workspaceId != nil || surfaceId != nil {
             return "unattributed events must not carry a target"
         }
+        if (workspaceId == nil) != (surfaceId == nil) {
+            return "attribution requires both workspace_id and surface_id"
+        }
+        if workspaceId == nil, surfaceId == nil, unattributedReason == nil {
+            return "an event without a target must carry unattributed_reason"
+        }
         if let unattributedReason, unattributedReason.isEmpty || unattributedReason.count > 128 {
             return "unattributed_reason must be 1-128 characters"
         }
-        if let detail, detail.count > Self.maximumDetailLength {
-            return "detail exceeds \(Self.maximumDetailLength) characters"
+        if let detail, detail.utf8.count > Self.maximumDetailLength {
+            return "detail exceeds \(Self.maximumDetailLength) UTF-8 bytes"
         }
         return nil
+    }
+
+    /// Truncates `value` to ``maximumDetailLength`` UTF-8 bytes on a
+    /// character boundary.
+    ///
+    /// - Parameter value: The raw detail text.
+    /// - Returns: The bounded detail.
+    public static func boundedDetail(_ value: String) -> String {
+        guard value.utf8.count > maximumDetailLength else { return value }
+        var result = ""
+        var bytes = 0
+        for character in value {
+            let characterBytes = String(character).utf8.count
+            if bytes + characterBytes > maximumDetailLength { break }
+            bytes += characterBytes
+            result.append(character)
+        }
+        return result
     }
 
     /// Whether `value` is a valid lowercase agent slug (1-64 characters of

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventDraft.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventDraft.swift
@@ -1,0 +1,168 @@
+public import Foundation
+
+/// One semantic agent event as emitted by a producer (the cmux CLI hook
+/// handlers), before the journal assigns it a sequence number.
+///
+/// The draft is the wire format of the `agent_journal_append` socket verb: a
+/// single-line JSON object with snake_case keys. Identity fields record the
+/// attribution *decided at emit time*; an event that could not be attributed
+/// carries ``unattributedReason`` instead of a guessed target and is preserved
+/// as a diagnostic rather than dropped.
+public struct AgentJournalEventDraft: Codable, Sendable, Equatable {
+    /// Wire schema version; bump when the draft shape changes incompatibly.
+    public static let currentSchemaVersion = 1
+
+    /// Longest accepted ``detail`` in UTF-8 form; longer values are truncated.
+    public static let maximumDetailLength = 500
+
+    /// Schema version of this draft (``currentSchemaVersion`` for new events).
+    public var schemaVersion: Int
+    /// Producer-chosen globally unique id; the journal's idempotency key.
+    public var eventId: String
+    /// Semantic kind of the event.
+    public var kind: AgentJournalEventKind
+    /// Producer wall-clock timestamp in milliseconds since the Unix epoch.
+    public var occurredAtMs: Int64
+    /// Adapter that produced the event (stable agent slug, e.g. `claude`).
+    public var source: String
+    /// Sidebar lifecycle status key the event applies to (e.g. `claude_code`).
+    public var agentKey: String
+    /// Native agent session id, when the adapter exposes one.
+    public var sessionId: String?
+    /// Workspace UUID the event was attributed to, if attribution succeeded.
+    public var workspaceId: String?
+    /// Surface (panel) UUID the event was attributed to, if attribution
+    /// succeeded. Lifecycle reduction requires this; without it the event is
+    /// diagnostic-only.
+    public var surfaceId: String?
+    /// Why attribution failed, when it did. Mutually exclusive with a trusted
+    /// target: emitters must never populate both this and a guessed
+    /// workspace/surface pair.
+    public var unattributedReason: String?
+    /// Whether the event came from a nested (sub)agent session. Subagent
+    /// events are journaled but excluded from surface lifecycle reduction.
+    public var isSubagent: Bool
+    /// For ``AgentJournalEventKind/turnCompleted``: the turn ended but
+    /// background work is still live, so the agent is still effectively
+    /// running.
+    public var pendingWork: Bool
+    /// The adapter's native hook event name, kept for diagnostics and for
+    /// auditing the semantic mapping.
+    public var nativeEvent: String?
+    /// Explicit phase assertion, honored only for
+    /// ``AgentJournalEventKind/stateChanged`` events (used by correction
+    /// paths that restore a known-good phase after a stale event).
+    public var declaredPhase: AgentLifecyclePhase?
+    /// Short human-readable context (e.g. a failure summary). Bounded by
+    /// ``maximumDetailLength``.
+    public var detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case eventId = "event_id"
+        case kind
+        case occurredAtMs = "occurred_at_ms"
+        case source
+        case agentKey = "agent_key"
+        case sessionId = "session_id"
+        case workspaceId = "workspace_id"
+        case surfaceId = "surface_id"
+        case unattributedReason = "unattributed_reason"
+        case isSubagent = "is_subagent"
+        case pendingWork = "pending_work"
+        case nativeEvent = "native_event"
+        case declaredPhase = "declared_phase"
+        case detail
+    }
+
+    /// Creates a draft, stamping the current schema version and truncating
+    /// ``detail`` to its bound.
+    ///
+    /// - Parameters:
+    ///   - eventId: Globally unique idempotency key (defaults to a fresh UUID).
+    ///   - kind: Semantic kind of the event.
+    ///   - occurredAtMs: Producer timestamp in ms since the Unix epoch.
+    ///   - source: Stable agent slug of the producing adapter.
+    ///   - agentKey: Sidebar lifecycle status key.
+    ///   - sessionId: Native session id, if any.
+    ///   - workspaceId: Attributed workspace UUID, if attribution succeeded.
+    ///   - surfaceId: Attributed surface UUID, if attribution succeeded.
+    ///   - unattributedReason: Why attribution failed, when it did.
+    ///   - isSubagent: Whether the event came from a nested agent session.
+    ///   - pendingWork: Whether a completed turn left live background work.
+    ///   - nativeEvent: The adapter's native hook event name.
+    ///   - declaredPhase: Explicit phase assertion for `stateChanged` events.
+    ///   - detail: Short human-readable context.
+    public init(
+        eventId: String = UUID().uuidString,
+        kind: AgentJournalEventKind,
+        occurredAtMs: Int64,
+        source: String,
+        agentKey: String,
+        sessionId: String? = nil,
+        workspaceId: String? = nil,
+        surfaceId: String? = nil,
+        unattributedReason: String? = nil,
+        isSubagent: Bool = false,
+        pendingWork: Bool = false,
+        nativeEvent: String? = nil,
+        declaredPhase: AgentLifecyclePhase? = nil,
+        detail: String? = nil
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.eventId = eventId
+        self.kind = kind
+        self.occurredAtMs = occurredAtMs
+        self.source = source
+        self.agentKey = agentKey
+        self.sessionId = sessionId
+        self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
+        self.unattributedReason = unattributedReason
+        self.isSubagent = isSubagent
+        self.pendingWork = pendingWork
+        self.nativeEvent = nativeEvent
+        self.declaredPhase = declaredPhase
+        self.detail = detail.map { value in
+            value.count > Self.maximumDetailLength
+                ? String(value.prefix(Self.maximumDetailLength))
+                : value
+        }
+    }
+
+    /// Validates the draft for journal admission.
+    ///
+    /// - Returns: A human-readable problem description, or `nil` when the
+    ///   draft is acceptable.
+    public func validationProblem() -> String? {
+        if schemaVersion < 1 { return "schema_version must be >= 1" }
+        if eventId.isEmpty || eventId.count > 128 { return "event_id must be 1-128 characters" }
+        if occurredAtMs < 0 { return "occurred_at_ms must be >= 0" }
+        if !Self.isValidSlug(source) { return "source must be a 1-64 character lowercase slug" }
+        if !Self.isValidSlug(agentKey) { return "agent_key must be a 1-64 character lowercase slug" }
+        if let workspaceId, UUID(uuidString: workspaceId) == nil { return "workspace_id must be a UUID" }
+        if let surfaceId, UUID(uuidString: surfaceId) == nil { return "surface_id must be a UUID" }
+        if unattributedReason != nil, workspaceId != nil || surfaceId != nil {
+            return "unattributed events must not carry a target"
+        }
+        if let unattributedReason, unattributedReason.isEmpty || unattributedReason.count > 128 {
+            return "unattributed_reason must be 1-128 characters"
+        }
+        if let detail, detail.count > Self.maximumDetailLength {
+            return "detail exceeds \(Self.maximumDetailLength) characters"
+        }
+        return nil
+    }
+
+    /// Whether `value` is a valid lowercase agent slug (1-64 characters of
+    /// `[a-z0-9._-]`), matching the notification meta grammar both sides of
+    /// the socket already agree on.
+    public static func isValidSlug(_ value: String) -> Bool {
+        guard !value.isEmpty, value.count <= 64 else { return false }
+        return value.allSatisfy { character in
+            character.isASCII
+                && (character.isLowercase || character.isNumber
+                    || character == "." || character == "_" || character == "-")
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventKind.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalEventKind.swift
@@ -1,0 +1,34 @@
+/// The semantic agent-event taxonomy recorded in the agent journal.
+///
+/// This is a port of the cmux-tui session journal's 12 `agent.*` event kinds
+/// (`cmux-tui/crates/cmux-tui-core/src/agent_hooks.rs`), so the macOS journal
+/// and the Rust journal describe agent activity in the same vocabulary. Sidebar
+/// lifecycle state is a deterministic fold over a stream of these kinds — never
+/// a substring classification of prose.
+public enum AgentJournalEventKind: String, Codable, Sendable, CaseIterable, Equatable {
+    /// An agent process booted or reset a session.
+    case sessionStarted = "agent.session.started"
+    /// A user prompt was submitted / the agent began working on a turn.
+    case turnStarted = "agent.turn.started"
+    /// The agent settled: the turn is over (unless `pendingWork` is set).
+    case turnCompleted = "agent.turn.completed"
+    /// A subagent was spawned by the session.
+    case childSpawned = "agent.child.spawned"
+    /// A subagent finished.
+    case childCompleted = "agent.child.completed"
+    /// A subagent failed.
+    case childFailed = "agent.child.failed"
+    /// The agent is blocked on a tool/permission approval.
+    case approvalRequested = "agent.approval.requested"
+    /// The agent asked the user a question and is waiting for the answer.
+    case questionRequested = "agent.question.requested"
+    /// The agent presented a plan for review and is waiting for approval.
+    case planReviewRequested = "agent.plan_review.requested"
+    /// The agent reported an error (stop failure, tool failure, on_error).
+    case errorReported = "agent.error.reported"
+    /// Catch-all for native events with no stronger semantic mapping. Only
+    /// reduces to a lifecycle phase when the event declares one explicitly.
+    case stateChanged = "agent.state.changed"
+    /// The session ended (teardown, replacement, or finalize).
+    case sessionEnded = "agent.session.ended"
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalReadPage.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalReadPage.swift
@@ -1,0 +1,35 @@
+/// One page of a sequence-ordered journal read.
+///
+/// `scannedThroughSequence` is the pagination cursor: it advances over every
+/// row the page scanned, including rows that failed to decode (foreign kinds
+/// written by a newer schema), so a reader can never stall on an undecodable
+/// run and never silently loses track of skipped history —
+/// ``skippedSequences`` names the rows the page could not decode.
+public struct AgentJournalReadPage: Sendable, Equatable {
+    /// The decoded events, in ascending sequence order.
+    public let events: [AgentJournalEvent]
+    /// The highest sequence the page scanned (0 when the page is empty);
+    /// pass this as the next `afterSequence`.
+    public let scannedThroughSequence: Int64
+    /// Sequences of scanned rows that could not be decoded.
+    public let skippedSequences: [Int64]
+
+    /// Creates a page.
+    ///
+    /// - Parameters:
+    ///   - events: The decoded events in ascending sequence order.
+    ///   - scannedThroughSequence: The highest scanned sequence.
+    ///   - skippedSequences: Sequences of rows that could not be decoded.
+    public init(
+        events: [AgentJournalEvent],
+        scannedThroughSequence: Int64,
+        skippedSequences: [Int64]
+    ) {
+        self.events = events
+        self.scannedThroughSequence = scannedThroughSequence
+        self.skippedSequences = skippedSequences
+    }
+
+    /// Whether the page scanned no rows (the read is exhausted).
+    public var isEmpty: Bool { scannedThroughSequence == 0 }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalReplayPolicy.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalReplayPolicy.swift
@@ -1,0 +1,41 @@
+/// What startup replay is allowed to paint.
+///
+/// Replay reproduces badges from the journal instead of trusting the last
+/// painted state, but it must not claim liveness the journal cannot prove
+/// after a relaunch:
+///
+/// - `needsInput` and `error` survive replay: the agent was blocked on the
+///   user, and that fact stays true across an app restart (the stale-badge
+///   bug class this design fixes).
+/// - `running` is downgraded out: a relaunch tore down local PTYs, so a
+///   journal-running agent is usually dead; the next live event restores the
+///   spinner honestly.
+/// - `idle` and `unknown` are dropped: painting them adds no user signal and
+///   `idle` would re-enter hibernation eligibility for panes whose agent is
+///   not actually alive.
+public struct AgentJournalReplayPolicy: Sendable {
+    /// Creates a policy.
+    public init() {}
+
+    /// Filters a reduced snapshot down to what startup replay may paint.
+    ///
+    /// - Parameter snapshot: The full reduced snapshot.
+    /// - Returns: The startup-safe snapshot.
+    public func startupSnapshot(from snapshot: AgentLifecycleSnapshot) -> AgentLifecycleSnapshot {
+        var phases: [String: [String: AgentLifecyclePhase]] = [:]
+        var newest: [String: [String: Int64]] = [:]
+        for (surfaceId, byAgent) in snapshot.phases {
+            for (agentKey, phase) in byAgent {
+                switch phase {
+                case .needsInput, .error:
+                    phases[surfaceId, default: [:]][agentKey] = phase
+                    newest[surfaceId, default: [:]][agentKey] =
+                        snapshot.newestOccurredAtMs[surfaceId]?[agentKey] ?? 0
+                case .running, .idle, .unknown:
+                    continue
+                }
+            }
+        }
+        return AgentLifecycleSnapshot(phases: phases, newestOccurredAtMs: newest)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStore.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStore.swift
@@ -70,6 +70,10 @@ public final class AgentJournalStore: @unchecked Sendable {
         }
     }
 
+    deinit {
+        close()
+    }
+
     /// Appends one event, or replays the receipt of a previous append with
     /// the same `event_id`.
     ///
@@ -131,11 +135,15 @@ public final class AgentJournalStore: @unchecked Sendable {
                         .optionalText(draft.detail),
                     ]
                 )
-                let sequence = try Self.scalarInt64(
+                guard let sequence = try Self.scalarInt64(
                     database,
                     "SELECT sequence FROM agent_journal WHERE event_id = ?1;",
                     binding: [.text(draft.eventId)]
-                ) ?? 0
+                ) else {
+                    // The insert happened in this same transaction; a missing
+                    // sequence is a storage fault, never a receipt.
+                    throw AgentJournalStoreError.stepFailed(0, "committed row has no sequence")
+                }
                 return AgentJournalAppendOutcome(
                     sequence: sequence,
                     committedAtMs: committedAtMs,
@@ -145,14 +153,19 @@ public final class AgentJournalStore: @unchecked Sendable {
         }
     }
 
-    /// Reads committed events in sequence order.
+    /// Reads one page of committed events in sequence order.
+    ///
+    /// The page's ``AgentJournalReadPage/scannedThroughSequence`` advances
+    /// over undecodable rows too (foreign kinds from a newer schema), so
+    /// pagination can never stall on them and skipped rows stay visible as
+    /// diagnostics instead of vanishing silently.
     ///
     /// - Parameters:
     ///   - afterSequence: Exclusive lower bound (pass 0 to read from the start).
-    ///   - limit: Maximum number of events returned.
-    /// - Returns: Events ordered by ascending sequence.
+    ///   - limit: Maximum number of rows scanned.
+    /// - Returns: The scanned page.
     /// - Throws: A storage error.
-    public func events(afterSequence: Int64, limit: Int) throws -> [AgentJournalEvent] {
+    public func readPage(afterSequence: Int64, limit: Int) throws -> AgentJournalReadPage {
         try withDatabase { database in
             let statement = try database.prepare(
                 """
@@ -168,13 +181,37 @@ public final class AgentJournalStore: @unchecked Sendable {
                 .int(afterSequence),
                 .int(Int64(max(0, limit))),
             ])
-            var results: [AgentJournalEvent] = []
+            var events: [AgentJournalEvent] = []
+            var scannedThrough: Int64 = 0
+            var skipped: [Int64] = []
             while database.step(statement) == SQLITE_ROW {
-                guard let event = Self.decodeRow(database, statement) else { continue }
-                results.append(event)
+                let sequence = database.columnInt64(statement, 0)
+                scannedThrough = max(scannedThrough, sequence)
+                if let event = Self.decodeRow(database, statement) {
+                    events.append(event)
+                } else {
+                    skipped.append(sequence)
+                }
             }
-            return results
+            return AgentJournalReadPage(
+                events: events,
+                scannedThroughSequence: scannedThrough,
+                skippedSequences: skipped
+            )
         }
+    }
+
+    /// Convenience over ``readPage(afterSequence:limit:)`` returning only the
+    /// decoded events. Callers that paginate must use the page form so the
+    /// cursor advances over undecodable rows.
+    ///
+    /// - Parameters:
+    ///   - afterSequence: Exclusive lower bound (pass 0 to read from the start).
+    ///   - limit: Maximum number of rows scanned.
+    /// - Returns: Events ordered by ascending sequence.
+    /// - Throws: A storage error.
+    public func events(afterSequence: Int64, limit: Int) throws -> [AgentJournalEvent] {
+        try readPage(afterSequence: afterSequence, limit: limit).events
     }
 
     /// The highest committed sequence (0 when the journal is empty).
@@ -222,13 +259,42 @@ public final class AgentJournalStore: @unchecked Sendable {
         }
     }
 
+    /// Loads the complete alias tables into memory, so a replay fold can
+    /// resolve identities without per-event SQL round-trips (see
+    /// ``AgentJournalAliasResolver``).
+    ///
+    /// - Returns: The workspace and surface alias maps (old id → new id).
+    /// - Throws: A storage error.
+    public func aliasMaps() throws -> (workspaces: [String: String], surfaces: [String: String]) {
+        try withDatabase { database in
+            func load(_ sql: String) throws -> [String: String] {
+                let statement = try database.prepare(sql)
+                defer { sqlite3_finalize(statement) }
+                var map: [String: String] = [:]
+                while database.step(statement) == SQLITE_ROW {
+                    guard let old = database.columnText(statement, 0),
+                          let new = database.columnText(statement, 1) else { continue }
+                    map[old] = new
+                }
+                return map
+            }
+            return (
+                workspaces: try load("SELECT old_workspace_id, new_workspace_id FROM workspace_alias;"),
+                surfaces: try load("SELECT old_surface_id, new_surface_id FROM surface_alias;")
+            )
+        }
+    }
+
     /// Resolves a surface UUID through the recorded alias chain to the most
     /// current identity.
     ///
     /// - Parameter surfaceId: The (possibly stale) surface UUID string.
-    /// - Returns: The most current surface UUID string.
+    /// - Returns: The most current surface UUID string, or `nil` when the
+    ///   chain exceeds ``maximumAliasChainLength`` (a recorded cycle) — the
+    ///   caller must treat the identity as unresolvable rather than trusting
+    ///   a partially resolved value.
     /// - Throws: A storage error.
-    public func resolvedSurfaceId(_ surfaceId: String) throws -> String {
+    public func resolvedSurfaceId(_ surfaceId: String) throws -> String? {
         try resolveAlias(
             surfaceId,
             sql: "SELECT new_surface_id FROM surface_alias WHERE old_surface_id = ?1;"
@@ -239,16 +305,17 @@ public final class AgentJournalStore: @unchecked Sendable {
     /// current identity.
     ///
     /// - Parameter workspaceId: The (possibly stale) workspace UUID string.
-    /// - Returns: The most current workspace UUID string.
+    /// - Returns: The most current workspace UUID string, or `nil` when the
+    ///   chain exceeds ``maximumAliasChainLength`` (a recorded cycle).
     /// - Throws: A storage error.
-    public func resolvedWorkspaceId(_ workspaceId: String) throws -> String {
+    public func resolvedWorkspaceId(_ workspaceId: String) throws -> String? {
         try resolveAlias(
             workspaceId,
             sql: "SELECT new_workspace_id FROM workspace_alias WHERE old_workspace_id = ?1;"
         )
     }
 
-    private func resolveAlias(_ identifier: String, sql: String) throws -> String {
+    private func resolveAlias(_ identifier: String, sql: String) throws -> String? {
         try withDatabase { database in
             var current = identifier
             var hops = 0
@@ -264,7 +331,9 @@ public final class AgentJournalStore: @unchecked Sendable {
                 current = next
                 hops += 1
             }
-            return current
+            // Chain cap exhausted: a recorded cycle. Fail closed instead of
+            // returning an arbitrary intermediate identity.
+            return nil
         }
     }
 
@@ -414,6 +483,16 @@ public final class AgentJournalStore: @unchecked Sendable {
             binding: []
         ) ?? 0
         guard count > Int64(maximumEventCountAtOpen) else { return }
+        // Cut by row rank, not by sequence arithmetic: prior prunes leave
+        // sequence gaps, so MAX(sequence) - N would retain the wrong count.
+        guard let cutoff = try scalarInt64(
+            database,
+            """
+            SELECT sequence FROM agent_journal
+            ORDER BY sequence DESC LIMIT 1 OFFSET ?1;
+            """,
+            binding: [.int(Int64(retainedEventCountAfterPrune - 1))]
+        ) else { return }
         try database.transaction {
             try database.exec(
                 """
@@ -422,12 +501,8 @@ public final class AgentJournalStore: @unchecked Sendable {
                 """
             )
             try database.exec(
-                """
-                DELETE FROM agent_journal WHERE sequence <= (
-                    SELECT COALESCE(MAX(sequence), 0) - ?1 FROM agent_journal
-                );
-                """,
-                binding: [.int(Int64(retainedEventCountAfterPrune))]
+                "DELETE FROM agent_journal WHERE sequence < ?1;",
+                binding: [.int(cutoff)]
             )
             try installImmutabilityTriggers(database)
         }

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStore.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStore.swift
@@ -1,0 +1,435 @@
+public import Foundation
+internal import SQLite3
+internal import os
+
+/// Append-only, durable store for semantic agent events.
+///
+/// Ported from the cmux-tui session journal's storage design: an append-only
+/// SQLite table with a strictly monotonic `sequence` (AUTOINCREMENT, never
+/// reused), immutability triggers that reject UPDATE/DELETE, WAL +
+/// `synchronous=FULL` so an acknowledged append is durable, and idempotent
+/// appends keyed by `event_id` so producer retries replay the original
+/// receipt instead of double-writing.
+///
+/// The store also owns two small mutable sidecar tables (deliberately outside
+/// the append-only contract): surface/workspace alias maps recorded during
+/// session restore, so events journaled against a previous run's runtime panel
+/// UUIDs can be re-attributed to the restored panels during replay.
+///
+/// Concurrency: all methods are synchronous and internally serialized by an
+/// unfair lock. This is the sanctioned short-synchronous-critical-section
+/// carve-out: the socket worker thread must produce the durable append
+/// acknowledgement synchronously (its reply contract), so an actor hop is not
+/// available there, and every guarded section is one bounded SQLite
+/// transaction.
+///
+/// ```swift
+/// let store = try AgentJournalStore(databaseURL: url)
+/// let outcome = try store.append(draft)
+/// let events = try store.events(afterSequence: 0, limit: 1024)
+/// ```
+public final class AgentJournalStore: @unchecked Sendable {
+    /// Prune trigger: when the journal holds more than this many events at
+    /// open, the oldest are pruned down to ``retainedEventCountAfterPrune``.
+    public static let maximumEventCountAtOpen = 200_000
+    /// Events retained by an open-time prune.
+    public static let retainedEventCountAfterPrune = 100_000
+    /// Longest alias chain follow before giving up (defends against cycles).
+    public static let maximumAliasChainLength = 32
+
+    // Lock justification: callers are the socket worker thread (which must
+    // reply with the committed sequence synchronously) and the app's journal
+    // consumer task; each guarded section is one bounded SQLite transaction.
+    private let lock = OSAllocatedUnfairLock<AgentJournalDatabase?>(initialState: nil)
+
+    /// Opens (creating and migrating as needed) the journal at `databaseURL`.
+    ///
+    /// - Parameter databaseURL: Location of the SQLite database file; parent
+    ///   directories are created if missing.
+    /// - Throws: ``AgentJournalStoreError`` when SQLite setup fails.
+    public init(databaseURL: URL) throws {
+        let directory = databaseURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let database = try AgentJournalDatabase(path: databaseURL.path)
+        do {
+            try Self.migrate(database)
+            try Self.pruneIfNeeded(database)
+        } catch {
+            database.close()
+            throw error
+        }
+        lock.withLock { $0 = database }
+    }
+
+    /// Closes the underlying connection; later calls throw
+    /// ``AgentJournalStoreError/closed``.
+    public func close() {
+        lock.withLock { database in
+            database?.close()
+            database = nil
+        }
+    }
+
+    /// Appends one event, or replays the receipt of a previous append with
+    /// the same `event_id`.
+    ///
+    /// - Parameters:
+    ///   - draft: The event to append; validated via
+    ///     ``AgentJournalEventDraft/validationProblem()``.
+    ///   - committedAt: Commit timestamp source (injectable for tests).
+    /// - Returns: The durable ``AgentJournalAppendOutcome``.
+    /// - Throws: ``AgentJournalStoreError/invalidDraft(_:)`` for inadmissible
+    ///   drafts, ``AgentJournalStoreError/idempotencyConflict(_:)`` when the
+    ///   same event id arrives with different content, or a storage error.
+    public func append(
+        _ draft: AgentJournalEventDraft,
+        committedAt: Date = Date()
+    ) throws -> AgentJournalAppendOutcome {
+        if let problem = draft.validationProblem() {
+            throw AgentJournalStoreError.invalidDraft(problem)
+        }
+        let committedAtMs = Int64(committedAt.timeIntervalSince1970 * 1000)
+        return try withDatabase { database in
+            try database.transaction {
+                if let existing = try Self.lookupByEventId(database, eventId: draft.eventId) {
+                    guard existing.draft == draft else {
+                        throw AgentJournalStoreError.idempotencyConflict(
+                            "event id \(draft.eventId) was retried with different content"
+                        )
+                    }
+                    return AgentJournalAppendOutcome(
+                        sequence: existing.sequence,
+                        committedAtMs: existing.committedAtMs,
+                        replayed: true
+                    )
+                }
+                try database.exec(
+                    """
+                    INSERT INTO agent_journal(
+                        event_id, schema_version, kind, occurred_at_ms, committed_at_ms,
+                        source, agent_key, session_id, workspace_id, surface_id,
+                        unattributed_reason, is_subagent, pending_work, native_event,
+                        declared_phase, detail
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16);
+                    """,
+                    binding: [
+                        .text(draft.eventId),
+                        .int(Int64(draft.schemaVersion)),
+                        .text(draft.kind.rawValue),
+                        .int(draft.occurredAtMs),
+                        .int(committedAtMs),
+                        .text(draft.source),
+                        .text(draft.agentKey),
+                        .optionalText(draft.sessionId),
+                        .optionalText(draft.workspaceId),
+                        .optionalText(draft.surfaceId),
+                        .optionalText(draft.unattributedReason),
+                        .int(draft.isSubagent ? 1 : 0),
+                        .int(draft.pendingWork ? 1 : 0),
+                        .optionalText(draft.nativeEvent),
+                        .optionalText(draft.declaredPhase?.rawValue),
+                        .optionalText(draft.detail),
+                    ]
+                )
+                let sequence = try Self.scalarInt64(
+                    database,
+                    "SELECT sequence FROM agent_journal WHERE event_id = ?1;",
+                    binding: [.text(draft.eventId)]
+                ) ?? 0
+                return AgentJournalAppendOutcome(
+                    sequence: sequence,
+                    committedAtMs: committedAtMs,
+                    replayed: false
+                )
+            }
+        }
+    }
+
+    /// Reads committed events in sequence order.
+    ///
+    /// - Parameters:
+    ///   - afterSequence: Exclusive lower bound (pass 0 to read from the start).
+    ///   - limit: Maximum number of events returned.
+    /// - Returns: Events ordered by ascending sequence.
+    /// - Throws: A storage error.
+    public func events(afterSequence: Int64, limit: Int) throws -> [AgentJournalEvent] {
+        try withDatabase { database in
+            let statement = try database.prepare(
+                """
+                SELECT sequence, event_id, schema_version, kind, occurred_at_ms, committed_at_ms,
+                       source, agent_key, session_id, workspace_id, surface_id,
+                       unattributed_reason, is_subagent, pending_work, native_event,
+                       declared_phase, detail
+                FROM agent_journal WHERE sequence > ?1 ORDER BY sequence ASC LIMIT ?2;
+                """
+            )
+            defer { sqlite3_finalize(statement) }
+            try database.bind(statement: statement, parameters: [
+                .int(afterSequence),
+                .int(Int64(max(0, limit))),
+            ])
+            var results: [AgentJournalEvent] = []
+            while database.step(statement) == SQLITE_ROW {
+                guard let event = Self.decodeRow(database, statement) else { continue }
+                results.append(event)
+            }
+            return results
+        }
+    }
+
+    /// The highest committed sequence (0 when the journal is empty).
+    ///
+    /// - Returns: The head sequence.
+    /// - Throws: A storage error.
+    public func headSequence() throws -> Int64 {
+        try withDatabase { database in
+            try Self.scalarInt64(
+                database,
+                "SELECT COALESCE(MAX(sequence), 0) FROM agent_journal;",
+                binding: []
+            ) ?? 0
+        }
+    }
+
+    /// Records identity aliases produced by a session restore, so events
+    /// journaled against the previous run's runtime UUIDs re-attach to the
+    /// restored panels during replay.
+    ///
+    /// - Parameters:
+    ///   - workspaceAliases: Old workspace UUID string → new workspace UUID string.
+    ///   - surfaceAliases: Old surface UUID string → new surface UUID string.
+    /// - Throws: A storage error.
+    public func recordRestoreAliases(
+        workspaceAliases: [String: String],
+        surfaceAliases: [String: String]
+    ) throws {
+        guard !workspaceAliases.isEmpty || !surfaceAliases.isEmpty else { return }
+        try withDatabase { database in
+            try database.transaction {
+                for (old, new) in workspaceAliases where old != new {
+                    try database.exec(
+                        "INSERT OR REPLACE INTO workspace_alias(old_workspace_id, new_workspace_id) VALUES (?1, ?2);",
+                        binding: [.text(old), .text(new)]
+                    )
+                }
+                for (old, new) in surfaceAliases where old != new {
+                    try database.exec(
+                        "INSERT OR REPLACE INTO surface_alias(old_surface_id, new_surface_id) VALUES (?1, ?2);",
+                        binding: [.text(old), .text(new)]
+                    )
+                }
+            }
+        }
+    }
+
+    /// Resolves a surface UUID through the recorded alias chain to the most
+    /// current identity.
+    ///
+    /// - Parameter surfaceId: The (possibly stale) surface UUID string.
+    /// - Returns: The most current surface UUID string.
+    /// - Throws: A storage error.
+    public func resolvedSurfaceId(_ surfaceId: String) throws -> String {
+        try resolveAlias(
+            surfaceId,
+            sql: "SELECT new_surface_id FROM surface_alias WHERE old_surface_id = ?1;"
+        )
+    }
+
+    /// Resolves a workspace UUID through the recorded alias chain to the most
+    /// current identity.
+    ///
+    /// - Parameter workspaceId: The (possibly stale) workspace UUID string.
+    /// - Returns: The most current workspace UUID string.
+    /// - Throws: A storage error.
+    public func resolvedWorkspaceId(_ workspaceId: String) throws -> String {
+        try resolveAlias(
+            workspaceId,
+            sql: "SELECT new_workspace_id FROM workspace_alias WHERE old_workspace_id = ?1;"
+        )
+    }
+
+    private func resolveAlias(_ identifier: String, sql: String) throws -> String {
+        try withDatabase { database in
+            var current = identifier
+            var hops = 0
+            while hops < Self.maximumAliasChainLength {
+                let statement = try database.prepare(sql)
+                defer { sqlite3_finalize(statement) }
+                try database.bind(statement: statement, parameters: [.text(current)])
+                guard database.step(statement) == SQLITE_ROW,
+                      let next = database.columnText(statement, 0),
+                      next != current else {
+                    return current
+                }
+                current = next
+                hops += 1
+            }
+            return current
+        }
+    }
+
+    private func withDatabase<Result>(
+        _ body: (AgentJournalDatabase) throws -> Result
+    ) throws -> Result {
+        // withLockUnchecked: results are plain value types and the closure
+        // only touches the lock-guarded connection; nothing escapes the
+        // critical section.
+        try lock.withLockUnchecked { database in
+            guard let database else { throw AgentJournalStoreError.closed }
+            return try body(database)
+        }
+    }
+
+    private static func lookupByEventId(
+        _ database: AgentJournalDatabase,
+        eventId: String
+    ) throws -> AgentJournalEvent? {
+        let statement = try database.prepare(
+            """
+            SELECT sequence, event_id, schema_version, kind, occurred_at_ms, committed_at_ms,
+                   source, agent_key, session_id, workspace_id, surface_id,
+                   unattributed_reason, is_subagent, pending_work, native_event,
+                   declared_phase, detail
+            FROM agent_journal WHERE event_id = ?1;
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        try database.bind(statement: statement, parameters: [.text(eventId)])
+        guard database.step(statement) == SQLITE_ROW else { return nil }
+        return decodeRow(database, statement)
+    }
+
+    private static func decodeRow(
+        _ database: AgentJournalDatabase,
+        _ statement: OpaquePointer?
+    ) -> AgentJournalEvent? {
+        guard let kindRaw = database.columnText(statement, 3),
+              let kind = AgentJournalEventKind(rawValue: kindRaw),
+              let eventId = database.columnText(statement, 1),
+              let source = database.columnText(statement, 6),
+              let agentKey = database.columnText(statement, 7) else {
+            return nil
+        }
+        var draft = AgentJournalEventDraft(
+            eventId: eventId,
+            kind: kind,
+            occurredAtMs: database.columnInt64(statement, 4),
+            source: source,
+            agentKey: agentKey,
+            sessionId: database.columnText(statement, 8),
+            workspaceId: database.columnText(statement, 9),
+            surfaceId: database.columnText(statement, 10),
+            unattributedReason: database.columnText(statement, 11),
+            isSubagent: database.columnInt64(statement, 12) != 0,
+            pendingWork: database.columnInt64(statement, 13) != 0,
+            nativeEvent: database.columnText(statement, 14),
+            declaredPhase: database.columnText(statement, 15)
+                .flatMap(AgentLifecyclePhase.init(rawValue:)),
+            detail: database.columnText(statement, 16)
+        )
+        draft.schemaVersion = Int(database.columnInt64(statement, 2))
+        return AgentJournalEvent(
+            sequence: database.columnInt64(statement, 0),
+            committedAtMs: database.columnInt64(statement, 5),
+            draft: draft
+        )
+    }
+
+    private static func scalarInt64(
+        _ database: AgentJournalDatabase,
+        _ sql: String,
+        binding parameters: [AgentJournalDatabase.BindValue]
+    ) throws -> Int64? {
+        let statement = try database.prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        try database.bind(statement: statement, parameters: parameters)
+        guard database.step(statement) == SQLITE_ROW else { return nil }
+        return database.columnInt64(statement, 0)
+    }
+
+    private static func migrate(_ database: AgentJournalDatabase) throws {
+        try database.exec(
+            """
+            CREATE TABLE IF NOT EXISTS agent_journal (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT UNIQUE NOT NULL,
+                schema_version INTEGER NOT NULL CHECK(schema_version > 0),
+                kind TEXT NOT NULL,
+                occurred_at_ms INTEGER NOT NULL CHECK(occurred_at_ms >= 0),
+                committed_at_ms INTEGER NOT NULL CHECK(committed_at_ms >= 0),
+                source TEXT NOT NULL,
+                agent_key TEXT NOT NULL,
+                session_id TEXT,
+                workspace_id TEXT,
+                surface_id TEXT,
+                unattributed_reason TEXT,
+                is_subagent INTEGER NOT NULL CHECK(is_subagent IN (0, 1)),
+                pending_work INTEGER NOT NULL CHECK(pending_work IN (0, 1)),
+                native_event TEXT,
+                declared_phase TEXT,
+                detail TEXT
+            );
+            CREATE INDEX IF NOT EXISTS agent_journal_by_surface_sequence
+                ON agent_journal(surface_id, sequence);
+            CREATE TABLE IF NOT EXISTS surface_alias (
+                old_surface_id TEXT PRIMARY KEY NOT NULL,
+                new_surface_id TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS workspace_alias (
+                old_workspace_id TEXT PRIMARY KEY NOT NULL,
+                new_workspace_id TEXT NOT NULL
+            );
+            PRAGMA user_version = 1;
+            """
+        )
+        try installImmutabilityTriggers(database)
+    }
+
+    private static func installImmutabilityTriggers(_ database: AgentJournalDatabase) throws {
+        try database.exec(
+            """
+            CREATE TRIGGER IF NOT EXISTS agent_journal_reject_update
+                BEFORE UPDATE ON agent_journal
+            BEGIN
+                SELECT RAISE(ABORT, 'agent journal is append-only');
+            END;
+            CREATE TRIGGER IF NOT EXISTS agent_journal_reject_delete
+                BEFORE DELETE ON agent_journal
+            BEGIN
+                SELECT RAISE(ABORT, 'agent journal is append-only');
+            END;
+            """
+        )
+    }
+
+    /// Retention: the append-only contract protects live history from
+    /// tampering, not from bounded aging-out. When the table exceeds the open
+    /// cap, drop the guard triggers inside one transaction, delete the oldest
+    /// rows down to the retained count, and reinstall the triggers.
+    /// AUTOINCREMENT guarantees pruned sequences are never reused.
+    private static func pruneIfNeeded(_ database: AgentJournalDatabase) throws {
+        let count = try scalarInt64(
+            database,
+            "SELECT COUNT(*) FROM agent_journal;",
+            binding: []
+        ) ?? 0
+        guard count > Int64(maximumEventCountAtOpen) else { return }
+        try database.transaction {
+            try database.exec(
+                """
+                DROP TRIGGER IF EXISTS agent_journal_reject_update;
+                DROP TRIGGER IF EXISTS agent_journal_reject_delete;
+                """
+            )
+            try database.exec(
+                """
+                DELETE FROM agent_journal WHERE sequence <= (
+                    SELECT COALESCE(MAX(sequence), 0) - ?1 FROM agent_journal
+                );
+                """,
+                binding: [.int(Int64(retainedEventCountAfterPrune))]
+            )
+            try installImmutabilityTriggers(database)
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStoreError.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentJournalStoreError.swift
@@ -1,0 +1,15 @@
+/// Errors thrown by ``AgentJournalStore``.
+public enum AgentJournalStoreError: Error, Sendable, Equatable {
+    /// `sqlite3_open_v2` failed with the given result code.
+    case openFailed(Int32)
+    /// Statement preparation failed with the given result code and message.
+    case prepareFailed(Int32, String)
+    /// Statement execution failed with the given result code and message.
+    case stepFailed(Int32, String)
+    /// The draft failed admission validation.
+    case invalidDraft(String)
+    /// The same event id was appended again with different content.
+    case idempotencyConflict(String)
+    /// The store has been closed.
+    case closed
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleAssignment.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleAssignment.swift
@@ -1,0 +1,23 @@
+/// One sidebar lifecycle mutation derived from the journal: set (or clear,
+/// when `phase` is `nil`) the entry for `agentKey` on `surfaceId`.
+public struct AgentLifecycleAssignment: Sendable, Equatable {
+    /// The surface UUID string as recorded on the journal events (pre-alias
+    /// resolution).
+    public let surfaceId: String
+    /// The sidebar lifecycle status key.
+    public let agentKey: String
+    /// The combined phase to apply, or `nil` to clear the entry.
+    public let phase: AgentLifecyclePhase?
+
+    /// Creates an assignment.
+    ///
+    /// - Parameters:
+    ///   - surfaceId: The surface UUID string as recorded on journal events.
+    ///   - agentKey: The sidebar lifecycle status key.
+    ///   - phase: The combined phase to apply, or `nil` to clear.
+    public init(surfaceId: String, agentKey: String, phase: AgentLifecyclePhase?) {
+        self.surfaceId = surfaceId
+        self.agentKey = agentKey
+        self.phase = phase
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecyclePhase.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecyclePhase.swift
@@ -1,0 +1,33 @@
+/// The lifecycle phase the reducer derives for one agent on one surface.
+///
+/// This is the journal-side superset of the app's sidebar lifecycle enum: the
+/// sidebar has no dedicated error rendering yet, so consumers project
+/// ``error`` onto their needs-input treatment while the journal keeps the
+/// honest phase.
+public enum AgentLifecyclePhase: String, Codable, Sendable, CaseIterable, Equatable {
+    /// The agent session exists but has given no activity signal yet.
+    case unknown
+    /// The agent is actively working on a turn.
+    case running
+    /// The agent is blocked on the user (approval, question, or plan review).
+    case needsInput
+    /// The last turn completed and nothing is pending.
+    case idle
+    /// The agent reported an error and is not making progress.
+    case error
+
+    /// Precedence used when several sessions of the same agent share one
+    /// surface: the surface shows the most demanding live session.
+    ///
+    /// Order (most to least demanding): `running` > `needsInput` > `error` >
+    /// `unknown` > `idle`.
+    public var combinePrecedence: Int {
+        switch self {
+        case .running: 5
+        case .needsInput: 4
+        case .error: 3
+        case .unknown: 2
+        case .idle: 1
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducer.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducer.swift
@@ -51,25 +51,18 @@ public struct AgentLifecycleReducer: Sendable {
             agentKey: agentKey,
             sessionKey: sessionKey
         )
-        if let previous, event.sequence <= previous.lastSequence {
-            // Duplicate or out-of-order stale arrival: the newest event by
-            // journal sequence already governs this session.
+        guard let transition = transition(for: event.draft, previous: previous) else {
+            // Non-lifecycle kind: a pure observation. It deliberately does
+            // not touch the session watermark, so a lifecycle event that
+            // arrives after a higher-sequence observation still applies —
+            // the fold stays a function of the highest-sequence
+            // lifecycle-bearing event alone, independent of delivery order.
             return false
         }
-        guard let transition = transition(for: event.draft, previous: previous) else {
-            // Non-lifecycle kind: bump the sequence watermark so replays stay
-            // idempotent, but keep the previous phase.
-            if let previous {
-                var bumped = previous
-                bumped.lastSequence = event.sequence
-                bumped.lastOccurredAtMs = event.draft.occurredAtMs
-                state.updateSession(
-                    surfaceId: surfaceId,
-                    agentKey: agentKey,
-                    sessionKey: sessionKey,
-                    state: bumped
-                )
-            }
+        if let previous, event.sequence <= previous.lastSequence {
+            // Duplicate or out-of-order stale arrival: the newest
+            // lifecycle-bearing event by journal sequence already governs
+            // this session.
             return false
         }
         let next = AgentSessionLifecycleState(

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducer.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducer.swift
@@ -1,0 +1,118 @@
+/// Deterministic fold from semantic agent events to lifecycle state.
+///
+/// Determinism contract (unit-tested): the fold's result is a pure function
+/// of the *set* of events, independent of delivery order or re-delivery —
+/// each session keeps only its newest event by journal sequence, duplicates
+/// and stale arrivals are dropped, and the surface-level phase is a
+/// precedence combine over live sessions.
+///
+/// ```swift
+/// var state = AgentLifecycleReducerState()
+/// let reducer = AgentLifecycleReducer()
+/// for event in events { reducer.apply(event, to: &state) }
+/// let snapshot = state.snapshot()
+/// ```
+public struct AgentLifecycleReducer: Sendable {
+    /// Creates a reducer.
+    public init() {}
+
+    /// Folds one event into `state`.
+    ///
+    /// - Parameters:
+    ///   - event: The committed journal event.
+    ///   - state: The accumulated state to mutate.
+    /// - Returns: `true` when the event changed lifecycle state (as opposed
+    ///   to being a duplicate, stale, diagnostic-only, or non-lifecycle
+    ///   event).
+    @discardableResult
+    public func apply(
+        _ event: AgentJournalEvent,
+        to state: inout AgentLifecycleReducerState
+    ) -> Bool {
+        state.advanceHead(to: event.sequence)
+        guard event.draft.unattributedReason == nil else {
+            state.recordUnattributed(event)
+            return false
+        }
+        guard let surfaceId = event.draft.surfaceId else {
+            // Attribution requires a surface: a workspace-only target would
+            // make the sidebar guess a pane. Preserve as a diagnostic.
+            state.recordUnattributed(event)
+            return false
+        }
+        guard !event.draft.isSubagent else {
+            // Subagent sessions never drive the hosting pane's badge.
+            return false
+        }
+        let agentKey = event.agentKey
+        let sessionKey = AgentLifecycleReducerState.sessionKey(for: event.draft)
+        let previous = state.session(
+            surfaceId: surfaceId,
+            agentKey: agentKey,
+            sessionKey: sessionKey
+        )
+        if let previous, event.sequence <= previous.lastSequence {
+            // Duplicate or out-of-order stale arrival: the newest event by
+            // journal sequence already governs this session.
+            return false
+        }
+        guard let transition = transition(for: event.draft, previous: previous) else {
+            // Non-lifecycle kind: bump the sequence watermark so replays stay
+            // idempotent, but keep the previous phase.
+            if let previous {
+                var bumped = previous
+                bumped.lastSequence = event.sequence
+                bumped.lastOccurredAtMs = event.draft.occurredAtMs
+                state.updateSession(
+                    surfaceId: surfaceId,
+                    agentKey: agentKey,
+                    sessionKey: sessionKey,
+                    state: bumped
+                )
+            }
+            return false
+        }
+        let next = AgentSessionLifecycleState(
+            phase: transition.phase,
+            ended: transition.ended,
+            lastSequence: event.sequence,
+            lastOccurredAtMs: event.draft.occurredAtMs
+        )
+        let combinedBefore = state.combinedPhase(surfaceId: surfaceId, agentKey: agentKey)
+        state.updateSession(
+            surfaceId: surfaceId,
+            agentKey: agentKey,
+            sessionKey: sessionKey,
+            state: next
+        )
+        let combinedAfter = state.combinedPhase(surfaceId: surfaceId, agentKey: agentKey)
+        return combinedBefore != combinedAfter
+    }
+
+    private func transition(
+        for draft: AgentJournalEventDraft,
+        previous: AgentSessionLifecycleState?
+    ) -> (phase: AgentLifecyclePhase, ended: Bool)? {
+        switch draft.kind {
+        case .sessionStarted:
+            return (.unknown, false)
+        case .turnStarted:
+            return (.running, false)
+        case .turnCompleted:
+            return (draft.pendingWork ? .running : .idle, false)
+        case .approvalRequested, .questionRequested, .planReviewRequested:
+            return (.needsInput, false)
+        case .errorReported:
+            return (.error, false)
+        case .sessionEnded:
+            return (previous?.phase ?? .unknown, true)
+        case .stateChanged:
+            // Only an explicit phase assertion moves state; plain
+            // state-changed events are observations.
+            guard let declared = draft.declaredPhase else { return nil }
+            return (declared, previous?.ended ?? false)
+        case .childSpawned, .childCompleted, .childFailed:
+            return nil
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducerState.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleReducerState.swift
@@ -1,0 +1,99 @@
+/// Accumulated reducer state: per-surface, per-agent, per-session lifecycle.
+///
+/// Keys are the identity strings recorded on the events themselves (the
+/// runtime UUIDs at emit time); alias resolution to the current runtime
+/// identity happens in the projection layer, not here, so the fold stays a
+/// pure function of the event stream.
+public struct AgentLifecycleReducerState: Sendable, Equatable {
+    /// `surfaceId → agentKey → sessionKey → state`.
+    public private(set) var sessions: [String: [String: [String: AgentSessionLifecycleState]]]
+    /// Unattributed diagnostic events seen by the fold (bounded).
+    public private(set) var unattributedEvents: [AgentJournalEvent]
+    /// Highest sequence this state has folded.
+    public private(set) var headSequence: Int64
+
+    /// Bound on retained unattributed diagnostics.
+    public static let maximumRetainedUnattributedEvents = 256
+
+    /// Creates an empty state.
+    public init() {
+        self.sessions = [:]
+        self.unattributedEvents = []
+        self.headSequence = 0
+    }
+
+    /// The session key an event folds into: the native session id when the
+    /// adapter provides one, otherwise a per-source singleton bucket.
+    ///
+    /// - Parameter draft: The event's draft.
+    /// - Returns: The session key.
+    public static func sessionKey(for draft: AgentJournalEventDraft) -> String {
+        if let sessionId = draft.sessionId, !sessionId.isEmpty {
+            return sessionId
+        }
+        return "@\(draft.source)"
+    }
+
+    /// Combined phase for one surface/agent pair across its live sessions,
+    /// or `nil` when every session has ended (the sidebar entry clears).
+    ///
+    /// - Parameters:
+    ///   - surfaceId: The surface UUID string as recorded on events.
+    ///   - agentKey: The sidebar lifecycle status key.
+    /// - Returns: The combined phase, or `nil`.
+    public func combinedPhase(surfaceId: String, agentKey: String) -> AgentLifecyclePhase? {
+        guard let bySession = sessions[surfaceId]?[agentKey] else { return nil }
+        let live = bySession.values.filter { !$0.ended }
+        return live.map(\.phase).max { $0.combinePrecedence < $1.combinePrecedence }
+    }
+
+    /// Full combined snapshot across all surfaces and agents.
+    ///
+    /// - Returns: The snapshot the projection layer diffs and applies.
+    public func snapshot() -> AgentLifecycleSnapshot {
+        var phases: [String: [String: AgentLifecyclePhase]] = [:]
+        var newestOccurredAtMs: [String: [String: Int64]] = [:]
+        for (surfaceId, byAgent) in sessions {
+            for (agentKey, bySession) in byAgent {
+                let live = bySession.values.filter { !$0.ended }
+                guard let phase = live.map(\.phase).max(by: {
+                    $0.combinePrecedence < $1.combinePrecedence
+                }) else { continue }
+                phases[surfaceId, default: [:]][agentKey] = phase
+                newestOccurredAtMs[surfaceId, default: [:]][agentKey] =
+                    live.map(\.lastOccurredAtMs).max() ?? 0
+            }
+        }
+        return AgentLifecycleSnapshot(phases: phases, newestOccurredAtMs: newestOccurredAtMs)
+    }
+
+    mutating func recordUnattributed(_ event: AgentJournalEvent) {
+        unattributedEvents.append(event)
+        if unattributedEvents.count > Self.maximumRetainedUnattributedEvents {
+            unattributedEvents.removeFirst(
+                unattributedEvents.count - Self.maximumRetainedUnattributedEvents
+            )
+        }
+    }
+
+    mutating func advanceHead(to sequence: Int64) {
+        headSequence = max(headSequence, sequence)
+    }
+
+    mutating func updateSession(
+        surfaceId: String,
+        agentKey: String,
+        sessionKey: String,
+        state: AgentSessionLifecycleState
+    ) {
+        sessions[surfaceId, default: [:]][agentKey, default: [:]][sessionKey] = state
+    }
+
+    func session(
+        surfaceId: String,
+        agentKey: String,
+        sessionKey: String
+    ) -> AgentSessionLifecycleState? {
+        sessions[surfaceId]?[agentKey]?[sessionKey]
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleSnapshot.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentLifecycleSnapshot.swift
@@ -1,0 +1,52 @@
+/// Combined lifecycle view derived from the journal: `surfaceId → agentKey →
+/// phase`, plus the newest producer timestamp behind each entry.
+///
+/// Consumers diff successive snapshots and apply the delta to the sidebar
+/// (set changed entries, clear vanished ones).
+public struct AgentLifecycleSnapshot: Sendable, Equatable {
+    /// Combined phase per surface and agent key.
+    public var phases: [String: [String: AgentLifecyclePhase]]
+    /// Producer timestamp (ms since Unix epoch) of the newest live event
+    /// behind each entry; used by replay policy decisions.
+    public var newestOccurredAtMs: [String: [String: Int64]]
+
+    /// Creates a snapshot.
+    ///
+    /// - Parameters:
+    ///   - phases: Combined phase per surface and agent key.
+    ///   - newestOccurredAtMs: Newest producer timestamp behind each entry.
+    public init(
+        phases: [String: [String: AgentLifecyclePhase]] = [:],
+        newestOccurredAtMs: [String: [String: Int64]] = [:]
+    ) {
+        self.phases = phases
+        self.newestOccurredAtMs = newestOccurredAtMs
+    }
+
+    /// Computes the assignments needed to move the sidebar from `previous`
+    /// to this snapshot.
+    ///
+    /// - Parameter previous: The last applied snapshot.
+    /// - Returns: Assignments for every changed entry, including explicit
+    ///   clears (`phase == nil`) for entries that vanished.
+    public func assignments(since previous: AgentLifecycleSnapshot) -> [AgentLifecycleAssignment] {
+        var result: [AgentLifecycleAssignment] = []
+        for (surfaceId, byAgent) in phases {
+            for (agentKey, phase) in byAgent where previous.phases[surfaceId]?[agentKey] != phase {
+                result.append(
+                    AgentLifecycleAssignment(surfaceId: surfaceId, agentKey: agentKey, phase: phase)
+                )
+            }
+        }
+        for (surfaceId, byAgent) in previous.phases {
+            for (agentKey, _) in byAgent where phases[surfaceId]?[agentKey] == nil {
+                result.append(
+                    AgentLifecycleAssignment(surfaceId: surfaceId, agentKey: agentKey, phase: nil)
+                )
+            }
+        }
+        return result.sorted { lhs, rhs in
+            (lhs.surfaceId, lhs.agentKey) < (rhs.surfaceId, rhs.agentKey)
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentSemanticEventMapper.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentSemanticEventMapper.swift
@@ -1,0 +1,130 @@
+/// Maps an adapter's native hook event to a semantic journal kind.
+///
+/// This is a Swift port of the cmux-tui journal's mapping table
+/// (`agent_hooks.rs` `semantic_kind`): matching runs over a normalized key
+/// (lowercased, all non-alphanumeric bytes stripped) so `SubagentStop`,
+/// `subagent_stop`, and `on-subagent-stop` all collapse to the same arm, and
+/// only a handful of adapters carry source-specific special cases. Everything
+/// that fails to map lands on ``AgentJournalEventKind/stateChanged`` — never
+/// on a fabricated needs-input state.
+///
+/// ```swift
+/// let mapper = AgentSemanticEventMapper()
+/// mapper.kind(source: "claude", nativeEvent: "Stop", toolName: nil)
+/// // .turnCompleted
+/// mapper.kind(source: "claude", nativeEvent: "PreToolUse", toolName: "ExitPlanMode")
+/// // .planReviewRequested
+/// ```
+public struct AgentSemanticEventMapper: Sendable {
+    /// Creates a mapper.
+    public init() {}
+
+    /// Resolves the semantic kind for a native hook event.
+    ///
+    /// - Parameters:
+    ///   - source: Stable agent slug of the adapter (e.g. `claude`, `grok`).
+    ///   - nativeEvent: The adapter's native hook event name.
+    ///   - toolName: The tool named by the event, when the adapter provides
+    ///     one; blocking tools map ahead of the event-name table.
+    /// - Returns: The semantic kind, ``AgentJournalEventKind/stateChanged``
+    ///   when nothing stronger matches.
+    public func kind(
+        source: String,
+        nativeEvent: String,
+        toolName: String? = nil
+    ) -> AgentJournalEventKind {
+        let event = Self.semanticKey(nativeEvent)
+        if let toolName {
+            switch Self.semanticKey(toolName) {
+            case "askuserquestion":
+                return .questionRequested
+            case "exitplanmode":
+                return .planReviewRequested
+            default:
+                break
+            }
+        }
+        if event == "questionasked" {
+            return .questionRequested
+        }
+        // Source-specific arms first (mirrors the Rust table's ordering).
+        switch (source, event) {
+        case ("antigravity", "sessionend"), ("antigravity", "onsessionend"),
+             ("hermes-agent", "sessionend"), ("hermes-agent", "onsessionend"):
+            // These providers use their session-end callback as a per-turn
+            // boundary and expose a distinct finalization event where available.
+            return .turnCompleted
+        case ("opencode", "sessioncreated"):
+            return .sessionStarted
+        case ("opencode", "sessionidle"):
+            return .turnCompleted
+        case ("opencode", "sessiondeleted"):
+            return .sessionEnded
+        case ("copilot", "notification"), ("codebuddy", "notification"), ("factory", "notification"):
+            // These Claude-compatible runtimes use Notification as their only
+            // reliable completed-turn callback.
+            return .turnCompleted
+        default:
+            break
+        }
+        if Self.childSpawnEvents.contains(event) { return .childSpawned }
+        if Self.childCompletionEvents.contains(event) { return .childCompleted }
+        if event == "subagentfailed" || event == "childfailed" { return .childFailed }
+        if Self.sessionStartEvents.contains(event) { return .sessionStarted }
+        if Self.turnStartEvents.contains(event) { return .turnStarted }
+        if Self.turnCompletionEvents.contains(event) { return .turnCompleted }
+        if Self.approvalEvents.contains(event) { return .approvalRequested }
+        if Self.errorEvents.contains(event) { return .errorReported }
+        if Self.sessionEndEvents.contains(event) { return .sessionEnded }
+        return .stateChanged
+    }
+
+    /// Normalizes a native event or tool name for table matching: lowercases
+    /// and strips every non-alphanumeric character, so naming-convention
+    /// variants collapse to one key.
+    ///
+    /// - Parameter raw: The raw native name.
+    /// - Returns: The normalized key.
+    public static func semanticKey(_ raw: String) -> String {
+        String(raw.lowercased().unicodeScalars.filter { scalar in
+            (scalar >= "a" && scalar <= "z") || (scalar >= "0" && scalar <= "9")
+        })
+    }
+
+    private static let childSpawnEvents: Set<String> = [
+        "subagentstart", "subagentstarted", "subagentspawned",
+        "agentspawn", "agentspawned",
+        "childstart", "childstarted", "childspawned",
+    ]
+
+    private static let childCompletionEvents: Set<String> = [
+        "subagentstop", "subagentended", "subagentcompleted",
+        "childstop", "childended", "childcompleted",
+    ]
+
+    private static let sessionStartEvents: Set<String> = [
+        "sessionstart", "onsessionstart", "onsessionreset",
+    ]
+
+    private static let turnStartEvents: Set<String> = [
+        "userpromptsubmit", "beforesubmitprompt", "beforeagent", "prellmcall",
+        "preinvocation", "agentstart", "turnstart", "beforeagentstart",
+    ]
+
+    private static let turnCompletionEvents: Set<String> = [
+        "stop", "afteragent", "afteragentresponse", "postllmcall", "oncomplete",
+        "turncompletion", "agentend", "taskcompleted", "turnend", "agentsettled",
+    ]
+
+    private static let approvalEvents: Set<String> = [
+        "permissionrequest", "permissionasked", "preapprovalrequest", "ontoolpermission",
+    ]
+
+    private static let errorEvents: Set<String> = [
+        "stopfailure", "onerror", "error", "posttoolusefailure",
+    ]
+
+    private static let sessionEndEvents: Set<String> = [
+        "sessionend", "onsessionend", "onsessionfinalize", "sessionshutdown",
+    ]
+}

--- a/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentSessionLifecycleState.swift
+++ b/Packages/macOS/CmuxAgentJournal/Sources/CmuxAgentJournal/AgentSessionLifecycleState.swift
@@ -1,0 +1,33 @@
+/// Reduced lifecycle state of one agent session on one surface.
+public struct AgentSessionLifecycleState: Sendable, Equatable {
+    /// The session's current phase.
+    public var phase: AgentLifecyclePhase
+    /// Whether the session has ended (ended sessions no longer contribute to
+    /// the surface's combined phase).
+    public var ended: Bool
+    /// Sequence of the newest event applied to this session; older or
+    /// duplicate events are dropped, which makes the fold deterministic under
+    /// re-delivery and permutation.
+    public var lastSequence: Int64
+    /// Producer timestamp of the newest applied event (ms since Unix epoch).
+    public var lastOccurredAtMs: Int64
+
+    /// Creates a session state.
+    ///
+    /// - Parameters:
+    ///   - phase: The session's current phase.
+    ///   - ended: Whether the session has ended.
+    ///   - lastSequence: Sequence of the newest applied event.
+    ///   - lastOccurredAtMs: Producer timestamp of the newest applied event.
+    public init(
+        phase: AgentLifecyclePhase,
+        ended: Bool,
+        lastSequence: Int64,
+        lastOccurredAtMs: Int64
+    ) {
+        self.phase = phase
+        self.ended = ended
+        self.lastSequence = lastSequence
+        self.lastOccurredAtMs = lastOccurredAtMs
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalAliasResolverTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalAliasResolverTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Alias resolver")
+struct AgentJournalAliasResolverTests {
+    @Test func resolvesChainsAndFailsClosedOnCycles() {
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        let c = UUID().uuidString
+        var resolver = AgentJournalAliasResolver(surfaces: [a: b])
+        resolver.merge(workspaces: [:], surfaces: [b: c])
+        #expect(resolver.resolvedSurfaceId(a) == c)
+        #expect(resolver.resolvedSurfaceId(c) == c)
+        let unknown = UUID().uuidString
+        #expect(resolver.resolvedSurfaceId(unknown) == unknown)
+
+        let cyclic = AgentJournalAliasResolver(surfaces: [a: b, b: a])
+        #expect(cyclic.resolvedSurfaceId(a) == nil)
+    }
+
+    @Test func matchesStoreSemantics() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alias-resolver-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = try AgentJournalStore(
+            databaseURL: directory.appendingPathComponent("journal.sqlite3")
+        )
+        defer { store.close() }
+        let old = UUID().uuidString
+        let new = UUID().uuidString
+        try store.recordRestoreAliases(workspaceAliases: [old: new], surfaceAliases: [old: new])
+        let maps = try store.aliasMaps()
+        let resolver = AgentJournalAliasResolver(
+            workspaces: maps.workspaces,
+            surfaces: maps.surfaces
+        )
+        let storeWorkspace = try store.resolvedWorkspaceId(old)
+        let storeSurface = try store.resolvedSurfaceId(old)
+        #expect(resolver.resolvedWorkspaceId(old) == storeWorkspace)
+        #expect(resolver.resolvedSurfaceId(old) == storeSurface)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalEventDraftTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalEventDraftTests.swift
@@ -29,18 +29,43 @@ struct AgentJournalEventDraftTests {
         draft.workspaceId = nil
         draft.surfaceId = nil
         #expect(draft.validationProblem() == nil)
+
+        // Attribution must be complete: half a target is rejected, and an
+        // event with no target must say why.
+        draft.unattributedReason = nil
+        #expect(draft.validationProblem() != nil)
+        draft.workspaceId = UUID().uuidString
+        #expect(draft.validationProblem() != nil)
+        draft.surfaceId = UUID().uuidString
+        #expect(draft.validationProblem() == nil)
     }
 
-    @Test func detailIsBounded() {
+    @Test func detailIsBoundedByUTF8Bytes() {
         let long = String(repeating: "x", count: 2_000)
-        let draft = AgentJournalEventDraft(
+        let ascii = AgentJournalEventDraft(
             kind: .turnCompleted,
             occurredAtMs: 1,
             source: "codex",
             agentKey: "codex",
+            unattributedReason: "test",
             detail: long
         )
-        #expect(draft.detail?.count == AgentJournalEventDraft.maximumDetailLength)
+        #expect(ascii.detail?.utf8.count == AgentJournalEventDraft.maximumDetailLength)
+
+        // Multi-byte characters truncate on a character boundary and never
+        // exceed the byte limit (500 emoji = 2000 UTF-8 bytes).
+        let emoji = AgentJournalEventDraft(
+            kind: .turnCompleted,
+            occurredAtMs: 1,
+            source: "codex",
+            agentKey: "codex",
+            unattributedReason: "test",
+            detail: String(repeating: "\u{1F600}", count: 500)
+        )
+        let bytes = emoji.detail?.utf8.count ?? 0
+        #expect(bytes <= AgentJournalEventDraft.maximumDetailLength)
+        #expect(bytes == 500)
+        #expect(emoji.validationProblem() == nil)
     }
 
     @Test func jsonRoundTripsWithSnakeCaseKeys() throws {

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalEventDraftTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalEventDraftTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Event draft wire format")
+struct AgentJournalEventDraftTests {
+    @Test func validationCatchesBadDrafts() {
+        var draft = AgentJournalEventDraft(
+            kind: .turnStarted,
+            occurredAtMs: 1,
+            source: "claude",
+            agentKey: "claude_code",
+            workspaceId: UUID().uuidString,
+            surfaceId: UUID().uuidString
+        )
+        #expect(draft.validationProblem() == nil)
+
+        draft.source = "Not A Slug"
+        #expect(draft.validationProblem() != nil)
+        draft.source = "claude"
+
+        draft.workspaceId = "not-a-uuid"
+        #expect(draft.validationProblem() != nil)
+        draft.workspaceId = UUID().uuidString
+
+        // A guessed target and an unattributed reason are mutually exclusive.
+        draft.unattributedReason = "target-unresolved"
+        #expect(draft.validationProblem() != nil)
+        draft.workspaceId = nil
+        draft.surfaceId = nil
+        #expect(draft.validationProblem() == nil)
+    }
+
+    @Test func detailIsBounded() {
+        let long = String(repeating: "x", count: 2_000)
+        let draft = AgentJournalEventDraft(
+            kind: .turnCompleted,
+            occurredAtMs: 1,
+            source: "codex",
+            agentKey: "codex",
+            detail: long
+        )
+        #expect(draft.detail?.count == AgentJournalEventDraft.maximumDetailLength)
+    }
+
+    @Test func jsonRoundTripsWithSnakeCaseKeys() throws {
+        let draft = AgentJournalEventDraft(
+            eventId: "event-1",
+            kind: .approvalRequested,
+            occurredAtMs: 123,
+            source: "grok",
+            agentKey: "grok",
+            sessionId: "s",
+            workspaceId: UUID().uuidString,
+            surfaceId: UUID().uuidString,
+            isSubagent: true,
+            pendingWork: true,
+            nativeEvent: "Notification",
+            detail: "d"
+        )
+        let data = try JSONEncoder().encode(draft)
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"event_id\""))
+        #expect(json.contains("\"agent_key\""))
+        #expect(json.contains("\"occurred_at_ms\""))
+        let decoded = try JSONDecoder().decode(AgentJournalEventDraft.self, from: data)
+        #expect(decoded == draft)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalImmutabilityTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalImmutabilityTests.swift
@@ -26,7 +26,7 @@ struct AgentJournalImmutabilityTests {
         // Tamper through a raw second connection: the schema itself (not the
         // Swift wrapper) must reject mutation of committed history.
         var handle: OpaquePointer?
-        #expect(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+        try #require(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
         defer { sqlite3_close_v2(handle) }
         let update = sqlite3_exec(handle, "UPDATE agent_journal SET kind = 'agent.turn.completed';", nil, nil, nil)
         #expect(update != SQLITE_OK)

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalImmutabilityTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalImmutabilityTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Journal immutability")
+struct AgentJournalImmutabilityTests {
+    @Test func updateAndDeleteAreRejectedByTriggers() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-journal-immutability-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("journal.sqlite3")
+        let store = try AgentJournalStore(databaseURL: url)
+        _ = try store.append(
+            AgentJournalEventDraft(
+                eventId: "event-1",
+                kind: .turnStarted,
+                occurredAtMs: 1,
+                source: "claude",
+                agentKey: "claude_code",
+                workspaceId: UUID().uuidString,
+                surfaceId: UUID().uuidString
+            )
+        )
+        store.close()
+
+        // Tamper through a raw second connection: the schema itself (not the
+        // Swift wrapper) must reject mutation of committed history.
+        var handle: OpaquePointer?
+        #expect(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+        defer { sqlite3_close_v2(handle) }
+        let update = sqlite3_exec(handle, "UPDATE agent_journal SET kind = 'agent.turn.completed';", nil, nil, nil)
+        #expect(update != SQLITE_OK)
+        let delete = sqlite3_exec(handle, "DELETE FROM agent_journal;", nil, nil, nil)
+        #expect(delete != SQLITE_OK)
+
+        var countStatement: OpaquePointer?
+        #expect(sqlite3_prepare_v2(handle, "SELECT COUNT(*) FROM agent_journal;", -1, &countStatement, nil) == SQLITE_OK)
+        defer { sqlite3_finalize(countStatement) }
+        #expect(sqlite3_step(countStatement) == SQLITE_ROW)
+        #expect(sqlite3_column_int64(countStatement, 0) == 1)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalReplayPolicyTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalReplayPolicyTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Replay policy")
+struct AgentJournalReplayPolicyTests {
+    private let policy = AgentJournalReplayPolicy()
+    private let surface = "5E7A11AA-0000-4000-8000-000000000001"
+
+    @Test func startupKeepsOnlyBlockedStates() {
+        let snapshot = AgentLifecycleSnapshot(
+            phases: [
+                surface: [
+                    "claude_code": .needsInput,
+                    "codex": .running,
+                    "grok": .idle,
+                    "gemini": .error,
+                    "kimi": .unknown,
+                ],
+            ],
+            newestOccurredAtMs: [
+                surface: [
+                    "claude_code": 10, "codex": 20, "grok": 30, "gemini": 40, "kimi": 50,
+                ],
+            ]
+        )
+        let startup = policy.startupSnapshot(from: snapshot)
+        #expect(startup.phases == [
+            surface: ["claude_code": .needsInput, "gemini": .error],
+        ])
+        #expect(startup.newestOccurredAtMs[surface]?["claude_code"] == 10)
+        #expect(startup.newestOccurredAtMs[surface]?["gemini"] == 40)
+    }
+
+    @Test func startupOfEmptySnapshotIsEmpty() {
+        let startup = policy.startupSnapshot(from: AgentLifecycleSnapshot())
+        #expect(startup.phases.isEmpty)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
@@ -212,8 +212,8 @@ struct AgentJournalStoreTests {
             // kind this build cannot decode. INSERT is allowed by design —
             // only UPDATE/DELETE are trigger-blocked.
             var handle: OpaquePointer?
-            #expect(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
             defer { sqlite3_close_v2(handle) }
+            try #require(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
             let insert = """
             INSERT INTO agent_journal(
                 event_id, schema_version, kind, occurred_at_ms, committed_at_ms,

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
@@ -76,9 +76,15 @@ struct AgentJournalStoreTests {
             try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
         }
         _ = try store.append(draft(eventId: "stable-id", kind: .turnStarted))
-        #expect(throws: AgentJournalStoreError.self) {
+        do {
             _ = try store.append(draft(eventId: "stable-id", kind: .turnCompleted))
+            Issue.record("same-id retry with different content must throw idempotencyConflict")
+        } catch AgentJournalStoreError.idempotencyConflict {
+            // Expected: the receipt guard, not some unrelated storage error.
         }
+        // The rejected append must not have written anything.
+        #expect(try store.headSequence() == 1)
+        #expect(try store.events(afterSequence: 0, limit: 10).count == 1)
         store.close()
     }
 
@@ -90,9 +96,15 @@ struct AgentJournalStoreTests {
         }
         var bad = draft()
         bad.unattributedReason = "target-unresolved"
-        #expect(throws: AgentJournalStoreError.self) {
+        do {
             _ = try store.append(bad)
+            Issue.record("a reason plus a target must be rejected as an invalid draft")
+        } catch AgentJournalStoreError.invalidDraft {
+            // Expected: admission validation, not some unrelated storage error.
         }
+        // The rejected append must not have written anything.
+        #expect(try store.headSequence() == 0)
+        #expect(try store.events(afterSequence: 0, limit: 10).isEmpty)
         store.close()
     }
 
@@ -110,6 +122,12 @@ struct AgentJournalStoreTests {
         #expect(events[0].sequence == outcome.sequence)
         #expect(events[0].draft.unattributedReason == "target-unresolved")
         store.close()
+        // Diagnostics are durable: an independent reopen still reads them.
+        let reopened = try AgentJournalStore(databaseURL: url)
+        defer { reopened.close() }
+        let reread = try reopened.events(afterSequence: 0, limit: 10)
+        #expect(reread.count == 1)
+        #expect(reread[0].draft == diagnostic)
     }
 
     @Test func roundTripsAllFields() throws {
@@ -137,10 +155,10 @@ struct AgentJournalStoreTests {
         let outcome = try store.append(draft())
         store.close()
         let reopened = try AgentJournalStore(databaseURL: url)
+        defer { reopened.close() }
         #expect(try reopened.headSequence() == outcome.sequence)
         let events = try reopened.events(afterSequence: 0, limit: 10)
         #expect(events.count == 1)
-        reopened.close()
     }
 
     @Test func surfaceAliasChainsResolve() throws {

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Agent journal store")
+struct AgentJournalStoreTests {
+    private func makeStore() throws -> (AgentJournalStore, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-journal-tests-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("journal.sqlite3")
+        return (try AgentJournalStore(databaseURL: url), url)
+    }
+
+    private func draft(
+        eventId: String = UUID().uuidString,
+        kind: AgentJournalEventKind = .turnStarted,
+        surfaceId: String? = UUID().uuidString,
+        workspaceId: String? = UUID().uuidString
+    ) -> AgentJournalEventDraft {
+        AgentJournalEventDraft(
+            eventId: eventId,
+            kind: kind,
+            occurredAtMs: 1_000,
+            source: "claude",
+            agentKey: "claude_code",
+            sessionId: "session-1",
+            workspaceId: workspaceId,
+            surfaceId: surfaceId
+        )
+    }
+
+    @Test func appendAssignsMonotonicSequences() throws {
+        let (store, _) = makeStoreOrFail()
+        let first = try store.append(draft())
+        let second = try store.append(draft())
+        #expect(first.sequence == 1)
+        #expect(second.sequence == 2)
+        #expect(!first.replayed && !second.replayed)
+        #expect(try store.headSequence() == 2)
+        store.close()
+    }
+
+    @Test func appendIsIdempotentByEventId() throws {
+        let (store, _) = makeStoreOrFail()
+        let event = draft(eventId: "stable-id")
+        let first = try store.append(event)
+        let replay = try store.append(event)
+        #expect(replay.sequence == first.sequence)
+        #expect(replay.replayed)
+        #expect(try store.events(afterSequence: 0, limit: 10).count == 1)
+        store.close()
+    }
+
+    @Test func appendRejectsSameIdWithDifferentContent() throws {
+        let (store, _) = makeStoreOrFail()
+        _ = try store.append(draft(eventId: "stable-id", kind: .turnStarted))
+        #expect(throws: AgentJournalStoreError.self) {
+            _ = try store.append(draft(eventId: "stable-id", kind: .turnCompleted))
+        }
+        store.close()
+    }
+
+    @Test func appendRejectsGuessedTargets() throws {
+        let (store, _) = makeStoreOrFail()
+        var bad = draft()
+        bad.unattributedReason = "target-unresolved"
+        #expect(throws: AgentJournalStoreError.self) {
+            _ = try store.append(bad)
+        }
+        store.close()
+    }
+
+    @Test func unattributedEventsAreDurable() throws {
+        let (store, _) = makeStoreOrFail()
+        var diagnostic = draft(surfaceId: nil, workspaceId: nil)
+        diagnostic.unattributedReason = "target-unresolved"
+        let outcome = try store.append(diagnostic)
+        let events = try store.events(afterSequence: 0, limit: 10)
+        #expect(events.count == 1)
+        #expect(events[0].sequence == outcome.sequence)
+        #expect(events[0].draft.unattributedReason == "target-unresolved")
+        store.close()
+    }
+
+    @Test func roundTripsAllFields() throws {
+        let (store, _) = makeStoreOrFail()
+        var event = draft(kind: .turnCompleted)
+        event.pendingWork = true
+        event.isSubagent = true
+        event.nativeEvent = "Stop"
+        event.detail = "did things"
+        event.declaredPhase = .running
+        _ = try store.append(event, committedAt: Date(timeIntervalSince1970: 42))
+        let read = try #require(try store.events(afterSequence: 0, limit: 1).first)
+        #expect(read.draft == event)
+        #expect(read.committedAtMs == 42_000)
+        store.close()
+    }
+
+    @Test func journalIsAppendOnlyAcrossReopen() throws {
+        let (store, url) = makeStoreOrFail()
+        let outcome = try store.append(draft())
+        store.close()
+        let reopened = try AgentJournalStore(databaseURL: url)
+        #expect(try reopened.headSequence() == outcome.sequence)
+        let events = try reopened.events(afterSequence: 0, limit: 10)
+        #expect(events.count == 1)
+        reopened.close()
+    }
+
+    @Test func surfaceAliasChainsResolve() throws {
+        let (store, _) = makeStoreOrFail()
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        let c = UUID().uuidString
+        try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [a: b])
+        try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [b: c])
+        #expect(try store.resolvedSurfaceId(a) == c)
+        #expect(try store.resolvedSurfaceId(b) == c)
+        #expect(try store.resolvedSurfaceId(c) == c)
+        let unknown = UUID().uuidString
+        #expect(try store.resolvedSurfaceId(unknown) == unknown)
+        store.close()
+    }
+
+    @Test func workspaceAliasResolves() throws {
+        let (store, _) = makeStoreOrFail()
+        let old = UUID().uuidString
+        let new = UUID().uuidString
+        try store.recordRestoreAliases(workspaceAliases: [old: new], surfaceAliases: [:])
+        #expect(try store.resolvedWorkspaceId(old) == new)
+        store.close()
+    }
+
+    @Test func aliasCyclesTerminate() throws {
+        let (store, _) = makeStoreOrFail()
+        let a = UUID().uuidString
+        let b = UUID().uuidString
+        try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [a: b])
+        try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [b: a])
+        // Chain following is bounded; the resolved id is one of the cycle
+        // members rather than an infinite loop.
+        let resolved = try store.resolvedSurfaceId(a)
+        #expect(resolved == a || resolved == b)
+        store.close()
+    }
+
+    @Test func readsPageBySequence() throws {
+        let (store, _) = makeStoreOrFail()
+        for _ in 0..<5 { _ = try store.append(draft()) }
+        let firstPage = try store.events(afterSequence: 0, limit: 2)
+        #expect(firstPage.map(\.sequence) == [1, 2])
+        let rest = try store.events(afterSequence: 2, limit: 10)
+        #expect(rest.map(\.sequence) == [3, 4, 5])
+        store.close()
+    }
+
+    @Test func closedStoreThrows() throws {
+        let (store, _) = makeStoreOrFail()
+        store.close()
+        #expect(throws: AgentJournalStoreError.closed) {
+            _ = try store.headSequence()
+        }
+    }
+
+    private func makeStoreOrFail() -> (AgentJournalStore, URL) {
+        do {
+            return try makeStore()
+        } catch {
+            fatalError("failed to open test store: \(error)")
+        }
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentJournalStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 @testable import CmuxAgentJournal
 
@@ -9,6 +10,15 @@ struct AgentJournalStoreTests {
             .appendingPathComponent("agent-journal-tests-\(UUID().uuidString)", isDirectory: true)
         let url = directory.appendingPathComponent("journal.sqlite3")
         return (try AgentJournalStore(databaseURL: url), url)
+    }
+
+    private func withStore(_ body: (AgentJournalStore, URL) throws -> Void) throws {
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        try body(store, url)
     }
 
     private func draft(
@@ -30,7 +40,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func appendAssignsMonotonicSequences() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         let first = try store.append(draft())
         let second = try store.append(draft())
         #expect(first.sequence == 1)
@@ -41,7 +55,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func appendIsIdempotentByEventId() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         let event = draft(eventId: "stable-id")
         let first = try store.append(event)
         let replay = try store.append(event)
@@ -52,7 +70,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func appendRejectsSameIdWithDifferentContent() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         _ = try store.append(draft(eventId: "stable-id", kind: .turnStarted))
         #expect(throws: AgentJournalStoreError.self) {
             _ = try store.append(draft(eventId: "stable-id", kind: .turnCompleted))
@@ -61,7 +83,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func appendRejectsGuessedTargets() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         var bad = draft()
         bad.unattributedReason = "target-unresolved"
         #expect(throws: AgentJournalStoreError.self) {
@@ -71,7 +97,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func unattributedEventsAreDurable() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         var diagnostic = draft(surfaceId: nil, workspaceId: nil)
         diagnostic.unattributedReason = "target-unresolved"
         let outcome = try store.append(diagnostic)
@@ -83,7 +113,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func roundTripsAllFields() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         var event = draft(kind: .turnCompleted)
         event.pendingWork = true
         event.isSubagent = true
@@ -98,7 +132,8 @@ struct AgentJournalStoreTests {
     }
 
     @Test func journalIsAppendOnlyAcrossReopen() throws {
-        let (store, url) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         let outcome = try store.append(draft())
         store.close()
         let reopened = try AgentJournalStore(databaseURL: url)
@@ -109,7 +144,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func surfaceAliasChainsResolve() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         let a = UUID().uuidString
         let b = UUID().uuidString
         let c = UUID().uuidString
@@ -124,7 +163,11 @@ struct AgentJournalStoreTests {
     }
 
     @Test func workspaceAliasResolves() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         let old = UUID().uuidString
         let new = UUID().uuidString
         try store.recordRestoreAliases(workspaceAliases: [old: new], surfaceAliases: [:])
@@ -133,20 +176,27 @@ struct AgentJournalStoreTests {
     }
 
     @Test func aliasCyclesTerminate() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         let a = UUID().uuidString
         let b = UUID().uuidString
         try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [a: b])
         try store.recordRestoreAliases(workspaceAliases: [:], surfaceAliases: [b: a])
-        // Chain following is bounded; the resolved id is one of the cycle
-        // members rather than an infinite loop.
-        let resolved = try store.resolvedSurfaceId(a)
-        #expect(resolved == a || resolved == b)
+        // Chain following is bounded; a recorded cycle fails closed with nil
+        // rather than returning an arbitrary intermediate identity.
+        #expect(try store.resolvedSurfaceId(a) == nil)
         store.close()
     }
 
     @Test func readsPageBySequence() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         for _ in 0..<5 { _ = try store.append(draft()) }
         let firstPage = try store.events(afterSequence: 0, limit: 2)
         #expect(firstPage.map(\.sequence) == [1, 2])
@@ -155,19 +205,48 @@ struct AgentJournalStoreTests {
         store.close()
     }
 
+    @Test func readPageAdvancesOverUndecodableRows() throws {
+        try withStore { store, url in
+            _ = try store.append(draft())
+            // A row written by a hypothetical newer schema: valid SQL, but a
+            // kind this build cannot decode. INSERT is allowed by design —
+            // only UPDATE/DELETE are trigger-blocked.
+            var handle: OpaquePointer?
+            #expect(sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+            defer { sqlite3_close_v2(handle) }
+            let insert = """
+            INSERT INTO agent_journal(
+                event_id, schema_version, kind, occurred_at_ms, committed_at_ms,
+                source, agent_key, is_subagent, pending_work, unattributed_reason
+            ) VALUES ('future-1', 2, 'agent.future.kind', 1, 1, 'claude', 'claude_code', 0, 0, 'x');
+            """
+            #expect(sqlite3_exec(handle, insert, nil, nil, nil) == SQLITE_OK)
+            _ = try store.append(draft())
+
+            let page = try store.readPage(afterSequence: 0, limit: 10)
+            #expect(page.events.map(\.sequence) == [1, 3])
+            #expect(page.skippedSequences == [2])
+            #expect(page.scannedThroughSequence == 3)
+
+            // Pagination cannot stall on an undecodable run: a page that
+            // decodes nothing still advances the cursor.
+            let onlyBad = try store.readPage(afterSequence: 1, limit: 1)
+            #expect(onlyBad.events.isEmpty)
+            #expect(onlyBad.scannedThroughSequence == 2)
+            #expect(!onlyBad.isEmpty)
+        }
+    }
+
     @Test func closedStoreThrows() throws {
-        let (store, _) = makeStoreOrFail()
+        let (store, url) = try makeStore()
+        defer {
+            store.close()
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
         store.close()
         #expect(throws: AgentJournalStoreError.closed) {
             _ = try store.headSequence()
         }
     }
 
-    private func makeStoreOrFail() -> (AgentJournalStore, URL) {
-        do {
-            return try makeStore()
-        } catch {
-            fatalError("failed to open test store: \(error)")
-        }
-    }
 }

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentLifecycleReducerTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentLifecycleReducerTests.swift
@@ -182,6 +182,20 @@ struct AgentLifecycleReducerTests {
         #expect(mutated == state)
     }
 
+    @Test func observationArrivingBeforeLifecycleEventDoesNotMaskIt() {
+        // A pure observation carries no watermark: a lifecycle event that
+        // arrives after a higher-sequence observation still applies, so the
+        // fold converges regardless of delivery order.
+        let events = [
+            event(1, .turnStarted),
+            event(2, .stateChanged),
+        ]
+        let inOrder = fold(events)
+        let reversed = fold([events[1], events[0]])
+        #expect(inOrder.snapshot() == reversed.snapshot())
+        #expect(reversed.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+    }
+
     @Test func declaredPhaseCorrectionApplies() {
         let state = fold([
             event(1, .turnStarted),

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentLifecycleReducerTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentLifecycleReducerTests.swift
@@ -1,0 +1,216 @@
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Agent lifecycle reducer")
+struct AgentLifecycleReducerTests {
+    private let reducer = AgentLifecycleReducer()
+    private let surface = "5E7A11AA-0000-4000-8000-000000000001"
+    private let workspace = "5E7A11AA-0000-4000-8000-0000000000AA"
+
+    private func event(
+        _ sequence: Int64,
+        _ kind: AgentJournalEventKind,
+        session: String = "s1",
+        agentKey: String = "claude_code",
+        surfaceId: String? = nil,
+        pendingWork: Bool = false,
+        isSubagent: Bool = false,
+        unattributedReason: String? = nil,
+        declaredPhase: AgentLifecyclePhase? = nil
+    ) -> AgentJournalEvent {
+        let attributed = unattributedReason == nil
+        let draft = AgentJournalEventDraft(
+            eventId: "event-\(sequence)",
+            kind: kind,
+            occurredAtMs: 1_000 + sequence,
+            source: "claude",
+            agentKey: agentKey,
+            sessionId: session,
+            workspaceId: attributed ? workspace : nil,
+            surfaceId: attributed ? (surfaceId ?? surface) : nil,
+            unattributedReason: unattributedReason,
+            isSubagent: isSubagent,
+            pendingWork: pendingWork,
+            declaredPhase: declaredPhase
+        )
+        return AgentJournalEvent(sequence: sequence, committedAtMs: 2_000 + sequence, draft: draft)
+    }
+
+    private func fold(_ events: [AgentJournalEvent]) -> AgentLifecycleReducerState {
+        var state = AgentLifecycleReducerState()
+        for event in events {
+            reducer.apply(event, to: &state)
+        }
+        return state
+    }
+
+    @Test func basicTurnLifecycle() {
+        let state = fold([
+            event(1, .sessionStarted),
+            event(2, .turnStarted),
+        ])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+
+        let idle = fold([
+            event(1, .sessionStarted),
+            event(2, .turnStarted),
+            event(3, .turnCompleted),
+        ])
+        #expect(idle.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .idle)
+    }
+
+    @Test func needsInputKinds() {
+        for kind in [AgentJournalEventKind.approvalRequested, .questionRequested, .planReviewRequested] {
+            let state = fold([event(1, .turnStarted), event(2, kind)])
+            #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .needsInput)
+        }
+    }
+
+    @Test func errorReportedBecomesErrorPhase() {
+        let state = fold([event(1, .turnStarted), event(2, .errorReported)])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .error)
+    }
+
+    @Test func pendingWorkKeepsTurnCompletedRunning() {
+        let state = fold([event(1, .turnStarted), event(2, .turnCompleted, pendingWork: true)])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+    }
+
+    @Test func sessionEndedClearsEntry() {
+        let state = fold([event(1, .turnStarted), event(2, .sessionEnded)])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == nil)
+        #expect(state.snapshot().phases[surface] == nil)
+    }
+
+    @Test func duplicateEventsAreIdempotent() {
+        let events = [event(1, .turnStarted), event(2, .approvalRequested)]
+        let once = fold(events)
+        let twice = fold(events + events + [events[0]])
+        #expect(once == twice)
+    }
+
+    @Test func outOfOrderDeliveryConvergesToSequenceOrder() {
+        let events = [
+            event(1, .turnStarted),
+            event(2, .approvalRequested),
+            event(3, .turnStarted),
+            event(4, .turnCompleted),
+        ]
+        let inOrder = fold(events)
+        let shuffles: [[AgentJournalEvent]] = [
+            [events[3], events[2], events[1], events[0]],
+            [events[1], events[3], events[0], events[2]],
+            [events[2], events[0], events[3], events[1]],
+        ]
+        for shuffled in shuffles {
+            #expect(fold(shuffled).snapshot() == inOrder.snapshot())
+        }
+        #expect(inOrder.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .idle)
+    }
+
+    @Test func replayFromScratchReproducesState() {
+        let events = [
+            event(1, .sessionStarted),
+            event(2, .turnStarted),
+            event(3, .questionRequested),
+            event(4, .turnStarted),
+            event(5, .turnCompleted),
+            event(6, .turnStarted),
+        ]
+        var incremental = AgentLifecycleReducerState()
+        for entry in events {
+            reducer.apply(entry, to: &incremental)
+        }
+        let replayed = fold(events)
+        #expect(incremental == replayed)
+        #expect(replayed.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+    }
+
+    @Test func multiSessionCombinePrecedence() {
+        // Newer session running while an older session is stuck needsInput:
+        // running wins (the pane is visibly busy).
+        let state = fold([
+            event(1, .approvalRequested, session: "old"),
+            event(2, .turnStarted, session: "new"),
+        ])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+
+        // Once the newer session completes, the stuck old session would pin
+        // needsInput — unless it ends.
+        let stuck = fold([
+            event(1, .approvalRequested, session: "old"),
+            event(2, .turnStarted, session: "new"),
+            event(3, .turnCompleted, session: "new"),
+        ])
+        #expect(stuck.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .needsInput)
+
+        let cleaned = fold([
+            event(1, .approvalRequested, session: "old"),
+            event(2, .turnStarted, session: "new"),
+            event(3, .sessionEnded, session: "old"),
+            event(4, .turnCompleted, session: "new"),
+        ])
+        #expect(cleaned.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .idle)
+    }
+
+    @Test func subagentEventsNeverDriveSurfaceLifecycle() {
+        let state = fold([event(1, .turnStarted, isSubagent: true)])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == nil)
+    }
+
+    @Test func unattributedEventsBecomeDiagnosticsNotState() {
+        let state = fold([
+            event(1, .approvalRequested, unattributedReason: "target-unresolved"),
+        ])
+        #expect(state.snapshot().phases.isEmpty)
+        #expect(state.unattributedEvents.count == 1)
+        #expect(state.unattributedEvents[0].draft.unattributedReason == "target-unresolved")
+    }
+
+    @Test func childAndObservationEventsKeepPhase() {
+        let state = fold([
+            event(1, .turnStarted),
+            event(2, .childSpawned),
+            event(3, .stateChanged),
+            event(4, .childCompleted),
+        ])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+        // Watermark advanced: replaying event 3 changes nothing.
+        var mutated = state
+        let changed = reducer.apply(event(3, .stateChanged), to: &mutated)
+        #expect(!changed)
+        #expect(mutated == state)
+    }
+
+    @Test func declaredPhaseCorrectionApplies() {
+        let state = fold([
+            event(1, .turnStarted),
+            event(2, .stateChanged, declaredPhase: .idle),
+        ])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .idle)
+    }
+
+    @Test func snapshotDiffProducesAssignmentsAndClears() {
+        let before = fold([event(1, .turnStarted)]).snapshot()
+        let after = fold([event(1, .turnStarted), event(2, .sessionEnded)]).snapshot()
+        let assignments = after.assignments(since: before)
+        #expect(assignments == [
+            AgentLifecycleAssignment(surfaceId: surface, agentKey: "claude_code", phase: nil),
+        ])
+
+        let changed = fold([event(1, .turnStarted), event(2, .questionRequested)]).snapshot()
+        #expect(changed.assignments(since: before) == [
+            AgentLifecycleAssignment(surfaceId: surface, agentKey: "claude_code", phase: .needsInput),
+        ])
+        #expect(changed.assignments(since: changed).isEmpty)
+    }
+
+    @Test func distinctAgentsOnOneSurfaceAreIndependent() {
+        let state = fold([
+            event(1, .turnStarted, agentKey: "claude_code"),
+            event(2, .approvalRequested, session: "s2", agentKey: "codex"),
+        ])
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "claude_code") == .running)
+        #expect(state.combinedPhase(surfaceId: surface, agentKey: "codex") == .needsInput)
+    }
+}

--- a/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentSemanticEventMapperTests.swift
+++ b/Packages/macOS/CmuxAgentJournal/Tests/CmuxAgentJournalTests/AgentSemanticEventMapperTests.swift
@@ -1,0 +1,68 @@
+import Testing
+@testable import CmuxAgentJournal
+
+@Suite("Semantic event mapper")
+struct AgentSemanticEventMapperTests {
+    private let mapper = AgentSemanticEventMapper()
+
+    @Test(arguments: [
+        // Generic arms shared by claude/codex/gemini/cursor/grok/kiro/kimi…
+        ("claude", "SessionStart", nil, AgentJournalEventKind.sessionStarted),
+        ("claude", "UserPromptSubmit", nil, .turnStarted),
+        ("claude", "Stop", nil, .turnCompleted),
+        ("claude", "SessionEnd", nil, .sessionEnded),
+        ("claude", "PermissionRequest", nil, .approvalRequested),
+        ("claude", "StopFailure", nil, .errorReported),
+        ("claude", "SubagentStart", nil, .childSpawned),
+        ("claude", "SubagentStop", nil, .childCompleted),
+        ("claude", "Notification", nil, .stateChanged),
+        ("codex", "SessionStart", nil, .sessionStarted),
+        ("codex", "Stop", nil, .turnCompleted),
+        ("cursor", "beforeSubmitPrompt", nil, .turnStarted),
+        ("cursor", "afterAgentResponse", nil, .turnCompleted),
+        ("gemini", "BeforeAgent", nil, .turnStarted),
+        ("gemini", "AfterAgent", nil, .turnCompleted),
+        ("kimi", "StopFailure", nil, .errorReported),
+        ("kiro", "agentSpawn", nil, .childSpawned),
+        ("rovodev", "on_complete", nil, .turnCompleted),
+        ("rovodev", "on_error", nil, .errorReported),
+        ("rovodev", "on_tool_permission", nil, .approvalRequested),
+        ("hermes-agent", "pre_llm_call", nil, .turnStarted),
+        ("hermes-agent", "post_llm_call", nil, .turnCompleted),
+        ("hermes-agent", "pre_approval_request", nil, .approvalRequested),
+        ("hermes-agent", "on_session_reset", nil, .sessionStarted),
+        ("hermes-agent", "on_session_finalize", nil, .sessionEnded),
+        // Source-specific arms.
+        ("antigravity", "SessionEnd", nil, .turnCompleted),
+        ("antigravity", "turn-completion", nil, .turnCompleted),
+        ("hermes-agent", "on_session_end", nil, .turnCompleted),
+        ("opencode", "session.created", nil, .sessionStarted),
+        ("opencode", "session.idle", nil, .turnCompleted),
+        ("opencode", "session.deleted", nil, .sessionEnded),
+        ("copilot", "Notification", nil, .turnCompleted),
+        ("codebuddy", "Notification", nil, .turnCompleted),
+        ("factory", "Notification", nil, .turnCompleted),
+        ("grok", "Notification", nil, .stateChanged),
+        // Blocking tools outrank event names.
+        ("claude", "PreToolUse", "AskUserQuestion", .questionRequested),
+        ("claude", "PreToolUse", "ExitPlanMode", .planReviewRequested),
+        ("codex", "PreToolUse", "exit_plan_mode", .planReviewRequested),
+        // questionAsked shortcut.
+        ("pi", "questionAsked", nil, .questionRequested),
+        // Unknown events observe, never fabricate needs-input.
+        ("claude", "SomethingBrandNew", nil, .stateChanged),
+        ("qoder", "", nil, .stateChanged),
+    ] as [(String, String, String?, AgentJournalEventKind)])
+    func mapsNativeEvents(entry: (String, String, String?, AgentJournalEventKind)) {
+        let (source, native, tool, expected) = entry
+        #expect(mapper.kind(source: source, nativeEvent: native, toolName: tool) == expected)
+    }
+
+    @Test func normalizationCollapsesNamingConventions() {
+        for variant in ["SubagentStop", "subagent_stop", "subagent-stop", "SUBAGENT.STOP"] {
+            #expect(mapper.kind(source: "claude", nativeEvent: variant, toolName: nil) == .childCompleted)
+        }
+        #expect(AgentSemanticEventMapper.semanticKey("On-Session_End") == "onsessionend")
+        #expect(AgentSemanticEventMapper.semanticKey("turn-completion") == "turncompletion")
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -409,6 +409,17 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         "clear_notifications",
     ]
 
+    /// The v1 agent-journal family: `agent_journal_append` commits one
+    /// semantic agent event to the append-only journal and replies with the
+    /// committed sequence — the emitting hook's durable acknowledgement. The
+    /// body runs on the socket worker (parse + one bounded SQLite
+    /// transaction); it is deliberately NOT main-thread callable so the
+    /// durability fsync can never run inline on the main thread. Internal
+    /// (not private) so the package tests can pin the exact set.
+    static let agentJournalV1Commands: Set<String> = [
+        "agent_journal_append",
+    ]
+
     /// The v1 terminal-read family (tranche C): `read_screen` is the v1 twin
     /// of `surface.read_text` — the Ghostty FFI capture takes one minimal
     /// `v2MainSync` hop and the (possibly multi-MB) tail/merge/base64
@@ -469,6 +480,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
     static let socketWorkerV1Commands: Set<String> =
         sidebarTelemetryV1Commands
             .union(notificationV1Commands)
+            .union(agentJournalV1Commands)
             .union(terminalReadV1Commands)
             .union(diagnosticReadV1Commands)
             .union(resolutionReadV1Commands)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -323,6 +323,8 @@ struct ControlCommandExecutionPolicyTests {
             "list_notifications", "clear_notifications",
         ]
         #expect(ControlCommandExecutionPolicy.notificationV1Commands == notification)
+        let agentJournal: Set<String> = ["agent_journal_append"]
+        #expect(ControlCommandExecutionPolicy.agentJournalV1Commands == agentJournal)
         let terminalRead: Set<String> = ["read_screen"]
         #expect(ControlCommandExecutionPolicy.terminalReadV1Commands == terminalRead)
         let diagnosticRead: Set<String> = ["iroh_diag"]
@@ -345,11 +347,13 @@ struct ControlCommandExecutionPolicyTests {
             ControlCommandExecutionPolicy.configurationMutationV1Commands
                 == configurationMutations
         )
-        let expectedWorker = telemetry.union(notification).union(terminalRead)
+        let expectedWorker = telemetry.union(notification).union(agentJournal)
+            .union(terminalRead)
             .union(diagnosticRead).union(resolutionReads).union(sends)
             .union(configurationMutations).union(windowCapture).union(["ping"])
         #expect(ControlCommandExecutionPolicy.socketWorkerV1Commands == expectedWorker)
-        // Every member except terminal and diagnostic reads, blocking
+        // Every member except terminal and diagnostic reads, the journal
+        // append (durability fsync must never run inline on main), blocking
         // configuration mutations, and async window capture is deliberately
         // main-thread callable (deadlock-free inline: bus enqueues plus
         // inline-collapsing hops).
@@ -358,6 +362,7 @@ struct ControlCommandExecutionPolicyTests {
                 == expectedWorker
                     .subtracting(terminalRead)
                     .subtracting(diagnosticRead)
+                    .subtracting(agentJournal)
                     .subtracting(configurationMutations)
                     .subtracting(windowCapture)
         )

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4130,23 +4130,6 @@
         }
       }
     },
-    "agent.generic.notification.body.needsAttention": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ needs your attention"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の確認が必要です"
-          }
-        }
-      }
-    },
     "agent.generic.notification.body.reportedError": {
       "extractionState": "manual",
       "localizations": {
@@ -4160,23 +4143,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ がエラーを報告しました"
-          }
-        }
-      }
-    },
-    "agent.generic.notification.body.sentNotification": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ sent a notification"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ から通知が届きました"
           }
         }
       }

--- a/Sources/AgentJournalLazyStore.swift
+++ b/Sources/AgentJournalLazyStore.swift
@@ -1,0 +1,66 @@
+import CmuxAgentJournal
+import Foundation
+import os
+
+/// Open-once gate for the agent journal store, so opening the SQLite journal
+/// (including its rare, potentially expensive open-time retention prune)
+/// never runs on the main thread: the main-actor callers of the lifecycle
+/// center only enqueue operations, while the store itself is first opened by
+/// whichever off-main caller needs it — the socket worker's append or the
+/// journal consumer task.
+final class AgentJournalLazyStore: Sendable {
+    private enum State {
+        case unopened(URL)
+        case opened(AgentJournalStore)
+        case unavailable
+    }
+
+    // Lock justification: an open-once compare-and-set from non-async
+    // callers (socket worker thread and the consumer task); the guarded
+    // section is one bounded SQLite open + migration.
+    private let state: OSAllocatedUnfairLock<State>
+
+    init(databaseURL: URL) {
+        self.state = OSAllocatedUnfairLock(initialState: .unopened(databaseURL))
+    }
+
+    /// The opened store, opening it on first use. Returns `nil` (and reports
+    /// the failure once on the event bus) when the journal cannot open.
+    func store() -> AgentJournalStore? {
+        // withLockUnchecked: the store class is Sendable and nothing else
+        // escapes the critical section.
+        state.withLockUnchecked { current in
+            switch current {
+            case .opened(let store):
+                return store
+            case .unavailable:
+                return nil
+            case .unopened(let url):
+                do {
+                    let store = try AgentJournalStore(databaseURL: url)
+                    current = .opened(store)
+                    return store
+                } catch {
+                    current = .unavailable
+                    CmuxEventBus.shared.publish(
+                        name: "agent.journal.open_failed",
+                        category: "agent",
+                        source: "journal",
+                        payload: ["error": String(describing: error)]
+                    )
+                    return nil
+                }
+            }
+        }
+    }
+
+    /// Closes the store if it was opened.
+    func close() {
+        state.withLockUnchecked { current in
+            if case .opened(let store) = current {
+                store.close()
+            }
+            current = .unavailable
+        }
+    }
+}

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -51,15 +51,30 @@ final class AgentJournalLifecycleCenter: Sendable {
             // restore records new aliases: canonicalizing a replay fold via
             // per-event SQL lookups would cost two round-trips per event.
             var aliases: AgentJournalAliasResolver?
-            func resolver(_ store: AgentJournalStore) -> AgentJournalAliasResolver {
+            func resolver(_ store: AgentJournalStore) -> AgentJournalAliasResolver? {
                 if let aliases { return aliases }
-                let maps = (try? store.aliasMaps()) ?? (workspaces: [:], surfaces: [:])
-                let loaded = AgentJournalAliasResolver(
-                    workspaces: maps.workspaces,
-                    surfaces: maps.surfaces
-                )
-                aliases = loaded
-                return loaded
+                do {
+                    let maps = try store.aliasMaps()
+                    let loaded = AgentJournalAliasResolver(
+                        workspaces: maps.workspaces,
+                        surfaces: maps.surfaces
+                    )
+                    aliases = loaded
+                    return loaded
+                } catch {
+                    // Fail closed: without alias state, canonicalization
+                    // could attach lifecycle to a stale identity. Drop the
+                    // operation with a diagnostic and retry on the next one.
+                    CmuxEventBus.shared.publish(
+                        name: "agent.journal.aliases_unavailable",
+                        category: "agent",
+                        source: "journal"
+                    )
+#if DEBUG
+                    cmuxDebugLog("agentJournal.aliases.loadError \(String(describing: error))")
+#endif
+                    return nil
+                }
             }
             for await operation in stream {
                 guard let store = lazyStore.store() else {
@@ -73,9 +88,10 @@ final class AgentJournalLifecycleCenter: Sendable {
                 }
                 switch operation {
                 case .ingest(let event):
+                    guard let eventAliases = resolver(store) else { continue }
                     if let application = Self.reduceIngest(
                         event,
-                        aliases: resolver(store),
+                        aliases: eventAliases,
                         reducer: reducer,
                         state: &state
                     ) {
@@ -87,11 +103,11 @@ final class AgentJournalLifecycleCenter: Sendable {
                     }
                 case .recordAliases(let workspaces, let surfaces):
                     do {
+                        defer { aliases?.merge(workspaces: workspaces, surfaces: surfaces) }
                         try store.recordRestoreAliases(
                             workspaceAliases: workspaces,
                             surfaceAliases: surfaces
                         )
-                        aliases?.merge(workspaces: workspaces, surfaces: surfaces)
 #if DEBUG
                         cmuxDebugLog(
                             "agentJournal.aliases.recorded surfaces=\(surfaces.count) " +
@@ -99,14 +115,24 @@ final class AgentJournalLifecycleCenter: Sendable {
                         )
 #endif
                     } catch {
+                        // In-memory state above keeps the live run correct;
+                        // the persistence gap (replay after relaunch) is
+                        // recorded in release builds too.
+                        CmuxEventBus.shared.publish(
+                            name: "agent.journal.alias_persist_failed",
+                            category: "agent",
+                            source: "journal",
+                            payload: ["surfaces": surfaces.count, "workspaces": workspaces.count]
+                        )
 #if DEBUG
                         cmuxDebugLog("agentJournal.aliases.error \(String(describing: error))")
 #endif
                     }
                 case .startupReplay:
+                    guard let replayAliases = resolver(store) else { continue }
                     let assignments = Self.reduceStartupReplay(
                         store: store,
-                        aliases: resolver(store),
+                        aliases: replayAliases,
                         reducer: reducer,
                         replayPolicy: replayPolicy,
                         state: &state
@@ -151,7 +177,12 @@ final class AgentJournalLifecycleCenter: Sendable {
         do {
             draft = try JSONDecoder().decode(AgentJournalEventDraft.self, from: data)
         } catch {
-            return "ERROR: invalid agent journal event: \(error.localizedDescription)"
+            // Stable product-level reply; implementation detail stays in the
+            // debug log (the caller's dead-letter keeps the draft itself).
+#if DEBUG
+            cmuxDebugLog("agentJournal.append.invalid \(String(describing: error))")
+#endif
+            return "ERROR: invalid agent journal event"
         }
         do {
             let outcome = try store.append(draft)
@@ -173,7 +204,16 @@ final class AgentJournalLifecycleCenter: Sendable {
 #endif
             return outcome.replayed ? "OK \(outcome.sequence) replayed" : "OK \(outcome.sequence)"
         } catch {
-            return "ERROR: agent journal append failed: \(String(describing: error))"
+            CmuxEventBus.shared.publish(
+                name: "agent.journal.append_failed",
+                category: "agent",
+                source: "journal",
+                payload: ["kind": draft.kind.rawValue]
+            )
+#if DEBUG
+            cmuxDebugLog("agentJournal.append.error \(String(describing: error))")
+#endif
+            return "ERROR: agent journal append failed"
         }
     }
 
@@ -256,10 +296,25 @@ final class AgentJournalLifecycleCenter: Sendable {
         var folded = 0
         var skipped = 0
         while true {
-            guard let page = try? store.readPage(afterSequence: cursor, limit: 2_048),
-                  !page.isEmpty else {
-                break
+            let page: AgentJournalReadPage
+            do {
+                page = try store.readPage(afterSequence: cursor, limit: 2_048)
+            } catch {
+                // An incomplete fold must not paint partial replay state:
+                // record the failure and paint nothing (live events still
+                // reduce and self-correct per session).
+                CmuxEventBus.shared.publish(
+                    name: "agent.journal.replay_failed",
+                    category: "agent",
+                    source: "journal",
+                    payload: ["cursor": cursor, "folded": folded]
+                )
+#if DEBUG
+                cmuxDebugLog("agentJournal.replay.error cursor=\(cursor) \(String(describing: error))")
+#endif
+                return []
             }
+            if page.isEmpty { break }
             for event in page.events {
                 reducer.apply(canonicalized(event, aliases: aliases), to: &state)
             }
@@ -294,16 +349,29 @@ final class AgentJournalLifecycleCenter: Sendable {
         aliases: AgentJournalAliasResolver
     ) -> AgentJournalEvent {
         var draft = event.draft
-        // A nil resolution means the alias chain hit its cycle cap; keep the
-        // original identity, which fails closed downstream (a dead surface
-        // is skipped at apply, never guessed).
-        if let surfaceId = draft.surfaceId,
-           let resolved = aliases.resolvedSurfaceId(surfaceId) {
-            draft.surfaceId = resolved
+        // A nil resolution means the alias chain hit its cycle cap (corrupt
+        // alias state): the current identity is unknowable, so fail closed —
+        // strip the target and keep the event as an explicit diagnostic
+        // instead of applying state under a possibly stale identity.
+        var cycled = false
+        if let surfaceId = draft.surfaceId {
+            if let resolved = aliases.resolvedSurfaceId(surfaceId) {
+                draft.surfaceId = resolved
+            } else {
+                cycled = true
+            }
         }
-        if let workspaceId = draft.workspaceId,
-           let resolved = aliases.resolvedWorkspaceId(workspaceId) {
-            draft.workspaceId = resolved
+        if let workspaceId = draft.workspaceId {
+            if let resolved = aliases.resolvedWorkspaceId(workspaceId) {
+                draft.workspaceId = resolved
+            } else {
+                cycled = true
+            }
+        }
+        if cycled {
+            draft.workspaceId = nil
+            draft.surfaceId = nil
+            draft.unattributedReason = "alias-cycle"
         }
         return AgentJournalEvent(
             sequence: event.sequence,
@@ -350,6 +418,15 @@ final class AgentJournalLifecycleCenter: Sendable {
             owner = nil
         }
         guard let owner else {
+            // Fail closed and record it in release builds too: the panel no
+            // longer exists, so the assignment is dropped, never re-homed.
+            CmuxEventBus.shared.publish(
+                name: "agent.journal.apply_skipped",
+                category: "agent",
+                source: "journal",
+                surfaceId: assignment.surfaceId,
+                payload: ["agent_key": assignment.agentKey, "reason": "panelGone"]
+            )
 #if DEBUG
             cmuxDebugLog(
                 "agentJournal.apply.skip surface=\(assignment.surfaceId.prefix(8)) " +

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -1,0 +1,357 @@
+import CmuxAgentJournal
+import Foundation
+
+/// App-side owner of the agent journal: the single writer for
+/// `agent_journal_append`, the ordered consumer that reduces committed events
+/// into sidebar lifecycle state, and the startup replayer that reproduces
+/// badges from history instead of the last painted state.
+///
+/// Ordering: appends commit synchronously on the socket worker (the durable
+/// acknowledgement returned to the emitting hook), then flow through one
+/// FIFO operation stream alongside restore-alias recording and the startup
+/// replay request, so identity aliases recorded during session restore are
+/// always visible to the replay fold that follows them.
+final class AgentJournalLifecycleCenter: Sendable {
+    static let shared = AgentJournalLifecycleCenter()
+
+    private enum Operation: Sendable {
+        case ingest(AgentJournalEvent)
+        case recordAliases(workspaces: [String: String], surfaces: [String: String])
+        case startupReplay
+    }
+
+    private let store: AgentJournalStore?
+    private let operations: AsyncStream<Operation>.Continuation?
+    private let reducer = AgentLifecycleReducer()
+    private let replayPolicy = AgentJournalReplayPolicy()
+    private let consumerTask: Task<Void, Never>?
+
+    convenience init() {
+        self.init(databaseURL: Self.defaultDatabaseURL())
+    }
+
+    init(databaseURL: URL?) {
+        var openedStore: AgentJournalStore?
+        if let databaseURL {
+            do {
+                openedStore = try AgentJournalStore(databaseURL: databaseURL)
+            } catch {
+                CmuxEventBus.shared.publish(
+                    name: "agent.journal.open_failed",
+                    category: "agent",
+                    source: "journal",
+                    payload: ["error": String(describing: error)]
+                )
+            }
+        }
+        self.store = openedStore
+        guard let openedStore else {
+            self.operations = nil
+            self.consumerTask = nil
+            return
+        }
+        var continuation: AsyncStream<Operation>.Continuation?
+        let stream = AsyncStream<Operation>(bufferingPolicy: .unbounded) { continuation = $0 }
+        self.operations = continuation
+        let reducer = self.reducer
+        let replayPolicy = self.replayPolicy
+        self.consumerTask = Task.detached(priority: .utility) {
+            var state = AgentLifecycleReducerState()
+            for await operation in stream {
+                switch operation {
+                case .ingest(let event):
+                    Self.consumeIngest(
+                        event,
+                        store: openedStore,
+                        reducer: reducer,
+                        state: &state
+                    )
+                case .recordAliases(let workspaces, let surfaces):
+                    try? openedStore.recordRestoreAliases(
+                        workspaceAliases: workspaces,
+                        surfaceAliases: surfaces
+                    )
+                case .startupReplay:
+                    Self.consumeStartupReplay(
+                        store: openedStore,
+                        reducer: reducer,
+                        replayPolicy: replayPolicy,
+                        state: &state
+                    )
+                }
+            }
+        }
+    }
+
+    deinit {
+        consumerTask?.cancel()
+        operations?.finish()
+        store?.close()
+    }
+
+    /// Whether the journal opened; when false the verb reports unavailable.
+    var isAvailable: Bool { store != nil }
+
+    /// Full body of the `agent_journal_append` socket verb: decode, commit
+    /// durably, enqueue reduction, and reply with the committed sequence.
+    ///
+    /// Runs on the socket worker thread; the reply IS the emitting hook's
+    /// durable acknowledgement, so the SQLite commit happens inline here.
+    func handleAppendCommand(_ args: String) -> String {
+        guard let store, let operations else {
+            return "ERROR: agent journal unavailable"
+        }
+        let payload = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !payload.isEmpty, let data = payload.data(using: .utf8) else {
+            return "ERROR: Usage: agent_journal_append <event-json>"
+        }
+        let draft: AgentJournalEventDraft
+        do {
+            draft = try JSONDecoder().decode(AgentJournalEventDraft.self, from: data)
+        } catch {
+            return "ERROR: invalid agent journal event: \(error.localizedDescription)"
+        }
+        do {
+            let outcome = try store.append(draft)
+            operations.yield(
+                .ingest(
+                    AgentJournalEvent(
+                        sequence: outcome.sequence,
+                        committedAtMs: outcome.committedAtMs,
+                        draft: draft
+                    )
+                )
+            )
+#if DEBUG
+            cmuxDebugLog(
+                "agentJournal.append kind=\(draft.kind.rawValue) agent=\(draft.agentKey) " +
+                    "seq=\(outcome.sequence) replayed=\(outcome.replayed ? 1 : 0) " +
+                    "attributed=\(draft.unattributedReason == nil ? 1 : 0)"
+            )
+#endif
+            return outcome.replayed ? "OK \(outcome.sequence) replayed" : "OK \(outcome.sequence)"
+        } catch {
+            return "ERROR: agent journal append failed: \(String(describing: error))"
+        }
+    }
+
+    /// Records the workspace/panel identity remaps produced by one restored
+    /// workspace, so journaled history re-attaches to the restored panels.
+    func noteRestoredIdentityAliases(
+        oldWorkspaceId: UUID?,
+        newWorkspaceId: UUID,
+        oldToNewPanelIds: [UUID: UUID]
+    ) {
+        guard let operations else { return }
+        var workspaces: [String: String] = [:]
+        if let oldWorkspaceId, oldWorkspaceId != newWorkspaceId {
+            workspaces[oldWorkspaceId.uuidString] = newWorkspaceId.uuidString
+        }
+        var surfaces: [String: String] = [:]
+        for (old, new) in oldToNewPanelIds where old != new {
+            surfaces[old.uuidString] = new.uuidString
+        }
+        guard !workspaces.isEmpty || !surfaces.isEmpty else { return }
+        operations.yield(.recordAliases(workspaces: workspaces, surfaces: surfaces))
+    }
+
+    /// Requests a replay of the journal into sidebar lifecycle state. Called
+    /// once session restore has settled (aliases recorded); idempotent — the
+    /// fold deduplicates by sequence, and only replay-safe phases repaint.
+    func noteStartupReplayReady() {
+        operations?.yield(.startupReplay)
+    }
+
+    // MARK: - Consumer
+
+    private static func consumeIngest(
+        _ event: AgentJournalEvent,
+        store: AgentJournalStore,
+        reducer: AgentLifecycleReducer,
+        state: inout AgentLifecycleReducerState
+    ) {
+        let canonical = canonicalized(event, store: store)
+        reducer.apply(canonical, to: &state)
+        guard canonical.draft.unattributedReason == nil else {
+            publishUnattributedDiagnostic(canonical)
+            return
+        }
+        guard let surfaceId = canonical.draft.surfaceId else {
+            publishUnattributedDiagnostic(canonical)
+            return
+        }
+        guard !canonical.draft.isSubagent else { return }
+        let assignment = AgentLifecycleAssignment(
+            surfaceId: surfaceId,
+            agentKey: canonical.agentKey,
+            phase: state.combinedPhase(surfaceId: surfaceId, agentKey: canonical.agentKey)
+        )
+        let workspaceHint = canonical.draft.workspaceId
+        Task { @MainActor in
+            Self.apply(assignment, workspaceHint: workspaceHint)
+        }
+    }
+
+    private static func consumeStartupReplay(
+        store: AgentJournalStore,
+        reducer: AgentLifecycleReducer,
+        replayPolicy: AgentJournalReplayPolicy,
+        state: inout AgentLifecycleReducerState
+    ) {
+        var cursor: Int64 = 0
+        var folded = 0
+        while true {
+            guard let page = try? store.events(afterSequence: cursor, limit: 2_048),
+                  !page.isEmpty else {
+                break
+            }
+            for event in page {
+                reducer.apply(canonicalized(event, store: store), to: &state)
+            }
+            folded += page.count
+            cursor = page[page.count - 1].sequence
+        }
+        let startup = replayPolicy.startupSnapshot(from: state.snapshot())
+        var assignments: [(AgentLifecycleAssignment, String?)] = []
+        for (surfaceId, byAgent) in startup.phases {
+            for (agentKey, phase) in byAgent {
+                assignments.append((
+                    AgentLifecycleAssignment(surfaceId: surfaceId, agentKey: agentKey, phase: phase),
+                    nil
+                ))
+            }
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "agentJournal.replay folded=\(folded) painted=\(assignments.count) " +
+                "unattributed=\(state.unattributedEvents.count)"
+        )
+#endif
+        guard !assignments.isEmpty else { return }
+        Task { @MainActor in
+            for (assignment, hint) in assignments {
+                Self.apply(assignment, workspaceHint: hint)
+            }
+        }
+    }
+
+    /// Rewrites the event's identity through the restore alias chains so
+    /// sessions that span an app relaunch reduce under one canonical surface.
+    private static func canonicalized(
+        _ event: AgentJournalEvent,
+        store: AgentJournalStore
+    ) -> AgentJournalEvent {
+        var draft = event.draft
+        if let surfaceId = draft.surfaceId,
+           let resolved = try? store.resolvedSurfaceId(surfaceId) {
+            draft.surfaceId = resolved
+        }
+        if let workspaceId = draft.workspaceId,
+           let resolved = try? store.resolvedWorkspaceId(workspaceId) {
+            draft.workspaceId = resolved
+        }
+        return AgentJournalEvent(
+            sequence: event.sequence,
+            committedAtMs: event.committedAtMs,
+            draft: draft
+        )
+    }
+
+    private static func publishUnattributedDiagnostic(_ event: AgentJournalEvent) {
+        CmuxEventBus.shared.publish(
+            name: "agent.journal.unattributed",
+            category: "agent",
+            source: "journal",
+            payload: [
+                "sequence": event.sequence,
+                "kind": event.kind.rawValue,
+                "agent": event.draft.source,
+                "agent_key": event.agentKey,
+                "native_event": event.draft.nativeEvent ?? "",
+                "reason": event.draft.unattributedReason ?? "missing-surface",
+            ]
+        )
+#if DEBUG
+        cmuxDebugLog(
+            "agentJournal.unattributed seq=\(event.sequence) kind=\(event.kind.rawValue) " +
+                "agent=\(event.draft.source) reason=\(event.draft.unattributedReason ?? "missing-surface")"
+        )
+#endif
+    }
+
+    @MainActor
+    private static func apply(_ assignment: AgentLifecycleAssignment, workspaceHint: String?) {
+        guard AgentHibernationLifecycleStatusKeys.isAllowed(assignment.agentKey) else { return }
+        guard let panelId = UUID(uuidString: assignment.surfaceId) else { return }
+        let owner: ControlSidebarPanelOwner?
+        if let dock = DockSplitStore.liveStores.first(where: { $0.containsPanel(panelId) }) {
+            owner = .dock(dock)
+        } else if let located = AppDelegate.shared?.workspaceContainingPanel(
+            panelId: panelId,
+            preferredWorkspaceId: workspaceHint.flatMap(UUID.init(uuidString:))
+        ) {
+            owner = .workspace(located.workspace)
+        } else {
+            owner = nil
+        }
+        guard let owner else {
+#if DEBUG
+            cmuxDebugLog(
+                "agentJournal.apply.skip surface=\(assignment.surfaceId.prefix(8)) " +
+                    "key=\(assignment.agentKey) reason=panelGone"
+            )
+#endif
+            return
+        }
+        if let phase = assignment.phase {
+            owner.setAgentLifecycle(
+                key: assignment.agentKey,
+                panelId: panelId,
+                lifecycle: Self.lifecycle(for: phase)
+            )
+        } else {
+            owner.clearAgentLifecycle(key: assignment.agentKey, panelId: panelId)
+        }
+    }
+
+    /// Projects the journal phase onto the sidebar's lifecycle enum. The
+    /// sidebar has no dedicated error rendering yet, so `error` uses the
+    /// needs-input treatment (matching the pre-journal pipeline) while the
+    /// journal retains the honest phase.
+    private static func lifecycle(for phase: AgentLifecyclePhase) -> AgentHibernationLifecycleState {
+        switch phase {
+        case .unknown: .unknown
+        case .running: .running
+        case .needsInput: .needsInput
+        case .idle: .idle
+        case .error: .needsInput
+        }
+    }
+
+    private static func defaultDatabaseURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        isRunningUnderAutomatedTests: Bool = SessionRestorePolicy.isRunningUnderAutomatedTests()
+    ) -> URL? {
+        if let override = ProcessInfo.processInfo.environment["CMUX_AGENT_JOURNAL_PATH"],
+           !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        guard !isRunningUnderAutomatedTests else { return nil }
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        let bundleID = bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBundleID = bundleID?.isEmpty == false ? bundleID! : "com.cmuxterm.app"
+        let safeBundleID = resolvedBundleID.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return appSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("agent-journal-\(safeBundleID).sqlite3", isDirectory: false)
+    }
+}

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -64,10 +64,22 @@ final class AgentJournalLifecycleCenter: Sendable {
                         }
                     }
                 case .recordAliases(let workspaces, let surfaces):
-                    try? store.recordRestoreAliases(
-                        workspaceAliases: workspaces,
-                        surfaceAliases: surfaces
-                    )
+                    do {
+                        try store.recordRestoreAliases(
+                            workspaceAliases: workspaces,
+                            surfaceAliases: surfaces
+                        )
+#if DEBUG
+                        cmuxDebugLog(
+                            "agentJournal.aliases.recorded surfaces=\(surfaces.count) " +
+                                "workspaces=\(workspaces.count)"
+                        )
+#endif
+                    } catch {
+#if DEBUG
+                        cmuxDebugLog("agentJournal.aliases.error \(String(describing: error))")
+#endif
+                    }
                 case .startupReplay:
                     let assignments = Self.reduceStartupReplay(
                         store: store,
@@ -156,6 +168,13 @@ final class AgentJournalLifecycleCenter: Sendable {
         for (old, new) in oldToNewPanelIds where old != new {
             surfaces[old.uuidString] = new.uuidString
         }
+#if DEBUG
+        cmuxDebugLog(
+            "agentJournal.aliases.note workspace=\(newWorkspaceId.uuidString.prefix(8)) " +
+                "pairs=\(oldToNewPanelIds.count) remapped=\(surfaces.count) " +
+                "workspaceRemapped=\(workspaces.count)"
+        )
+#endif
         guard !workspaces.isEmpty || !surfaces.isEmpty else { return }
         operations.yield(.recordAliases(workspaces: workspaces, surfaces: surfaces))
     }

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -62,7 +62,15 @@ final class AgentJournalLifecycleCenter: Sendable {
                 return loaded
             }
             for await operation in stream {
-                guard let store = lazyStore.store() else { continue }
+                guard let store = lazyStore.store() else {
+                    // Fails closed (no badges), but never silently: the open
+                    // failure itself was reported on the event bus, and each
+                    // dropped operation is visible in the debug log.
+#if DEBUG
+                    cmuxDebugLog("agentJournal.op.dropped reason=storeUnavailable")
+#endif
+                    continue
+                }
                 switch operation {
                 case .ingest(let event):
                     if let application = Self.reduceIngest(

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -47,13 +47,27 @@ final class AgentJournalLifecycleCenter: Sendable {
             let reducer = AgentLifecycleReducer()
             let replayPolicy = AgentJournalReplayPolicy()
             var state = AgentLifecycleReducerState()
+            // Loaded once from the store, then maintained in memory as
+            // restore records new aliases: canonicalizing a replay fold via
+            // per-event SQL lookups would cost two round-trips per event.
+            var aliases: AgentJournalAliasResolver?
+            func resolver(_ store: AgentJournalStore) -> AgentJournalAliasResolver {
+                if let aliases { return aliases }
+                let maps = (try? store.aliasMaps()) ?? (workspaces: [:], surfaces: [:])
+                let loaded = AgentJournalAliasResolver(
+                    workspaces: maps.workspaces,
+                    surfaces: maps.surfaces
+                )
+                aliases = loaded
+                return loaded
+            }
             for await operation in stream {
                 guard let store = lazyStore.store() else { continue }
                 switch operation {
                 case .ingest(let event):
                     if let application = Self.reduceIngest(
                         event,
-                        store: store,
+                        aliases: resolver(store),
                         reducer: reducer,
                         state: &state
                     ) {
@@ -69,6 +83,7 @@ final class AgentJournalLifecycleCenter: Sendable {
                             workspaceAliases: workspaces,
                             surfaceAliases: surfaces
                         )
+                        aliases?.merge(workspaces: workspaces, surfaces: surfaces)
 #if DEBUG
                         cmuxDebugLog(
                             "agentJournal.aliases.recorded surfaces=\(surfaces.count) " +
@@ -83,6 +98,7 @@ final class AgentJournalLifecycleCenter: Sendable {
                 case .startupReplay:
                     let assignments = Self.reduceStartupReplay(
                         store: store,
+                        aliases: resolver(store),
                         reducer: reducer,
                         replayPolicy: replayPolicy,
                         state: &state
@@ -105,9 +121,10 @@ final class AgentJournalLifecycleCenter: Sendable {
         lazyStore?.close()
     }
 
-    /// Whether the journal is usable (opens it if this is the first access;
-    /// callers must be off-main).
-    var isAvailable: Bool { lazyStore?.store() != nil }
+    /// Whether the journal is configured (a database URL resolved). The
+    /// store itself opens lazily off-main on first append/consume; this
+    /// check never opens it, so it is safe from any context.
+    var isAvailable: Bool { lazyStore != nil }
 
     /// Full body of the `agent_journal_append` socket verb: decode, commit
     /// durably, enqueue reduction, and reply with the committed sequence.
@@ -195,11 +212,11 @@ final class AgentJournalLifecycleCenter: Sendable {
 
     private static func reduceIngest(
         _ event: AgentJournalEvent,
-        store: AgentJournalStore,
+        aliases: AgentJournalAliasResolver,
         reducer: AgentLifecycleReducer,
         state: inout AgentLifecycleReducerState
     ) -> LifecycleApplication? {
-        let canonical = canonicalized(event, store: store)
+        let canonical = canonicalized(event, aliases: aliases)
         reducer.apply(canonical, to: &state)
         guard canonical.draft.unattributedReason == nil else {
             publishUnattributedDiagnostic(canonical)
@@ -222,22 +239,27 @@ final class AgentJournalLifecycleCenter: Sendable {
 
     private static func reduceStartupReplay(
         store: AgentJournalStore,
+        aliases: AgentJournalAliasResolver,
         reducer: AgentLifecycleReducer,
         replayPolicy: AgentJournalReplayPolicy,
         state: inout AgentLifecycleReducerState
     ) -> [AgentLifecycleAssignment] {
         var cursor: Int64 = 0
         var folded = 0
+        var skipped = 0
         while true {
-            guard let page = try? store.events(afterSequence: cursor, limit: 2_048),
+            guard let page = try? store.readPage(afterSequence: cursor, limit: 2_048),
                   !page.isEmpty else {
                 break
             }
-            for event in page {
-                reducer.apply(canonicalized(event, store: store), to: &state)
+            for event in page.events {
+                reducer.apply(canonicalized(event, aliases: aliases), to: &state)
             }
-            folded += page.count
-            cursor = page[page.count - 1].sequence
+            folded += page.events.count
+            skipped += page.skippedSequences.count
+            // Advance over undecodable rows too so a foreign-schema run can
+            // never stall the fold or hide the events behind it.
+            cursor = page.scannedThroughSequence
         }
         let startup = replayPolicy.startupSnapshot(from: state.snapshot())
         var assignments: [AgentLifecycleAssignment] = []
@@ -250,8 +272,8 @@ final class AgentJournalLifecycleCenter: Sendable {
         }
 #if DEBUG
         cmuxDebugLog(
-            "agentJournal.replay folded=\(folded) painted=\(assignments.count) " +
-                "unattributed=\(state.unattributedEvents.count)"
+            "agentJournal.replay folded=\(folded) skipped=\(skipped) " +
+                "painted=\(assignments.count) unattributed=\(state.unattributedEvents.count)"
         )
 #endif
         return assignments
@@ -261,15 +283,18 @@ final class AgentJournalLifecycleCenter: Sendable {
     /// sessions that span an app relaunch reduce under one canonical surface.
     private static func canonicalized(
         _ event: AgentJournalEvent,
-        store: AgentJournalStore
+        aliases: AgentJournalAliasResolver
     ) -> AgentJournalEvent {
         var draft = event.draft
+        // A nil resolution means the alias chain hit its cycle cap; keep the
+        // original identity, which fails closed downstream (a dead surface
+        // is skipped at apply, never guessed).
         if let surfaceId = draft.surfaceId,
-           let resolved = try? store.resolvedSurfaceId(surfaceId) {
+           let resolved = aliases.resolvedSurfaceId(surfaceId) {
             draft.surfaceId = resolved
         }
         if let workspaceId = draft.workspaceId,
-           let resolved = try? store.resolvedWorkspaceId(workspaceId) {
+           let resolved = aliases.resolvedWorkspaceId(workspaceId) {
             draft.workspaceId = resolved
         }
         return AgentJournalEvent(

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -9,8 +9,11 @@ import Foundation
 /// Ordering: appends commit synchronously on the socket worker (the durable
 /// acknowledgement returned to the emitting hook), then flow through one
 /// FIFO operation stream alongside restore-alias recording and the startup
-/// replay request, so identity aliases recorded during session restore are
-/// always visible to the replay fold that follows them.
+/// replay request. The consumer awaits every main-actor application before
+/// taking the next operation, so sidebar assignments always apply in journal
+/// order — a startup replay can never land after a newer live event's
+/// assignment. The store itself is opened lazily off-main (see
+/// ``AgentJournalLazyStore``), so main-actor callers only ever enqueue.
 final class AgentJournalLifecycleCenter: Sendable {
     static let shared = AgentJournalLifecycleCenter()
 
@@ -20,10 +23,8 @@ final class AgentJournalLifecycleCenter: Sendable {
         case startupReplay
     }
 
-    private let store: AgentJournalStore?
+    private let lazyStore: AgentJournalLazyStore?
     private let operations: AsyncStream<Operation>.Continuation?
-    private let reducer = AgentLifecycleReducer()
-    private let replayPolicy = AgentJournalReplayPolicy()
     private let consumerTask: Task<Void, Never>?
 
     convenience init() {
@@ -31,53 +32,56 @@ final class AgentJournalLifecycleCenter: Sendable {
     }
 
     init(databaseURL: URL?) {
-        var openedStore: AgentJournalStore?
-        if let databaseURL {
-            do {
-                openedStore = try AgentJournalStore(databaseURL: databaseURL)
-            } catch {
-                CmuxEventBus.shared.publish(
-                    name: "agent.journal.open_failed",
-                    category: "agent",
-                    source: "journal",
-                    payload: ["error": String(describing: error)]
-                )
-            }
-        }
-        self.store = openedStore
-        guard let openedStore else {
+        guard let databaseURL else {
+            self.lazyStore = nil
             self.operations = nil
             self.consumerTask = nil
             return
         }
+        let lazyStore = AgentJournalLazyStore(databaseURL: databaseURL)
+        self.lazyStore = lazyStore
         var continuation: AsyncStream<Operation>.Continuation?
         let stream = AsyncStream<Operation>(bufferingPolicy: .unbounded) { continuation = $0 }
         self.operations = continuation
-        let reducer = self.reducer
-        let replayPolicy = self.replayPolicy
         self.consumerTask = Task.detached(priority: .utility) {
+            let reducer = AgentLifecycleReducer()
+            let replayPolicy = AgentJournalReplayPolicy()
             var state = AgentLifecycleReducerState()
             for await operation in stream {
+                guard let store = lazyStore.store() else { continue }
                 switch operation {
                 case .ingest(let event):
-                    Self.consumeIngest(
+                    if let application = Self.reduceIngest(
                         event,
-                        store: openedStore,
+                        store: store,
                         reducer: reducer,
                         state: &state
-                    )
+                    ) {
+                        // Await the application so assignments reach the
+                        // sidebar in journal-consumer order.
+                        await MainActor.run {
+                            Self.apply(application.assignment, workspaceHint: application.workspaceHint)
+                        }
+                    }
                 case .recordAliases(let workspaces, let surfaces):
-                    try? openedStore.recordRestoreAliases(
+                    try? store.recordRestoreAliases(
                         workspaceAliases: workspaces,
                         surfaceAliases: surfaces
                     )
                 case .startupReplay:
-                    Self.consumeStartupReplay(
-                        store: openedStore,
+                    let assignments = Self.reduceStartupReplay(
+                        store: store,
                         reducer: reducer,
                         replayPolicy: replayPolicy,
                         state: &state
                     )
+                    if !assignments.isEmpty {
+                        await MainActor.run {
+                            for assignment in assignments {
+                                Self.apply(assignment, workspaceHint: nil)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -86,11 +90,12 @@ final class AgentJournalLifecycleCenter: Sendable {
     deinit {
         consumerTask?.cancel()
         operations?.finish()
-        store?.close()
+        lazyStore?.close()
     }
 
-    /// Whether the journal opened; when false the verb reports unavailable.
-    var isAvailable: Bool { store != nil }
+    /// Whether the journal is usable (opens it if this is the first access;
+    /// callers must be off-main).
+    var isAvailable: Bool { lazyStore?.store() != nil }
 
     /// Full body of the `agent_journal_append` socket verb: decode, commit
     /// durably, enqueue reduction, and reply with the committed sequence.
@@ -98,7 +103,7 @@ final class AgentJournalLifecycleCenter: Sendable {
     /// Runs on the socket worker thread; the reply IS the emitting hook's
     /// durable acknowledgement, so the SQLite commit happens inline here.
     func handleAppendCommand(_ args: String) -> String {
-        guard let store, let operations else {
+        guard let store = lazyStore?.store(), let operations else {
             return "ERROR: agent journal unavailable"
         }
         let payload = args.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -164,40 +169,44 @@ final class AgentJournalLifecycleCenter: Sendable {
 
     // MARK: - Consumer
 
-    private static func consumeIngest(
+    private struct LifecycleApplication: Sendable {
+        let assignment: AgentLifecycleAssignment
+        let workspaceHint: String?
+    }
+
+    private static func reduceIngest(
         _ event: AgentJournalEvent,
         store: AgentJournalStore,
         reducer: AgentLifecycleReducer,
         state: inout AgentLifecycleReducerState
-    ) {
+    ) -> LifecycleApplication? {
         let canonical = canonicalized(event, store: store)
         reducer.apply(canonical, to: &state)
         guard canonical.draft.unattributedReason == nil else {
             publishUnattributedDiagnostic(canonical)
-            return
+            return nil
         }
         guard let surfaceId = canonical.draft.surfaceId else {
             publishUnattributedDiagnostic(canonical)
-            return
+            return nil
         }
-        guard !canonical.draft.isSubagent else { return }
-        let assignment = AgentLifecycleAssignment(
-            surfaceId: surfaceId,
-            agentKey: canonical.agentKey,
-            phase: state.combinedPhase(surfaceId: surfaceId, agentKey: canonical.agentKey)
+        guard !canonical.draft.isSubagent else { return nil }
+        return LifecycleApplication(
+            assignment: AgentLifecycleAssignment(
+                surfaceId: surfaceId,
+                agentKey: canonical.agentKey,
+                phase: state.combinedPhase(surfaceId: surfaceId, agentKey: canonical.agentKey)
+            ),
+            workspaceHint: canonical.draft.workspaceId
         )
-        let workspaceHint = canonical.draft.workspaceId
-        Task { @MainActor in
-            Self.apply(assignment, workspaceHint: workspaceHint)
-        }
     }
 
-    private static func consumeStartupReplay(
+    private static func reduceStartupReplay(
         store: AgentJournalStore,
         reducer: AgentLifecycleReducer,
         replayPolicy: AgentJournalReplayPolicy,
         state: inout AgentLifecycleReducerState
-    ) {
+    ) -> [AgentLifecycleAssignment] {
         var cursor: Int64 = 0
         var folded = 0
         while true {
@@ -212,13 +221,12 @@ final class AgentJournalLifecycleCenter: Sendable {
             cursor = page[page.count - 1].sequence
         }
         let startup = replayPolicy.startupSnapshot(from: state.snapshot())
-        var assignments: [(AgentLifecycleAssignment, String?)] = []
+        var assignments: [AgentLifecycleAssignment] = []
         for (surfaceId, byAgent) in startup.phases {
             for (agentKey, phase) in byAgent {
-                assignments.append((
-                    AgentLifecycleAssignment(surfaceId: surfaceId, agentKey: agentKey, phase: phase),
-                    nil
-                ))
+                assignments.append(
+                    AgentLifecycleAssignment(surfaceId: surfaceId, agentKey: agentKey, phase: phase)
+                )
             }
         }
 #if DEBUG
@@ -227,12 +235,7 @@ final class AgentJournalLifecycleCenter: Sendable {
                 "unattributed=\(state.unattributedEvents.count)"
         )
 #endif
-        guard !assignments.isEmpty else { return }
-        Task { @MainActor in
-            for (assignment, hint) in assignments {
-                Self.apply(assignment, workspaceHint: hint)
-            }
-        }
+        return assignments
     }
 
     /// Rewrites the event's identity through the restore alias chains so

--- a/Sources/AgentJournalLifecycleCenter.swift
+++ b/Sources/AgentJournalLifecycleCenter.swift
@@ -315,6 +315,12 @@ final class AgentJournalLifecycleCenter: Sendable {
         } else {
             owner.clearAgentLifecycle(key: assignment.agentKey, panelId: panelId)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "agentJournal.apply surface=\(assignment.surfaceId.prefix(8)) " +
+                "key=\(assignment.agentKey) phase=\(assignment.phase?.rawValue ?? "clear")"
+        )
+#endif
     }
 
     /// Projects the journal phase onto the sidebar's lifecycle enum. The

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3602,6 +3602,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let didApplyStartupSessionRestore = attemptStartupSessionRestoreIfNeeded(
             primaryWindow: primaryWindow
         )
+        if !didApplyStartupSessionRestore, didAttemptStartupSessionRestore {
+            // No snapshot restore ran (fresh start / restore disabled):
+            // replay the agent journal now. When a restore DID run,
+            // completeSessionRestoreOperation triggers replay after the
+            // restored panel-identity aliases are recorded.
+            AgentJournalLifecycleCenter.shared.noteStartupReplayReady()
+        }
         if Self.shouldSaveSessionSnapshotAfterMainWindowRegistration(
             isTerminatingApp: isTerminatingApp,
             didApplyStartupSessionRestore: didApplyStartupSessionRestore,
@@ -3710,6 +3717,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func completeSessionRestoreOperation(isManualReopen: Bool) {
+        // Every restored workspace has enqueued its identity aliases by now;
+        // the journal consumer is FIFO, so the replay fold sees all of them.
+        AgentJournalLifecycleCenter.shared.noteStartupReplayReady()
         startupSessionSnapshot = nil
         let wasApplyingSessionRestore = isApplyingSessionRestore
         isApplyingSessionRestore = false

--- a/Sources/TerminalController+AgentJournal.swift
+++ b/Sources/TerminalController+AgentJournal.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension TerminalController {
+    /// v1 worker body for `agent_journal_append`: parse and durably commit on
+    /// this worker thread (the reply carries the committed sequence — the
+    /// emitting hook's durable acknowledgement), with reduction and sidebar
+    /// application deferred onto the journal center's ordered consumer.
+    nonisolated func agentJournalAppend(_ args: String) -> String {
+        AgentJournalLifecycleCenter.shared.handleAppendCommand(args)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1237,6 +1237,12 @@ class TerminalController {
                 return (true, listNotifications())
             case "clear_notifications":
                 return (true, clearNotifications(args))
+            // The v1 agent-journal family: the append commits durably on this
+            // worker thread (the reply is the emitting hook's durable
+            // acknowledgement); reduction and sidebar application run on the
+            // journal center's ordered consumer.
+            case "agent_journal_append":
+                return (true, agentJournalAppend(args))
             // The v1 terminal-read family (tranche C): the Ghostty capture
             // takes one v2MainSync hop, the (possibly multi-MB) formatting
             // runs here on this worker thread. NOT mainThreadCallable — the

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -339,6 +339,14 @@ extension Workspace {
             AppDelegate.shared?.notificationStore?.clearRestoredUnreadIndicator(forTabId: id)
         }
         AppDelegate.shared?.notificationStore?.restoreSessionNotifications(restoredNotifications, forTabId: id)
+        // Record the identity remap for the agent journal: events journaled
+        // against the previous run's runtime workspace/panel UUIDs re-attach
+        // to the restored panels during replay through these aliases.
+        AgentJournalLifecycleCenter.shared.noteRestoredIdentityAliases(
+            oldWorkspaceId: snapshot.workspaceId,
+            newWorkspaceId: id,
+            oldToNewPanelIds: oldToNewPanelIds
+        )
         syncUnreadBadgeStateForAllPanels()
         if startupRestoreCommitOwner == .workspaceTopology {
             terminalStartupRestoreCoordinator.commitPendingRestores()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -118,6 +118,9 @@
 		A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
 		A76110010000000000000003 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
 		A76110020000000000000001 /* AgentHookNotificationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */; };
+		A77A0005A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */; };
+		A77A000EA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A000DA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift */; };
+		A77A000CA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A000BA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift */; };
 		0A1107110000000000000010 /* AgentNotificationDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000011 /* AgentNotificationDelivery.swift */; };
 		A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */; };
 		A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */; };
@@ -615,7 +618,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00005A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
-		8295A0018295A0018295A001 /* CmuxAlertContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295A0028295A0028295A002 /* CmuxAlertContent.swift */; };
+				8295A0018295A0018295A001 /* CmuxAlertContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295A0028295A0028295A002 /* CmuxAlertContent.swift */; };
 		8295A0058295A0058295A005 /* CmuxAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295A0068295A0068295A006 /* CmuxAlertContentTests.swift */; };
 		8295A0038295A0038295A003 /* CmuxAlertScrollableDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295A0048295A0048295A004 /* CmuxAlertScrollableDetailsView.swift */; };
 		E3309A07 /* cmuxApp+EqualizeSplitsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */; };
@@ -642,6 +645,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		89930008AABBCCDDEEFF0001 /* CMUXCLI+AgentHookProcessBindingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930008AABBCCDDEEFF0002 /* CMUXCLI+AgentHookProcessBindingResult.swift */; };
 		89930007AABBCCDDEEFF0001 /* CMUXCLI+AgentHookProcessBindingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930007AABBCCDDEEFF0002 /* CMUXCLI+AgentHookProcessBindingSource.swift */; };
 		C6711A050000000000000001 /* CMUXCLI+AgentHookRestoreEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B050000000000000001 /* CMUXCLI+AgentHookRestoreEvidence.swift */; };
+		A77A000AA1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A0009A1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift */; };
 		B9000068A1B2C3D4E5F60719 /* CMUXCLI+AmpExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000069A1B2C3D4E5F60719 /* CMUXCLI+AmpExtension.swift */; };
 		0CB4E9797AD54D3BB9CF06F9 /* CMUXCLI+AutoNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5257257034CA4729B1211166 /* CMUXCLI+AutoNaming.swift */; };
 		6D9C51AB30A64B1ABC819142 /* CMUXCLI+AutoNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5257257034CA4729B1211166 /* CMUXCLI+AutoNaming.swift */; };
@@ -2277,6 +2281,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F87910190000000000000001 /* TerminalConfigurationReloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87910190000000000000002 /* TerminalConfigurationReloadCoordinator.swift */; };
 		F87930000000000000000001 /* TerminalConfigurationReloadEnqueueResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87930000000000000000002 /* TerminalConfigurationReloadEnqueueResult.swift */; };
 		F87920000000000000000005 /* TerminalConfigurationReloadPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87920000000000000000006 /* TerminalConfigurationReloadPhase.swift */; };
+		A77A0007A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A0008A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift */; };
 		D35A00000000000000000014 /* TerminalController+AgentPromptDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */; };
 		8054A0030000000000000003 /* TerminalController+BrowserAutomationRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8054A0040000000000000004 /* TerminalController+BrowserAutomationRecovery.swift */; };
 		D35A00000000000000000011 /* TerminalController+BrowserDesignMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000011 /* TerminalController+BrowserDesignMode.swift */; };
@@ -2993,6 +2998,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000100 /* AgentHookFailureStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookFailureStage.swift; sourceTree = "<group>"; };
 		A76110010000000000000002 /* AgentHookNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicy.swift; sourceTree = "<group>"; };
 		A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicyTests.swift; sourceTree = "<group>"; };
+		A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalLifecycleCenter.swift; sourceTree = "<group>"; };
+		A77A000DA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalLifecycleCenterTests.swift; sourceTree = "<group>"; };
+		A77A000BA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalTestSupport.swift; sourceTree = "<group>"; };
 		0A1107110000000000000011 /* AgentNotificationDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationDelivery.swift; sourceTree = "<group>"; };
 		A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGate.swift; sourceTree = "<group>"; };
 		A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGateTests.swift; sourceTree = "<group>"; };
@@ -3502,6 +3510,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		89930008AABBCCDDEEFF0002 /* CMUXCLI+AgentHookProcessBindingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AgentHookProcessBindingResult.swift"; sourceTree = "<group>"; };
 		89930007AABBCCDDEEFF0002 /* CMUXCLI+AgentHookProcessBindingSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AgentHookProcessBindingSource.swift"; sourceTree = "<group>"; };
 		C6711B050000000000000001 /* CMUXCLI+AgentHookRestoreEvidence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AgentHookRestoreEvidence.swift"; sourceTree = "<group>"; };
+		A77A0009A1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AgentJournalEmission.swift"; sourceTree = "<group>"; };
 		B9000069A1B2C3D4E5F60719 /* CMUXCLI+AmpExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AmpExtension.swift"; sourceTree = "<group>"; };
 		5257257034CA4729B1211166 /* CMUXCLI+AutoNaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AutoNaming.swift"; sourceTree = "<group>"; };
 		5257257034CA4729B121116A /* CMUXCLI+AutoNamingDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AutoNamingDispatch.swift"; sourceTree = "<group>"; };
@@ -5059,6 +5068,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F87910190000000000000002 /* TerminalConfigurationReloadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfigurationReloadCoordinator.swift; sourceTree = "<group>"; };
 		F87930000000000000000002 /* TerminalConfigurationReloadEnqueueResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfigurationReloadEnqueueResult.swift; sourceTree = "<group>"; };
 		F87920000000000000000006 /* TerminalConfigurationReloadPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalConfigurationReloadPhase.swift; sourceTree = "<group>"; };
+		A77A0008A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+AgentJournal.swift"; sourceTree = "<group>"; };
 		D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+AgentPromptDelivery.swift"; sourceTree = "<group>"; };
 		8054A0040000000000000004 /* TerminalController+BrowserAutomationRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+BrowserAutomationRecovery.swift"; sourceTree = "<group>"; };
 		D35B00000000000000000011 /* TerminalController+BrowserDesignMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+BrowserDesignMode.swift"; sourceTree = "<group>"; };
@@ -5596,6 +5606,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			buildActionMask = 2147483647;
 			files = (
 				AC4A6E7C4A700001AC4A0001 /* CmuxAgentChat in Frameworks */,
+				A77A0003A1B2C3D4E5F60001 /* CmuxAgentJournal in Frameworks */,
 				A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				C9A2B00000000000000000B3 /* CmuxAppKitSupportUI in Frameworks */,
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
@@ -5662,6 +5673,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A77A0004A1B2C3D4E5F60001 /* CmuxAgentJournal in Frameworks */,
 				A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				C79470010000000000000005 /* CmuxControlSocket in Frameworks */,
 				CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */,
@@ -6881,6 +6893,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6313B1A1 /* PaneMemoryDescriptor.swift */,
 				6313A1A1 /* PaneMemoryGuardrail.swift */,
 				A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */,
+				A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */,
+				A77A0008A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift */,
 				6313B2A1 /* PaneMemoryGuardrailEngine.swift */,
 				6313B3A1 /* PaneMemoryGuardrailEngineOutput.swift */,
 				6313C6A1 /* PaneMemoryGuardrailSampleBatch.swift */,
@@ -7684,6 +7698,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */,
 				C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */,
 				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
+				A77A0009A1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift */,
 				FEEDC1A50000000000000002 /* FeedEventClassifier.swift */,
 				B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */,
 				A10052000000000000000001 /* SocketClient+StartupWait.swift */,
@@ -8423,6 +8438,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */,
 				A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */,
 				A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */,
+				A77A000BA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift */,
+				A77A000DA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift */,
 				A5D41233A1B2C3D4E5F60718 /* ClaudeBackgroundWorkNotifyTests.swift */,
 				F0F0CF0E0000000000000002 /* CLINotifyClaudeForkOfForkRegressionTests.swift */,
 				C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */,
@@ -8570,6 +8587,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */,
 				A5C0DE0000000000000000A2 /* CMUXProjectModel */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				A77A0002A1B2C3D4E5F60001 /* CmuxAgentJournal */,
 				CA52A005CA52A005CA52A005 /* CmuxCanvas */,
 				CA53A005CA53A005CA53A005 /* CmuxCanvasUI */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
@@ -8626,6 +8644,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			packageProductDependencies = (
 				A5001251 /* Sentry */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				A77A0002A1B2C3D4E5F60001 /* CmuxAgentJournal */,
 				C750100000000000000000A2 /* CmuxControlSocket */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
@@ -8691,6 +8710,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			name = cmuxTests;
 			packageProductDependencies = (
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				A77A0002A1B2C3D4E5F60001 /* CmuxAgentJournal */,
 				C750100000000000000000A2 /* CmuxControlSocket */,
 				1A0B0C0D0E0F101112132012 /* CmuxIrohTransport */,
 				C1A072000000000000000002 /* CmuxMobileRPC */,
@@ -8765,6 +8785,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE49000000000000000003 /* XCLocalSwiftPackageReference "CmuxExtensionSidebarExamples" */,
 				A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */,
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
+				A77A0001A1B2C3D4E5F60001 /* XCLocalSwiftPackageReference "CmuxAgentJournal" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				CC0033E15A1B2C3D4E5F0010 /* XCLocalSwiftPackageReference "CmuxDiffComments" */,
 				CA52A004CA52A004CA52A004 /* XCLocalSwiftPackageReference "CmuxCanvas" */,
@@ -9079,6 +9100,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F65760050000000000000001 /* AgentHibernationTranscriptGuard.swift in Sources */,
 				F65760200000000000000001 /* AgentHibernationTranscriptHookStoreFileMirror.swift in Sources */,
 				F65760210000000000000001 /* AgentHibernationTranscriptHookStoreRecord.swift in Sources */,
+				A77A0005A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift in Sources */,
 				0A1107110000000000000010 /* AgentNotificationDelivery.swift in Sources */,
 				A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */,
 				C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */,
@@ -10389,6 +10411,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F87910190000000000000001 /* TerminalConfigurationReloadCoordinator.swift in Sources */,
 				F87930000000000000000001 /* TerminalConfigurationReloadEnqueueResult.swift in Sources */,
 				F87920000000000000000005 /* TerminalConfigurationReloadPhase.swift in Sources */,
+				A77A0007A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift in Sources */,
 				D35A00000000000000000014 /* TerminalController+AgentPromptDelivery.swift in Sources */,
 				8054A0030000000000000003 /* TerminalController+BrowserAutomationRecovery.swift in Sources */,
 				D35A00000000000000000011 /* TerminalController+BrowserDesignMode.swift in Sources */,
@@ -10831,6 +10854,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				89930008AABBCCDDEEFF0001 /* CMUXCLI+AgentHookProcessBindingResult.swift in Sources */,
 				89930007AABBCCDDEEFF0001 /* CMUXCLI+AgentHookProcessBindingSource.swift in Sources */,
 				C6711A050000000000000001 /* CMUXCLI+AgentHookRestoreEvidence.swift in Sources */,
+				A77A000AA1B2C3D4E5F60001 /* CMUXCLI+AgentJournalEmission.swift in Sources */,
 				B9000068A1B2C3D4E5F60719 /* CMUXCLI+AmpExtension.swift in Sources */,
 				6D9C51AB30A64B1ABC819142 /* CMUXCLI+AutoNaming.swift in Sources */,
 				6D9C51AB30A64B1ABC81914A /* CMUXCLI+AutoNamingDispatch.swift in Sources */,
@@ -11044,6 +11068,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F65760250000000000000001 /* AgentHibernationTranscriptSnapshotRaceTests.swift in Sources */,
 				A76110010000000000000003 /* AgentHookNotificationPolicy.swift in Sources */,
 				A76110020000000000000001 /* AgentHookNotificationPolicyTests.swift in Sources */,
+				A77A000EA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift in Sources */,
+				A77A000CA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift in Sources */,
 				A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */,
 				79390003AA11BB22CC33DD03 /* AgentNotificationLiveRetargetTests.swift in Sources */,
 				7939000FAA11BB22CC33DD0F /* AgentNotificationMoveRaceTests.swift in Sources */,
@@ -12181,6 +12207,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CMUXAgentLaunch;
 		};
+		A77A0001A1B2C3D4E5F60001 /* XCLocalSwiftPackageReference "CmuxAgentJournal" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/macOS/CmuxAgentJournal;
+		};
 		A5C0DE0000000000000000A1 /* XCLocalSwiftPackageReference "CMUXProjectModel" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CMUXProjectModel;
@@ -12399,6 +12429,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */;
 			productName = CMUXAgentLaunch;
+		};
+		A77A0002A1B2C3D4E5F60001 /* CmuxAgentJournal */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A77A0001A1B2C3D4E5F60001 /* XCLocalSwiftPackageReference "CmuxAgentJournal" */;
+			productName = CmuxAgentJournal;
 		};
 		A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
 		A76110010000000000000003 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
 		A76110020000000000000001 /* AgentHookNotificationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */; };
+		A77A0010A1B2C3D4E5F60001 /* AgentJournalLazyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A000FA1B2C3D4E5F60001 /* AgentJournalLazyStore.swift */; };
 		A77A0005A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */; };
 		A77A000EA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A000DA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift */; };
 		A77A000CA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77A000BA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift */; };
@@ -2998,6 +2999,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000100 /* AgentHookFailureStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookFailureStage.swift; sourceTree = "<group>"; };
 		A76110010000000000000002 /* AgentHookNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicy.swift; sourceTree = "<group>"; };
 		A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicyTests.swift; sourceTree = "<group>"; };
+		A77A000FA1B2C3D4E5F60001 /* AgentJournalLazyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalLazyStore.swift; sourceTree = "<group>"; };
 		A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalLifecycleCenter.swift; sourceTree = "<group>"; };
 		A77A000DA1B2C3D4E5F60001 /* AgentJournalLifecycleCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalLifecycleCenterTests.swift; sourceTree = "<group>"; };
 		A77A000BA1B2C3D4E5F60001 /* AgentJournalTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentJournalTestSupport.swift; sourceTree = "<group>"; };
@@ -6894,6 +6896,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6313A1A1 /* PaneMemoryGuardrail.swift */,
 				A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */,
 				A77A0006A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift */,
+				A77A000FA1B2C3D4E5F60001 /* AgentJournalLazyStore.swift */,
 				A77A0008A1B2C3D4E5F60001 /* TerminalController+AgentJournal.swift */,
 				6313B2A1 /* PaneMemoryGuardrailEngine.swift */,
 				6313B3A1 /* PaneMemoryGuardrailEngineOutput.swift */,
@@ -9100,6 +9103,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F65760050000000000000001 /* AgentHibernationTranscriptGuard.swift in Sources */,
 				F65760200000000000000001 /* AgentHibernationTranscriptHookStoreFileMirror.swift in Sources */,
 				F65760210000000000000001 /* AgentHibernationTranscriptHookStoreRecord.swift in Sources */,
+				A77A0010A1B2C3D4E5F60001 /* AgentJournalLazyStore.swift in Sources */,
 				A77A0005A1B2C3D4E5F60001 /* AgentJournalLifecycleCenter.swift in Sources */,
 				0A1107110000000000000010 /* AgentNotificationDelivery.swift in Sources */,
 				A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */,

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -106,6 +106,9 @@
       location = "container:Packages/macOS"
       name = "Packages (macOS)">
       <FileRef
+         location = "group:CmuxAgentJournal">
+      </FileRef>
+      <FileRef
          location = "group:CMUXAgentLaunch">
       </FileRef>
       <FileRef

--- a/cmuxTests/AgentHookNotificationPolicyTests.swift
+++ b/cmuxTests/AgentHookNotificationPolicyTests.swift
@@ -29,14 +29,17 @@ struct AgentHookNotificationPolicyTests {
         #expect(arbitrary.status == nil)
         #expect(arbitrary.notifyCategory == .idleReminder)
 
+        // An empty, cue-less message fabricates nothing: no needs-input
+        // claim and no body (callers reuse a stored summary or skip the
+        // banner). The old "%@ needs your attention" fallback is gone.
         let emptyFallback = AgentHookNotificationClassifier.classify(
             displayName: "Grok",
             signal: "",
             message: "",
             isFallback: true
         )
-        #expect(emptyFallback.status == .needsInput)
-        #expect(emptyFallback.notifyCategory == .idleReminder)
+        #expect(emptyFallback.status == nil)
+        #expect(emptyFallback.body.isEmpty)
         #expect(emptyFallback.isFallback == true)
     }
 

--- a/cmuxTests/AgentJournalLifecycleCenterTests.swift
+++ b/cmuxTests/AgentJournalLifecycleCenterTests.swift
@@ -1,0 +1,72 @@
+import CmuxAgentJournal
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Agent journal lifecycle center")
+struct AgentJournalLifecycleCenterTests {
+    @Test func appendCommandCommitsDurablyAndReplaysIdempotently() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-journal-center-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("journal.sqlite3", isDirectory: false)
+        let center = AgentJournalLifecycleCenter(databaseURL: url)
+        #expect(center.isAvailable)
+
+        let draft = AgentJournalEventDraft(
+            eventId: "event-1",
+            kind: .turnStarted,
+            occurredAtMs: 1,
+            source: "claude",
+            agentKey: "claude_code",
+            sessionId: "session-1",
+            workspaceId: UUID().uuidString,
+            surfaceId: UUID().uuidString
+        )
+        let json = try #require(String(data: JSONEncoder().encode(draft), encoding: .utf8))
+        #expect(center.handleAppendCommand(json) == "OK 1")
+        // The reply is the durable receipt: a retry with the same event id
+        // replays the original sequence instead of double-writing.
+        #expect(center.handleAppendCommand(json) == "OK 1 replayed")
+        #expect(center.handleAppendCommand("not json").hasPrefix("ERROR:"))
+        #expect(center.handleAppendCommand("").hasPrefix("ERROR:"))
+
+        // The committed event survives independent reopen (what startup
+        // replay reads after a relaunch).
+        let store = try AgentJournalStore(databaseURL: url)
+        #expect(try store.headSequence() == 1)
+        let events = try store.events(afterSequence: 0, limit: 10)
+        #expect(events.count == 1)
+        #expect(events.first?.draft == draft)
+        store.close()
+    }
+
+    @Test func guessedTargetsAreRejectedAtAdmission() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-journal-center-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("journal.sqlite3", isDirectory: false)
+        let center = AgentJournalLifecycleCenter(databaseURL: url)
+        var draft = AgentJournalEventDraft(
+            eventId: "event-guessed",
+            kind: .approvalRequested,
+            occurredAtMs: 1,
+            source: "codex",
+            agentKey: "codex",
+            workspaceId: UUID().uuidString,
+            surfaceId: UUID().uuidString
+        )
+        draft.unattributedReason = "target-unresolved"
+        let json = try #require(String(data: JSONEncoder().encode(draft), encoding: .utf8))
+        #expect(center.handleAppendCommand(json).hasPrefix("ERROR:"))
+    }
+
+    @Test func unavailableJournalReportsError() {
+        let center = AgentJournalLifecycleCenter(databaseURL: nil)
+        #expect(!center.isAvailable)
+        #expect(center.handleAppendCommand("{}") == "ERROR: agent journal unavailable")
+    }
+}

--- a/cmuxTests/AgentJournalTestSupport.swift
+++ b/cmuxTests/AgentJournalTestSupport.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Shared parsing for `agent_journal_append <json>` lines captured by the CLI
+/// hook mock socket servers: the structured replacement for the old
+/// `set_agent_lifecycle` prefix assertions.
+struct AgentJournalAppendCapture {
+    /// The decoded draft object of one captured append line.
+    let draft: [String: Any]
+
+    var kind: String? { draft["kind"] as? String }
+    var agentKey: String? { draft["agent_key"] as? String }
+    var sessionId: String? { draft["session_id"] as? String }
+    var workspaceId: String? { draft["workspace_id"] as? String }
+    var surfaceId: String? { draft["surface_id"] as? String }
+    var unattributedReason: String? { draft["unattributed_reason"] as? String }
+    var isSubagent: Bool { draft["is_subagent"] as? Bool ?? false }
+    var pendingWork: Bool { draft["pending_work"] as? Bool ?? false }
+
+    static func captures(in commands: [String]) -> [AgentJournalAppendCapture] {
+        commands.compactMap { line in
+            guard line.hasPrefix("agent_journal_append ") else { return nil }
+            let payload = String(line.dropFirst("agent_journal_append ".count))
+            guard let data = payload.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return AgentJournalAppendCapture(draft: object)
+        }
+    }
+
+    static func first(
+        in commands: [String],
+        kind: String,
+        agentKey: String? = nil,
+        sessionId: String? = nil
+    ) -> AgentJournalAppendCapture? {
+        captures(in: commands).first { capture in
+            capture.kind == kind
+                && (agentKey == nil || capture.agentKey == agentKey)
+                && (sessionId == nil || capture.sessionId == sessionId)
+        }
+    }
+
+    static func contains(
+        _ commands: [String],
+        kind: String,
+        agentKey: String? = nil,
+        sessionId: String? = nil
+    ) -> Bool {
+        first(in: commands, kind: kind, agentKey: agentKey, sessionId: sessionId) != nil
+    }
+}

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -244,9 +244,11 @@ struct CLICodexHookTimeoutRegressionTests {
                 return event["hook_event_name"] as? String == "PreToolUse"
             }
         })
-        #expect(commands.snapshot().contains {
-            $0.hasPrefix("set_agent_lifecycle codex needsInput --tab=\(workspaceId)")
-                && $0.contains("--panel=\(surfaceId)")
+        #expect(AgentJournalAppendCapture.captures(in: commands.snapshot()).contains { capture in
+            capture.kind == "agent.approval.requested"
+                && capture.agentKey == "codex"
+                && capture.workspaceId == workspaceId
+                && capture.surfaceId == surfaceId
         })
     }
 
@@ -911,7 +913,7 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         #expect(result.stdout == "{}\n")
         let sentCommands = commands.snapshot()
-        #expect(!sentCommands.contains { $0.hasPrefix("set_agent_lifecycle codex unknown ") })
+        #expect(!AgentJournalAppendCapture.contains(sentCommands, kind: "agent.session.started", agentKey: "codex"))
         #expect(!sentCommands.contains { codexHookJSONObject($0)?["method"] as? String == "feed.push" })
         #expect(!sentCommands.contains { codexHookJSONObject($0)?["method"] as? String == "surface.resume.set" })
 
@@ -994,7 +996,7 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         #expect(result.stdout == "{}\n")
         let sentCommands = commands.snapshot()
-        #expect(sentCommands.contains { $0.hasPrefix("set_agent_lifecycle codex unknown ") })
+        #expect(AgentJournalAppendCapture.contains(sentCommands, kind: "agent.session.started", agentKey: "codex"))
         #expect(sentCommands.contains { codexHookJSONObject($0)?["method"] as? String == "surface.resume.set" })
 
         let saved = try #require(
@@ -1105,7 +1107,7 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         #expect(result.stdout == "{}\n")
         let sentCommands = commands.snapshot()
-        #expect(!sentCommands.contains { $0.hasPrefix("set_agent_lifecycle codex unknown ") })
+        #expect(!AgentJournalAppendCapture.contains(sentCommands, kind: "agent.session.started", agentKey: "codex"))
         #expect(!sentCommands.contains { codexHookJSONObject($0)?["method"] as? String == "surface.resume.set" })
 
         let saved = try #require(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -176,14 +176,16 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(result.status, 0, result.stderr)
 
         XCTAssertTrue(
-            context.state.commands.contains {
-                $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
-                    && $0.contains("--panel=\(context.surfaceId)")
+            AgentJournalAppendCapture.captures(in: context.state.commands).contains { capture in
+                capture.kind == "agent.plan_review.requested"
+                    && capture.agentKey == "claude_code"
+                    && capture.workspaceId == context.workspaceId
+                    && capture.surfaceId == context.surfaceId
             },
-            "ExitPlanMode PreToolUse must drive Needs input, saw \(context.state.commands)"
+            "ExitPlanMode PreToolUse must journal a plan-review request, saw \(context.state.commands)"
         )
         XCTAssertFalse(
-            context.state.commands.contains { $0.contains("set_agent_lifecycle claude_code running") },
+            AgentJournalAppendCapture.contains(context.state.commands, kind: "agent.turn.started", agentKey: "claude_code"),
             "ExitPlanMode PreToolUse must not drive Running while blocked on plan approval, saw \(context.state.commands)"
         )
         XCTAssertFalse(
@@ -235,14 +237,16 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(result.status, 0, result.stderr)
 
         XCTAssertTrue(
-            context.state.commands.contains {
-                $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
-                    && $0.contains("--panel=\(context.surfaceId)")
+            AgentJournalAppendCapture.captures(in: context.state.commands).contains { capture in
+                capture.kind == "agent.question.requested"
+                    && capture.agentKey == "claude_code"
+                    && capture.workspaceId == context.workspaceId
+                    && capture.surfaceId == context.surfaceId
             },
-            "AskUserQuestion PreToolUse must drive Needs input, saw \(context.state.commands)"
+            "AskUserQuestion PreToolUse must journal a question request, saw \(context.state.commands)"
         )
         XCTAssertFalse(
-            context.state.commands.contains { $0.contains("set_agent_lifecycle claude_code running") },
+            AgentJournalAppendCapture.contains(context.state.commands, kind: "agent.turn.started", agentKey: "claude_code"),
             "AskUserQuestion PreToolUse must not drive Running, saw \(context.state.commands)"
         )
         XCTAssertFalse(
@@ -291,13 +295,15 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(result.status, 0, result.stderr)
 
         XCTAssertTrue(
-            context.state.commands.contains {
-                $0.hasPrefix("set_agent_lifecycle claude_code needsInput --tab=\(context.workspaceId)")
+            AgentJournalAppendCapture.captures(in: context.state.commands).contains { capture in
+                capture.kind == "agent.question.requested"
+                    && capture.agentKey == "claude_code"
+                    && capture.workspaceId == context.workspaceId
             },
-            "AskUserQuestion PreToolUse must drive Needs input in every mode, saw \(context.state.commands)"
+            "AskUserQuestion PreToolUse must journal a question request in every mode, saw \(context.state.commands)"
         )
         XCTAssertFalse(
-            context.state.commands.contains { $0.contains("set_agent_lifecycle claude_code running") },
+            AgentJournalAppendCapture.contains(context.state.commands, kind: "agent.turn.started", agentKey: "claude_code"),
             "AskUserQuestion PreToolUse must not drive Running, saw \(context.state.commands)"
         )
         XCTAssertFalse(
@@ -1867,11 +1873,13 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let notificationCommands = Array(context.state.commands.dropFirst(notificationStart))
         XCTAssertTrue(
-            notificationCommands.contains {
-                $0.hasPrefix("set_agent_lifecycle codex needsInput --tab=\(context.workspaceId)")
-                    && $0.contains("--panel=\(context.surfaceId)")
+            AgentJournalAppendCapture.captures(in: notificationCommands).contains { capture in
+                capture.kind == "agent.approval.requested"
+                    && capture.agentKey == "codex"
+                    && capture.workspaceId == context.workspaceId
+                    && capture.surfaceId == context.surfaceId
             },
-            "Notification requiring user input must correct the visible lifecycle, saw \(notificationCommands)"
+            "Notification requiring user input must journal a needs-input approval request, saw \(notificationCommands)"
         )
 
         state = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: stateURL)) as? [String: Any])
@@ -1919,9 +1927,14 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(staleStop.status, 0, staleStop.stderr)
 
         let staleStopCommands = Array(context.state.commands.dropFirst(staleStopStart))
-        XCTAssertFalse(
-            staleStopCommands.contains { $0.hasPrefix("set_agent_lifecycle codex idle ") },
-            "A stale Stop from an older session must not mark the surface idle, saw \(staleStopCommands)"
+        XCTAssertTrue(
+            AgentJournalAppendCapture.contains(
+                staleStopCommands,
+                kind: "agent.turn.completed",
+                agentKey: "codex",
+                sessionId: oldSessionId
+            ),
+            "A stale Stop journals the old session's completion (the reducer keeps the newer running session in charge), saw \(staleStopCommands)"
         )
         XCTAssertFalse(
             staleStopCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },
@@ -1979,9 +1992,14 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(staleNotification.status, 0, staleNotification.stderr)
 
         let staleNotificationCommands = Array(context.state.commands.dropFirst(staleNotificationStart))
-        XCTAssertFalse(
-            staleNotificationCommands.contains { $0.hasPrefix("set_agent_lifecycle codex idle ") },
-            "A stale idle notification must not mark the newer session idle, saw \(staleNotificationCommands)"
+        XCTAssertTrue(
+            AgentJournalAppendCapture.contains(
+                staleNotificationCommands,
+                kind: "agent.turn.completed",
+                agentKey: "codex",
+                sessionId: oldSessionId
+            ),
+            "A stale idle notification journals the old session's completion (the reducer keeps the newer running session in charge), saw \(staleNotificationCommands)"
         )
         XCTAssertFalse(
             staleNotificationCommands.contains { $0.hasPrefix("set_status codex ") && $0.contains(" Idle ") },

--- a/cmuxTests/CLIOmpHookBindingTests.swift
+++ b/cmuxTests/CLIOmpHookBindingTests.swift
@@ -186,7 +186,7 @@ struct CLIOmpHookBindingTests {
             $0.hasPrefix("set_agent_pid omp.\(resumedSessionId) ")
         })
         let lifecycleIndex = try #require(commands.firstIndex {
-            $0.hasPrefix("set_agent_lifecycle omp ")
+            $0.hasPrefix("agent_journal_append ") && $0.contains("\"agent_key\":\"omp\"")
         })
         let clearIndex = try #require(commands.firstIndex {
             Self.jsonObject($0)?["method"] as? String == "surface.resume.clear"

--- a/cmuxTests/CampfireHookNotificationTests.swift
+++ b/cmuxTests/CampfireHookNotificationTests.swift
@@ -45,11 +45,13 @@ struct CampfireHookNotificationTests {
             "Campfire permission notification should be localized and notification-gated in Swift, saw \(notificationCommands)"
         )
         #expect(
-            notificationCommands.contains {
-                $0.hasPrefix("set_agent_lifecycle campfire needsInput --tab=\(context.workspaceId)")
-                    && $0.contains("--panel=\(context.surfaceId)")
+            AgentJournalAppendCapture.captures(in: notificationCommands).contains { capture in
+                capture.kind == "agent.approval.requested"
+                    && capture.agentKey == "campfire"
+                    && capture.workspaceId == context.workspaceId
+                    && capture.surfaceId == context.surfaceId
             },
-            "Campfire permission notification must mark the surface as needing input, saw \(notificationCommands)"
+            "Campfire permission notification must journal a needs-input approval request, saw \(notificationCommands)"
         )
 
         let stateURL = context.root.appendingPathComponent("campfire-hook-sessions.json")

--- a/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
+++ b/cmuxTests/ClaudeBackgroundWorkNotifyTests.swift
@@ -17,8 +17,16 @@ struct ClaudeBackgroundWorkNotifyTests {
         snapshot.first { $0.hasPrefix("set_status claude_code \(value) ") }
     }
 
-    private func lifecycleLine(_ snapshot: [String], value: String) -> String? {
-        snapshot.first { $0.hasPrefix("set_agent_lifecycle claude_code \(value) ") }
+    private func journalEvent(
+        _ snapshot: [String],
+        kind: String,
+        pendingWork: Bool? = nil
+    ) -> AgentJournalAppendCapture? {
+        AgentJournalAppendCapture.captures(in: snapshot).first { capture in
+            capture.kind == kind
+                && capture.agentKey == "claude_code"
+                && (pendingWork == nil || capture.pendingWork == pendingWork)
+        }
     }
 
     private func runStopHook(
@@ -80,11 +88,12 @@ struct ClaudeBackgroundWorkNotifyTests {
         #expect(statusLine(snapshot, value: "Running") != nil,
                 "Pending stop must show a Running pill, not Idle; saw \(snapshot)")
         #expect(statusLine(snapshot, value: "Idle") == nil)
-        // And the hibernation lifecycle must stay non-idle so the planner can't
-        // SIGTERM the live background task.
-        #expect(lifecycleLine(snapshot, value: "running") != nil,
-                "Pending stop must publish a running lifecycle; saw \(snapshot)")
-        #expect(lifecycleLine(snapshot, value: "idle") == nil)
+        // And the journaled turn boundary must carry pending_work=true so the
+        // reduced lifecycle stays running (non-hibernatable) while the
+        // background task is live.
+        #expect(journalEvent(snapshot, kind: "agent.turn.completed", pendingWork: true) != nil,
+                "Pending stop must journal a pending turn completion; saw \(snapshot)")
+        #expect(journalEvent(snapshot, kind: "agent.turn.completed", pendingWork: false) == nil)
     }
 
     @Test func stopWithEmptyArraysTagsIdleAndCachesFalse() throws {
@@ -96,11 +105,13 @@ struct ClaudeBackgroundWorkNotifyTests {
         #expect(notifyLine(snapshot, containing: "c=turn-complete;p=0") != nil,
                 "Truly-idle stop must tag pending=0; saw \(snapshot)")
         #expect(cached == false)
-        // Truly-idle turn end keeps the "Idle" pill and the hibernatable lifecycle.
+        // Truly-idle turn end keeps the "Idle" pill and journals a
+        // non-pending turn completion (which reduces to the hibernatable
+        // idle lifecycle).
         #expect(statusLine(snapshot, value: "Idle") != nil,
                 "Truly-idle stop must show the Idle pill; saw \(snapshot)")
-        #expect(lifecycleLine(snapshot, value: "idle") != nil,
-                "Truly-idle stop must publish an idle lifecycle; saw \(snapshot)")
+        #expect(journalEvent(snapshot, kind: "agent.turn.completed", pendingWork: false) != nil,
+                "Truly-idle stop must journal a non-pending turn completion; saw \(snapshot)")
     }
 
     @Test func stopWithPendingCronTagsPending() throws {
@@ -231,6 +242,12 @@ struct ClaudeBackgroundWorkNotifyTests {
         // banner is suppressed app-side and the pane is still Running.
         #expect(statusLine(snapshot, value: "Needs input") == nil,
                 "Pending idle_prompt must not set a Needs input pill; saw \(snapshot)")
+        // And the journal must record it as an observation, never as a
+        // needs-input question, so the reduced lifecycle stays running.
+        #expect(journalEvent(snapshot, kind: "agent.question.requested") == nil,
+                "Pending idle_prompt must not journal a needs-input question; saw \(snapshot)")
+        #expect(journalEvent(snapshot, kind: "agent.state.changed") != nil,
+                "Pending idle_prompt must still journal an observation; saw \(snapshot)")
     }
 
     @Test func idlePromptAfterIdleStopTagsNotPending() throws {
@@ -272,8 +289,11 @@ struct ClaudeBackgroundWorkNotifyTests {
         let snapshot = context.state.snapshot()
         #expect(notifyLine(snapshot, containing: "c=idle-reminder;p=0") != nil,
                 "idle_prompt after an idle stop must tag pending=0; saw \(snapshot)")
-        // With no pending work this is a real waiting state, so the pill flips.
+        // With no pending work this is a real waiting state, so the pill
+        // flips and the journal records the needs-input question.
         #expect(statusLine(snapshot, value: "Needs input") != nil,
                 "Idle idle_prompt must still set the Needs input pill; saw \(snapshot)")
+        #expect(journalEvent(snapshot, kind: "agent.question.requested") != nil,
+                "Idle idle_prompt must journal a needs-input question; saw \(snapshot)")
     }
 }

--- a/cmuxTests/ClaudeHookLiveDeliveryTargetTests.swift
+++ b/cmuxTests/ClaudeHookLiveDeliveryTargetTests.swift
@@ -86,6 +86,13 @@ struct ClaudeHookLiveDeliveryTargetTests {
             !commands.contains { $0.hasPrefix("set_agent_lifecycle ") || $0.hasPrefix("set_status ") },
             "A subagent completion must not settle the parent lifecycle/status; saw \(commands)"
         )
+        // The journal still records the fact, tagged as a subagent event so
+        // the reducer keeps it off the hosting pane's badge.
+        #expect(
+            AgentJournalAppendCapture.captures(in: commands)
+                .allSatisfy { $0.isSubagent || $0.kind == "agent.state.changed" },
+            "Subagent events must be journaled with the subagent tag; saw \(commands)"
+        )
     }
 
     /// Two Claude agents in two workspaces: the session record for this agent


### PR DESCRIPTION
Closes #10467

## What this does

Makes macOS sidebar agent lifecycle **journal-backed**: Running / NeedsInput / Idle / Error are now derived by a deterministic reducer folding an ordered, durable stream of semantic `agent.*` events, replacing the lossy substring-heuristic pipeline (`AgentHookNotificationClassifier` → fire-and-forget `set_agent_lifecycle`).

The design is a Swift port of the cmux-tui session journal (`cmux-tui/crates/cmux-tui-core/`): the same 12 `agent.*` semantic kinds, the same normalized-key native-event mapping table (including the antigravity/hermes/opencode/copilot-trio special cases), an append-only SQLite store with a monotonic sequence, immutability triggers, `synchronous=FULL` durability, and idempotent appends keyed by event id.

## Architecture

**New package `Packages/macOS/CmuxAgentJournal`** (no dependencies, fully headless-testable):
- `AgentJournalEventKind` — the 12 semantic kinds (`agent.session.started`, `agent.turn.started/completed`, `agent.approval/question/plan_review.requested`, `agent.error.reported`, `agent.child.*`, `agent.state.changed`, `agent.session.ended`).
- `AgentSemanticEventMapper` — native hook event name → semantic kind (port of `agent_hooks.rs` `semantic_kind`, normalized-key matching).
- `AgentJournalStore` — append-only SQLite journal: AUTOINCREMENT sequence (never reused), UPDATE/DELETE rejected by triggers (tamper-tested through a raw second connection), WAL + FULL synchronous, idempotent appends with replayed receipts, restore-time identity alias tables, bounded open-time retention.
- `AgentLifecycleReducer` — the deterministic fold: per-session newest-event-wins by journal sequence (duplicates and out-of-order arrivals drop), surface phase = precedence combine over live sessions (`running > needsInput > error > unknown > idle`), subagent events never drive the hosting pane, unattributed events become bounded diagnostics, `agent.session.ended` clears the entry.
- `AgentJournalReplayPolicy` — what a relaunch may repaint: `needsInput`/`error` survive replay (the stale-badge bug class); `running`/`idle`/`unknown` wait for live evidence (a relaunch tore down local PTYs, and repainting `idle` would re-enter hibernation eligibility for dead agents).

**CLI (emit side)** — every hook action lane in `runClaudeHook` / `runGenericAgentHook` now emits exactly one semantic event via the new synchronous `agent_journal_append` socket verb. The reply carries the committed sequence — a durable acknowledgement to the hook emitter. Attribution is decided at emit time: only authoritative/validated targets ride the event; a target-resolution failure emits an explicitly **unattributed** event (never a guessed pane). Emission failures are appended to a bounded dead-letter file (`~/.cmuxterm/agent-journal-dead-letter.jsonl`) plus the throttled hook-failure telemetry channel — never swallowed. The CLI no longer sends `set_agent_lifecycle` at all (the app-side verb remains for compatibility).

**App (reduce side)** — `AgentJournalLifecycleCenter` owns the journal (single writer), commits appends on the socket worker (the durable-ack contract), and reduces on one FIFO consumer: live events apply per-surface assignments through the existing `ControlSidebarPanelOwner` → `Workspace.setAgentLifecycle` path (workspace and Dock owners both). Session restore records workspace/panel identity aliases (`oldToNewPanelIds`) into the journal's sidecar tables; startup replay folds the whole journal, resolves events through the alias chains, and repaints replay-safe states — badges come from history, not from the last painted state. Unattributed events surface as `agent.journal.unattributed` on `CmuxEventBus` (plus debug log), satisfying "diagnostic, not guessed, not dropped".

## The fabrication path is gone

- `AgentHookNotificationClassifier`'s final branch no longer returns `"%@ needs your attention"` + a fabricated `needsInput`; an empty, cue-less message yields an empty body and **no status claim**.
- The Claude notification handler's localized-string comparison (`body.contains("needs your attention")`) is replaced by an explicit empty-body marker; a payload with no usable message reuses the stored session summary for display only, or skips the banner entirely — the journal still records the event as an observation.
- The generic handler's fallback rebuild no longer adopts a stale on-disk status; lifecycle claims come exclusively from the semantic event.
- The now-unused `agent.generic.notification.body.needsAttention` / `.sentNotification` keys were removed from `Localizable.xcstrings` (en + ja).

## Substring hacks: subsumed or reduced

- **Lifecycle** no longer depends on any substring heuristic: the native hook event name (`StopFailure`, `pre_approval_request`, `PermissionRequest`, Claude's structured `notification_type`, AskUserQuestion/ExitPlanMode tools) maps through the semantic table first; the prose classifier's verdict is only the last-resort adapter fallback for `Notification`-style events with no structured signal — exactly the role the issue prescribes.
- The stale-session guards (`hasNewerRunningSession`, `staleIdleNotificationHasNewerRunningSession`, `shouldApplyClaudeHookVisibleMutation`) are subsumed by the reducer's per-session fold: a stale session's completion is journaled as *that session's* fact and the newer running session keeps the pane badge (covered by reducer unit tests and the updated CLI integration tests).
- Grok internal-notification sniffing and the grok/antigravity body-hash notification dedupe remain, explicitly reduced to the **banner-text lane only** — they no longer influence lifecycle.

## Acceptance criteria → where

- Deterministic reducer + unit tests over sequences (duplicates, out-of-order permutations, replay-from-scratch, multi-session combine, subagent exclusion, session supersession): `AgentLifecycleReducerTests` (35 package tests total).
- Relaunch reproduces badges from replay: `AgentJournalStore` durability/reopen tests, `AgentJournalReplayPolicyTests`, alias-chain tests; app wiring in `AgentJournalLifecycleCenter` + restore-alias recording in `Workspace.restoreSessionSnapshot`.
- Unattributable events → diagnostics: emit-side unattributed drafts (admission rejects a reason+target combination), reducer diagnostics, `CmuxEventBus` event; `AgentJournalLifecycleCenterTests.guessedTargetsAreRejectedAtAdmission`.
- Fabrication path gone: classifier + handler changes above; `AgentHookNotificationPolicyTests.classificationTable` updated to pin the new contract.
- CLI behavior-level coverage updated to the journal contract: `ClaudeBackgroundWorkNotifyTests`, `CLINotifyProcessIntegrationRegressionTests`, `CLICodexHookTimeoutRegressionTests`, `CampfireHookNotificationTests`, `CLIOmpHookBindingTests`, `ClaudeHookLiveDeliveryTargetTests`.

## Deliberate behavior notes

- `/clear` session-start no longer paints a Running spinner (it journals `agent.session.started` → unknown); the spinner appears at the next prompt submit. The old behavior claimed activity that wasn't happening.
- A Notification hook with no usable message no longer produces a banner (previously it fabricated one); state still flows through the journal.
- The reducer keeps an honest `error` phase; the sidebar projection maps it onto the needs-input treatment (the sidebar has no dedicated error rendering yet — follow-up below).

## Follow-ups (out of scope for this PR)

- Migrate the notification *text* feed (`notify_target_async`) onto the journal so unread items are also a fold over events.
- Dedicated sidebar rendering for the `error` phase.
- Drain the CLI dead-letter file on reconnect.
- Retire the app-side `set_agent_lifecycle` verb once external emitters are confirmed gone; route `FeedCoordinator`'s app-internal needs-input writes through the journal.
- Re-fold on reopen of a closed workspace (aliases are recorded; only startup replay consumes them today).

## Localization audit

Audited: removed two now-unused keys (`agent.generic.notification.body.needsAttention`, `agent.generic.notification.body.sentNotification`) from `Resources/Localizable.xcstrings` (en + ja entries removed together). No new user-facing strings were added — journal/dead-letter/diagnostic strings are wire-protocol and log text, not UI. Existing localized classifier strings are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789795772&installation_model_id=21920&pr_number=10490&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10490&signature=621d0c283dcdc0a30605490c55859e222e1df0e0f3215743c0336c1a2f424d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Journal-backs the macOS sidebar agent lifecycle with a durable semantic event log and a deterministic reducer; startup replays badges from history. Old: substring heuristics with fire-and-forget set_agent_lifecycle; new: agent.* events via agent_journal_append reduced into lifecycle. Side effects: no spinner on /clear until the next prompt, empty notifications emit no banner or status, startup repaints only needs-input/error, subagent events don’t change host badges, observations don’t alter lifecycle, and uncorroborated foreign env claims journal unattributed diagnostics. Replay and alias errors now fail closed and publish sanitized events.

- Adds `CmuxAgentJournal`: append-only SQLite journal (WAL + FULL sync, immutability triggers, idempotent appends), semantic mapper, deterministic reducer, startup replay policy, and in-memory alias resolver. Pagination advances past undecodable future kinds; retention prunes by row rank; deinit closes; undecodable rows and unavailable-store ops are logged.
- Introduces worker-lane agent_journal_append; reply is the durable commit sequence; returns stable product-level errors. Append failures publish agent.journal.append_failed; replay read failures publish agent.journal.replay_failed and paint nothing; alias-state failures drop operations with agent.journal.aliases_unavailable, alias-persist failures publish agent.journal.alias_persist_failed, alias cycles retag events as unattributed("alias-cycle"); missing-panel apply skips publish agent.journal.apply_skipped.
- Wires AgentJournalLifecycleCenter: single writer + FIFO consumer that awaits main-actor application in order; lazy off-main store open; startup replay; workspace/panel alias recording. isAvailable reports config without opening; DEBUG probes log alias recording and applied assignments.
- CLI emits exactly one semantic event per hook; malformed/partial targets demote to unattributed(malformed-target); delivery failures write O_APPEND records to ~/.cmuxterm/agent-journal-dead-letter.jsonl. Removes the “%@ needs your attention” fabrication; rebuilt summaries re-notify once (deduped). Unattributed events publish agent.journal.unattributed. CI builds/tests `CmuxAgentJournal`.

**Rollout**
- Migrate remaining emitters off set_agent_lifecycle to agent_journal_append. Validate: startup replays only needs-input/error; subagent events don’t change host badges; empty Notification yields no banner/status; /clear shows no spinner until next prompt; observation-only events don’t shift lifecycle; foreign env claims produce unattributed diagnostics; failures publish the sanitized events listed above.

<sup>Written for commit 9ef45b03e9816e650026b59e91edef3dcff05eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable agent activity journaling for sessions, turns, approvals, questions, errors, and session endings.
  * Lifecycle state now restores across app launches and remains synchronized after workspace or panel restoration.
  * Added support for background work, subagents, stale events, deduplication, and failure recovery.

* **Bug Fixes**
  * Empty or unrecognized notifications no longer display fabricated messages or incorrectly request user input.
  * Improved handling of unavailable or failed journal events without silently losing state.

* **Documentation**
  * Added guidance covering journal events, lifecycle behavior, replay, and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->