### PR TITLE
terminal: strip trailing line references before path probing

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
@@ -61,61 +61,49 @@ extension String {
         return String(characters[..<end])
     }
 
-    /// Strips a trailing editor-style line reference from the receiver.
+    /// Strips one trailing editor-style line reference from the receiver.
     ///
     /// Compilers, linters, ripgrep and AI coding agents all print locations as
     /// `path:line`, `path:line:column` or `path:startLine-endLine`. The
     /// reference is not part of the file name, so path probing needs the bare
     /// path as a candidate too.
     ///
-    /// Only ASCII digit runs qualify, so a path whose final colon-separated
-    /// segment is non-numeric is left alone. At most two segments are removed,
-    /// which covers `:line:column` without eating genuine path components.
+    /// Exactly one `:<line>` or `:<startLine>-<endLine>` run is removed per
+    /// call so callers can probe every stripping depth in order, letting a file
+    /// whose name genuinely ends in `:<digits>` still win. Only ASCII digit runs
+    /// qualify, so a non-numeric final segment is left alone.
     ///
-    /// - Returns: The receiver without its trailing line reference, or `nil`
-    ///   when there is no such reference or nothing would remain.
+    /// - Returns: The receiver without its final line reference, or `nil` when
+    ///   there is no such reference or nothing would remain.
     public func strippingTrailingLineSuffix() -> String? {
         func isASCIIDigit(_ character: Character) -> Bool {
             character.isASCII && character.isNumber
         }
 
-        /// Removes one `:<digits>` or `:<digits>-<digits>` run from the end.
-        func strippingOneSegment(_ characters: [Character]) -> [Character]? {
-            var end = characters.count
+        let characters = Array(self)
+        var end = characters.count
 
-            var trailingDigits = 0
+        var trailingDigits = 0
+        while end > 0, isASCIIDigit(characters[end - 1]) {
+            end -= 1
+            trailingDigits += 1
+        }
+        guard trailingDigits > 0 else { return nil }
+
+        // Optional `-<digits>` prefix, so `:144-198` is one reference.
+        if end > 0, characters[end - 1] == "-" {
+            end -= 1
+            var leadingDigits = 0
             while end > 0, isASCIIDigit(characters[end - 1]) {
                 end -= 1
-                trailingDigits += 1
+                leadingDigits += 1
             }
-            guard trailingDigits > 0 else { return nil }
-
-            // Optional `-<digits>` prefix, so `:144-198` is one reference.
-            if end > 0, characters[end - 1] == "-" {
-                end -= 1
-                var leadingDigits = 0
-                while end > 0, isASCIIDigit(characters[end - 1]) {
-                    end -= 1
-                    leadingDigits += 1
-                }
-                guard leadingDigits > 0 else { return nil }
-            }
-
-            guard end > 0, characters[end - 1] == ":" else { return nil }
-            end -= 1
-            return Array(characters[..<end])
+            guard leadingDigits > 0 else { return nil }
         }
 
-        var characters = Array(self)
-        var strippedAny = false
-        for _ in 0..<2 {
-            guard let stripped = strippingOneSegment(characters) else { break }
-            characters = stripped
-            strippedAny = true
-        }
-
-        guard strippedAny, !characters.isEmpty else { return nil }
-        return String(characters)
+        guard end > 1, characters[end - 1] == ":" else { return nil }
+        end -= 1
+        return String(characters[..<end])
     }
 
     /// Returns the bottom `rows` lines of captured terminal text.
@@ -194,14 +182,22 @@ extension String {
                 appendUnique(punctuationTrimmed)
             }
 
-            // Line references come last so a file that genuinely ends in
-            // `:<digits>` still wins over its stripped spelling.
-            if let lineStripped = trimmed.strippingTrailingLineSuffix() {
-                appendUnique(lineStripped)
+            // Every stripping depth, shallowest first, so `backup:2024:7`
+            // probes `backup:2024` before `backup` and a file that genuinely
+            // ends in `:<digits>` still wins over its stripped spelling. Two
+            // depths cover `:line` and `:line:column`.
+            func appendLineSuffixStrippings(of token: String) {
+                var current = token
+                for _ in 0..<2 {
+                    guard let stripped = current.strippingTrailingLineSuffix() else { return }
+                    appendUnique(stripped)
+                    current = stripped
+                }
             }
-            if punctuationTrimmed != trimmed,
-               let lineStripped = punctuationTrimmed.strippingTrailingLineSuffix() {
-                appendUnique(lineStripped)
+
+            appendLineSuffixStrippings(of: trimmed)
+            if punctuationTrimmed != trimmed {
+                appendLineSuffixStrippings(of: punctuationTrimmed)
             }
         }
 

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
@@ -61,6 +61,63 @@ extension String {
         return String(characters[..<end])
     }
 
+    /// Strips a trailing editor-style line reference from the receiver.
+    ///
+    /// Compilers, linters, ripgrep and AI coding agents all print locations as
+    /// `path:line`, `path:line:column` or `path:startLine-endLine`. The
+    /// reference is not part of the file name, so path probing needs the bare
+    /// path as a candidate too.
+    ///
+    /// Only ASCII digit runs qualify, so a path whose final colon-separated
+    /// segment is non-numeric is left alone. At most two segments are removed,
+    /// which covers `:line:column` without eating genuine path components.
+    ///
+    /// - Returns: The receiver without its trailing line reference, or `nil`
+    ///   when there is no such reference or nothing would remain.
+    public func strippingTrailingLineSuffix() -> String? {
+        func isASCIIDigit(_ character: Character) -> Bool {
+            character.isASCII && character.isNumber
+        }
+
+        /// Removes one `:<digits>` or `:<digits>-<digits>` run from the end.
+        func strippingOneSegment(_ characters: [Character]) -> [Character]? {
+            var end = characters.count
+
+            var trailingDigits = 0
+            while end > 0, isASCIIDigit(characters[end - 1]) {
+                end -= 1
+                trailingDigits += 1
+            }
+            guard trailingDigits > 0 else { return nil }
+
+            // Optional `-<digits>` prefix, so `:144-198` is one reference.
+            if end > 0, characters[end - 1] == "-" {
+                end -= 1
+                var leadingDigits = 0
+                while end > 0, isASCIIDigit(characters[end - 1]) {
+                    end -= 1
+                    leadingDigits += 1
+                }
+                guard leadingDigits > 0 else { return nil }
+            }
+
+            guard end > 0, characters[end - 1] == ":" else { return nil }
+            end -= 1
+            return Array(characters[..<end])
+        }
+
+        var characters = Array(self)
+        var strippedAny = false
+        for _ in 0..<2 {
+            guard let stripped = strippingOneSegment(characters) else { break }
+            characters = stripped
+            strippedAny = true
+        }
+
+        guard strippedAny, !characters.isEmpty else { return nil }
+        return String(characters)
+    }
+
     /// Returns the bottom `rows` lines of captured terminal text.
     ///
     /// - Parameter rows: The number of visible rows.
@@ -135,6 +192,16 @@ extension String {
             let punctuationTrimmed = trimmed.trimmingTrailingTerminalPunctuation()
             if punctuationTrimmed != trimmed {
                 appendUnique(punctuationTrimmed)
+            }
+
+            // Line references come last so a file that genuinely ends in
+            // `:<digits>` still wins over its stripped spelling.
+            if let lineStripped = trimmed.strippingTrailingLineSuffix() {
+                appendUnique(lineStripped)
+            }
+            if punctuationTrimmed != trimmed,
+               let lineStripped = punctuationTrimmed.strippingTrailingLineSuffix() {
+                appendUnique(lineStripped)
             }
         }
 

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -93,7 +93,8 @@ public struct TerminalPathResolver: Sendable {
     /// Resolves an open-URL request payload to an existing file path.
     ///
     /// Text that parses as a URL with a scheme is never treated as a file
-    /// path; everything else goes through ``resolveQuicklookPath(_:cwd:)``.
+    /// path, except when the scheme is an artifact of a trailing line
+    /// reference; everything else goes through ``resolveQuicklookPath(_:cwd:)``.
     ///
     /// - Parameters:
     ///   - rawText: The raw open-URL text from the runtime.
@@ -102,7 +103,14 @@ public struct TerminalPathResolver: Sendable {
     public func resolveOpenURLFilePath(_ rawText: String, cwd: String?) -> String? {
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        guard URL(string: trimmed)?.scheme == nil else { return nil }
+        if URL(string: trimmed)?.scheme != nil {
+            // A bare filename carrying a line reference parses as a URL whose
+            // "scheme" is the filename itself: `main.py:1292` yields scheme
+            // `main.py`. Retry once without the reference — a genuine URL still
+            // has a scheme after stripping and stays rejected.
+            guard let withoutLineReference = trimmed.strippingTrailingLineSuffix(),
+                  URL(string: withoutLineReference)?.scheme == nil else { return nil }
+        }
         return resolveQuicklookPath(trimmed, cwd: cwd)
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -252,8 +252,12 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 
-    @Test func stripsLineAndColumn() {
-        #expect("app/models/user.rb:12:5".strippingTrailingLineSuffix() == "app/models/user.rb")
+    @Test func stripsOneSegmentPerCall() {
+        #expect("app/models/user.rb:12:5".strippingTrailingLineSuffix() == "app/models/user.rb:12")
+    }
+
+    @Test func stripsRangeBeforeColumn() {
+        #expect("report.md:10-20:5".strippingTrailingLineSuffix() == "report.md:10-20")
     }
 
     @Test func stripsFromAbsolutePath() {
@@ -280,10 +284,8 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         #expect(":144".strippingTrailingLineSuffix() == nil)
     }
 
-    @Test func stripsAtMostTwoSegments() {
-        // `:8` and `:16` come off; `:4` is left so genuine path components with
-        // numeric names are not eaten wholesale.
-        #expect("/tmp/a:4:8:16".strippingTrailingLineSuffix() == "/tmp/a:4")
+    @Test func ignoresColonAtStartOfToken() {
+        #expect(":12".strippingTrailingLineSuffix() == nil)
     }
 }
 
@@ -357,6 +359,89 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
                 "src/main.py:1292",
                 cwd: "/tmp/cmux-linesuffix"
             ) == path
+        )
+    }
+}
+
+@Suite struct TerminalLineSuffixCandidateDepthTests {
+    /// Every stripping depth is probed, so an intermediate spelling that really
+    /// exists wins over the fully stripped one.
+    @Test func prefersIntermediateSpellingThatReallyExists() {
+        let intermediate = "/tmp/cmux-linesuffix/backup:2024"
+        let fullyStripped = "/tmp/cmux-linesuffix/backup"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([intermediate, fullyStripped]))
+                .resolveQuicklookPath("\(intermediate):7", cwd: "/tmp") == intermediate
+        )
+    }
+
+    @Test func fallsBackToFullyStrippedWhenIntermediateIsAbsent() {
+        let fullyStripped = "/tmp/cmux-linesuffix/backup"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([fullyStripped]))
+                .resolveQuicklookPath("\(fullyStripped):2024:7", cwd: "/tmp") == fullyStripped
+        )
+    }
+
+    @Test func prefersIntermediateSpellingForRangeThenColumn() {
+        let intermediate = "/tmp/cmux-linesuffix/report.md:10-20"
+        let fullyStripped = "/tmp/cmux-linesuffix/report.md"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([intermediate, fullyStripped]))
+                .resolveQuicklookPath("\(intermediate):5", cwd: "/tmp") == intermediate
+        )
+    }
+
+    @Test func stopsAfterTwoDepths() {
+        // `:8` and `:16` come off; `:4` stays, so numeric path components are
+        // not eaten wholesale.
+        let path = "/tmp/cmux-linesuffix/a:4"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path]))
+                .resolveQuicklookPath("\(path):8:16", cwd: "/tmp") == path
+        )
+    }
+}
+
+@Suite struct TerminalOpenURLBareFilenameTests {
+    /// `URL(string: "main.py:1292")?.scheme` is `main.py`, so the scheme guard
+    /// used to reject bare filenames carrying a line reference.
+    @Test func resolvesBareFilenameWithLineNumber() {
+        let path = "/tmp/cmux-linesuffix/main.py"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveOpenURLFilePath(
+                "main.py:1292",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == path
+        )
+    }
+
+    @Test func resolvesExtensionlessBareFilenameWithLineNumber() {
+        let path = "/tmp/cmux-linesuffix/README"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveOpenURLFilePath(
+                "README:12",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == path
+        )
+    }
+
+    @Test func stillRejectsRealURLWithPort() {
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([])).resolveOpenURLFilePath(
+                "http://example.com:8080",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == nil
+        )
+    }
+
+    @Test func stillRejectsFileURL() {
+        #expect(
+            TerminalPathResolver(fileExists: existsIn(["/tmp/cmux-linesuffix/main.py"]))
+                .resolveOpenURLFilePath(
+                    "file:///tmp/cmux-linesuffix/main.py",
+                    cwd: "/tmp/cmux-linesuffix"
+                ) == nil
         )
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -239,3 +239,124 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 }
+
+@Suite struct TerminalPathLineSuffixTests {
+    @Test func stripsLineNumber() {
+        #expect("src/main.py:1292".strippingTrailingLineSuffix() == "src/main.py")
+    }
+
+    @Test func stripsLineRange() {
+        #expect(
+            "docs/synthetic-monitoring.md:144-198".strippingTrailingLineSuffix()
+                == "docs/synthetic-monitoring.md"
+        )
+    }
+
+    @Test func stripsLineAndColumn() {
+        #expect("app/models/user.rb:12:5".strippingTrailingLineSuffix() == "app/models/user.rb")
+    }
+
+    @Test func stripsFromAbsolutePath() {
+        #expect("/tmp/fixtures/notes.md:7".strippingTrailingLineSuffix() == "/tmp/fixtures/notes.md")
+    }
+
+    @Test func ignoresPathWithoutLineSuffix() {
+        #expect("docs/synthetic-monitoring.md".strippingTrailingLineSuffix() == nil)
+    }
+
+    @Test func ignoresNonNumericFinalSegment() {
+        #expect("/tmp/fixtures/notes.md:draft".strippingTrailingLineSuffix() == nil)
+    }
+
+    @Test func ignoresTrailingColonWithoutDigits() {
+        #expect("/tmp/fixtures/notes.md:".strippingTrailingLineSuffix() == nil)
+    }
+
+    @Test func ignoresDigitsWithoutColon() {
+        #expect("/tmp/fixtures/chapter2".strippingTrailingLineSuffix() == nil)
+    }
+
+    @Test func ignoresBareLineReferenceWithNoPath() {
+        #expect(":144".strippingTrailingLineSuffix() == nil)
+    }
+
+    @Test func stripsAtMostTwoSegments() {
+        // `:8` and `:16` come off; `:4` is left so genuine path components with
+        // numeric names are not eaten wholesale.
+        #expect("/tmp/a:4:8:16".strippingTrailingLineSuffix() == "/tmp/a:4")
+    }
+}
+
+@Suite struct TerminalQuicklookLineSuffixResolutionTests {
+    @Test func resolvesRelativePathWithLineNumber() {
+        let path = "/tmp/cmux-linesuffix/src/main.py"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveQuicklookPath(
+                "src/main.py:1292",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == path
+        )
+    }
+
+    @Test func resolvesRelativePathWithLineRange() {
+        let path = "/tmp/cmux-linesuffix/docs/notes.md"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveQuicklookPath(
+                "docs/notes.md:144-198",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == path
+        )
+    }
+
+    @Test func resolvesAbsolutePathWithLineAndColumn() {
+        let path = "/tmp/cmux-linesuffix/app/user.rb"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveQuicklookPath(
+                "\(path):12:5",
+                cwd: "/tmp"
+            ) == path
+        )
+    }
+
+    @Test func resolvesLineSuffixFollowedByTrailingPunctuation() {
+        let path = "/tmp/cmux-linesuffix/docs/notes.md"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveQuicklookPath(
+                "\(path):144).",
+                cwd: "/tmp"
+            ) == path
+        )
+    }
+
+    @Test func prefersLiteralPathThatReallyEndsWithLineSuffix() {
+        let literalPath = "/tmp/cmux-linesuffix/backup:2024"
+        let strippedPath = "/tmp/cmux-linesuffix/backup"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([literalPath, strippedPath])).resolveQuicklookPath(
+                literalPath,
+                cwd: "/tmp"
+            ) == literalPath
+        )
+    }
+
+    @Test func stillReturnsNilWhenNeitherSpellingExists() {
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([])).resolveQuicklookPath(
+                "src/missing.py:10",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == nil
+        )
+    }
+}
+
+@Suite struct TerminalOpenURLLineSuffixTests {
+    @Test func openURLResolvesPathWithLineNumber() {
+        let path = "/tmp/cmux-linesuffix/src/main.py"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([path])).resolveOpenURLFilePath(
+                "src/main.py:1292",
+                cwd: "/tmp/cmux-linesuffix"
+            ) == path
+        )
+    }
+}


### PR DESCRIPTION
Fixes #9830.

## Summary

Cmd-clicking a `path:line` reference in a cmux terminal — the format every compiler, linter, and AI coding agent prints — opened `https://path:line` in the system browser instead of the file. `cmux open "path:line"` failed the same way.

## Root cause

`pathResolutionCandidates()` in `String+TerminalPathTokens.swift` generates the spellings that `TerminalPathResolver` probes against the filesystem. It trims trailing sentence punctuation, quotes, and bracket pairs, but never a trailing `:<digits>` run — so the existence check ran against the literal `src/main.py:1292`, found nothing, and `resolveOpenURLFilePath` returned nil.

Control then reached `BrowserURLResolver.navigableURL(from:)`:

```swift
if trimmed.contains(":") || trimmed.contains("/") || trimmed.contains(".") {
    return URL(string: "https://\(trimmed)")
}
```

which produced the `https://src/main.py:1292` that ended up in the browser.

## Change

Adds `String.strippingTrailingLineSuffix()` and probes it as an additional candidate. It handles `:line`, `:line:column`, and `:startLine-endLine`, matches ASCII digits only (so a non-numeric final segment like `notes.md:draft` is left alone), and removes at most two segments so genuine path components aren't eaten.

It's applied to both the raw token and the punctuation-trimmed one, so `notes.md:144).` resolves too.

**Non-regressive by construction:** `resolveQuicklookPath` returns the first *existing* candidate, and the new candidates are appended last. Any input that resolved before resolves to the same path — the change can only turn a `nil` into a hit. A file genuinely named `backup:2024` still wins over `backup`, mirroring the existing `prefersLiteralPathThatReallyEndsWithDot` / `...Paren` invariants.

## Scope

Deliberately limited to the `:line` half of #9830. Two things left out:

- **`file://` mangling** (Repro 2 in the issue) — separate defect in a different code path.
- **Jumping to the line** once the file opens. The suffix is parsed and discarded here; threading the line number through to the preview would touch `TerminalLinkOpenCoordinator` and the file-opening protocol. Happy to follow up if wanted.

## Testing

26 tests added to `TerminalPathResolverTests.swift` (24 → 50), in the existing Swift Testing style and reusing the `existsIn` helper: single-segment stripping, ranges and columns, negative cases (non-numeric segment, bare colon, digits without colon, leading-colon token), resolver-level resolution for relative and absolute paths, punctuation-after-suffix, candidate-depth ordering, bare-filename open-URL resolution, and the literal-path-wins invariants.

**Disclosure on how this was verified.** The `CmuxTerminalCore` library target builds cleanly in-tree under the package's real settings (Swift 6 language mode, `ExistentialAny`, `InternalImportsByDefault`), and the test file passes `swiftc -parse`. I was **not** able to run `swift test`: this machine has Command Line Tools but not full Xcode, and `_Testing_Foundation` — the cross-import overlay `import Testing` needs — ships only with Xcode. To verify behavior I compiled `String+TerminalPathTokens.swift` and `TerminalPathResolver.swift` standalone with the same flags and ran every assertion, including four ported from the existing suite as regression checks: 30/30 pass. So the logic is verified but the suite has not been executed as Swift Testing — worth a reviewer running it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file path recognition for references with line numbers, line ranges, and line-and-column locations.
  * Supports paths with trailing punctuation while preserving valid matching files.
  * Resolves annotated paths for Quick Look and open-in-editor actions, including bare filenames.

* **Bug Fixes**
  * Prevents invalid or incomplete line suffixes from being interpreted as file paths.
  * Preserves literal files whose names legitimately end with numeric segments.
  * Continues rejecting genuine web and file URLs as local paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->