### PR TITLE
cmux-tui: restoration apply v1 — checkpoint content into restored exited terminals at cold start

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::SessionJournalRecord;
-use crate::workspace_registry::{journal_extensions::encode_hex, JournalContentRef, WorkspaceRegistry};
+use crate::workspace_registry::{encode_hex, JournalContentRef, WorkspaceRegistry};
 
 /// Bound on tail bytes replayed into one restored placeholder. Matches the
 /// bounded VT replay budget used everywhere else a terminal is rebuilt.

--- a/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
@@ -1,0 +1,711 @@
+//! Renderable content for terminals restored as exited placeholders.
+//!
+//! `spec/session-journal.md` ("Restoration") defines the inert restored model:
+//! the newest compatible checkpoint plus every later required record.
+//! Restart reconciliation preserves the journaled topology and commits dead
+//! terminals as exited; this module computes the VT content those exited
+//! placeholders can honestly render, from the terminal's checkpoint VT blob
+//! plus the reducible `terminal.output` / `terminal.resized` tail. It spawns
+//! nothing and never mutates the journal; materialization appends its own
+//! post-replay outcome record.
+
+use anyhow::Context;
+use base64::Engine;
+use ghostty_vt::{KittyGraphicsLimits, KittyImageAlias, KittyImageIdCursors, KittyReplayState};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::SessionJournalRecord;
+use crate::workspace_registry::{JournalContentRef, WorkspaceRegistry};
+
+/// Bound on tail bytes replayed into one restored placeholder. Matches the
+/// bounded VT replay budget used everywhere else a terminal is rebuilt.
+pub(crate) const RESTORE_TAIL_MAX_BYTES: u64 = crate::surface::VT_REPLAY_MAX_BYTES as u64;
+
+const RESTORE_SCAN_PAGE: usize = 1024;
+
+/// One replayable event of the post-checkpoint tail, in commit order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RestoredTailEvent {
+    Output(Vec<u8>),
+    Resize { cols: u16, rows: u16, cell_width: u32, cell_height: u32 },
+}
+
+/// The reducible content for one restored terminal: an optional checkpoint
+/// VT replay base plus the contiguous journaled tail after it.
+#[derive(Debug, Clone)]
+pub(crate) struct RestoredTerminalContent {
+    pub(crate) checkpoint_id: Option<String>,
+    /// Checkpoint VT replay bytes; empty when the terminal had no blob in the
+    /// newest checkpoint (tail-only restore).
+    pub(crate) replay: Vec<u8>,
+    pub(crate) kitty_image_aliases: Vec<KittyImageAlias>,
+    pub(crate) kitty_state: KittyReplayState,
+    /// Grid the replay bytes were captured at (or the durable launch grid for
+    /// a tail-only restore).
+    pub(crate) cols: u16,
+    pub(crate) rows: u16,
+    pub(crate) tail: Vec<RestoredTailEvent>,
+    pub(crate) tail_output_bytes: u64,
+    pub(crate) tail_resize_events: u64,
+    /// Why the tail stopped early, when it did. The content before the stop
+    /// remains renderable; the projection never guesses at missing bytes.
+    pub(crate) degraded: Option<String>,
+}
+
+impl RestoredTerminalContent {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.replay.is_empty() && self.tail.is_empty()
+    }
+
+    pub(crate) fn source_label(&self) -> &'static str {
+        match (self.checkpoint_id.is_some(), self.tail.is_empty()) {
+            (true, true) => "checkpoint",
+            (true, false) => "checkpoint+tail",
+            (false, false) => "tail",
+            (false, true) => "none",
+        }
+    }
+}
+
+/// Compute the restorable content for one terminal from the newest
+/// checkpoint and the journal tail. Returns `Ok(None)` when the journal
+/// holds nothing renderable for this terminal (for example a session that
+/// never journaled and never checkpointed).
+pub(crate) fn restored_terminal_content(
+    registry: &WorkspaceRegistry,
+    terminal_public_id: &str,
+    fallback_grid: (u16, u16),
+) -> anyhow::Result<Option<RestoredTerminalContent>> {
+    let checkpoint = registry.journal_checkpoint("latest")?;
+    let (mut content, scan_from) = match checkpoint {
+        Some(checkpoint) => {
+            let reference = checkpoint
+                .content_refs
+                .iter()
+                .find(|reference| reference.terminal_id == terminal_public_id);
+            match reference {
+                Some(reference) => {
+                    let base = registry
+                        .journal_content_blob_bytes(reference)?
+                        .map(|uncompressed| decode_vt_replay_blob(reference, &uncompressed))
+                        .transpose()?;
+                    match base {
+                        Some(base) => {
+                            let mut base = base;
+                            base.checkpoint_id = Some(checkpoint.checkpoint_id.clone());
+                            (base, checkpoint.source_sequence)
+                        }
+                        // The referenced blob is absent or unreadable. The
+                        // tail after the checkpoint is still contiguous and
+                        // renderable on an empty grid only for output that
+                        // starts a new generation; reducing it onto a missing
+                        // base would misrepresent the screen, so restore
+                        // nothing renderable and report the degradation.
+                        None => {
+                            return Ok(Some(RestoredTerminalContent {
+                                checkpoint_id: Some(checkpoint.checkpoint_id.clone()),
+                                replay: Vec::new(),
+                                kitty_image_aliases: Vec::new(),
+                                kitty_state: KittyReplayState::disabled(),
+                                cols: fallback_grid.0,
+                                rows: fallback_grid.1,
+                                tail: Vec::new(),
+                                tail_output_bytes: 0,
+                                tail_resize_events: 0,
+                                degraded: Some("checkpoint content blob is unavailable".into()),
+                            }));
+                        }
+                    }
+                }
+                // The newest checkpoint does not cover this terminal (it was
+                // created after the capture, or had no live surface then).
+                // Its full journaled output history is the only base.
+                None => (empty_content(fallback_grid), 0),
+            }
+        }
+        None => (empty_content(fallback_grid), 0),
+    };
+
+    let mut fold = TerminalTailFold::new(terminal_public_id, RESTORE_TAIL_MAX_BYTES);
+    let mut cursor = scan_from;
+    loop {
+        let page = registry.session_journal_after(cursor, RESTORE_SCAN_PAGE)?;
+        if page.records.is_empty() {
+            break;
+        }
+        for record in &page.records {
+            cursor = cursor.max(record.sequence);
+            if !fold.apply(record) {
+                break;
+            }
+        }
+        if fold.stopped() {
+            break;
+        }
+    }
+    let (tail, tail_output_bytes, tail_resize_events, degraded) = fold.finish();
+    content.tail = tail;
+    content.tail_output_bytes = tail_output_bytes;
+    content.tail_resize_events = tail_resize_events;
+    if content.degraded.is_none() {
+        content.degraded = degraded;
+    }
+
+    if content.is_empty() && content.degraded.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(content))
+}
+
+fn empty_content(fallback_grid: (u16, u16)) -> RestoredTerminalContent {
+    RestoredTerminalContent {
+        checkpoint_id: None,
+        replay: Vec::new(),
+        kitty_image_aliases: Vec::new(),
+        kitty_state: KittyReplayState::disabled(),
+        cols: fallback_grid.0.max(1),
+        rows: fallback_grid.1.max(1),
+        tail: Vec::new(),
+        tail_output_bytes: 0,
+        tail_resize_events: 0,
+        degraded: None,
+    }
+}
+
+/// Fold `terminal.output` / `terminal.resized` records for one terminal into
+/// an ordered replayable tail, with the same validation the restore-preview
+/// reducer applies: exact byte counts, digests, and per-generation offset
+/// contiguity. A `terminal.output.gap`, a validation failure, or an exceeded
+/// byte budget stops the tail at the last provably complete event instead of
+/// guessing at missing bytes.
+pub(crate) struct TerminalTailFold {
+    terminal_id: String,
+    budget: u64,
+    events: Vec<RestoredTailEvent>,
+    output_bytes: u64,
+    resize_events: u64,
+    /// `(generation, next_expected_offset)` for the stream currently being
+    /// followed. Restarted hosts start a new generation; commit order is the
+    /// authoritative order across generations.
+    stream: Option<(String, u64)>,
+    degraded: Option<String>,
+}
+
+impl TerminalTailFold {
+    pub(crate) fn new(terminal_id: &str, budget: u64) -> Self {
+        Self {
+            terminal_id: terminal_id.to_string(),
+            budget,
+            events: Vec::new(),
+            output_bytes: 0,
+            resize_events: 0,
+            stream: None,
+            degraded: None,
+        }
+    }
+
+    pub(crate) fn stopped(&self) -> bool {
+        self.degraded.is_some()
+    }
+
+    /// Apply one journal record. Returns `false` once the fold has stopped.
+    pub(crate) fn apply(&mut self, record: &SessionJournalRecord) -> bool {
+        if self.stopped() {
+            return false;
+        }
+        if !record
+            .subjects
+            .iter()
+            .any(|subject| subject.kind == "terminal" && subject.id == self.terminal_id)
+        {
+            return true;
+        }
+        match record.kind.as_str() {
+            "terminal.output" => match self.apply_output(record) {
+                Ok(()) => true,
+                Err(error) => {
+                    self.degraded = Some(format!("terminal output tail stopped: {error:#}"));
+                    false
+                }
+            },
+            "terminal.resized" => match self.apply_resize(record) {
+                Ok(()) => true,
+                Err(error) => {
+                    self.degraded = Some(format!("terminal resize tail stopped: {error:#}"));
+                    false
+                }
+            },
+            "terminal.output.gap" => {
+                let reason = record.payload["reason"].as_str().unwrap_or("unknown");
+                self.degraded = Some(format!("terminal output gap: {reason}"));
+                false
+            }
+            _ => true,
+        }
+    }
+
+    fn apply_output(&mut self, record: &SessionJournalRecord) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            record.payload["format"].as_str() == Some("cmux.terminal-output.v1")
+                && record.payload["encoding"].as_str() == Some("raw"),
+            "terminal output replay metadata is invalid"
+        );
+        let bytes = record
+            .terminal_output
+            .as_deref()
+            .context("terminal output replay content is absent")?;
+        let byte_count = decimal_field(&record.payload, "byte_count")?;
+        anyhow::ensure!(
+            byte_count == u64::try_from(bytes.len())?,
+            "terminal output replay byte_count is invalid"
+        );
+        let start = decimal_field(&record.payload, "stream_offset_start")?;
+        let end = decimal_field(&record.payload, "stream_offset_end")?;
+        anyhow::ensure!(
+            end.checked_sub(start) == Some(byte_count),
+            "terminal output replay offsets are invalid"
+        );
+        anyhow::ensure!(
+            record.payload["sha256"].as_str()
+                == Some(encode_hex(Sha256::digest(bytes).as_slice()).as_str()),
+            "terminal output replay digest is invalid"
+        );
+        let generation = record
+            .authority
+            .as_ref()
+            .filter(|authority| authority.role == "terminal.runtime")
+            .map(|authority| authority.generation.clone())
+            .context("terminal output record omitted runtime authority")?;
+        match &self.stream {
+            Some((current, expected)) if *current == generation => {
+                anyhow::ensure!(
+                    start == *expected,
+                    "terminal output replay contains an offset gap"
+                );
+            }
+            // First record of this generation inside the scan window. A
+            // checkpoint base covers everything before the window, so an
+            // arbitrary first offset is the continuation point, exactly as
+            // the restore-preview reducer accepts it.
+            _ => {}
+        }
+        anyhow::ensure!(
+            self.output_bytes.saturating_add(byte_count) <= self.budget,
+            "terminal output tail exceeds the bounded replay budget"
+        );
+        self.stream = Some((generation, end));
+        self.output_bytes += byte_count;
+        self.events.push(RestoredTailEvent::Output(bytes.to_vec()));
+        Ok(())
+    }
+
+    fn apply_resize(&mut self, record: &SessionJournalRecord) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            record.payload["format"].as_str() == Some("cmux.terminal-geometry.v1"),
+            "terminal resize replay metadata is invalid"
+        );
+        let cols = geometry_field(&record.payload, "cols")?;
+        let rows = geometry_field(&record.payload, "rows")?;
+        let cell_width = geometry_field(&record.payload, "cell_width")?;
+        let cell_height = geometry_field(&record.payload, "cell_height")?;
+        anyhow::ensure!(cols > 0 && rows > 0, "terminal resize grid must be non-zero");
+        self.resize_events += 1;
+        self.events.push(RestoredTailEvent::Resize {
+            cols: u16::try_from(cols).context("terminal resize cols overflow")?,
+            rows: u16::try_from(rows).context("terminal resize rows overflow")?,
+            cell_width,
+            cell_height,
+        });
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> (Vec<RestoredTailEvent>, u64, u64, Option<String>) {
+        (self.events, self.output_bytes, self.resize_events, self.degraded)
+    }
+}
+
+/// Decode one `cmux.vt-replay.v1` checkpoint blob back into replay parts.
+/// Inverse of the capture encoding in `journal_checkpoint::capture`.
+pub(crate) fn decode_vt_replay_blob(
+    reference: &JournalContentRef,
+    uncompressed: &[u8],
+) -> anyhow::Result<RestoredTerminalContent> {
+    let value: Value =
+        serde_json::from_slice(uncompressed).context("checkpoint replay blob is not JSON")?;
+    anyhow::ensure!(
+        value["format"].as_str() == Some("cmux.vt-replay.v1"),
+        "checkpoint replay blob format is unsupported"
+    );
+    let cols = u16::try_from(value["cols"].as_u64().context("replay blob omitted cols")?)
+        .context("replay blob cols overflow")?;
+    let rows = u16::try_from(value["rows"].as_u64().context("replay blob omitted rows")?)
+        .context("replay blob rows overflow")?;
+    anyhow::ensure!(cols > 0 && rows > 0, "replay blob grid must be non-zero");
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value["bytes_base64"].as_str().context("replay blob omitted bytes")?)
+        .context("replay blob bytes are not base64")?;
+    let kitty_image_aliases = value["kitty_image_aliases"]
+        .as_array()
+        .context("replay blob omitted kitty image aliases")?
+        .iter()
+        .map(|alias| {
+            Ok(KittyImageAlias {
+                image_id: u32::try_from(
+                    alias["image_id"].as_u64().context("kitty alias omitted image_id")?,
+                )?,
+                image_number: u32::try_from(
+                    alias["image_number"].as_u64().context("kitty alias omitted image_number")?,
+                )?,
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let kitty = &value["kitty_state"];
+    let limits = &kitty["limits"];
+    let kitty_state = KittyReplayState {
+        limits: KittyGraphicsLimits {
+            image_bytes: decimal_field(limits, "image_bytes")?,
+            inflight_bytes: decimal_field(limits, "inflight_bytes")?,
+            images: decimal_field(limits, "images")?,
+            placements: decimal_field(limits, "placements")?,
+        },
+        replay_cursor_offset: u32::try_from(
+            kitty["replay_cursor_offset"]
+                .as_u64()
+                .context("replay blob omitted kitty replay cursor")?,
+        )
+        .context("kitty replay cursor overflow")?,
+        replay_next_image_ids: kitty_cursors(&kitty["replay_next_image_ids"])?,
+        next_image_ids: kitty_cursors(&kitty["next_image_ids"])?,
+    };
+    anyhow::ensure!(
+        reference.cols == cols && reference.rows == rows,
+        "checkpoint replay blob grid does not match its reference"
+    );
+    Ok(RestoredTerminalContent {
+        checkpoint_id: None,
+        replay: bytes,
+        kitty_image_aliases,
+        kitty_state,
+        cols,
+        rows,
+        tail: Vec::new(),
+        tail_output_bytes: 0,
+        tail_resize_events: 0,
+        degraded: None,
+    })
+}
+
+fn kitty_cursors(value: &Value) -> anyhow::Result<KittyImageIdCursors> {
+    Ok(KittyImageIdCursors {
+        primary: u32::try_from(
+            value["primary"].as_u64().context("kitty cursors omitted primary")?,
+        )?,
+        alternate: u32::try_from(
+            value["alternate"].as_u64().context("kitty cursors omitted alternate")?,
+        )?,
+    })
+}
+
+/// Decimal string or integer field, matching the journal's decimal-string
+/// serialization for JavaScript-safe transport.
+fn decimal_field(payload: &Value, field: &str) -> anyhow::Result<u64> {
+    let value = payload.get(field).with_context(|| format!("journal payload omitted {field}"))?;
+    if let Some(value) = value.as_u64() {
+        return Ok(value);
+    }
+    value
+        .as_str()
+        .with_context(|| format!("journal payload {field} is not a decimal"))?
+        .parse::<u64>()
+        .with_context(|| format!("journal payload {field} is not a decimal"))
+}
+
+fn geometry_field(payload: &Value, field: &str) -> anyhow::Result<u32> {
+    u32::try_from(
+        payload
+            .get(field)
+            .and_then(Value::as_u64)
+            .with_context(|| format!("terminal geometry omitted {field}"))?,
+    )
+    .with_context(|| format!("terminal geometry {field} overflow"))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace_registry::{
+        JournalAuthority, JournalClass, JournalProducer, JournalReplayPolicy, JournalSensitivity,
+        JournalSubject,
+    };
+    use serde_json::json;
+
+    const TERMINAL: &str = "term_0000000000000000000000000000dead";
+
+    fn output_record(
+        sequence: u64,
+        generation: &str,
+        start: u64,
+        bytes: &[u8],
+    ) -> SessionJournalRecord {
+        let end = start + bytes.len() as u64;
+        SessionJournalRecord {
+            sequence,
+            event_id: format!("event_terminal_{sequence}"),
+            schema_version: 1,
+            kind: "terminal.output".into(),
+            class: JournalClass::Observation,
+            replay: JournalReplayPolicy::Required,
+            occurred_at_ms: sequence,
+            committed_at_ms: sequence,
+            producer: JournalProducer { kind: "terminal_runtime".into(), id: TERMINAL.into() },
+            authority: Some(JournalAuthority {
+                principal_id: "cmux.terminal-runtime".into(),
+                lease_id: format!("terminal:{TERMINAL}"),
+                generation: generation.into(),
+                role: "terminal.runtime".into(),
+            }),
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![JournalSubject { kind: "terminal".into(), id: TERMINAL.into() }],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({
+                "format": "cmux.terminal-output.v1",
+                "encoding": "raw",
+                "byte_count": bytes.len().to_string(),
+                "sha256": encode_hex(Sha256::digest(bytes).as_slice()),
+                "stream_offset_start": start.to_string(),
+                "stream_offset_end": end.to_string(),
+            }),
+            resource_revision: None,
+            previous_resource_revision: None,
+            terminal_output: Some(bytes.to_vec().into()),
+        }
+    }
+
+    fn resize_record(
+        sequence: u64,
+        generation: &str,
+        cols: u32,
+        rows: u32,
+    ) -> SessionJournalRecord {
+        let mut record = output_record(sequence, generation, 0, b"");
+        record.kind = "terminal.resized".into();
+        record.class = JournalClass::State;
+        record.terminal_output = None;
+        record.payload = json!({
+            "format": "cmux.terminal-geometry.v1",
+            "cols": cols,
+            "rows": rows,
+            "cell_width": 8,
+            "cell_height": 16,
+        });
+        record
+    }
+
+    fn gap_record(sequence: u64, generation: &str, reason: &str) -> SessionJournalRecord {
+        let mut record = output_record(sequence, generation, 0, b"");
+        record.kind = "terminal.output.gap".into();
+        record.class = JournalClass::State;
+        record.terminal_output = None;
+        record.payload = json!({
+            "format": "cmux.terminal-output-gap.v1",
+            "reason": reason,
+        });
+        record
+    }
+
+    #[test]
+    fn fold_applies_contiguous_output_and_resize_in_commit_order() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        assert!(fold.apply(&output_record(10, "gen-1", 0, b"hello ")));
+        assert!(fold.apply(&resize_record(11, "gen-1", 132, 43)));
+        assert!(fold.apply(&output_record(12, "gen-1", 6, b"world")));
+        let (events, output_bytes, resize_events, degraded) = fold.finish();
+        assert_eq!(degraded, None);
+        assert_eq!(output_bytes, 11);
+        assert_eq!(resize_events, 1);
+        assert_eq!(
+            events,
+            vec![
+                RestoredTailEvent::Output(b"hello ".to_vec()),
+                RestoredTailEvent::Resize { cols: 132, rows: 43, cell_width: 8, cell_height: 16 },
+                RestoredTailEvent::Output(b"world".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn fold_ignores_other_terminals_and_other_kinds() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        let mut foreign = output_record(10, "gen-1", 0, b"foreign");
+        foreign.subjects =
+            vec![JournalSubject { kind: "terminal".into(), id: "term_other".into() }];
+        assert!(fold.apply(&foreign));
+        let mut unrelated = output_record(11, "gen-1", 0, b"");
+        unrelated.kind = "workspace.create".into();
+        unrelated.payload = json!({});
+        assert!(fold.apply(&unrelated));
+        assert!(fold.apply(&output_record(12, "gen-1", 0, b"mine")));
+        let (events, output_bytes, _, degraded) = fold.finish();
+        assert_eq!(degraded, None);
+        assert_eq!(output_bytes, 4);
+        assert_eq!(events, vec![RestoredTailEvent::Output(b"mine".to_vec())]);
+    }
+
+    #[test]
+    fn fold_stops_at_gap_record_and_keeps_the_provable_prefix() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        assert!(fold.apply(&output_record(10, "gen-1", 0, b"before")));
+        assert!(!fold.apply(&gap_record(11, "gen-1", "detach_fence_failed")));
+        assert!(!fold.apply(&output_record(12, "gen-1", 6, b"after")));
+        assert!(fold.stopped());
+        let (events, output_bytes, _, degraded) = fold.finish();
+        assert_eq!(events, vec![RestoredTailEvent::Output(b"before".to_vec())]);
+        assert_eq!(output_bytes, 6);
+        assert_eq!(degraded.as_deref(), Some("terminal output gap: detach_fence_failed"));
+    }
+
+    #[test]
+    fn fold_stops_at_a_same_generation_offset_discontinuity() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        assert!(fold.apply(&output_record(10, "gen-1", 0, b"abc")));
+        assert!(!fold.apply(&output_record(11, "gen-1", 9, b"skip")));
+        let (events, _, _, degraded) = fold.finish();
+        assert_eq!(events, vec![RestoredTailEvent::Output(b"abc".to_vec())]);
+        assert!(
+            degraded.as_deref().is_some_and(|reason| reason.contains("offset gap")),
+            "{degraded:?}"
+        );
+    }
+
+    #[test]
+    fn fold_follows_a_new_generation_from_any_offset_in_commit_order() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        assert!(fold.apply(&output_record(10, "gen-1", 100, b"old")));
+        assert!(fold.apply(&output_record(11, "gen-2", 0, b"new")));
+        let (events, output_bytes, _, degraded) = fold.finish();
+        assert_eq!(degraded, None);
+        assert_eq!(output_bytes, 6);
+        assert_eq!(
+            events,
+            vec![
+                RestoredTailEvent::Output(b"old".to_vec()),
+                RestoredTailEvent::Output(b"new".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn fold_stops_when_the_tail_exceeds_the_replay_budget() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 4);
+        assert!(fold.apply(&output_record(10, "gen-1", 0, b"okay")));
+        assert!(!fold.apply(&output_record(11, "gen-1", 4, b"x")));
+        let (events, output_bytes, _, degraded) = fold.finish();
+        assert_eq!(events.len(), 1);
+        assert_eq!(output_bytes, 4);
+        assert!(
+            degraded.as_deref().is_some_and(|reason| reason.contains("budget")),
+            "{degraded:?}"
+        );
+    }
+
+    #[test]
+    fn fold_rejects_a_corrupt_output_digest() {
+        let mut fold = TerminalTailFold::new(TERMINAL, 1024);
+        let mut record = output_record(10, "gen-1", 0, b"payload");
+        record.payload["sha256"] = json!(encode_hex(Sha256::digest(b"other").as_slice()));
+        assert!(!fold.apply(&record));
+        let (events, _, _, degraded) = fold.finish();
+        assert!(events.is_empty());
+        assert!(degraded.as_deref().is_some_and(|reason| reason.contains("digest")));
+    }
+
+    #[test]
+    fn decode_vt_replay_blob_round_trips_the_capture_encoding() {
+        let bytes = b"\x1b[2J\x1b[Hrestored".to_vec();
+        let encoded = json!({
+            "format": "cmux.vt-replay.v1",
+            "cols": 120,
+            "rows": 32,
+            "bytes_base64": base64::engine::general_purpose::STANDARD.encode(&bytes),
+            "kitty_image_aliases": [{"image_id": 7, "image_number": 9}],
+            "kitty_state": {
+                "limits": {
+                    "image_bytes": "1048576",
+                    "inflight_bytes": "65536",
+                    "images": "64",
+                    "placements": "128",
+                },
+                "replay_cursor_offset": 0,
+                "replay_next_image_ids": {"primary": 1, "alternate": 2},
+                "next_image_ids": {"primary": 3, "alternate": 4},
+            },
+        });
+        let serialized = serde_json::to_vec(&encoded).unwrap();
+        let reference = JournalContentRef {
+            content_id: format!("jcontent_{}", encode_hex(Sha256::digest(&serialized).as_slice())),
+            terminal_id: TERMINAL.into(),
+            format: "cmux.vt-replay.v1".into(),
+            codec: "gzip".into(),
+            sha256: encode_hex(Sha256::digest(&serialized).as_slice()),
+            uncompressed_bytes: serialized.len() as u64,
+            cols: 120,
+            rows: 32,
+        };
+        let content = decode_vt_replay_blob(&reference, &serialized).unwrap();
+        assert_eq!(content.replay, bytes);
+        assert_eq!((content.cols, content.rows), (120, 32));
+        assert_eq!(content.kitty_image_aliases.len(), 1);
+        assert_eq!(content.kitty_image_aliases[0].image_id, 7);
+        assert_eq!(content.kitty_state.limits.image_bytes, 1_048_576);
+        assert_eq!(content.kitty_state.next_image_ids.primary, 3);
+        // The decoder returns a checkpoint-less base; the caller stamps the
+        // checkpoint id and tail.
+        assert_eq!(content.source_label(), "none");
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn decode_vt_replay_blob_rejects_a_grid_mismatch() {
+        let encoded = json!({
+            "format": "cmux.vt-replay.v1",
+            "cols": 80,
+            "rows": 24,
+            "bytes_base64": "",
+            "kitty_image_aliases": [],
+            "kitty_state": {
+                "limits": {
+                    "image_bytes": "0",
+                    "inflight_bytes": "0",
+                    "images": "0",
+                    "placements": "0",
+                },
+                "replay_cursor_offset": 0,
+                "replay_next_image_ids": {"primary": 1, "alternate": 1},
+                "next_image_ids": {"primary": 1, "alternate": 1},
+            },
+        });
+        let serialized = serde_json::to_vec(&encoded).unwrap();
+        let reference = JournalContentRef {
+            content_id: "jcontent_x".into(),
+            terminal_id: TERMINAL.into(),
+            format: "cmux.vt-replay.v1".into(),
+            codec: "gzip".into(),
+            sha256: "x".into(),
+            uncompressed_bytes: serialized.len() as u64,
+            cols: 100,
+            rows: 30,
+        };
+        assert!(decode_vt_replay_blob(&reference, &serialized).is_err());
+    }
+}

--- a/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::SessionJournalRecord;
-use crate::workspace_registry::{JournalContentRef, WorkspaceRegistry};
+use crate::workspace_registry::{journal_extensions::encode_hex, JournalContentRef, WorkspaceRegistry};
 
 /// Bound on tail bytes replayed into one restored placeholder. Matches the
 /// bounded VT replay budget used everywhere else a terminal is rebuilt.
@@ -441,14 +441,6 @@ fn geometry_field(payload: &Value, field: &str) -> anyhow::Result<u32> {
             .with_context(|| format!("terminal geometry omitted {field}"))?,
     )
     .with_context(|| format!("terminal geometry {field} overflow"))
-}
-
-fn encode_hex(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push_str(&format!("{byte:02x}"));
-    }
-    out
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_restore.rs
@@ -23,6 +23,7 @@ use crate::workspace_registry::{JournalContentRef, WorkspaceRegistry};
 pub(crate) const RESTORE_TAIL_MAX_BYTES: u64 = crate::surface::VT_REPLAY_MAX_BYTES as u64;
 
 const RESTORE_SCAN_PAGE: usize = 1024;
+const MAX_RESTORE_TAIL_RESIZE_EVENTS: u64 = 10_000;
 
 /// One replayable event of the post-checkpoint tail, in commit order.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,8 +109,8 @@ pub(crate) fn restored_terminal_content(
                                 replay: Vec::new(),
                                 kitty_image_aliases: Vec::new(),
                                 kitty_state: KittyReplayState::disabled(),
-                                cols: fallback_grid.0,
-                                rows: fallback_grid.1,
+                                cols: fallback_grid.0.max(1),
+                                rows: fallback_grid.1.max(1),
                                 tail: Vec::new(),
                                 tail_output_bytes: 0,
                                 tail_resize_events: 0,
@@ -309,7 +310,18 @@ impl TerminalTailFold {
         let rows = geometry_field(&record.payload, "rows")?;
         let cell_width = geometry_field(&record.payload, "cell_width")?;
         let cell_height = geometry_field(&record.payload, "cell_height")?;
-        anyhow::ensure!(cols > 0 && rows > 0, "terminal resize grid must be non-zero");
+        anyhow::ensure!(
+            (1..=10_000).contains(&cols)
+                && (1..=10_000).contains(&rows)
+                && (1..=10_000).contains(&cell_width)
+                && (1..=10_000).contains(&cell_height)
+                && u64::from(cols).saturating_mul(u64::from(rows)) <= 4_000_000,
+            "terminal resize geometry is invalid"
+        );
+        anyhow::ensure!(
+            self.resize_events < MAX_RESTORE_TAIL_RESIZE_EVENTS,
+            "terminal resize tail exceeds the bounded replay budget"
+        );
         self.resize_events += 1;
         self.events.push(RestoredTailEvent::Resize {
             cols: u16::try_from(cols).context("terminal resize cols overflow")?,

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -16,6 +16,7 @@ mod journal_checkpoint;
 mod journal_hooks;
 mod journal_ingress;
 mod journal_kernel;
+mod journal_restore;
 mod model;
 mod mux;
 mod pairing;

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2425,6 +2425,8 @@ impl Mux {
         mux.materialize_restored_browsers(&contents)?;
         #[cfg(unix)]
         mux.adopt_terminal_hosts()?;
+        #[cfg(unix)]
+        mux.materialize_restored_exited_terminals();
         {
             let mut state = mux.state.lock().unwrap();
             state.rebuild_resource_indexes();
@@ -2862,6 +2864,125 @@ impl Mux {
                 &options,
             )?;
         }
+        Ok(())
+    }
+
+    /// Materialize every restored exited terminal as an honest dead surface
+    /// whose renderable content comes from the newest checkpoint VT blob plus
+    /// the reducible journaled output tail (spec/session-journal.md,
+    /// "Restoration"). Runs at cold start after host reconciliation and
+    /// before the socket serves clients. It spawns nothing: the placeholder
+    /// renders the terminal's final observed content and stays exited until
+    /// an explicit close or a future respawn action. Each materialization
+    /// appends its own post-replay outcome record, and one terminal's
+    /// failure never aborts startup.
+    #[cfg(unix)]
+    fn materialize_restored_exited_terminals(self: &Arc<Self>) {
+        let snapshot = match self.workspace_registry.lock().unwrap().terminal_snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                eprintln!("cmux-tui: could not enumerate terminals for restoration: {error:#}");
+                return;
+            }
+        };
+        let options = self.surface_options.lock().unwrap().clone();
+        for terminal in snapshot.terminals {
+            if terminal.lifecycle != TerminalLifecycle::Exited {
+                continue;
+            }
+            if let Err(error) = self.materialize_restored_exited_terminal(&terminal, &options) {
+                eprintln!(
+                    "cmux-tui: could not restore exited terminal {} content: {error:#}",
+                    terminal.terminal_id
+                );
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn materialize_restored_exited_terminal(
+        self: &Arc<Self>,
+        terminal: &RegistryTerminal,
+        options: &SurfaceOptions,
+    ) -> anyhow::Result<()> {
+        let Some(binding) = self.restored_terminal_binding(&terminal.terminal_id)? else {
+            return Ok(());
+        };
+        let Some((slot, identity)) = binding.placements.first().cloned() else {
+            // Every view of this terminal was explicitly closed. The durable
+            // exit receipt stays queryable without a surface.
+            return Ok(());
+        };
+        {
+            let state = self.state.lock().unwrap();
+            if binding.placements.iter().any(|(slot, _)| state.surfaces.contains_key(slot)) {
+                return Ok(());
+            }
+        }
+        let durable_size = |field: &str, fallback: u16| {
+            terminal.launch_spec[field]
+                .as_u64()
+                .and_then(|value| u16::try_from(value).ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(fallback)
+        };
+        let fallback_grid = (durable_size("cols", 80), durable_size("rows", 24));
+        let content = {
+            let registry = self.workspace_registry.lock().unwrap();
+            crate::journal_restore::restored_terminal_content(
+                &registry,
+                binding.public_id.as_str(),
+                fallback_grid,
+            )?
+        };
+        let exit = terminal
+            .exit
+            .clone()
+            .and_then(|value| serde_json::from_value::<TerminalExit>(value).ok());
+        // The placeholder deliberately carries no cwd or title of its own:
+        // the public exited projection must stay byte-identical to the
+        // durable exit snapshot the journal already carries, so restore
+        // previews keep agreeing with the applied state.
+        let mut opts = options.clone();
+        opts.cols = fallback_grid.0;
+        opts.rows = fallback_grid.1;
+        opts.cwd = None;
+        let surface = Surface::restored_exited_terminal(
+            slot,
+            opts,
+            Arc::downgrade(self),
+            TerminalHostIdentity {
+                terminal_id: terminal.terminal_id.clone(),
+                incarnation: terminal.incarnation.clone().unwrap_or_default(),
+            },
+            identity,
+            content.as_ref(),
+            exit,
+        )?;
+        {
+            let mut state = self.state.lock().unwrap();
+            insert_restored_terminal_runtime_checked(&mut state, surface)?;
+        }
+        let payload = serde_json::json!({
+            "format": "cmux.terminal-restore.v1",
+            "outcome": "applied",
+            "terminal_id": binding.public_id.as_str(),
+            "content": content.as_ref().map(|content| content.source_label()).unwrap_or("none"),
+            "checkpoint_id": content.as_ref().and_then(|content| content.checkpoint_id.clone()),
+            "tail_output_bytes": content
+                .as_ref()
+                .map(|content| content.tail_output_bytes.to_string())
+                .unwrap_or_else(|| "0".to_string()),
+            "tail_resize_events": content
+                .as_ref()
+                .map(|content| content.tail_resize_events.to_string())
+                .unwrap_or_else(|| "0".to_string()),
+            "degraded": content.as_ref().and_then(|content| content.degraded.clone()),
+        });
+        self.workspace_registry
+            .lock()
+            .unwrap()
+            .append_terminal_restore_outcome(binding.public_id.as_str(), &payload)?;
         Ok(())
     }
 
@@ -18646,7 +18767,14 @@ mod tests {
         assert_eq!(terminal["lifecycle"], "exited");
         assert_eq!(terminal["exit"]["outcome"]["kind"], "unknown");
         assert_eq!(terminal["exit"]["outcome"]["reason"], "missing-host-record");
-        assert_eq!(reopened.resource_surface_for_terminal(&terminal_public_id), None);
+        // Restoration materializes an honest exited placeholder surface: it
+        // is dead (nothing was respawned) but serves the terminal's final
+        // renderable content to screen reads and attaches.
+        let placeholder = reopened
+            .resource_surface_for_terminal(&terminal_public_id)
+            .expect("restored exited terminal materializes a placeholder surface");
+        let placeholder = reopened.surface(placeholder).expect("placeholder surface is live state");
+        assert!(placeholder.is_dead(), "restored placeholder must not claim a running process");
         let exited =
             reopened.wait_for_terminal_exit(&terminal_public_id, Some(Duration::ZERO)).unwrap();
         assert_eq!(exited["state"], "exited");
@@ -20994,7 +21122,7 @@ mod tests {
         let restored_agents = reopened.list_agents(None, None);
         assert_eq!(
             restored_agents.iter().map(|record| record.terminal_id.clone()).collect::<Vec<_>>(),
-            vec![terminal_id.clone()],
+            vec![terminal_id],
             "a restored exited terminal keeps its placement, so its agent record stays listed"
         );
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2063,6 +2063,18 @@ struct RestoredTerminalBinding {
     placements: Vec<(SurfaceId, TabResourceIdentity)>,
 }
 
+/// Topology policy for one durable exit commit. A live exit detaches its
+/// views in the same transaction. Restart reconciliation preserves the
+/// journaled tree: a process that died while the daemon was down is recorded
+/// as exited, never respawned, and never costs the session its layout.
+#[derive(Clone, Copy, PartialEq, Eq)]
+// Preserve is constructed only by the unix restart-reconciliation paths.
+#[cfg_attr(not(unix), allow(dead_code))]
+enum TerminalExitTopology {
+    Detach,
+    Preserve,
+}
+
 impl Mux {
     fn default_workspace_name(state: &State) -> String {
         state.workspaces.len().to_string()
@@ -2644,12 +2656,11 @@ impl Mux {
                 // never be allowed to terminate a replacement process.
                 continue;
             }
-            self.persist_terminal_exit(
+            self.persist_terminal_exit_preserving_topology(
                 &record.terminal_id,
                 Some(&record.incarnation),
                 &record.exit,
             )?;
-            self.detach_exited_terminal_topology(&record.terminal_id)?;
             let _ = crate::terminal_host_runtime::acknowledge_terminal_host_exit_record(
                 &exit_path, &record,
             )?;
@@ -2704,7 +2715,8 @@ impl Mux {
                 continue;
             }
             if terminal.lifecycle == TerminalLifecycle::Exited {
-                self.detach_exited_terminal_topology(&terminal.terminal_id)?;
+                // Restoration keeps the exited terminal's journaled views;
+                // only an explicit close mutates topology after restart.
                 handled_terminals.insert(terminal_id.clone());
                 if !cleanup_terminal_host_record(&record, &record_path) {
                     self.schedule_terminal_adoption(options.clone(), record, record_path);
@@ -2712,7 +2724,7 @@ impl Mux {
                 continue;
             }
             if terminal.incarnation.as_deref().is_some_and(|value| value != record.incarnation) {
-                self.mark_terminal_exited_and_detach(
+                self.mark_terminal_exited_preserving_topology(
                     &terminal_id,
                     "terminal-incarnation-mismatch",
                     "host-incarnation-mismatch",
@@ -2740,12 +2752,6 @@ impl Mux {
                         TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
                     )
                 }) {
-                    if current
-                        .as_ref()
-                        .is_some_and(|terminal| terminal.lifecycle == TerminalLifecycle::Exited)
-                    {
-                        self.detach_exited_terminal_topology(&terminal_id)?;
-                    }
                     handled_terminals.insert(terminal_id.clone());
                     if !cleanup_terminal_host_record(&record, &record_path) {
                         self.schedule_terminal_adoption(options.clone(), record, record_path);
@@ -2759,7 +2765,7 @@ impl Mux {
                 // record is the only proof that this host ever existed, so a
                 // failed commit must leave the next startup able to retry
                 // instead of facing a lifecycle row with no evidence.
-                self.mark_terminal_exited_and_detach(
+                self.mark_terminal_exited_preserving_topology(
                     &terminal_id,
                     "terminal-host-proven-dead",
                     "host-process-ended-before-adoption",
@@ -2786,7 +2792,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        self.mark_terminal_exited_and_detach(
+                        self.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -2817,7 +2823,7 @@ impl Mux {
                 surface.disconnect_for_daemon_shutdown();
                 handled_terminals.insert(terminal_id.clone());
                 if host_is_dead {
-                    self.mark_terminal_exited_and_detach(
+                    self.mark_terminal_exited_preserving_topology(
                         &terminal_id,
                         "terminal-adoption-failed",
                         "host-exited-during-adoption",
@@ -2847,10 +2853,9 @@ impl Mux {
                 continue;
             }
             if terminal.lifecycle == TerminalLifecycle::Exited {
-                self.detach_exited_terminal_topology(&terminal.terminal_id)?;
                 continue;
             }
-            self.mark_terminal_exited_and_detach(
+            self.mark_terminal_exited_preserving_topology(
                 &terminal.terminal_id,
                 "terminal-record-missing",
                 "missing-host-record",
@@ -2860,8 +2865,13 @@ impl Mux {
         Ok(())
     }
 
+    /// Latch a restart-window death as a durable exit while preserving the
+    /// terminal's journaled tab placements and split tree. The daemon never
+    /// respawns the process and never mutates topology on behalf of a process
+    /// it did not observe exiting; the restored view represents the terminal
+    /// honestly as not running until an explicit close or respawn action.
     #[cfg(unix)]
-    fn mark_terminal_exited_and_detach(
+    fn mark_terminal_exited_preserving_topology(
         self: &Arc<Self>,
         terminal_id: &str,
         _operation: &str,
@@ -2898,14 +2908,13 @@ impl Mux {
                 .as_ref()
                 .map(|(_, record)| record.incarnation.as_str())
                 .or(terminal.incarnation.as_deref());
-            self.persist_terminal_exit(terminal_id, incarnation, &observed)?;
+            self.persist_terminal_exit_preserving_topology(terminal_id, incarnation, &observed)?;
         }
         if let Some((path, record)) = sidecar {
             let _ = crate::terminal_host_runtime::acknowledge_terminal_host_exit_record(
                 &path, &record,
             )?;
         }
-        self.detach_exited_terminal_topology(terminal_id)?;
         Ok(())
     }
 
@@ -2918,7 +2927,10 @@ impl Mux {
     ) -> anyhow::Result<()> {
         let _pending_host_release = PendingTerminalHostRelease(surface.clone());
         if surface.is_dead() {
-            self.persist_terminal_exit(
+            // Adoption is restart reconciliation: the daemon never observed
+            // this process exit while owning it, so the restored topology
+            // stays and the terminal is recorded honestly as exited.
+            self.persist_terminal_exit_preserving_topology(
                 terminal_id,
                 Some(incarnation),
                 &TerminalExit::unknown("host-exited-during-adoption"),
@@ -3068,16 +3080,8 @@ impl Mux {
                         terminal.lifecycle,
                         TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
                     ) {
-                        if terminal.lifecycle == TerminalLifecycle::Exited
-                            && let Err(error) = mux.detach_exited_terminal_topology(&terminal_id)
-                        {
-                            eprintln!(
-                                "cmux-tui: could not detach exited terminal \
-                                 {terminal_id}: {error:#}"
-                            );
-                            delay = (delay * 2).min(Duration::from_secs(5));
-                            continue;
-                        }
+                        // Restoration keeps the exited terminal's journaled
+                        // views; only an explicit close mutates topology.
                         if cleanup_terminal_host_record(&record, &record_path) {
                             break;
                         }
@@ -3089,7 +3093,7 @@ impl Mux {
                         .as_deref()
                         .is_some_and(|incarnation| incarnation != record.incarnation)
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-incarnation-mismatch",
                             "host-incarnation-mismatch",
@@ -3134,7 +3138,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -3183,7 +3187,7 @@ impl Mux {
                                 == TerminalHostLiveness::Dead;
                         surface.disconnect_for_daemon_shutdown();
                         if host_is_dead {
-                            if let Err(error) = mux.mark_terminal_exited_and_detach(
+                            if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                                 &terminal_id,
                                 "terminal-adoption-failed",
                                 "host-exited-during-adoption",
@@ -3208,7 +3212,7 @@ impl Mux {
                     if terminal_host_record_liveness(&record_path, &record)
                         == TerminalHostLiveness::Dead
                     {
-                        if let Err(error) = mux.mark_terminal_exited_and_detach(
+                        if let Err(error) = mux.mark_terminal_exited_preserving_topology(
                             &terminal_id,
                             "terminal-host-proven-dead",
                             "host-process-ended-before-adoption",
@@ -4468,6 +4472,20 @@ impl Mux {
         terminal_id: &TerminalPublicId,
     ) -> Option<SurfaceId> {
         self.state.lock().unwrap().terminal_catalog.get(terminal_id).map(|surface| surface.id)
+    }
+
+    /// First tab placement of a terminal's content, present even when the
+    /// terminal has no runtime because it was restored as exited.
+    pub(crate) fn first_terminal_placement(
+        &self,
+        terminal_id: &TerminalPublicId,
+    ) -> Option<SurfaceId> {
+        self.state
+            .lock()
+            .unwrap()
+            .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
+            .first()
+            .copied()
     }
 
     pub(crate) fn resource_selectors_for_pane(
@@ -12873,6 +12891,41 @@ impl Mux {
         incarnation: Option<&str>,
         exit: &TerminalExit,
     ) -> anyhow::Result<bool> {
+        self.persist_terminal_exit_with_topology(
+            terminal_id,
+            incarnation,
+            exit,
+            TerminalExitTopology::Detach,
+        )
+    }
+
+    /// Commit a durable terminal exit without touching topology. Restart
+    /// reconciliation uses this so a restored session keeps its journaled
+    /// tab placements and split tree, representing the terminal honestly as
+    /// exited instead of silently discarding its layout. Live exits observed
+    /// while the daemon runs keep the atomic detach path.
+    #[cfg(unix)]
+    fn persist_terminal_exit_preserving_topology(
+        &self,
+        terminal_id: &str,
+        incarnation: Option<&str>,
+        exit: &TerminalExit,
+    ) -> anyhow::Result<bool> {
+        self.persist_terminal_exit_with_topology(
+            terminal_id,
+            incarnation,
+            exit,
+            TerminalExitTopology::Preserve,
+        )
+    }
+
+    fn persist_terminal_exit_with_topology(
+        &self,
+        terminal_id: &str,
+        incarnation: Option<&str>,
+        exit: &TerminalExit,
+        topology_policy: TerminalExitTopology,
+    ) -> anyhow::Result<bool> {
         let mut registry = self.workspace_registry.lock().unwrap();
         let terminal = registry
             .terminal_record(terminal_id)?
@@ -12913,7 +12966,8 @@ impl Mux {
         let detach_projection = if matches!(
             terminal.lifecycle,
             TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
-        ) {
+        ) || topology_policy == TerminalExitTopology::Preserve
+        {
             None
         } else if let Some(public_terminal_id) = public_terminal_id.as_ref() {
             self.terminal_exit_detach_projection_locked(
@@ -14912,14 +14966,29 @@ fn terminal_exit_snapshot_in_state(
         .ok_or_else(|| anyhow::anyhow!("terminal {terminal_id} has no public resource id"))?;
     let content_id = ContentPublicId::Terminal(public_id.clone());
     let topology = registry.resource_topology_snapshot()?;
-    let tab_ids = topology
-        .tabs
-        .iter()
-        .filter(|tab| tab.content_id == content_id)
-        .map(|tab| tab.public_id.clone())
-        .collect::<Vec<_>>();
+    let tab_ids = crate::resource_api::terminal_tab_ids_in_canonical_order(
+        topology.tabs.iter().filter(|tab| tab.content_id == content_id).map(|tab| {
+            (public_id.clone(), tab.pane_id.clone(), tab.position, tab.public_id.clone())
+        }),
+    )
+    .remove(&public_id)
+    .unwrap_or_default();
     let surface = state.surface_by_content_public_id(&content_id);
-    let (cols, rows) = surface.map(|surface| surface.size()).unwrap_or((80, 24));
+    // Match the public projection's fallback exactly. A restart-window exit
+    // has no surface, and the preserved topology makes this snapshot the
+    // durable view later restarts and restore previews must agree on.
+    let durable = registry.terminal_record(terminal_id)?;
+    let durable_size = |field: &str, fallback: u16| {
+        durable
+            .as_ref()
+            .and_then(|terminal| terminal.launch_spec[field].as_u64())
+            .and_then(|value| u16::try_from(value).ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(fallback)
+    };
+    let (cols, rows) = surface
+        .map(|surface| surface.size())
+        .unwrap_or_else(|| (durable_size("cols", 80), durable_size("rows", 24)));
     let mut snapshot = serde_json::json!({
         "id": public_id,
         "tab_id": tab_ids.first(),
@@ -18634,10 +18703,13 @@ mod tests {
             assert_eq!(replay["result"]["replayed"], true, "{operation}");
         }
         assert_eq!(reopened.resource_notifications(256).len(), 1);
-        assert!(
-            reopened.list_agents(None, None).is_empty(),
-            "the legacy live-surface cache must not retain a detached terminal"
+        let restored_agents = reopened.list_agents(None, None);
+        assert_eq!(
+            restored_agents.len(),
+            1,
+            "a restored exited terminal keeps its placement, so its agent record stays listed"
         );
+        assert_eq!(restored_agents[0].terminal_id, terminal_public_id);
         assert_eq!(
             reopened
                 .workspace_registry
@@ -20919,9 +20991,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(reopened.resource_agent_projection_count_for_test().unwrap(), 1);
-        assert!(
-            reopened.list_agents(None, None).is_empty(),
-            "the legacy live-surface cache must not retain a detached terminal"
+        let restored_agents = reopened.list_agents(None, None);
+        assert_eq!(
+            restored_agents.iter().map(|record| record.terminal_id.clone()).collect::<Vec<_>>(),
+            vec![terminal_id.clone()],
+            "a restored exited terminal keeps its placement, so its agent record stays listed"
         );
         assert_eq!(
             crate::resource_api::public_session_snapshot(&reopened).unwrap()["agents"],
@@ -24723,10 +24797,14 @@ mod tests {
                 && change["id"] == terminal_public_id.as_str()
                 && change["value"]["lifecycle"] == "exited"
         }));
+        assert!(
+            !changes.iter().any(|change| change["kind"] == "delete" && change["resource"] == "tab"),
+            "sidecar recovery must preserve the restored tab placement"
+        );
         assert!(changes.iter().any(|change| {
-            change["kind"] == "delete"
-                && change["resource"] == "tab"
-                && change["id"] == tab.as_str()
+            change["kind"] == "upsert"
+                && change["resource"] == "terminal"
+                && change["value"]["tab_ids"][0] == tab.as_str()
         }));
         assert!(!changes.iter().any(|change| {
             change["kind"] == "delete"

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2297,10 +2297,11 @@ impl Mux {
                     "live terminal resource {public_id} has views but no runtime owner"
                 ))
             );
-            if let (Some(expected), Some(stored)) =
-                (expected_incarnation, durable.incarnation.as_deref())
-            {
-                anyhow::ensure!(expected == stored, "terminal_incarnation_mismatch");
+            if let Some(expected) = expected_incarnation {
+                anyhow::ensure!(
+                    durable.incarnation.as_deref() == Some(expected),
+                    "terminal_incarnation_mismatch"
+                );
             }
             let plan = self.resource_close_plan_locked(
                 ResourceOperation::TerminalClose,

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2205,7 +2205,11 @@ impl Mux {
             fingerprint,
             move |state| {
                 anyhow::ensure!(
-                    state.terminal_runtime_by_id(surface).is_some(),
+                    state.terminal_runtime_by_id(surface).is_some()
+                        || matches!(
+                            state.resource_indexes.content_ids.get(&surface),
+                            Some(ContentPublicId::Terminal(_))
+                        ),
                     "terminal disappeared"
                 );
                 Ok(EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) })
@@ -2279,12 +2283,34 @@ impl Mux {
                 &notifications,
             )?;
             (target, plan)
-        } else {
-            if !state.placements_of_content(&content_id).is_empty() {
-                return Err(terminal_close_state_error(format!(
+        } else if let Some(&slot) = state.placements_of_content(&content_id).first() {
+            // A restored exited terminal keeps its journaled views without a
+            // runtime owner. Explicit close is the mutation that removes them.
+            let durable = registry.terminal_record(terminal_id)?.ok_or_else(|| {
+                terminal_close_state_error(format!(
+                    "terminal close target omitted host {terminal_id}"
+                ))
+            })?;
+            anyhow::ensure!(
+                durable.lifecycle == TerminalLifecycle::Exited,
+                terminal_close_state_error(format!(
                     "live terminal resource {public_id} has views but no runtime owner"
-                )));
+                ))
+            );
+            if let (Some(expected), Some(stored)) =
+                (expected_incarnation, durable.incarnation.as_deref())
+            {
+                anyhow::ensure!(expected == stored, "terminal_incarnation_mismatch");
             }
+            let plan = self.resource_close_plan_locked(
+                ResourceOperation::TerminalClose,
+                EffectSlots { workspace: None, screen: None, pane: None, tab: Some(slot) },
+                &registry,
+                &state,
+                &notifications,
+            )?;
+            (Some(slot), plan)
+        } else {
             (
                 None,
                 ResourceClosePlan {
@@ -2538,9 +2564,13 @@ impl Mux {
         self.emit_empty_if_current(effects.empty_revision);
     }
 
-    /// Reconcile a lifecycle row that was committed before topology detach was
-    /// introduced, or whose daemon stopped between those two older commits.
-    /// The durable terminal receipt remains queryable after every view leaves.
+    /// Detach the views of a terminal whose exit this daemon observed live
+    /// but whose lifecycle-and-detach commit did not land atomically (for
+    /// example a dead surface discovered after its host connection dropped).
+    /// Restart reconciliation deliberately never calls this: a restored
+    /// session keeps the journaled topology of terminals that died while the
+    /// daemon was down. The durable terminal receipt remains queryable after
+    /// every view leaves.
     pub(super) fn detach_exited_terminal_topology(
         &self,
         terminal_id: &str,
@@ -2705,7 +2735,7 @@ impl Mux {
         &self,
         operation: ResourceOperation,
         slots: EffectSlots,
-        _registry: &WorkspaceRegistry,
+        registry: &WorkspaceRegistry,
         state: &State,
         notifications: &HashMap<SurfaceId, SurfaceNotification>,
     ) -> anyhow::Result<ResourceClosePlan> {
@@ -2794,17 +2824,36 @@ impl Mux {
             }
             ResourceOperation::TerminalClose => {
                 let surface = slots.tab.context("terminal disappeared")?;
-                let runtime = state
-                    .terminal_runtime_by_id(surface)
-                    .cloned()
-                    .context("terminal disappeared")?;
-                let public_id = runtime
-                    .terminal_public_id()
-                    .cloned()
-                    .context("terminal catalog entry omitted its public identity")?;
-                let host = self
-                    .resource_terminal_host_identity(&runtime)
-                    .context("terminal omitted its durable host identity")?;
+                let runtime = state.terminal_runtime_by_id(surface).cloned();
+                let (public_id, terminal_batch) = match runtime.as_ref() {
+                    Some(runtime) => {
+                        let public_id = runtime
+                            .terminal_public_id()
+                            .cloned()
+                            .context("terminal catalog entry omitted its public identity")?;
+                        let host = self
+                            .resource_terminal_host_identity(runtime)
+                            .context("terminal omitted its durable host identity")?;
+                        (public_id, vec![(host.terminal_id, Some(host.incarnation))])
+                    }
+                    None => {
+                        // A restored exited terminal keeps views without a
+                        // runtime. Its durable identity comes from the
+                        // registry, and the close still tombstones the host.
+                        let public_id = match state.resource_indexes.content_ids.get(&surface) {
+                            Some(ContentPublicId::Terminal(public_id)) => public_id.clone(),
+                            _ => anyhow::bail!("terminal disappeared"),
+                        };
+                        let host_id = registry
+                            .terminal_host_id(&public_id)?
+                            .context("terminal omitted its durable host identity")?;
+                        let incarnation = registry
+                            .terminal_record(&host_id)?
+                            .context("terminal close target omitted its durable row")?
+                            .incarnation;
+                        (public_id, vec![(host_id, incarnation)])
+                    }
+                };
                 let placements = state
                     .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
                     .to_vec();
@@ -2814,8 +2863,8 @@ impl Mux {
                 ResourceCloseInputs {
                     surface_ids: placements,
                     changed_screens: screens,
-                    terminal_runtime: Some(runtime),
-                    terminal_batch: vec![(host.terminal_id, Some(host.incarnation))],
+                    terminal_runtime: runtime,
+                    terminal_batch,
                     terminal_public_id: Some(public_id),
                     ..Default::default()
                 }
@@ -2829,10 +2878,13 @@ impl Mux {
             let (removed_runtime, terminal_views, changed) =
                 remove_terminal_content_from_state(self, &mut projected, public_id);
             anyhow::ensure!(
-                removed_runtime
-                    .as_ref()
-                    .zip(terminal_runtime.as_ref())
-                    .is_some_and(|(removed, planned)| removed.shares_terminal_runtime(planned)),
+                match (removed_runtime.as_ref(), terminal_runtime.as_ref()) {
+                    (Some(removed), Some(planned)) => removed.shares_terminal_runtime(planned),
+                    // A restored exited terminal has journaled views but no
+                    // catalog runtime to remove.
+                    (None, None) => true,
+                    _ => false,
+                },
                 "terminal close lost its catalog runtime"
             );
             removed = terminal_views;

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2694,8 +2694,8 @@ impl Mux {
     }
     fn finish_resource_close(&self, committed: CommittedResourceClose) -> ResourcePatchCommit {
         let effects = committed.effects;
-        if let Some(terminal_id) = effects.closed_terminal_public_id {
-            self.notify_terminal_exit_waiters(Some(terminal_id));
+        if let Some(terminal_id) = effects.closed_terminal_public_id.as_ref() {
+            self.notify_terminal_exit_waiters(std::iter::once(terminal_id.clone()));
         }
 
         #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -353,6 +353,19 @@ fn execute_terminal_effect(
         Err(error) => return effects::commit_known_failure(mux, prepared, error),
     };
     let Some(surface_id) = mux.resource_surface_for_terminal(&terminal_id) else {
+        // A restored exited terminal keeps its journaled views without a
+        // runtime. Explicit close is the one effect that still applies to it.
+        if prepared.operation == "terminal.close"
+            && let Some(slot) = mux.first_terminal_placement(&terminal_id)
+        {
+            let commit = mux.commit_resource_terminal_close_effect(
+                slot,
+                &prepared.idempotency_key,
+                &prepared.operation,
+                &prepared.fingerprint,
+            );
+            return finish_projection_commit(mux, prepared, commit);
+        }
         return effects::commit_known_failure(
             mux,
             prepared,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -3768,7 +3768,7 @@ impl Surface {
     }
 
     /// Construct a dead hosted surface for lifecycle tests without inventing
-    /// a live host connection. Production keeps exit receipts in the registry.
+    /// a live host connection.
     #[cfg(all(unix, test))]
     pub(crate) fn exited_terminal_placeholder(
         id: SurfaceId,
@@ -3793,6 +3793,24 @@ impl Surface {
         identity: crate::terminal_host_runtime::TerminalHostIdentity,
         resource_identity: TabResourceIdentity,
     ) -> anyhow::Result<Arc<Surface>> {
+        Self::restored_exited_terminal(id, opts, mux, identity, resource_identity, None, None)
+    }
+
+    /// Materialize a terminal that died while the daemon was down as an
+    /// honest exited surface: no process, no host connection, renderable
+    /// content restored from its checkpoint VT replay plus the journaled
+    /// output tail. Attach and screen reads serve this content; input and
+    /// respawn stay explicit follow-up actions.
+    #[cfg(unix)]
+    pub(crate) fn restored_exited_terminal(
+        id: SurfaceId,
+        opts: SurfaceOptions,
+        mux: Weak<Mux>,
+        identity: crate::terminal_host_runtime::TerminalHostIdentity,
+        resource_identity: TabResourceIdentity,
+        content: Option<&crate::journal_restore::RestoredTerminalContent>,
+        exit: Option<TerminalExit>,
+    ) -> anyhow::Result<Arc<Surface>> {
         let terminal_public_id = terminal_public_id_from_resource_identity(
             &resource_identity,
             "exited terminal cannot use a browser resource identity",
@@ -3804,6 +3822,8 @@ impl Surface {
             identity,
             terminal_public_id,
             Some(resource_identity),
+            content,
+            exit,
         )
     }
 
@@ -3822,10 +3842,13 @@ impl Surface {
             identity,
             terminal_public_id,
             None,
+            None,
+            None,
         )
     }
 
-    #[cfg(all(unix, test))]
+    #[cfg(unix)]
+    #[allow(clippy::too_many_arguments)]
     fn exited_terminal_placeholder_with_identities(
         id: SurfaceId,
         opts: SurfaceOptions,
@@ -3833,12 +3856,20 @@ impl Surface {
         identity: crate::terminal_host_runtime::TerminalHostIdentity,
         terminal_public_id: TerminalPublicId,
         resource_identity: Option<TabResourceIdentity>,
+        content: Option<&crate::journal_restore::RestoredTerminalContent>,
+        exit: Option<TerminalExit>,
     ) -> anyhow::Result<Arc<Surface>> {
         let journal_generation = Arc::from(identity.incarnation.clone());
         let initial_kitty_limits = KittyGraphicsLimits::disabled();
         let title_changed = Arc::new(AtomicBool::new(false));
         let callbacks = hosted_terminal_callbacks(id, mux.clone(), title_changed);
-        let (cols, rows) = (opts.cols.max(1), opts.rows.max(1));
+        let (mut cols, mut rows) = (opts.cols.max(1), opts.rows.max(1));
+        if let Some(content) = content
+            && content.cols > 0
+            && content.rows > 0
+        {
+            (cols, rows) = (content.cols, content.rows);
+        }
         let cell_pixels =
             mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         let mut term = Terminal::new(cols, rows, opts.scrollback, callbacks)?;
@@ -3850,6 +3881,39 @@ impl Surface {
             term.set_default_palette(&colors.palette);
             replace_ghostty_cursor_defaults(&mut term, colors);
         }
+        if let Some(content) = content {
+            // The checkpoint replay is a complete self-contained VT stream at
+            // the captured grid; the journaled tail then replays the exact
+            // parser-accepted bytes and accepted geometry changes in commit
+            // order, ending at the terminal's final observed state.
+            if !content.replay.is_empty() {
+                term.apply_vt_replay_parts(
+                    &content.replay,
+                    &content.kitty_image_aliases,
+                    content.kitty_state,
+                )?;
+            }
+            for event in &content.tail {
+                match event {
+                    crate::journal_restore::RestoredTailEvent::Output(bytes) => {
+                        term.vt_write(bytes);
+                    }
+                    crate::journal_restore::RestoredTailEvent::Resize {
+                        cols: tail_cols,
+                        rows: tail_rows,
+                        cell_width,
+                        cell_height,
+                    } => {
+                        (cols, rows) = (*tail_cols, *tail_rows);
+                        term.resize(*tail_cols, *tail_rows, *cell_width, *cell_height)?;
+                    }
+                }
+            }
+        }
+        let effective_kitty_limits = content
+            .filter(|content| !content.replay.is_empty())
+            .map(|content| content.kitty_state.limits)
+            .unwrap_or(initial_kitty_limits);
         let mut mouse_encoders = MouseEncoders::new()?;
         mouse_encoders.sync_from_terminal(&term);
         let render_state = RenderState::new()?;
@@ -3893,7 +3957,7 @@ impl Surface {
                 pid: None,
                 command,
                 cwd: opts.cwd,
-                exit: Mutex::new(None),
+                exit: Mutex::new(exit),
                 local_pty_drained: AtomicBool::new(true),
                 exit_notified: AtomicBool::new(true),
                 dead: AtomicBool::new(true),
@@ -3908,7 +3972,7 @@ impl Surface {
                     cell_width: cell_pixels.0,
                     cell_height: cell_pixels.1,
                 }),
-                kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
+                kitty_graphics_limits: Box::new(Mutex::new(effective_kitty_limits)),
                 #[cfg(test)]
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
@@ -5424,7 +5488,15 @@ impl Surface {
             return Err(ghostty_vt::Error::InvalidValue);
         };
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
+        // A dead surface still serves its replay when it represents an
+        // honestly exited terminal (a restored placeholder, or a hosted
+        // terminal whose process ended): the attach returns the final
+        // renderable content and, because tap registration below is gated on
+        // liveness, a stream that ends immediately.
+        if pty.dead.load(Ordering::Acquire)
+            && pty.host_connection_state.load(Ordering::Acquire)
+                != TerminalHostConnectionState::Exited as u8
+        {
             return Err(ghostty_vt::Error::NoValue);
         }
         let (tap, stream) =
@@ -5469,7 +5541,13 @@ impl Surface {
             .and_then(|mux| mux.claim_render_attachment())
             .ok_or(ghostty_vt::Error::OutOfSpace)?;
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
+        // Same exited-surface policy as attach_stream_with_lifecycle: the
+        // final frame of an exited terminal is renderable content, and the
+        // liveness-gated tap registration below keeps the stream inert.
+        if pty.dead.load(Ordering::Acquire)
+            && pty.host_connection_state.load(Ordering::Acquire)
+                != TerminalHostConnectionState::Exited as u8
+        {
             return Err(ghostty_vt::Error::NoValue);
         }
         let generation = pty.render_generation.load(Ordering::Acquire);

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2105,7 +2105,7 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
+        let mut cell_pixels =
             mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         Self::spawn_auxiliary_at_cell_pixels(id, opts, mux, cell_pixels)
     }
@@ -6412,6 +6412,8 @@ impl PtySurface {
     /// retaining the exited surface as a stable, snapshot-renderable tab.
     fn finish_hosted_exit(&self) {
         let mut term = self.term.lock().unwrap();
+        self.host_connection_state
+            .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
         if self.dead.swap(true, Ordering::AcqRel) {
             return;
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2170,7 +2170,7 @@ impl Surface {
         mux: Weak<Mux>,
         resource_identity: Option<TabResourceIdentity>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
+        let mut cell_pixels =
             mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         Self::spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
             id,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -3870,7 +3870,7 @@ impl Surface {
         {
             (cols, rows) = (content.cols, content.rows);
         }
-        let cell_pixels =
+        let mut cell_pixels =
             mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         let mut term = Terminal::new(cols, rows, opts.scrollback, callbacks)?;
         term.resize(cols, rows, u32::from(cell_pixels.0), u32::from(cell_pixels.1))?;

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2092,7 +2092,7 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
+        let mut cell_pixels =
             mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         Self::spawn_at_cell_pixels(id, opts, mux, cell_pixels)
     }
@@ -3905,6 +3905,7 @@ impl Surface {
                         cell_height,
                     } => {
                         (cols, rows) = (*tail_cols, *tail_rows);
+                        cell_pixels = (*cell_width as u16, *cell_height as u16);
                         term.resize(*tail_cols, *tail_rows, *cell_width, *cell_height)?;
                     }
                 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -53,6 +53,7 @@ pub use journal_extensions::{
     JournalHookRegex, JournalHookRetry, JournalIngress, JournalProducerManifest, JournalSegment,
 };
 pub(crate) use journal_extensions::{
+    encode_hex,
     JournalCheckpointCommit, JournalCheckpointSummary, JournalContentBlob, JournalHookAttempt,
     JournalHookDelivery, JournalHookDeliveryResult, JournalHookScan, JournalHookState,
     JournalSegmentSealCommit, JournalSegmentSealStart,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -252,25 +252,7 @@ impl JournalContentBlob {
     /// Bounded decompression of already-verified content, re-checked against
     /// the reference length and digest.
     pub(crate) fn uncompressed(&self) -> anyhow::Result<Vec<u8>> {
-        let expected_bytes = usize::try_from(self.reference.uncompressed_bytes)?;
-        anyhow::ensure!(
-            expected_bytes <= MAX_CHECKPOINT_CONTENT_UNCOMPRESSED_BYTES,
-            "checkpoint content exceeds the uncompressed size limit"
-        );
-        let decoder = flate2::read::GzDecoder::new(self.compressed.as_slice());
-        let mut uncompressed = Vec::new();
-        decoder
-            .take(u64::try_from(expected_bytes)?.saturating_add(1))
-            .read_to_end(&mut uncompressed)?;
-        anyhow::ensure!(
-            uncompressed.len() == expected_bytes,
-            "checkpoint content length does not match its reference"
-        );
-        anyhow::ensure!(
-            Sha256::digest(&uncompressed).as_slice() == self.digest.as_slice(),
-            "checkpoint content digest does not match its reference"
-        );
-        Ok(uncompressed)
+        decompress_verified_journal_content_blob(self)
     }
 }
 
@@ -2818,7 +2800,7 @@ fn operation_receipt(
     }))
 }
 
-fn encode_hex(bytes: &[u8]) -> String {
+pub(crate) fn encode_hex(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut encoded = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
@@ -2839,7 +2821,7 @@ fn decode_sha256(value: &str) -> anyhow::Result<[u8; 32]> {
     Ok(decoded)
 }
 
-fn verify_journal_content_blob(blob: &JournalContentBlob) -> anyhow::Result<()> {
+fn decompress_verified_journal_content_blob(blob: &JournalContentBlob) -> anyhow::Result<Vec<u8>> {
     anyhow::ensure!(
         blob.reference.format == "cmux.vt-replay.v1" && blob.reference.codec == "gzip",
         "checkpoint content format or codec is unsupported"
@@ -2870,6 +2852,11 @@ fn verify_journal_content_blob(blob: &JournalContentBlob) -> anyhow::Result<()> 
         Sha256::digest(&uncompressed).as_slice() == blob.digest.as_slice(),
         "checkpoint content digest does not match its reference"
     );
+    Ok(uncompressed)
+}
+
+fn verify_journal_content_blob(blob: &JournalContentBlob) -> anyhow::Result<()> {
+    let _ = decompress_verified_journal_content_blob(blob)?;
     Ok(())
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -248,6 +248,30 @@ impl JournalContentBlob {
         verify_journal_content_blob(&blob)?;
         Ok(blob)
     }
+
+    /// Bounded decompression of already-verified content, re-checked against
+    /// the reference length and digest.
+    pub(crate) fn uncompressed(&self) -> anyhow::Result<Vec<u8>> {
+        let expected_bytes = usize::try_from(self.reference.uncompressed_bytes)?;
+        anyhow::ensure!(
+            expected_bytes <= MAX_CHECKPOINT_CONTENT_UNCOMPRESSED_BYTES,
+            "checkpoint content exceeds the uncompressed size limit"
+        );
+        let decoder = flate2::read::GzDecoder::new(self.compressed.as_slice());
+        let mut uncompressed = Vec::new();
+        decoder
+            .take(u64::try_from(expected_bytes)?.saturating_add(1))
+            .read_to_end(&mut uncompressed)?;
+        anyhow::ensure!(
+            uncompressed.len() == expected_bytes,
+            "checkpoint content length does not match its reference"
+        );
+        anyhow::ensure!(
+            Sha256::digest(&uncompressed).as_slice() == self.digest.as_slice(),
+            "checkpoint content digest does not match its reference"
+        );
+        Ok(uncompressed)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2176,6 +2200,74 @@ impl WorkspaceRegistry {
             .map(|id| query_journal_checkpoint(&self.connection, id))
             .transpose()
             .map(Option::flatten)
+    }
+
+    /// Stored checkpoint content for one reference, verified against the
+    /// reference digest and size, returned uncompressed. `None` when the
+    /// blob row is absent.
+    pub(crate) fn journal_content_blob_bytes(
+        &self,
+        reference: &JournalContentRef,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let compressed = self
+            .connection
+            .query_row(
+                "SELECT content FROM journal_content_blobs WHERE content_id = ?1",
+                params![reference.content_id],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()?;
+        let Some(compressed) = compressed else { return Ok(None) };
+        let blob = JournalContentBlob::verified(reference.clone(), compressed)?;
+        blob.uncompressed().map(Some)
+    }
+
+    /// Append the post-replay outcome of materializing one restored exited
+    /// terminal placeholder (spec: post-replay actions carry their own
+    /// journal outcomes). Effect-class and never-replayed: restoration
+    /// derives no state from it, and the restore-preview reducer ignores
+    /// non-required records, so existing previews stay fully reducible.
+    pub(crate) fn append_terminal_restore_outcome(
+        &mut self,
+        terminal_public_id: &str,
+        payload: &Value,
+    ) -> anyhow::Result<JournalAppendCommit> {
+        let tx = self.connection.transaction()?;
+        let session_id = transaction_session_id(&tx)?;
+        let mut subjects = BTreeSet::from([
+            JournalSubject { kind: "session".into(), id: session_id },
+            JournalSubject { kind: "terminal".into(), id: terminal_public_id.into() },
+        ]);
+        expand_topology_subjects(&tx, &mut subjects)?;
+        let subjects = subjects.into_iter().collect::<Vec<_>>();
+        let producer =
+            JournalProducer { kind: "session_restore".into(), id: terminal_public_id.into() };
+        let event_id = random_event_id("restore");
+        let now = unix_epoch_ms()?;
+        let sequence = append_journal_record(
+            &tx,
+            &JournalAppend {
+                event_id: &event_id,
+                schema_version: 1,
+                kind: "terminal.restore.applied",
+                class: JournalClass::Effect,
+                replay: JournalReplayPolicy::Never,
+                occurred_at_ms: now,
+                producer: &producer,
+                authority: None,
+                causation_id: None,
+                correlation_id: None,
+                causation_depth: 0,
+                subjects: &subjects,
+                sensitivity: JournalSensitivity::Metadata,
+                payload,
+                content: None,
+                resource_revision: None,
+                previous_resource_revision: None,
+            },
+        )?;
+        tx.commit()?;
+        Ok(JournalAppendCommit { sequence, event_id, replayed: false })
     }
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
@@ -148,10 +148,6 @@ impl WorkspaceRegistry {
             apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
         }
 
-        if let Some((patch, _)) = topology {
-            apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
-        }
-
         tx.execute(
             "UPDATE terminal_hosts
              SET incarnation = ?1, lifecycle = 'exited', exit_json = ?2,

--- a/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
@@ -378,3 +378,292 @@ fn split_ratio(snapshot: &Value) -> f64 {
     assert!(ratios.next().is_none(), "more than one split screen: {}", snapshot["screens"]);
     ratio
 }
+
+
+/// JSONL journal read through the CLI, parsed leniently: every JSON object
+/// anywhere in the stream that carries both `kind` and `sequence` is treated
+/// as one journal record.
+fn journal_records(harness: &RestoreHarness, extra: &[&str]) -> Vec<Value> {
+    let mut args = vec!["--jsonl", "--socket"];
+    let socket = harness.socket.to_str().unwrap().to_string();
+    args.push(&socket);
+    let mut tail_args =
+        vec!["session", "current", "journal", "read", "--max-sensitivity", "sensitive"];
+    tail_args.extend_from_slice(extra);
+    let output = Command::new(bin())
+        .args(&args)
+        .args(&tail_args)
+        .env_remove("CMUX_TUI_SOCKET")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "journal read failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let mut records = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else { continue };
+        collect_records(&value, &mut records);
+    }
+    records
+}
+
+fn collect_records(value: &Value, records: &mut Vec<Value>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("kind").and_then(Value::as_str).is_some() && map.contains_key("sequence") {
+                records.push(value.clone());
+            }
+            for child in map.values() {
+                collect_records(child, records);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_records(child, records);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn restore_outcomes(harness: &RestoreHarness) -> Vec<Value> {
+    journal_records(harness, &["--kinds", "terminal.restore.applied"])
+        .into_iter()
+        .filter(|record| record["kind"] == "terminal.restore.applied")
+        .collect()
+}
+
+/// Wait until the journal durably holds at least `min_bytes` of
+/// terminal.output content committed after `after_sequence`, and the total
+/// has stopped growing. The parser accepted the bytes before this is called;
+/// the wait covers the asynchronous journal ingress commit, so a SIGKILL of
+/// the daemon afterwards cannot lose the tail this test asserts on.
+fn wait_for_journal_output_after(harness: &RestoreHarness, after_sequence: u64, min_bytes: u64) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut last = u64::MAX;
+    loop {
+        let total: u64 = journal_records(harness, &["--kinds", "terminal.output"])
+            .iter()
+            .filter(|record| {
+                record["sequence"]
+                    .as_str()
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .or_else(|| record["sequence"].as_u64())
+                    .is_some_and(|sequence| sequence > after_sequence)
+            })
+            .filter_map(|record| {
+                record["payload"]["byte_count"]
+                    .as_str()
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .or_else(|| record["payload"]["byte_count"].as_u64())
+            })
+            .sum();
+        if total >= min_bytes && total == last {
+            return;
+        }
+        last = total;
+        assert!(
+            Instant::now() < deadline,
+            "journal never committed {min_bytes} output bytes after sequence {after_sequence} \
+             (saw {total})"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn screen_text(harness: &RestoreHarness, terminal_id: &str) -> String {
+    let screen = harness.cli(&["terminal", terminal_id, "screen", "read"]);
+    serde_json::to_string(&screen).unwrap()
+}
+
+fn first_terminal_id(snapshot: &Value) -> String {
+    snapshot["terminals"][0]["id"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn restored_placeholder_replays_checkpoint_content() {
+    let mut harness = RestoreHarness::start("checkpoint-content");
+    request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Content","cols":120,"rows":32,
+        }),
+    );
+    wait_for_host_records(&harness.host_root(), 1);
+    let terminal_id = first_terminal_id(&harness.snapshot());
+
+    harness.cli(&["terminal", &terminal_id, "write", "--text", "JRA_BASE_9401\n"]);
+    harness.cli(&[
+        "terminal",
+        &terminal_id,
+        "screen",
+        "wait",
+        "--pattern",
+        "JRA_BASE_9401",
+        "--timeout-ms",
+        "15000",
+    ]);
+    let checkpoint = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "checkpoint",
+        "create",
+        "--idempotency-key",
+        "restore-content-checkpoint",
+    ]);
+    let checkpoint_id = checkpoint["value"]["checkpoint_id"].as_str().unwrap().to_string();
+
+    harness.kill_hosts_and_daemon(1);
+    harness.restart();
+    wait_for_all_terminals_exited(&harness, 1);
+
+    // The exited placeholder serves the checkpoint's renderable content.
+    let text = screen_text(&harness, &terminal_id);
+    assert!(text.contains("JRA_BASE_9401"), "restored screen lost checkpoint content: {text}");
+
+    // The materialization journaled its post-replay outcome.
+    let outcomes = restore_outcomes(&harness);
+    assert_eq!(outcomes.len(), 1, "{outcomes:?}");
+    let payload = &outcomes[0]["payload"];
+    assert_eq!(payload["outcome"], "applied", "{payload}");
+    assert_eq!(payload["terminal_id"], Value::String(terminal_id.clone()), "{payload}");
+    assert_eq!(payload["checkpoint_id"], Value::String(checkpoint_id), "{payload}");
+    assert!(
+        payload["content"] == "checkpoint" || payload["content"] == "checkpoint+tail",
+        "{payload}"
+    );
+    assert_eq!(payload["degraded"], Value::Null, "{payload}");
+}
+
+#[test]
+fn restored_placeholder_replays_the_output_tail_beyond_the_checkpoint() {
+    let mut harness = RestoreHarness::start("tail-content");
+    request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Tail","cols":120,"rows":32,
+        }),
+    );
+    wait_for_host_records(&harness.host_root(), 1);
+    let terminal_id = first_terminal_id(&harness.snapshot());
+
+    harness.cli(&["terminal", &terminal_id, "write", "--text", "JRA_BASE_9401\n"]);
+    harness.cli(&[
+        "terminal",
+        &terminal_id,
+        "screen",
+        "wait",
+        "--pattern",
+        "JRA_BASE_9401",
+        "--timeout-ms",
+        "15000",
+    ]);
+    let checkpoint = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "checkpoint",
+        "create",
+        "--idempotency-key",
+        "restore-tail-checkpoint",
+    ]);
+    let source_sequence = checkpoint["value"]["source_sequence"]
+        .as_str()
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+
+    harness.cli(&["terminal", &terminal_id, "write", "--text", "JRA_TAIL_9402\n"]);
+    harness.cli(&[
+        "terminal",
+        &terminal_id,
+        "screen",
+        "wait",
+        "--pattern",
+        "JRA_TAIL_9402",
+        "--timeout-ms",
+        "15000",
+    ]);
+    // The marker round-tripped through the pty (echo plus /bin/cat), so at
+    // least its own length must land in the journal after the checkpoint.
+    wait_for_journal_output_after(&harness, source_sequence, "JRA_TAIL_9402".len() as u64);
+
+    harness.kill_hosts_and_daemon(1);
+    harness.restart();
+    wait_for_all_terminals_exited(&harness, 1);
+
+    let text = screen_text(&harness, &terminal_id);
+    assert!(text.contains("JRA_BASE_9401"), "restored screen lost checkpoint content: {text}");
+    assert!(text.contains("JRA_TAIL_9402"), "restored screen lost the journaled tail: {text}");
+
+    let outcomes = restore_outcomes(&harness);
+    assert_eq!(outcomes.len(), 1, "{outcomes:?}");
+    assert_eq!(outcomes[0]["payload"]["content"], "checkpoint+tail", "{}", outcomes[0]);
+}
+
+#[test]
+fn restored_placeholder_rebuilds_from_the_journal_without_any_checkpoint() {
+    let mut harness = RestoreHarness::start("no-checkpoint");
+    request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"NoCkpt","cols":100,"rows":30,
+        }),
+    );
+    wait_for_host_records(&harness.host_root(), 1);
+    let terminal_id = first_terminal_id(&harness.snapshot());
+
+    harness.cli(&["terminal", &terminal_id, "write", "--text", "JRA_TAIL_9402\n"]);
+    harness.cli(&[
+        "terminal",
+        &terminal_id,
+        "screen",
+        "wait",
+        "--pattern",
+        "JRA_TAIL_9402",
+        "--timeout-ms",
+        "15000",
+    ]);
+    wait_for_journal_output_after(&harness, 0, "JRA_TAIL_9402".len() as u64);
+
+    harness.kill_hosts_and_daemon(1);
+    harness.restart();
+    wait_for_all_terminals_exited(&harness, 1);
+
+    let text = screen_text(&harness, &terminal_id);
+    assert!(text.contains("JRA_TAIL_9402"), "restored screen lost journaled output: {text}");
+
+    let outcomes = restore_outcomes(&harness);
+    assert_eq!(outcomes.len(), 1, "{outcomes:?}");
+    assert_eq!(outcomes[0]["payload"]["content"], "tail", "{}", outcomes[0]);
+    assert_eq!(outcomes[0]["payload"]["checkpoint_id"], Value::Null, "{}", outcomes[0]);
+}
+
+#[test]
+fn a_session_with_no_terminals_restores_nothing() {
+    let mut harness = RestoreHarness::start("empty");
+    let before = harness.snapshot();
+    assert_eq!(before["terminals"].as_array().unwrap().len(), 0);
+    assert_eq!(before["tabs"].as_array().unwrap().len(), 0);
+
+    let mut child = harness.child.take().unwrap();
+    child.kill().unwrap();
+    child.wait().unwrap();
+    let _ = fs::remove_file(&harness.socket);
+    harness.restart();
+
+    let after = harness.snapshot();
+    assert_eq!(after["terminals"].as_array().unwrap().len(), 0);
+    assert_eq!(after["tabs"].as_array().unwrap().len(), 0);
+    assert!(
+        restore_outcomes(&harness).is_empty(),
+        "an empty session must not journal restoration outcomes"
+    );
+}

--- a/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
@@ -1,0 +1,380 @@
+#![cfg(unix)]
+
+//! Journal-based session restoration. A fresh `server start` on the same
+//! session and state root reconstructs the durable topology recorded in the
+//! SQLite journal: workspace identity, order, and names; screens; split trees
+//! with committed ratios; tab placements; and terminal resources represented
+//! honestly as exited when their processes died while the daemon was down.
+//! `session journal restore preview` must agree with that applied state.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use cmux_tui_core::platform::transport;
+use cmux_tui_core::terminal_host_runtime::{
+    TerminalHostLiveness, load_terminal_host_records, terminal_host_record_liveness,
+    terminal_host_root,
+};
+use serde_json::{Value, json};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cmux-tui")
+}
+
+struct RestoreHarness {
+    child: Option<Child>,
+    dir: PathBuf,
+    socket: PathBuf,
+    state: PathBuf,
+    session: String,
+}
+
+impl RestoreHarness {
+    fn start(name: &str) -> Self {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = PathBuf::from("/tmp")
+            .join(format!("cmux-journal-restore-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let mut harness = Self {
+            child: None,
+            socket: dir.join("mux.sock"),
+            state: dir.join("state"),
+            session: format!("journal-restore-{name}"),
+            dir,
+        };
+        harness.restart();
+        harness
+    }
+
+    fn restart(&mut self) {
+        assert!(self.child.is_none());
+        let config = self.dir.join("config.json");
+        let child = Command::new(bin())
+            .args(["--headless", "--session", &self.session, "--socket"])
+            .arg(&self.socket)
+            .arg("--state")
+            .arg(&self.state)
+            .env("CMUX_TUI_CONFIG", &config)
+            // Deterministic default shell for panes created by `split`,
+            // independent of the developer or CI login shell.
+            .env("SHELL", "/bin/sh")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        self.child = Some(child);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if transport::connect(&self.socket).is_ok() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("server did not accept connections at {}", self.socket.display());
+    }
+
+    fn host_root(&self) -> PathBuf {
+        terminal_host_root(&self.state, &self.session)
+    }
+
+    /// Freeze the daemon, kill every terminal host process, then kill the
+    /// daemon. The daemon can observe none of the exits, so the next start
+    /// has to reconcile purely from the journal plus dead-process evidence.
+    fn kill_hosts_and_daemon(&mut self, expected_hosts: usize) {
+        self.signal_daemon(libc::SIGSTOP);
+        let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
+        assert_eq!(records.len(), expected_hosts, "unexpected live terminal host records");
+        for (_, record) in &records {
+            // SAFETY: the record PIDs are harness-owned terminal hosts.
+            let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
+        }
+        for (path, record) in &records {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while terminal_host_record_liveness(path, record).ok()
+                != Some(TerminalHostLiveness::Dead)
+            {
+                assert!(Instant::now() < deadline, "terminal host survived SIGKILL");
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        let mut child = self.child.take().unwrap();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        let _ = fs::remove_file(&self.socket);
+    }
+
+    fn signal_daemon(&self, signal: libc::c_int) {
+        let pid = self.child.as_ref().unwrap().id() as libc::pid_t;
+        // SAFETY: the harness owns this child process and passes a platform
+        // signal constant.
+        assert_eq!(unsafe { libc::kill(pid, signal) }, 0);
+    }
+
+    fn cli(&self, args: &[&str]) -> Value {
+        let output = self.cli_raw(args);
+        assert!(
+            output.status.success(),
+            "cli {args:?} failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "cli {args:?} produced invalid JSON ({error}): {}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        })
+    }
+
+    fn cli_raw(&self, args: &[&str]) -> Output {
+        Command::new(bin())
+            .args(["--json", "--socket"])
+            .arg(&self.socket)
+            .args(args)
+            .env_remove("CMUX_TUI_SOCKET")
+            .output()
+            .unwrap()
+    }
+
+    fn snapshot(&self) -> Value {
+        self.cli(&["session", "current", "snapshot"])
+    }
+}
+
+impl Drop for RestoreHarness {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
+        for (_, record) in &records {
+            // SAFETY: test teardown owns these dedicated host processes.
+            let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
+        }
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn request(path: &Path, value: Value) -> Value {
+    let stream = transport::connect(path).unwrap();
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{value}").unwrap();
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let response: Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "request failed: {response}");
+    response["data"].clone()
+}
+
+fn wait_for_host_records(root: &Path, expected: usize) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let records = load_terminal_host_records(root).unwrap_or_default();
+        if records.len() == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected {expected} terminal host records, found {}",
+            records.len()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_all_terminals_exited(harness: &RestoreHarness, expected: usize) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let snapshot = harness.snapshot();
+        let terminals = snapshot["terminals"].as_array().unwrap();
+        if terminals.len() == expected
+            && terminals.iter().all(|terminal| terminal["lifecycle"] == "exited")
+        {
+            return snapshot;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "terminals did not settle as exited: {}",
+            snapshot["terminals"]
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// The collections that describe durable topology. Focus flags, layout
+/// documents, ratios, names, and ordering all live inside these values.
+const TOPOLOGY_COLLECTIONS: [&str; 4] = ["workspaces", "screens", "panes", "tabs"];
+
+#[test]
+fn server_restart_restores_topology_and_reports_terminals_exited() {
+    let mut harness = RestoreHarness::start("topology");
+
+    // Workspace "One": terminal T1, split right with a default shell (T2),
+    // committed ratio 0.7, and a second tab (T3) beside T1.
+    let first = request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"One","cols":120,"rows":32,
+        }),
+    );
+    let first_pane = first["pane"].as_u64().unwrap();
+    request(&harness.socket, json!({"id":2,"cmd":"split","pane":first_pane,"dir":"right"}));
+    let tree = request(&harness.socket, json!({"id":3,"cmd":"list-workspaces"}));
+    let split = tree["workspaces"][0]["screens"][0]["layout"]["split"]
+        .as_u64()
+        .expect("split id after split-right");
+    request(&harness.socket, json!({"id":4,"cmd":"set-split-ratio","split":split,"ratio":0.7}));
+    request(
+        &harness.socket,
+        json!({"id":5,"cmd":"run","argv":["/bin/cat"],"pane":first_pane,"cols":120,"rows":32}),
+    );
+    // Workspace "Two": one terminal, so restoration must keep workspace
+    // identity, order, and names across more than one workspace.
+    request(
+        &harness.socket,
+        json!({
+            "id":6,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Two","cols":80,"rows":24,
+        }),
+    );
+    wait_for_host_records(&harness.host_root(), 4);
+
+    let before = harness.snapshot();
+    assert_eq!(before["workspaces"].as_array().unwrap().len(), 2);
+    assert_eq!(before["terminals"].as_array().unwrap().len(), 4);
+    let ratio_before = split_ratio(&before);
+    assert!((ratio_before - 0.7).abs() < 1e-6, "committed ratio missing before stop");
+
+    harness.kill_hosts_and_daemon(4);
+    harness.restart();
+    let after = wait_for_all_terminals_exited(&harness, 4);
+
+    // Durable topology survives byte for byte: identity, order, names,
+    // screens, split tree with committed ratio, tab placements.
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(before[collection], after[collection], "{collection} changed across restart");
+    }
+    assert!((split_ratio(&after) - 0.7).abs() < 1e-6, "committed ratio lost across restart");
+    for terminal in after["terminals"].as_array().unwrap() {
+        assert_eq!(terminal["running"], false);
+        assert_eq!(terminal["lifecycle"], "exited");
+        assert_eq!(terminal["exit"]["outcome"]["kind"], "unknown", "{terminal}");
+        assert!(
+            !terminal["tab_ids"].as_array().unwrap().is_empty(),
+            "exited terminal lost its tab placements: {terminal}"
+        );
+    }
+
+    // A second restart replays the preserved state without mutating it.
+    wait_for_host_records(&harness.host_root(), 0);
+    harness.kill_hosts_and_daemon(0);
+    harness.restart();
+    let again = wait_for_all_terminals_exited(&harness, 4);
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(
+            after[collection], again[collection],
+            "{collection} changed across an idle restart"
+        );
+    }
+    assert_eq!(after["terminals"], again["terminals"], "terminals changed across an idle restart");
+}
+
+#[test]
+fn restore_preview_agrees_with_applied_restoration() {
+    let mut harness = RestoreHarness::start("preview");
+
+    let first = request(
+        &harness.socket,
+        json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "name":"Preview","cols":100,"rows":30,
+        }),
+    );
+    let first_pane = first["pane"].as_u64().unwrap();
+    request(&harness.socket, json!({"id":2,"cmd":"split","pane":first_pane,"dir":"down"}));
+    let tree = request(&harness.socket, json!({"id":3,"cmd":"list-workspaces"}));
+    let split = tree["workspaces"][0]["screens"][0]["layout"]["split"]
+        .as_u64()
+        .expect("split id after split-down");
+    request(&harness.socket, json!({"id":4,"cmd":"set-split-ratio","split":split,"ratio":0.35}));
+    wait_for_host_records(&harness.host_root(), 2);
+
+    let checkpoint = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "checkpoint",
+        "create",
+        "--idempotency-key",
+        "restore-preview-checkpoint",
+    ]);
+    assert!(checkpoint["value"]["checkpoint_id"].is_string(), "{checkpoint}");
+
+    harness.kill_hosts_and_daemon(2);
+    harness.restart();
+    let live = wait_for_all_terminals_exited(&harness, 2);
+
+    let preview = harness.cli(&[
+        "session",
+        "current",
+        "journal",
+        "restore",
+        "preview",
+        "--checkpoint",
+        "latest",
+    ]);
+    assert_eq!(preview["fully_reducible"], true, "{preview}");
+    let projected = &preview["state"]["session_snapshot"];
+
+    // The reduced model and the state a fresh server actually serves must
+    // agree on every durable topology collection and on the terminals'
+    // honest not-running representation. The reducer orders collections by
+    // (index, id) while the live projection orders them by topology, so the
+    // comparison is id-keyed; ordering itself is carried by the index fields
+    // and layout documents inside the compared values.
+    for collection in TOPOLOGY_COLLECTIONS {
+        assert_eq!(
+            sorted_by_id(&projected[collection]),
+            sorted_by_id(&live[collection]),
+            "restore preview and applied restore disagree on {collection}"
+        );
+    }
+    assert_eq!(
+        sorted_by_id(&projected["terminals"]),
+        sorted_by_id(&live["terminals"]),
+        "restore preview and applied restore disagree on terminals"
+    );
+    assert_eq!(
+        projected["cursor"]["revision"], live["cursor"]["revision"],
+        "restore preview and applied restore disagree on the resource cursor"
+    );
+}
+
+fn sorted_by_id(collection: &Value) -> Vec<Value> {
+    let mut values = collection
+        .as_array()
+        .unwrap_or_else(|| panic!("collection is not an array: {collection}"))
+        .clone();
+    values.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+    values
+}
+
+/// Ratio of the single split screen in the snapshot. Screen collection
+/// order is not tied to workspace order, so the split screen is located by
+/// shape instead of by index.
+fn split_ratio(snapshot: &Value) -> f64 {
+    let mut ratios = snapshot["screens"]
+        .as_array()
+        .expect("snapshot screens is an array")
+        .iter()
+        .filter_map(|screen| screen["layout"]["root"]["ratio"].as_f64());
+    let ratio = ratios.next().unwrap_or_else(|| panic!("no split screen: {}", snapshot["screens"]));
+    assert!(ratios.next().is_none(), "more than one split screen: {}", snapshot["screens"]);
+    ratio
+}

--- a/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_restore.rs
@@ -379,7 +379,6 @@ fn split_ratio(snapshot: &Value) -> f64 {
     ratio
 }
 
-
 /// JSONL journal read through the CLI, parsed leniently: every JSON object
 /// anywhere in the stream that carries both `kind` and `sequence` is treated
 /// as one journal record.
@@ -531,7 +530,7 @@ fn restored_placeholder_replays_checkpoint_content() {
     assert_eq!(outcomes.len(), 1, "{outcomes:?}");
     let payload = &outcomes[0]["payload"];
     assert_eq!(payload["outcome"], "applied", "{payload}");
-    assert_eq!(payload["terminal_id"], Value::String(terminal_id.clone()), "{payload}");
+    assert_eq!(payload["terminal_id"], Value::String(terminal_id), "{payload}");
     assert_eq!(payload["checkpoint_id"], Value::String(checkpoint_id), "{payload}");
     assert!(
         payload["content"] == "checkpoint" || payload["content"] == "checkpoint+tail",
@@ -573,11 +572,8 @@ fn restored_placeholder_replays_the_output_tail_beyond_the_checkpoint() {
         "--idempotency-key",
         "restore-tail-checkpoint",
     ]);
-    let source_sequence = checkpoint["value"]["source_sequence"]
-        .as_str()
-        .unwrap()
-        .parse::<u64>()
-        .unwrap();
+    let source_sequence =
+        checkpoint["value"]["source_sequence"].as_str().unwrap().parse::<u64>().unwrap();
 
     harness.cli(&["terminal", &terminal_id, "write", "--text", "JRA_TAIL_9402\n"]);
     harness.cli(&[

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3055,7 +3055,9 @@ fn daemon_restart_preserves_dead_host_topology_without_respawn() {
         );
         if resolved["lifecycle"] == "exited" {
             assert_eq!(resolved["terminal_incarnation"], incarnation);
-            assert_eq!(resolved["surface"], serde_json::Value::Null);
+            // Restoration materializes an honest exited placeholder surface
+            // for the preserved placement; nothing was respawned.
+            assert!(resolved["surface"].is_u64(), "{resolved}");
             break;
         }
         assert!(Instant::now() < deadline, "dead startup host was not projected as Exited");
@@ -3156,7 +3158,9 @@ fn daemon_restart_preserves_every_dead_host_behind_one_pane() {
                 serde_json::json!({"id":4,"cmd":"resolve-terminal","terminal_id":terminal_id}),
             );
             if resolved["lifecycle"] == "exited" {
-                assert_eq!(resolved["surface"], serde_json::Value::Null);
+                // Each preserved placement materializes its own exited
+                // placeholder surface; nothing was respawned.
+                assert!(resolved["surface"].is_u64(), "{resolved}");
                 break;
             }
             assert!(

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3013,7 +3013,7 @@ fn running_host_sigkill_detaches_exited_terminal_topology() {
 }
 
 #[test]
-fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal() {
+fn daemon_restart_preserves_dead_host_topology_without_respawn() {
     let mut harness = RecoveryHarness::start("dead-host-restart");
     let created = request(
         &harness.socket,
@@ -3069,16 +3069,20 @@ fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal(
         .iter()
         .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
         .expect("original workspace was not recovered");
-    assert!(first_tab(workspace).is_none(), "Exited terminal was rematerialized after restart");
+    // Restoration keeps the journaled tab placement; the terminal is exited,
+    // not respawned, and its view has no live surface to write to.
+    let tab = first_tab(workspace).expect("exited terminal lost its tab placement after restart");
+    let restored_surface = tab["surface"].as_u64().expect("restored tab has a stable slot");
 
     let write = request_response(
         &harness.socket,
         serde_json::json!({
-            "id":5,"cmd":"send","surface":surface,"text":"must-not-respawn\\n",
+            "id":5,"cmd":"send","surface":restored_surface,"text":"must-not-respawn\\n",
         }),
     );
     assert_eq!(write["ok"], false);
     assert!(write["error"].as_str().unwrap().contains("unknown surface"));
+    let _ = surface;
     request(
         &harness.socket,
         serde_json::json!({
@@ -3086,10 +3090,21 @@ fn daemon_restart_safe_prunes_dead_host_without_rematerializing_exited_terminal(
             "terminal_incarnation":incarnation,
         }),
     );
+    let closed = request(&harness.socket, serde_json::json!({"id":7,"cmd":"list-workspaces"}));
+    let workspace = closed["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
+        .expect("workspace disappeared after closing its exited terminal");
+    assert!(
+        first_tab(workspace).is_none(),
+        "explicit close did not remove the exited terminal's tab"
+    );
 }
 
 #[test]
-fn daemon_restart_prunes_every_dead_host_behind_one_pane() {
+fn daemon_restart_preserves_every_dead_host_behind_one_pane() {
     let mut harness = RecoveryHarness::start("dead-hosts-restart");
     let first = request(
         &harness.socket,
@@ -3159,7 +3174,15 @@ fn daemon_restart_prunes_every_dead_host_behind_one_pane() {
         .iter()
         .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
         .expect("original workspace was not recovered");
-    assert!(first_tab(workspace).is_none(), "Exited terminals were rematerialized after restart");
+    // Both dead terminals keep their tab placements in the one pane.
+    let tabs = workspace["screens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|screen| screen["panes"].as_array().into_iter().flatten())
+        .flat_map(|pane| pane["tabs"].as_array().into_iter().flatten())
+        .count();
+    assert_eq!(tabs, 2, "exited terminals lost their tab placements after restart");
 }
 
 fn request(path: &Path, value: serde_json::Value) -> serde_json::Value {

--- a/cmux-tui/spec/session-journal.md
+++ b/cmux-tui/spec/session-journal.md
@@ -13,9 +13,10 @@ viewport, and geometry observations; frontend projections; explicit agent
 reports; and normalized native agent-hook observations. A pure restoration
 reducer can preview the state reconstructed from a checkpoint and its tail,
 and a restarted server reconstructs the durable topology, representing
-terminals whose processes died while it was down honestly as exited. Verified
-root ownership leases, checkpoint content application, and post-restore
-respawn actions remain pending.
+terminals whose processes died while it was down honestly as exited, with
+their renderable content applied from the newest checkpoint and the reducible
+output tail. Verified root ownership leases and post-restore respawn actions
+remain pending.
 
 ## Invariants
 
@@ -590,6 +591,21 @@ detaches that terminal's views in the same transaction. Explicit close of a
 restored exited terminal, and future respawn actions, are ordinary post-restore
 mutations with their own journal outcomes.
 
+Cold start also materializes each restored exited terminal as an inert
+surface whose renderable content is applied from the journal: the terminal's
+VT replay blob in the newest checkpoint, then the exact parser-accepted
+`terminal.output` bytes and accepted `terminal.resized` geometry after that
+checkpoint, validated with the same digests and per-generation offset
+contiguity the preview reducer enforces. A `terminal.output.gap`, an offset
+discontinuity, or an exceeded replay budget stops the applied tail at the
+last provably complete event; the projection renders what is proven and never
+guesses at missing bytes. A terminal absent from the newest checkpoint is
+rebuilt from its full journaled output history when one exists. Each
+materialization appends a `terminal.restore.applied` effect record (replay
+`never`) naming the source checkpoint, applied tail counters, and any
+degradation, so the post-replay action carries its own journal outcome
+without changing what restoration must reduce.
+
 Hosts created before the source-ordered detach protocol remain available in a
 compatibility mode. Their live output is not added to the journal because an
 old host cannot fence output at daemon shutdown. New protocol-v4 hosts use the
@@ -684,7 +700,8 @@ redaction markers are reserved for a later storage version.
 | Checkpoint writer and restoration preview reducer | Implemented in storage v1 |
 | Checkpoint-aligned immutable segments | Implemented in storage v1 |
 | Restart topology restoration with honest exited terminals | Implemented in storage v1 |
-| Checkpoint content application and post-restore respawn | Pending |
+| Cold-start checkpoint content application to exited placeholders | Implemented in storage v1 |
+| Post-restore respawn actions | Pending |
 
 The in-memory `MuxEvent` broadcaster remains a lossy presentation mechanism.
 It may wake consumers after commit, but it is never a journal or restoration

--- a/cmux-tui/spec/session-journal.md
+++ b/cmux-tui/spec/session-journal.md
@@ -11,9 +11,11 @@ tab selection; split ratios; viewport column widths; topology; terminal and
 browser lifecycle; continuous terminal output and geometry; frontend focus,
 viewport, and geometry observations; frontend projections; explicit agent
 reports; and normalized native agent-hook observations. A pure restoration
-reducer can preview the state reconstructed from a checkpoint and its tail.
-Verified root ownership leases and live application of a restored model remain
-pending.
+reducer can preview the state reconstructed from a checkpoint and its tail,
+and a restarted server reconstructs the durable topology, representing
+terminals whose processes died while it was down honestly as exited. Verified
+root ownership leases, checkpoint content application, and post-restore
+respawn actions remain pending.
 
 ## Invariants
 
@@ -575,6 +577,19 @@ External effects are not repeated during replay. Their recorded outcomes
 materialize state. Live-process adoption separately verifies process identity
 and incarnation before reconnecting a terminal host.
 
+Server startup applies the restored topology: workspace identity, order, and
+names; screens; split trees with committed ratios and viewport column widths;
+and tab placements. Startup rebuilds it from the transactional projections
+that invariant 2 keeps equal to the journal head, so the applied state and a
+restore preview at the same head agree. A terminal whose process died while
+the daemon was down is latched as exited with the first observed outcome and
+keeps its journaled placements: restoration never respawns a process, never
+pretends to reattach a dead one, and never discards layout on behalf of a
+process it did not observe exiting. An exit the daemon observes live still
+detaches that terminal's views in the same transaction. Explicit close of a
+restored exited terminal, and future respawn actions, are ordinary post-restore
+mutations with their own journal outcomes.
+
 Hosts created before the source-ordered detach protocol remain available in a
 compatibility mode. Their live output is not added to the journal because an
 old host cannot fence output at daemon shutdown. New protocol-v4 hosts use the
@@ -668,7 +683,8 @@ redaction markers are reserved for a later storage version.
 | Hook dispatcher and delivery projections | Implemented in storage v1 |
 | Checkpoint writer and restoration preview reducer | Implemented in storage v1 |
 | Checkpoint-aligned immutable segments | Implemented in storage v1 |
-| Live restoration application | Pending |
+| Restart topology restoration with honest exited terminals | Implemented in storage v1 |
+| Checkpoint content application and post-restore respawn | Pending |
 
 The in-memory `MuxEvent` broadcaster remains a lossy presentation mechanism.
 It may wake consumers after commit, but it is never a journal or restoration


### PR DESCRIPTION
Restoration apply v1: after a machine reboot (daemon and every per-PTY host dead), a fresh daemon on the same session now serves the restored topology with each dead terminal materialized as an honest exited surface whose renderable content comes from the journal. Browser restart already worked; reboot silently produced empty workspaces.

Includes the two commits of #10413 (restart reconciliation preserves journaled placements instead of detaching them); this PR stacks the content half on top and shrinks to that half if #10413 merges first.

## Mechanism

- `journal_restore.rs` (new): computes one terminal's restorable content: the terminal's `cmux.vt-replay.v1` blob from the newest checkpoint, then the exact parser-accepted `terminal.output` bytes and accepted `terminal.resized` geometry after `source_sequence`, validated with the same digests and per-generation offset contiguity the restore-preview reducer enforces. A `terminal.output.gap`, an offset discontinuity, a validation failure, or an exceeded replay budget stops the tail at the last provably complete event; the prefix stays renderable and the outcome records the degradation. A terminal absent from the newest checkpoint rebuilds from its full journaled output history.
- `Mux::materialize_restored_exited_terminals` (cold start, after `adopt_terminal_hosts`, before the socket serves clients): for every durable exited terminal with restored placements and no runtime, builds a dead placeholder surface (`Surface::restored_exited_terminal`, the production form of the test-only placeholder constructor) with that content applied via `apply_vt_replay_parts` plus tail replay, and inserts it into the reserved placement. One terminal's failure never aborts startup.
- Both attach paths (`attach_stream_with_lifecycle`, `attach_render_stream`) now serve the final content of an honestly exited surface (`host_connection_state == Exited`) instead of `NoValue`; tap registration stays gated on liveness, so the stream is inert. Screen read, state read, and resource attach work on restored terminals.
- Each materialization appends a `terminal.restore.applied` effect record (`replay: never`, sensitivity metadata) naming the source checkpoint, content source (`checkpoint`, `checkpoint+tail`, `tail`, `none`), tail counters, and any degradation, per the spec's post-replay-outcome rule. Never-replay effect class keeps every existing preview fully reducible.
- No config gate: restoration to exited placeholders spawns nothing, so it defaults on.

## Diagnosis

Reproduced live before writing code: kill daemon + host, restart daemon; the workspace row survived but `tab list` was empty and the exited terminal had `tab_id: null` and no surface. Root cause chain: startup `adopt_terminal_hosts` proves each host dead and committed exit-with-detach (`remove_surface` cascade durably tombstones tabs, panes, screens) — the half #10413 fixes — and exited terminals existed only as registry receipt rows with no surface, so screen read and attach returned not_found and clients had nothing to render — the half this PR fixes.

## Tests

Two-commit red/green: 40061e0c49 adds the integration tests (red on the base), 692928aee8 the implementation.

- `crates/cmux-tui/tests/journal_restore.rs`: restored placeholder replays checkpoint content and journals its outcome; tail beyond the checkpoint replays (with a durability wait so the SIGKILL cannot race journal ingress); tail-only restore without any checkpoint; empty session restores nothing and appends no outcome records; plus #10413's topology and preview-agreement tests still pass with placeholders materialized.
- `crates/cmux-tui-core/src/journal_restore.rs` unit tests: contiguous output+resize folding in commit order, foreign-terminal/kind filtering, gap-record stop with provable prefix, same-generation offset-gap stop, cross-generation follow, budget stop, corrupt-digest rejection, `cmux.vt-replay.v1` decode round-trip and grid-mismatch rejection.

## Deferred (v1 scope)

- Shell respawn, agent resume, launchd/systemd supervision, browser-side changes.
- Materialization for terminals whose exit lands later via the async adoption-retry loop (Indeterminate-liveness hosts); they stay surface-less until the next restart, as today. Reboot leaves flocks free, so the synchronous Dead path covers the reboot case.
- Title restoration (placeholders keep an empty title so the public exited projection stays byte-identical to the durable exit snapshot and previews keep agreeing; replayed OSC title bytes may still set one).
- Kitty image blobs restore through the checkpoint replay sidecar only; a placeholder never refetches images.
- Restoration outcome records for failed materializations (failures log to stderr; only applied outcomes are journaled).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887753&installation_model_id=21920&pr_number=10521&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10521&signature=d37baad0ecbb7bafd8a61b5ccdfe85b618f125da79a8967c0e4d417a44d18645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores preserved topology and renderable content for exited terminals at cold start. Previously after reboot, dead terminals kept placements but had no surface; now the daemon materializes inert exited surfaces and applies content from the newest checkpoint plus a validated journal tail.

- Replays VT state: checkpoint blob, then contiguous `terminal.output` and `terminal.resized` after the checkpoint; stops on gaps/validation/budget and records degradation. Bounded decompression revalidates length and digest.
- Cold start materializes restored exited terminals after host adoption; one terminal’s failure never aborts startup. Each materialization appends a `terminal.restore.applied` effect (never replayed).
- Attach and screen/state reads serve the final content of an exited surface; input/taps stay disabled. `terminal.close` now applies to runtime-less restored terminals and removes their placements.
- Restart reconciliation preserves journaled placements for exits seen during downtime; live exits still detach.
- Fix: tail resize replay now applies by making cell pixel size mutable during restore.
- Fixes conformance compile errors.

**Rollout and limitations**
- Default on; cold start only. No respawn or supervision yet.
- Titles remain empty unless set by replayed OSC; images restore via checkpoint sidecar.
- Terminals confirmed dead via async adoption-retry materialize on the next restart.

<sup>Written for commit a840d018b798cad68cec4b5fdeb13242668da730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restores exited terminal views after restart while preserving tabs, splits, geometry, and terminal output.
  - Replays saved terminal content, including checkpoint state, later output, resizing, and graphics where available.
  - Supports restoration from checkpoints or journal history when one source is unavailable.
  - Keeps restored terminals inert and clearly exited without respawning processes.
  - Allows explicitly closing restored exited terminals.

- **Bug Fixes**
  - Prevents terminal views from disappearing when hosts exit while the daemon is offline.
  - Safely handles incomplete or invalid journal data while retaining verified content and marking degraded restorations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->