### PR TITLE
cmux-tui SDKs: expect 103 commands after client-focus-v1

### DIFF
--- a/cmux-tui/bindings/cpp/tests/test_generated.cpp
+++ b/cmux-tui/bindings/cpp/tests/test_generated.cpp
@@ -84,7 +84,7 @@ static_assert(std::is_same_v<
 static_assert(!std::is_copy_constructible_v<cmux::raw::EventStream>);
 static_assert(std::is_move_constructible_v<cmux::raw::EventStream>);
 
-constexpr std::size_t kExpectedRawCommandCount = 101U;
+constexpr std::size_t kExpectedRawCommandCount = 103U;
 constexpr std::array<std::string_view, 4> kViewportHistoryCommandNames{
     "clear-history",
     "new-pane-right",

--- a/cmux-tui/bindings/go/raw/client_test.go
+++ b/cmux-tui/bindings/go/raw/client_test.go
@@ -20,8 +20,8 @@ import (
 
 func TestGeneratedInventoryHasTypedMethodForEveryCommand(t *testing.T) {
 	commands := AllCommandMetadata()
-	if len(commands) != 101 {
-		t.Fatalf("generated commands = %d, want 101", len(commands))
+	if len(commands) != 103 {
+		t.Fatalf("generated commands = %d, want 103", len(commands))
 	}
 	clientType := reflect.TypeOf((*Client)(nil))
 	commandNames := make(map[string]struct{}, len(commands))

--- a/cmux-tui/bindings/java/tests/com/cmux/raw/GeneratedCoverageTest.java
+++ b/cmux-tui/bindings/java/tests/com/cmux/raw/GeneratedCoverageTest.java
@@ -20,7 +20,7 @@ public final class GeneratedCoverageTest {
     public static void main(String[] args) throws Exception {
         check(Protocol.VERSION == 12, "protocol version");
         check("1.0.0".equals(Protocol.SDK_VERSION), "SDK release version");
-        check(Commands.ALL.size() == 101, "all 101 commands generated");
+        check(Commands.ALL.size() == 103, "all 103 commands generated");
         check(Events.ALL.size() == 46, "all 46 events generated");
 
         Map<String, Method> methods = Arrays.stream(GeneratedCmuxClient.class.getDeclaredMethods())

--- a/cmux-tui/bindings/python/tests/test_protocol.py
+++ b/cmux-tui/bindings/python/tests/test_protocol.py
@@ -22,7 +22,7 @@ from cmux.raw._generated.metadata import COMMANDS, EVENTS, IR_SHA256
 class GeneratedProtocolTests(unittest.TestCase):
     def test_protocol_inventory_is_exhaustive(self) -> None:
         self.assertEqual(MUX_PROTOCOL, 12)
-        self.assertEqual(len(COMMANDS), 101)
+        self.assertEqual(len(COMMANDS), 103)
         self.assertEqual(set(COMMANDS), set(SCHEMA["commands"]))
         self.assertEqual(set(EVENTS), set(SCHEMA["events"]))
         self.assertEqual(len(IR_SHA256), 64)

--- a/cmux-tui/bindings/typescript/test/generated.test.ts
+++ b/cmux-tui/bindings/typescript/test/generated.test.ts
@@ -12,7 +12,7 @@ import {
 test("generated protocol coverage matches the canonical v12 IR", () => {
   assert.equal(MUX_PROTOCOL_VERSION, 12);
   assert.equal(SDK_SCHEMA_VERSION, 2);
-  assert.equal(Object.keys(COMMAND_METADATA).length, 101);
+  assert.equal(Object.keys(COMMAND_METADATA).length, 103);
   assert.equal(Object.keys(EVENT_METADATA).length, 46);
   assert.equal(SDK_IR_SHA256.length, 64);
   assert.deepEqual(Object.keys(PROFILES).sort(), [

--- a/cmux-tui/bindings/zig/examples/watch.zig
+++ b/cmux-tui/bindings/zig/examples/watch.zig
@@ -126,7 +126,7 @@ test "package consumer imports handwritten root and generated raw module" {
         wheel.pointer_frame_seq,
     );
     try std.testing.expectEqual(
-        @as(usize, 101),
+        @as(usize, 103),
         cmux.raw.protocol.command_count,
     );
     try std.testing.expectEqual(

--- a/cmux-tui/bindings/zig/src/raw.zig
+++ b/cmux-tui/bindings/zig/src/raw.zig
@@ -44,7 +44,7 @@ test {
     _ = @import("raw/wire_presence_test.zig");
     _ = @import("raw/generated/presence_test.zig");
     std.testing.refAllDecls(protocol);
-    try std.testing.expectEqual(@as(usize, 101), protocol.command_count);
+    try std.testing.expectEqual(@as(usize, 103), protocol.command_count);
     for ([_][]const u8{
         "browser-frame-presented",
         "browser-key-press",


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/commit/980f8e80c7 (client-focus-v1) added `report-focus` and `client-focus` to the command inventory and regenerated every binding, but the seven per-language coverage assertions still expect 101 commands, so the `cmux-tui SDKs` workflow fails on main at each language's count fatal. This bumps the assertions to 103. Event count stays 46 and the frozen v10/v11 conformance baselines are untouched; `bindings/generate.sh` is a no-op on this base, confirming the generated code already matches the inventory.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789875546&installation_model_id=21920&pr_number=10516&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10516&signature=5c996a63dc3a08a788f19980adba3bd2d645a961cd54109702d9d1dea82174a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns all SDK coverage assertions with the current inventory by bumping the expected command count from 101 to 103, reflecting the addition of `report-focus` and `client-focus`. This fixes the failing checks in the `cmux-tui` SDK workflow.

- Updates tests/examples in Go, TypeScript, Python, Java, C++, and Zig only; `bindings/generate.sh` is a no-op (generated code already matches).
- Protocol stays v12; event count remains 46; frozen v10/v11 conformance baselines are unchanged.
- No migration required for SDK consumers.

<sup>Written for commit da727e8f5f1605fab9d5dad61f13818b691557e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated protocol coverage checks across supported language bindings to reflect the current command inventory.
  - Added recognition for two newly generated protocol commands, increasing the expected total from 101 to 103.
  - Synchronized package-consumer validation with the updated command count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->