### PR TITLE
Fix sidebar group header labels resolving the inverted color scheme

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -16278,6 +16278,7 @@ private struct SidebarMetadataRows: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
+    @Environment(\.colorScheme) private var colorScheme
     private let collapsedEntryLimit = 3
 
     var body: some View {
@@ -16301,7 +16302,14 @@ private struct SidebarMetadataRows: View {
                 }
                 .buttonStyle(.plain)
                 .cmuxFont(size: 10 * fontScale, weight: .semibold)
-                .foregroundColor(isActive ? activeSecondaryForegroundColor : .secondary.opacity(0.9))
+                .foregroundColor(
+                    isActive
+                        ? activeSecondaryForegroundColor
+                        : Color(nsColor: sidebarForegroundNSColor(
+                            opacity: 0.9,
+                            colorScheme: colorScheme
+                        ))
+                )
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
@@ -16430,6 +16438,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
+    @Environment(\.colorScheme) private var colorScheme
     private let collapsedBlockLimit = 1
 
     var body: some View {
@@ -16453,7 +16462,14 @@ private struct SidebarMetadataMarkdownBlocks: View {
                 }
                 .buttonStyle(.plain)
                 .cmuxFont(size: 10 * fontScale, weight: .semibold)
-                .foregroundColor(isActive ? activeSecondaryForegroundColor : .secondary.opacity(0.9))
+                .foregroundColor(
+                    isActive
+                        ? activeSecondaryForegroundColor
+                        : Color(nsColor: sidebarForegroundNSColor(
+                            opacity: 0.9,
+                            colorScheme: colorScheme
+                        ))
+                )
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -16278,7 +16278,6 @@ private struct SidebarMetadataRows: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
-    @Environment(\.colorScheme) private var colorScheme
     private let collapsedEntryLimit = 3
 
     var body: some View {
@@ -16306,8 +16305,7 @@ private struct SidebarMetadataRows: View {
                     isActive
                         ? activeSecondaryForegroundColor
                         : Color(nsColor: sidebarForegroundNSColor(
-                            opacity: 0.9,
-                            colorScheme: colorScheme
+                            opacity: 0.9
                         ))
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -16438,7 +16436,6 @@ private struct SidebarMetadataMarkdownBlocks: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
-    @Environment(\.colorScheme) private var colorScheme
     private let collapsedBlockLimit = 1
 
     var body: some View {
@@ -16466,8 +16463,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
                     isActive
                         ? activeSecondaryForegroundColor
                         : Color(nsColor: sidebarForegroundNSColor(
-                            opacity: 0.9,
-                            colorScheme: colorScheme
+                            opacity: 0.9
                         ))
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -50,6 +50,15 @@ func sidebarActiveForegroundNSColor(
     return baseColor.withAlphaComponent(clampedOpacity)
 }
 
+func sidebarForegroundNSColor(
+    opacity: CGFloat,
+    colorScheme: ColorScheme
+) -> NSColor {
+    let clampedOpacity = max(0, min(opacity, 1))
+    let baseColor: NSColor = colorScheme == .dark ? .white : .black
+    return baseColor.withAlphaComponent(clampedOpacity)
+}
+
 func titlebarControlForegroundNSColor(opacity: CGFloat) -> NSColor {
     let app = GhosttyApp.shared
     let bestMatch = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -50,13 +50,15 @@ func sidebarActiveForegroundNSColor(
     return baseColor.withAlphaComponent(clampedOpacity)
 }
 
-func sidebarForegroundNSColor(
-    opacity: CGFloat,
-    colorScheme: ColorScheme
-) -> NSColor {
+func sidebarForegroundNSColor(opacity: CGFloat) -> NSColor {
     let clampedOpacity = max(0, min(opacity, 1))
-    let baseColor: NSColor = colorScheme == .dark ? .white : .black
-    return baseColor.withAlphaComponent(clampedOpacity)
+    // Resolved per drawing appearance, not captured at render time: the sidebar
+    // hosting context does not reliably re-render on mid-session system
+    // appearance switches, so a snapshot color goes stale (black-on-dark).
+    return NSColor(name: nil) { appearance in
+        let baseColor: NSColor = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .white : .black
+        return baseColor.withAlphaComponent(clampedOpacity)
+    }
 }
 
 func titlebarControlForegroundNSColor(opacity: CGFloat) -> NSColor {

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -95,7 +95,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onContextMenuDisappear: () -> Void
 
     @State private var contextMenuVisible = false
-    @Environment(\.colorScheme) private var colorScheme
 
 #if DEBUG
     // Plain-value environment probe set only by SidebarLazyLayoutScaleTests;
@@ -184,8 +183,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 Text(name)
                     .cmuxFont(size: metrics.nameFontSize, weight: .semibold)
                     .foregroundStyle(Color(nsColor: sidebarForegroundNSColor(
-                        opacity: isAnchorActive ? 1.0 : 0.9,
-                        colorScheme: colorScheme
+                        opacity: isAnchorActive ? 1.0 : 0.9
                     )))
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -95,6 +95,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onContextMenuDisappear: () -> Void
 
     @State private var contextMenuVisible = false
+    @Environment(\.colorScheme) private var colorScheme
 
 #if DEBUG
     // Plain-value environment probe set only by SidebarLazyLayoutScaleTests;
@@ -182,7 +183,10 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                     .accessibilityHidden(true)
                 Text(name)
                     .cmuxFont(size: metrics.nameFontSize, weight: .semibold)
-                    .foregroundStyle(isAnchorActive ? Color.primary : Color.primary.opacity(0.9))
+                    .foregroundStyle(Color(nsColor: sidebarForegroundNSColor(
+                        opacity: isAnchorActive ? 1.0 : 0.9,
+                        colorScheme: colorScheme
+                    )))
                     .lineLimit(1)
                     .truncationMode(.tail)
                 if anchorUnreadCount > 0 {

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -52,34 +52,63 @@ final class SidebarActiveForegroundColorTests: XCTestCase {
         XCTAssertEqual(color.alphaComponent, 0.65, accuracy: 0.001)
     }
 
-    func testDarkSidebarUsesWhiteWhenTheAppAppearanceIsLight() {
-        guard let color = sidebarForegroundNSColor(
-            opacity: 0.9,
-            colorScheme: .dark
-        ).usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible color")
+    func testSidebarForegroundResolvesWhiteUnderDarkAppearance() {
+        guard let darkAppearance = NSAppearance(named: .darkAqua) else {
+            XCTFail("Expected darkAqua appearance")
             return
         }
 
-        XCTAssertEqual(color.redComponent, 1, accuracy: 0.001)
-        XCTAssertEqual(color.greenComponent, 1, accuracy: 0.001)
-        XCTAssertEqual(color.blueComponent, 1, accuracy: 0.001)
-        XCTAssertEqual(color.alphaComponent, 0.9, accuracy: 0.001)
+        darkAppearance.performAsCurrentDrawingAppearance {
+            guard let color = sidebarForegroundNSColor(opacity: 0.9).usingColorSpace(.sRGB) else {
+                XCTFail("Expected sRGB-convertible color")
+                return
+            }
+            XCTAssertEqual(color.redComponent, 1, accuracy: 0.001)
+            XCTAssertEqual(color.greenComponent, 1, accuracy: 0.001)
+            XCTAssertEqual(color.blueComponent, 1, accuracy: 0.001)
+            XCTAssertEqual(color.alphaComponent, 0.9, accuracy: 0.001)
+        }
     }
 
-    func testLightSidebarUsesBlackWhenTheAppAppearanceIsDark() {
-        guard let color = sidebarForegroundNSColor(
-            opacity: 0.8,
-            colorScheme: .light
-        ).usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible color")
+    func testSidebarForegroundResolvesBlackUnderLightAppearance() {
+        guard let lightAppearance = NSAppearance(named: .aqua) else {
+            XCTFail("Expected aqua appearance")
             return
         }
 
-        XCTAssertEqual(color.redComponent, 0, accuracy: 0.001)
-        XCTAssertEqual(color.greenComponent, 0, accuracy: 0.001)
-        XCTAssertEqual(color.blueComponent, 0, accuracy: 0.001)
-        XCTAssertEqual(color.alphaComponent, 0.8, accuracy: 0.001)
+        lightAppearance.performAsCurrentDrawingAppearance {
+            guard let color = sidebarForegroundNSColor(opacity: 0.8).usingColorSpace(.sRGB) else {
+                XCTFail("Expected sRGB-convertible color")
+                return
+            }
+            XCTAssertEqual(color.redComponent, 0, accuracy: 0.001)
+            XCTAssertEqual(color.greenComponent, 0, accuracy: 0.001)
+            XCTAssertEqual(color.blueComponent, 0, accuracy: 0.001)
+            XCTAssertEqual(color.alphaComponent, 0.8, accuracy: 0.001)
+        }
+    }
+
+    func testSidebarForegroundTracksAppearanceSwitchesAtDrawTime() {
+        // Regression: a mid-session light/dark switch must change what the SAME
+        // color instance draws, without any view re-render.
+        guard let darkAppearance = NSAppearance(named: .darkAqua),
+              let lightAppearance = NSAppearance(named: .aqua) else {
+            XCTFail("Expected system appearances")
+            return
+        }
+
+        let color = sidebarForegroundNSColor(opacity: 0.9)
+        var darkRed: CGFloat = -1
+        var lightRed: CGFloat = -1
+        darkAppearance.performAsCurrentDrawingAppearance {
+            darkRed = color.usingColorSpace(.sRGB)?.redComponent ?? -1
+        }
+        lightAppearance.performAsCurrentDrawingAppearance {
+            lightRed = color.usingColorSpace(.sRGB)?.redComponent ?? -1
+        }
+
+        XCTAssertEqual(darkRed, 1, accuracy: 0.001)
+        XCTAssertEqual(lightRed, 0, accuracy: 0.001)
     }
 }
 

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -51,6 +51,36 @@ final class SidebarActiveForegroundColorTests: XCTestCase {
         XCTAssertEqual(color.blueComponent, 1, accuracy: 0.001)
         XCTAssertEqual(color.alphaComponent, 0.65, accuracy: 0.001)
     }
+
+    func testDarkSidebarUsesWhiteWhenTheAppAppearanceIsLight() {
+        guard let color = sidebarForegroundNSColor(
+            opacity: 0.9,
+            colorScheme: .dark
+        ).usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+
+        XCTAssertEqual(color.redComponent, 1, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 1, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 1, accuracy: 0.001)
+        XCTAssertEqual(color.alphaComponent, 0.9, accuracy: 0.001)
+    }
+
+    func testLightSidebarUsesBlackWhenTheAppAppearanceIsDark() {
+        guard let color = sidebarForegroundNSColor(
+            opacity: 0.8,
+            colorScheme: .light
+        ).usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+
+        XCTAssertEqual(color.redComponent, 0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 0, accuracy: 0.001)
+        XCTAssertEqual(color.alphaComponent, 0.8, accuracy: 0.001)
+    }
 }
 
 


### PR DESCRIPTION
## Problem

Workspace-group header names in the sidebar render with the wrong color scheme whenever the group's anchor workspace is not the selected workspace: white text in light mode, black text in dark mode — unreadable either way. Only the group whose anchor is currently selected renders correctly.

`SidebarWorkspaceGroupHeaderView` styles the name with `Color.primary.opacity(0.9)` for the non-active branch, and that opacity-wrapped dynamic color resolves against the inverted appearance in the sidebar's hosting context. Plain `Color.primary` (the active branch) resolves correctly, which is why exactly one group header is readable at a time.

Reproduce on v0.64.22: create two or more workspace groups, select a workspace that is not a group anchor, toggle light/dark — every group header label renders in the opposite scheme's color. Not config-dependent: reproduces with and without `sidebarAppearance` tints, at any `tintOpacity`.

## Fix

Resolve the label color explicitly from the view's own `@Environment(\.colorScheme)` via a new `sidebarForegroundNSColor(opacity:colorScheme:)` helper, keeping the existing 1.0 / 0.9 opacity distinction for active vs inactive anchors. Test added first (`SidebarOrderingTests`) requiring sidebar-scoped foreground colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789838622&installation_model_id=21920&pr_number=10509&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10509&signature=4b80b86792808ef7bd52d3c78b5643500623827ac7469f7fda11f22179b02eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable sidebar group headers and metadata labels caused by colors resolving against the wrong appearance. Previously inactive items could render white in light mode and black in dark mode; now labels resolve at draw time against the current appearance, preserving 1.0/0.9 opacity and the active metadata color.

- Add sidebar-scoped dynamic color: sidebarForegroundNSColor(opacity:) returns an NSColor that resolves per drawing appearance; remove Environment color-scheme plumbing.
- Use it in SidebarWorkspaceGroupHeaderView, SidebarMetadataRows, and SidebarMetadataMarkdownBlocks; active metadata still uses activeSecondaryForegroundColor.
- Tests assert white in darkAqua, black in aqua with expected alpha, and that a single color instance tracks mid-session appearance switches.
- Reviewer sanity check: create 2+ groups, select a non-anchor, toggle light/dark during the session; headers and metadata remain readable without requiring a re-render.

<sup>Written for commit c95f9a4fed0edf8a8e47b6e28d1bcb94ef4588d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar text contrast and readability in both light and dark appearance modes.
  * Preserved distinct styling for active and inactive sidebar items.
  * Ensured sidebar colors update correctly when switching appearance modes.

* **Tests**
  * Added coverage verifying sidebar foreground colors and opacity across appearance modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->