### PR TITLE
Fix iOS pairing across multiple Mac DEV builds

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
@@ -25,6 +25,9 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
     /// The Mac app instance's authoritative route tag. `nil` from older Macs
     /// that predate per-instance route authority.
     public let macInstanceTag: String?
+    /// The Mac app bundle namespace used by the trust broker. `nil` from older
+    /// Macs that predate namespace-aware authenticated host status.
+    public let macClientNamespace: String?
     /// Process-unique epoch for the Mac's terminal-theme revision counter.
     /// A changed value tells iOS that low revisions belong to a new producer.
     public let terminalThemeRevisionEpoch: String?
@@ -49,6 +52,7 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
         case macDisplayName = "mac_display_name"
         case macDeviceID = "mac_device_id"
         case macInstanceTag = "mac_instance_tag"
+        case macClientNamespace = "mac_client_namespace"
         case terminalThemeRevisionEpoch = "terminal_theme_revision_epoch"
         case macAppVersion = "mac_app_version"
         case macAppBuild = "mac_app_build"
@@ -64,6 +68,7 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
         macDeviceID = try container.decodeIfPresent(String.self, forKey: .macDeviceID)
             .map(cmxCanonicalDeviceID)
         macInstanceTag = try container.decodeIfPresent(String.self, forKey: .macInstanceTag)
+        macClientNamespace = try container.decodeIfPresent(String.self, forKey: .macClientNamespace)
         terminalThemeRevisionEpoch = try container.decodeIfPresent(String.self, forKey: .terminalThemeRevisionEpoch)
         macAppVersion = try container.decodeIfPresent(String.self, forKey: .macAppVersion)
         macAppBuild = try container.decodeIfPresent(String.self, forKey: .macAppBuild)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileDiscoveredIrohMac.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileDiscoveredIrohMac.swift
@@ -13,6 +13,8 @@ public struct MobileDiscoveredIrohMac: Equatable, Sendable {
     public let displayName: String?
     /// Exact running cmux app-instance tag asserted by the broker.
     public let instanceTag: String
+    /// Exact bundle-derived Mac namespace asserted by the broker.
+    public let clientNamespace: String
     /// Iroh-pinned routes for this endpoint.
     public let routes: [CmxAttachRoute]
     /// Capabilities asserted by the authenticated broker binding.
@@ -27,7 +29,8 @@ public struct MobileDiscoveredIrohMac: Equatable, Sendable {
         instanceTag: String,
         routes: [CmxAttachRoute],
         lastSeenAt: Date,
-        capabilities: [String] = []
+        capabilities: [String] = [],
+        clientNamespace: String = "legacy"
     ) {
         let identity = CmxMacAppInstanceIdentity(
             macDeviceID: deviceID,
@@ -36,6 +39,7 @@ public struct MobileDiscoveredIrohMac: Equatable, Sendable {
         self.deviceID = identity.macDeviceID
         self.displayName = displayName
         self.instanceTag = identity.instanceTag ?? ""
+        self.clientNamespace = clientNamespace
         self.routes = routes
         self.lastSeenAt = lastSeenAt
         self.capabilities = capabilities

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -8,45 +8,20 @@ internal import Foundation
 /// while this policy supplies the compatibility boundary used by persistence,
 /// registry projection, and live connection validation.
 public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
-    /// A tagged development build may use its matching Mac tag plus an explicit
-    /// set of sibling tags baked into that build. The additional set is empty by
-    /// default, preserving per-tag isolation for ordinary development builds.
-    case development(
-        expectedInstanceTag: String,
-        additionalInstanceTags: Set<String>
-    )
+    /// A development iOS build may use any authenticated development Mac tag.
+    /// The exact tag remains part of each Mac's identity; this case only defines
+    /// the development build lane.
+    case development
     /// A distributed iOS build may use Stable and Nightly Mac releases.
     case official
 
-    public static func development(
-        expectedInstanceTag: String
-    ) -> MobileMacBuildCompatibilityPolicy {
-        .development(
-            expectedInstanceTag: expectedInstanceTag,
-            additionalInstanceTags: []
-        )
-    }
-
     /// Resolves the policy compiled into the running iOS app.
     ///
-    /// - Parameters:
-    ///   - buildScope: The tagged development scope, when this is a tagged DEBUG build.
-    ///   - compatibleMacTags: Comma-separated sibling Mac tags intentionally
-    ///     admitted by this development build.
-    /// - Returns: Explicit development compatibility for DEBUG builds and official
+    /// - Returns: Development-lane compatibility for DEBUG builds and official
     ///   compatibility for distributed builds.
-    public static func current(
-        buildScope: MobileIOSBuildScope?,
-        compatibleMacTags: String? = nil
-    ) -> MobileMacBuildCompatibilityPolicy {
+    public static func current() -> MobileMacBuildCompatibilityPolicy {
         #if DEBUG
-        let additionalTags = Set((compatibleMacTags ?? "")
-            .split(separator: ",")
-            .map(String.init))
-        return .development(
-            expectedInstanceTag: buildScope?.value ?? "dev",
-            additionalInstanceTags: additionalTags
-        )
+        return .development
         #else
         return .official
         #endif
@@ -62,13 +37,8 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
     public func allows(instanceTag: String?) -> Bool {
         guard let normalizedTag = Self.normalized(instanceTag) else { return false }
         switch self {
-        case let .development(expectedInstanceTag, additionalInstanceTags):
-            if normalizedTag == Self.normalized(expectedInstanceTag) {
-                return true
-            }
-            return additionalInstanceTags.contains {
-                normalizedTag == Self.normalized($0)
-            }
+        case .development:
+            return normalizedTag != "default" && normalizedTag != "nightly"
         case .official:
             return normalizedTag == "default" || normalizedTag == "nightly"
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -8,6 +8,13 @@ internal import Foundation
 /// while this policy supplies the compatibility boundary used by persistence,
 /// registry projection, and live connection validation.
 public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
+    private static let nonDevelopmentTags: Set<String> = [
+        "default",
+        "nightly",
+        "rc",
+        "staging",
+    ]
+
     /// A development iOS build may use any authenticated development Mac tag.
     /// The exact tag remains part of each Mac's identity; this case only defines
     /// the development build lane.
@@ -46,7 +53,7 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
                !Self.isDevelopmentMacNamespace(clientNamespace) {
                 return false
             }
-            return normalizedTag != "default" && normalizedTag != "nightly"
+            return !Self.nonDevelopmentTags.contains(normalizedTag)
         case .official:
             if let clientNamespace,
                clientNamespace != "legacy",

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -34,14 +34,38 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
     ///
     /// - Parameter instanceTag: The tag reported by authenticated host status.
     /// - Returns: `true` only when the Mac instance is compatible.
-    public func allows(instanceTag: String?) -> Bool {
+    public func allows(
+        instanceTag: String?,
+        clientNamespace: String? = nil
+    ) -> Bool {
         guard let normalizedTag = Self.normalized(instanceTag) else { return false }
         switch self {
         case .development:
+            if let clientNamespace,
+               clientNamespace != "legacy",
+               !Self.isDevelopmentMacNamespace(clientNamespace) {
+                return false
+            }
             return normalizedTag != "default" && normalizedTag != "nightly"
         case .official:
+            if let clientNamespace,
+               clientNamespace != "legacy",
+               !Self.isOfficialMacNamespace(clientNamespace) {
+                return false
+            }
             return normalizedTag == "default" || normalizedTag == "nightly"
         }
+    }
+
+    private static func isDevelopmentMacNamespace(_ value: String) -> Bool {
+        value == "mac:com.cmuxterm.app.debug"
+            || value.hasPrefix("mac:com.cmuxterm.app.debug.")
+    }
+
+    private static func isOfficialMacNamespace(_ value: String) -> Bool {
+        value == "mac:com.cmuxterm.app"
+            || value == "mac:com.cmuxterm.app.nightly"
+            || value.hasPrefix("mac:com.cmuxterm.app.nightly.")
     }
 
     /// Returns whether authenticated host status is compatible with this build.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -83,10 +83,17 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
     /// fail-closed, as do development builds and newer untagged Mac releases.
     public func allowsAuthenticatedHost(
         instanceTag: String?,
+        clientNamespace: String? = nil,
         macAppVersion: String?,
         usesLocallyAuthorizedTailscaleRoute: Bool
     ) -> Bool {
-        if allows(instanceTag: instanceTag) {
+        if case .development = self, clientNamespace == nil {
+            // Direct pairing has no broker binding to supply the Mac bundle
+            // namespace. Require host status to carry it so manual and QR
+            // routes enforce the same channel boundary as discovery.
+            return false
+        }
+        if allows(instanceTag: instanceTag, clientNamespace: clientNamespace) {
             return true
         }
         guard case .official = self,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -399,7 +399,7 @@ extension MobilePairingFailureCategory {
             if macChannelIsRelease {
                 return L10n.string(
                     "mobile.pairing.guidance.authEnvironment",
-                    defaultValue: "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use this DEV app with a Mac that has the same DEV tag."
+                    defaultValue: "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use a DEV iPhone build with any DEV Mac build."
                 )
             }
             // Reaches production users (TestFlight/App Store scanning a dev
@@ -411,7 +411,7 @@ extension MobilePairingFailureCategory {
         case .buildIncompatible:
             return L10n.string(
                 "mobile.pairing.guidance.buildIncompatible",
-                defaultValue: "DEV builds must use the same DEV tag. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
+                defaultValue: "DEV iPhone builds connect to any DEV Mac build. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
             )
         case .ticketExpired, .unsupportedRoute, .noSupportedRoute:
             return L10n.string(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
@@ -13,11 +13,13 @@ extension MobileShellComposite {
     /// narrow 0.64.17 Tailscale compatibility boundary.
     func authenticatedMacBuildIsCompatible(
         instanceTag: String?,
+        clientNamespace: String? = nil,
         macAppVersion: String?,
         client: MobileCoreRPCClient
     ) -> Bool {
         buildCompatibilityPolicy?.allowsAuthenticatedHost(
             instanceTag: instanceTag,
+            clientNamespace: clientNamespace,
             macAppVersion: macAppVersion,
             usesLocallyAuthorizedTailscaleRoute: client.usesLocallyAuthorizedTailscaleRoute
         ) ?? true

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -426,8 +426,7 @@ extension MobileShellComposite {
         // but the other Macs are a read-only snapshot. Re-aggregate them on
         // foreground so workspaces created on another Mac while backgrounded
         // appear without a manual pull-to-refresh.
-        if multiMacAggregationEnabled,
-           connectionState == .connected,
+        if connectionState == .connected,
            remoteClient != nil {
             self.scheduleSecondaryAggregation(discoverLivePeers: true)
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4239,6 +4239,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 deviceID: payload.macDeviceID,
                 displayName: payload.macDisplayName,
                 instanceTag: payload.macInstanceTag,
+                clientNamespace: payload.macClientNamespace,
                 macAppVersion: payload.macAppVersion
             )
         }
@@ -4260,6 +4261,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         deviceID: String?,
         displayName: String?,
         instanceTag: String?,
+        clientNamespace: String? = nil,
         macAppVersion: String? = nil
     ) async {
         guard remoteClient === client,
@@ -4303,6 +4305,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let resolvedTag = instanceTag?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard authenticatedMacBuildIsCompatible(
             instanceTag: resolvedTag,
+            clientNamespace: clientNamespace,
             macAppVersion: macAppVersion,
             client: client
         ) else {
@@ -9318,6 +9321,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     let reportedInstanceTag = hasAuthenticatedIdentity ? status.macInstanceTag : nil
                     guard authenticatedMacBuildIsCompatible(
                         instanceTag: reportedInstanceTag,
+                        clientNamespace: status.macClientNamespace,
                         macAppVersion: status.macAppVersion,
                         client: client
                     ) else {
@@ -11796,6 +11800,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 deviceID: payload.macDeviceID,
                 displayName: payload.macDisplayName,
                 instanceTag: payload.macInstanceTag,
+                clientNamespace: payload.macClientNamespace,
                 macAppVersion: payload.macAppVersion
             )
             guard isCurrentRemoteConnection(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2714,7 +2714,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return .superseded
         }
         if let outcome = race.value {
-            if outcome.didConnect, multiMacAggregationEnabled {
+            if outcome.didConnect {
                 // Start secondary dials only after the bounded foreground
                 // operation has handed ownership back to this shared entry.
                 // This preserves foreground-first ordering even though the
@@ -3453,7 +3453,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Presence is the pool's membership authority. Reconcile on every
         // online/offline/snapshot/routes transition so offline Macs stop
         // consuming battery and newly online Macs are warmed immediately.
-        if presence != nil, multiMacAggregationEnabled {
+        if presence != nil {
             switch update {
             case .seen:
                 break
@@ -3534,8 +3534,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     await routeSyncTask.value
                     guard !Task.isCancelled else { return }
                     guard await self.isScopeCurrent(scope),
-                          self.presence != nil,
-                          self.multiMacAggregationEnabled else {
+                          self.presence != nil else {
                         return
                     }
                     // The scope check suspends. Drain any route operation that
@@ -5116,7 +5115,29 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         allowsNewConnections: Bool = true,
         discoverLivePeers: Bool = false
     ) async {
-        guard let pairedMacStore, multiMacAggregationEnabled else { return }
+        guard let pairedMacStore else { return }
+        if !multiMacAggregationEnabled {
+            // The aggregation preference controls ongoing workspace fan-out,
+            // not account admission. A legacy install may have this switch
+            // persisted as false, but opening the app must still discover and
+            // persist every authenticated Mac instance so Computer Order is
+            // complete without a QR per build.
+            guard discoverLivePeers,
+                  connectionState == .connected,
+                  remoteClient != nil,
+                  let scope = await currentScopeSnapshot(),
+                  await isAggregationScopeValid(scope) else { return }
+            let loadedMacs = (try? await pairedMacStore.loadAll(
+                stackUserID: scope.userID,
+                teamID: scope.teamID
+            )) ?? []
+            guard await isAggregationScopeValid(scope) else { return }
+            await establishDiscoveredSecondaryIrohMacs(
+                scope: scope,
+                excluding: loadedMacs
+            )
+            return
+        }
         let retryEvidenceGenerationAtStart =
             secondaryAggregationRetryEvidenceGeneration
         // Require a concrete signed-in user before any load/connection: a nil/empty
@@ -9601,7 +9622,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     }
                     // Aggregate the user's other Macs' workspaces in the background.
                     // Best-effort; never blocks the foreground connect.
-                    if multiMacAggregationEnabled, !isReconnectingStoredMac {
+                    if !isReconnectingStoredMac {
                         self.scheduleSecondaryAggregation(
                             discoverLivePeers: true
                         )
@@ -13728,7 +13749,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // Re-aggregate the other Macs too, so pull-to-refresh surfaces
             // workspaces created on a secondary Mac since the last fetch (the
             // read-only secondary list is a snapshot, not a live subscription).
-            if self?.multiMacAggregationEnabled == true {
+            if self?.connectionState == .connected,
+               self?.remoteClient != nil {
                 await self?.refreshSecondaryMacWorkspaces(
                     discoverLivePeers: true
                 )

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -122,13 +122,12 @@ import Testing
         #expect(rows.first?.teamID == nil)
     }
 
-    @Test func buildScopeHidesSiblingTagAndMatchingLegacyPeer() async throws {
+    @Test func buildScopeKeepsSiblingTagsAndHidesMatchingLegacyPeer() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
-        let feature = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "feature"
-        ).scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
+        let feature = MobileMacBuildCompatibilityPolicy.development
+            .scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
 
         try await feature.upsert(
             macDeviceID: "mac-a",
@@ -163,7 +162,7 @@ import Testing
 
         let rows = try await feature.loadAll(stackUserID: "user-1", teamID: "team-a")
 
-        #expect(rows.map(\.instanceTag) == ["feature"])
+        #expect(Set(rows.compactMap(\.instanceTag)) == ["feature", "other"])
     }
 
     @Test func compatibleSiblingTagsSurviveFullBuildScopeDecoratorRail() async throws {
@@ -173,10 +172,7 @@ import Testing
             inner: inner,
             scope: try #require(MobileIOSBuildScope("phand1"))
         )
-        let production = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "phand1",
-            additionalInstanceTags: ["phand2", "phand3"]
-        ).scoping(scoped)
+        let production = MobileMacBuildCompatibilityPolicy.development.scoping(scoped)
 
         for (index, tag) in ["phand1", "phand2", "phand3"].enumerated() {
             try await production.upsert(
@@ -200,13 +196,12 @@ import Testing
         ])
     }
 
-    @Test func newerTeamlessSiblingTagIsNotVisibleOrActive() async throws {
+    @Test func newerTeamlessSiblingTagIsVisibleWithoutStealingActiveSelection() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
-        let feature = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "feature"
-        ).scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
+        let feature = MobileMacBuildCompatibilityPolicy.development
+            .scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
         try await feature.upsert(
             macDeviceID: "mac-a",
             displayName: "Selected",
@@ -231,7 +226,7 @@ import Testing
         let rows = try await feature.loadAll(
             stackUserID: "user-1", teamID: "team-a"
         )
-        #expect(rows.count == 1)
+        #expect(Set(rows.compactMap(\.instanceTag)) == ["feature", "feature-b"])
         let selected = try #require(rows.first { $0.instanceTag == "feature" })
         #expect(selected.teamID == "team-a")
         #expect(selected.routes == [try route("10.0.0.1")])
@@ -470,9 +465,7 @@ import Testing
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
         let scoped = IOSBuildScopedPairedMacStore(inner: inner, scope: scope)
-        let stack = MobileMacBuildCompatibilityPolicy
-            .development(expectedInstanceTag: "feature")
-            .scoping(scoped)
+        let stack = MobileMacBuildCompatibilityPolicy.development.scoping(scoped)
 
         // A team-scoped row for the device, written through the full rail.
         try await stack.upsert(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -283,10 +283,7 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
-            buildCompatibilityPolicy: .development(
-                expectedInstanceTag: "phand1",
-                additionalInstanceTags: ["phand2", "phand3"]
-            ),
+            buildCompatibilityPolicy: .development,
             personalIrohDiscovery: ScriptedIrohDiscovery(
                 snapshots: [candidates]
             ),
@@ -392,10 +389,7 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
-            buildCompatibilityPolicy: .development(
-                expectedInstanceTag: "phand1",
-                additionalInstanceTags: ["phand2", "phand3"]
-            ),
+            buildCompatibilityPolicy: .development,
             personalIrohDiscovery: ScriptedIrohDiscovery(
                 snapshots: [candidates]
             ),

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -328,6 +328,89 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func zeroTouchAdmissionStillRunsWhenWorkspaceAggregationWasPreviouslyDisabled() async throws {
+        let candidates = [
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "a",
+                instanceTag: "phand1",
+                routeID: "iroh-phand1"
+            ),
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "b",
+                instanceTag: "phand2",
+                routeID: "iroh-phand2"
+            ),
+        ]
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        var routers: [String: LivenessHostRouter] = [:]
+        for candidate in candidates {
+            let router = LivenessHostRouter()
+            await router.setHostIdentity(
+                deviceID: candidate.deviceID,
+                instanceTag: candidate.instanceTag,
+                displayName: candidate.displayName
+            )
+            routers[candidate.routes[0].id] = router
+        }
+        let defaults = UserDefaults(
+            suiteName: "iroh-disabled-aggregation-discovery-\(UUID().uuidString)"
+        )!
+        defaults.set(false, forKey: "multiMacAggregation")
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: RoutedZeroTouchFactory(routers: routers),
+                now: { Self.fixedNow },
+                supportedRouteKinds: [.iroh]
+            ),
+            isSignedIn: true,
+            pairedMacStore: store,
+            buildCompatibilityPolicy: .development,
+            personalIrohDiscovery: ScriptedIrohDiscovery(
+                snapshots: [candidates]
+            ),
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: defaults,
+            multiMacAggregationDefaults: defaults
+        )
+        defer {
+            for (_, subscription) in shell.secondaryMacSubscriptions {
+                subscription.cancel()
+            }
+            Task { await shell.remoteClient?.disconnect() }
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        try await store.upsert(
+            macDeviceID: candidates[0].deviceID,
+            displayName: candidates[0].displayName,
+            routes: candidates[0].routes,
+            instanceTag: candidates[0].instanceTag,
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: candidates[0].lastSeenAt
+        )
+        await shell.loadPairedMacs()
+
+        #expect(await shell.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(try await pollUntil {
+            shell.pairedMacs.count == 2
+                && shell.liveMacConnections.count == 2
+        })
+    }
+
+    @Test
     func discoveredSecondaryCandidatesDialConcurrently() async throws {
         let candidates = [
             try candidate(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -97,6 +97,23 @@ import Testing
             macAppVersion: "0.64.17",
             usesLocallyAuthorizedTailscaleRoute: true
         ))
+        #expect(!development.allowsAuthenticatedHost(
+            instanceTag: "sibling",
+            macAppVersion: nil,
+            usesLocallyAuthorizedTailscaleRoute: false
+        ))
+        #expect(development.allowsAuthenticatedHost(
+            instanceTag: "sibling",
+            clientNamespace: "mac:com.cmuxterm.app.debug.sibling",
+            macAppVersion: nil,
+            usesLocallyAuthorizedTailscaleRoute: false
+        ))
+        #expect(!development.allowsAuthenticatedHost(
+            instanceTag: "sibling",
+            clientNamespace: "mac:com.cmuxterm.app.staging.sibling",
+            macAppVersion: nil,
+            usesLocallyAuthorizedTailscaleRoute: false
+        ))
     }
 
     @Test func scopedDevelopmentStorePreservesSiblingRows() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -6,14 +6,14 @@ import Testing
 @testable import CmuxMobileShell
 
 @Suite struct MobileMacBuildCompatibilityPolicyTests {
-    @Test func developmentRequiresExactTag() {
+    @Test func developmentAllowsSiblingTagsWithoutBuildMetadata() {
         let policy = MobileMacBuildCompatibilityPolicy.development(
             expectedInstanceTag: "icap"
         )
 
         #expect(policy.allows(instanceTag: "icap"))
         #expect(policy.allows(instanceTag: " ICAP "))
-        #expect(!policy.allows(instanceTag: "tsmig"))
+        #expect(policy.allows(instanceTag: "tsmig"))
         #expect(!policy.allows(instanceTag: "default"))
         #expect(!policy.allows(instanceTag: "nightly"))
         #expect(!policy.allows(instanceTag: nil))
@@ -109,7 +109,7 @@ import Testing
         ))
     }
 
-    @Test func scopedStoreHidesAndRejectsIncompatibleRows() async throws {
+    @Test func scopedDevelopmentStorePreservesSiblingRows() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -138,12 +138,12 @@ import Testing
             .development(expectedInstanceTag: "icap")
             .scoping(raw)
 
-        #expect(try await scoped.loadAll(
+        #expect(Set(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
-        ).map(\.instanceTag) == ["icap"])
+        ).compactMap(\.instanceTag)) == ["icap", "tsmig"])
         #expect(try await scoped.activeMac(
             stackUserID: "user-1", teamID: "team-a"
-        ) == nil)
+        )?.instanceTag == "tsmig")
 
         try await scoped.upsert(
             macDeviceID: "other-mac",
@@ -157,7 +157,7 @@ import Testing
         )
         #expect(try await raw.loadAll(
             stackUserID: "user-1", teamID: "team-a"
-        ).allSatisfy { $0.macDeviceID != "other-mac" })
+        ).contains { $0.macDeviceID == "other-mac" && $0.instanceTag == "tsmig" })
     }
 
     @Test func scopedStoreKeepsUnclaimedLegacyRowsMigratable() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -15,6 +15,14 @@ import Testing
         #expect(!policy.allows(instanceTag: "default"))
         #expect(!policy.allows(instanceTag: "nightly"))
         #expect(!policy.allows(instanceTag: nil))
+        #expect(policy.allows(
+            instanceTag: "sibling",
+            clientNamespace: "mac:com.cmuxterm.app.debug.sibling"
+        ))
+        #expect(!policy.allows(
+            instanceTag: "sibling",
+            clientNamespace: "mac:com.cmuxterm.app.staging.sibling"
+        ))
     }
 
     @Test func currentDevelopmentPolicyNeedsNoBuildMetadata() {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -14,6 +14,8 @@ import Testing
         #expect(policy.allows(instanceTag: "tsmig"))
         #expect(!policy.allows(instanceTag: "default"))
         #expect(!policy.allows(instanceTag: "nightly"))
+        #expect(!policy.allows(instanceTag: "rc"))
+        #expect(!policy.allows(instanceTag: "staging"))
         #expect(!policy.allows(instanceTag: nil))
         #expect(policy.allows(
             instanceTag: "sibling",

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -7,9 +7,7 @@ import Testing
 
 @Suite struct MobileMacBuildCompatibilityPolicyTests {
     @Test func developmentAllowsSiblingTagsWithoutBuildMetadata() {
-        let policy = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "icap"
-        )
+        let policy = MobileMacBuildCompatibilityPolicy.development
 
         #expect(policy.allows(instanceTag: "icap"))
         #expect(policy.allows(instanceTag: " ICAP "))
@@ -19,30 +17,14 @@ import Testing
         #expect(!policy.allows(instanceTag: nil))
     }
 
-    @Test func developmentAllowsOnlyExplicitSiblingTags() {
-        let policy = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "phand1",
-            additionalInstanceTags: ["phand2", " PHAND3 "]
-        )
+    @Test func currentDevelopmentPolicyNeedsNoBuildMetadata() {
+        let policy = MobileMacBuildCompatibilityPolicy.current()
 
         #expect(policy.allows(instanceTag: "phand1"))
         #expect(policy.allows(instanceTag: "phand2"))
         #expect(policy.allows(instanceTag: "phand3"))
-        #expect(!policy.allows(instanceTag: "phand4"))
+        #expect(policy.allows(instanceTag: "unrelated"))
         #expect(!policy.allows(instanceTag: "default"))
-    }
-
-    @Test func currentDevelopmentPolicyParsesBuildMetadataAllowlist() throws {
-        let scope = try #require(MobileIOSBuildScope("phand1"))
-        let policy = MobileMacBuildCompatibilityPolicy.current(
-            buildScope: scope,
-            compatibleMacTags: "phand2, PHAND3 "
-        )
-
-        #expect(policy.allows(instanceTag: "phand1"))
-        #expect(policy.allows(instanceTag: "phand2"))
-        #expect(policy.allows(instanceTag: "phand3"))
-        #expect(!policy.allows(instanceTag: "unrelated"))
     }
 
     @Test func officialKeepsStableAndNightlyAsDistinctAllowedIdentities() {
@@ -88,9 +70,7 @@ import Testing
 
     @Test func legacyExceptionNeverWeakensTaggedOrDevelopmentIdentity() {
         let official = MobileMacBuildCompatibilityPolicy.official
-        let development = MobileMacBuildCompatibilityPolicy.development(
-            expectedInstanceTag: "tsauth"
-        )
+        let development = MobileMacBuildCompatibilityPolicy.development
 
         #expect(official.allowsAuthenticatedHost(
             instanceTag: "default",
@@ -134,9 +114,7 @@ import Testing
                 now: Date(timeIntervalSince1970: seen)
             )
         }
-        let scoped = MobileMacBuildCompatibilityPolicy
-            .development(expectedInstanceTag: "icap")
-            .scoping(raw)
+        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
 
         #expect(Set(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
@@ -188,9 +166,7 @@ import Testing
             teamID: "team-a",
             now: Date(timeIntervalSince1970: 1)
         )
-        let scoped = MobileMacBuildCompatibilityPolicy
-            .development(expectedInstanceTag: "icap")
-            .scoping(raw)
+        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
 
         #expect(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
@@ -212,7 +188,7 @@ import Testing
         ).first?.routes == [updatedRoute])
     }
 
-    @Test func scopedRemoveAllPreservesIncompatibleRows() async throws {
+    @Test func scopedRemoveAllRemovesAllDevelopmentRows() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -237,15 +213,13 @@ import Testing
                 now: Date(timeIntervalSince1970: seenAt)
             )
         }
-        let scoped = MobileMacBuildCompatibilityPolicy
-            .development(expectedInstanceTag: "icap")
-            .scoping(raw)
+        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
 
         try await scoped.removeAll()
 
         #expect(try await raw.loadAll(
             stackUserID: nil, teamID: nil
-        ).compactMap(\.instanceTag) == ["tsmig"])
+        ).isEmpty)
     }
 
     @Test func officialStoreKeepsStableAndNightlyButRejectsDevelopment() async throws {
@@ -281,9 +255,9 @@ import Testing
     }
 
     @MainActor
-    @Test func registryProjectionKeepsOnlyCompatibleInstances() {
+    @Test func registryProjectionKeepsEveryDevelopmentInstance() {
         let store = MobileShellComposite(
-            buildCompatibilityPolicy: .development(expectedInstanceTag: "icap")
+            buildCompatibilityPolicy: .development
         )
         let device = RegistryDevice(
             deviceId: "shared-mac",
@@ -303,14 +277,14 @@ import Testing
         let projected = store.compatibleRegistryDevices([device])
 
         #expect(projected.count == 1)
-        #expect(projected[0].instances.map(\.tag) == ["icap"])
-        #expect(projected[0].lastSeenAt == Date(timeIntervalSince1970: 10))
+        #expect(projected[0].instances.map(\.tag) == ["icap", "tsmig"])
+        #expect(projected[0].lastSeenAt == Date(timeIntervalSince1970: 20))
     }
 
     @MainActor
-    @Test func presenceProjectionKeepsOnlyCompatibleInstances() {
+    @Test func presenceProjectionKeepsEveryDevelopmentInstance() {
         let store = MobileShellComposite(
-            buildCompatibilityPolicy: .development(expectedInstanceTag: "icap")
+            buildCompatibilityPolicy: .development
         )
         let icap = PresenceInstance(
             deviceId: "shared-mac",
@@ -347,9 +321,9 @@ import Testing
             return
         }
         #expect(snapshot.devices.count == 1)
-        #expect(snapshot.devices[0].instances.map(\.tag) == ["icap"])
-        #expect(!snapshot.devices[0].online)
-        #expect(snapshot.devices[0].lastSeenAt == 10)
-        #expect(store.compatiblePresenceUpdate(.online(tsmig)) == nil)
+        #expect(snapshot.devices[0].instances.map(\.tag) == ["icap", "tsmig"])
+        #expect(snapshot.devices[0].online)
+        #expect(snapshot.devices[0].lastSeenAt == 20)
+        #expect(store.compatiblePresenceUpdate(.online(tsmig)) == .online(tsmig))
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
@@ -194,7 +194,7 @@ import Testing
         #expect(category == .buildIncompatible)
         #expect(category.analyticsReason == "build_incompatible")
         #expect(category.message.contains("cannot connect"))
-        #expect(category.guidance?.contains("same DEV tag") == true)
+        #expect(category.guidance?.contains("any DEV Mac build") == true)
         #expect(!category.isAuthorizationFailure)
     }
 
@@ -209,7 +209,7 @@ import Testing
         #expect(category.message != MobilePairingFailureCategory.authFailed.message)
         #expect(!category.message.contains("Make sure both devices are signed in"))
         #expect(category.guidance?.contains("BETA") == true)
-        #expect(category.guidance?.contains("same DEV tag") == true)
+        #expect(category.guidance?.contains("any DEV Mac build") == true)
         // Signing out cannot move the account to another Stack project, so this
         // must not drive the re-auth (Sign Out) prompt.
         #expect(!category.isAuthorizationFailure)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgetWildcardBreadthTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgetWildcardBreadthTests.swift
@@ -572,13 +572,13 @@ private struct EnumerationFailingStore: MobilePairedMacStoring {
         let base = try MobilePairedMacStore(
             databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
         )
-        // A row tagged for a DIFFERENT build ("other") plus the untagged row the
+        // A row tagged for an incompatible distributed build plus the untagged row the
         // user forgets. Tagged first so the untagged upsert cannot claim it.
         try await base.upsert(
             macDeviceID: "mac-a",
-            displayName: "Desk Mac (other)",
+            displayName: "Desk Mac (Stable)",
             routes: [try Self.route("100.82.214.113")],
-            instanceTag: "other",
+            instanceTag: "default",
             markActive: false,
             stackUserID: "user-1",
             teamID: nil,
@@ -595,12 +595,10 @@ private struct EnumerationFailingStore: MobilePairedMacStoring {
             now: Date(timeIntervalSince1970: 2)
         )
         let forget = WildcardRecordingForget()
-        // Production rail: this build expects tag "mine", so the "other" row is
-        // incompatible — visible to the cleanup enumeration but historically
+        // Development rail: the Stable row is incompatible, visible to the
+        // cleanup enumeration but historically
         // silently skipped by the compatibility guard on exact-scope deletes.
-        let compatible = MobileMacBuildCompatibilityPolicy
-            .development(expectedInstanceTag: "mine")
-            .scoping(base)
+        let compatible = MobileMacBuildCompatibilityPolicy.development.scoping(base)
         let store = MobileShellComposite(
             isSignedIn: true,
             connectionState: .connected,
@@ -619,7 +617,7 @@ private struct EnumerationFailingStore: MobilePairedMacStoring {
         let ok = await store.forgetHiddenComputer(hidden)
 
         #expect(ok)
-        // The wildcard revoke killed the "other" binding too, so its local row
+        // The wildcard revoke killed the Stable binding too, so its local row
         // must be gone — not silently skipped while the forget reports success.
         let remaining = try await base.loadAll(stackUserID: "user-1", teamID: nil)
         #expect(!remaining.contains { $0.macDeviceID == "mac-a" })

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -83,6 +83,7 @@ actor LivenessHostRouter {
     // tests from exercising the one-shot legacy identity recovery request.
     private var macDeviceID: String? = "test-mac"
     private var macInstanceTag: String? = "default"
+    private var macClientNamespace: String? = "mac:com.cmuxterm.app.debug"
     private var macDisplayName: String? = "Test Mac"
     private var workspaceListResponseHook: (@Sendable () -> Void)?
     private var workspaceIDs = ["live-workspace"]
@@ -291,9 +292,15 @@ actor LivenessHostRouter {
         self.capabilities = capabilities
     }
 
-    func setHostIdentity(deviceID: String?, instanceTag: String?, displayName: String? = nil) {
+    func setHostIdentity(
+        deviceID: String?,
+        instanceTag: String?,
+        displayName: String? = nil,
+        clientNamespace: String? = "mac:com.cmuxterm.app.debug"
+    ) {
         macDeviceID = deviceID
         macInstanceTag = instanceTag
+        macClientNamespace = clientNamespace
         macDisplayName = displayName
     }
 
@@ -570,6 +577,9 @@ actor LivenessHostRouter {
             } else {
                 if let macDeviceID { result["mac_device_id"] = macDeviceID }
                 if let macInstanceTag { result["mac_instance_tag"] = macInstanceTag }
+                if let macClientNamespace {
+                    result["mac_client_namespace"] = macClientNamespace
+                }
                 if let macDisplayName { result["mac_display_name"] = macDisplayName }
             }
             return try? Self.resultFrame(id: id, result: result)

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -280,6 +280,11 @@ final class MobileHostService {
         payload["terminal_theme_revision_epoch"] = terminalThemeRevisionEpoch
         payload["mac_device_id"] = MobileHostIdentity.deviceID()
         payload["mac_instance_tag"] = MobileHostIdentity.instanceTag()
+        if let clientNamespace = CmxIrohMacBundleNamespace(
+            bundleIdentifier: Bundle.main.bundleIdentifier
+        )?.rawValue {
+            payload["mac_client_namespace"] = clientNamespace
+        }
         payload["phone_push"] = [
             "forwarding_enabled": PhonePushConfiguration.forwardingEnabled(
                 in: phonePushDefaults

--- a/cmuxTests/MobileHostIdentityTests.swift
+++ b/cmuxTests/MobileHostIdentityTests.swift
@@ -154,6 +154,7 @@ struct MobileHostIdentityTests {
 
         let payload = MobileHostService.identityStatusPayload(routes: [])
         #expect(payload["mac_instance_tag"] as? String == "future-one")
+        #expect((payload["mac_client_namespace"] as? String)?.hasPrefix("mac:") == true)
         #expect(!(payload["terminal_theme_revision_epoch"] as? String ?? "").isEmpty)
     }
 

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -22,8 +22,6 @@
 	<string>$(CMUX_DEV_TAG)</string>
 	<key>CMUXKeychainAccessGroup</key>
 	<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CMUXCompatibleMacTags</key>
-	<string>$(CMUX_COMPATIBLE_MAC_TAGS)</string>
 	<key>CMUXGitSHA</key>
 	<string>$(CMUX_GIT_SHA)</string>
 	<key>CMUXCrashReportingEnabled</key>

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -26,9 +26,6 @@ CURRENT_PROJECT_VERSION = 1
 // CMUXGitSHA / CMUXDevTag Info.plist keys that AppVersionInfo reads.
 CMUX_GIT_SHA =
 CMUX_DEV_TAG =
-// Optional comma-separated Mac development tags intentionally compatible with
-// one tagged iOS build. Empty keeps the default exact-tag boundary.
-CMUX_COMPATIBLE_MAC_TAGS =
 
 // Per-developer presence/paired-Mac-backup worker override, baked into the
 // CMUXPresenceBaseURL Info.plist key so a normally-tapped dev device build (which
@@ -41,11 +38,10 @@ CMUX_PRESENCE_BASE_URL =
 
 // Auth-environment override, baked into the CMUXAuthEnvironment Info.plist key
 // so a normally-tapped dev device build (no shell env) can sign in against the
-// PRODUCTION Stack project when testing production-account behavior. Build
-// compatibility remains separate: a tagged DEV iOS build uses its exact Mac tag
-// plus any explicitly baked CMUX_COMPATIBLE_MAC_TAGS. Empty by default (DEBUG -> development,
-// Release -> production). ios/scripts/reload.sh --prod-auth sets it to
-// "production". Keep the Info.plist key name in sync with
+// PRODUCTION Stack project when testing production-account behavior. Empty by
+// default (DEBUG -> development, Release -> production).
+// ios/scripts/reload.sh --prod-auth sets it to "production". Keep the Info.plist
+// key name in sync with
 // MobileAuthComposition.authEnvironmentInfoPlistKey.
 CMUX_IOS_AUTH_ENV =
 

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6093,13 +6093,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use this DEV app with a Mac that has the same DEV tag."
+            "value": "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use a DEV iPhone build with any DEV Mac build."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "BETA、INTERNAL、または App Store アプリは Stable または Nightly と一緒に使用してください。この DEV アプリは同じ DEV タグを持つ Mac と一緒に使用してください。"
+            "value": "BETA、INTERNAL、または App Store アプリは Stable または Nightly と一緒に使用してください。DEV iPhone ビルドは任意の DEV Mac ビルドと一緒に使用できます。"
           }
         }
       }
@@ -6127,13 +6127,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DEV builds must use the same DEV tag. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
+            "value": "DEV iPhone builds connect to any DEV Mac build. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "DEV ビルド同士は同じ DEV タグを使用する必要があります。BETA、INTERNAL、App Store ビルドは Stable または Nightly にのみ接続できます。"
+            "value": "DEV iPhone ビルドは任意の DEV Mac ビルドに接続できます。BETA、INTERNAL、App Store ビルドは Stable または Nightly にのみ接続できます。"
           }
         }
       }

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -31,12 +31,7 @@ struct cmuxApp: App {
             reachability: reachability,
             diagnosticLog: diagnosticLog
         )
-        let buildCompatibilityPolicy = MobileMacBuildCompatibilityPolicy.current(
-            buildScope: MobileIOSBuildScope.current(),
-            compatibleMacTags: Bundle.main.object(
-                forInfoDictionaryKey: "CMUXCompatibleMacTags"
-            ) as? String
-        )
+        let buildCompatibilityPolicy = MobileMacBuildCompatibilityPolicy.current()
         let iroh = MobileIrohRuntimeComposition(
             apiBaseURL: auth.config.apiBaseURL,
             reachability: reachability,

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
@@ -186,20 +186,46 @@ public actor MobileIrohRouteCatalog {
     /// builds and then broker recency.
     public func liveMacCandidates(
         preferredTag: String,
-        compatibleWith policy: MobileMacBuildCompatibilityPolicy? = nil
+        compatibleWith policy: MobileMacBuildCompatibilityPolicy? = nil,
+        limit: Int? = nil
     ) -> [MobileDiscoveredIrohMac] {
-        liveMacs
-            .filter { policy?.allows(instanceTag: $0.instanceTag) ?? true }
-            .sorted { left, right in
-                let leftRank = Self.tagRank(left.instanceTag, preferred: preferredTag)
-                let rightRank = Self.tagRank(right.instanceTag, preferred: preferredTag)
-                if leftRank != rightRank { return leftRank < rightRank }
-                if left.lastSeenAt != right.lastSeenAt {
-                    return left.lastSeenAt > right.lastSeenAt
-                }
-                if left.deviceID != right.deviceID { return left.deviceID < right.deviceID }
-                return left.instanceTag < right.instanceTag
-            }
+        guard let limit else {
+            return liveMacs
+                .filter { policy?.allows(instanceTag: $0.instanceTag) ?? true }
+                .sorted { Self.candidateSortsBefore($0, $1, preferredTag: preferredTag) }
+        }
+        guard limit > 0 else { return [] }
+
+        // Automatic admission only needs the best few candidates. Keep a
+        // bounded ordered buffer so a large authenticated fleet costs O(n*k)
+        // instead of sorting every row at O(n log n), where k is the limit.
+        var best: [MobileDiscoveredIrohMac] = []
+        best.reserveCapacity(min(limit, liveMacs.count))
+        for candidate in liveMacs
+            where policy?.allows(instanceTag: candidate.instanceTag) ?? true {
+            let insertionIndex = best.firstIndex {
+                Self.candidateSortsBefore(candidate, $0, preferredTag: preferredTag)
+            } ?? best.endIndex
+            guard insertionIndex < limit || best.count < limit else { continue }
+            best.insert(candidate, at: insertionIndex)
+            if best.count > limit { best.removeLast() }
+        }
+        return best
+    }
+
+    private static func candidateSortsBefore(
+        _ left: MobileDiscoveredIrohMac,
+        _ right: MobileDiscoveredIrohMac,
+        preferredTag: String
+    ) -> Bool {
+        let leftRank = tagRank(left.instanceTag, preferred: preferredTag)
+        let rightRank = tagRank(right.instanceTag, preferred: preferredTag)
+        if leftRank != rightRank { return leftRank < rightRank }
+        if left.lastSeenAt != right.lastSeenAt {
+            return left.lastSeenAt > right.lastSeenAt
+        }
+        if left.deviceID != right.deviceID { return left.deviceID < right.deviceID }
+        return left.instanceTag < right.instanceTag
     }
 
     /// Drops live first-pair candidates without disturbing verified routes for

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
@@ -174,7 +174,8 @@ public actor MobileIrohRouteCatalog {
                 instanceTag: identity.instanceTag ?? "",
                 routes: [route],
                 lastSeenAt: timestampParser.parse(binding.lastSeenAt),
-                capabilities: binding.capabilities
+                capabilities: binding.capabilities,
+                clientNamespace: binding.clientNamespace
             )
         }
     }
@@ -191,7 +192,12 @@ public actor MobileIrohRouteCatalog {
     ) -> [MobileDiscoveredIrohMac] {
         guard let limit else {
             return liveMacs
-                .filter { policy?.allows(instanceTag: $0.instanceTag) ?? true }
+                .filter {
+                    policy?.allows(
+                        instanceTag: $0.instanceTag,
+                        clientNamespace: $0.clientNamespace
+                    ) ?? true
+                }
                 .sorted { Self.candidateSortsBefore($0, $1, preferredTag: preferredTag) }
         }
         guard limit > 0 else { return [] }
@@ -202,7 +208,10 @@ public actor MobileIrohRouteCatalog {
         var best: [MobileDiscoveredIrohMac] = []
         best.reserveCapacity(min(limit, liveMacs.count))
         for candidate in liveMacs
-            where policy?.allows(instanceTag: candidate.instanceTag) ?? true {
+            where policy?.allows(
+                instanceTag: candidate.instanceTag,
+                clientNamespace: candidate.clientNamespace
+            ) ?? true {
             let insertionIndex = best.firstIndex {
                 Self.candidateSortsBefore(candidate, $0, preferredTag: preferredTag)
             } ?? best.endIndex

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2336,8 +2336,8 @@ public final class MobileIrohRuntimeComposition:
         for policy: MobileMacBuildCompatibilityPolicy?
     ) -> [String]? {
         switch policy {
-        case let .development(expectedInstanceTag, additionalInstanceTags):
-            [expectedInstanceTag] + additionalInstanceTags.sorted()
+        case .development:
+            nil
         case .official:
             ["default", "nightly"]
         case nil:

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -647,7 +647,8 @@ public final class MobileIrohRuntimeComposition:
         guard self.runtime === runtime else { return [] }
         let candidates = await routeCatalog.liveMacCandidates(
             preferredTag: tag,
-            compatibleWith: discoveryCompatibilityPolicy
+            compatibleWith: discoveryCompatibilityPolicy,
+            limit: 4
         )
         recordDiscoveryOutcome(candidateCount: candidates.count)
         return candidates

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -489,7 +489,8 @@ struct MobileIrohRuntimeCompositionTests {
                 endpointID: String(repeating: "a", count: 64),
                 platform: "mac",
                 pairingEnabled: true,
-                tag: "lane-a"
+                tag: "lane-a",
+                clientNamespace: "mac:com.cmuxterm.app.debug.lane-a"
             ),
             mobileIrohBinding(
                 bindingID: "31000000-0000-4000-8000-000000000004",
@@ -498,7 +499,8 @@ struct MobileIrohRuntimeCompositionTests {
                 endpointID: String(repeating: "b", count: 64),
                 platform: "mac",
                 pairingEnabled: true,
-                tag: "lane-b"
+                tag: "lane-b",
+                clientNamespace: "mac:com.cmuxterm.app.debug.lane-b"
             ),
             mobileIrohBinding(
                 bindingID: "31000000-0000-4000-8000-000000000007",
@@ -507,7 +509,8 @@ struct MobileIrohRuntimeCompositionTests {
                 endpointID: String(repeating: "c", count: 64),
                 platform: "mac",
                 pairingEnabled: true,
-                tag: "default"
+                tag: "default",
+                clientNamespace: "mac:com.cmuxterm.app"
             ),
         ])
         let catalog = MobileIrohRouteCatalog()
@@ -2024,10 +2027,11 @@ private func mobileIrohBinding(
     platform: String,
     pairingEnabled: Bool,
     tag: String = "test",
+    clientNamespace: String? = nil,
     lastSeenAt: String = "2027-07-10T12:00:00.000Z",
     pathHints: [[String: Any]] = []
 ) -> [String: Any] {
-    [
+    var object: [String: Any] = [
         "binding_id": bindingID,
         "device_id": deviceID,
         "app_instance_id": appInstanceID,
@@ -2040,6 +2044,10 @@ private func mobileIrohBinding(
         "path_hints": pathHints,
         "last_seen_at": lastSeenAt,
     ]
+    if let clientNamespace {
+        object["client_namespace"] = clientNamespace
+    }
+    return object
 }
 
 private func mobileIrohDiscovery(

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -480,7 +480,7 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
-    func taggedDevelopmentDiscoveryCannotCrossIntoAnotherAgentLane() async throws {
+    func taggedDevelopmentDiscoveryIncludesSiblingMacBuilds() async throws {
         let discovery = try mobileIrohDiscovery(bindings: [
             mobileIrohBinding(
                 bindingID: "31000000-0000-4000-8000-000000000001",
@@ -514,11 +514,11 @@ struct MobileIrohRuntimeCompositionTests {
         await catalog.activate(scope: 4)
         await catalog.replace(with: discovery, scope: 4)
 
-        let isolated = await catalog.liveMacCandidates(
+        let development = await catalog.liveMacCandidates(
             preferredTag: "lane-a",
-            compatibleWith: .development(expectedInstanceTag: "lane-a")
+            compatibleWith: .development
         )
-        #expect(isolated.map(\.instanceTag) == ["lane-a"])
+        #expect(development.map(\.instanceTag) == ["lane-a", "lane-b"])
 
         let official = await catalog.liveMacCandidates(
             preferredTag: "lane-a",

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -520,6 +520,13 @@ struct MobileIrohRuntimeCompositionTests {
         )
         #expect(development.map(\.instanceTag) == ["lane-a", "lane-b"])
 
+        let boundedDevelopment = await catalog.liveMacCandidates(
+            preferredTag: "lane-a",
+            compatibleWith: .development,
+            limit: 1
+        )
+        #expect(boundedDevelopment.map(\.instanceTag) == ["lane-a"])
+
         let official = await catalog.liveMacCandidates(
             preferredTag: "lane-a",
             compatibleWith: .official

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobilePairingAccountPreflightTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobilePairingAccountPreflightTests.swift
@@ -52,7 +52,7 @@ import Testing
         #expect(message != MobilePairingFailureCategory.authFailed.message)
         #expect(!message.contains("Make sure both devices are signed in"))
         #expect(category?.guidance?.contains("BETA") == true)
-        #expect(category?.guidance?.contains("same DEV tag") == true)
+        #expect(category?.guidance?.contains("any DEV Mac build") == true)
         #expect(category?.analyticsReason == "auth_environment_mismatch")
         // Re-authenticating cannot move the account to another Stack project,
         // so this must not drive the Sign Out re-auth prompt.

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: ios/scripts/reload.sh --tag <tag> [--compatible-mac-tags <tag,...>] [--simulator <name>] [--simulator-id <id>] [--no-launch]
+Usage: ios/scripts/reload.sh --tag <tag> [--simulator <name>] [--simulator-id <id>] [--no-launch]
        ios/scripts/reload.sh --tag <tag> --device [--device-id <id>] [--device-name <name>] [--team <team-id>] [--no-launch]
        ios/scripts/reload.sh --tag <tag> --device-only [--device-id <id>] [--device-name <name>] [--team <team-id>] [--no-launch]
        ios/scripts/reload.sh --tag <tag> --simulator-only
@@ -29,16 +29,9 @@ the tagged Mac app. Opt out granularly:
   --no-attach    sign in, but do not auto-pair to the Mac
   --no-setup     plain install + launch (today's behavior)
 
-  --compatible-mac-tags <tag,...>
-                 intentionally admits additional Mac DEV tags while keeping this
-                 iOS bundle and its saved data under --tag. At most five total
-                 tags, including --tag, may be admitted.
-
   --prod-auth    sign this DEV build in against PRODUCTION auth (bakes
                  CMUXAuthEnvironment=production into Info.plist; the presence
-                 worker and API base follow the channel in-app). This does not
-                 change build compatibility unless --compatible-mac-tags is
-                 also supplied. Implies
+                 worker and API base follow the channel in-app). Implies
                  --no-sign-in (dogfood auto-login creds are dev-channel);
                  sign in in-app with your real account and use the IN-APP
                  scanner.
@@ -67,7 +60,6 @@ require_option_value() {
 }
 
 TAG=""
-COMPATIBLE_MAC_TAGS="${CMUX_IOS_COMPATIBLE_MAC_TAGS:-}"
 SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-iPhone 17}"
 SIMULATOR_ID="${IOS_SIMULATOR_ID:-}"
 # Track whether the caller picked a simulator explicitly (flag or env); when
@@ -94,8 +86,7 @@ NO_SETUP=0
 # Also honored via CMUX_SWIFT_FRONTEND_WORKAROUND=1.
 SWIFT_FRONTEND_WORKAROUND="${CMUX_SWIFT_FRONTEND_WORKAROUND:-0}"
 # --prod-auth: bake CMUXAuthEnvironment=production so the dev build signs in
-# against the production Stack project. Build compatibility remains exact-tag
-# unless the caller explicitly supplies sibling Mac tags.
+# against the production Stack project.
 PROD_AUTH=0
 
 while [[ $# -gt 0 ]]; do
@@ -103,11 +94,6 @@ while [[ $# -gt 0 ]]; do
     --tag)
       require_option_value "$1" "${2:-}"
       TAG="${2:-}"
-      shift 2
-      ;;
-    --compatible-mac-tags)
-      require_option_value "$1" "${2:-}"
-      COMPATIBLE_MAC_TAGS="${2:-}"
       shift 2
       ;;
     --simulator)
@@ -326,44 +312,6 @@ source "$IOS_DIR/../scripts/lib/mobile-attach.sh"
 # Fail before building if the tag would collide with a fallback/reserved identity
 # or exceed the cloud presence limit.
 if ! cmux_attach_validate_dev_tag "$TAG"; then
-  exit 1
-fi
-compatible_tag_count=1
-if [[ -n "$COMPATIBLE_MAC_TAGS" ]]; then
-  case "$COMPATIBLE_MAC_TAGS" in
-    ,*|*,|*,,*)
-      echo "error: --compatible-mac-tags contains an empty tag" >&2
-      exit 1
-      ;;
-  esac
-  previous_ifs="$IFS"
-  normalized_primary_tag="$(printf '%s' "$TAG" | tr '[:upper:]' '[:lower:]')"
-  seen_compatible_tags=",$normalized_primary_tag,"
-  IFS=','
-  for compatible_tag in $COMPATIBLE_MAC_TAGS; do
-    IFS="$previous_ifs"
-    compatible_tag="$(printf '%s' "$compatible_tag" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    if [[ -z "$compatible_tag" ]]; then
-      echo "error: --compatible-mac-tags contains an empty tag" >&2
-      exit 1
-    fi
-    if ! cmux_attach_validate_dev_tag "$compatible_tag"; then
-      exit 1
-    fi
-    normalized_compatible_tag="$(printf '%s' "$compatible_tag" | tr '[:upper:]' '[:lower:]')"
-    case "$seen_compatible_tags" in
-      *",$normalized_compatible_tag,"*) ;;
-      *)
-        compatible_tag_count=$((compatible_tag_count + 1))
-        seen_compatible_tags="${seen_compatible_tags}${normalized_compatible_tag},"
-        ;;
-    esac
-    IFS=','
-  done
-  IFS="$previous_ifs"
-fi
-if (( compatible_tag_count > 5 )); then
-  echo "error: --compatible-mac-tags may admit at most five total tags including --tag" >&2
   exit 1
 fi
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
@@ -778,7 +726,6 @@ reload_simulator() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME" \
     CMUX_GIT_SHA="$GIT_SHA" \
     CMUX_DEV_TAG="$TAG" \
-    CMUX_COMPATIBLE_MAC_TAGS="$COMPATIBLE_MAC_TAGS" \
     CMUX_PRESENCE_BASE_URL="${CMUX_PRESENCE_BASE_URL:-}" \
     CMUX_IOS_AUTH_ENV="$CMUX_IOS_AUTH_ENV_VALUE" \
     CMUX_API_BASE_URL="$CMUX_IOS_SIMULATOR_API_BASE_URL_VALUE" \
@@ -987,7 +934,6 @@ reload_device() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME"
     CMUX_GIT_SHA="$GIT_SHA"
     CMUX_DEV_TAG="$TAG"
-    CMUX_COMPATIBLE_MAC_TAGS="$COMPATIBLE_MAC_TAGS"
     CMUX_PRESENCE_BASE_URL="${CMUX_PRESENCE_BASE_URL:-}"
     CMUX_IOS_AUTH_ENV="$CMUX_IOS_AUTH_ENV_VALUE"
     CMUX_API_BASE_URL="$CMUX_IOS_DEVICE_API_BASE_URL_VALUE"

--- a/web/services/iroh/buildCompatibility.ts
+++ b/web/services/iroh/buildCompatibility.ts
@@ -6,7 +6,7 @@ const OFFICIAL_IOS_NAMESPACES = new Set([
   "dev.cmux.app.demo",
 ]);
 const DEVELOPMENT_IOS_NAMESPACE_PREFIX = "dev.cmux.ios.";
-const OFFICIAL_MAC_TAGS = new Set(["default", "nightly"]);
+const DEVELOPMENT_MAC_NAMESPACE_PREFIX = "mac:com.cmuxterm.app.debug";
 
 type BuildBinding = {
   readonly platform: string;
@@ -43,18 +43,19 @@ function iosBindingMacLaneCompatible(
     || target.clientNamespace.startsWith("mac:");
   if (!targetHasCompatibleNamespace) return false;
 
+  const callerIsDevelopmentIOS = isDevelopmentIOSNamespace(caller.clientNamespace);
+  const targetIsDevelopmentMac = isDevelopmentMacNamespace(target.clientNamespace);
+
   // A tagged DEV iOS build is the control surface for all tagged DEV Mac
   // builds. The tag still identifies each Mac instance for persistence and
   // ordering, but it is not a compatibility lane boundary. Keep this behind
   // the use-only fallback flag so stale-binding revocation remains exact-tag.
   const targetTag = target.tag.trim().toLowerCase();
-  if (
-    legacyDefaultFallback
-    && caller.clientNamespace.startsWith(DEVELOPMENT_IOS_NAMESPACE_PREFIX)
-    && target.clientNamespace.startsWith("mac:")
-    && !OFFICIAL_MAC_TAGS.has(targetTag)
-  ) {
-    return true;
+  if (callerIsDevelopmentIOS) {
+    if (!targetIsDevelopmentMac || targetTag === "default" || targetTag === "nightly") {
+      return false;
+    }
+    return legacyDefaultFallback || caller.tag === target.tag;
   }
 
   // iOS builds that predate the X-Cmux-App-Namespace header register as
@@ -71,6 +72,15 @@ function iosBindingMacLaneCompatible(
     return target.tag === "default" || target.tag === "nightly";
   }
   return caller.tag === target.tag;
+}
+
+function isDevelopmentMacNamespace(clientNamespace: string): boolean {
+  return clientNamespace === DEVELOPMENT_MAC_NAMESPACE_PREFIX
+    || clientNamespace.startsWith(`${DEVELOPMENT_MAC_NAMESPACE_PREFIX}.`);
+}
+
+function isDevelopmentIOSNamespace(clientNamespace: string): boolean {
+  return clientNamespace.startsWith(DEVELOPMENT_IOS_NAMESPACE_PREFIX);
 }
 
 /**

--- a/web/services/iroh/buildCompatibility.ts
+++ b/web/services/iroh/buildCompatibility.ts
@@ -7,6 +7,7 @@ const OFFICIAL_IOS_NAMESPACES = new Set([
 ]);
 const DEVELOPMENT_IOS_NAMESPACE_PREFIX = "dev.cmux.ios.";
 const DEVELOPMENT_MAC_NAMESPACE_PREFIX = "mac:com.cmuxterm.app.debug";
+const NON_DEVELOPMENT_MAC_TAGS = new Set(["default", "nightly", "rc", "staging"]);
 
 type BuildBinding = {
   readonly platform: string;
@@ -52,7 +53,7 @@ function iosBindingMacLaneCompatible(
   // the use-only fallback flag so stale-binding revocation remains exact-tag.
   const targetTag = target.tag.trim().toLowerCase();
   if (callerIsDevelopmentIOS) {
-    if (!targetIsDevelopmentMac || targetTag === "default" || targetTag === "nightly") {
+    if (!targetIsDevelopmentMac || NON_DEVELOPMENT_MAC_TAGS.has(targetTag)) {
       return false;
     }
     return legacyDefaultFallback || caller.tag === target.tag;

--- a/web/services/iroh/buildCompatibility.ts
+++ b/web/services/iroh/buildCompatibility.ts
@@ -5,6 +5,8 @@ const OFFICIAL_IOS_NAMESPACES = new Set([
   "dev.cmux.app.internal",
   "dev.cmux.app.demo",
 ]);
+const DEVELOPMENT_IOS_NAMESPACE_PREFIX = "dev.cmux.ios.";
+const OFFICIAL_MAC_TAGS = new Set(["default", "nightly"]);
 
 type BuildBinding = {
   readonly platform: string;
@@ -40,6 +42,20 @@ function iosBindingMacLaneCompatible(
   const targetHasCompatibleNamespace = target.clientNamespace === "legacy"
     || target.clientNamespace.startsWith("mac:");
   if (!targetHasCompatibleNamespace) return false;
+
+  // A tagged DEV iOS build is the control surface for all tagged DEV Mac
+  // builds. The tag still identifies each Mac instance for persistence and
+  // ordering, but it is not a compatibility lane boundary. Keep this behind
+  // the use-only fallback flag so stale-binding revocation remains exact-tag.
+  const targetTag = target.tag.trim().toLowerCase();
+  if (
+    legacyDefaultFallback
+    && caller.clientNamespace.startsWith(DEVELOPMENT_IOS_NAMESPACE_PREFIX)
+    && target.clientNamespace.startsWith("mac:")
+    && !OFFICIAL_MAC_TAGS.has(targetTag)
+  ) {
+    return true;
+  }
 
   // iOS builds that predate the X-Cmux-App-Namespace header register as
   // `legacy` and cannot send anything newer, so the missing namespace is the

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -1395,7 +1395,7 @@ describe("Iroh discovery and grants", () => {
     expect(fixture.repository.pairGrantAudits).toHaveLength(0);
   });
 
-  test("pair grants reject a Mac from another build lane", async () => {
+  test("pair grants accept another tagged DEV Mac", async () => {
     const fixture = makeFixture();
     const initiator = binding({
       userId: USER_A,
@@ -1417,22 +1417,21 @@ describe("Iroh discovery and grants", () => {
       acceptorBindingId: acceptor.id,
     };
 
-    await expectEffectFailure(
-      fixture.broker.issuePairGrant(
-        USER_A,
+    const result = await Effect.runPromise(fixture.broker.issuePairGrant(
+      USER_A,
+      body,
+      NOW,
+      initiator.clientNamespace,
+      fixture.bindingProof(
+        initiator.id,
+        "POST",
+        "api/devices/iroh/pair-grants",
         body,
-        NOW,
-        initiator.clientNamespace,
-        fixture.bindingProof(
-          initiator.id,
-          "POST",
-          "api/devices/iroh/pair-grants",
-          body,
-        ),
       ),
-      "IrohForbiddenError",
-    );
-    expect(fixture.repository.pairGrantAudits).toHaveLength(0);
+    )) as { grant: string };
+
+    expect(result.grant.split(".")).toHaveLength(3);
+    expect(fixture.repository.pairGrantAudits).toHaveLength(1);
   });
 
   test("an official iOS binding can pair with a Nightly Mac", async () => {
@@ -1700,7 +1699,7 @@ describe("Iroh discovery and grants", () => {
     expect(fixture.repository.pairGrantAudits).toHaveLength(0);
   });
 
-  test("tagged discovery never exposes sibling Mac lane metadata", async () => {
+  test("tagged DEV discovery exposes every tagged DEV Mac binding", async () => {
     const fixture = makeFixture();
     const iosA = binding({
       platform: "ios",
@@ -1736,6 +1735,7 @@ describe("Iroh discovery and grants", () => {
     expect(discovered.bindings.map((row) => row.binding_id)).toEqual([
       iosA.id,
       macA.id,
+      macB.id,
     ].sort());
   });
 

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -99,6 +99,16 @@ describe("Iroh build compatibility", () => {
       tag: "staging",
       clientNamespace: "mac:com.cmuxterm.app.staging",
     }))).toBe(false);
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "rc",
+      clientNamespace: "mac:com.cmuxterm.app.debug.rc",
+    }))).toBe(false);
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "staging",
+      clientNamespace: "mac:com.cmuxterm.app.debug.staging",
+    }))).toBe(false);
     expect(canIOSBindingForgetMac(ios, binding({
       platform: "mac",
       tag: "msta",

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -69,6 +69,33 @@ describe("Iroh build compatibility", () => {
     expect(canIOSBindingUseMac(ios, stagingMac)).toBe(true);
   });
 
+  test("a tagged DEV iOS build may discover every tagged DEV Mac build", () => {
+    const ios = binding({
+      platform: "ios",
+      tag: "mdev",
+      clientNamespace: "dev.cmux.ios.mdev",
+    });
+    const siblingTags = ["msta", "mnyt", "cdial"];
+
+    for (const tag of siblingTags) {
+      expect(canIOSBindingUseMac(ios, binding({
+        platform: "mac",
+        tag,
+        clientNamespace: `mac:${tag}`,
+      }))).toBe(true);
+    }
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "default",
+      clientNamespace: "mac:com.cmuxterm.app",
+    }))).toBe(false);
+    expect(canIOSBindingForgetMac(ios, binding({
+      platform: "mac",
+      tag: "msta",
+      clientNamespace: "mac:msta",
+    }))).toBe(false);
+  });
+
   test("a legacy default-lane iOS binding may use default and nightly Macs", () => {
     const legacyIos = binding({
       platform: "ios",

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -81,7 +81,7 @@ describe("Iroh build compatibility", () => {
       expect(canIOSBindingUseMac(ios, binding({
         platform: "mac",
         tag,
-        clientNamespace: `mac:${tag}`,
+        clientNamespace: `mac:com.cmuxterm.app.debug.${tag}`,
       }))).toBe(true);
     }
     expect(canIOSBindingUseMac(ios, binding({
@@ -89,11 +89,40 @@ describe("Iroh build compatibility", () => {
       tag: "default",
       clientNamespace: "mac:com.cmuxterm.app",
     }))).toBe(false);
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "rc",
+      clientNamespace: "mac:com.cmuxterm.app.rc",
+    }))).toBe(false);
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "staging",
+      clientNamespace: "mac:com.cmuxterm.app.staging",
+    }))).toBe(false);
     expect(canIOSBindingForgetMac(ios, binding({
       platform: "mac",
       tag: "msta",
-      clientNamespace: "mac:msta",
+      clientNamespace: "mac:com.cmuxterm.app.debug.msta",
     }))).toBe(false);
+  });
+
+  test("tagged DEV discovery requires a DEV Mac bundle namespace", () => {
+    const ios = binding({
+      platform: "ios",
+      tag: "mdev",
+      clientNamespace: "dev.cmux.ios.mdev",
+    });
+
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "mdev",
+      clientNamespace: "mac:com.cmuxterm.app.staging.mdev",
+    }))).toBe(false);
+    expect(canIOSBindingUseMac(ios, binding({
+      platform: "mac",
+      tag: "mdev",
+      clientNamespace: "mac:com.cmuxterm.app.debug.mdev",
+    }))).toBe(true);
   });
 
   test("a legacy default-lane iOS binding may use default and nightly Macs", () => {
@@ -115,7 +144,7 @@ describe("Iroh build compatibility", () => {
     const featureMac = binding({
       platform: "mac",
       tag: "feature-b",
-      clientNamespace: "mac:feature-b",
+      clientNamespace: "mac:com.cmuxterm.app.debug.feature-b",
     });
 
     expect(canIOSBindingUseMac(legacyIos, defaultMac)).toBe(true);
@@ -137,7 +166,7 @@ describe("Iroh build compatibility", () => {
     const sameLaneMac = binding({
       platform: "mac",
       tag: "feature-a",
-      clientNamespace: "mac:feature-a",
+      clientNamespace: "mac:com.cmuxterm.app.debug.feature-a",
     });
 
     expect(canIOSBindingUseMac(taggedLegacyIos, nightlyMac)).toBe(false);
@@ -1406,7 +1435,7 @@ describe("Iroh discovery and grants", () => {
     });
     const acceptor = binding({
       userId: USER_A,
-      clientNamespace: "mac:feature-b",
+      clientNamespace: "mac:com.cmuxterm.app.debug.feature-b",
       tag: "feature-b",
       platform: "mac",
       pairingEnabled: true,
@@ -1709,12 +1738,12 @@ describe("Iroh discovery and grants", () => {
     });
     const macA = binding({
       platform: "mac",
-      clientNamespace: "mac:feature-a",
+      clientNamespace: "mac:com.cmuxterm.app.debug.feature-a",
       tag: "feature-a",
     });
     const macB = binding({
       platform: "mac",
-      clientNamespace: "mac:feature-b",
+      clientNamespace: "mac:com.cmuxterm.app.debug.feature-b",
       tag: "feature-b",
     });
     fixture.repository.bindings.push(iosA, macA, macB);


### PR DESCRIPTION
## Summary

- let a DEV iPhone discover and pair with any non-release Mac DEV tag
- retain the exact Mac device ID, instance tag, Stack user ID, and team ID owner scope
- remove the empty build-time compatible-tag allowlist and its reload plumbing
- keep Stable and Nightly separate and restricted to distributed iOS builds
- update English and Japanese pairing guidance

## Verification

- device archive compiled from commit 0cf55c2941
- macOS tag mdev cloud build passed
- regression tests are split into test-only commit 8c3be7c59d and fix commit 0cf55c2941
- plist, localization JSON, shell syntax, and diff checks passed
- hosted Computer Order UI regression and physical iPhone multi-Mac verification are in progress

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887069&installation_model_id=21920&pr_number=10519&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10519&signature=4d7b91d020844d93f7cf8e2fd66e4417764054b3a633b68c61f305b51d5f9333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let DEV iOS builds discover and pair with any authenticated DEV Mac tag; previously DEV-to-DEV required an exact tag. Stable/Nightly behavior, revocation breadth, and distributed build compatibility remain unchanged. DEV pairing now rejects Stable/Nightly/RC/Staging tags and non‑DEV Mac namespaces, and direct pairing requires the Mac bundle namespace.

- Policy: `.development` now covers all DEV tags; `.official` unchanged. `MobileMacBuildCompatibilityPolicy.current()` takes no parameters. Compatibility checks include the Mac client namespace; DEV discovery/pairing reject non‑DEV Mac bundles, and DEV direct pairing rejects Macs that do not report a namespace.
- Discovery/presence/registry: Preserve the Mac client namespace in discovery and pass it through compatibility filtering. DEV projections include sibling DEV instances. Foreground reconnects, presence updates, and refreshes always schedule secondary aggregation; when aggregation is off, we still discover and persist authenticated Macs but do not fan‑out workspaces. Automatic discovery ranks by tag proximity and recency and limits candidates to 4.
- Guard/broker (web): DEV cross‑tag discovery and pair grants require a DEV iOS namespace and a DEV Mac debug namespace; Stable/Nightly/RC/Staging Macs and non‑DEV namespaces are excluded. Forget/revocation stays exact‑tag.
- Runtime/config/scripts: Remove DEV tag filters. Drop `CMUXCompatibleMacTags`/`CMUX_COMPATIBLE_MAC_TAGS` and the `--compatible-mac-tags` flag in `ios/scripts/reload.sh`. The Mac host status payload now includes `mac_client_namespace`.
- UX/tests: Update pairing guidance (EN/JA). Add tests for namespace gating (including authenticated host status), cross‑tag DEV discovery/pairing, bounded discovery, zero‑touch admission with aggregation off, and web trust‑broker behavior.

**Migration**
- Replace `.development(expectedInstanceTag:..., additionalInstanceTags:...)` with `.development`.
- Replace `MobileMacBuildCompatibilityPolicy.current(buildScope:..., compatibleMacTags:...)` with `MobileMacBuildCompatibilityPolicy.current()`.
- Remove `CMUXCompatibleMacTags`/`CMUX_COMPATIBLE_MAC_TAGS` and stop passing `--compatible-mac-tags` to `ios/scripts/reload.sh`.

<sup>Written for commit 77883a1cd0cf7ea8f34b25a35ebe9e9a5074fdd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development iPhone builds can discover and pair with tagged development Mac builds across sibling lanes.
  * Development discovery excludes Stable, Nightly, RC, and Staging builds.
  * Mac client identity information improves build compatibility validation.
  * Multi-Mac discovery and synchronization continue during reconnects and workspace refreshes when explicitly requested.
  * Discovery results can be limited to a specified number of Mac builds.
* **Bug Fixes**
  * Updated pairing guidance and localized messages to reflect broader development-build compatibility.
  * Removed obsolete compatibility-tag configuration and override support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->