### PR TITLE
Add account-free local Tailscale pairing for iOS

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxByteTransportRequest.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxByteTransportRequest.swift
@@ -11,6 +11,9 @@ public enum CmxTransportAuthorizationMode: Equatable, Sendable {
     /// the pairing UI is the authorization event, and the value never outlives
     /// that pairing dial.
     case userAuthorizedTailscalePairing(CmxUserTailscalePairingAuthorization)
+    /// A user-approved local-pairing QR may send its device-local bearer only
+    /// to the exact Tailscale peer named by that QR.
+    case localTailscalePairing(CmxUserTailscalePairingAuthorization)
     /// The transport handshake admitted this exact peer and account binding.
     case transportAdmission
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohTransportPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohTransportPolicy.swift
@@ -172,7 +172,8 @@ extension CmxAttachTicket {
                 $0.disclosed(for: .authenticated, at: now)
             },
             expiresAt: expiresAt,
-            authToken: authToken
+            authToken: authToken,
+            localPairing: localPairing
         )
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
@@ -25,10 +25,15 @@ import Foundation
 /// build (`av`/`ab`) only ever decorated that warning's message, so they are
 /// no longer written; the decoder still reads them from older Macs' codes.
 ///
-/// Both grammars share these properties:
-/// - **No auth token.** The owner's Stack access token is the host's sole
-///   authorization gate; a token in the QR authorized nothing and made the
-///   code look like a leaked credential.
+/// Opt-in local-only pairing uses v4:
+/// `cmux-ios://attach?v=4&d=<mac-device-id>&pc=<compat>&k=<bearer>&r=<host>:<port>...`.
+/// Unlike the compatibility grammar, this code deliberately carries a bearer
+/// capability. Possession of that code plus reachability through the tailnet
+/// replaces the Stack same-account check.
+///
+/// The legacy v2 and v3 grammars share these properties:
+/// - **No auth token.** The owner's Stack access token authorizes those paths;
+///   a token in either legacy QR authorized nothing.
 /// - **No expiry.** Ticket age authorizes nothing, so a code that sat on
 ///   screen for an hour still pairs.
 /// - **No display name, no device id, no build metadata.** All arrive
@@ -46,10 +51,10 @@ import Foundation
 ///   into an `NWConnection` `.waiting` black hole for the full request
 ///   timeout before the Tailscale route was ever tried.
 ///
-/// The payloads are deliberately *not* wrapped in base64 JSON: anyone can read
-/// the URL off the QR and see for themselves that it carries only an address.
-/// Plain text is also smaller, which lowers the QR version (fewer, larger
-/// modules) and makes the code scan faster from a Mac screen.
+/// The payloads are deliberately *not* wrapped in base64 JSON. Plain text is
+/// smaller, which lowers the QR version (fewer, larger modules) and makes the
+/// code scan faster from a Mac screen. A v4 URL is a credential and must be
+/// handled like any other bearer secret.
 ///
 /// Compatibility: the Mac pairing window emits only a Tailscale pairing
 /// payload. v3 remains decodable for existing Iroh links and explicit
@@ -61,12 +66,14 @@ public struct CmxPairingQRCode: Sendable {
     /// The newest grammar version this build can decode.
     ///
     /// Distinct from ``CmxAttachTicket/currentVersion`` (the ticket structure
-    /// version): v1 URLs carry base64 JSON, v2 carries Tailscale routes, and
-    /// v3 carries one bare Iroh EndpointID.
-    public static let version = 3
+    /// version): v1 URLs carry base64 JSON, v2 carries account-authorized
+    /// Tailscale routes, v3 carries one bare Iroh EndpointID, and v4 carries a
+    /// local capability plus exact Tailscale routes.
+    public static let version = 4
 
     private static let tailscaleVersion = 2
     private static let irohVersion = 3
+    private static let localTailscaleVersion = 4
 
     /// Defensive cap on routes accepted from a scanned code. The Mac's route
     /// resolver emits at most a couple (MagicDNS name + Tailscale IP); a QR
@@ -123,6 +130,27 @@ public struct CmxPairingQRCode: Sendable {
                 return "r=\(hostPortString(host: host, port: port))"
             })
             items = compatibilityItems
+        case .localTailscalePairing:
+            guard let routes = encodableTailscaleRoutes(of: ticket),
+                  let deviceID = normalizedNonEmpty(ticket.macDeviceID),
+                  let bearer = normalizedNonEmpty(ticket.authToken) else {
+                return nil
+            }
+            var localItems = [
+                "v=\(Self.localTailscaleVersion)",
+                "d=\(percentEncodeQueryValue(deviceID))",
+                "k=\(percentEncodeQueryValue(bearer))",
+            ]
+            if let compatibilityVersion = ticket.macPairingCompatibilityVersion {
+                localItems.append("pc=\(compatibilityVersion)")
+            }
+            localItems.append(contentsOf: routes.map { route -> String in
+                guard case let .hostPort(host, port) = route.endpoint else {
+                    return ""
+                }
+                return "r=\(hostPortString(host: host, port: port))"
+            })
+            items = localItems
         }
         // The scheme is channel-specific (see ``CmxPairingURLScheme``): a dev
         // Mac's QR opens the dev iOS build, a release Mac's QR opens the
@@ -141,6 +169,10 @@ public struct CmxPairingQRCode: Sendable {
             encodableIrohIdentity(of: ticket) != nil
         case .legacyPrivateNetworkCompatibility:
             encodableTailscaleRoutes(of: ticket) != nil
+        case .localTailscalePairing:
+            encodableTailscaleRoutes(of: ticket) != nil
+                && normalizedNonEmpty(ticket.macDeviceID) != nil
+                && normalizedNonEmpty(ticket.authToken) != nil
         }
     }
 
@@ -212,7 +244,9 @@ public struct CmxPairingQRCode: Sendable {
         guard let version = Self.attachURLVersion(components) else {
             return false
         }
-        return version == Self.tailscaleVersion || version == Self.irohVersion
+        return version == Self.tailscaleVersion
+            || version == Self.irohVersion
+            || version == Self.localTailscaleVersion
     }
 
     /// The integer grammar version declared by an attach URL's `v` query item,
@@ -243,9 +277,10 @@ public struct CmxPairingQRCode: Sendable {
 
     /// Decode a supported plain pairing URL into a validated ticket.
     ///
-    /// The ticket comes back unscoped with an empty `macDeviceID`; the shell
+    /// Legacy tickets come back unscoped with an empty `macDeviceID`; the shell
     /// recovers the Mac's identity post-handshake from `mobile.host.status`.
-    /// - Parameter components: A parsed v2 or v3 attach URL.
+    /// Local v4 tickets carry the stable device id needed for persistence.
+    /// - Parameter components: A parsed v2, v3, or v4 attach URL.
     /// - Throws: ``MobileSyncPairingPayloadError/invalidURL`` for malformed
     ///   input and ``MobileSyncPairingPayloadError/loopbackRouteRejected``
     ///   when any route names a loopback host (a scanned code must never
@@ -259,6 +294,8 @@ public struct CmxPairingQRCode: Sendable {
             return try decodeTailscale(components)
         case Self.irohVersion:
             return try decodeIroh(components)
+        case Self.localTailscaleVersion:
+            return try decodeLocalTailscale(components)
         default:
             throw MobileSyncPairingPayloadError.invalidURL
         }
@@ -299,6 +336,36 @@ private extension CmxPairingQRCode {
             routes: routes,
             expiresAt: nil,
             authToken: nil
+        )
+        try ticket.validate()
+        return ticket
+    }
+
+    /// Decode the v4 local-only Tailscale grammar.
+    func decodeLocalTailscale(_ components: URLComponents) throws -> CmxAttachTicket {
+        let items = components.queryItems ?? []
+        guard items.filter({ $0.name == "v" }).count == 1,
+              items.filter({ $0.name == "d" }).count == 1,
+              items.filter({ $0.name == "k" }).count == 1,
+              let deviceID = queryValue(named: "d", in: components),
+              !deviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let bearer = queryValue(named: "k", in: components),
+              !bearer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MobileSyncPairingPayloadError.invalidURL
+        }
+        let routeTicket = try decodeTailscale(components)
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: deviceID,
+            macDisplayName: nil,
+            macUserEmail: nil,
+            macUserID: nil,
+            macPairingCompatibilityVersion: routeTicket.macPairingCompatibilityVersion,
+            routes: routeTicket.routes,
+            expiresAt: nil,
+            authToken: bearer,
+            localPairing: true
         )
         try ticket.validate()
         return ticket

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingRouteDisclosureMode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingRouteDisclosureMode.swift
@@ -11,4 +11,9 @@ public enum CmxPairingRouteDisclosureMode: Equatable, Sendable {
     /// Preserve the pre-Iroh compact route grammar for a Tailscale pairing
     /// code. This discloses the selected tailnet destination.
     case legacyPrivateNetworkCompatibility
+    /// Encode a Tailscale destination together with an explicit local-pairing
+    /// bearer. This mode is opt-in because possession of the QR grants access
+    /// without a Stack account; the surrounding tailnet remains the network
+    /// boundary.
+    case localTailscalePairing
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTransport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTransport.swift
@@ -251,6 +251,7 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
         case routes
         case expiresAt
         case authToken = "auth_token"
+        case localPairing
     }
 
     /// Tolerant decode keys for the auth-token field only.
@@ -282,12 +283,14 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
     public let macAppBuild: String?
     public let routes: [CmxAttachRoute]
     /// When the ticket's attach token stops being usable, or `nil` for tickets
-    /// that never expire (the pairing QR carries no token and no expiry; Stack
-    /// auth is the host's sole authorization gate). Expiry is data for the
-    /// token consumers (`MobileCoreRPCClient`, the host's ticket store), not a
-    /// structural validity condition; see ``isExpired(at:)``.
+    /// that never expire. Legacy account pairing QRs carry no token; local
+    /// pairing carries a durable capability. Expiry is data for temporary-token
+    /// consumers, not a structural validity condition; see ``isExpired(at:)``.
     public let expiresAt: Date?
     public let authToken: String?
+    /// Whether `authToken` is a durable, user-approved local-pairing
+    /// capability instead of temporary attach-ticket context.
+    public let localPairing: Bool
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -307,7 +310,8 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
             macAppBuild: container.decodeIfPresent(String.self, forKey: .macAppBuild),
             routes: container.decode([CmxAttachRoute].self, forKey: .routes),
             expiresAt: container.decodeIfPresent(Date.self, forKey: .expiresAt),
-            authToken: try Self.decodeAuthToken(from: decoder)
+            authToken: try Self.decodeAuthToken(from: decoder),
+            localPairing: try container.decodeIfPresent(Bool.self, forKey: .localPairing) ?? false
         )
         try validate()
     }
@@ -339,7 +343,8 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
         macAppBuild: String? = nil,
         routes: [CmxAttachRoute],
         expiresAt: Date? = nil,
-        authToken: String? = nil
+        authToken: String? = nil,
+        localPairing: Bool = false
     ) throws {
         self.version = version
         self.workspaceID = workspaceID
@@ -354,13 +359,15 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
         self.routes = routes
         self.expiresAt = expiresAt
         self.authToken = authToken
+        self.localPairing = localPairing
         try validate()
     }
 
     /// Structural validity only. Expiry is intentionally NOT validated here:
-    /// a scanned pairing QR must keep working however long it sat on screen
-    /// (the host authorizes by Stack account, not by ticket age). Token-based
-    /// consumers check ``isExpired(at:)`` where the token is actually used.
+    /// a scanned pairing QR must keep working however long it sat on screen.
+    /// Consumers of temporary tokens check ``isExpired(at:)`` where the token
+    /// is actually used; durable local capabilities intentionally have no
+    /// expiry.
     public func validate() throws {
         guard version == Self.currentVersion else {
             throw CmxAttachTicketError.unsupportedVersion(version)

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CompactAttachTicket.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CompactAttachTicket.swift
@@ -79,6 +79,8 @@ private extension Array where Element == CmxAttachRoute {
             }
         case .legacyPrivateNetworkCompatibility:
             return self
+        case .localTailscalePairing:
+            return filter { $0.kind == .tailscale }
         }
     }
 

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import CMUXMobileCore
 
-/// Coverage for the minimal v2 pairing-QR grammar: bare Tailscale
-/// `host:port` routes in the URL query, nothing else.
+/// Coverage for the compact pairing-QR grammars, including local Tailscale
+/// capabilities and the legacy account-authorized forms.
 @Suite struct CmxPairingQRCodeTests {
     private func tailscaleRoute(
         index: Int,
@@ -49,6 +49,33 @@ import Testing
             ticket,
             routeDisclosureMode: .legacyPrivateNetworkCompatibility
         )
+    }
+
+    @Test func localPairingRoundTripsCapabilityAndExactRoutes() throws {
+        let routes = [try tailscaleRoute(index: 0, host: "100.64.0.5")]
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "123e4567-e89b-42d3-a456-426614174004",
+            macDisplayName: "Local Mac",
+            macPairingCompatibilityVersion: 1,
+            routes: routes,
+            authToken: "v1.local-capability",
+            localPairing: true
+        )
+
+        let url = try #require(CmxPairingQRCode().encode(
+            ticket,
+            routeDisclosureMode: .localTailscalePairing
+        ))
+        let decoded = try CmxPairingQRCode().decode(try components(url))
+
+        #expect(url.contains("v=4"))
+        #expect(decoded.macDeviceID == ticket.macDeviceID)
+        #expect(decoded.authToken == ticket.authToken)
+        #expect(decoded.localPairing)
+        #expect(decoded.routes == routes)
+        #expect(decoded.expiresAt == nil)
     }
 
     @Test func roundTripsSingleRoute() throws {
@@ -303,6 +330,26 @@ import Testing
     }
 
     @Test(arguments: [
+        "cmux-ios://attach?v=4&d=mac&k=secret",
+        "cmux-ios://attach?v=4&d=&k=secret&r=100.64.0.5:58465",
+        "cmux-ios://attach?v=4&d=mac&k=&r=100.64.0.5:58465",
+        "cmux-ios://attach?v=4&d=mac&d=other&k=secret&r=100.64.0.5:58465",
+        "cmux-ios://attach?v=4&d=mac&k=secret&k=other&r=100.64.0.5:58465",
+    ])
+    func decodeRejectsMalformedLocalPairingCodes(url: String) throws {
+        #expect(throws: (any Error).self) {
+            try CmxPairingQRCode().decode(try components(url))
+        }
+    }
+
+    @Test func localPairingRejectsLoopbackRoute() throws {
+        let url = "cmux-ios://attach?v=4&d=mac&k=secret&r=127.0.0.1:58465"
+        #expect(throws: MobileSyncPairingPayloadError.loopbackRouteRejected) {
+            try CmxPairingQRCode().decode(try components(url))
+        }
+    }
+
+    @Test(arguments: [
         "cmux-ios://attach?v=3",
         "cmux-ios://attach?v=3&i=",
         "cmux-ios://attach?v=3&i=abc",
@@ -329,6 +376,9 @@ import Testing
         #expect(CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=2&r=100.64.0.5:58465"))
         #expect(CmxPairingQRCode().isPairingCodeURLString(
             "cmux-ios://attach?v=3&i=\(String(repeating: "c", count: 64))"
+        ))
+        #expect(CmxPairingQRCode().isPairingCodeURLString(
+            "cmux-ios://attach?v=4&d=mac&k=secret&r=100.64.0.5:58465"
         ))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=1&payload=abc"))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://pair?v=1&payload=abc"))

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -33,7 +33,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     public var usesLocallyAuthorizedTailscaleRoute: Bool {
         guard route.kind == .tailscale else { return false }
         switch transportRequest.authorizationMode {
-        case .legacyTailscaleBearer, .userAuthorizedTailscalePairing:
+        case .legacyTailscaleBearer, .userAuthorizedTailscalePairing, .localTailscalePairing:
             return true
         case .stackBearer, .transportAdmission:
             return false
@@ -99,9 +99,9 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                       host: host,
                       port: port
                   ) {
-            authorizationMode = .userAuthorizedTailscalePairing(
-                userTailscalePairingAuthorization
-            )
+            authorizationMode = ticket.localPairing
+                ? .localTailscalePairing(userTailscalePairingAuthorization)
+                : .userAuthorizedTailscalePairing(userTailscalePairingAuthorization)
         } else {
             authorizationMode = .stackBearer
         }
@@ -540,6 +540,26 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                 stackAccessToken: nil
             )
         }
+        if case .localTailscalePairing = transportRequest.authorizationMode {
+            guard let attachToken = ticket.authToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !attachToken.isEmpty else {
+                throw MobileShellConnectionError.authorizationFailed(
+                    L10n.string(
+                        "mobile.pairing.localCredentialUnavailable",
+                        defaultValue: "Pair this Mac again to refresh its local credential."
+                    )
+                )
+            }
+            if Self.requestRequiresAuth(request) || isHostStatusRequest(request) {
+                request["auth"] = ["attach_token": attachToken]
+            } else {
+                request.removeValue(forKey: "auth")
+            }
+            return AuthenticatedRequestPayload(
+                data: try JSONSerialization.data(withJSONObject: request),
+                stackAccessToken: nil
+            )
+        }
         let requestNeedsAuth = Self.requestRequiresAuth(request)
         let requestIsCoveredByAttachTicket = !Self.requestNeedsStackAuthFallback(request, ticket: ticket)
         var auth: [String: Any] = [:]
@@ -560,14 +580,11 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                 throw MobileShellConnectionError.attachTicketExpired
             }
         }
-        // The host treats Stack auth as the SOLE authorization gate: EVERY
-        // authorized request must carry the owner's stack_access_token, even when
-        // an attach_token is also present. The attach ticket is route-discovery
-        // and workspace-selection only and never authorizes on its own, so a
-        // request that ships attach_token-only (e.g. ticket-covered workspace.list)
-        // is rejected host-side with `missingStackTokens`. Always present the
-        // Stack token for authorized requests; attach_token rides along as
-        // supplementary route/workspace context.
+        // This is the account-authorized path; the local-pairing capability
+        // returned above never reaches it. Every authorized account request
+        // carries the owner's stack_access_token, even when an attach_token is
+        // also present. In this mode the attach ticket only supplies route and
+        // workspace context.
         let shouldSendStackAuth = requestNeedsAuth
         if shouldSendStackAuth {
             guard canSendStackBearer else {
@@ -645,7 +662,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         switch transportRequest.authorizationMode {
         case .stackBearer, .legacyTailscaleBearer, .userAuthorizedTailscalePairing:
             true
-        case .transportAdmission:
+        case .localTailscalePairing, .transportAdmission:
             false
         }
     }
@@ -669,6 +686,12 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                 port: port
             )
         case let .userAuthorizedTailscalePairing(authorization):
+            guard route.kind == .tailscale,
+                  case let .hostPort(host, port) = route.endpoint else {
+                return false
+            }
+            return authorization.authorizes(host: host, port: port)
+        case let .localTailscalePairing(authorization):
             guard route.kind == .tailscale,
                   case let .hostPort(host, port) = route.endpoint else {
                 return false

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/CmxAttachTicketInputTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/CmxAttachTicketInputTests.swift
@@ -262,10 +262,11 @@ import Testing
         // The current grammar version is not "newer", so it decodes normally
         // rather than tripping the unrecognized-version path.
         let decoded = try CmxAttachTicketInput.decode(
-            "cmux-ios://attach?v=\(CmxPairingQRCode.version)&i="
-                + String(repeating: "c", count: 64)
+            "cmux-ios://attach?v=\(CmxPairingQRCode.version)"
+                + "&d=mac-device&k=local-capability&r=100.64.0.5:58465"
         )
         #expect(decoded.routes.count == 1)
-        #expect(decoded.routes.first?.kind == .iroh)
+        #expect(decoded.routes.first?.kind == .tailscale)
+        #expect(decoded.localPairing)
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
@@ -685,6 +685,60 @@ import Testing
         _ = try? await task.value
     }
 
+    @Test func localTailscalePairingCarriesOnlyItsLocalCapability() async throws {
+        let route = try hostPortRoute(
+            kind: .tailscale,
+            host: "100.64.0.5",
+            port: 58_465
+        )
+        let transport = QueuedCancellationProbeTransport()
+        let capture = TransportRequestCapture()
+        let stackTokenRequested = AsyncFlag()
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: IntentRecordingTransportFactory(
+                transport: transport,
+                capture: capture
+            ),
+            stackAccessTokenProvider: {
+                await stackTokenRequested.set()
+                return "must-not-cross-local-pairing"
+            }
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "123e4567-e89b-42d3-a456-426614174004",
+            macDisplayName: "Local Mac",
+            routes: [route],
+            authToken: "local-capability",
+            localPairing: true
+        )
+        let authorization = try CmxUserTailscalePairingAuthorization(
+            host: "100.64.0.5",
+            port: 58_465
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            userTailscalePairingAuthorization: authorization
+        )
+        let request = try MobileCoreRPCClient.requestData(method: "workspace.list")
+
+        let task = Task { try await client.sendRequest(request) }
+        let sent = try await transport.waitForSentRequestCount(1)
+        let frame = try #require(sent.first)
+
+        #expect(frame.attachToken == "local-capability")
+        #expect(frame.stackAccessToken == nil)
+        #expect(frame.hasAuth)
+        #expect(!(await stackTokenRequested.isSet()))
+        #expect(capture.request()?.authorizationMode == .localTailscalePairing(authorization))
+        task.cancel()
+        await transport.releaseFirstSend()
+        _ = try? await task.value
+    }
+
     @Test func exactLegacyTailscaleEvidenceCarriesStackBearer() async throws {
         let macDeviceID = "123e4567-e89b-42d3-a456-426614174004"
         let route = try hostPortRoute(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4283,7 +4283,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             macAppBuild: ticket.macAppBuild,
             routes: ticket.routes,
             expiresAt: ticket.expiresAt,
-            authToken: ticket.authToken
+            authToken: ticket.authToken,
+            localPairing: ticket.localPairing
             ) {
             resolvedTicket = adopted
         } else {
@@ -4495,9 +4496,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // An explicit in-app code entry (the Mac's Tailscale pairing window
         // shows either the tokenless v1 compatibility ticket or the bare-route
         // v2 grammar) authorizes the exact Tailscale destinations it named.
-        // External URL opens never mint this.
+        // A v4 local-pairing URL is itself an explicit capability grant, so a
+        // Camera/deep-link open receives the same exact-route authorization.
         let userTailscalePairingAuthorizations: [CmxUserTailscalePairingAuthorization]
-        if userEnteredPairingCode {
+        if userEnteredPairingCode || ticket.localPairing {
             userTailscalePairingAuthorizations = ticket.routes.compactMap { route in
                 guard route.kind == .tailscale,
                       case let .hostPort(host, port) = route.endpoint else {
@@ -9805,7 +9807,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 macAppBuild: ticket.macAppBuild,
                 routes: ticket.routes,
                 expiresAt: ticket.expiresAt,
-                authToken: ticket.authToken
+                authToken: ticket.authToken,
+                localPairing: ticket.localPairing
               ) else {
             return ticket
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileAppView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileAppView.swift
@@ -25,6 +25,8 @@ public struct CMUXMobileAppView: View {
     /// reconnect decision. Root view lifecycle callbacks share this instance.
     @State private var startupConnectionCoordinator = MobileStartupConnectionCoordinator()
     private let signOutHook: MobileSignOutHook
+    private let localPairingCredentialStore:
+        any MobileLocalPairingCredentialStoring
     #if os(iOS)
     private let onboardingStore: MobileOnboardingStore
     #endif
@@ -46,7 +48,9 @@ public struct CMUXMobileAppView: View {
         browserStreamStore: BrowserStreamStore = BrowserStreamStore(),
         simulatorStreamStore: MobileSimulatorStreamStore = MobileSimulatorStreamStore(),
         onboardingStore: MobileOnboardingStore = MobileOnboardingStore(defaults: .standard, forceComplete: true),
-        signOutHook: MobileSignOutHook = MobileSignOutHook()
+        signOutHook: MobileSignOutHook = MobileSignOutHook(),
+        localPairingCredentialStore: any MobileLocalPairingCredentialStoring =
+            NoopMobileLocalPairingCredentialStore()
     ) {
         _store = State(initialValue: store)
         _browserStore = State(initialValue: browserStore)
@@ -54,6 +58,7 @@ public struct CMUXMobileAppView: View {
         _simulatorStreamStore = State(initialValue: simulatorStreamStore)
         self.onboardingStore = onboardingStore
         self.signOutHook = signOutHook
+        self.localPairingCredentialStore = localPairingCredentialStore
     }
     #else
     /// Creates the app view on non-iOS platforms.
@@ -74,6 +79,7 @@ public struct CMUXMobileAppView: View {
         _browserStreamStore = State(initialValue: browserStreamStore)
         _simulatorStreamStore = State(initialValue: simulatorStreamStore)
         self.signOutHook = signOutHook
+        self.localPairingCredentialStore = NoopMobileLocalPairingCredentialStore()
     }
     #endif
 
@@ -84,6 +90,7 @@ public struct CMUXMobileAppView: View {
             store: store,
             onboardingStore: onboardingStore,
             signOutHook: signOutHook,
+            localPairingCredentialStore: localPairingCredentialStore,
             startupConnectionCoordinator: startupConnectionCoordinator
         )
             .environment(browserStore)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -30,6 +30,8 @@ struct CMUXMobileRootView: View {
     @State private var connectionMethodObservationToken: MobileConnectionMethod?
     @Environment(\.dogfoodAttachPreparation) private var dogfoodAttachPreparation
     private let signOutHook: MobileSignOutHook
+    private let localPairingCredentialStore:
+        any MobileLocalPairingCredentialStoring
     private let startupConnectionCoordinator: MobileStartupConnectionCoordinator
     #if os(iOS)
     @Environment(MobilePushCoordinator.self) private var pushCoordinator
@@ -76,11 +78,13 @@ struct CMUXMobileRootView: View {
         store: CMUXMobileShellStore,
         onboardingStore: MobileOnboardingStore,
         signOutHook: MobileSignOutHook,
+        localPairingCredentialStore: any MobileLocalPairingCredentialStoring,
         startupConnectionCoordinator: MobileStartupConnectionCoordinator
     ) {
         self.store = store
         self.onboardingStore = onboardingStore
         self.signOutHook = signOutHook
+        self.localPairingCredentialStore = localPairingCredentialStore
         self.startupConnectionCoordinator = startupConnectionCoordinator
         var initialRootPresentation = MobileRootPresentationState()
         #if DEBUG
@@ -110,6 +114,7 @@ struct CMUXMobileRootView: View {
     ) {
         self.store = store
         self.signOutHook = signOutHook
+        self.localPairingCredentialStore = NoopMobileLocalPairingCredentialStore()
         self.startupConnectionCoordinator = startupConnectionCoordinator
     }
     #endif
@@ -304,6 +309,9 @@ struct CMUXMobileRootView: View {
             // barrier; the coordinator still serializes this with the normal
             // lifecycle callbacks, so it cannot start a duplicate dial.
             await finishAuthenticationBootstrapAndConnect()
+        }
+        .task {
+            await restoreLocalPairingIfNeeded()
         }
         .onChange(of: store.tailscaleSetupStatus, initial: true) { _, status in
             tailscaleSetupPrompt.apply(.shellStatusChanged(status))
@@ -1175,6 +1183,9 @@ struct CMUXMobileRootView: View {
                 result.didConnect ? .appOpenURLHandled : .appOpenURLRejected,
                 failure: failure
             )
+            if result.didConnect, isLocalPairingURL(rawURL) {
+                await localPairingCredentialStore.saveAttachURL(rawURL)
+            }
             switch followUp {
             case .none:
                 break
@@ -1272,6 +1283,7 @@ struct CMUXMobileRootView: View {
             // store.signOut() makes; this clears everything up front.
             toasts.dismissAll()
             store.signOut()
+            await localPairingCredentialStore.clearAttachURL()
             let serverTeardown = signOutHook.begin()
             await authManager.signOut(onSignedOut: serverTeardown)
             diagnosticLog?.recordAppEvent(
@@ -1279,6 +1291,24 @@ struct CMUXMobileRootView: View {
                 failure: authManager.isAuthenticated ? .protocolViolation : nil
             )
         }
+    }
+
+    private func restoreLocalPairingIfNeeded() async {
+        await authManager.awaitBootstrapped()
+        guard !authManager.isAuthenticated,
+              !didAuthenticateWithAttachTicket,
+              store.connectionState != .connected,
+              let attachURL = await localPairingCredentialStore.loadAttachURL(),
+              isLocalPairingURL(attachURL) else { return }
+        connectAttachURL(attachURL)
+    }
+
+    private func isLocalPairingURL(_ rawURL: String) -> Bool {
+        guard let components = URLComponents(string: rawURL),
+              let ticket = try? CmxPairingQRCode().decode(components) else {
+            return false
+        }
+        return ticket.localPairing
     }
 
     @discardableResult

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLocalPairingCredentialStoring.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLocalPairingCredentialStoring.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Device-local persistence for the most recently approved local pairing.
+///
+/// The concrete iOS app stores this value in Keychain. Package previews use
+/// the no-op default so no view owns credential-storage policy.
+public protocol MobileLocalPairingCredentialStoring: Sendable {
+    /// Loads the most recently connected local pairing URL.
+    func loadAttachURL() async -> String?
+    /// Replaces the stored local pairing after a successful connection.
+    func saveAttachURL(_ attachURL: String) async
+    /// Removes the local pairing during explicit sign-out.
+    func clearAttachURL() async
+}
+
+/// A credential store that deliberately persists nothing.
+public struct NoopMobileLocalPairingCredentialStore:
+    MobileLocalPairingCredentialStoring {
+    /// Creates a no-op credential store.
+    public init() {}
+
+    public func loadAttachURL() async -> String? { nil }
+    public func saveAttachURL(_ attachURL: String) async {}
+    public func clearAttachURL() async {}
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransportFactory.swift
@@ -73,8 +73,9 @@ public struct CmxNetworkByteTransportFactory: CmxRouteAwareByteTransportFactory 
                 ) else {
                     throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
                 }
-            case let .userAuthorizedTailscalePairing(authorization):
-                // Anchored on the exact user-entered destination; any claimed
+            case let .userAuthorizedTailscalePairing(authorization),
+                 let .localTailscalePairing(authorization):
+                // Anchored on the exact user-approved destination; any claimed
                 // device identity is self-reported and grants nothing extra.
                 guard authorization.authorizes(host: host, port: port) else {
                     throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteProof.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteProof.swift
@@ -159,8 +159,9 @@ struct CmxTailscaleRouteProofValidator {
             ) else {
                 throw CmxTailscaleRouteProofError.authorizationEvidenceMismatch
             }
-        case let .userAuthorizedTailscalePairing(authorization):
-            // A user-entered code authorizes only its exact destination; any
+        case let .userAuthorizedTailscalePairing(authorization),
+             let .localTailscalePairing(authorization):
+            // A user-approved code authorizes only its exact destination; any
             // device identity it claims is self-reported and grants nothing.
             guard authorization.authorizes(host: host, port: port) else {
                 throw CmxTailscaleRouteProofError.authorizationEvidenceMismatch

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -138458,6 +138458,23 @@
         }
       }
     },
+    "mobile.pairing.localOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local pairing · Tailscale only · No cmux account"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルペアリング · Tailscale のみ · cmux アカウント不要"
+          }
+        }
+      }
+    },
     "mobile.pairing.manual.copied": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Mobile/MobileAttachTicketStore.swift
+++ b/Sources/Mobile/MobileAttachTicketStore.swift
@@ -23,6 +23,34 @@ final class MobileAttachTicketStore {
     private let lock = NSLock()
     private var recordsByAuthToken: [String: Record] = [:]
 
+    /// Creates a non-expiring local-only pairing ticket. Its capability is
+    /// independently verified by ``MobileLocalPairingAuthority`` and is not
+    /// entered into the temporary attach-ticket registry.
+    func createLocalPairingTicket(
+        routes: [CmxAttachRoute],
+        capability: String,
+        macPairingCompatibilityVersion: Int? = nil,
+        macAppVersion: String? = nil,
+        macAppBuild: String? = nil
+    ) throws -> CmxAttachTicket {
+        guard !routes.isEmpty else {
+            throw MobileAttachTicketStoreError.noRoutes
+        }
+        return try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: MobileHostIdentity.deviceID(),
+            macDisplayName: MobileHostIdentity.instanceDisplayName(),
+            macPairingCompatibilityVersion: macPairingCompatibilityVersion,
+            macAppVersion: macAppVersion,
+            macAppBuild: macAppBuild,
+            routes: routes,
+            expiresAt: nil,
+            authToken: capability,
+            localPairing: true
+        )
+    }
+
     func createTicket(
         workspaceID: String,
         terminalID: String?,

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxAuthRuntime
+import CmuxControlSocket
 import CmuxGit
 import CmuxIrohTransport
 import CmuxMobileTransport
@@ -323,13 +324,12 @@ final class MobileHostService {
     /// cached identity-free payload without touching the main actor or the
     /// Stack verifier — the DoS posture of the public probe is unchanged, and
     /// an arbitrary process that can reach the port receives no private route
-    /// hints or account identity. A request that does present the owner's
-    /// same-account Stack token (the iOS client attaches it to status
-    /// whenever it has one) is verified and answered with the Mac's identity,
-    /// which is what a freshly QR-paired phone needs to key its paired-Mac
-    /// record. A token that fails verification degrades to the identity-free
-    /// payload rather than an error: reachability stays observable, and the
-    /// authorized verbs that follow surface the auth failure properly.
+    /// hints or account identity. A request that presents either the approved
+    /// local capability or the owner's same-account Stack token is answered
+    /// with the Mac's identity, which a freshly paired phone needs to key its
+    /// paired-Mac record. A token that fails verification degrades to the
+    /// identity-free payload rather than an error: reachability stays
+    /// observable, and authorized verbs surface the auth failure properly.
     /// Verification goes through the same gate as the authorized verbs
     /// (``verifiedStackCaller(for:)``), so a DEBUG dev-token client that can
     /// list workspaces also sees identity.
@@ -343,6 +343,13 @@ final class MobileHostService {
     /// picks it up later). A flood of unique garbage tokens therefore cannot
     /// queue unbounded Stack lookups behind this verb.
     nonisolated static func networkStatusResult(for request: MobileHostRPCRequest) async -> MobileHostRPCResult {
+        if await MainActor.run(body: {
+            MobileHostService.shared.localPairingAuthority.verifies(
+                request.auth?.attachToken
+            )
+        }) {
+            return MobileHostPublicStatusCache.result(includeIdentity: true)
+        }
         let trimmedToken = request.auth?.stackAccessToken?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedToken?.isEmpty == false else {
             return MobileHostPublicStatusCache.result(includeIdentity: false)
@@ -370,6 +377,7 @@ final class MobileHostService {
     private let callbackQueue = DispatchQueue(label: "dev.cmux.mobile.host-listener")
     private let routeResolver = MobileRouteResolver()
     private let ticketStore = MobileAttachTicketStore()
+    private let localPairingAuthority = MobileLocalPairingAuthority()
     private var listener: NWListener?
     private var listenerGeneration = UUID()
     private var listenerUsesEphemeralFallback = false
@@ -1481,6 +1489,30 @@ final class MobileHostService {
         )
     }
 
+    /// Creates an account-free pairing code restricted to Tailscale routes.
+    /// Scanning the code is the explicit authorization event.
+    func createLocalTailscalePairingTicket(
+        pairingURLScheme: CmxPairingURLScheme? =
+            CmxPairingURLSchemeResolver().resolved
+    ) throws -> [String: Any] {
+        let routes = MobileHostPublicStatusCache.snapshot().filter {
+            $0.kind == .tailscale
+        }
+        let build = MobileHostBuildIdentity.current()
+        let ticket = try ticketStore.createLocalPairingTicket(
+            routes: routes,
+            capability: localPairingAuthority.issueCapability(),
+            macPairingCompatibilityVersion: CmxMobileDefaults.pairingCompatibilityVersion,
+            macAppVersion: build.appVersion,
+            macAppBuild: build.appBuild
+        )
+        return try ticketStore.payload(
+            for: ticket,
+            routeDisclosureMode: .localTailscalePairing,
+            pairingURLScheme: pairingURLScheme
+        )
+    }
+
     private static func filteredRoutes(
         _ routes: [CmxAttachRoute],
         routeID: String?,
@@ -1644,13 +1676,14 @@ final class MobileHostService {
         guard Self.requiresAuthorization(method: request.method) else {
             return nil
         }
-        // Stack auth is the SOLE authorization gate for the mobile data plane.
-        // The attach ticket is route-discovery and workspace-selection only; it
-        // never authorizes on its own. Every operation must present the Mac
-        // owner's same-account Stack access token. Consequences: a leaked or
-        // photographed QR is useless without the owner's signed-in account, and
-        // pairing is bound to "who is signed in on this Mac" rather than a stored
-        // ticket, so it survives Mac restarts and ticket expiry.
+        if localPairingAuthority.verifies(request.auth?.attachToken) {
+            return nil
+        }
+        // The opt-in local capability was checked above. In the normal account
+        // path, Stack auth remains the authorization gate: every operation must
+        // present the Mac owner's same-account access token. The ordinary attach
+        // ticket only supplies route and workspace context and never authorizes
+        // on its own.
         if devStackTokenAuthorized(request) {
             return ticketAuthorizationResultIfNeeded(for: request)
         }

--- a/Sources/Mobile/MobileLocalPairingAuthority.swift
+++ b/Sources/Mobile/MobileLocalPairingAuthority.swift
@@ -1,0 +1,39 @@
+import CmuxControlSocket
+import Foundation
+
+/// Issues and verifies persistent, bundle-scoped capabilities for local-only
+/// mobile pairing. A capability is useful only together with the exact
+/// Tailscale endpoint carried by its pairing code.
+struct MobileLocalPairingAuthority: Sendable {
+    private let authority: SocketClientCapabilityAuthority
+
+    init(bundleIdentifier: String? = Bundle.main.bundleIdentifier) {
+        let normalizedBundleIdentifier = bundleIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let audience: String
+        if let normalizedBundleIdentifier,
+           !normalizedBundleIdentifier.isEmpty {
+            audience = normalizedBundleIdentifier
+        } else {
+            audience = "com.cmuxterm.app"
+        }
+        let store = SocketClientCapabilitySecretStore(
+            service: "\(audience).mobile-local-pairing-capability.v1"
+        )
+        authority = SocketClientCapabilityAuthority(
+            secret: store.loadOrCreateSecret(),
+            audience: "\(audience).mobile-local-pairing"
+        )
+    }
+
+    func issueCapability() -> String {
+        authority.issueCapability()
+    }
+
+    func verifies(_ capability: String?) -> Bool {
+        guard let capability = capability?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !capability.isEmpty else { return false }
+        return authority.verifies(capability)
+    }
+}

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -4,11 +4,11 @@ import CmuxAuthRuntime
 import Foundation
 import Observation
 
-/// Drives the in-app iOS pairing window. Gates pairing on the Mac being signed
-/// in (authorization is a Stack same-account check), then turns on the pairing
-/// host and mints a Tailscale pairing code. Automatic Iroh discovery needs no
-/// QR. The displayed Tailscale code never expires and is never regenerated on
-/// a timer; Refresh Code re-mints on demand.
+/// Drives the in-app iOS pairing window. Signed-in Macs mint the existing
+/// same-account code; signed-out Macs mint a local capability restricted to
+/// the advertised Tailscale route. Automatic Iroh discovery needs no QR. The
+/// displayed code never expires and is never regenerated on a timer; Refresh
+/// Code re-mints on demand.
 ///
 /// Reads auth state from the app's shared ``CmuxAuthRuntime/AuthCoordinator``
 /// (via `AppDelegate`); sign-in routes through the shared ``HostAccountFlow``
@@ -86,6 +86,9 @@ final class MobilePairingModel {
     private(set) var state: State = .loading
     /// The signed-in account email, shown in the checklist. `nil` when signed out.
     private(set) var signedInEmail: String?
+    /// Whether the displayed QR authorizes through a device-local capability
+    /// instead of a Stack account.
+    private(set) var isUsingLocalPairing = false
     /// Exact iOS apps this Mac build can intentionally address.
     let availableIOSAppTargets: [MobileIOSAppTarget]
     /// The exact iOS app addressed by newly minted QR codes.
@@ -109,10 +112,9 @@ final class MobilePairingModel {
     ///     instance. (Resolved in the `@MainActor` init body rather than as a
     ///     default argument, since default args are evaluated nonisolated and
     ///     `MobileHostService.shared` is main-actor isolated.)
-    ///   - ticketTTL: Lifetime of the minted attach token in seconds. Defaults
-    ///     to 600. Covers only the RPC/v1 fallback token the mint produces as a
-    ///     side effect; the displayed Tailscale QR carries no token and never
-    ///     expires.
+    ///   - ticketTTL: Lifetime of the account-authorized attach token in
+    ///     seconds. Defaults to 600. Local pairing uses a separate durable
+    ///     capability and ignores this value.
     init(host: MobileHostService? = nil, ticketTTL: TimeInterval = 600) {
         self.host = host ?? .shared
         self.ticketTTL = ticketTTL
@@ -152,9 +154,8 @@ final class MobilePairingModel {
         await refresh()
     }
 
-    /// Re-evaluates sign-in state and, when signed in, brings the listener up
-    /// and mints a fresh attach ticket. Safe to call repeatedly (Refresh button,
-    /// or the view re-running it when auth state settles).
+    /// Re-evaluates sign-in state, brings the listener up, and mints the
+    /// appropriate account or local attach ticket. Safe to call repeatedly.
     func refresh() async {
         connectionObservationTask?.cancel()
         connectionObservationTask = nil
@@ -172,11 +173,8 @@ final class MobilePairingModel {
         }
         await coordinator.awaitBootstrapped()
         guard generation == refreshGeneration else { return }
-        guard coordinator.isAuthenticated else {
-            signedInEmail = nil
-            state = .signedOut
-            return
-        }
+        let usesLocalPairing = !coordinator.isAuthenticated
+        isUsingLocalPairing = usesLocalPairing
         signedInEmail = coordinator.currentUser?.primaryEmail
         state = .preparing
         enablePairingHost()
@@ -200,13 +198,19 @@ final class MobilePairingModel {
             return
         }
         do {
-            let payload = try await host.createAttachTicket(
-                workspaceID: "",
-                terminalID: nil,
-                ttl: ticketTTL,
-                routeDisclosureMode: routePlan.disclosureMode,
-                pairingURLScheme: selectedIOSAppTarget.pairingURLScheme
-            )
+            let payload = if usesLocalPairing {
+                try host.createLocalTailscalePairingTicket(
+                    pairingURLScheme: selectedIOSAppTarget.pairingURLScheme
+                )
+            } else {
+                try await host.createAttachTicket(
+                    workspaceID: "",
+                    terminalID: nil,
+                    ttl: ticketTTL,
+                    routeDisclosureMode: routePlan.disclosureMode,
+                    pairingURLScheme: selectedIOSAppTarget.pairingURLScheme
+                )
+            }
             guard generation == refreshGeneration else { return }
             guard let attachURL = payload["attach_url"] as? String, !attachURL.isEmpty else {
                 state = .failed(

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -495,6 +495,13 @@ struct MobilePairingView: View {
                     .cmuxFont(.caption)
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
+            } else if model.isUsingLocalPairing {
+                Text(String(
+                    localized: "mobile.pairing.localOnly",
+                    defaultValue: "Local pairing · Tailscale only · No cmux account"
+                ))
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.secondary)
             }
             Spacer()
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1452,6 +1452,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE73840000000000000001 /* MobileHostWorkspaceTicketAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */; };
 		58812E32EA724C5CAB36BE98 /* MobileIOSAppTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6499A4985B4CD4B7F3D9C0 /* MobileIOSAppTarget.swift */; };
 		86BEAF78BDAB4871996E9EF2 /* MobileIOSPairingTargetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1148AEDC5E59435E879326ED /* MobileIOSPairingTargetStore.swift */; };
+		A8C0A1100000000000000002 /* MobileLocalPairingAuthority.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C0A1100000000000000001 /* MobileLocalPairingAuthority.swift */; };
 		C0DEFEF90000000000000001 /* MobileNotificationFeedWireItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFEF90000000000000002 /* MobileNotificationFeedWireItem.swift */; };
 		9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */; };
 		0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */; };
@@ -4254,6 +4255,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostWorkspaceTicketAuthorizationTests.swift; sourceTree = "<group>"; };
 		0B6499A4985B4CD4B7F3D9C0 /* MobileIOSAppTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobileIOSAppTarget.swift"; sourceTree = "<group>"; };
 		1148AEDC5E59435E879326ED /* MobileIOSPairingTargetStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileIOSPairingTargetStore.swift; sourceTree = "<group>"; };
+		A8C0A1100000000000000001 /* MobileLocalPairingAuthority.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileLocalPairingAuthority.swift; sourceTree = "<group>"; };
 		C0DEFEF90000000000000002 /* MobileNotificationFeedWireItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileNotificationFeedWireItem.swift; sourceTree = "<group>"; };
 		A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePairingConnectionTransitionTests.swift; sourceTree = "<group>"; };
 		04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingModel.swift"; sourceTree = "<group>"; };
@@ -5906,6 +5908,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */,
 				A1B2C3D4E5F60718293A4C02 /* MobileHostOrderedRequestQueue.swift */,
 				7ACA497A6831165EA879C642 /* MobileHostService.swift */,
+				A8C0A1100000000000000001 /* MobileLocalPairingAuthority.swift */,
 				D80AFFF3844843A789F89241 /* MobileRemoteControlPolicy.swift */,
 				A2DBE587F52C8A3B2A2CFCB8 /* MobileStateSync.swift */,
 				1B0B09010000000000000001 /* MobileHostIrohRuntime.swift */,
@@ -9861,6 +9864,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C1A070000000000000000005 /* MobileHostTransportAuthorization.swift in Sources */,
 				58812E32EA724C5CAB36BE98 /* MobileIOSAppTarget.swift in Sources */,
 				86BEAF78BDAB4871996E9EF2 /* MobileIOSPairingTargetStore.swift in Sources */,
+				A8C0A1100000000000000002 /* MobileLocalPairingAuthority.swift in Sources */,
 				C0DEFEF90000000000000001 /* MobileNotificationFeedWireItem.swift in Sources */,
 				0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */,
 				325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */,

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6529,6 +6529,23 @@
         }
       }
     },
+    "mobile.pairing.localCredentialUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pair this Mac again to refresh its local credential."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac をもう一度ペアリングして、ローカル認証情報を更新してください。"
+          }
+        }
+      }
+    },
     "mobile.pairing.secureRouteRequired": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -62,6 +62,8 @@ public struct CMUXMobileRootScene: View {
     /// non-iOS roots, which simply shows no Tailscale guidance.
     private let tailscaleStatusMonitor: (any TailscaleStatusObserving)?
     private let pairedMacStore: (any MobilePairedMacStoring)?
+    private let localPairingCredentialStore:
+        any MobileLocalPairingCredentialStoring
     /// The app-wide toast presenter, hosted at this root so toasts float over
     /// every screen (including sheets) and any descendant can present through
     /// `@Environment(ToastCenter.self)`.
@@ -147,6 +149,9 @@ public struct CMUXMobileRootScene: View {
         self.buildCompatibilityPolicy = buildCompatibilityPolicy
         self.signOutHook = signOutHook
         self.pairedMacStore = Self.openPairedMacStore(diagnosticLog: diagnosticLog)
+        self.localPairingCredentialStore = MobileLocalPairingKeychainStore(
+            accessGroup: auth.keychainAccessGroup
+        )
         self.draftStore = InMemoryTerminalDraftStore()
         self.diagnosticLog = diagnosticLog
         _toastCenter = State(initialValue: ToastCenter(diagnosticLog: diagnosticLog))
@@ -172,6 +177,7 @@ public struct CMUXMobileRootScene: View {
         self.buildCompatibilityPolicy = buildCompatibilityPolicy
         self.tailscaleStatusMonitor = nil
         self.pairedMacStore = Self.openPairedMacStore(diagnosticLog: nil)
+        self.localPairingCredentialStore = NoopMobileLocalPairingCredentialStore()
         self.draftStore = InMemoryTerminalDraftStore()
         self.diagnosticLog = nil
         _toastCenter = State(initialValue: ToastCenter())
@@ -421,7 +427,8 @@ public struct CMUXMobileRootScene: View {
             browserStreamStore: browserStreamStore,
             simulatorStreamStore: simulatorStreamStore,
             onboardingStore: onboardingStore,
-            signOutHook: signOutHook
+            signOutHook: signOutHook,
+            localPairingCredentialStore: localPairingCredentialStore
         )
         #else
         return CMUXMobileAppView(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileLocalPairingKeychainStore.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileLocalPairingKeychainStore.swift
@@ -1,0 +1,47 @@
+import CmuxIrohTransport
+import CmuxMobileShellUI
+import Foundation
+
+/// Keychain adapter for one device-local pairing URL.
+actor MobileLocalPairingKeychainStore: MobileLocalPairingCredentialStoring {
+    private static let account = "last-successful-local-pairing"
+    private let keychain: CmxIrohKeychainCredentialStore
+
+    init(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        accessGroup: String?
+    ) {
+        let normalized = bundleIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let namespace: String
+        if let normalized, !normalized.isEmpty {
+            namespace = normalized
+        } else {
+            namespace = "com.cmux.app"
+        }
+        keychain = CmxIrohKeychainCredentialStore(
+            service: "\(namespace).mobile-local-pairing.v1",
+            accessGroup: accessGroup
+        )
+    }
+
+    func loadAttachURL() async -> String? {
+        guard let data = try? await keychain.read(account: Self.account),
+              let value = String(data: data, encoding: .utf8),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    func saveAttachURL(_ attachURL: String) async {
+        guard let data = attachURL.data(using: .utf8) else { return }
+        try? await keychain.write(
+            data,
+            account: Self.account,
+            accessibility: .afterFirstUnlockThisDeviceOnly
+        )
+    }
+
+    func clearAttachURL() async {
+        try? await keychain.delete(account: Self.account)
+    }
+}


### PR DESCRIPTION
## Summary
- add a v4 pairing QR containing a durable Mac-issued local capability and exact Tailscale routes
- let signed-out Macs pair iPhones without Stack Auth while preserving the existing signed-in account flow
- persist the last successful local pairing in the iPhone device Keychain for reconnect after relaunch
- localize the new Mac and iPhone messages in English and Japanese

## Security model
- scanning the QR is the explicit authorization event
- the iOS transport can send the capability only to an exact user-approved Tailscale destination
- loopback routes and malformed or duplicate local credentials are rejected
- local pairing never requests or transmits a Stack access token

## Validation
- CMUXMobileCore CmxPairingQRCodeTests: pass (18 tests)
- CmuxMobileTransport full suite: pass (42 tests)
- CmuxMobileRPC focused local pairing and version tests: pass
- tagged macOS build local-tailpair: pass
- isolated simulator build: pass
- signed physical build installed and launched on kiPhone26: pass
- pbxproj checks and test-wiring lint: pass
- localization catalogs parsed and en/ja keys audited

The full CMUXMobileCore SwiftPM suite still reports the existing DiagnosticEventPresentationTests localization failures; the pairing suite itself passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789932137&installation_model_id=21920&pr_number=10534&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10534&signature=f7db719790fd94baabf7b1cf636b2506146470bd261fb582eaed2bf3767d8b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables account-free local pairing over Tailscale so signed-out Macs can pair iPhones. Previously pairing required a signed-in Stack account; now a v4 QR carries a durable local capability bound to exact Tailscale routes while the existing account flow is unchanged.

- Review highlights:
  - Adds pairing URL v4 and route disclosure mode `.localTailscalePairing` in `CMUXMobileCore`: `CmxPairingQRCode.version = 4` encodes device id `d`, capability `k`, and exact routes `r`; decodes v4 with strict validation and rejects loopback routes.
  - Extends `CmxAttachTicket` with `localPairing` and persists device id and capability; `CompactAttachTicket` limits routes to Tailscale in local mode.
  - Introduces transport auth mode `.localTailscalePairing`; `CmuxMobileTransport` and `CmuxMobileRPC` enforce exact host:port, send only the local capability (no Stack token), and skip attach token expiry checks; network status returns identity when the capability verifies.
  - Adds `MobileLocalPairingAuthority` for issuing/verifying durable capabilities and a host API `createLocalTailscalePairingTicket`; signed-in account pairing remains the default path.
  - iOS persists the last successful local pairing in Keychain via `MobileLocalPairingKeychainStore` and restores it on launch; sign-out clears it. UI shows a localized “Local pairing · Tailscale only · No cmux account” banner.
  - Updates tests across `CMUXMobileCore` and `CmuxMobileRPC`; new local-pairing cases pass; legacy v2/v3 decode remains supported.

- Rollout notes:
  - Local pairing is opt-in and emitted when the Mac is signed out; account pairing is unchanged when signed in.
  - Treat v4 URLs and field `k` as bearer secrets; they authorize only the exact Tailscale destination and never send a Stack token.
  - No migration required. If you provide a custom Keychain group, pass a `localPairingCredentialStore` to `CMUXMobileAppView`.

<sup>Written for commit 0b7b74bc237740ad3b5eb2d1dfad00a6b46fdb6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-free local pairing for Tailscale-only connections.
  * Signed-out Macs can now display local pairing QR codes.
  * Local pairing credentials are securely saved and restored on iOS.
  * Local pairing uses device-specific authorization and avoids account-token fallback.
  * Added localized status and re-pairing messages in English and Japanese.
* **Bug Fixes**
  * Preserved local pairing state when attach tickets are reconstructed or disclosed.
  * Added validation for malformed, unsupported, or invalid local pairing codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->