### PR TITLE
fix: readable text on tinted solidFill sidebar rows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15772,7 +15772,11 @@ struct TabItemView: View, Equatable {
         let titleRowSpacing: CGFloat = spinnerOnLeading ? 6 : 8
         let badgeFont = magnifiedFont(scaledFontSize(9), weight: .semibold)
         let spinnerTooltip = SidebarWorkspaceLoadingTooltip.text(count: workspaceSnapshot.activeCodingAgentCount)
-        let spinnerColor = usesInvertedActiveForeground ? selectedWorkspaceForegroundNSColor(opacity: 0.55) : .secondaryLabelColor
+        let spinnerColor: NSColor = usesInvertedActiveForeground
+            ? selectedWorkspaceForegroundNSColor(opacity: 0.55)
+            : (tintedTextBackgroundNSColor.map {
+                cmuxReadableForegroundNSColor(on: $0, meeting: 4.5, preferredOpacity: 0.6)
+            } ?? .secondaryLabelColor)
         let rowView = VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .sidebarTitleFirstLineCenter, spacing: titleRowSpacing) {
 
@@ -16312,7 +16316,26 @@ struct TabItemView: View, Equatable {
     }
 
     private var pullRequestForegroundColor: Color {
-        isActive ? activeSecondaryColor(0.75) : .secondary
+        // `activeSecondaryColor` already routes an inactive, custom-tinted
+        // `solidFill` row through the readable-foreground derivation, so the PR
+        // status text stays legible on a bright card instead of using a fixed
+        // `.secondary` that fails contrast.
+        activeSecondaryColor(0.75)
+    }
+
+    /// Keeps an explicit status hue (e.g. the blue "Running"/progress color)
+    /// when it already reads on an inactive tinted row, else derives a readable
+    /// foreground against the tint. Returns `untinted` unchanged on any row that
+    /// draws on the sidebar's own surface. Mirrors the AppKit
+    /// `SidebarRowPalette.legibleOnTint`.
+    private func legibleStatusColor(_ system: NSColor, untinted: Color) -> Color {
+        guard let background = tintedTextBackgroundNSColor else { return untinted }
+        let resolved = SidebarAppearanceColorResolver().resolvedColor(system, for: colorScheme)
+        return Color(nsColor: cmuxReadableForegroundNSColor(
+            preferred: resolved,
+            on: background,
+            minimumContrast: 4.5
+        ))
     }
 
     private func openPullRequestLink(_ url: URL) {
@@ -16357,11 +16380,11 @@ struct TabItemView: View, Equatable {
             }
         }
         switch level {
-        case .info: return .secondary
-        case .progress: return .blue
-        case .success: return .green
-        case .warning: return .orange
-        case .error: return .red
+        case .info: return activeSecondaryColor(0.5)
+        case .progress: return legibleStatusColor(.systemBlue, untinted: .blue)
+        case .success: return legibleStatusColor(.systemGreen, untinted: .green)
+        case .warning: return legibleStatusColor(.systemOrange, untinted: .orange)
+        case .error: return legibleStatusColor(.systemRed, untinted: .red)
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15528,16 +15528,42 @@ struct TabItemView: View, Equatable {
         isActive
     }
 
+    /// Non-nil only for an inactive, custom-tinted `solidFill` row: the vivid
+    /// surface the row's text sits on, so text derives a readable foreground
+    /// against it instead of `.primary` / `.secondary`, which fail contrast on a
+    /// bright card. Mirrors the AppKit `SidebarRowPalette.tintedTextBackground`.
+    private var tintedTextBackgroundNSColor: NSColor? {
+        sidebarWorkspaceRowTintedTextBackgroundNSColor(
+            activeTabIndicatorStyle: activeTabIndicatorStyle,
+            isActive: isActive,
+            isMultiSelected: isMultiSelected,
+            customColorHex: workspaceSnapshot.customColorHex,
+            colorScheme: colorScheme
+        )
+    }
+
     private var activePrimaryTextColor: Color {
-        usesInvertedActiveForeground
-            ? Color(nsColor: selectedWorkspaceForegroundNSColor(opacity: 1.0))
-            : .primary
+        if usesInvertedActiveForeground {
+            return Color(nsColor: selectedWorkspaceForegroundNSColor(opacity: 1.0))
+        }
+        if let background = tintedTextBackgroundNSColor {
+            return Color(nsColor: cmuxReadableForegroundNSColor(on: background, meeting: 4.5, preferredOpacity: 1.0))
+        }
+        return .primary
     }
 
     private func activeSecondaryColor(_ opacity: Double = 0.75) -> Color {
-        usesInvertedActiveForeground
-            ? Color(nsColor: selectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity)))
-            : .secondary
+        if usesInvertedActiveForeground {
+            return Color(nsColor: selectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity)))
+        }
+        if let background = tintedTextBackgroundNSColor {
+            return Color(nsColor: cmuxReadableForegroundNSColor(
+                on: background,
+                meeting: 4.5,
+                preferredOpacity: max(CGFloat(opacity), 0.6)
+            ))
+        }
+        return .secondary
     }
 
     private var activeUnreadBadgeFillColor: Color {
@@ -15886,6 +15912,7 @@ struct TabItemView: View, Equatable {
                         isActive: usesInvertedActiveForeground,
                         activeForegroundColor: activeSecondaryColor(0.95),
                         activeSecondaryForegroundColor: activeSecondaryColor(0.65),
+                        inactiveTintBackgroundNSColor: tintedTextBackgroundNSColor,
                         fontScale: fontScale,
                         onFocus: { updateSelection() }
                     )
@@ -16569,6 +16596,9 @@ private struct SidebarMetadataRows: View {
     let isActive: Bool
     let activeForegroundColor: Color
     let activeSecondaryForegroundColor: Color
+    /// Vivid card surface behind an inactive tinted `solidFill` row; text
+    /// derives a readable foreground against it instead of `.secondary`.
+    var inactiveTintBackgroundNSColor: NSColor? = nil
     let fontScale: CGFloat
     let onFocus: () -> Void
 
@@ -16582,6 +16612,7 @@ private struct SidebarMetadataRows: View {
                     entry: entry,
                     isActive: isActive,
                     activeForegroundColor: activeForegroundColor,
+                    inactiveTintBackgroundNSColor: inactiveTintBackgroundNSColor,
                     fontScale: fontScale,
                     onFocus: onFocus
                 )
@@ -16622,6 +16653,7 @@ private struct SidebarMetadataEntryRow: View {
     let entry: SidebarStatusEntry
     let isActive: Bool
     let activeForegroundColor: Color
+    var inactiveTintBackgroundNSColor: NSColor? = nil
     let fontScale: CGFloat
     let onFocus: () -> Void
 
@@ -16667,9 +16699,23 @@ private struct SidebarMetadataEntryRow: View {
             return activeForegroundColor
         }
         if let raw = entry.color, let explicit = Color(hex: raw) {
+            // On a tinted card the explicit status hue (e.g. blue "Running")
+            // must stay legible; fall back to a readable foreground when it
+            // fails contrast against the vivid tint.
+            if !isActive, let background = inactiveTintBackgroundNSColor, let ns = NSColor(hex: raw) {
+                return Color(nsColor: cmuxReadableForegroundNSColor(
+                    preferred: ns,
+                    on: background,
+                    minimumContrast: 4.5
+                ))
+            }
             return explicit
         }
-        return isActive ? activeForegroundColor.opacity(0.84) : .secondary
+        if isActive { return activeForegroundColor.opacity(0.84) }
+        if let background = inactiveTintBackgroundNSColor {
+            return Color(nsColor: cmuxReadableForegroundNSColor(on: background, meeting: 4.5, preferredOpacity: 0.75))
+        }
+        return .secondary
     }
 
     private var iconView: AnyView? {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -753,7 +753,10 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                     ? palette.selectedForeground(1.0)
                     : palette.secondary(0.95).withAlphaComponent(0.84)
             } else {
-                entryColor = explicitColor ?? palette.secondary()
+                // On a custom-tinted row the explicit status hue (e.g. the blue
+                // "Running") must stay legible against the vivid card; fall back
+                // to a readable foreground when it fails contrast.
+                entryColor = explicitColor.map { palette.legibleOnTint($0) } ?? palette.secondary()
             }
             metadataRows[index].configureMetadataEntry(
                 entry,

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -404,12 +404,17 @@ final class SidebarRowIconTextLine: NSView {
             default: color = palette.secondary(0.9)
             }
         } else {
+            // On a custom-tinted row the fixed status hues fail contrast against
+            // the vivid card, so route them through `legibleOnTint` (a no-op on
+            // untinted rows). `semantic(...)` resolves the system color to a
+            // concrete sRGB value first, matching the row's cmux scheme and
+            // keeping the contrast math off a catalog color.
             switch log.level {
             case .info: color = palette.secondary(0.5)
-            case .progress: color = .systemBlue
-            case .success: color = .systemGreen
-            case .warning: color = .systemOrange
-            case .error: color = .systemRed
+            case .progress: color = palette.legibleOnTint(palette.semantic(.systemBlue))
+            case .success: color = palette.legibleOnTint(palette.semantic(.systemGreen))
+            case .warning: color = palette.legibleOnTint(palette.semantic(.systemOrange))
+            case .error: color = palette.legibleOnTint(palette.semantic(.systemRed))
             }
         }
         iconView.isHidden = false

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -32,17 +32,54 @@ struct SidebarRowPalette {
         )
     }
 
+    /// Non-nil only for an inactive, custom-tinted `solidFill` row: the vivid
+    /// surface its text is actually drawn on. Text roles derive a readable
+    /// foreground against it instead of the fixed semantic/accent colors, which
+    /// fail WCAG contrast on a bright card
+    /// (https://github.com/manaflow-ai/cmux/issues/2586-adjacent sidebar report).
+    var tintedTextBackground: NSColor? {
+        sidebarWorkspaceRowTintedTextBackgroundNSColor(
+            activeTabIndicatorStyle: model.settings.activeTabIndicatorStyle,
+            isActive: model.isActive,
+            isMultiSelected: model.isMultiSelected,
+            customColorHex: model.snapshot.customColorHex,
+            colorScheme: colorScheme
+        )
+    }
+
     var primaryText: NSColor {
-        model.isActive ? selectedForeground(1.0) : semantic(.labelColor)
+        if model.isActive { return selectedForeground(1.0) }
+        if let background = tintedTextBackground {
+            return cmuxReadableForegroundNSColor(on: background, meeting: 4.5, preferredOpacity: 1.0)
+        }
+        return semantic(.labelColor)
     }
 
     func secondary(
         _ selectedOpacity: CGFloat = 0.75,
         inactiveOpacity: CGFloat? = nil
     ) -> NSColor {
-        model.isActive
-            ? selectedForeground(selectedOpacity)
-            : semantic(.secondaryLabelColor, opacity: inactiveOpacity)
+        if model.isActive { return selectedForeground(selectedOpacity) }
+        if let background = tintedTextBackground {
+            return cmuxReadableForegroundNSColor(
+                on: background,
+                meeting: 4.5,
+                preferredOpacity: max(selectedOpacity, 0.6)
+            )
+        }
+        return semantic(.secondaryLabelColor, opacity: inactiveOpacity)
+    }
+
+    /// Keeps an explicit, full-opacity color (e.g. the blue "Running" status
+    /// tint) when it already reads on a tinted row, else a readable-base
+    /// foreground. A no-op on untinted rows.
+    func legibleOnTint(_ preferred: NSColor, minimumContrast: CGFloat = 4.5) -> NSColor {
+        guard let background = tintedTextBackground else { return preferred }
+        return cmuxReadableForegroundNSColor(
+            preferred: preferred,
+            on: background,
+            minimumContrast: minimumContrast
+        )
     }
 
     /// Link color for row-owned text. AppKit paints `.link` runs in
@@ -51,7 +88,9 @@ struct SidebarRowPalette {
     /// blue. Active rows therefore derive the link color from the selected
     /// foreground so a custom `sidebarSelectionColorHex` stays legible.
     var linkText: NSColor {
-        model.isActive ? selectedForeground(1.0) : semantic(.linkColor)
+        if model.isActive { return selectedForeground(1.0) }
+        if tintedTextBackground != nil { return legibleOnTint(semantic(.linkColor)) }
+        return semantic(.linkColor)
     }
 
 }

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -198,8 +198,10 @@ func cmuxReadableForegroundNSColor(
 
 /// Approximate surface the sidebar paints behind a workspace row: the window
 /// shows through the sidebar material, so a near-window neutral is a faithful
-/// enough base for the tinted-row contrast math. Only the ~30% not covered by
-/// the tint comes from here, so small errors do not flip the readable choice.
+/// enough base for the tinted-row contrast math. The tint dominates the
+/// composite (0.7 drawn opacity for a plain inactive row, 0.35 when
+/// multi-selected), so a small error in this base rarely flips the readable
+/// white/black choice — most influential for the multi-selected case.
 func sidebarRowTintBaseBackgroundNSColor(for colorScheme: ColorScheme) -> NSColor {
     colorScheme == .dark
         ? NSColor(srgbRed: 0.12, green: 0.12, blue: 0.13, alpha: 1)

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -171,6 +171,68 @@ func cmuxReadableForegroundNSColor(
     return cmuxReadableForegroundNSColor(on: backgroundColor, opacity: preferredColor.alphaComponent)
 }
 
+/// Least-opaque readable foreground (white or black chosen by `background`
+/// luminance) that meets `minimumContrast` against `background`, starting the
+/// search at `preferredOpacity` so softer text roles stay as soft as legibility
+/// allows. Returns full opacity when even that can't clear the bar.
+///
+/// Used for text on a custom-tinted sidebar row, where the row's background is a
+/// vivid color rather than the sidebar's own surface, so the fixed semantic /
+/// accent colors would fail contrast (https://github.com/manaflow-ai/cmux/issues/2586-adjacent).
+func cmuxReadableForegroundNSColor(
+    on background: NSColor,
+    meeting minimumContrast: CGFloat,
+    preferredOpacity: CGFloat
+) -> NSColor {
+    let base: NSColor = cmuxReadableColorScheme(for: background) == .dark ? .white : .black
+    var opacity = max(0, min(preferredOpacity, 1))
+    while opacity < 1 {
+        let composited = cmuxCompositedNSColor(base.withAlphaComponent(opacity), over: background)
+        if cmuxContrastRatio(foreground: composited, background: background) >= minimumContrast {
+            break
+        }
+        opacity = min(1, opacity + 0.04)
+    }
+    return base.withAlphaComponent(opacity)
+}
+
+/// Approximate surface the sidebar paints behind a workspace row: the window
+/// shows through the sidebar material, so a near-window neutral is a faithful
+/// enough base for the tinted-row contrast math. Only the ~30% not covered by
+/// the tint comes from here, so small errors do not flip the readable choice.
+func sidebarRowTintBaseBackgroundNSColor(for colorScheme: ColorScheme) -> NSColor {
+    colorScheme == .dark
+        ? NSColor(srgbRed: 0.12, green: 0.12, blue: 0.13, alpha: 1)
+        : NSColor(srgbRed: 0.96, green: 0.96, blue: 0.97, alpha: 1)
+}
+
+/// The composited surface an INACTIVE, custom-tinted, `solidFill` row actually
+/// paints — i.e. the background its text sits on. `nil` when the row draws on
+/// the sidebar's own surface (leftRail, active, or no custom color), where the
+/// standard semantic/accent colors already apply and nothing should change.
+func sidebarWorkspaceRowTintedTextBackgroundNSColor(
+    activeTabIndicatorStyle: WorkspaceIndicatorStyle,
+    isActive: Bool,
+    isMultiSelected: Bool,
+    customColorHex: String?,
+    colorScheme: ColorScheme
+) -> NSColor? {
+    guard activeTabIndicatorStyle == .solidFill, !isActive, customColorHex != nil else {
+        return nil
+    }
+    let style = sidebarWorkspaceRowBackgroundStyle(
+        activeTabIndicatorStyle: .solidFill,
+        isActive: false,
+        isMultiSelected: isMultiSelected,
+        customColorHex: customColorHex,
+        colorScheme: colorScheme,
+        sidebarSelectionColorHex: nil
+    )
+    guard let tint = style.color, style.opacity > 0 else { return nil }
+    let drawn = tint.withAlphaComponent(style.opacity * tint.alphaComponent)
+    return cmuxCompositedNSColor(drawn, over: sidebarRowTintBaseBackgroundNSColor(for: colorScheme))
+}
+
 func cmuxCompositedNSColor(_ foreground: NSColor, over background: NSColor) -> NSColor {
     let fg = foreground.usingColorSpace(.sRGB) ?? foreground
     let bg = background.usingColorSpace(.sRGB) ?? background

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -13,6 +13,7 @@ struct SidebarAppKitRowCellTests {
         title: String = "Workspace",
         customDescription: String? = nil,
         isPinned: Bool = false,
+        customColorHex: String? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
         metadataBlocks: [SidebarMetadataBlock] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
@@ -24,7 +25,7 @@ struct SidebarAppKitRowCellTests {
             title: title,
             customDescription: customDescription,
             isPinned: isPinned,
-            customColorHex: nil,
+            customColorHex: customColorHex,
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: "",
             remoteStateHelpText: "",
@@ -62,6 +63,7 @@ struct SidebarAppKitRowCellTests {
         canClose: Bool = true,
         settings: SidebarTabItemSettingsSnapshot? = nil,
         customDescription: String? = nil,
+        customColorHex: String? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
         metadataBlocks: [SidebarMetadataBlock] = [],
         shortcutHintText: String? = nil,
@@ -75,6 +77,7 @@ struct SidebarAppKitRowCellTests {
             snapshot: makeSnapshot(
                 customDescription: customDescription,
                 isPinned: isPinned,
+                customColorHex: customColorHex,
                 metadataEntries: metadataEntries,
                 metadataBlocks: metadataBlocks
             ),
@@ -105,6 +108,54 @@ struct SidebarAppKitRowCellTests {
             isMetadataExpanded: false,
             isMarkdownExpanded: isMarkdownExpanded
         )
+    }
+
+    /// Regression: on an inactive, custom-tinted `solidFill` row the background
+    /// is a vivid color, so the title and secondary/status text must derive a
+    /// readable foreground against that tint instead of the fixed semantic
+    /// colors, which fail WCAG 4.5:1 on a bright card. Repro of the sidebar
+    /// "white/blue text unreadable on a colored workspace" report.
+    @Test
+    func tintedSolidFillRowTextStaysLegibleOnBrightCard() throws {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set("solidFill", forKey: "sidebarActiveTabIndicatorStyle")
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+
+        // Radix yellow 9: a deliberately bright tint where fixed white / dimmed
+        // text is unreadable.
+        let tint = "#FFE629"
+        let model = Self.makeModel(
+            isActive: false,
+            settings: settings,
+            customColorHex: tint
+        )
+        let palette = SidebarRowPalette(model: model)
+
+        // The surface the row's text actually sits on: the solidFill tint at
+        // its drawn opacity, composited over the dark sidebar base.
+        let style = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: false,
+            isMultiSelected: false,
+            customColorHex: tint,
+            colorScheme: .dark,
+            sidebarSelectionColorHex: nil
+        )
+        let drawnTint = try #require(style.color).withAlphaComponent(CGFloat(style.opacity))
+        let rowBackground = cmuxCompositedNSColor(
+            drawnTint,
+            over: sidebarRowTintBaseBackgroundNSColor(for: .dark)
+        )
+
+        func contrastOnRow(_ foreground: NSColor) -> CGFloat {
+            cmuxContrastRatio(
+                foreground: cmuxCompositedNSColor(foreground, over: rowBackground),
+                background: rowBackground
+            )
+        }
+
+        #expect(contrastOnRow(palette.primaryText) >= 4.5)
+        #expect(contrastOnRow(palette.secondary()) >= 4.5)
     }
 
     private static func makeSwiftUIRow(

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -156,6 +156,14 @@ struct SidebarAppKitRowCellTests {
 
         #expect(contrastOnRow(palette.primaryText) >= 4.5)
         #expect(contrastOnRow(palette.secondary()) >= 4.5)
+
+        // The explicit status hue (the fixed accent blue used for "Running")
+        // is unreadable on the bright card and must be adapted by legibleOnTint
+        // — the shared path the metadata status text and log-level icons route
+        // through.
+        let statusAccent = cmuxAccentNSColor(for: .dark)
+        #expect(contrastOnRow(statusAccent) < 4.5)
+        #expect(contrastOnRow(palette.legibleOnTint(statusAccent)) >= 4.5)
     }
 
     private static func makeSwiftUIRow(


### PR DESCRIPTION
## Problem

On an **inactive, custom-tinted `solidFill` workspace row**, the sidebar paints the workspace's color as the row background (the tint, brightened, at 0.7 opacity), but the row's text keeps the colors designed for the dark sidebar surface — white title, dimmed-white secondary path, and a fixed blue accent for the "Running" / "Needs input" status. On a bright tint these fail WCAG contrast badly (title ≈ 2.1:1, secondary ≈ 1.6:1).

Reported as "the white/blue text is unreadable on a colored workspace." Selected rows are fine because they draw on the selection color; only inactive *tinted* rows regress.

## Root cause

`SidebarRowPalette` (AppKit list, the default renderer) and `TabItemView` (legacy SwiftUI / mobile) compute inactive-row text from the app color scheme, not from the row's actual tinted background. `cmuxAccentNSColor` and explicit per-entry status hues never adapt either.

## Fix

Shared readable-foreground helpers in `SidebarAppearanceSupport`:

- `sidebarWorkspaceRowTintedTextBackgroundNSColor(...)` — the composited surface a tinted inactive `solidFill` row actually paints; `nil` for leftRail / active / untinted rows (those are untouched).
- `cmuxReadableForegroundNSColor(on:meeting:preferredOpacity:)` — picks white or black by that surface's luminance and lifts opacity only as far as needed to clear 4.5:1, so softer roles stay soft where legibility allows.

Both render paths route through them:

- **AppKit** — `SidebarRowPalette.primaryText` / `secondary()` / `linkText`, plus the explicit status hue in the metadata slot.
- **SwiftUI** — `TabItemView.activePrimaryTextColor` / `activeSecondaryColor`, plus `SidebarMetadataEntryRow`.

Vivid workspace colors stay; the text becomes legible (white on dark tints, black on bright ones).

## Tests

`cmuxTests/SidebarAppKitRowCellTests.tintedSolidFillRowTextStaysLegibleOnBrightCard`, shipped as two commits so CI shows the test catching the bug:

1. test + contrast primitives → **red** (`primaryText` 2.09:1, `secondary` 1.64:1 on Radix yellow-9)
2. render-path wiring → **green**

## Scope / what this is not

- Only inactive, custom-tinted, `solidFill` rows change. `leftRail` (the default indicator style), active, multi-selected-untinted, and untinted rows are unchanged.
- Not a theme or opacity change — the card colors are untouched; only the text adapts.
- The sidebar base used for the contrast math is an approximation (the window shows through the sidebar material); the tint at 0.7 dominates, so it doesn't flip the readable choice.
- Known minor gap: the rare "Show more" toggle inside `SidebarMetadataMarkdownBlocks` (SwiftUI, only when >3 markdown blocks) is not adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789820328&installation_model_id=21920&pr_number=10508&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10508&signature=3d7a36b2d8666c169dcf6b57e13b130b3669ea93fb20ea1198ebcc78894eb0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable text and status colors on inactive, custom‑tinted `solidFill` sidebar rows by deriving readable foregrounds from the tinted background. Previously these rows used dark-surface constants (white/dimmed-white and fixed status hues) that failed contrast on bright tints; now text, links, status icons/text, PR text, and the spinner adapt to meet 4.5:1 while preserving original hues when already legible.

- Adds shared readable-foreground helpers in `SidebarAppearanceSupport` and a `legibleOnTint` path to keep explicit hues when they pass contrast, otherwise fall back to black/white with minimal opacity lift.
- AppKit: routes `SidebarRowPalette.primaryText`, `secondary()`, and `linkText` through readable helpers; explicit metadata/status hues and log-level icons use `palette.legibleOnTint(...)`.
- SwiftUI: `TabItemView` computes `activePrimaryTextColor`/`activeSecondaryColor` against the tinted background and adapts PR-status text, spinner, and `SidebarMetadataEntryRow` status colors via the same helpers (`inactiveTintBackgroundNSColor` plumbed through).
- Scope: only inactive, custom‑tinted `solidFill` rows change. LeftRail, active, multi-selected-untinted, and untinted rows are unchanged.
- Test: `cmuxTests/SidebarAppKitRowCellTests.tintedSolidFillRowTextStaysLegibleOnBrightCard` now passes and covers the `legibleOnTint` fallback for explicit status hues.

<sup>Written for commit d98cd09e70fa1285f11419fd8f1cf5d68ffc5073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text, icon, spinner, pull-request, and status colors for inactive sidebar rows with custom tints.
  * Preserved preferred status colors when readable while adapting them when contrast is insufficient.
  * Improved metadata readability on unselected workspace rows.

* **Tests**
  * Added regression coverage for contrast on brightly tinted inactive sidebar rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->