### PR TITLE
Pairing follow-ups: app-target picker on the Iroh tab; no re-mint after close

### DIFF
--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -284,6 +284,9 @@ final class MobilePairingModel {
     /// Tailscale address changes while the window sits open, the Refresh Code
     /// button re-mints on demand.
     func stopObserving() {
+        // Invalidate any pending generation-guarded work (e.g. the observer's
+        // spawned re-mint) so nothing revives the pairing host after close.
+        refreshGeneration &+= 1
         connectionObservationTask?.cancel()
         connectionObservationTask = nil
     }
@@ -324,7 +327,11 @@ final class MobilePairingModel {
                 if case .needsReachableTransport = self.state,
                    PairingRoutePlan.make(routes: status.routes) != nil {
                     Task { @MainActor [weak self] in
-                        await self?.refresh()
+                        // Re-check the generation at execution time: a window
+                        // close (stopObserving) or a newer refresh must not
+                        // let this pending re-mint revive the pairing host.
+                        guard let self, generation == self.refreshGeneration else { return }
+                        await self.refresh()
                     }
                     return
                 }

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -289,6 +289,13 @@ struct MobilePairingView: View {
         if waiting {
             waitingIndicator
         }
+
+        // The selected iOS app matters beyond the QR: it addresses the
+        // paired-Mac records Iroh discovery hands to that exact app, so the
+        // picker stays available on the automatic path too.
+        if model.availableIOSAppTargets.count > 1 {
+            pairingTargetPicker
+        }
     }
 
     private var waitingIndicator: some View {


### PR DESCRIPTION
## Summary

- What changed? Two small follow-ups to #10498 from the post-merge bot review round. (1) The "Open with" iOS app-target picker now also renders on the **Iroh** tab when the build exposes multiple targets — the selected target addresses the paired-Mac records Iroh discovery hands to that exact app, so it matters beyond the QR scheme. (2) The host-status observer's spawned re-mint now re-checks the refresh generation at execution time and `stopObserving()` bumps the generation, so a pending re-mint can no longer revive the pairing host after the window closes.
- Why? Bot findings on #10498 that landed after merge; both are real, both are tiny.

## Testing

- `./scripts/reload.sh --tag pairing-polish` builds clean.
- The connection-count baseline heuristic finding (greptile) is pre-existing behavior, display-only, and intentionally unchanged.

## Demo Video

- No visual change beyond the picker appearing on the Iroh tab in multi-target builds.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789805006&installation_model_id=21920&pr_number=10502&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10502&signature=cadbd9efd34871ad86b492b8e8af798ac1bc7d511ab748a08c07caf612beb2db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the iOS app-target picker on the Iroh tab in multi-target builds and prevents a pending re-mint from running after the pairing window closes. This ensures the selected app receives Iroh discovery records and avoids reviving the pairing host post-close.

- Old vs new (picker): Previously the picker appeared only on the QR path. Now it also appears on the Iroh tab when multiple iOS app targets exist. The selected app determines which app receives the paired-Mac records via Iroh; no other UI changes.
- Old vs new (re-mint): Previously a re-mint spawned by the host-status observer could run after the window closed and revive the host. Now stopObserving invalidates pending work and the re-mint checks the current generation before calling refresh, dropping stale tasks.

<sup>Written for commit 5eb0b690ab83482f4e1d2ffd39b36b7fdde8afcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the iOS app target picker to the automatic pairing flow when multiple app targets are available.
  - Improved pairing reliability by preventing outdated background operations from restarting pairing after the window closes or a newer refresh begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->