### PR TITLE
Fix tab drags dying after the first drag (stale drag-pasteboard capture)

### DIFF
--- a/Sources/SessionDragSessionSource.swift
+++ b/Sources/SessionDragSessionSource.swift
@@ -48,6 +48,9 @@ final class SessionDragSessionSource: NSObject, NSDraggingSource {
         )
 #endif
         finishDrag()
+        // Residual transfer types on the system drag pasteboard keep
+        // drop-capture hit-testing armed after the session ends.
+        transferRegistration.clearResidualCapability(from: NSPasteboard(name: .drag))
     }
 
     func finishDrag() {


### PR DESCRIPTION
## Problem

After any bonsplit tab drag ends, the system drag pasteboard keeps advertising `com.splittabbar.tabtransfer` until an unrelated drag replaces it. Drop-capture hit-testing (`WindowTerminalHostView.performHitTest`, `PaneDropTargetView.performHitTest`) keys off those pasteboard **types** with no liveness check, so one completed or canceled tab drag leaves later pointer drag/hover/up events captured by drop-target overlays. Symptom reported while dogfooding #10203: with two markdown files in one horizontal tab list, the first drag works and every subsequent tab drag is dead (`begin native session` never fires again); pointer routing stays degraded until some other app's drag rewrites the pasteboard, which makes the bug look intermittent.

Debug-log evidence: after a drop at 22:39:59, plain mouse moves produce endless `terminal.paneDrop.hitTest capture=1 hasTransfer=1 types=com.splittabbar.tabtransfer` and the next drag attempt shows only `window.sendEvent.bonsplitPaneTabDrag suppress=1 hit=PaneDropTargetView` with no native session. `NSPasteboard(name: .drag)` still contained `com.splittabbar.tabtransfer` with no drag in progress.

## Fix

The registry already treats residual pasteboard data as dead (`resolve(from:)` rejects it); the missing piece was removing the residue itself:

- Bumps bonsplit to manaflow-ai/bonsplit#223: `TabDragTransferRegistration.clearResidualCapability(from:)` clears a pasteboard only while it still carries that lease's exact capability value (a newer drag's contents are never clobbered), and `TabDragSessionSource` calls it when its native dragging session ends. Regression tests live in that PR.
- Applies the same end-of-session clear to cmux's `SessionDragSessionSource`.

## Validation

- bonsplit suite green including 2 new regression tests (residual clear + newer-capability guard).
- Debug build compiles clean on this branch.
- Dogfooded in a tagged build: consecutive markdown tab drags keep working and the drag pasteboard is empty after each session ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789798295&installation_model_id=21920&pr_number=10493&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10493&signature=01f59e86e2a4291775c808c0ed11dd9026a1a74216f294c1b657b3d2e29b4da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale tab/session drag data from the system drag pasteboard when a native drag session ends. Previously, the pasteboard kept `com.splittabbar.tabtransfer` after a drag, so drop-capture hit-testing stayed armed and subsequent tab drags never armed; now we clear the residual capability only if it matches the ended session to avoid clobbering newer drags.

- Bumps `bonsplit` to include guarded residual-capability clearing in its tab drag source with regression tests.
- Adds the same end-of-session clear in SessionDragSessionSource by calling transferRegistration.clearResidualCapability(from: NSPasteboard(name: .drag)).
- No migrations or config changes.

<sup>Written for commit 77a8c4cee05e4150e16c149ca49bf41945ee4401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drag-and-drop cleanup now removes leftover transfer data after a drag session ends, improving pasteboard reliability.
* **Maintenance**
  * Updated the embedded layout component to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->