### PR TITLE
fix(ios): restore terminal output sink conformance

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -12894,11 +12894,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// to current state; ending iteration (or cancelling the consuming task)
     /// unregisters the surface and clears its viewport pin on the Mac.
     /// - Parameter surfaceID: The terminal surface identifier.
+    /// - Returns: An `AsyncStream` of output byte chunks.
+    public func terminalOutputStream(
+        surfaceID: String
+    ) -> AsyncStream<MobileTerminalOutputChunk> {
+        terminalOutputStream(surfaceID: surfaceID, ownerID: nil)
+    }
+
+    /// The owner-aware output stream for a terminal surface.
+    ///
+    /// - Parameter surfaceID: The terminal surface identifier.
     /// - Parameter ownerID: Optional identity for the mounted UI consumer.
     /// - Returns: An `AsyncStream` of output byte chunks.
     public func terminalOutputStream(
         surfaceID: String,
-        ownerID: UUID? = nil
+        ownerID: UUID?
     ) -> AsyncStream<MobileTerminalOutputChunk> {
         AsyncStream { continuation in
             let streamToken = registerTerminalOutput(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit)
 import CMUXMobileCore
 import CmuxAgentChat
+import CmuxMobileDiagnostics
 import CmuxMobileShell
 import CmuxMobileSupport
 import CmuxMobileTerminal
@@ -766,7 +767,10 @@ extension GhosttySurfaceRepresentable.Coordinator {
             outputConsumerRecoveryOverlay = overlay
         }
 
-        private func removeOutputConsumerRecoveryOverlay() {
+        // This teardown helper is shared with the coordinator lifecycle in
+        // GhosttySurfaceRepresentable.swift, so it must remain visible across
+        // the two extension files.
+        func removeOutputConsumerRecoveryOverlay() {
             outputConsumerRecoveryOverlay?.removeFromSuperview()
             outputConsumerRecoveryOverlay = nil
         }


### PR DESCRIPTION
The merged terminal replay fix changed `MobileShellComposite.terminalOutputStream` to accept an optional owner ID. Swift default arguments do not satisfy the existing one-argument `MobileTerminalOutputSinking` protocol requirement, so the CMUX INTERNAL TestFlight workflow fails during compilation.

Add the required one-argument overload and forward it to the owner-aware implementation with a nil owner. Remove the default from the owner-aware overload so the two entry points are unambiguous.

Failure: https://github.com/manaflow-ai/cmux/actions/runs/32442338943

Verification: `git diff --check`; no tests added or run per request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789876720&installation_model_id=21920&pr_number=10517&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10517&signature=d20b4819ae8235afeb0e014c3b72a83faee023f96192d5e22bae40e435ba55c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores iOS conformance to `MobileTerminalOutputSinking` and unblocks the INTERNAL TestFlight build. Also fixes a Shell UI compile error by making the recovery overlay teardown helper visible across extensions.

- Reintroduces terminalOutputStream(surfaceID:) and forwards to terminalOutputStream(surfaceID:ownerID:) with nil.
- Removes the default from ownerID to avoid overload ambiguity.
- Exposes removeOutputConsumerRecoveryOverlay() for cross-file use and adds `CmuxMobileDiagnostics` import.
- No runtime behavior change; existing call sites continue to compile. To specify an owner, call the two-parameter overload.

<sup>Written for commit 174b9ef88e1989cf186648286badc8fd370761c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output stream access for more reliable shell integration.
  * Enhanced recovery overlay handling during terminal output disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->