### PR TITLE
cmux-tui: checkpoint capture keys its fence to one snapshot cut, reconnect skips report once

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -873,6 +873,74 @@ mod tests {
         assert_ne!(first["state_sha256"], second["state_sha256"]);
     }
 
+    /// A terminal-host reconnect creates its checkpoint while the rest of the
+    /// session keeps journaling. Capture reads the journal head and the public
+    /// session snapshot as its consistency cut; a record committed between
+    /// those two reads is a normal concurrent write, not a torn capture, and
+    /// must not abort the checkpoint with "session changed during checkpoint
+    /// capture". On a busy session that spurious abort made every reconnect
+    /// checkpoint fail and surfaced as repeated status toasts.
+    #[test]
+    fn reconnect_checkpoint_capture_tolerates_a_racing_journal_write() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-journal-capture-race-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let mux = Mux::open_persistent("checkpoint-race", crate::SurfaceOptions::default(), &root)
+            .unwrap();
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel::<()>(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel::<()>(0);
+        let capture_mux = mux.clone();
+        let capture = std::thread::spawn(move || {
+            crate::resource_api::set_snapshot_before_projection_hook(move || {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            });
+            capture_mux.create_journal_checkpoint("terminal_host_reconnect", "capture_race_1")
+        });
+        entered_rx.recv().unwrap();
+
+        // The capture thread is paused inside its snapshot cut. Commit a
+        // journal record from another writer before letting it proceed.
+        mux.put_journal_producer(
+            &JournalProducerManifest {
+                producer_id: "capture_race".into(),
+                namespace: "plugin.capture_race".into(),
+                manifest_version: 1,
+                max_sensitivity: JournalSensitivity::Metadata,
+                permissions: vec!["journal.append.plugin.capture_race".into()],
+                events: vec![JournalEventSchema {
+                    kind: "plugin.capture_race.event".into(),
+                    schema_version: 1,
+                    class: JournalClass::Observation,
+                    replay: JournalReplayPolicy::Advisory,
+                    sensitivity: JournalSensitivity::Metadata,
+                    payload_schema: json!({"type":"object"}),
+                }],
+            },
+            "client_test",
+            "capture_race_producer",
+        )
+        .unwrap();
+        let head_after_write = mux.session_journal_after(0, 1).unwrap().head_sequence;
+        release_tx.send(()).unwrap();
+
+        let commit = capture
+            .join()
+            .unwrap()
+            .expect("a journal write racing the snapshot cut must not abort checkpoint capture");
+        assert_eq!(
+            commit.checkpoint.source_sequence, head_after_write,
+            "the checkpoint cut must cover the racing journal write"
+        );
+        let preview = mux.journal_restore_preview("latest").unwrap();
+        assert_eq!(preview["fully_reducible"], true);
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn checkpoint_aligned_segments_remain_transparently_replayable() {
         let root = std::env::temp_dir().join(format!(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -40,9 +40,13 @@ pub(crate) fn capture(mux: &Mux) -> anyhow::Result<CapturedCheckpoint> {
     // Per-terminal epochs below reject a parser snapshot taken while its
     // corresponding journal frame is still being enqueued.
     mux.flush_terminal_journal()?;
-    let head_before = mux.session_journal_after(0, 1)?.head_sequence;
-    let snapshot = crate::resource_api::public_session_snapshot(mux)
-        .map_err(|error| anyhow::anyhow!("capture public session snapshot: {error:?}"))?;
+    // The snapshot and the journal head form one consistency cut, read under
+    // a single registry + state lock hold. A journal record committed before
+    // the cut is covered by the snapshot; the fence below only has to reject
+    // writes that land after it, while terminal content is being captured.
+    let (snapshot, head_before) =
+        crate::resource_api::public_session_snapshot_with_journal_head(mux)
+            .map_err(|error| anyhow::anyhow!("capture public session snapshot: {error:?}"))?;
     let producers = mux.journal_producer_manifests()?;
     let hooks = mux
         .journal_hook_states()?
@@ -144,10 +148,12 @@ pub(crate) fn capture(mux: &Mux) -> anyhow::Result<CapturedCheckpoint> {
     }
 
     mux.flush_terminal_journal()?;
-    let head_after = mux.session_journal_after(0, 1)?.head_sequence;
-    let cursor_after = crate::resource_api::public_session_snapshot(mux)
-        .map_err(|error| anyhow::anyhow!("verify public session snapshot: {error:?}"))?["cursor"]
-        .clone();
+    // Verify against one cut as well, so a write landing between two separate
+    // head and cursor reads cannot fail a capture that was in fact stable.
+    let (verify_snapshot, head_after) =
+        crate::resource_api::public_session_snapshot_with_journal_head(mux)
+            .map_err(|error| anyhow::anyhow!("verify public session snapshot: {error:?}"))?;
+    let cursor_after = verify_snapshot["cursor"].clone();
     anyhow::ensure!(
         head_before == head_after && snapshot["cursor"] == cursor_after,
         "session changed during checkpoint capture"

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1992,6 +1992,12 @@ pub struct Mux {
     /// reread SQLite by cursor, so missed or coalesced notifications are safe.
     journal_event_epoch: Mutex<u64>,
     journal_event_changed: Condvar,
+    /// True once a skipped terminal-host reconnect checkpoint has been
+    /// surfaced as a status event. A machine resume reconnects every hosted
+    /// terminal at once, so per-terminal reporting would toast N times for
+    /// one underlying condition. Cleared when a reconnect checkpoint
+    /// succeeds again.
+    reconnect_checkpoint_skip_reported: AtomicBool,
     #[cfg(test)]
     journal_segment_prepare_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
     terminal_exit_waiters: TerminalExitWaiters,
@@ -2350,6 +2356,7 @@ impl Mux {
             journal_hook_runtime: Arc::new(crate::journal_hooks::JournalHookRuntime::default()),
             journal_event_epoch: Mutex::new(0),
             journal_event_changed: Condvar::new(),
+            reconnect_checkpoint_skip_reported: AtomicBool::new(false),
             #[cfg(test)]
             journal_segment_prepare_hook: Mutex::new(None),
             terminal_exit_waiters: TerminalExitWaiters::default(),
@@ -5084,6 +5091,30 @@ impl Mux {
             self.publish_journal_event();
         }
         Ok(())
+    }
+
+    /// Reports a skipped terminal-host reconnect checkpoint at most once
+    /// until a later reconnect checkpoint succeeds. A checkpoint is a
+    /// journal-replay optimization: skipping one only moves the next replay
+    /// boundary back, so repeated skips are daemon-log noise, not per-toast
+    /// news.
+    pub(crate) fn report_skipped_reconnect_checkpoint(
+        &self,
+        terminal_id: impl std::fmt::Display,
+        error: &anyhow::Error,
+    ) {
+        let message = format!(
+            "skipped terminal {terminal_id} reconnect checkpoint (replay starts from the previous boundary): {error:#}"
+        );
+        if self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
+            eprintln!("cmux-tui: {message}");
+        } else {
+            self.emit(MuxEvent::Status(message));
+        }
+    }
+
+    pub(crate) fn note_reconnect_checkpoint_captured(&self) {
+        self.reconnect_checkpoint_skip_reported.store(false, Ordering::Release);
     }
 
     pub(crate) fn create_journal_checkpoint(
@@ -16454,6 +16485,44 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    /// A machine resume reconnects every hosted terminal at once. When
+    /// checkpoint capture keeps losing its consistency race on a busy
+    /// session, the skip must surface as one status event, not one toast per
+    /// terminal per reconnect. A later successful checkpoint re-arms the
+    /// report.
+    #[test]
+    fn reconnect_checkpoint_skip_status_is_reported_once_until_recovery() {
+        let mux = test_mux();
+        let events = mux.subscribe();
+        let skip_statuses = |events: &MuxEventReceiver| {
+            events
+                .try_iter()
+                .filter(|event| {
+                    matches!(event, MuxEvent::Status(message)
+                        if message.contains("reconnect checkpoint"))
+                })
+                .count()
+        };
+
+        let error = anyhow::anyhow!("session changed during checkpoint capture");
+        mux.report_skipped_reconnect_checkpoint("term_one", &error);
+        mux.report_skipped_reconnect_checkpoint("term_two", &error);
+        mux.report_skipped_reconnect_checkpoint("term_one", &error);
+        assert_eq!(
+            skip_statuses(&events),
+            1,
+            "repeated checkpoint skips must collapse into one status event"
+        );
+
+        mux.note_reconnect_checkpoint_captured();
+        mux.report_skipped_reconnect_checkpoint("term_three", &error);
+        assert_eq!(
+            skip_statuses(&events),
+            1,
+            "a skip after a successful checkpoint is a new condition and reports again"
+        );
     }
 
     fn assert_terminal_view_detached(mux: &Mux, surface: SurfaceId) {

--- a/cmux-tui/crates/cmux-tui-core/src/resource_api.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_api.rs
@@ -61,7 +61,7 @@ pub(crate) fn public_frontend_projection_snapshot(
 }
 
 #[cfg(test)]
-fn set_snapshot_before_projection_hook(hook: impl FnOnce() + 'static) {
+pub(crate) fn set_snapshot_before_projection_hook(hook: impl FnOnce() + 'static) {
     SNAPSHOT_BEFORE_PROJECTION_HOOK.with(|slot| {
         *slot.borrow_mut() = Some(Box::new(hook));
     });

--- a/cmux-tui/crates/cmux-tui-core/src/resource_api.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_api.rs
@@ -461,6 +461,18 @@ pub(crate) fn public_terminal_snapshot(
 }
 
 pub(crate) fn public_session_snapshot(mux: &Mux) -> Result<Value, ResourceError> {
+    public_session_snapshot_with_journal_head(mux).map(|(snapshot, _)| snapshot)
+}
+
+/// Returns the public session snapshot together with the session journal head
+/// read under the same registry + state projection lock. The pair is one
+/// consistent cut: every journal record at or below the returned head is
+/// reflected in the snapshot, and every later record is not. Checkpoint
+/// capture keys its consistency fence to this cut so a journal write that
+/// merely precedes the cut cannot spuriously abort the capture.
+pub(crate) fn public_session_snapshot_with_journal_head(
+    mux: &Mux,
+) -> Result<(Value, u64), ResourceError> {
     // Collect the auxiliary runtime before taking the registry + state
     // projection lock. Sidebar status locks its own lifecycle and then looks
     // up a surface in State, so doing this inside the projection would invert
@@ -471,6 +483,7 @@ pub(crate) fn public_session_snapshot(mux: &Mux) -> Result<Value, ResourceError>
     #[cfg(test)]
     run_snapshot_before_projection_hook();
     mux.with_resource_projection(|registry, state| {
+        let journal_head = registry.session_journal_after(0, 1)?.head_sequence;
         let registry_snapshot = registry.snapshot()?;
         let topology = registry.resource_topology_snapshot()?;
         let terminal_registry = registry.terminal_snapshot()?;
@@ -727,7 +740,7 @@ pub(crate) fn public_session_snapshot(mux: &Mux) -> Result<Value, ResourceError>
             .collect::<Result<Vec<_>, ResourceError>>()?;
         let _terminal_defaults = public_projections.terminal_defaults;
 
-        Ok(json!({
+        let snapshot = json!({
             "machine": machine_snapshot(&context),
             "session": session_snapshot(&context),
             "workspaces": workspaces,
@@ -745,7 +758,8 @@ pub(crate) fn public_session_snapshot(mux: &Mux) -> Result<Value, ResourceError>
                 "generation": topology.generation,
                 "revision": topology.revision.to_string(),
             },
-        }))
+        });
+        Ok((snapshot, journal_head))
     })
     .map_err(operation_failed)
 }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -3565,11 +3565,12 @@ impl Surface {
                                     &checkpoint_key,
                                 );
                             }
-                            if let Err(error) = checkpoint {
-                                reconnect_mux.emit(MuxEvent::Status(format!(
-                                    "skipped terminal {} reconnect checkpoint (replay starts from the previous boundary): {error:#}",
-                                    identity.terminal_id
-                                )));
+                            match checkpoint {
+                                Ok(_) => reconnect_mux.note_reconnect_checkpoint_captured(),
+                                Err(error) => reconnect_mux.report_skipped_reconnect_checkpoint(
+                                    &identity.terminal_id,
+                                    &error,
+                                ),
                             }
                         }
                         reconnect_mux.reconcile_deferred_cell_pixel_ack(


### PR DESCRIPTION
Fixes the repeated "could not checkpoint terminal ... reconnect: session changed during checkpoint capture" status toasts reported while dogfooding the daemon-backed terminal spike (https://github.com/manaflow-ai/cmux/pull/10408).

## Root cause

Checkpoint capture (`crates/cmux-tui-core/src/journal_checkpoint.rs`) read the session journal head and the public session snapshot under separate lock holds, then required `head_before == head_after` around the whole capture. Any journal record committed between the head read and the snapshot tripped the fence at `journal_checkpoint.rs:153` with "session changed during checkpoint capture", even though the snapshot already covered that record and was a consistent cut. On a busy session, terminal-host reconnect checkpoints therefore failed persistently. Before https://github.com/manaflow-ai/cmux/pull/10484 the caller in `surface.rs` additionally treated that failure as a connection failure, disconnecting the freshly reconnected host and re-running the reconnect, whose own journal writes re-poisoned every other terminal's capture window (the toast storm). 10484 made the caller non-destructive; this PR fixes the capture layer and the remaining per-event toast noise.

Status events themselves are not journaled (the event bus is in-memory only), so the toasts did not directly self-perpetuate; the reconnect loop's journal writes did.

## Fix

- Commit 1 (red): `reconnect_checkpoint_capture_tolerates_a_racing_journal_write` pauses capture inside its snapshot cut with the existing test hook, commits a producer-install journal record from a second writer, and asserts capture still succeeds with a cut covering the racing write. Fails on main with "session changed during checkpoint capture".
- Commit 2 (green): `public_session_snapshot_with_journal_head` reads the journal head inside the same registry + state projection lock as the snapshot, so the pair is one consistency cut. Capture keys both its cut and its verify read to that pair. A record committed before the cut can no longer abort the capture; the fence still rejects writes that land while terminal content blobs are being captured, which are the torn captures the abort exists for.
- When capture still loses that narrower race after its bounded in-place retries, the skip now reports through `Mux::report_skipped_reconnect_checkpoint` at most once until a later reconnect checkpoint succeeds; further skips go to the daemon log. A machine resume reconnects every hosted terminal at once, so per-event toasts multiplied one condition by the terminal count. New test: `reconnect_checkpoint_skip_status_is_reported_once_until_recovery`.

## Spec tension

`spec/session-journal.md` requires a checkpoint's content to match its source sequence exactly (restoration applies later records on top, and terminal content blobs carry no stream offsets replay could use to skip double-applied bytes). The abort-on-change fence is therefore kept for writes inside the blob-capture window; this PR only removes the spurious aborts for writes the snapshot cut already covers, and quiets the caller. Making blob capture fully atomic against writers would need per-blob stream offsets in the checkpoint format; left as a follow-up if skips remain visible in the field.

## Testing

Hosted cmux-tui workflow, filter `reconnect_checkpoint`, Linux + macOS.

- Red (commit 094f7e69f1, test only): https://github.com/manaflow-ai/cmux/actions/runs/32347571689 fails with `a journal write racing the snapshot cut must not abort checkpoint capture: session changed during checkpoint capture` on both platforms.
- Green (head 5e798b82eb): https://github.com/manaflow-ai/cmux/actions/runs/32347575069 passes; both `reconnect_checkpoint_capture_tolerates_a_racing_journal_write` and `reconnect_checkpoint_skip_status_is_reported_once_until_recovery` ran and passed on Linux and macOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789804532&installation_model_id=21920&pr_number=10501&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10501&signature=2a0906364b8ade9a7eec0a332b3774106b9ccd08d33190dd7440a1c3101748db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keys reconnect checkpoint capture to a single snapshot cut and collapses repeated skip toasts into one status event. This removes persistent “session changed during checkpoint capture” toasts on busy sessions while keeping torn-capture protection.

- Reads the journal head and public session snapshot under one lock via `public_session_snapshot_with_journal_head`, and uses the same cut for verify. Writes before the cut no longer abort capture; writes during blob capture still fence and abort.
- On retry exhaustion, `Mux::report_skipped_reconnect_checkpoint` emits one Status until reset by `Mux::note_reconnect_checkpoint_captured`; further skips go to the daemon log. `Surface` now calls these helpers.
- Adds tests: `reconnect_checkpoint_capture_tolerates_a_racing_journal_write` and `reconnect_checkpoint_skip_status_is_reported_once_until_recovery`.

<sup>Written for commit 5e798b82eb338c7ba42f6f30988261bd3c3b79e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect checkpoint reliability by capturing terminal state and journal updates consistently, including concurrent writes.
  * Prevented repeated reconnect checkpoint warnings from flooding status messages.
  * Reconnect checkpoint notifications now reset after a successful capture.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
