### PR TITLE
fix(web): name the retag context type instead of 'as typeof gl'

### DIFF
--- a/cmux-tui/frontends/web/src/lib/webglRenderer.ts
+++ b/cmux-tui/frontends/web/src/lib/webglRenderer.ts
@@ -25,9 +25,14 @@ export function retagWebglDisplayP3(
 ): "display-p3" | "srgb" | null {
   const canvas = getCanvas(host);
   if (canvas === null) return null;
-  let gl: (WebGL2RenderingContext & { drawingBufferColorSpace?: string }) | null = null;
+  // Named type instead of `as typeof gl`: a typeof query in the cast
+  // resolves against the control-flow-narrowed type of `gl` (which is
+  // `null` right after its initializer), typing the variable as `null`
+  // and everything after the guard as `never`.
+  type RetaggableContext = WebGL2RenderingContext & { drawingBufferColorSpace?: string };
+  let gl: RetaggableContext | null = null;
   try {
-    gl = canvas.getContext("webgl2") as typeof gl;
+    gl = canvas.getContext("webgl2") as RetaggableContext | null;
   } catch {
     return null;
   }


### PR DESCRIPTION
main's web-frontend gate is red: `drawingBufferColorSpace does not exist on type 'never'` in webglRenderer.ts. A `typeof` query inside a cast resolves against the control-flow-narrowed type at that point - `gl` was just initialized to `null`, so `as typeof gl` casts to `null`, the variable types as `null`, and everything past the null guard narrows to `never`. A named context type keeps the intended shape. Verified locally with the exact CI steps (TypeScript SDK build, `npm ci`, `tsc -b`, 214 web tests pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789809411&installation_model_id=21920&pr_number=10504&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10504&signature=a16111dc43543866f7b7df76eb0b701a7afc89f2f01bc87a75de3b82f99e8c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeScript control-flow narrowing bug in `webglRenderer.ts` that broke the web-frontend gate. Replaces `as typeof gl` (after a null init) with a named `RetaggableContext` to avoid `never` narrowing and keep `drawingBufferColorSpace` typed correctly.

- Type-only change; no runtime behavior changes.
- Verified with SDK build, `npm ci`, `tsc -b`; all 214 web tests pass.
- No API or config changes.

<sup>Written for commit 64edf42dabd774f07b6f0c2b2b4fe6d7cfa081c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebGL rendering context handling to enhance reliability and compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->