### PR TITLE
Polish the Tailscale Pairing window: QR-first layout, app badge, transport debug rows

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -138084,23 +138084,6 @@
         }
       }
     },
-    "mobile.pairing.codeMode.tailscaleDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale pairing code. Keep Tailscale connected on both devices. Both devices must be connected to the same Tailscale network."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale ペアリングコードです。両方のデバイスで Tailscale の接続を維持してください。両方のデバイスを同じ Tailscale ネットワークに接続する必要があります。"
-          }
-        }
-      }
-    },
     "mobile.panel.artifact.error.forbidden": {
       "extractionState": "manual",
       "localizations": {
@@ -138475,23 +138458,6 @@
         }
       }
     },
-    "mobile.pairing.getApp.prompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don't have it yet?"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まだお持ちでないですか？"
-          }
-        }
-      }
-    },
     "mobile.pairing.manual.copied": {
       "extractionState": "manual",
       "localizations": {
@@ -138507,6 +138473,331 @@
             "value": "コピー済み"
           }
         }
+      }
+    },
+    "mobile.pairing.getApp.badge.caption": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "نزّل cmux لجهاز" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Preuzmite cmux za" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Hent cmux til" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Lade cmux für" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Download cmux for" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Descarga cmux para" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Téléchargez cmux pour" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Scarica cmux per" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmuxをダウンロード" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ទាញយក cmux សម្រាប់" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "cmux 다운로드" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Last ned cmux til" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Pobierz cmux na" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Baixe o cmux para" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скачать cmux для" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ดาวน์โหลด cmux สำหรับ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "cmux'u indirin" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Завантажити cmux для" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "下载 cmux" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "下載 cmux" } }
+      }
+    },
+    "mobile.pairing.getApp.badge.platform": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "da": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "de": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "en": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "es": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "it": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhone版" } },
+        "km": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "iPhone용" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "th": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "iPhone 版" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "iPhone 版" } }
+      }
+    },
+    "mobile.pairing.heading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "اقرن جهاز iPhone الخاص بك" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Uparite svoj iPhone" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Par din iPhone" } },
+        "de": { "stringUnit": { "state": "translated", "value": "iPhone koppeln" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pair your iPhone" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Empareja tu iPhone" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Jumelez votre iPhone" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Abbina il tuo iPhone" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneをペアリング" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ផ្គូផ្គង iPhone របស់អ្នក" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "iPhone 페어링" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Par iPhonen din" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Sparuj swojego iPhone'a" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Emparelhe seu iPhone" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подключите свой iPhone" } },
+        "th": { "stringUnit": { "state": "translated", "value": "จับคู่ iPhone ของคุณ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuzu eşleyin" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Підключіть свій iPhone" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "配对您的 iPhone" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "配對您的 iPhone" } }
+      }
+    },
+    "mobile.pairing.needsTransport.irohHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "لا يزال بإمكان أجهزة iPhone المسجّلة الدخول الاتصال تلقائيًا عبر Iroh. Tailscale مطلوب فقط للإقران عبر رمز QR." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Prijavljeni iPhone uređaji i dalje se mogu automatski povezati preko Iroha. Tailscale je potreban samo za QR uparivanje." } },
+        "da": { "stringUnit": { "state": "translated", "value": "iPhones, der er logget ind, kan stadig oprette forbindelse automatisk via Iroh. Tailscale er kun nødvendig til QR-parring." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Angemeldete iPhones können sich weiterhin automatisch über Iroh verbinden. Tailscale wird nur für die QR-Kopplung benötigt." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Signed-in iPhones can still connect automatically over Iroh. Tailscale is only needed for QR pairing." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Los iPhone con sesión iniciada pueden seguir conectándose automáticamente a través de Iroh. Tailscale solo es necesario para el emparejamiento por QR." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Les iPhone connectés peuvent toujours se connecter automatiquement via Iroh. Tailscale n'est nécessaire que pour le jumelage par QR." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Gli iPhone con l'accesso effettuato possono comunque connettersi automaticamente tramite Iroh. Tailscale serve solo per l'abbinamento via QR." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "サインイン済みのiPhoneは、引き続きIroh経由で自動的に接続できます。TailscaleはQRペアリングにのみ必要です。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "iPhone ដែលបានចូលគណនីនៅតែអាចភ្ជាប់ដោយស្វ័យប្រវត្តិតាមរយៈ Iroh បាន។ Tailscale ត្រូវការតែសម្រាប់ការផ្គូផ្គងតាម QR ប៉ុណ្ណោះ។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로그인된 iPhone은 여전히 Iroh를 통해 자동으로 연결할 수 있습니다. Tailscale은 QR 페어링에만 필요합니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "iPhoner som er pålogget, kan fortsatt koble til automatisk via Iroh. Tailscale trengs bare til QR-paring." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zalogowane iPhone'y nadal mogą łączyć się automatycznie przez Iroh. Tailscale jest potrzebny tylko do parowania przez kod QR." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhones conectados ainda podem se conectar automaticamente via Iroh. O Tailscale só é necessário para o emparelhamento por QR." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "iPhone, вошедшие в учётную запись, по-прежнему могут подключаться автоматически через Iroh. Tailscale нужен только для подключения по QR-коду." } },
+        "th": { "stringUnit": { "state": "translated", "value": "iPhone ที่ลงชื่อเข้าแล้วยังคงเชื่อมต่อโดยอัตโนมัติผ่าน Iroh ได้ Tailscale จำเป็นเฉพาะการจับคู่ด้วย QR เท่านั้น" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Oturum açmış iPhone'lar yine de Iroh üzerinden otomatik olarak bağlanabilir. Tailscale yalnızca QR ile eşleme için gereklidir." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "iPhone, що увійшли в обліковий запис, усе ще можуть підключатися автоматично через Iroh. Tailscale потрібен лише для підключення за QR-кодом." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已登录的 iPhone 仍可通过 Iroh 自动连接。仅在使用二维码配对时才需要 Tailscale。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已登入的 iPhone 仍可透過 Iroh 自動連線。僅在使用 QR Code 配對時才需要 Tailscale。" } }
+      }
+    },
+    "mobile.pairing.scanInstruction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "في cmux على جهاز iPhone، سجّل الدخول بالحساب نفسه، واختر Tailscale، ثم امسح هذا الرمز." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "U cmux-u na svom iPhoneu prijavite se istim računom, odaberite Tailscale, a zatim skenirajte ovaj kôd." } },
+        "da": { "stringUnit": { "state": "translated", "value": "I cmux på din iPhone skal du logge ind med den samme konto, vælge Tailscale og derefter scanne denne kode." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Melde dich in cmux auf deinem iPhone mit demselben Konto an, wähle Tailscale und scanne dann diesen Code." } },
+        "en": { "stringUnit": { "state": "translated", "value": "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code." } },
+        "es": { "stringUnit": { "state": "translated", "value": "En cmux en tu iPhone, inicia sesión con la misma cuenta, elige Tailscale y luego escanea este código." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Dans cmux sur votre iPhone, connectez-vous avec le même compte, choisissez Tailscale, puis scannez ce code." } },
+        "it": { "stringUnit": { "state": "translated", "value": "In cmux sul tuo iPhone, accedi con lo stesso account, scegli Tailscale e poi scansiona questo codice." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneのcmuxで同じアカウントにサインインし、Tailscaleを選択して、このコードをスキャンしてください。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "នៅក្នុង cmux លើ iPhone របស់អ្នក ចូលគណនីដូចគ្នា ជ្រើសរើស Tailscale បន្ទាប់មកស្កេនកូដនេះ។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "iPhone의 cmux에서 동일한 계정으로 로그인하고 Tailscale을 선택한 다음 이 코드를 스캔하세요." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "I cmux på iPhonen din logger du på med samme konto, velger Tailscale og skanner deretter denne koden." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "W cmux na swoim iPhonie zaloguj się na to samo konto, wybierz Tailscale, a następnie zeskanuj ten kod." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "No cmux no seu iPhone, entre com a mesma conta, escolha Tailscale e depois escaneie este código." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "В cmux на iPhone войдите в ту же учётную запись, выберите Tailscale, затем отсканируйте этот код." } },
+        "th": { "stringUnit": { "state": "translated", "value": "ใน cmux บน iPhone ของคุณ ให้ลงชื่อเข้าด้วยบัญชีเดียวกัน เลือก Tailscale แล้วสแกนโค้ดนี้" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuzdaki cmux'ta aynı hesapla oturum açın, Tailscale'i seçin ve ardından bu kodu tarayın." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "У cmux на iPhone увійдіть у той самий обліковий запис, виберіть Tailscale, а потім відскануйте цей код." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在 iPhone 上的 cmux 中，使用同一账户登录，选择 Tailscale，然后扫描此码。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "在 iPhone 上的 cmux 中，使用同一帳戶登入，選擇 Tailscale，然後掃描此代碼。" } }
+      }
+    },
+    "mobile.pairing.signedInAs": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تم تسجيل الدخول باسم %@" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Prijavljeni ste kao %@" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Logget ind som %@" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Angemeldet als %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Signed in as %@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Sesión iniciada como %@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Connecté en tant que %@" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Accesso effettuato come %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@でサインイン中" } },
+        "km": { "stringUnit": { "state": "translated", "value": "បានចូលជា %@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%@(으)로 로그인됨" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Pålogget som %@" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zalogowano jako %@" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conectado como %@" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выполнен вход как %@" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ลงชื่อเข้าเป็น %@" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "%@ olarak oturum açıldı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Ви увійшли як %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已登录为 %@" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已登入為 %@" } }
+      }
+    },
+    "mobile.pairing.subheading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "امسح الرمز باستخدام cmux على جهاز iPhone لإقران هذا الـ Mac عبر Tailscale." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Skenirajte kôd pomoću cmux-a na svom iPhoneu da biste uparili ovaj Mac preko Tailscalea." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Scan koden med cmux på din iPhone for at parre denne Mac via Tailscale." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Scanne den Code mit cmux auf deinem iPhone, um diesen Mac über Tailscale zu koppeln." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Scan the code with cmux on your iPhone to pair this Mac over Tailscale." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Escanea el código con cmux en tu iPhone para emparejar este Mac a través de Tailscale." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Scannez le code avec cmux sur votre iPhone pour jumeler ce Mac via Tailscale." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Scansiona il codice con cmux sul tuo iPhone per abbinare questo Mac tramite Tailscale." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneのcmuxでコードをスキャンすると、Tailscale経由でこのMacをペアリングできます。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ស្កេនកូដដោយប្រើ cmux នៅលើ iPhone របស់អ្នក ដើម្បីផ្គូផ្គង Mac នេះតាមរយៈ Tailscale។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "iPhone의 cmux로 코드를 스캔하면 Tailscale을 통해 이 Mac을 페어링할 수 있습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Skann koden med cmux på iPhonen din for å pare denne Macen via Tailscale." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zeskanuj kod za pomocą cmux na swoim iPhonie, aby sparować tego Maca przez Tailscale." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Escaneie o código com o cmux no seu iPhone para emparelhar este Mac via Tailscale." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отсканируйте код в cmux на iPhone, чтобы подключить этот Mac через Tailscale." } },
+        "th": { "stringUnit": { "state": "translated", "value": "สแกนโค้ดด้วย cmux บน iPhone ของคุณเพื่อจับคู่ Mac เครื่องนี้ผ่าน Tailscale" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bu Mac'i Tailscale üzerinden eşlemek için kodu iPhone'unuzdaki cmux ile tarayın." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Відскануйте код у cmux на iPhone, щоб підключити цей Mac через Tailscale." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用 iPhone 上的 cmux 扫描该码，即可通过 Tailscale 配对这台 Mac。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "使用 iPhone 上的 cmux 掃描該代碼，即可透過 Tailscale 配對這台 Mac。" } }
+      }
+    },
+    "mobile.pairing.transport.iroh.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تعثر أجهزة iPhone المسجّلة الدخول إلى حسابك على هذا الـ Mac تلقائيًا عبر Iroh — بتشفير من طرف إلى طرف، مباشرةً عند الإمكان، وعبر مُرحّل cmux عند التعذّر. لا حاجة إلى رمز." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "iPhone uređaji prijavljeni na vaš račun automatski pronalaze ovaj Mac preko Iroha — s end-to-end enkripcijom, direktno kad je moguće, a preko cmux releja kad nije. Kôd nije potreban." } },
+        "da": { "stringUnit": { "state": "translated", "value": "iPhones, der er logget ind på din konto, finder automatisk denne Mac via Iroh — end-to-end-krypteret, direkte når det er muligt og via et cmux-relæ, når det ikke er. Ingen kode nødvendig." } },
+        "de": { "stringUnit": { "state": "translated", "value": "iPhones, die mit deinem Konto angemeldet sind, finden diesen Mac automatisch über Iroh — Ende-zu-Ende-verschlüsselt, direkt wenn möglich, sonst über ein cmux-Relay. Kein Code nötig." } },
+        "en": { "stringUnit": { "state": "translated", "value": "iPhones signed in to your account find this Mac automatically over Iroh — end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Los iPhone con sesión iniciada en tu cuenta encuentran este Mac automáticamente a través de Iroh: cifrado de extremo a extremo, directo cuando es posible y mediante un relay de cmux cuando no. No se necesita código." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Les iPhone connectés à votre compte trouvent automatiquement ce Mac via Iroh — chiffré de bout en bout, en direct quand c'est possible, via un relais cmux sinon. Aucun code nécessaire." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Gli iPhone con l'accesso effettuato al tuo account trovano questo Mac automaticamente tramite Iroh — crittografato end-to-end, in modo diretto quando possibile e tramite un relay cmux quando non lo è. Nessun codice necessario." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アカウントにサインインしたiPhoneは、Irohを介してこのMacを自動的に検出します。エンドツーエンド暗号化で、可能な場合は直接、そうでない場合はcmuxリレー経由で接続します。コードは不要です。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "iPhone ដែលបានចូលគណនីរបស់អ្នក រកឃើញ Mac នេះដោយស្វ័យប្រវត្តិតាមរយៈ Iroh — អ៊ិនគ្រីបពីចុងដល់ចុង ដោយផ្ទាល់នៅពេលអាច និងតាមរយៈ relay របស់ cmux នៅពេលមិនអាច។ មិនត្រូវការកូដទេ។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정에 로그인된 iPhone은 Iroh를 통해 이 Mac을 자동으로 찾습니다. 종단 간 암호화되며, 가능하면 직접, 불가능하면 cmux 릴레이를 통해 연결합니다. 코드가 필요 없습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "iPhoner som er logget på kontoen din, finner denne Macen automatisk via Iroh — ende-til-ende-kryptert, direkte når det er mulig og via et cmux-relé når det ikke er det. Ingen kode nødvendig." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "iPhone'y zalogowane na Twoje konto automatycznie znajdują tego Maca przez Iroh — z szyfrowaniem end-to-end, bezpośrednio gdy to możliwe, a przez przekaźnik cmux gdy nie. Kod nie jest potrzebny." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhones conectados à sua conta encontram este Mac automaticamente via Iroh — criptografado de ponta a ponta, direto quando possível e por um relay do cmux quando não. Nenhum código necessário." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "iPhone, вошедшие в вашу учётную запись, находят этот Mac автоматически через Iroh — со сквозным шифрованием, напрямую, когда это возможно, и через ретранслятор cmux, когда нет. Код не нужен." } },
+        "th": { "stringUnit": { "state": "translated", "value": "iPhone ที่ลงชื่อเข้าบัญชีของคุณจะพบ Mac เครื่องนี้โดยอัตโนมัติผ่าน Iroh — เข้ารหัสจากต้นทางถึงปลายทาง เชื่อมต่อโดยตรงเมื่อทำได้ และผ่านรีเลย์ของ cmux เมื่อทำไม่ได้ ไม่ต้องใช้โค้ด" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Hesabınızda oturum açmış iPhone'lar bu Mac'i Iroh üzerinden otomatik olarak bulur — uçtan uca şifreli, mümkün olduğunda doğrudan, olmadığında bir cmux aktarıcısı üzerinden. Kod gerekmez." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "iPhone, що увійшли у ваш обліковий запис, знаходять цей Mac автоматично через Iroh — з наскрізним шифруванням, напряму, коли це можливо, і через ретранслятор cmux, коли ні. Код не потрібен." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "登录了您账户的 iPhone 会通过 Iroh 自动发现这台 Mac——端到端加密，可行时直接连接，否则经由 cmux 中继。无需扫码。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "登入您帳戶的 iPhone 會透過 Iroh 自動發現這台 Mac——端對端加密，可行時直接連線，否則經由 cmux 中繼。無需掃碼。" } }
+      }
+    },
+    "mobile.pairing.transport.status.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "متصل" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Povezano" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Forbundet" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Verbunden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Connected" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Conectado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Connecté" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Connesso" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "接続済み" } },
+        "km": { "stringUnit": { "state": "translated", "value": "បានភ្ជាប់" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "연결됨" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Tilkoblet" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Połączono" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conectado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подключено" } },
+        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมต่อแล้ว" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bağlı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Підключено" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已连接" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已連線" } }
+      }
+    },
+    "mobile.pairing.transport.status.notDetected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "لم يُكتشف" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Nije otkriveno" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Ikke fundet" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Nicht erkannt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Not detected" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No detectado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Non détecté" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Non rilevato" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "未検出" } },
+        "km": { "stringUnit": { "state": "translated", "value": "រកមិនឃើញ" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "감지되지 않음" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Ikke funnet" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie wykryto" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não detectado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не обнаружено" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ไม่พบ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Algılanmadı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не виявлено" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未检测到" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "未偵測到" } }
+      }
+    },
+    "mobile.pairing.transport.status.notRegistered": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "غير مسجّل" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Nije registrovano" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Ikke registreret" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Nicht registriert" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Not registered" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No registrado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Non enregistré" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Non registrato" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "未登録" } },
+        "km": { "stringUnit": { "state": "translated", "value": "មិនទាន់ចុះឈ្មោះ" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "등록되지 않음" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Ikke registrert" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Niezarejestrowano" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não registrado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не зарегистрировано" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ยังไม่ได้ลงทะเบียน" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Kayıtlı değil" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не зареєстровано" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未注册" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "未註冊" } }
+      }
+    },
+    "mobile.pairing.transport.status.ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "جاهز" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Spremno" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Klar" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Bereit" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Ready" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Listo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Prêt" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Pronto" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "準備完了" } },
+        "km": { "stringUnit": { "state": "translated", "value": "រួចរាល់" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "준비됨" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Klar" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Gotowe" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Pronto" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Готово" } },
+        "th": { "stringUnit": { "state": "translated", "value": "พร้อม" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Hazır" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Готово" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "就绪" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "就緒" } }
+      }
+    },
+    "mobile.pairing.transport.tailscale.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "يُقرِن هذا الرمز عبر Tailscale بدلًا من ذلك. يجب أن يكون كلا الجهازين متصلًا بشبكة Tailscale نفسها." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Ovaj kôd uparuje preko Tailscalea. Oba uređaja moraju biti povezana na istu Tailscale mrežu." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Denne kode parrer via Tailscale i stedet. Begge enheder skal være forbundet til det samme Tailscale-netværk." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Dieser Code koppelt stattdessen über Tailscale. Beide Geräte müssen mit demselben Tailscale-Netzwerk verbunden sein." } },
+        "en": { "stringUnit": { "state": "translated", "value": "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Este código empareja a través de Tailscale. Ambos dispositivos deben estar conectados a la misma red de Tailscale." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ce code jumelle via Tailscale à la place. Les deux appareils doivent être connectés au même réseau Tailscale." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Questo codice abbina invece tramite Tailscale. Entrambi i dispositivi devono essere connessi alla stessa rete Tailscale." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このコードは代わりにTailscale経由でペアリングします。両方のデバイスが同じTailscaleネットワークに接続されている必要があります。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "កូដនេះផ្គូផ្គងតាមរយៈ Tailscale ជំនួសវិញ។ ឧបករណ៍ទាំងពីរត្រូវតែភ្ជាប់ទៅបណ្ដាញ Tailscale ដូចគ្នា។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 코드는 대신 Tailscale을 통해 페어링합니다. 두 기기가 동일한 Tailscale 네트워크에 연결되어 있어야 합니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Denne koden parer via Tailscale i stedet. Begge enhetene må være koblet til det samme Tailscale-nettverket." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Ten kod paruje natomiast przez Tailscale. Oba urządzenia muszą być połączone z tą samą siecią Tailscale." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Este código emparelha via Tailscale. Os dois dispositivos precisam estar conectados à mesma rede Tailscale." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Этот код выполняет подключение через Tailscale. Оба устройства должны быть подключены к одной и той же сети Tailscale." } },
+        "th": { "stringUnit": { "state": "translated", "value": "โค้ดนี้ใช้จับคู่ผ่าน Tailscale แทน อุปกรณ์ทั้งสองต้องเชื่อมต่อกับเครือข่าย Tailscale เดียวกัน" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bu kod bunun yerine Tailscale üzerinden eşler. Her iki cihaz da aynı Tailscale ağına bağlı olmalıdır." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Цей код виконує підключення через Tailscale. Обидва пристрої мають бути підключені до однієї мережі Tailscale." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此码改为通过 Tailscale 配对。两台设备必须连接到同一个 Tailscale 网络。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "此代碼改為透過 Tailscale 配對。兩台裝置必須連線到同一個 Tailscale 網路。" } }
       }
     },
     "mobile.pairing.manual.copyIP": {
@@ -138556,23 +138847,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "スキャンできない場合は、この Mac を手動で追加します:"
-          }
-        }
-      }
-    },
-    "mobile.pairing.needsTailscale.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This Mac has no Tailscale address, so your iPhone can't reach it. Install Tailscale on this Mac and your iPhone (same account), then refresh."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac には Tailscale アドレスがないため、iPhone から接続できません。この Mac と iPhone の両方に（同じアカウントで）Tailscale をインストールしてから、更新してください。"
           }
         }
       }
@@ -138645,40 +138919,6 @@
         }
       }
     },
-    "mobile.pairing.req.signIn.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign in to authorize this Mac for pairing."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac のペアリングを許可するにはサインインしてください。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.req.signIn.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signed in to cmux"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux にサインイン済み"
-          }
-        }
-      }
-    },
     "mobile.pairing.req.tailscale.get": {
       "extractionState": "manual",
       "localizations": {
@@ -138692,23 +138932,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tailscale を入手"
-          }
-        }
-      }
-    },
-    "mobile.pairing.req.tailscale.hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale must be installed and connected on both this Mac and your iPhone. Both devices must be connected to the same Tailscale network."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac と iPhone の両方に Tailscale をインストールして接続してください。両方のデバイスを同じ Tailscale ネットワークに接続する必要があります。"
           }
         }
       }
@@ -138730,40 +138953,6 @@
         }
       }
     },
-    "mobile.pairing.req.tailscale.reachable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale is connected on this Mac. It must also be installed and connected on your iPhone. Both devices must be connected to the same Tailscale network."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac は Tailscale に接続済みです。iPhone にも Tailscale をインストールして接続してください。両方のデバイスを同じ Tailscale ネットワークに接続する必要があります。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.req.tailscale.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tailscale"
-          }
-        }
-      }
-    },
     "mobile.pairing.retry": {
       "extractionState": "manual",
       "localizations": {
@@ -138777,466 +138966,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "再試行"
-          }
-        }
-      }
-    },
-    "mobile.pairing.signIn.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign In"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サインイン"
-          }
-        }
-      }
-    },
-    "mobile.pairing.signIn.connecting": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جارٍ الاتصال…"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povezivanje…"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Forbinder…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindung wird hergestellt…"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectando…"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connexion…"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connessione…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続しています…"
-          }
-        },
-        "km": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "កំពុងភ្ជាប់…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "연결 중…"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kobler til…"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Łączenie…"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectando…"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Подключение…"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเชื่อมต่อ…"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bağlanıyor…"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Підключення…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在连接…"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在連接…"
-          }
-        }
-      }
-    },
-    "mobile.pairing.signIn.openInBrowser": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فتح في المتصفح"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otvori u pregledniku"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Åbn i browser"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Im Browser öffnen"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open in Browser"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir en el navegador"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrir dans le navigateur"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri nel browser"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザで開く"
-          }
-        },
-        "km": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "បើកក្នុងកម្មវិធីរុករក"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "브라우저에서 열기"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Åpne i nettleser"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz w przeglądarce"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir no navegador"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открыть в браузере"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดในเบราว์เซอร์"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tarayıcıda Aç"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрити у браузері"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在浏览器中打开"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在瀏覽器中打開"
-          }
-        }
-      }
-    },
-    "mobile.pairing.signIn.prompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign in with your cmux account to pair your iPhone."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iPhone をペアリングするには、cmux アカウントでサインインしてください。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.signIn.slowHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قد تتوقف نافذة تسجيل الدخول في النظام عن الاستجابة. إذا لم يحدث شيء، فافتح تسجيل الدخول في المتصفح الافتراضي بدلاً من ذلك."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sistemski prozor za prijavu može prestati odgovarati. Ako se ništa ne dogodi, otvorite prijavu u zadanom pregledniku."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Systemets loginvindue kan holde op med at svare. Hvis der ikke sker noget, skal du i stedet åbne login i din standardbrowser."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das System-Anmeldefenster reagiert möglicherweise nicht mehr. Wenn nichts passiert, öffne die Anmeldung stattdessen in deinem Standardbrowser."
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The system sign-in window may stop responding. If nothing happens, open sign-in in your default browser instead."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La ventana de inicio de sesión del sistema puede dejar de responder. Si no sucede nada, abre el inicio de sesión en tu navegador predeterminado."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La fenêtre de connexion du système peut ne plus répondre. Si rien ne se passe, ouvrez plutôt la connexion dans votre navigateur par défaut."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La finestra di accesso di sistema potrebbe smettere di rispondere. Se non succede nulla, apri l’accesso nel browser predefinito."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システムのサインインウィンドウが応答しなくなることがあります。何も起きない場合は、デフォルトのブラウザでサインインを開いてください。"
-          }
-        },
-        "km": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "បង្អួចចូលគណនីរបស់ប្រព័ន្ធអាចឈប់ឆ្លើយតប។ ប្រសិនបើគ្មានអ្វីកើតឡើង សូមបើកការចូលគណនីក្នុងកម្មវិធីរុករកលំនាំដើមរបស់អ្នកជំនួសវិញ។"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 로그인 창이 응답하지 않을 수 있습니다. 아무 반응이 없으면 기본 브라우저에서 로그인을 열어 주세요."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Systemets påloggingsvindu kan slutte å svare. Hvis ingenting skjer, åpner du påloggingen i standardnettleseren i stedet."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Systemowe okno logowania może przestać odpowiadać. Jeśli nic się nie dzieje, otwórz logowanie w domyślnej przeglądarce."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A janela de login do sistema pode parar de responder. Se nada acontecer, abra o login no navegador padrão."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Системное окно входа может перестать отвечать. Если ничего не происходит, откройте вход в браузере по умолчанию."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หน้าต่างลงชื่อเข้าของระบบอาจหยุดตอบสนอง หากไม่มีอะไรเกิดขึ้น ให้เปิดการลงชื่อเข้าในเบราว์เซอร์เริ่มต้นแทน"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sistem oturum açma penceresi yanıt vermeyi durdurabilir. Hiçbir şey olmazsa oturum açmayı varsayılan tarayıcınızda açın."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Системне вікно входу може перестати відповідати. Якщо нічого не відбувається, відкрийте вхід у браузері за умовчанням."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统登录窗口可能会停止响应。如果没有任何反应，请改用默认浏览器打开登录。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系統登入視窗可能會停止回應。如果沒有任何反應，請改用預設瀏覽器開啟登入。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.step.install": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install cmux on your iPhone and open it."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iPhone に cmux をインストールして開きます。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.step.scan": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "On your iPhone, choose Tailscale, tap Scan QR Code, then scan the code above."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続方法として Tailscale を選び、「QR コードをスキャン」をタップして上のコードにカメラを向けます。"
-          }
-        }
-      }
-    },
-    "mobile.pairing.step.signIn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign in with the same account you use on this Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この Mac と同じアカウントでサインインします。"
           }
         }
       }
@@ -139356,40 +139085,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "iPhone を待っています…"
-          }
-        }
-      }
-    },
-    "mobile.pairing.window.heading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pair your iPhone with Tailscale"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TailscaleでiPhoneをペアリング"
-          }
-        }
-      }
-    },
-    "mobile.pairing.window.subheading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iPhones on your cmux account connect automatically. Use this code only for Tailscale."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "同じ cmux アカウントでサインインしている iPhone は自動的に接続されます。iPhone の接続方法で Tailscale を選択した場合は、このコードを使用してください。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -138475,6 +138475,81 @@
         }
       }
     },
+    "mobile.pairing.irohInstruction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "ثبّت cmux على جهاز iPhone وسجّل الدخول بالحساب نفسه. يتصل تلقائيًا — لا حاجة إلى رمز." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Instalirajte cmux na svoj iPhone i prijavite se istim računom. Povezuje se automatski — kôd nije potreban." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Installer cmux på din iPhone, og log ind med den samme konto. Den forbinder automatisk — ingen kode nødvendig." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Installiere cmux auf deinem iPhone und melde dich mit demselben Konto an. Die Verbindung erfolgt automatisch — kein Code nötig." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Install cmux on your iPhone and sign in with the same account. It connects automatically — no code needed." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Instala cmux en tu iPhone e inicia sesión con la misma cuenta. Se conecta automáticamente: no se necesita código." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Installez cmux sur votre iPhone et connectez-vous avec le même compte. La connexion est automatique — aucun code nécessaire." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Installa cmux sul tuo iPhone e accedi con lo stesso account. Si connette automaticamente — nessun codice necessario." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneにcmuxをインストールし、同じアカウントにサインインしてください。自動的に接続されます。コードは不要です。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ដំឡើង cmux នៅលើ iPhone របស់អ្នក ហើយចូលគណនីដូចគ្នា។ វាភ្ជាប់ដោយស្វ័យប្រវត្តិ — មិនត្រូវការកូដទេ។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "iPhone에 cmux를 설치하고 동일한 계정으로 로그인하세요. 자동으로 연결되며 코드가 필요 없습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Installer cmux på iPhonen din og logg på med samme konto. Den kobler til automatisk — ingen kode nødvendig." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zainstaluj cmux na swoim iPhonie i zaloguj się na to samo konto. Łączy się automatycznie — kod nie jest potrzebny." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Instale o cmux no seu iPhone e entre com a mesma conta. Ele conecta automaticamente — nenhum código necessário." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Установите cmux на iPhone и войдите в ту же учётную запись. Подключение происходит автоматически — код не нужен." } },
+        "th": { "stringUnit": { "state": "translated", "value": "ติดตั้ง cmux บน iPhone ของคุณและลงชื่อเข้าด้วยบัญชีเดียวกัน ระบบจะเชื่อมต่อโดยอัตโนมัติ — ไม่ต้องใช้โค้ด" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuza cmux'u yükleyin ve aynı hesapla oturum açın. Otomatik olarak bağlanır — kod gerekmez." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Установіть cmux на iPhone та увійдіть у той самий обліковий запис. Підключення відбувається автоматично — код не потрібен." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在 iPhone 上安装 cmux 并使用同一账户登录。它会自动连接——无需扫码。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "在 iPhone 上安裝 cmux 並使用同一帳戶登入。它會自動連線——無需掃碼。" } }
+      }
+    },
+    "mobile.pairing.subheading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "زامن مساحات عمل الطرفية مع جهاز iPhone الخاص بك." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Sinhronizujte svoje terminalske radne prostore sa svojim iPhoneom." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Synkroniser dine terminal-arbejdsområder til din iPhone." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Synchronisiere deine Terminal-Arbeitsbereiche mit deinem iPhone." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Sync your terminal workspaces to your iPhone." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Sincroniza tus espacios de trabajo de terminal con tu iPhone." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Synchronisez vos espaces de travail de terminal avec votre iPhone." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Sincronizza i tuoi spazi di lavoro del terminale con il tuo iPhone." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ターミナルのワークスペースをiPhoneと同期します。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ធ្វើសមកាលកម្មកន្លែងធ្វើការតឺមីណាល់របស់អ្នកទៅ iPhone របស់អ្នក។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "터미널 워크스페이스를 iPhone과 동기화하세요." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Synkroniser terminalarbeidsområdene dine til iPhonen din." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Synchronizuj swoje terminalowe przestrzenie robocze z iPhone'em." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Sincronize seus espaços de trabalho de terminal com o seu iPhone." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Синхронизируйте рабочие пространства терминала со своим iPhone." } },
+        "th": { "stringUnit": { "state": "translated", "value": "ซิงค์เวิร์กสเปซเทอร์มินัลของคุณไปยัง iPhone ของคุณ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Terminal çalışma alanlarınızı iPhone'unuzla eşitleyin." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Синхронізуйте робочі простори термінала зі своїм iPhone." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "将您的终端工作区同步到 iPhone。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "將您的終端機工作區同步到 iPhone。" } }
+      }
+    },
+    "mobile.pairing.transportPicker": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "الاتصال" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Veza" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Forbindelse" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Verbindung" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Connection" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Conexión" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Connexion" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Connessione" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "接続" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ការតភ្ជាប់" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "연결" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Tilkobling" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Połączenie" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conexão" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подключение" } },
+        "th": { "stringUnit": { "state": "translated", "value": "การเชื่อมต่อ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bağlantı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Підключення" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連線" } }
+      }
+    },
     "mobile.pairing.getApp.badge.caption": {
       "extractionState": "manual",
       "localizations": {
@@ -138550,31 +138625,6 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "配對您的 iPhone" } }
       }
     },
-    "mobile.pairing.needsTransport.irohHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "لا يزال بإمكان أجهزة iPhone المسجّلة الدخول الاتصال تلقائيًا عبر Iroh. Tailscale مطلوب فقط للإقران عبر رمز QR." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Prijavljeni iPhone uređaji i dalje se mogu automatski povezati preko Iroha. Tailscale je potreban samo za QR uparivanje." } },
-        "da": { "stringUnit": { "state": "translated", "value": "iPhones, der er logget ind, kan stadig oprette forbindelse automatisk via Iroh. Tailscale er kun nødvendig til QR-parring." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Angemeldete iPhones können sich weiterhin automatisch über Iroh verbinden. Tailscale wird nur für die QR-Kopplung benötigt." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Signed-in iPhones can still connect automatically over Iroh. Tailscale is only needed for QR pairing." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Los iPhone con sesión iniciada pueden seguir conectándose automáticamente a través de Iroh. Tailscale solo es necesario para el emparejamiento por QR." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Les iPhone connectés peuvent toujours se connecter automatiquement via Iroh. Tailscale n'est nécessaire que pour le jumelage par QR." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Gli iPhone con l'accesso effettuato possono comunque connettersi automaticamente tramite Iroh. Tailscale serve solo per l'abbinamento via QR." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "サインイン済みのiPhoneは、引き続きIroh経由で自動的に接続できます。TailscaleはQRペアリングにのみ必要です。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "iPhone ដែលបានចូលគណនីនៅតែអាចភ្ជាប់ដោយស្វ័យប្រវត្តិតាមរយៈ Iroh បាន។ Tailscale ត្រូវការតែសម្រាប់ការផ្គូផ្គងតាម QR ប៉ុណ្ណោះ។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "로그인된 iPhone은 여전히 Iroh를 통해 자동으로 연결할 수 있습니다. Tailscale은 QR 페어링에만 필요합니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "iPhoner som er pålogget, kan fortsatt koble til automatisk via Iroh. Tailscale trengs bare til QR-paring." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Zalogowane iPhone'y nadal mogą łączyć się automatycznie przez Iroh. Tailscale jest potrzebny tylko do parowania przez kod QR." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhones conectados ainda podem se conectar automaticamente via Iroh. O Tailscale só é necessário para o emparelhamento por QR." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "iPhone, вошедшие в учётную запись, по-прежнему могут подключаться автоматически через Iroh. Tailscale нужен только для подключения по QR-коду." } },
-        "th": { "stringUnit": { "state": "translated", "value": "iPhone ที่ลงชื่อเข้าแล้วยังคงเชื่อมต่อโดยอัตโนมัติผ่าน Iroh ได้ Tailscale จำเป็นเฉพาะการจับคู่ด้วย QR เท่านั้น" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Oturum açmış iPhone'lar yine de Iroh üzerinden otomatik olarak bağlanabilir. Tailscale yalnızca QR ile eşleme için gereklidir." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "iPhone, що увійшли в обліковий запис, усе ще можуть підключатися автоматично через Iroh. Tailscale потрібен лише для підключення за QR-кодом." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已登录的 iPhone 仍可通过 Iroh 自动连接。仅在使用二维码配对时才需要 Tailscale。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已登入的 iPhone 仍可透過 Iroh 自動連線。僅在使用 QR Code 配對時才需要 Tailscale。" } }
-      }
-    },
     "mobile.pairing.scanInstruction": {
       "extractionState": "manual",
       "localizations": {
@@ -138623,31 +138673,6 @@
         "uk": { "stringUnit": { "state": "translated", "value": "Ви увійшли як %@" } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "已登录为 %@" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "已登入為 %@" } }
-      }
-    },
-    "mobile.pairing.subheading": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "امسح الرمز باستخدام cmux على جهاز iPhone لإقران هذا الـ Mac عبر Tailscale." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Skenirajte kôd pomoću cmux-a na svom iPhoneu da biste uparili ovaj Mac preko Tailscalea." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Scan koden med cmux på din iPhone for at parre denne Mac via Tailscale." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Scanne den Code mit cmux auf deinem iPhone, um diesen Mac über Tailscale zu koppeln." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Scan the code with cmux on your iPhone to pair this Mac over Tailscale." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Escanea el código con cmux en tu iPhone para emparejar este Mac a través de Tailscale." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Scannez le code avec cmux sur votre iPhone pour jumeler ce Mac via Tailscale." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Scansiona il codice con cmux sul tuo iPhone per abbinare questo Mac tramite Tailscale." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneのcmuxでコードをスキャンすると、Tailscale経由でこのMacをペアリングできます。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ស្កេនកូដដោយប្រើ cmux នៅលើ iPhone របស់អ្នក ដើម្បីផ្គូផ្គង Mac នេះតាមរយៈ Tailscale។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "iPhone의 cmux로 코드를 스캔하면 Tailscale을 통해 이 Mac을 페어링할 수 있습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Skann koden med cmux på iPhonen din for å pare denne Macen via Tailscale." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Zeskanuj kod za pomocą cmux na swoim iPhonie, aby sparować tego Maca przez Tailscale." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Escaneie o código com o cmux no seu iPhone para emparelhar este Mac via Tailscale." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Отсканируйте код в cmux на iPhone, чтобы подключить этот Mac через Tailscale." } },
-        "th": { "stringUnit": { "state": "translated", "value": "สแกนโค้ดด้วย cmux บน iPhone ของคุณเพื่อจับคู่ Mac เครื่องนี้ผ่าน Tailscale" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Bu Mac'i Tailscale üzerinden eşlemek için kodu iPhone'unuzdaki cmux ile tarayın." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Відскануйте код у cmux на iPhone, щоб підключити цей Mac через Tailscale." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用 iPhone 上的 cmux 扫描该码，即可通过 Tailscale 配对这台 Mac。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "使用 iPhone 上的 cmux 掃描該代碼，即可透過 Tailscale 配對這台 Mac。" } }
       }
     },
     "mobile.pairing.transport.iroh.detail": {

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -29,8 +29,10 @@ final class MobilePairingModel {
         /// A phone has attached to the listener; show a paired/success state
         /// instead of the QR + spinner.
         case connected(Ready)
-        /// No phone-reachable Tailscale route is available yet.
-        case needsReachableTransport
+        /// No phone-reachable Tailscale route is available yet. Carries the
+        /// live Iroh registration state so the window's Iroh tab keeps
+        /// working while Tailscale QR pairing is unavailable.
+        case needsReachableTransport(reachableViaIroh: Bool)
         /// The listener could not be started or no ticket could be minted.
         case failed(String)
     }
@@ -176,7 +178,9 @@ final class MobilePairingModel {
             return
         }
         guard let routePlan = PairingRoutePlan.make(routes: status.routes) else {
-            state = .needsReachableTransport
+            state = .needsReachableTransport(
+                reachableViaIroh: Self.hasIrohRoute(status.routes)
+            )
             observeRouteAvailability()
             return
         }
@@ -203,14 +207,16 @@ final class MobilePairingModel {
                     attachURL: attachURL,
                     tailscaleLines: Self.tailscaleLines(status.routes),
                     manualEntry: CmxManualPairingEntry.best(in: status.routes),
-                    reachableViaIroh: status.routes.contains { $0.kind == .iroh }
+                    reachableViaIroh: Self.hasIrohRoute(status.routes)
                 )
             )
             observeConnections()
         } catch MobileAttachTicketStoreError.noRoutes,
                 MobileAttachTicketStoreError.routeUnavailable,
                 MobileAttachTicketStoreError.invalidAttachURL {
-            state = .needsReachableTransport
+            state = .needsReachableTransport(
+                reachableViaIroh: Self.hasIrohRoute(host.statusSnapshot().routes)
+            )
             observeRouteAvailability()
         } catch {
             state = .failed(
@@ -297,7 +303,8 @@ final class MobilePairingModel {
     }
 
     /// Automatically replaces the temporary no-route state when a Tailscale
-    /// route appears. This is event-driven by the host status cache.
+    /// route appears, and keeps the state's Iroh registration flag live in
+    /// the meantime. This is event-driven by the host status cache.
     private func observeRouteAvailability() {
         connectionObservationTask?.cancel()
         let generation = refreshGeneration
@@ -307,6 +314,13 @@ final class MobilePairingModel {
                 guard !Task.isCancelled,
                       generation == self.refreshGeneration else { return }
                 guard PairingRoutePlan.make(routes: status.routes) != nil else {
+                    let reachableViaIroh = Self.hasIrohRoute(status.routes)
+                    if case let .needsReachableTransport(current) = self.state,
+                       current != reachableViaIroh {
+                        self.state = .needsReachableTransport(
+                            reachableViaIroh: reachableViaIroh
+                        )
+                    }
                     continue
                 }
                 Task { @MainActor [weak self] in
@@ -344,6 +358,11 @@ final class MobilePairingModel {
         // Never force the listener on under a managed remote-control disable.
         guard MobileRemoteControlPolicy.isEnabled else { return }
         UserDefaults.standard.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
+    }
+
+    /// Whether this Mac's Iroh endpoint is registered in `routes`.
+    private nonisolated static func hasIrohRoute(_ routes: [CmxAttachRoute]) -> Bool {
+        routes.contains { $0.kind == .iroh }
     }
 
     /// Whether `route` can serve a physical iPhone: a Tailscale route that does

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -44,6 +44,9 @@ final class MobilePairingModel {
         /// The best route for manual phone entry, behind the "Copy IP" and
         /// "Copy Port" buttons. `nil` when no phone-dialable route exists.
         let manualEntry: CmxManualPairingEntry?
+        /// Whether this Mac's Iroh endpoint is registered, so signed-in
+        /// iPhones can discover it automatically without any QR.
+        let reachableViaIroh: Bool
 
         /// Whether at least one Tailscale route resolved.
         var reachableViaTailscale: Bool { !tailscaleLines.isEmpty }
@@ -199,7 +202,8 @@ final class MobilePairingModel {
                 Ready(
                     attachURL: attachURL,
                     tailscaleLines: Self.tailscaleLines(status.routes),
-                    manualEntry: CmxManualPairingEntry.best(in: status.routes)
+                    manualEntry: CmxManualPairingEntry.best(in: status.routes),
+                    reachableViaIroh: status.routes.contains { $0.kind == .iroh }
                 )
             )
             observeConnections()
@@ -252,12 +256,6 @@ final class MobilePairingModel {
         }
     }
 
-    /// Launches the Mac browser sign-in flow. Fire-and-forget; the view re-runs
-    /// ``refresh()`` when the coordinator's auth state settles.
-    func signIn() {
-        state = .loading
-        AppDelegate.shared?.auth?.browserSignIn.beginSignIn()
-    }
     /// Cancels the connection observation. Call when the window closes.
     ///
     /// There is deliberately no timer to cancel: the displayed code never

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -27,8 +27,10 @@ final class MobilePairingModel {
         /// A ticket is ready to display.
         case ready(Ready)
         /// A phone has attached to the listener; show a paired/success state
-        /// instead of the QR + spinner.
-        case connected(Ready)
+        /// instead of the QR + spinner. Carries the state to restore when the
+        /// connection count falls back to the baseline (the QR waiting state,
+        /// or the Iroh-only waiting state when no Tailscale route exists).
+        indirect case connected(from: State)
         /// No phone-reachable Tailscale route is available yet. Carries the
         /// live Iroh registration state so the window's Iroh tab keeps
         /// working while Tailscale QR pairing is unavailable.
@@ -52,6 +54,19 @@ final class MobilePairingModel {
 
         /// Whether at least one Tailscale route resolved.
         var reachableViaTailscale: Bool { !tailscaleLines.isEmpty }
+
+        /// The same ticket with its route-derived diagnostics recomputed from
+        /// a fresh host status. The displayed `attachURL` is intentionally
+        /// kept: the code on screen is never regenerated behind the user's
+        /// back; Refresh Code re-mints on demand.
+        func updatingRoutes(_ routes: [CmxAttachRoute]) -> Ready {
+            Ready(
+                attachURL: attachURL,
+                tailscaleLines: MobilePairingModel.tailscaleLines(routes),
+                manualEntry: CmxManualPairingEntry.best(in: routes),
+                reachableViaIroh: MobilePairingModel.hasIrohRoute(routes)
+            )
+        }
     }
 
     struct PairingRoutePlan: Equatable, Sendable {
@@ -181,7 +196,7 @@ final class MobilePairingModel {
             state = .needsReachableTransport(
                 reachableViaIroh: Self.hasIrohRoute(status.routes)
             )
-            observeRouteAvailability()
+            observeHostStatus()
             return
         }
         do {
@@ -210,14 +225,14 @@ final class MobilePairingModel {
                     reachableViaIroh: Self.hasIrohRoute(status.routes)
                 )
             )
-            observeConnections()
+            observeHostStatus()
         } catch MobileAttachTicketStoreError.noRoutes,
                 MobileAttachTicketStoreError.routeUnavailable,
                 MobileAttachTicketStoreError.invalidAttachURL {
             state = .needsReachableTransport(
                 reachableViaIroh: Self.hasIrohRoute(host.statusSnapshot().routes)
             )
-            observeRouteAvailability()
+            observeHostStatus()
         } catch {
             state = .failed(
                 String(
@@ -273,11 +288,13 @@ final class MobilePairingModel {
         connectionObservationTask = nil
     }
 
-    /// Watches the mobile host's connection status while a code is displayed and
-    /// flips between `.ready` (QR shown, waiting) and `.connected` (a phone has
-    /// attached). Cancelled and superseded on each ``refresh()`` via the generation
-    /// guard, and on ``stopObserving()``.
-    private func observeConnections() {
+    /// Watches the mobile host's status while the window is open: flips
+    /// waiting states to `.connected` (and back) as phones attach and detach,
+    /// keeps the route-derived transport diagnostics fresh, and re-mints when
+    /// a Tailscale route first appears in the no-route state. Cancelled and
+    /// superseded on each ``refresh()`` via the generation guard, and on
+    /// ``stopObserving()``.
+    private func observeHostStatus() {
         connectionObservationTask?.cancel()
         let generation = refreshGeneration
         // Connections already present when this code is displayed (another phone
@@ -293,62 +310,69 @@ final class MobilePairingModel {
             for await status in self.host.statusUpdates() {
                 if Task.isCancelled { return }
                 guard generation == self.refreshGeneration else { return }
-                self.state = Self.connectionTransition(
+                let next = Self.statusTransition(
                     from: self.state,
+                    routes: status.routes,
                     activeConnectionCount: status.activeConnectionCount,
                     baselineConnectionCount: baseline
                 )
-            }
-        }
-    }
-
-    /// Automatically replaces the temporary no-route state when a Tailscale
-    /// route appears, and keeps the state's Iroh registration flag live in
-    /// the meantime. This is event-driven by the host status cache.
-    private func observeRouteAvailability() {
-        connectionObservationTask?.cancel()
-        let generation = refreshGeneration
-        connectionObservationTask = Task { [weak self] in
-            guard let self else { return }
-            for await status in self.host.statusUpdates() {
-                guard !Task.isCancelled,
-                      generation == self.refreshGeneration else { return }
-                guard PairingRoutePlan.make(routes: status.routes) != nil else {
-                    let reachableViaIroh = Self.hasIrohRoute(status.routes)
-                    if case let .needsReachableTransport(current) = self.state,
-                       current != reachableViaIroh {
-                        self.state = .needsReachableTransport(
-                            reachableViaIroh: reachableViaIroh
-                        )
+                if next != self.state {
+                    self.state = next
+                }
+                // A Tailscale route appearing in the no-route state is the one
+                // change a state edit can't express: the QR needs a fresh mint.
+                if case .needsReachableTransport = self.state,
+                   PairingRoutePlan.make(routes: status.routes) != nil {
+                    Task { @MainActor [weak self] in
+                        await self?.refresh()
                     }
-                    continue
+                    return
                 }
-                Task { @MainActor [weak self] in
-                    await self?.refresh()
-                }
-                return
             }
         }
     }
 
-    /// Computes the next render state from a connection-count change, relative to
-    /// the `baselineConnectionCount` captured when the code was displayed. A
-    /// connection *above* the baseline (a phone that attached after the QR was
-    /// shown) flips a displayed ticket from `.ready` to `.connected`; dropping
-    /// back to the baseline flips it back so the QR returns. All other states
-    /// pass through unchanged. Pure, so the transition is unit tested without a
-    /// live host.
-    static func connectionTransition(
+    /// Computes the next render state from a host status event. Pure, so the
+    /// transitions are unit tested without a live host.
+    ///
+    /// A connection *above* the `baselineConnectionCount` captured when the
+    /// waiting state was entered (a phone that attached afterwards) flips
+    /// `.ready` and `.needsReachableTransport` to `.connected`; dropping back
+    /// to the baseline restores the prior waiting state. Waiting states also
+    /// absorb route changes so the transport diagnostics stay live: the Iroh
+    /// flag, the Tailscale lines, and the manual entry follow `routes`, while
+    /// the displayed `attachURL` is deliberately never regenerated here (the
+    /// code on screen never changes behind the user's back; Refresh Code
+    /// re-mints on demand).
+    static func statusTransition(
         from current: State,
+        routes: [CmxAttachRoute],
         activeConnectionCount: Int,
         baselineConnectionCount: Int
     ) -> State {
         let connected = activeConnectionCount > baselineConnectionCount
         switch current {
         case let .ready(ready) where connected:
-            return .connected(ready)
-        case let .connected(ready) where !connected:
-            return .ready(ready)
+            return .connected(from: .ready(ready.updatingRoutes(routes)))
+        case let .ready(ready):
+            return .ready(ready.updatingRoutes(routes))
+        case .needsReachableTransport where connected:
+            return .connected(
+                from: .needsReachableTransport(
+                    reachableViaIroh: hasIrohRoute(routes)
+                )
+            )
+        case .needsReachableTransport:
+            return .needsReachableTransport(reachableViaIroh: hasIrohRoute(routes))
+        case let .connected(prior) where !connected:
+            return statusTransition(
+                from: prior,
+                routes: routes,
+                activeConnectionCount: activeConnectionCount,
+                baselineConnectionCount: baselineConnectionCount
+            )
+        case .connected:
+            return current
         default:
             return current
         }
@@ -373,7 +397,7 @@ final class MobilePairingModel {
         route.kind == .tailscale && !CmxLoopbackHost().matches(route)
     }
 
-    private static func tailscaleLines(_ routes: [CmxAttachRoute]) -> [String] {
+    private nonisolated static func tailscaleLines(_ routes: [CmxAttachRoute]) -> [String] {
         routes.compactMap { route in
             guard route.kind == .tailscale,
                   case let .hostPort(host, port) = route.endpoint else {

--- a/Sources/Mobile/Pairing/MobilePairingView+Connected.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView+Connected.swift
@@ -19,65 +19,6 @@ extension MobilePairingView {
         .frame(maxWidth: .infinity, minHeight: 200)
     }
 
-    var steps: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            step(1, String(localized: "mobile.pairing.step.install", defaultValue: "Install cmux on your iPhone and open it."))
-            HStack(spacing: 4) {
-                Spacer(minLength: 30)
-                Text(String(localized: "mobile.pairing.getApp.prompt", defaultValue: "Don't have it yet?"))
-                    .cmuxFont(.caption)
-                    .foregroundStyle(.secondary)
-                Link(
-                    String(localized: "mobile.pairing.getApp.link", defaultValue: "Get cmux for iPhone"),
-                    destination: Self.iphoneAppURL
-                )
-                .cmuxFont(.caption)
-                Spacer(minLength: 0)
-            }
-            step(2, String(localized: "mobile.pairing.step.signIn", defaultValue: "Sign in with the same account you use on this Mac."))
-            step(3, String(
-                localized: "mobile.pairing.step.scan",
-                defaultValue: "On your iPhone, choose Tailscale, tap Scan QR Code, then scan the code above."
-            ))
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    func step(_ number: Int, _ text: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Text("\(number)")
-                .cmuxFont(.caption, weight: .bold)
-                .foregroundStyle(.white)
-                .frame(width: 20, height: 20)
-                .background(Color.accentColor, in: Circle())
-            Text(text).cmuxFont(.callout).fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
-    }
-
-    @ViewBuilder
-    func manualFallback(_ ready: MobilePairingModel.Ready) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
-                .cmuxFont(.caption, weight: .semibold)
-                .foregroundStyle(.secondary)
-            ForEach(ready.tailscaleLines, id: \.self) { line in
-                Text(line).cmuxFont(.caption, design: .monospaced)
-                    .textSelection(.enabled).foregroundStyle(.secondary)
-            }
-            if let entry = ready.manualEntry {
-                HStack(spacing: 8) {
-                    copyButton(label: String(localized: "mobile.pairing.manual.copyIP", defaultValue: "Copy IP"), value: entry.host)
-                    copyButton(label: String(localized: "mobile.pairing.manual.copyPort", defaultValue: "Copy Port"), value: String(entry.port))
-                }
-                .padding(.top, 2)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
-    }
-
     func copyButton(label: String, value: String) -> some View {
         Button {
             guard GhosttyApp.terminalPasteboard.writeString(

--- a/Sources/Mobile/Pairing/MobilePairingView+Connected.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView+Connected.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 extension MobilePairingView {
     @ViewBuilder
-    func connectedContent(_ ready: MobilePairingModel.Ready) -> some View {
+    var connectedContent: some View {
         VStack(spacing: 12) {
             Image(systemName: "checkmark.circle.fill")
                 .cmuxFont(size: 36)

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -177,8 +177,8 @@ struct MobilePairingView: View {
             failure(message: message)
         case let .ready(ready):
             readyContent(ready)
-        case let .connected(ready):
-            connectedContent(ready)
+        case .connected:
+            connectedContent
         }
     }
 

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -4,17 +4,28 @@ import CMUXMobileCore
 import CmuxAuthRuntime
 import SwiftUI
 
-/// The macOS Tailscale QR flow for pairing an iPhone with this Mac.
+/// The macOS window for pairing an iPhone with this Mac.
 ///
-/// Automatic Iroh discovery needs no QR: the window leads with the Tailscale
-/// code and a prominent get-the-app badge, then explains both transports in a
-/// details section that doubles as the user's debugging surface (live Iroh and
-/// Tailscale state, manual-entry routes, signed-in account).
+/// A transport chooser leads the page: Iroh pairing is automatic for
+/// signed-in iPhones and needs no QR, while the Tailscale tab shows the QR
+/// used when the iPhone's connection method is explicitly set to Tailscale.
+/// Each tab ends in a status row that doubles as the debugging surface
+/// (live transport state, manual-entry routes, signed-in account).
 struct MobilePairingView: View {
+    /// The transport whose pairing flow the window presents.
+    enum TransportChoice: Hashable {
+        case iroh
+        case tailscale
+    }
+
     @State private var model = MobilePairingModel()
     @State private var signInModel = AccountSignInModel(
         flow: AppDelegate.shared?.auth?.accountFlow
     )
+    /// The user's explicit tab pick. `nil` until they touch the chooser; the
+    /// effective tab then follows Iroh readiness (Iroh when ready, else
+    /// Tailscale) so the page opens on the transport that will work.
+    @State private var chosenTransport: TransportChoice?
     /// The manual-entry value that was just copied (the host or the port
     /// string), so only the matching button shows the brief "Copied" flash.
     /// The two values can never collide: one is a host, the other a port.
@@ -74,21 +85,40 @@ struct MobilePairingView: View {
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 16) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "mobile.pairing.heading", defaultValue: "Pair your iPhone"))
-                    .cmuxFont(.title2, weight: .semibold)
-                Text(String(
-                    localized: "mobile.pairing.subheading",
-                    defaultValue: "Scan the code with cmux on your iPhone to pair this Mac over Tailscale."
-                ))
-                    .cmuxFont(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 12)
-            getIPhoneAppBadge
+        VStack(alignment: .leading, spacing: 2) {
+            Text(String(localized: "mobile.pairing.heading", defaultValue: "Pair your iPhone"))
+                .cmuxFont(.title2, weight: .semibold)
+            Text(String(
+                localized: "mobile.pairing.subheading",
+                defaultValue: "Sync your terminal workspaces to your iPhone."
+            ))
+                .cmuxFont(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    // MARK: Transport chooser
+
+    private func effectiveTransport(reachableViaIroh: Bool) -> TransportChoice {
+        chosenTransport ?? (reachableViaIroh ? .iroh : .tailscale)
+    }
+
+    private func transportPicker(reachableViaIroh: Bool) -> some View {
+        Picker(
+            String(localized: "mobile.pairing.transportPicker", defaultValue: "Connection"),
+            selection: Binding(
+                get: { effectiveTransport(reachableViaIroh: reachableViaIroh) },
+                set: { chosenTransport = $0 }
+            )
+        ) {
+            // Transport product names are literal tokens, not translatable copy.
+            Text(verbatim: "Iroh").tag(TransportChoice.iroh)
+            Text(verbatim: "Tailscale").tag(TransportChoice.tailscale)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(maxWidth: 280)
     }
 
     /// The App Store-badge-styled button for getting cmux on the iPhone.
@@ -141,8 +171,8 @@ struct MobilePairingView: View {
                 Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
                     .foregroundStyle(.secondary)
             }
-        case .needsReachableTransport:
-            needsReachableTransportContent
+        case let .needsReachableTransport(reachableViaIroh):
+            needsReachableTransportContent(reachableViaIroh: reachableViaIroh)
         case let .failed(message):
             failure(message: message)
         case let .ready(ready):
@@ -150,43 +180,6 @@ struct MobilePairingView: View {
         case let .connected(ready):
             connectedContent(ready)
         }
-    }
-
-    private var needsReachableTransportContent: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "network.slash")
-                .cmuxFont(size: 28)
-                .foregroundStyle(.orange)
-            Text(String(
-                localized: "mobile.pairing.req.tailscale.missing",
-                defaultValue: """
-                Tailscale is not connected on this Mac. Install it on both devices \
-                and connect both to the same Tailscale network.
-                """
-            ))
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Text(String(
-                localized: "mobile.pairing.needsTransport.irohHint",
-                defaultValue: "Signed-in iPhones can still connect automatically over Iroh. Tailscale is only needed for QR pairing."
-            ))
-                .cmuxFont(.caption)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Link(
-                String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
-                destination: Self.tailscaleDownloadURL
-            )
-            .buttonStyle(.borderedProminent)
-            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
-                Task { await model.refresh() }
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        }
-        .frame(maxWidth: .infinity, minHeight: 200)
     }
 
     @ViewBuilder
@@ -218,47 +211,101 @@ struct MobilePairingView: View {
         .frame(maxWidth: .infinity, minHeight: 200)
     }
 
+    // MARK: Ready
+
     @ViewBuilder
     private func readyContent(_ ready: MobilePairingModel.Ready) -> some View {
+        let transport = effectiveTransport(reachableViaIroh: ready.reachableViaIroh)
+
         VStack(alignment: .center, spacing: 14) {
-            // The spec 4-module quiet zone (white margin) is baked into the QR
-            // bitmap itself, so the code gets no extra white card padding here:
-            // the old 12pt-padded white card doubled the visible quiet zone.
-            // Width is capped so the whole QR, the waiting indicator, and the
-            // transport details all fit the default window without scrolling.
-            MobilePairingQRImageView(payload: ready.attachURL)
-                .frame(maxWidth: 320)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(Color.secondary.opacity(0.2))
-                )
-
-            HStack(spacing: 6) {
-                ProgressView().controlSize(.small)
-                Text(String(localized: "mobile.pairing.waiting", defaultValue: "Waiting for your iPhone…"))
-                    .cmuxFont(.callout)
-                    .foregroundStyle(.secondary)
-            }
-
-            Text(String(
-                localized: "mobile.pairing.scanInstruction",
-                defaultValue: "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code."
-            ))
-            .cmuxFont(.caption)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
-
-            if model.availableIOSAppTargets.count > 1 {
-                pairingTargetPicker
+            transportPicker(reachableViaIroh: ready.reachableViaIroh)
+            getIPhoneAppBadge
+            if transport == .tailscale {
+                tailscaleReadyBody(ready)
+            } else {
+                irohBody(waiting: ready.reachableViaIroh)
             }
         }
         .frame(maxWidth: .infinity)
 
         Divider()
 
-        transportDetails(ready)
+        if transport == .tailscale {
+            tailscaleRow(ready)
+            manualEntry(ready)
+        } else {
+            irohRow(reachableViaIroh: ready.reachableViaIroh)
+        }
+
+        footer
+    }
+
+    @ViewBuilder
+    private func tailscaleReadyBody(_ ready: MobilePairingModel.Ready) -> some View {
+        // The spec 4-module quiet zone (white margin) is baked into the QR
+        // bitmap itself, so the code gets no extra white card padding here:
+        // the old 12pt-padded white card doubled the visible quiet zone.
+        // Width is capped so the whole QR, the waiting indicator, and the
+        // transport details all fit the default window without scrolling.
+        MobilePairingQRImageView(payload: ready.attachURL)
+            .frame(maxWidth: 320)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.secondary.opacity(0.2))
+            )
+
+        HStack(spacing: 10) {
+            waitingIndicator
+            refreshButton
+        }
+
+        Text(String(
+            localized: "mobile.pairing.scanInstruction",
+            defaultValue: "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code."
+        ))
+        .cmuxFont(.caption)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+
+        if model.availableIOSAppTargets.count > 1 {
+            pairingTargetPicker
+        }
+    }
+
+    @ViewBuilder
+    private func irohBody(waiting: Bool) -> some View {
+        Text(String(
+            localized: "mobile.pairing.irohInstruction",
+            defaultValue: "Install cmux on your iPhone and sign in with the same account. It connects automatically — no code needed."
+        ))
+        .cmuxFont(.callout)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 420)
+
+        if waiting {
+            waitingIndicator
+        }
+    }
+
+    private var waitingIndicator: some View {
+        HStack(spacing: 6) {
+            ProgressView().controlSize(.small)
+            Text(String(localized: "mobile.pairing.waiting", defaultValue: "Waiting for your iPhone…"))
+                .cmuxFont(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var refreshButton: some View {
+        Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
+            Task { await model.refresh() }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
     }
 
     private var pairingTargetPicker: some View {
@@ -292,57 +339,96 @@ struct MobilePairingView: View {
         }
     }
 
-    // MARK: Transport details (explanation + debugging surface)
+    // MARK: No reachable Tailscale route
 
-    /// Explains the two transports and shows their live state. This is the
-    /// window's debugging surface: Iroh registration, Tailscale routes with
-    /// manual-entry copy buttons, and the signed-in account.
-    private func transportDetails(_ ready: MobilePairingModel.Ready) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            transportRow(
-                name: "Iroh",
-                healthy: ready.reachableViaIroh,
-                status: ready.reachableViaIroh
-                    ? String(localized: "mobile.pairing.transport.status.ready", defaultValue: "Ready")
-                    : String(localized: "mobile.pairing.transport.status.notRegistered", defaultValue: "Not registered"),
-                detail: String(
-                    localized: "mobile.pairing.transport.iroh.detail",
-                    defaultValue: """
-                    iPhones signed in to your account find this Mac automatically over Iroh — \
-                    end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed.
-                    """
-                )
-            ) {
-                EmptyView()
+    @ViewBuilder
+    private func needsReachableTransportContent(reachableViaIroh: Bool) -> some View {
+        let transport = effectiveTransport(reachableViaIroh: reachableViaIroh)
+
+        VStack(alignment: .center, spacing: 14) {
+            transportPicker(reachableViaIroh: reachableViaIroh)
+            getIPhoneAppBadge
+            if transport == .iroh {
+                irohBody(waiting: reachableViaIroh)
+            } else {
+                tailscaleMissingBody
             }
-
-            transportRow(
-                name: "Tailscale",
-                healthy: ready.reachableViaTailscale,
-                status: ready.reachableViaTailscale
-                    ? String(localized: "mobile.pairing.transport.status.connected", defaultValue: "Connected")
-                    : String(localized: "mobile.pairing.transport.status.notDetected", defaultValue: "Not detected"),
-                detail: String(
-                    localized: "mobile.pairing.transport.tailscale.detail",
-                    defaultValue: "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network."
-                )
-            ) {
-                if !ready.reachableViaTailscale {
-                    Link(
-                        String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
-                        destination: Self.tailscaleDownloadURL
-                    )
-                    .cmuxFont(.caption)
-                }
-            }
-
-            if ready.reachableViaTailscale {
-                manualEntry(ready)
-            }
-
-            footer
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity)
+
+        Divider()
+
+        if transport == .iroh {
+            irohRow(reachableViaIroh: reachableViaIroh)
+        }
+
+        footer
+    }
+
+    @ViewBuilder
+    private var tailscaleMissingBody: some View {
+        Image(systemName: "network.slash")
+            .cmuxFont(size: 28)
+            .foregroundStyle(.orange)
+        Text(String(
+            localized: "mobile.pairing.req.tailscale.missing",
+            defaultValue: """
+            Tailscale is not connected on this Mac. Install it on both devices \
+            and connect both to the same Tailscale network.
+            """
+        ))
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        Link(
+            String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
+            destination: Self.tailscaleDownloadURL
+        )
+        .buttonStyle(.borderedProminent)
+        refreshButton
+    }
+
+    // MARK: Transport status rows (debugging surface)
+
+    private func irohRow(reachableViaIroh: Bool) -> some View {
+        transportRow(
+            name: "Iroh",
+            healthy: reachableViaIroh,
+            status: reachableViaIroh
+                ? String(localized: "mobile.pairing.transport.status.ready", defaultValue: "Ready")
+                : String(localized: "mobile.pairing.transport.status.notRegistered", defaultValue: "Not registered"),
+            detail: String(
+                localized: "mobile.pairing.transport.iroh.detail",
+                defaultValue: """
+                iPhones signed in to your account find this Mac automatically over Iroh — \
+                end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed.
+                """
+            )
+        ) {
+            EmptyView()
+        }
+    }
+
+    private func tailscaleRow(_ ready: MobilePairingModel.Ready) -> some View {
+        transportRow(
+            name: "Tailscale",
+            healthy: ready.reachableViaTailscale,
+            status: ready.reachableViaTailscale
+                ? String(localized: "mobile.pairing.transport.status.connected", defaultValue: "Connected")
+                : String(localized: "mobile.pairing.transport.status.notDetected", defaultValue: "Not detected"),
+            detail: String(
+                localized: "mobile.pairing.transport.tailscale.detail",
+                defaultValue: "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network."
+            )
+        ) {
+            if !ready.reachableViaTailscale {
+                Link(
+                    String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
+                    destination: Self.tailscaleDownloadURL
+                )
+                .cmuxFont(.caption)
+            }
+        }
     }
 
     private func transportRow<Trailing: View>(
@@ -370,6 +456,7 @@ struct MobilePairingView: View {
         }
     }
 
+    @ViewBuilder
     private func manualEntry(_ ready: MobilePairingModel.Ready) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
@@ -403,11 +490,6 @@ struct MobilePairingView: View {
                     .textSelection(.enabled)
             }
             Spacer()
-            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
-                Task { await model.refresh() }
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
         }
     }
 

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -6,9 +6,10 @@ import SwiftUI
 
 /// The macOS Tailscale QR flow for pairing an iPhone with this Mac.
 ///
-/// Automatic Iroh discovery needs no QR. This window walks the user through
-/// same-account authorization and shows the Tailscale code used when the
-/// iPhone's connection method is explicitly set to Tailscale.
+/// Automatic Iroh discovery needs no QR: the window leads with the Tailscale
+/// code and a prominent get-the-app badge, then explains both transports in a
+/// details section that doubles as the user's debugging surface (live Iroh and
+/// Tailscale state, manual-entry routes, signed-in account).
 struct MobilePairingView: View {
     @State private var model = MobilePairingModel()
     @State private var signInModel = AccountSignInModel(
@@ -41,8 +42,6 @@ struct MobilePairingView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 header
-                requirements
-                Divider()
                 content
             }
             .padding(24)
@@ -75,114 +74,56 @@ struct MobilePairingView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(String(localized: "mobile.pairing.window.heading", defaultValue: "Pair your iPhone with Tailscale"))
-                .cmuxFont(.title2, weight: .semibold)
-            Text(String(
-                localized: "mobile.pairing.window.subheading",
-                defaultValue: "iPhones on your cmux account connect automatically. Use this code only for Tailscale."
-            ))
-                .cmuxFont(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    // MARK: Requirements checklist
-
-    private var requirements: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            signInRow
-            tailscaleRow
-        }
-    }
-
-    private var signInRow: some View {
-        requirementRow(
-            title: String(localized: "mobile.pairing.req.signIn.title", defaultValue: "Signed in to cmux"),
-            subtitle: model.signedInEmail
-                ?? String(localized: "mobile.pairing.req.signIn.subtitle", defaultValue: "Sign in to authorize this Mac for pairing.")
-        ) {
-            EmptyView()
-        }
-    }
-
-    private var tailscaleRow: some View {
-        let reachable = tailscaleReachable
-        return requirementRow(
-            title: String(
-                localized: "mobile.pairing.req.tailscale.title",
-                defaultValue: "Tailscale"
-            ),
-            subtitle: tailscaleSubtitle(reachable: reachable)
-        ) {
-            if reachable == false {
-                Link(
-                    String(
-                        localized: "mobile.pairing.req.tailscale.get",
-                        defaultValue: "Get Tailscale"
-                    ),
-                    destination: Self.tailscaleDownloadURL
-                )
-                .cmuxFont(.callout)
-            }
-        }
-    }
-
-    private var tailscaleReachable: Bool? {
-        switch model.state {
-        case let .ready(ready): return ready.reachableViaTailscale
-        case let .connected(ready): return ready.reachableViaTailscale
-        case .needsReachableTransport: return false
-        default: return nil
-        }
-    }
-
-    private func tailscaleSubtitle(reachable: Bool?) -> String {
-        switch reachable {
-        case .some(true):
-            return String(
-                localized: "mobile.pairing.req.tailscale.reachable",
-                defaultValue: """
-                Tailscale is connected on this Mac. It must also be installed and connected on your iPhone. \
-                Both devices must be connected to the same Tailscale network.
-                """
-            )
-        case .some(false):
-            return String(
-                localized: "mobile.pairing.req.tailscale.missing",
-                defaultValue: """
-                Tailscale is not connected on this Mac. Install it on both devices \
-                and connect both to the same Tailscale network.
-                """
-            )
-        case .none:
-            return String(
-                localized: "mobile.pairing.req.tailscale.hint",
-                defaultValue: """
-                Tailscale must be installed and connected on both this Mac and your iPhone. \
-                Both devices must be connected to the same Tailscale network.
-                """
-            )
-        }
-    }
-
-    private func requirementRow<Trailing: View>(
-        title: String,
-        subtitle: String,
-        @ViewBuilder trailing: () -> Trailing
-    ) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
+        HStack(alignment: .top, spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(title).cmuxFont(.callout, weight: .medium)
-                Text(subtitle)
-                    .cmuxFont(.caption)
+                Text(String(localized: "mobile.pairing.heading", defaultValue: "Pair your iPhone"))
+                    .cmuxFont(.title2, weight: .semibold)
+                Text(String(
+                    localized: "mobile.pairing.subheading",
+                    defaultValue: "Scan the code with cmux on your iPhone to pair this Mac over Tailscale."
+                ))
+                    .cmuxFont(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            Spacer(minLength: 8)
-            trailing()
+            Spacer(minLength: 12)
+            getIPhoneAppBadge
         }
+    }
+
+    /// The App Store-badge-styled button for getting cmux on the iPhone.
+    private var getIPhoneAppBadge: some View {
+        Link(destination: Self.iphoneAppURL) {
+            HStack(spacing: 8) {
+                Image(systemName: "apple.logo")
+                    .cmuxFont(size: 20)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(String(
+                        localized: "mobile.pairing.getApp.badge.caption",
+                        defaultValue: "Download cmux for"
+                    ))
+                        .cmuxFont(.caption2)
+                    Text(String(
+                        localized: "mobile.pairing.getApp.badge.platform",
+                        defaultValue: "iPhone"
+                    ))
+                        .cmuxFont(.title3, weight: .semibold)
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .background(Color.black, in: RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(Color.white.opacity(0.3))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(
+            localized: "mobile.pairing.getApp.link",
+            defaultValue: "Get cmux for iPhone"
+        ))
     }
 
     // MARK: Gated content
@@ -223,6 +164,14 @@ struct MobilePairingView: View {
                 and connect both to the same Tailscale network.
                 """
             ))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(String(
+                localized: "mobile.pairing.needsTransport.irohHint",
+                defaultValue: "Signed-in iPhones can still connect automatically over Iroh. Tailscale is only needed for QR pairing."
+            ))
+                .cmuxFont(.caption)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -271,22 +220,14 @@ struct MobilePairingView: View {
 
     @ViewBuilder
     private func readyContent(_ ready: MobilePairingModel.Ready) -> some View {
-        if model.availableIOSAppTargets.count > 1 {
-            pairingTargetPicker
-        }
-
-        // Manual entry sits above the QR so Copy IP / Copy Port are reachable
-        // without scrolling (they used to sit below the steps, below the fold).
-        manualFallback(ready)
-
         VStack(alignment: .center, spacing: 14) {
             // The spec 4-module quiet zone (white margin) is baked into the QR
             // bitmap itself, so the code gets no extra white card padding here:
             // the old 12pt-padded white card doubled the visible quiet zone.
-            // Width is capped so the manual block, the whole QR, and the
-            // waiting indicator all fit the default window without scrolling.
+            // Width is capped so the whole QR, the waiting indicator, and the
+            // transport details all fit the default window without scrolling.
             MobilePairingQRImageView(payload: ready.attachURL)
-                .frame(maxWidth: 380)
+                .frame(maxWidth: 320)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
@@ -301,38 +242,33 @@ struct MobilePairingView: View {
             }
 
             Text(String(
-                localized: "mobile.pairing.codeMode.tailscaleDetail",
-                defaultValue: """
-                Tailscale pairing code. Keep Tailscale connected on both devices. \
-                Both devices must be connected to the same Tailscale network.
-                """
+                localized: "mobile.pairing.scanInstruction",
+                defaultValue: "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code."
             ))
             .cmuxFont(.caption)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if model.availableIOSAppTargets.count > 1 {
+                pairingTargetPicker
+            }
         }
         .frame(maxWidth: .infinity)
 
-        steps
+        Divider()
 
-        HStack {
-            Spacer()
-            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
-                Task { await model.refresh() }
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        }
+        transportDetails(ready)
     }
 
     private var pairingTargetPicker: some View {
-        HStack {
+        HStack(spacing: 6) {
             Text(String(
                 localized: "mobile.pairing.targetApp",
                 defaultValue: "Open with"
             ))
-                .cmuxFont(.callout, weight: .medium)
-            Spacer()
+                .cmuxFont(.caption)
+                .foregroundStyle(.secondary)
             Picker(
                 String(
                     localized: "mobile.pairing.targetApp",
@@ -351,6 +287,127 @@ struct MobilePairingView: View {
             }
             .labelsHidden()
             .pickerStyle(.menu)
+            .controlSize(.small)
+            .fixedSize()
+        }
+    }
+
+    // MARK: Transport details (explanation + debugging surface)
+
+    /// Explains the two transports and shows their live state. This is the
+    /// window's debugging surface: Iroh registration, Tailscale routes with
+    /// manual-entry copy buttons, and the signed-in account.
+    private func transportDetails(_ ready: MobilePairingModel.Ready) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            transportRow(
+                name: "Iroh",
+                healthy: ready.reachableViaIroh,
+                status: ready.reachableViaIroh
+                    ? String(localized: "mobile.pairing.transport.status.ready", defaultValue: "Ready")
+                    : String(localized: "mobile.pairing.transport.status.notRegistered", defaultValue: "Not registered"),
+                detail: String(
+                    localized: "mobile.pairing.transport.iroh.detail",
+                    defaultValue: """
+                    iPhones signed in to your account find this Mac automatically over Iroh — \
+                    end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed.
+                    """
+                )
+            ) {
+                EmptyView()
+            }
+
+            transportRow(
+                name: "Tailscale",
+                healthy: ready.reachableViaTailscale,
+                status: ready.reachableViaTailscale
+                    ? String(localized: "mobile.pairing.transport.status.connected", defaultValue: "Connected")
+                    : String(localized: "mobile.pairing.transport.status.notDetected", defaultValue: "Not detected"),
+                detail: String(
+                    localized: "mobile.pairing.transport.tailscale.detail",
+                    defaultValue: "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network."
+                )
+            ) {
+                if !ready.reachableViaTailscale {
+                    Link(
+                        String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
+                        destination: Self.tailscaleDownloadURL
+                    )
+                    .cmuxFont(.caption)
+                }
+            }
+
+            if ready.reachableViaTailscale {
+                manualEntry(ready)
+            }
+
+            footer
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func transportRow<Trailing: View>(
+        name: String,
+        healthy: Bool,
+        status: String,
+        detail: String,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(healthy ? Color.green : Color.orange)
+                    .frame(width: 6, height: 6)
+                Text(name).cmuxFont(.callout, weight: .medium)
+                Text(status).cmuxFont(.caption).foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                trailing()
+            }
+            Text(detail)
+                .cmuxFont(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.leading, 12)
+        }
+    }
+
+    private func manualEntry(_ ready: MobilePairingModel.Ready) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "mobile.pairing.manual.title", defaultValue: "Can't scan? Add this Mac manually:"))
+                .cmuxFont(.caption, weight: .semibold)
+                .foregroundStyle(.secondary)
+            ForEach(ready.tailscaleLines, id: \.self) { line in
+                Text(line).cmuxFont(.caption, design: .monospaced)
+                    .textSelection(.enabled).foregroundStyle(.secondary)
+            }
+            if let entry = ready.manualEntry {
+                HStack(spacing: 8) {
+                    copyButton(label: String(localized: "mobile.pairing.manual.copyIP", defaultValue: "Copy IP"), value: entry.host)
+                    copyButton(label: String(localized: "mobile.pairing.manual.copyPort", defaultValue: "Copy Port"), value: String(entry.port))
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.leading, 12)
+    }
+
+    private var footer: some View {
+        HStack(alignment: .firstTextBaseline) {
+            if let email = model.signedInEmail {
+                Text(String(
+                    format: String(localized: "mobile.pairing.signedInAs", defaultValue: "Signed in as %@"),
+                    locale: .current,
+                    email
+                ))
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            Button(String(localized: "mobile.pairing.refresh", defaultValue: "Refresh Code")) {
+                Task { await model.refresh() }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
     }
 

--- a/cmuxTests/MobilePairingConnectionTransitionTests.swift
+++ b/cmuxTests/MobilePairingConnectionTransitionTests.swift
@@ -9,7 +9,7 @@ import Testing
 #endif
 
 @MainActor
-@Suite("Mobile pairing connection transition")
+@Suite("Mobile pairing status transition")
 struct MobilePairingConnectionTransitionTests {
     private func makeReady() -> MobilePairingModel.Ready {
         MobilePairingModel.Ready(
@@ -20,22 +20,30 @@ struct MobilePairingConnectionTransitionTests {
         )
     }
 
+    /// Routes matching ``makeReady()``, so a transition that recomputes the
+    /// diagnostics from them reproduces the same `Ready` value.
+    private func matchingRoutes() throws -> [CmxAttachRoute] {
+        [try irohRoute(), try tailscaleRoute()]
+    }
+
     @Test("A phone attaching above the baseline flips a displayed ticket to connected")
-    func readyFlipsToConnectedOnAttach() {
+    func readyFlipsToConnectedOnAttach() throws {
         let ready = makeReady()
-        let next = MobilePairingModel.connectionTransition(
+        let next = MobilePairingModel.statusTransition(
             from: .ready(ready),
+            routes: try matchingRoutes(),
             activeConnectionCount: 1,
             baselineConnectionCount: 0
         )
-        #expect(next == .connected(ready))
+        #expect(next == .connected(from: .ready(ready)))
     }
 
     @Test("A ready ticket with no new connections stays in the waiting state")
-    func readyStaysReadyWithoutConnections() {
+    func readyStaysReadyWithoutConnections() throws {
         let ready = makeReady()
-        let next = MobilePairingModel.connectionTransition(
+        let next = MobilePairingModel.statusTransition(
             from: .ready(ready),
+            routes: try matchingRoutes(),
             activeConnectionCount: 0,
             baselineConnectionCount: 0
         )
@@ -43,30 +51,33 @@ struct MobilePairingConnectionTransitionTests {
     }
 
     @Test("Pairing an additional device: an already-connected phone does not flip the new QR")
-    func additionalDeviceStaysReadyUntilNewConnectionAboveBaseline() {
+    func additionalDeviceStaysReadyUntilNewConnectionAboveBaseline() throws {
         let ready = makeReady()
         // One phone already attached when the QR is shown (baseline 1). The same
         // count must keep showing the QR so a second device can still pair.
-        let stillWaiting = MobilePairingModel.connectionTransition(
+        let stillWaiting = MobilePairingModel.statusTransition(
             from: .ready(ready),
+            routes: try matchingRoutes(),
             activeConnectionCount: 1,
             baselineConnectionCount: 1
         )
         #expect(stillWaiting == .ready(ready))
         // A second device attaches (count rises above the baseline) -> connected.
-        let connected = MobilePairingModel.connectionTransition(
+        let connected = MobilePairingModel.statusTransition(
             from: .ready(ready),
+            routes: try matchingRoutes(),
             activeConnectionCount: 2,
             baselineConnectionCount: 1
         )
-        #expect(connected == .connected(ready))
+        #expect(connected == .connected(from: .ready(ready)))
     }
 
     @Test("Connected flips back to ready when the new connection drops to the baseline")
-    func connectedFlipsBackToReadyWhenConnectionsDrop() {
+    func connectedFlipsBackToReadyWhenConnectionsDrop() throws {
         let ready = makeReady()
-        let next = MobilePairingModel.connectionTransition(
-            from: .connected(ready),
+        let next = MobilePairingModel.statusTransition(
+            from: .connected(from: .ready(ready)),
+            routes: try matchingRoutes(),
             activeConnectionCount: 1,
             baselineConnectionCount: 1
         )
@@ -74,20 +85,79 @@ struct MobilePairingConnectionTransitionTests {
     }
 
     @Test("Connected stays connected while the new phone remains attached")
-    func connectedStaysConnectedWithActiveConnections() {
+    func connectedStaysConnectedWithActiveConnections() throws {
         let ready = makeReady()
-        let next = MobilePairingModel.connectionTransition(
-            from: .connected(ready),
+        let next = MobilePairingModel.statusTransition(
+            from: .connected(from: .ready(ready)),
+            routes: try matchingRoutes(),
             activeConnectionCount: 2,
             baselineConnectionCount: 1
         )
-        #expect(next == .connected(ready))
+        #expect(next == .connected(from: .ready(ready)))
+    }
+
+    @Test("An Iroh-only attach flips the no-Tailscale waiting state to connected")
+    func needsReachableTransportFlipsToConnectedOnAttach() throws {
+        let next = MobilePairingModel.statusTransition(
+            from: .needsReachableTransport(reachableViaIroh: true),
+            routes: [try irohRoute()],
+            activeConnectionCount: 1,
+            baselineConnectionCount: 0
+        )
+        #expect(next == .connected(
+            from: .needsReachableTransport(reachableViaIroh: true)
+        ))
+    }
+
+    @Test("Connected without a Tailscale route falls back to the no-route waiting state")
+    func connectedFallsBackToNeedsReachableTransportWhenConnectionsDrop() throws {
+        let next = MobilePairingModel.statusTransition(
+            from: .connected(
+                from: .needsReachableTransport(reachableViaIroh: true)
+            ),
+            routes: [try irohRoute()],
+            activeConnectionCount: 0,
+            baselineConnectionCount: 0
+        )
+        #expect(next == .needsReachableTransport(reachableViaIroh: true))
+    }
+
+    @Test("Ready diagnostics follow route changes while the code stays fixed")
+    func readyDiagnosticsFollowRouteChanges() throws {
+        let ready = makeReady()
+        // Iroh deregisters while the window is open: the diagnostics update,
+        // the displayed code does not.
+        let next = MobilePairingModel.statusTransition(
+            from: .ready(ready),
+            routes: [try tailscaleRoute()],
+            activeConnectionCount: 0,
+            baselineConnectionCount: 0
+        )
+        guard case let .ready(updated) = next else {
+            Issue.record("expected .ready, got \(next)")
+            return
+        }
+        #expect(updated.attachURL == ready.attachURL)
+        #expect(updated.reachableViaIroh == false)
+        #expect(updated.tailscaleLines == ready.tailscaleLines)
+    }
+
+    @Test("The no-route waiting state tracks Iroh registration")
+    func needsReachableTransportTracksIrohRegistration() throws {
+        let next = MobilePairingModel.statusTransition(
+            from: .needsReachableTransport(reachableViaIroh: false),
+            routes: [try irohRoute()],
+            activeConnectionCount: 0,
+            baselineConnectionCount: 0
+        )
+        #expect(next == .needsReachableTransport(reachableViaIroh: true))
     }
 
     @Test("Preparing is unaffected by connection-count changes")
-    func preparingIsUnaffected() {
-        let next = MobilePairingModel.connectionTransition(
+    func preparingIsUnaffected() throws {
+        let next = MobilePairingModel.statusTransition(
             from: .preparing,
+            routes: try matchingRoutes(),
             activeConnectionCount: 1,
             baselineConnectionCount: 0
         )
@@ -95,9 +165,10 @@ struct MobilePairingConnectionTransitionTests {
     }
 
     @Test("Signed-out is unaffected by connection-count changes")
-    func signedOutIsUnaffected() {
-        let next = MobilePairingModel.connectionTransition(
+    func signedOutIsUnaffected() throws {
+        let next = MobilePairingModel.statusTransition(
             from: .signedOut,
+            routes: try matchingRoutes(),
             activeConnectionCount: 1,
             baselineConnectionCount: 0
         )

--- a/cmuxTests/MobilePairingConnectionTransitionTests.swift
+++ b/cmuxTests/MobilePairingConnectionTransitionTests.swift
@@ -15,7 +15,8 @@ struct MobilePairingConnectionTransitionTests {
         MobilePairingModel.Ready(
             attachURL: "cmux-ios://attach?v=2&r=100.64.0.1:7777",
             tailscaleLines: ["100.64.0.1:7777"],
-            manualEntry: CmxManualPairingEntry(host: "100.64.0.1", port: 7777)
+            manualEntry: CmxManualPairingEntry(host: "100.64.0.1", port: 7777),
+            reachableViaIroh: true
         )
     }
 


### PR DESCRIPTION
## Summary

- What changed? Rebuilt the Tailscale Pairing window. A segmented **Iroh / Tailscale** chooser sits at the top, under a one-line header. The **Iroh** tab has no QR at all: a centered App Store-style "Download cmux for iPhone" badge, an "install and sign in — it connects automatically" instruction, a waiting indicator, and a live Iroh status row (Ready / Not registered). The **Tailscale** tab shows the same centered badge above the QR, with **Refresh Code next to the waiting indicator directly under the code**, the scan instruction, and a Tailscale status row with the manual-entry `host:port` lines and Copy IP / Copy Port. A "Signed in as …" footer closes both tabs. The effective tab defaults to Iroh when the Iroh endpoint is registered, else Tailscale; a tap overrides. `State.needsReachableTransport` now carries `reachableViaIroh`, kept live by the route observer, so the Iroh tab still works while no Tailscale route exists. Deleted along the way: the requirements checklist, the numbered steps, three near-identical Tailscale captions, the dead `MobilePairingModel.signIn()`, and 19 orphaned `mobile.pairing.*` catalog keys.
- Why? The page repeated the same Tailscale sentence three times, buried the QR below a checklist, and hid the get-the-app link in a caption — and it never explained that Iroh pairing is automatic. The chooser makes the automatic path the default and keeps the QR for the Tailscale-only flow; debugging info (transport state, routes, account) is one compact section per tab.

## Testing

- `./scripts/reload.sh --tag pairing-polish` builds clean (low-space guard needs `CMUX_ALLOW_LOW_SPACE_BUILD=1`).
- Drove the tagged Debug app (`workspace-action mobile_connect`): Iroh tab renders badge + instruction + waiting + Iroh Ready row and defaults on when Iroh is registered; clicking Tailscale shows badge, QR (320pt), waiting + Refresh Code under the code, scan instruction, Tailscale Connected row, manual entry with copy buttons, signed-in footer. Everything fits without scrolling.
- `MobilePairingConnectionTransitionTests` updated for `Ready.reachableViaIroh` (local `xcodebuild test` is guard-denied on this machine; CI runs it).
- Localization audit: all new user-facing strings route through `String(localized:defaultValue:)`; new/changed keys (`heading`, `subheading`, `scanInstruction`, `irohInstruction`, `transportPicker`, `signedInAs`, badge caption/platform, 4 transport status words, 2 transport details) carry translations for all 20 catalog locales; removed keys verified unreferenced. "Iroh"/"Tailscale" segment labels are literal product names via `Text(verbatim:)`.

## Demo Video

- Screenshots in PR comment.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pairing over Iroh for signed-in iPhones.
  * Added selectable Iroh and Tailscale pairing, including QR codes, manual entry, and transport status.
  * Added iPhone app download badges and optional app-target selection.
  * Added clearer waiting, signed-in, retry, and connection status states.
* **Improvements**
  * Simplified pairing by removing outdated instructions, fallback steps, and requirements checklists.
  * Updated localized messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->