### PR TITLE
iOS: paste images and files as attachments in the Task Composer and terminal composer

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ComposerFileAttachments.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ComposerFileAttachments.swift
@@ -1,0 +1,65 @@
+internal import CmuxMobileShellModel
+internal import Foundation
+
+extension MobileShellComposite {
+    /// Whether the FOREGROUND Mac advertises the chunked task-attachment upload
+    /// verb the terminal composer's file sends ride on. Stage-time gate for
+    /// pasting files into the composer; the send-time upload re-checks the
+    /// capability authoritatively.
+    public var supportsComposerFileAttachments: Bool {
+        supportedHostCapabilities.contains(Self.taskAttachmentCapability)
+    }
+
+    /// Uploads one staged composer FILE attachment to the foreground Mac and
+    /// returns its final absolute path there.
+    ///
+    /// The pending attachment's bytes live in memory (like staged images), while
+    /// the shared task-attachment uploader reads from a file, so the bytes are
+    /// written to an app-owned temp file for the duration of the upload and
+    /// always removed afterwards. The attachment's own id is reused as the
+    /// upload id so a retry after a failed text send stays idempotent per
+    /// operation.
+    func uploadPendingFileAttachment(
+        _ attachment: MobilePendingAttachment
+    ) async -> Result<String, MobileWorkspaceMutationFailure> {
+        guard attachment.kind == .file, let macDeviceID = foregroundMacDeviceID else {
+            return .failure(.notConnected(hostDisplayName: nil))
+        }
+        let fileName = attachment.displayName
+            ?? "pasted-file" + (attachment.format.isEmpty ? "" : ".\(attachment.format)")
+        let suffix = attachment.format.isEmpty ? "" : ".\(attachment.format)"
+        let stagedURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-composer-upload-\(UUID().uuidString)\(suffix)")
+        do {
+            try await writeStagedBytes(attachment.data, to: stagedURL)
+        } catch {
+            return .failure(.rejected(hostDisplayName: nil))
+        }
+        defer { try? FileManager.default.removeItem(at: stagedURL) }
+        let staged = TaskComposerAttachment(
+            id: attachment.id,
+            kind: .file,
+            displayName: fileName,
+            localStagedFileURL: stagedURL,
+            byteCount: attachment.data.count
+        )
+        return await uploadTaskAttachment(
+            staged,
+            operationID: UUID(),
+            macDeviceID: macDeviceID,
+            instanceTag: activeMacInstanceTag
+        )
+    }
+
+    /// Write the staged bytes off the main actor so a multi-MB file does not
+    /// stall the composer mid-send.
+    private func writeStagedBytes(_ data: Data, to url: URL) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask(priority: .utility) {
+                try Task.checkCancellation()
+                try data.write(to: url, options: .atomic)
+            }
+            try await group.waitForAll()
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ComposerFileAttachments.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ComposerFileAttachments.swift
@@ -16,9 +16,11 @@ extension MobileShellComposite {
     /// The pending attachment's bytes live in memory (like staged images), while
     /// the shared task-attachment uploader reads from a file, so the bytes are
     /// written to an app-owned temp file for the duration of the upload and
-    /// always removed afterwards. The attachment's own id is reused as the
-    /// upload id so a retry after a failed text send stays idempotent per
-    /// operation.
+    /// always removed afterwards. The attachment's own id serves as BOTH the
+    /// operation id and the upload id: the Mac store answers a re-upload of a
+    /// completed (operation, upload) pair with the existing path, so retrying
+    /// after a failed text send reuses the already-uploaded file instead of
+    /// orphaning one copy per attempt.
     func uploadPendingFileAttachment(
         _ attachment: MobilePendingAttachment
     ) async -> Result<String, MobileWorkspaceMutationFailure> {
@@ -45,7 +47,7 @@ extension MobileShellComposite {
         )
         return await uploadTaskAttachment(
             staged,
-            operationID: UUID(),
+            operationID: attachment.id,
             macDeviceID: macDeviceID,
             instanceTag: activeMacInstanceTag
         )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -809,6 +809,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// rejected outright (the view bounds the encode below this, but the store
     /// re-enforces it as the single source of truth).
     public nonisolated static let maxPendingAttachmentImageBytes = 8 * 1024 * 1024
+    /// Per-file byte cap for one staged FILE attachment, matching the
+    /// task-attachment upload limit its send-time transport enforces on the
+    /// Mac side. Larger than the per-image cap because files are not
+    /// re-encoded down; the per-terminal and global byte budgets still bound
+    /// the aggregate.
+    public nonisolated static let maxPendingAttachmentFileBytes =
+        TaskComposerAttachment.maximumFileBytes
     /// GLOBAL encoded-bytes budget summed across EVERY terminal's staged set, not
     /// just the target's. The per-terminal cap bounds one draft, but each live
     /// terminal carries its own per-terminal budget, so staging photos across many
@@ -8201,6 +8208,91 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// total can never exceed the cap. The store is the single source of truth.
     @discardableResult
     public func addPendingAttachment(_ data: Data, format: String, forTerminalID terminalID: String? = nil) -> MobilePendingAttachment.ID? {
+        stagePendingAttachment(
+            kind: .image,
+            data: data,
+            format: format,
+            displayName: nil,
+            forTerminalID: terminalID
+        )
+    }
+
+    /// Stage arbitrary file bytes as a pending attachment for a terminal. The
+    /// bytes are uploaded to the Mac at send time (through the chunked
+    /// task-attachment verb) and the message references the returned path,
+    /// shell-quoted, ahead of the user's text.
+    /// - Parameters:
+    ///   - data: The raw file bytes, already under the per-file cap.
+    ///   - fileExtension: A lowercase extension hint for the chip and upload.
+    ///   - displayName: The user-visible file name, sent as the upload name.
+    ///   - terminalID: The terminal to stage under; `nil` falls back to the
+    ///     selected terminal.
+    /// - Returns: The new attachment's stable id, or `nil` when nothing was
+    ///   staged (see ``addPendingAttachment(_:format:forTerminalID:)``).
+    @discardableResult
+    public func addPendingFileAttachment(
+        _ data: Data,
+        fileExtension: String,
+        displayName: String,
+        forTerminalID terminalID: String? = nil
+    ) -> MobilePendingAttachment.ID? {
+        stagePendingAttachment(
+            kind: .file,
+            data: data,
+            format: fileExtension,
+            displayName: displayName,
+            forTerminalID: terminalID
+        )
+    }
+
+    /// Stage file bytes only if the captured session token still matches and
+    /// (when explicit) the target terminal still exists — the same stale-result
+    /// guard as the image variant, for the paste path whose materialization and
+    /// disk reads await off-main.
+    @discardableResult
+    public func addPendingFileAttachment(
+        _ data: Data,
+        fileExtension: String,
+        displayName: String,
+        forTerminalID terminalID: String? = nil,
+        ifSessionGeneration capturedGeneration: Int
+    ) -> MobilePendingAttachment.ID? {
+        guard capturedGeneration == signInGeneration else {
+            recordAppEvent(
+                .terminalAttachmentRejected,
+                correlationID: terminalID,
+                failure: .superseded
+            )
+            return nil
+        }
+        if let terminalID, !terminalExistsInTopology(terminalID) {
+            recordAppEvent(
+                .terminalAttachmentRejected,
+                correlationID: terminalID,
+                failure: .superseded
+            )
+            return nil
+        }
+        return addPendingFileAttachment(
+            data,
+            fileExtension: fileExtension,
+            displayName: displayName,
+            forTerminalID: terminalID
+        )
+    }
+
+    /// The single validated staging path: every image and file add (plain or
+    /// session-guarded) funnels through here so the per-kind size cap, the
+    /// per-terminal count/byte budgets, and the global all-terminals budgets
+    /// are enforced atomically against the CURRENT staged set on the main
+    /// actor.
+    private func stagePendingAttachment(
+        kind: MobilePendingAttachment.Kind,
+        data: Data,
+        format: String,
+        displayName: String?,
+        forTerminalID terminalID: String?
+    ) -> MobilePendingAttachment.ID? {
         let key = terminalID ?? selectedTerminalID?.rawValue
         func reject(
             _ failure: DiagnosticFailureKind,
@@ -8218,11 +8310,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let key else { return reject(.noRoute) }
         // Reject any add for a terminal that is not in the current topology, so a
         // closed/recreated/stale id can never accrue orphaned bytes the user can no
-        // longer see or send. This is the single validated path: both the base
-        // call and the session-guarded variant funnel through here.
+        // longer see or send.
         guard terminalExistsInTopology(key) else { return reject(.superseded) }
-        // A single image larger than the per-image cap is rejected outright.
-        guard data.count <= Self.maxPendingAttachmentImageBytes else {
+        // A single item larger than its kind's cap is rejected outright: images
+        // are bounded by the encode target, files by the send-time upload limit.
+        let perItemCap = switch kind {
+        case .image: Self.maxPendingAttachmentImageBytes
+        case .file: Self.maxPendingAttachmentFileBytes
+        }
+        guard data.count <= perItemCap else {
             return reject(.payloadTooLarge, count: data.count)
         }
         let existing = pendingAttachmentsByTerminalID[key] ?? []
@@ -8254,7 +8350,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard globalBytes + data.count <= Self.maxPendingAttachmentTotalBytesAllTerminals else {
             return reject(.resourceLimitReached, count: globalBytes + data.count)
         }
-        let attachment = MobilePendingAttachment(data: data, format: format)
+        let attachment = MobilePendingAttachment(
+            kind: kind,
+            data: data,
+            format: format,
+            displayName: displayName
+        )
         pendingAttachmentsByTerminalID[key, default: []].append(attachment)
         recordAppEvent(
             .terminalAttachmentStaged,
@@ -8423,13 +8524,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// reconciliation still keys on that captured terminal (not the live
     /// selection).
     ///
-    /// - Parameter capturedText: The exact text to send, snapshotted by the
-    ///   caller before any await. When `nil`, the live ``terminalInputText`` is
-    ///   read (the text-only entry points have no earlier await, so there is no
-    ///   snapshot to drift). ``submitComposer()`` MUST pass a snapshot: a terminal
-    ///   switch or a field edit during its image awaits would otherwise make this
-    ///   send (and the draft reconcile) read a different terminal's draft or skip
-    ///   the text the user actually composed at Send time.
+    /// - Parameters:
+    ///   - capturedText: The exact text to send, snapshotted by the
+    ///     caller before any await. When `nil`, the live ``terminalInputText`` is
+    ///     read (the text-only entry points have no earlier await, so there is no
+    ///     snapshot to drift). ``submitComposer()`` MUST pass a snapshot: a terminal
+    ///     switch or a field edit during its attachment awaits would otherwise make
+    ///     this send (and the draft reconcile) read a different terminal's draft or
+    ///     skip the text the user actually composed at Send time.
+    ///   - draftTextToReconcile: What the FIELD held at Send time, when it
+    ///     differs from the sent text. ``submitComposer()`` prepends uploaded
+    ///     file paths to the sent text, so the post-ack draft clear must compare
+    ///     the field against the un-prepended snapshot or it would never match
+    ///     and the sent draft would resurrect. `nil` means the sent text IS the
+    ///     field text.
     ///
     /// - Returns: `true` when the Mac acknowledged the paste (or the text was
     ///   empty, i.e. nothing to send), `false` when the send failed so the caller
@@ -8438,7 +8546,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func submitComposerInput(
         workspaceID: MobileWorkspacePreview.ID,
         terminalID: MobileTerminalPreview.ID,
-        capturedText: String? = nil
+        capturedText: String? = nil,
+        draftTextToReconcile: String? = nil
     ) async -> Bool {
         let text = capturedText ?? terminalInputText
         // Empty text is "nothing to send", which is a success from the caller's
@@ -8462,8 +8571,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // user switched terminals while the ack was in flight, the switch persists
         // the outgoing text as the captured terminal's draft, and the sent text
         // must be cleared from that key, not from whatever terminal is selected
-        // when the ack returns.
-        await reconcileComposerDraftAfterSend(sentText: text, submittedTerminalID: terminalID)
+        // when the ack returns. A files-only send has an empty field snapshot,
+        // so there is no draft to clear.
+        let draftText = draftTextToReconcile ?? text
+        if !draftText.isEmpty {
+            await reconcileComposerDraftAfterSend(
+                sentText: draftText,
+                submittedTerminalID: terminalID
+            )
+        }
         return true
     }
 
@@ -8538,15 +8654,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let submitSignInGeneration = signInGeneration
         let submitConnectionGeneration = connectionGeneration
         let submitClient = remoteClient
-        // Deliver each image first and await it, so the agent's terminal has the
-        // file paths before the text arrives. Remove each only after its send is
-        // acknowledged; on failure stop and keep the rest (and the text) staged.
+        // Deliver each attachment first and await it, so the agent's terminal has
+        // the file paths before the text arrives. Images travel inline through
+        // `terminal.paste_image` and are removed per-ack; files are uploaded
+        // through the chunked task-attachment verb and their returned Mac paths
+        // are prepended (shell-quoted) to the text below. On failure stop and
+        // keep the rest (and the text) staged.
+        var uploadedFilePaths: [(id: MobilePendingAttachment.ID, path: String)] = []
         for attachment in attachments {
             // Re-check the captured session/connection still matches before each
-            // image send (the previous iteration's send was awaited). A mismatch
-            // means the session or transport was replaced mid-submit; abort
-            // without sending so nothing leaks into the new session. Attachments
-            // are left staged (no removal happened for this iteration).
+            // attachment send (the previous iteration's send was awaited). A
+            // mismatch means the session or transport was replaced mid-submit;
+            // abort without sending so nothing leaks into the new session.
+            // Attachments are left staged (no removal happened for this
+            // iteration).
             guard isComposerSubmitIdentityCurrent(
                 signIn: submitSignInGeneration,
                 connection: submitConnectionGeneration,
@@ -8554,7 +8675,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             ) else { return false }
             // Re-check the attachment is still staged for the captured terminal
             // before uploading it. The user can delete a not-yet-acked chip while
-            // an earlier image's send is in flight; that removes it from
+            // an earlier attachment's send is in flight; that removes it from
             // `pendingAttachmentsByTerminalID`, but this loop iterates a snapshot
             // taken before the awaits. Skipping the removed one keeps the local
             // snapshot from re-uploading bytes the user already dismissed. Runs on
@@ -8562,17 +8683,31 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // removal.
             guard pendingAttachments(forTerminalID: submittedTerminalID.rawValue)
                 .contains(where: { $0.id == attachment.id }) else { continue }
-            let sent = await submitTerminalPasteImage(
-                attachment.data,
-                format: attachment.format,
-                workspaceID: workspaceID,
-                terminalID: submittedTerminalID
-            )
-            guard sent else { return false }
-            removePendingAttachment(id: attachment.id, forTerminalID: submittedTerminalID.rawValue)
+            switch attachment.kind {
+            case .image:
+                let sent = await submitTerminalPasteImage(
+                    attachment.data,
+                    format: attachment.format,
+                    workspaceID: workspaceID,
+                    terminalID: submittedTerminalID
+                )
+                guard sent else { return false }
+                removePendingAttachment(id: attachment.id, forTerminalID: submittedTerminalID.rawValue)
+            case .file:
+                guard case .success(let path) =
+                        await uploadPendingFileAttachment(attachment) else {
+                    return false
+                }
+                // NOT removed yet: the path is only useful once the text send
+                // that references it acks. Removing now would strand the file if
+                // that send fails; keeping it staged means a retry re-uploads (a
+                // fresh path on whatever Mac is then current) instead of silently
+                // dropping the attachment.
+                uploadedFilePaths.append((id: attachment.id, path: path))
+            }
         }
         // Re-check the captured identity one last time before the text send. The
-        // final image's send was awaited above, so a sign-out / Mac switch /
+        // final attachment's send was awaited above, so a sign-out / Mac switch /
         // reconnect could have landed after it; abort (keep the text staged in the
         // field) rather than paste the user's message into the now-current
         // session.
@@ -8581,15 +8716,34 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             connection: submitConnectionGeneration,
             client: submitClient
         ) else { return false }
-        // Submit the captured text to the captured terminal (a no-op when empty,
-        // e.g. an images-only send). All images acked by here, so the text
+        // Prepend each uploaded file's quoted Mac path BEFORE the user's message
+        // (an agent reads the references, then the message about them). The
+        // field itself never contained the paths, so the draft reconcile below
+        // compares against the field snapshot, not the composed text.
+        var composedText = ""
+        for (_, path) in uploadedFilePaths {
+            composedText = TerminalComposerAttachmentInsertion(path: path)
+                .appending(to: composedText)
+        }
+        composedText += submittedText
+        // Submit the composed text to the captured terminal (a no-op when empty,
+        // e.g. an images-only send; a files-only send is non-empty because of
+        // the prepended paths). All attachments acked by here, so the text
         // follows. Passing the snapshot (not the live field) keeps this immune to
-        // a switch/edit that happened during the image awaits above.
+        // a switch/edit that happened during the attachment awaits above.
         sendSucceeded = await submitComposerInput(
             workspaceID: workspaceID,
             terminalID: submittedTerminalID,
-            capturedText: submittedText
+            capturedText: composedText,
+            draftTextToReconcile: submittedText
         )
+        if sendSucceeded {
+            // The text referencing the uploaded paths is acked; the file chips
+            // are now delivered and can leave the staged set.
+            for (id, _) in uploadedFilePaths {
+                removePendingAttachment(id: id, forTerminalID: submittedTerminalID.rawValue)
+            }
+        }
         return sendSucceeded
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -8207,12 +8207,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// path and the second add re-reads the (already-grown) set, so the combined
     /// total can never exceed the cap. The store is the single source of truth.
     @discardableResult
-    public func addPendingAttachment(_ data: Data, format: String, forTerminalID terminalID: String? = nil) -> MobilePendingAttachment.ID? {
+    public func addPendingAttachment(
+        _ data: Data,
+        format: String,
+        thumbnailData: Data? = nil,
+        forTerminalID terminalID: String? = nil
+    ) -> MobilePendingAttachment.ID? {
         stagePendingAttachment(
             kind: .image,
             data: data,
             format: format,
             displayName: nil,
+            thumbnailData: thumbnailData,
             forTerminalID: terminalID
         )
     }
@@ -8234,6 +8240,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         _ data: Data,
         fileExtension: String,
         displayName: String,
+        thumbnailData: Data? = nil,
         forTerminalID terminalID: String? = nil
     ) -> MobilePendingAttachment.ID? {
         stagePendingAttachment(
@@ -8241,6 +8248,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             data: data,
             format: fileExtension,
             displayName: displayName,
+            thumbnailData: thumbnailData,
             forTerminalID: terminalID
         )
     }
@@ -8254,6 +8262,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         _ data: Data,
         fileExtension: String,
         displayName: String,
+        thumbnailData: Data? = nil,
         forTerminalID terminalID: String? = nil,
         ifSessionGeneration capturedGeneration: Int
     ) -> MobilePendingAttachment.ID? {
@@ -8277,6 +8286,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             data,
             fileExtension: fileExtension,
             displayName: displayName,
+            thumbnailData: thumbnailData,
             forTerminalID: terminalID
         )
     }
@@ -8291,6 +8301,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         data: Data,
         format: String,
         displayName: String?,
+        thumbnailData: Data?,
         forTerminalID terminalID: String?
     ) -> MobilePendingAttachment.ID? {
         let key = terminalID ?? selectedTerminalID?.rawValue
@@ -8354,7 +8365,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             kind: kind,
             data: data,
             format: format,
-            displayName: displayName
+            displayName: displayName,
+            thumbnailData: thumbnailData
         )
         pendingAttachmentsByTerminalID[key, default: []].append(attachment)
         recordAppEvent(
@@ -8389,6 +8401,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func addPendingAttachment(
         _ data: Data,
         format: String,
+        thumbnailData: Data? = nil,
         forTerminalID terminalID: String? = nil,
         ifSessionGeneration capturedGeneration: Int
     ) -> MobilePendingAttachment.ID? {
@@ -8414,7 +8427,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             )
             return nil
         }
-        return addPendingAttachment(data, format: format, forTerminalID: terminalID)
+        return addPendingAttachment(
+            data,
+            format: format,
+            thumbnailData: thumbnailData,
+            forTerminalID: terminalID
+        )
     }
 
     /// Whether a terminal id is present in the current workspace/terminal

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerFileAttachmentSubmitTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerFileAttachmentSubmitTests.swift
@@ -1,0 +1,190 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// End-to-end tests over the real RPC wire (a scripted recording host) for the
+/// composer's FILE attachment sends: staged files upload through the chunked
+/// task-attachment verb at submit time, their returned Mac paths land in the
+/// message shell-quoted ahead of the user's text, chips are removed only after
+/// the text send acks, and any failure keeps everything staged for a retry.
+@MainActor
+@Suite struct ComposerFileAttachmentSubmitTests {
+    private static let fileCapabilities: Set<String> = [
+        "workspace.task_create.v1",
+        "task.attachments.v1",
+    ]
+
+    private static func bytes(_ s: String) -> Data { Data(s.utf8) }
+
+    @Test func uploadsStagedFileAndPrependsQuotedPathToText() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: Self.fileCapabilities
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingFileAttachment(
+            Self.bytes("pdf-bytes"),
+            fileExtension: "pdf",
+            displayName: "report.pdf",
+            forTerminalID: termA
+        )
+        store.terminalInputText = "review this"
+
+        let sent = await store.submitComposer()
+
+        #expect(sent)
+        let uploads = await router.recordedAttachmentUploads()
+        #expect(uploads.count == 1)
+        #expect(uploads.first?.fileName == "report.pdf")
+        #expect(uploads.first?.last == true)
+        #expect(uploads.first?.totalBytes == Self.bytes("pdf-bytes").count)
+        let pastes = await router.recordedPastes()
+        #expect(pastes.map(\.text) == ["'/tmp/uploads/report.pdf' review this"])
+        #expect(pastes.map(\.surfaceID) == [termA])
+        #expect(store.pendingAttachments(forTerminalID: termA).isEmpty)
+        #expect(store.terminalInputText.isEmpty)
+    }
+
+    @Test func filesOnlySendComposesPathsMessage() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: Self.fileCapabilities
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingFileAttachment(
+            Self.bytes("aaa"),
+            fileExtension: "txt",
+            displayName: "a.txt",
+            forTerminalID: termA
+        )
+        store.addPendingFileAttachment(
+            Self.bytes("bbb"),
+            fileExtension: "bin",
+            displayName: "b.bin",
+            forTerminalID: termA
+        )
+
+        let sent = await store.submitComposer()
+
+        #expect(sent)
+        let pastes = await router.recordedPastes()
+        #expect(pastes.map(\.text) == ["'/tmp/uploads/a.txt' '/tmp/uploads/b.bin' "])
+        #expect(store.pendingAttachments(forTerminalID: termA).isEmpty)
+    }
+
+    @Test func failedUploadKeepsFileStagedAndTextUnsent() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: Self.fileCapabilities
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingFileAttachment(
+            Self.bytes("keep me"),
+            fileExtension: "txt",
+            displayName: "keep.txt",
+            forTerminalID: termA
+        )
+        store.terminalInputText = "still mine"
+
+        await router.setRejectAttachmentUpload(true)
+        let sent = await store.submitComposer()
+
+        #expect(!sent)
+        #expect(store.pendingAttachments(forTerminalID: termA).count == 1)
+        #expect(store.terminalInputText == "still mine")
+        let pastes = await router.recordedPastes()
+        #expect(pastes.isEmpty)
+        #expect(store.terminalSendStatus(forTerminalID: termA) == .failed)
+    }
+
+    @Test func mixedImageAndFileSendRoutesEachTransport() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: Self.fileCapabilities
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingAttachment(
+            Self.bytes("image"),
+            format: "png",
+            forTerminalID: termA
+        )
+        store.addPendingFileAttachment(
+            Self.bytes("notes"),
+            fileExtension: "md",
+            displayName: "notes.md",
+            forTerminalID: termA
+        )
+        store.terminalInputText = "both attached"
+
+        let sent = await store.submitComposer()
+
+        #expect(sent)
+        let images = await router.recordedPasteImages()
+        #expect(images.map(\.format) == ["png"])
+        let uploads = await router.recordedAttachmentUploads()
+        #expect(uploads.map(\.fileName) == ["notes.md"])
+        let pastes = await router.recordedPastes()
+        #expect(pastes.map(\.text) == ["'/tmp/uploads/notes.md' both attached"])
+        #expect(store.pendingAttachments(forTerminalID: termA).isEmpty)
+    }
+
+    @Test func missingHostCapabilityFailsFileSendAndKeepsChip() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: ["workspace.task_create.v1"]
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingFileAttachment(
+            Self.bytes("blocked"),
+            fileExtension: "txt",
+            displayName: "blocked.txt",
+            forTerminalID: termA
+        )
+        store.terminalInputText = "cannot go"
+
+        let sent = await store.submitComposer()
+
+        #expect(!sent)
+        #expect(store.pendingAttachments(forTerminalID: termA).count == 1)
+        #expect(store.terminalInputText == "cannot go")
+        let uploads = await router.recordedAttachmentUploads()
+        #expect(uploads.isEmpty)
+        let pastes = await router.recordedPastes()
+        #expect(pastes.isEmpty)
+    }
+
+    @Test func quotedPathEscapesApostrophesInFileName() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            hostCapabilities: Self.fileCapabilities
+        )
+        let termA = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        store.addPendingFileAttachment(
+            Self.bytes("quoted"),
+            fileExtension: "pdf",
+            displayName: "Customer's report.pdf",
+            forTerminalID: termA
+        )
+
+        let sent = await store.submitComposer()
+
+        #expect(sent)
+        let pastes = await router.recordedPastes()
+        #expect(pastes.map(\.text) == [
+            "'/tmp/uploads/Customer'\\''s report.pdf' ",
+        ])
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
@@ -84,6 +84,74 @@ import Testing
         #expect(composite.pendingAttachments(forTerminalID: "term-a").isEmpty)
     }
 
+    @Test func fileAddStagesKindDisplayNameAndExtension() throws {
+        let composite = Self.makeComposite()
+        let id = try #require(composite.addPendingFileAttachment(
+            Self.bytes("file-bytes"),
+            fileExtension: "pdf",
+            displayName: "Q3 report.pdf",
+            forTerminalID: "term-a"
+        ))
+        let staged = composite.pendingAttachments(forTerminalID: "term-a")
+        #expect(staged.map(\.id) == [id])
+        #expect(staged.first?.kind == .file)
+        #expect(staged.first?.displayName == "Q3 report.pdf")
+        #expect(staged.first?.format == "pdf")
+        #expect(composite.composerCanSend(forTerminalID: "term-a"))
+    }
+
+    @Test func imageAddsStayImageKindWithoutDisplayName() {
+        let composite = Self.makeComposite()
+        composite.addPendingAttachment(Self.bytes("img"), format: "png", forTerminalID: "term-a")
+        let staged = composite.pendingAttachments(forTerminalID: "term-a")
+        #expect(staged.first?.kind == .image)
+        #expect(staged.first?.displayName == nil)
+    }
+
+    /// A payload between the 8 MB image cap and the 32 MB file cap is accepted
+    /// as a file but rejected as an image: the per-item cap is kind-specific.
+    @Test func perItemCapIsKindSpecific() {
+        let composite = Self.makeComposite()
+        let midSized = Data(count: MobileShellComposite.maxPendingAttachmentImageBytes + 1)
+
+        composite.addPendingAttachment(midSized, format: "png", forTerminalID: "term-a")
+        #expect(composite.pendingAttachments(forTerminalID: "term-a").isEmpty)
+
+        composite.addPendingFileAttachment(
+            midSized,
+            fileExtension: "bin",
+            displayName: "big.bin",
+            forTerminalID: "term-a"
+        )
+        #expect(composite.pendingAttachments(forTerminalID: "term-a").count == 1)
+    }
+
+    @Test func fileAddRejectsOverFileCap() {
+        let composite = Self.makeComposite()
+        let oversized = Data(count: MobileShellComposite.maxPendingAttachmentFileBytes + 1)
+        composite.addPendingFileAttachment(
+            oversized,
+            fileExtension: "bin",
+            displayName: "too-big.bin",
+            forTerminalID: "term-a"
+        )
+        #expect(composite.pendingAttachments(forTerminalID: "term-a").isEmpty)
+    }
+
+    @Test func staleSessionGenerationDropsFileAdd() {
+        let composite = Self.makeComposite()
+        let captured = composite.currentSessionGeneration
+        composite.signOut()
+        composite.addPendingFileAttachment(
+            Self.bytes("stale"),
+            fileExtension: "txt",
+            displayName: "stale.txt",
+            forTerminalID: "term-a",
+            ifSessionGeneration: captured
+        )
+        #expect(composite.pendingAttachments(forTerminalID: "term-a").isEmpty)
+    }
+
     @Test func removeDropsOnlyTheTargetedAttachment() {
         let composite = Self.makeComposite()
         composite.addPendingAttachment(Self.bytes("one"), format: "png", forTerminalID: "term-a")

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
@@ -100,6 +100,30 @@ import Testing
         #expect(composite.composerCanSend(forTerminalID: "term-a"))
     }
 
+    /// The chip preview travels ON the staged attachment, so a composer view
+    /// recreated by a terminal/workspace switch re-renders the same thumbnail
+    /// instead of a placeholder.
+    @Test func thumbnailDataPersistsOnStagedAttachments() throws {
+        let composite = Self.makeComposite()
+        let thumb = Self.bytes("thumb-bytes")
+        let imageID = try #require(composite.addPendingAttachment(
+            Self.bytes("img"),
+            format: "png",
+            thumbnailData: thumb,
+            forTerminalID: "term-a"
+        ))
+        let fileID = try #require(composite.addPendingFileAttachment(
+            Self.bytes("file"),
+            fileExtension: "pdf",
+            displayName: "doc.pdf",
+            thumbnailData: thumb,
+            forTerminalID: "term-a"
+        ))
+        let staged = composite.pendingAttachments(forTerminalID: "term-a")
+        #expect(staged.first { $0.id == imageID }?.thumbnailData == thumb)
+        #expect(staged.first { $0.id == fileID }?.thumbnailData == thumb)
+    }
+
     @Test func imageAddsStayImageKindWithoutDisplayName() {
         let composite = Self.makeComposite()
         composite.addPendingAttachment(Self.bytes("img"), format: "png", forTerminalID: "term-a")

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
@@ -41,6 +41,12 @@ actor RoutingHostRouter {
         var surfaceID: String
         var text: String
     }
+    struct AttachmentUploadRecord: Sendable {
+        var fileName: String
+        var offset: Int
+        var last: Bool
+        var totalBytes: Int
+    }
     struct WorkspaceCreateRecord: Sendable, Equatable {
         var groupID: String?
         var title: String?
@@ -51,6 +57,8 @@ actor RoutingHostRouter {
     }
     private(set) var pasteImages: [PasteImageRecord] = []
     private(set) var pastes: [PasteRecord] = []
+    private(set) var attachmentUploads: [AttachmentUploadRecord] = []
+    private var rejectAttachmentUpload = false
     let terminalInputRecorder = RoutingTerminalInputRecorder()
     private(set) var directorySearchQueries: [String] = []
     private(set) var dismisses: [(notificationIDs: [String], clientID: String?)] = []
@@ -190,6 +198,14 @@ actor RoutingHostRouter {
 
     func recordedPasteImages() -> [PasteImageRecord] { pasteImages }
     func recordedPastes() -> [PasteRecord] { pastes }
+    func recordedAttachmentUploads() -> [AttachmentUploadRecord] { attachmentUploads }
+
+    /// Reject every mobile.task.attachment.upload with an error frame, modeling
+    /// a host that cannot store the file (the composer must keep the chip and
+    /// leave the text unsent).
+    func setRejectAttachmentUpload(_ reject: Bool) {
+        rejectAttachmentUpload = reject
+    }
     func recordedDirectorySearchQueries() -> [String] { directorySearchQueries }
     func recordedTaskModelListProviders() -> [String] { taskModelListProviders }
     func recordedDirectoryListRequests() -> [(path: String, offset: Int, limit: Int)] {
@@ -220,6 +236,10 @@ actor RoutingHostRouter {
         var directoryOffset: Int?
         var directoryLimit: Int?
         var provider: String?
+        var fileName: String?
+        var uploadOffset: Int?
+        var uploadLast: Bool?
+        var uploadTotalBytes: Int?
     }
 
     func response(_ info: RequestInfo) async -> Data? {
@@ -434,6 +454,24 @@ actor RoutingHostRouter {
             let text = info.text ?? ""
             pastes.append(PasteRecord(surfaceID: surfaceID, text: text))
             return try? Self.resultFrame(id: id, result: [:])
+        case "mobile.task.attachment.upload":
+            let fileName = info.fileName ?? ""
+            let last = info.uploadLast ?? false
+            let totalBytes = info.uploadTotalBytes ?? 0
+            attachmentUploads.append(AttachmentUploadRecord(
+                fileName: fileName,
+                offset: info.uploadOffset ?? 0,
+                last: last,
+                totalBytes: totalBytes
+            ))
+            if rejectAttachmentUpload {
+                return try? Self.errorFrame(id: id, message: "attachment upload rejected")
+            }
+            var result: [String: Any] = ["received_bytes": totalBytes]
+            if last {
+                result["path"] = "/tmp/uploads/\(fileName)"
+            }
+            return try? Self.resultFrame(id: id, result: result)
         case "terminal.input":
             return await terminalInputResponse(info)
         case "notification.dismiss":
@@ -542,7 +580,11 @@ private actor RoutingTransport: CmxByteTransport {
                 directoryPath: params?["path"] as? String,
                 directoryOffset: params?["offset"] as? Int,
                 directoryLimit: params?["limit"] as? Int,
-                provider: params?["provider"] as? String
+                provider: params?["provider"] as? String,
+                fileName: params?["file_name"] as? String,
+                uploadOffset: params?["offset"] as? Int,
+                uploadLast: params?["last"] as? Bool,
+                uploadTotalBytes: params?["total_bytes"] as? Int
             )
             Task { [router, weak self] in
                 guard let response = await router.response(info) else {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobilePendingAttachment.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobilePendingAttachment.swift
@@ -1,32 +1,59 @@
 public import Foundation
 
-/// A picked image held in the composer as a pending attachment, sent to the
-/// terminal agent on the next composer submit (iMessage-style: pick now, send
-/// with the message).
+/// A picked or pasted item held in the composer as a pending attachment, sent
+/// to the terminal agent on the next composer submit (iMessage-style: stage
+/// now, send with the message).
 ///
 /// Value type so the store logic (add/remove/clear, per-terminal keying) is
-/// host-testable without UIKit. The bytes are already encoded the same way the
-/// clipboard paste path encodes them (PNG, or JPEG when over the size cap); the
-/// composer view builds the thumbnail from ``data`` at render time.
+/// host-testable without UIKit. Image bytes are already encoded the way the
+/// clipboard paste path encodes them (PNG, or JPEG when over the size cap) and
+/// travel through `terminal.paste_image`; file bytes are uploaded to the Mac at
+/// send time and land in the message as a shell-quoted absolute path. The
+/// composer view builds image thumbnails from ``data`` at render time.
 public struct MobilePendingAttachment: Identifiable, Equatable, Sendable {
+    /// How the staged bytes reach the Mac on submit.
+    public enum Kind: Equatable, Sendable {
+        /// An encoded image sent inline through `terminal.paste_image`.
+        case image
+        /// Arbitrary file bytes uploaded through the chunked task-attachment
+        /// verb; the message references the returned Mac path.
+        case file
+    }
+
     /// Stable identity so the chip row can diff and the remove action can target
     /// one attachment without relying on byte equality.
     public let id: UUID
-    /// The encoded image bytes (PNG/JPEG), ready to hand to
-    /// `submitTerminalPasteImage(_:format:)` as-is.
+    /// Transport selector for the submit path.
+    public let kind: Kind
+    /// The staged bytes: encoded image bytes (PNG/JPEG) for ``Kind/image``,
+    /// raw file bytes for ``Kind/file``.
     public let data: Data
-    /// A lowercase file-extension hint (e.g. `"png"`/`"jpg"`) for the Mac side,
-    /// matching the clipboard paste path's format argument.
+    /// A lowercase file-extension hint (e.g. `"png"`/`"jpg"`, or the file's own
+    /// extension), matching the clipboard paste path's format argument.
     public let format: String
+    /// The user-visible file name shown on a file chip and sent to the Mac as
+    /// the upload's file name. `nil` for images, whose chips render thumbnails.
+    public let displayName: String?
 
     /// Creates a pending attachment.
     /// - Parameters:
     ///   - id: Stable identity; defaults to a fresh `UUID`.
-    ///   - data: The encoded image bytes.
-    ///   - format: A lowercase format hint (`"png"`/`"jpg"`).
-    public init(id: UUID = UUID(), data: Data, format: String) {
+    ///   - kind: Transport selector; defaults to ``Kind/image`` to match the
+    ///     pre-file callers.
+    ///   - data: The staged bytes.
+    ///   - format: A lowercase file-extension hint (`"png"`/`"jpg"`/`"pdf"`).
+    ///   - displayName: User-visible file name for ``Kind/file`` chips.
+    public init(
+        id: UUID = UUID(),
+        kind: Kind = .image,
+        data: Data,
+        format: String,
+        displayName: String? = nil
+    ) {
         self.id = id
+        self.kind = kind
         self.data = data
         self.format = format
+        self.displayName = displayName
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobilePendingAttachment.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobilePendingAttachment.swift
@@ -34,6 +34,11 @@ public struct MobilePendingAttachment: Identifiable, Equatable, Sendable {
     /// The user-visible file name shown on a file chip and sent to the Mac as
     /// the upload's file name. `nil` for images, whose chips render thumbnails.
     public let displayName: String?
+    /// A small encoded chip preview, built ONCE at stage time (image
+    /// downsample, or a Quick Look thumbnail for files). Carried on the staged
+    /// value — not in a view-side cache — so a terminal or workspace switch
+    /// that recreates the composer view re-renders the same preview.
+    public let thumbnailData: Data?
 
     /// Creates a pending attachment.
     /// - Parameters:
@@ -43,17 +48,20 @@ public struct MobilePendingAttachment: Identifiable, Equatable, Sendable {
     ///   - data: The staged bytes.
     ///   - format: A lowercase file-extension hint (`"png"`/`"jpg"`/`"pdf"`).
     ///   - displayName: User-visible file name for ``Kind/file`` chips.
+    ///   - thumbnailData: Small encoded chip preview, if available.
     public init(
         id: UUID = UUID(),
         kind: Kind = .image,
         data: Data,
         format: String,
-        displayName: String? = nil
+        displayName: String? = nil,
+        thumbnailData: Data? = nil
     ) {
         self.id = id
         self.kind = kind
         self.data = data
         self.format = format
         self.displayName = displayName
+        self.thumbnailData = thumbnailData
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/TerminalComposerAttachmentInsertion.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/TerminalComposerAttachmentInsertion.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Inserts one uploaded attachment's Mac path into a composer message as a
+/// POSIX single-quoted token, so the receiving agent sees an unambiguous file
+/// reference even when the name contains spaces or quotes.
+///
+/// Lives in the model package because the store quotes paths at send time
+/// (the paths exist only after the send-time upload), while tests verify the
+/// exact quoting without a store.
+public struct TerminalComposerAttachmentInsertion: Sendable {
+    public let path: String
+
+    public init(path: String) {
+        self.path = path
+    }
+
+    /// The path wrapped in single quotes, with interior single quotes escaped
+    /// as `'\''` (end quote, escaped quote, reopen quote).
+    public var quotedPath: String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Appends the quoted path to `draft` with a single separating space and a
+    /// trailing space, so successive insertions and the user's message stay
+    /// whitespace-delimited: `"'a.txt' 'b.bin' message"`.
+    public func appending(to draft: String) -> String {
+        if draft.isEmpty {
+            return quotedPath + " "
+        }
+        let separator = draft.last?.isWhitespace == true ? "" : " "
+        return draft + separator + quotedPath + " "
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/TerminalComposerAttachmentInsertionTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/TerminalComposerAttachmentInsertionTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShellModel
+
+@Suite struct TerminalComposerAttachmentInsertionTests {
+    @Test func quotesPlainPathWithTrailingSeparator() {
+        let insertion = TerminalComposerAttachmentInsertion(path: "/tmp/uploads/report.pdf")
+        #expect(insertion.appending(to: "") == "'/tmp/uploads/report.pdf' ")
+    }
+
+    @Test func escapesInteriorSingleQuotes() {
+        let insertion = TerminalComposerAttachmentInsertion(
+            path: "/tmp/Customer's report.pdf"
+        )
+        #expect(
+            insertion.appending(to: "cat")
+                == "cat '/tmp/Customer'\\''s report.pdf' "
+        )
+    }
+
+    @Test func appendsWithoutDoublingWhitespaceSeparators() {
+        let first = TerminalComposerAttachmentInsertion(path: "/a.txt")
+        let second = TerminalComposerAttachmentInsertion(path: "/b.txt")
+        let composed = second.appending(to: first.appending(to: ""))
+        #expect(composed == "'/a.txt' '/b.txt' ")
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAttachmentQuickLookView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAttachmentQuickLookView.swift
@@ -1,0 +1,90 @@
+#if os(iOS)
+import QuickLook
+import SwiftUI
+
+/// Hosts Quick Look over one on-disk file without copying or re-encoding it.
+/// Shared by the task composer's attachment preview and the terminal
+/// composer's chip preview so both surfaces present staged attachments the
+/// same way.
+struct MobileAttachmentQuickLookView: UIViewControllerRepresentable {
+    let fileURL: URL
+    let title: String
+    var accessibilityIdentifier = "MobileAttachmentQuickLook"
+
+    func makeCoordinator() -> MobileAttachmentQuickLookCoordinator {
+        MobileAttachmentQuickLookCoordinator(
+            item: MobileAttachmentQuickLookItem(
+                fileURL: fileURL,
+                title: title
+            )
+        )
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        controller.view.accessibilityIdentifier = accessibilityIdentifier
+        return controller
+    }
+
+    func updateUIViewController(
+        _ controller: QLPreviewController,
+        context: Context
+    ) {
+        let didChange = context.coordinator.update(
+            fileURL: fileURL,
+            title: title
+        )
+        if didChange {
+            controller.reloadData()
+        }
+    }
+}
+
+/// Retains the item object for Quick Look's data-source lifetime.
+@MainActor
+final class MobileAttachmentQuickLookCoordinator:
+    NSObject,
+    QLPreviewControllerDataSource
+{
+    private var item: MobileAttachmentQuickLookItem
+
+    init(item: MobileAttachmentQuickLookItem) {
+        self.item = item
+    }
+
+    func update(fileURL: URL, title: String) -> Bool {
+        guard item.fileURL != fileURL || item.title != title else { return false }
+        item = MobileAttachmentQuickLookItem(
+            fileURL: fileURL,
+            title: title
+        )
+        return true
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        1
+    }
+
+    func previewController(
+        _ controller: QLPreviewController,
+        previewItemAt index: Int
+    ) -> any QLPreviewItem {
+        item
+    }
+}
+
+/// Supplies the staged URL and user-visible name to Quick Look.
+final class MobileAttachmentQuickLookItem: NSObject, QLPreviewItem {
+    let fileURL: URL
+    let title: String
+
+    var previewItemURL: URL? { fileURL }
+    var previewItemTitle: String? { title }
+
+    init(fileURL: URL, title: String) {
+        self.fileURL = fileURL
+        self.title = title
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteInterceptingTextView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteInterceptingTextView.swift
@@ -1,0 +1,33 @@
+#if os(iOS)
+import UIKit
+
+/// A `UITextView` whose system Paste action routes image and file pasteboard
+/// content to the hosting composer (which stages it as attachments) while
+/// plain text keeps native paste behavior. Both composer prompt editors
+/// subclass this so every paste entry point — edit menu, hardware Cmd+V,
+/// keyboard paste key — shares one interception path.
+@MainActor
+class MobilePasteInterceptingTextView: UITextView {
+    /// Stages the pasteboard's attachment content; returns `true` when the
+    /// paste was consumed (so native text insertion must not also run).
+    var pasteAttachments: (() -> Bool)?
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        // Advertise Paste for image/file content the native text view would
+        // refuse. The probe reads only pasteboard metadata, so the paste
+        // privacy prompt cannot fire from menu construction.
+        if action == #selector(paste(_:)),
+           isEditable,
+           pasteAttachments != nil,
+           MobilePasteboardReader().hasAttachmentContent(in: .general) {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        if pasteAttachments?() == true { return }
+        super.paste(sender)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
@@ -128,6 +128,27 @@ struct MobilePasteboardReader: Sendable {
         return results
     }
 
+    /// Copy one security-scoped picked file (e.g. from a Files importer) into
+    /// the same app-owned wrapper the paste path uses, so both entry points
+    /// feed one staging flow and one cleanup.
+    func materializePickedFile(at url: URL) async -> MobilePastedAttachment? {
+        await withTaskGroup(of: URL?.self) { group in
+            group.addTask(priority: .utility) {
+                let hasScope = url.startAccessingSecurityScopedResource()
+                defer {
+                    if hasScope { url.stopAccessingSecurityScopedResource() }
+                }
+                return copyIntoTemporaryStorage(url, name: url.lastPathComponent)
+            }
+            guard let copied = await group.next() ?? nil else { return nil }
+            return MobilePastedAttachment(
+                kind: .file,
+                url: copied,
+                displayName: copied.lastPathComponent
+            )
+        }
+    }
+
     /// Release copies produced by ``materializeAttachments(from:)``. Each file
     /// lives alone in an app-owned wrapper directory, so the wrapper is removed
     /// with it. Foreign URLs are left untouched.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
@@ -1,0 +1,229 @@
+#if os(iOS)
+import Foundation
+import UIKit
+import UniformTypeIdentifiers
+
+/// One pasteboard item materialized into an app-owned temporary file, ready to
+/// hand to a composer's stager. The file lives alone inside a uniquely named
+/// wrapper directory (the wrapper carries the uniqueness so the file keeps its
+/// user-visible name); the staging caller owns the copy and must release it
+/// with ``MobilePasteboardReader/cleanUp(_:)`` once staged.
+struct MobilePastedAttachment: Sendable {
+    enum Kind: Sendable {
+        case image
+        case file
+    }
+
+    let kind: Kind
+    /// App-owned temporary copy of the pasted bytes.
+    let url: URL
+    /// The user-visible name: the original file name when the provider carries
+    /// one, otherwise a generated `pasted-image.<ext>` style fallback.
+    let displayName: String
+}
+
+/// The single classification and materialization point for attachment pastes
+/// in the task and terminal composers.
+///
+/// `hasAttachmentContent` is a cheap metadata probe (safe for
+/// `canPerformAction`, it never reads pasteboard contents so it cannot trigger
+/// the iOS paste privacy prompt). `materializeAttachments` performs the actual
+/// read: every image or file item is copied into app-owned temporary storage
+/// through its `NSItemProvider` — files copied from Files.app are often exposed
+/// ONLY through providers, and a provider's file must be copied out inside its
+/// load completion while the temporary security scope is valid.
+struct MobilePasteboardReader: Sendable {
+    /// Whether the pasteboard holds anything the composers stage as an
+    /// attachment: an image, or a file-URL-backed item. Plain text and web
+    /// URLs are NOT attachment content; they fall through to native paste.
+    func hasAttachmentContent(in pasteboard: UIPasteboard) -> Bool {
+        if pasteboard.hasImages { return true }
+        return pasteboard.itemProviders.contains { provider in
+            provider.registeredTypeIdentifiers.contains { identifier in
+                identifier == UTType.fileURL.identifier
+                    || UTType(identifier)?.conforms(to: .image) == true
+            }
+        }
+    }
+
+    /// Materialize every image and file item on the pasteboard into app-owned
+    /// temporary copies, in item order. A provider that fails to load or copy
+    /// is skipped so one bad item cannot drop the rest of a multi-item paste.
+    func materializeAttachments(
+        from pasteboard: UIPasteboard
+    ) async -> [MobilePastedAttachment] {
+        var results: [MobilePastedAttachment] = []
+        let providers = pasteboard.itemProviders
+        for provider in providers {
+            if let imageType = registeredImageType(of: provider) {
+                if let attachment = await materializeImage(
+                    provider,
+                    contentType: imageType
+                ) {
+                    results.append(attachment)
+                }
+            } else if provider.registeredTypeIdentifiers
+                .contains(UTType.fileURL.identifier) {
+                if let attachment = await materializeFile(provider) {
+                    results.append(attachment)
+                }
+            }
+        }
+        // Some sources put an image on the pasteboard without a matching item
+        // provider representation; fall back to the decoded image itself.
+        if results.isEmpty, pasteboard.hasImages,
+           let data = pasteboard.image?.pngData(),
+           let url = writeIntoTemporaryStorage(data, name: "pasted-image.png") {
+            results.append(MobilePastedAttachment(
+                kind: .image,
+                url: url,
+                displayName: "pasted-image.png"
+            ))
+        }
+        return results
+    }
+
+    /// Release copies produced by ``materializeAttachments(from:)``. Each file
+    /// lives alone in an app-owned wrapper directory, so the wrapper is removed
+    /// with it. Foreign URLs are left untouched.
+    func cleanUp(_ attachments: [MobilePastedAttachment]) {
+        for attachment in attachments {
+            let wrapper = attachment.url.deletingLastPathComponent()
+            guard wrapper.lastPathComponent.hasPrefix(Self.wrapperPrefix) else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: wrapper)
+        }
+    }
+
+    private static let wrapperPrefix = "cmux-pasted-attachment-"
+
+    /// The most specific registered raster type, so the copied file keeps a
+    /// faithful extension (`png`/`jpeg`/`heic`) for the image preparer.
+    private func registeredImageType(of provider: NSItemProvider) -> UTType? {
+        provider.registeredTypeIdentifiers
+            .compactMap { UTType($0) }
+            .first { $0.conforms(to: .image) }
+    }
+
+    private func materializeImage(
+        _ provider: NSItemProvider,
+        contentType: UTType
+    ) async -> MobilePastedAttachment? {
+        let suggestedName = provider.suggestedName
+        let url: URL? = await withCheckedContinuation { continuation in
+            provider.loadFileRepresentation(
+                forTypeIdentifier: contentType.identifier
+            ) { loaded, _ in
+                // Copy inside the completion, while the provider-scoped temp
+                // file is still valid.
+                let name = imageFileName(
+                    suggested: suggestedName,
+                    loaded: loaded,
+                    contentType: contentType
+                )
+                continuation.resume(
+                    returning: loaded.flatMap {
+                        copyIntoTemporaryStorage($0, name: name)
+                    }
+                )
+            }
+        }
+        guard let url else { return nil }
+        return MobilePastedAttachment(
+            kind: .image,
+            url: url,
+            displayName: url.lastPathComponent
+        )
+    }
+
+    private func materializeFile(
+        _ provider: NSItemProvider
+    ) async -> MobilePastedAttachment? {
+        let url: URL? = await withCheckedContinuation { continuation in
+            provider.loadFileRepresentation(
+                forTypeIdentifier: UTType.fileURL.identifier
+            ) { loaded, _ in
+                continuation.resume(
+                    returning: loaded.flatMap {
+                        copyIntoTemporaryStorage($0, name: $0.lastPathComponent)
+                    }
+                )
+            }
+        }
+        guard let url else { return nil }
+        return MobilePastedAttachment(
+            kind: .file,
+            url: url,
+            displayName: url.lastPathComponent
+        )
+    }
+
+    /// A user-presentable image file name whose extension matches the loaded
+    /// representation: the provider's suggested name when present, else the
+    /// loaded file's own name, else a `pasted-image` fallback.
+    private func imageFileName(
+        suggested: String?,
+        loaded: URL?,
+        contentType: UTType
+    ) -> String {
+        let ext = loaded?.pathExtension.isEmpty == false
+            ? loaded!.pathExtension
+            : (contentType.preferredFilenameExtension ?? "png")
+        let stem: String
+        if let suggested, !suggested.isEmpty {
+            stem = (suggested as NSString).deletingPathExtension
+        } else if let loadedName = loaded?.deletingPathExtension().lastPathComponent,
+                  !loadedName.isEmpty {
+            stem = loadedName
+        } else {
+            stem = "pasted-image"
+        }
+        return "\(stem).\(ext)"
+    }
+
+    /// Copy one provider-scoped file into `tmp/<unique wrapper>/<name>` so the
+    /// durable copy keeps the user-visible file name for chips and previews.
+    private func copyIntoTemporaryStorage(_ source: URL, name: String) -> URL? {
+        let fileName = name.isEmpty ? UUID().uuidString : name
+        guard let wrapper = makeWrapperDirectory() else { return nil }
+        let destination = wrapper.appendingPathComponent(fileName)
+        do {
+            try FileManager.default.copyItem(at: source, to: destination)
+            return destination
+        } catch {
+            try? FileManager.default.removeItem(at: wrapper)
+            return nil
+        }
+    }
+
+    private func writeIntoTemporaryStorage(_ data: Data, name: String) -> URL? {
+        guard let wrapper = makeWrapperDirectory() else { return nil }
+        let destination = wrapper.appendingPathComponent(name)
+        do {
+            try data.write(to: destination, options: .atomic)
+            return destination
+        } catch {
+            try? FileManager.default.removeItem(at: wrapper)
+            return nil
+        }
+    }
+
+    private func makeWrapperDirectory() -> URL? {
+        let wrapper = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                Self.wrapperPrefix + UUID().uuidString,
+                isDirectory: true
+            )
+        do {
+            try FileManager.default.createDirectory(
+                at: wrapper,
+                withIntermediateDirectories: true
+            )
+            return wrapper
+        } catch {
+            return nil
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteboardAttachments.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import CmuxMobileDiagnostics
 import Foundation
 import UIKit
 import UniformTypeIdentifiers
@@ -33,17 +34,33 @@ struct MobilePastedAttachment: Sendable {
 /// ONLY through providers, and a provider's file must be copied out inside its
 /// load completion while the temporary security scope is valid.
 struct MobilePasteboardReader: Sendable {
+    /// How one pasteboard item should be staged, resolved from the provider's
+    /// registered type identifiers ONLY (metadata, never content):
+    /// - an image flavor stages as an image;
+    /// - a `public.file-url` flavor stages as a file loaded through the URL;
+    /// - a concrete document payload (pdf, zip, movie, …) with NO text or
+    ///   web-URL flavor stages as a file loaded through that type — Files.app
+    ///   exposes copied documents this way, registering the file's own content
+    ///   type rather than `public.file-url`;
+    /// - anything carrying a text or web-URL flavor is NOT attachment content,
+    ///   so rich text, plain text, and links keep native text paste.
+    enum ItemClassification {
+        case image(loadAs: UTType)
+        case file(loadAs: UTType)
+    }
+
     /// Whether the pasteboard holds anything the composers stage as an
-    /// attachment: an image, or a file-URL-backed item. Plain text and web
-    /// URLs are NOT attachment content; they fall through to native paste.
+    /// attachment. Metadata-only; logs the per-item type identifiers to the
+    /// debug log so a miss is diagnosable from a dogfood device.
     func hasAttachmentContent(in pasteboard: UIPasteboard) -> Bool {
-        if pasteboard.hasImages { return true }
-        return pasteboard.itemProviders.contains { provider in
-            provider.registeredTypeIdentifiers.contains { identifier in
-                identifier == UTType.fileURL.identifier
-                    || UTType(identifier)?.conforms(to: .image) == true
-            }
-        }
+        let providers = pasteboard.itemProviders
+        let matched = pasteboard.hasImages
+            || providers.contains { classification(of: $0) != nil }
+            // Some sources register a file URL at the pasteboard level without
+            // mirroring it into the item provider's registered types.
+            || pasteboard.contains(pasteboardTypes: [UTType.fileURL.identifier])
+        logClassification(of: providers, pasteboard: pasteboard, matched: matched)
+        return matched
     }
 
     /// Materialize every image and file item on the pasteboard into app-owned
@@ -55,18 +72,23 @@ struct MobilePasteboardReader: Sendable {
         var results: [MobilePastedAttachment] = []
         let providers = pasteboard.itemProviders
         for provider in providers {
-            if let imageType = registeredImageType(of: provider) {
+            switch classification(of: provider) {
+            case .image(let contentType):
                 if let attachment = await materializeImage(
                     provider,
-                    contentType: imageType
+                    contentType: contentType
                 ) {
                     results.append(attachment)
                 }
-            } else if provider.registeredTypeIdentifiers
-                .contains(UTType.fileURL.identifier) {
-                if let attachment = await materializeFile(provider) {
+            case .file(let contentType):
+                if let attachment = await materializeFile(
+                    provider,
+                    contentType: contentType
+                ) {
                     results.append(attachment)
                 }
+            case nil:
+                continue
             }
         }
         // Some sources put an image on the pasteboard without a matching item
@@ -79,6 +101,29 @@ struct MobilePasteboardReader: Sendable {
                 url: url,
                 displayName: "pasted-image.png"
             ))
+        }
+        // Last resort for sources that register a file URL at the pasteboard
+        // level without a provider representation: copy the URLs directly.
+        // This is a content read, which is fine here — materialization only
+        // runs for a user-invoked paste.
+        if results.isEmpty,
+           pasteboard.contains(pasteboardTypes: [UTType.fileURL.identifier]) {
+            for url in pasteboard.urls ?? [] where url.isFileURL {
+                let hasScope = url.startAccessingSecurityScopedResource()
+                defer {
+                    if hasScope { url.stopAccessingSecurityScopedResource() }
+                }
+                if let copied = copyIntoTemporaryStorage(
+                    url,
+                    name: url.lastPathComponent
+                ) {
+                    results.append(MobilePastedAttachment(
+                        kind: .file,
+                        url: copied,
+                        displayName: copied.lastPathComponent
+                    ))
+                }
+            }
         }
         return results
     }
@@ -98,12 +143,57 @@ struct MobilePasteboardReader: Sendable {
 
     private static let wrapperPrefix = "cmux-pasted-attachment-"
 
-    /// The most specific registered raster type, so the copied file keeps a
-    /// faithful extension (`png`/`jpeg`/`heic`) for the image preparer.
-    private func registeredImageType(of provider: NSItemProvider) -> UTType? {
-        provider.registeredTypeIdentifiers
-            .compactMap { UTType($0) }
-            .first { $0.conforms(to: .image) }
+    func classification(of provider: NSItemProvider) -> ItemClassification? {
+        classification(ofRegisteredTypeIdentifiers: provider.registeredTypeIdentifiers)
+    }
+
+    /// Pure classification over registered type identifiers, ordered
+    /// most-specific-first as NSItemProvider reports them.
+    func classification(
+        ofRegisteredTypeIdentifiers identifiers: [String]
+    ) -> ItemClassification? {
+        let types = identifiers.compactMap { UTType($0) }
+        if let imageType = types.first(where: { $0.conforms(to: .image) }) {
+            return .image(loadAs: imageType)
+        }
+        if identifiers.contains(UTType.fileURL.identifier) {
+            return .file(loadAs: .fileURL)
+        }
+        // A text or web-URL flavor anywhere on the item means the user copied
+        // something meant to paste AS text (rich text, a link with a title),
+        // even when a data flavor (web archive, RTFD) rides along.
+        let hasTextFlavor = types.contains {
+            $0.conforms(to: .text) || $0 == .url
+        }
+        guard !hasTextFlavor else { return nil }
+        if let dataType = types.first(where: {
+            $0.conforms(to: .data) && !$0.conforms(to: .url)
+        }) {
+            return .file(loadAs: dataType)
+        }
+        return nil
+    }
+
+    /// One privacy-acceptable debug line per probe: type identifiers only
+    /// (never content), so a Files.app copy that fails to classify on a
+    /// dogfood device can be diagnosed from the copied-off debug log.
+    private func logClassification(
+        of providers: [NSItemProvider],
+        pasteboard: UIPasteboard,
+        matched: Bool
+    ) {
+        #if DEBUG
+        let items = providers
+            .map { provider in
+                "[" + provider.registeredTypeIdentifiers.joined(separator: "|") + "]"
+            }
+            .joined(separator: ",")
+        MobileDebugLog.shared.append(
+            "paste.probe matched=\(matched ? 1 : 0) hasImages=\(pasteboard.hasImages ? 1 : 0) "
+                + "hasStrings=\(pasteboard.hasStrings ? 1 : 0) hasURLs=\(pasteboard.hasURLs ? 1 : 0) "
+                + "items=\(items.isEmpty ? "none" : items)"
+        )
+        #endif
     }
 
     private func materializeImage(
@@ -117,10 +207,11 @@ struct MobilePasteboardReader: Sendable {
             ) { loaded, _ in
                 // Copy inside the completion, while the provider-scoped temp
                 // file is still valid.
-                let name = imageFileName(
+                let name = pastedFileName(
                     suggested: suggestedName,
                     loaded: loaded,
-                    contentType: contentType
+                    contentType: contentType,
+                    fallbackStem: "pasted-image"
                 )
                 continuation.resume(
                     returning: loaded.flatMap {
@@ -138,15 +229,29 @@ struct MobilePasteboardReader: Sendable {
     }
 
     private func materializeFile(
-        _ provider: NSItemProvider
+        _ provider: NSItemProvider,
+        contentType: UTType
     ) async -> MobilePastedAttachment? {
+        let suggestedName = provider.suggestedName
         let url: URL? = await withCheckedContinuation { continuation in
             provider.loadFileRepresentation(
-                forTypeIdentifier: UTType.fileURL.identifier
+                forTypeIdentifier: contentType.identifier
             ) { loaded, _ in
+                let name: String
+                if contentType == .fileURL {
+                    // A URL-backed load lands with the real file's own name.
+                    name = loaded?.lastPathComponent ?? UUID().uuidString
+                } else {
+                    name = pastedFileName(
+                        suggested: suggestedName,
+                        loaded: loaded,
+                        contentType: contentType,
+                        fallbackStem: "pasted-file"
+                    )
+                }
                 continuation.resume(
                     returning: loaded.flatMap {
-                        copyIntoTemporaryStorage($0, name: $0.lastPathComponent)
+                        copyIntoTemporaryStorage($0, name: name)
                     }
                 )
             }
@@ -159,27 +264,28 @@ struct MobilePasteboardReader: Sendable {
         )
     }
 
-    /// A user-presentable image file name whose extension matches the loaded
+    /// A user-presentable file name whose extension matches the loaded
     /// representation: the provider's suggested name when present, else the
-    /// loaded file's own name, else a `pasted-image` fallback.
-    private func imageFileName(
+    /// loaded file's own name, else the given fallback stem.
+    private func pastedFileName(
         suggested: String?,
         loaded: URL?,
-        contentType: UTType
+        contentType: UTType,
+        fallbackStem: String
     ) -> String {
         let ext = loaded?.pathExtension.isEmpty == false
             ? loaded!.pathExtension
-            : (contentType.preferredFilenameExtension ?? "png")
-        let stem: String
+            : (contentType.preferredFilenameExtension ?? "bin")
         if let suggested, !suggested.isEmpty {
-            stem = (suggested as NSString).deletingPathExtension
-        } else if let loadedName = loaded?.deletingPathExtension().lastPathComponent,
-                  !loadedName.isEmpty {
-            stem = loadedName
-        } else {
-            stem = "pasted-image"
+            let stem = (suggested as NSString).deletingPathExtension
+            let suggestedExt = (suggested as NSString).pathExtension
+            return suggestedExt.isEmpty ? "\(stem).\(ext)" : suggested
         }
-        return "\(stem).\(ext)"
+        if let loadedName = loaded?.deletingPathExtension().lastPathComponent,
+           !loadedName.isEmpty {
+            return "\(loadedName).\(ext)"
+        }
+        return "\(fallbackStem).\(ext)"
     }
 
     /// Copy one provider-scoped file into `tmp/<unique wrapper>/<name>` so the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAttachmentPickerMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAttachmentPickerMenu.swift
@@ -13,6 +13,7 @@ struct TaskComposerAttachmentPickerMenu: View {
     let isDisabled: Bool
     let choosePhotos: () -> Void
     let chooseFiles: () -> Void
+    let pasteAttachments: () -> Void
 
     var body: some View {
         Menu {
@@ -32,6 +33,15 @@ struct TaskComposerAttachmentPickerMenu: View {
                         defaultValue: "Choose Files"
                     ),
                     systemImage: "folder"
+                )
+            }
+            Button(action: pasteAttachments) {
+                Label(
+                    L10n.string(
+                        "mobile.taskComposer.attachments.paste",
+                        defaultValue: "Paste"
+                    ),
+                    systemImage: "doc.on.clipboard"
                 )
             }
         } label: {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAttachmentPreview.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAttachmentPreview.swift
@@ -1,7 +1,6 @@
 #if os(iOS)
 import CmuxMobileShellModel
 import CmuxMobileSupport
-import QuickLook
 import SwiftUI
 
 /// Presents the exact staged attachment through the system document preview.
@@ -12,9 +11,10 @@ struct TaskComposerAttachmentPreview: View {
 
     var body: some View {
         NavigationStack {
-            TaskComposerAttachmentQuickLookView(
+            MobileAttachmentQuickLookView(
                 fileURL: attachment.localStagedFileURL,
-                title: attachment.displayName
+                title: attachment.displayName,
+                accessibilityIdentifier: "MobileTaskComposerAttachmentQuickLook"
             )
             .navigationTitle(attachment.displayName)
             .navigationBarTitleDisplayMode(.inline)
@@ -30,89 +30,6 @@ struct TaskComposerAttachmentPreview: View {
             }
         }
         .accessibilityIdentifier("MobileTaskComposerAttachmentPreview")
-    }
-}
-
-/// Hosts Quick Look without copying or re-encoding the staged file.
-private struct TaskComposerAttachmentQuickLookView: UIViewControllerRepresentable {
-    let fileURL: URL
-    let title: String
-
-    func makeCoordinator() -> TaskComposerAttachmentQuickLookCoordinator {
-        TaskComposerAttachmentQuickLookCoordinator(
-            item: TaskComposerAttachmentQuickLookItem(
-                fileURL: fileURL,
-                title: title
-            )
-        )
-    }
-
-    func makeUIViewController(context: Context) -> QLPreviewController {
-        let controller = QLPreviewController()
-        controller.dataSource = context.coordinator
-        controller.view.accessibilityIdentifier =
-            "MobileTaskComposerAttachmentQuickLook"
-        return controller
-    }
-
-    func updateUIViewController(
-        _ controller: QLPreviewController,
-        context: Context
-    ) {
-        let didChange = context.coordinator.update(
-            fileURL: fileURL,
-            title: title
-        )
-        if didChange {
-            controller.reloadData()
-        }
-    }
-}
-
-/// Retains the item object for Quick Look's data-source lifetime.
-@MainActor
-private final class TaskComposerAttachmentQuickLookCoordinator:
-    NSObject,
-    QLPreviewControllerDataSource
-{
-    private var item: TaskComposerAttachmentQuickLookItem
-
-    init(item: TaskComposerAttachmentQuickLookItem) {
-        self.item = item
-    }
-
-    func update(fileURL: URL, title: String) -> Bool {
-        guard item.fileURL != fileURL || item.title != title else { return false }
-        item = TaskComposerAttachmentQuickLookItem(
-            fileURL: fileURL,
-            title: title
-        )
-        return true
-    }
-
-    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        1
-    }
-
-    func previewController(
-        _ controller: QLPreviewController,
-        previewItemAt index: Int
-    ) -> any QLPreviewItem {
-        item
-    }
-}
-
-/// Supplies the staged URL and original user-visible name to Quick Look.
-private final class TaskComposerAttachmentQuickLookItem: NSObject, QLPreviewItem {
-    let fileURL: URL
-    let title: String
-
-    var previewItemURL: URL? { fileURL }
-    var previewItemTitle: String? { title }
-
-    init(fileURL: URL, title: String) {
-        self.fileURL = fileURL
-        self.title = title
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
@@ -48,6 +48,11 @@ struct TaskComposerLayout: View {
     let requestStartAgain: () -> Void
     let chooseAttachmentPhotos: () -> Void
     let chooseAttachmentFiles: () -> Void
+    /// Stages pasted images/files as attachments; `true` consumes the paste.
+    /// Shared by the prompt editor's system Paste action and the attachment
+    /// menu's Paste item (which ignores the result — text-only pasteboards
+    /// simply stage nothing there).
+    let pasteAttachments: () -> Bool
     let removeAttachment: (UUID) -> Void
 
     @State private var isPromptFocused = false
@@ -106,7 +111,8 @@ struct TaskComposerLayout: View {
                     "mobile.taskComposer.prompt",
                     defaultValue: "Prompt"
                 ),
-                accessibilityHint: promptPlaceholder
+                accessibilityHint: promptPlaceholder,
+                pasteAttachments: pasteAttachments
             )
                 .padding(.horizontal, 20)
                 .padding(.vertical, 18)
@@ -212,7 +218,8 @@ struct TaskComposerLayout: View {
                     style: .circularPlus,
                     isDisabled: isDisabled,
                     choosePhotos: chooseAttachmentPhotos,
-                    chooseFiles: chooseAttachmentFiles
+                    chooseFiles: chooseAttachmentFiles,
+                    pasteAttachments: { _ = pasteAttachments() }
                 )
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptEditor.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptEditor.swift
@@ -10,6 +10,8 @@ struct TaskComposerPromptEditor: UIViewRepresentable {
     let isDisabled: Bool
     let accessibilityLabel: String
     let accessibilityHint: String
+    /// Stages pasted images/files as attachments; `true` consumes the paste.
+    let pasteAttachments: () -> Bool
 
     func makeCoordinator() -> TaskComposerPromptEditorCoordinator {
         TaskComposerPromptEditorCoordinator(text: $text, isFocused: $isFocused)
@@ -34,6 +36,7 @@ struct TaskComposerPromptEditor: UIViewRepresentable {
             guard let textView else { return }
             coordinator?.restoreManualContentOffset(in: textView)
         }
+        textView.pasteAttachments = pasteAttachments
         updateInteractionState(of: textView)
         return textView
     }
@@ -42,6 +45,7 @@ struct TaskComposerPromptEditor: UIViewRepresentable {
         context.coordinator.update(text: $text, isFocused: $isFocused)
         textView.accessibilityLabel = accessibilityLabel
         textView.accessibilityHint = accessibilityHint
+        textView.pasteAttachments = pasteAttachments
         updateInteractionState(of: textView)
 
         // Assigning the same text again resets UITextView's selection/caret

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptTextView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptTextView.swift
@@ -2,9 +2,10 @@
 import UIKit
 
 /// Gives the prompt coordinator one post-layout hook to restore a user-owned
-/// viewport after UIKit performs caret-visibility layout.
+/// viewport after UIKit performs caret-visibility layout. Inherits the paste
+/// interception that stages pasted images/files as task attachments.
 @MainActor
-final class TaskComposerPromptTextView: UITextView {
+final class TaskComposerPromptTextView: MobilePasteInterceptingTextView {
     var restoreManualContentOffset: (() -> Void)?
 
     override func layoutSubviews() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+Attachments.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+Attachments.swift
@@ -55,13 +55,118 @@ extension TaskComposerSheet {
         isAttachmentFileImporterPresented = true
     }
 
-    func stageSelectedPhotos(_ items: [PhotosPickerItem]) {
-        store.recordAppEvent(.photoPickerSelected, count: items.count)
+    /// Stage the pasteboard's image/file content as task attachments. The
+    /// shared action behind the prompt editor's system Paste and the attachment
+    /// menu's Paste item.
+    ///
+    /// - Returns: `true` when the paste was consumed as attachment content (so
+    ///   the editor must not also insert text), `false` when the pasteboard has
+    ///   no attachment content or attachments are not available here — native
+    ///   text paste then proceeds untouched. The availability gate is the SAME
+    ///   one that hides the attachment button (plain-shell templates and Macs
+    ///   without the task-attachment capability), so a paste cannot smuggle an
+    ///   attachment past the UI gate.
+    func stagePasteboardAttachments() -> Bool {
+        guard showsAttachmentButton, !submissionPhase.disablesRequestEditing else {
+            return false
+        }
+        let reader = MobilePasteboardReader()
+        // Classify BEFORE the count gate: a text-only paste must never be
+        // consumed here, even when the attachment list is full.
+        guard reader.hasAttachmentContent(in: .general) else { return false }
+        guard remainingAttachmentCount > 0 else {
+            attachmentAlertMessage = Self.attachmentCountFailureMessage
+            store.recordAppEvent(
+                .taskAttachmentLimitReached,
+                failure: .attachmentCountLimitReached,
+                count: attachments.count
+            )
+            return true
+        }
+        beginAttachmentStaging {
+            let items = await reader.materializeAttachments(from: .general)
+            defer { reader.cleanUp(items) }
+            guard !Task.isCancelled else { return }
+            guard !items.isEmpty else {
+                attachmentAlertMessage = Self.attachmentUnreadableFailureMessage
+                store.recordAppEvent(
+                    .attachmentPreparationFailed,
+                    failure: .unknown
+                )
+                return
+            }
+            for item in items.prefix(remainingAttachmentCount) {
+                guard !Task.isCancelled else { return }
+                do {
+                    store.recordAppEvent(.attachmentPreparationStarted)
+                    let stager = TaskComposerAttachmentStager()
+                    let attachment: TaskComposerAttachment = switch item.kind {
+                    case .image:
+                        try await stager.stageImage(
+                            at: item.url,
+                            originalFileName: item.displayName
+                        )
+                    case .file:
+                        try await stager.stageFile(at: item.url)
+                    }
+                    guard !Task.isCancelled else {
+                        try? FileManager.default.removeItem(
+                            at: attachment.localStagedFileURL
+                        )
+                        return
+                    }
+                    appendAttachment(attachment)
+                    store.recordAppEvent(
+                        .attachmentPreparationSucceeded,
+                        correlationID: attachment.id.uuidString,
+                        count: attachment.byteCount
+                    )
+                } catch is CancellationError {
+                    store.recordAppEvent(
+                        .attachmentPreparationFailed,
+                        failure: .cancelled
+                    )
+                    return
+                } catch {
+                    store.recordAppEvent(
+                        .attachmentPreparationFailed,
+                        failure: DiagnosticFailureKind.classify(error)
+                    )
+                    attachmentAlertMessage = Self.attachmentStagingFailureMessage(
+                        error
+                    )
+                }
+            }
+        }
+        return true
+    }
+
+    /// Replace the in-flight staging task with a new one whose completion only
+    /// clears the shared handle if it is STILL the current batch. Without the
+    /// generation check, a cancelled older batch finishing late would nil out
+    /// the newer batch's handle and re-enable submit while staging is still in
+    /// flight.
+    private func beginAttachmentStaging(
+        _ operation: @escaping @MainActor () async -> Void
+    ) {
         attachmentStagingTask?.cancel()
+        attachmentStagingGeneration += 1
+        let generation = attachmentStagingGeneration
         attachmentStagingTask = Task { @MainActor in
             defer {
+                if attachmentStagingGeneration == generation {
+                    attachmentStagingTask = nil
+                }
+            }
+            await operation()
+        }
+    }
+
+    func stageSelectedPhotos(_ items: [PhotosPickerItem]) {
+        store.recordAppEvent(.photoPickerSelected, count: items.count)
+        beginAttachmentStaging {
+            defer {
                 attachmentPhotoSelection = []
-                attachmentStagingTask = nil
             }
             for item in items.prefix(remainingAttachmentCount) {
                 guard !Task.isCancelled else { return }
@@ -120,9 +225,7 @@ extension TaskComposerSheet {
             )
             return
         }
-        attachmentStagingTask?.cancel()
-        attachmentStagingTask = Task { @MainActor in
-            defer { attachmentStagingTask = nil }
+        beginAttachmentStaging {
             for url in urls.prefix(remainingAttachmentCount) {
                 guard !Task.isCancelled else { return }
                 do {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -52,6 +52,10 @@ struct TaskComposerSheet: View {
     @State var attachmentPhotoSelection: [PhotosPickerItem] = []
     @State var isAttachmentFileImporterPresented = false
     @State var attachmentStagingTask: Task<Void, Never>?
+    /// Monotonic batch token: each staging batch bumps it, and a finishing
+    /// batch clears ``attachmentStagingTask`` only when its own token is still
+    /// current, so a stale (cancelled) batch cannot drop a newer batch's handle.
+    @State var attachmentStagingGeneration = 0
     @State var attachmentAlertMessage: String?
     /// Draft typing is sampled once per composer presentation so this bounded
     /// log records that editing occurred without one event per keystroke.
@@ -492,6 +496,7 @@ struct TaskComposerSheet: View {
             requestStartAgain: { isStartAgainConfirmationPresented = true },
             chooseAttachmentPhotos: presentAttachmentPhotoPicker,
             chooseAttachmentFiles: presentAttachmentFileImporter,
+            pasteAttachments: stagePasteboardAttachments,
             removeAttachment: removeAttachment
         )
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerAttachmentPreviewSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerAttachmentPreviewSheet.swift
@@ -1,0 +1,136 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// Quick Look preview for one staged terminal-composer attachment.
+///
+/// Pending attachments hold their bytes in memory (unlike the task composer's
+/// file-backed staging), so the sheet materializes them into an app-owned
+/// temp file — named with the user-visible file name so Quick Look renders
+/// the right document type and title — and removes the wrapper directory when
+/// the sheet goes away.
+struct TerminalComposerAttachmentPreviewSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let attachment: MobilePendingAttachment
+
+    private enum MaterializationState {
+        case loading
+        case ready(URL)
+        case failed
+    }
+
+    @State private var state: MaterializationState = .loading
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(previewTitle)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(L10n.string(
+                            "mobile.common.done",
+                            defaultValue: "Done"
+                        )) {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+        .task(id: attachment.id) {
+            await materialize()
+        }
+        .onDisappear {
+            cleanUpMaterializedFile()
+        }
+        .accessibilityIdentifier("MobileComposerAttachmentPreview")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .ready(let fileURL):
+            MobileAttachmentQuickLookView(
+                fileURL: fileURL,
+                title: previewTitle,
+                accessibilityIdentifier: "MobileComposerAttachmentQuickLook"
+            )
+        case .failed:
+            Label(
+                L10n.string(
+                    "mobile.composer.attachment.previewFailed",
+                    defaultValue: "This attachment couldn’t be previewed."
+                ),
+                systemImage: "exclamationmark.triangle"
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    /// The user-visible name: the file's own name for file chips, a generated
+    /// `image.<ext>` for images (their chips render thumbnails, not names).
+    private var previewTitle: String {
+        attachment.displayName ?? "image.\(attachment.format)"
+    }
+
+    private static let wrapperPrefix = "cmux-composer-preview-"
+
+    /// Write the staged bytes off the main actor into a wrapper directory that
+    /// carries the uniqueness, so the file inside keeps the user-visible name
+    /// (Quick Look shows it and picks the renderer from its extension).
+    private func materialize() async {
+        guard case .loading = state else { return }
+        let data = attachment.data
+        // A path separator or colon in a display name would escape the wrapper
+        // or read as a volume separator.
+        let fileName = previewTitle
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+        let wrapper = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                Self.wrapperPrefix + UUID().uuidString,
+                isDirectory: true
+            )
+        let destination = wrapper.appendingPathComponent(
+            fileName.isEmpty ? UUID().uuidString : fileName
+        )
+        let written: Bool = await withTaskGroup(of: Bool.self) { group in
+            group.addTask(priority: .utility) {
+                do {
+                    try FileManager.default.createDirectory(
+                        at: wrapper,
+                        withIntermediateDirectories: true
+                    )
+                    try data.write(to: destination, options: .atomic)
+                    return true
+                } catch {
+                    try? FileManager.default.removeItem(at: wrapper)
+                    return false
+                }
+            }
+            return await group.next() ?? false
+        }
+        guard !Task.isCancelled else {
+            try? FileManager.default.removeItem(at: wrapper)
+            return
+        }
+        state = written ? .ready(destination) : .failed
+    }
+
+    private func cleanUpMaterializedFile() {
+        guard case .ready(let fileURL) = state else { return }
+        let wrapper = fileURL.deletingLastPathComponent()
+        guard wrapper.lastPathComponent.hasPrefix(Self.wrapperPrefix) else {
+            return
+        }
+        try? FileManager.default.removeItem(at: wrapper)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerPromptEditor.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerPromptEditor.swift
@@ -1,0 +1,144 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// The terminal composer's message field, inheriting the shared paste
+/// interception so pasted images/files stage as pending attachments.
+@MainActor
+final class TerminalComposerPromptTextView: MobilePasteInterceptingTextView {
+    /// Placeholder shown while the field is empty, owned here so visibility
+    /// tracks every text mutation (typing, paste, dictation, external clears).
+    let placeholderLabel = UILabel()
+
+    override var text: String! {
+        didSet { placeholderLabel.isHidden = !(text ?? "").isEmpty }
+    }
+
+    // Typing mutates the text storage without passing through the `text`
+    // setter, but every content change triggers layout, so visibility is
+    // re-derived here to cover keystrokes, dictation, and IME composition.
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        placeholderLabel.isHidden = !(text ?? "").isEmpty
+    }
+}
+
+/// A UIKit-backed replacement for the composer's `TextField(axis: .vertical)`
+/// whose ONLY behavioral addition is paste interception (system edit menu,
+/// hardware Cmd+V, keyboard paste key) for attachment content — SwiftUI's
+/// `TextField` offers no paste hook on iOS.
+///
+/// Geometry contract: the editor reproduces `TextField(axis: .vertical)
+/// .lineLimit(1...14)` exactly. The surrounding container provides the field's
+/// 40pt one-line floor and paddings, so the editor carries NO insets of its
+/// own (any inset here would stack on the container's and fatten the field);
+/// its `sizeThatFits` reports the text's own height clamped to 1–14 lines,
+/// enabling internal scrolling only past the cap.
+struct TerminalComposerPromptEditor: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+    let placeholder: String
+    let textColor: UIColor
+    let isDisabled: Bool
+    /// Stages pasted images/files as attachments; `true` consumes the paste.
+    let pasteAttachments: () -> Bool
+
+    /// The 1...14 line growth window mirrored from the replaced `TextField`.
+    private static let maximumLineCount: CGFloat = 14
+
+    func makeCoordinator() -> TaskComposerPromptEditorCoordinator {
+        TaskComposerPromptEditorCoordinator(text: $text, isFocused: $isFocused)
+    }
+
+    func makeUIView(context: Context) -> TerminalComposerPromptTextView {
+        let textView = TerminalComposerPromptTextView()
+        textView.delegate = context.coordinator
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.backgroundColor = .clear
+        // The container already pads the field; zero insets keep the one-line
+        // field at its 40pt baseline instead of stacking heights.
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isScrollEnabled = false
+        // Natural-language input to an agent: the same text assistance the
+        // replaced TextField enabled (the raw terminal field keeps these off).
+        textView.autocapitalizationType = .sentences
+        textView.autocorrectionType = .yes
+        textView.spellCheckingType = .yes
+        textView.accessibilityIdentifier = "MobileComposerField"
+        textView.pasteAttachments = pasteAttachments
+
+        let placeholderLabel = textView.placeholderLabel
+        placeholderLabel.font = textView.font
+        placeholderLabel.adjustsFontForContentSizeCategory = true
+        placeholderLabel.textColor = .placeholderText
+        placeholderLabel.isAccessibilityElement = false
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        textView.addSubview(placeholderLabel)
+        NSLayoutConstraint.activate([
+            placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor),
+            placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+        ])
+
+        applyState(to: textView)
+        textView.text = text
+        return textView
+    }
+
+    func updateUIView(_ textView: TerminalComposerPromptTextView, context: Context) {
+        context.coordinator.update(text: $text, isFocused: $isFocused)
+        textView.pasteAttachments = pasteAttachments
+        applyState(to: textView)
+
+        // Assigning the same text again resets UITextView's selection/caret
+        // layout; user edits already changed the backing view, so only external
+        // mutations (a send clearing the draft, a terminal switch swapping it)
+        // need an assignment here.
+        if textView.text != text {
+            let selection = textView.selectedRange
+            textView.text = text
+            let textLength = (text as NSString).length
+            let location = min(selection.location, textLength)
+            textView.selectedRange = NSRange(
+                location: location,
+                length: min(selection.length, textLength - location)
+            )
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView textView: TerminalComposerPromptTextView,
+        context: Context
+    ) -> CGSize? {
+        guard let width = proposal.width, width > 0 else { return nil }
+        let lineHeight = (textView.font ?? UIFont.preferredFont(forTextStyle: .body)).lineHeight
+        let fitted = textView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        ).height
+        let minimum = ceil(lineHeight)
+        let maximum = ceil(lineHeight * Self.maximumLineCount)
+        // Internal scrolling only once the 14-line cap binds; below it the
+        // field grows and the band reserves the height.
+        let shouldScroll = fitted > maximum
+        if textView.isScrollEnabled != shouldScroll {
+            textView.isScrollEnabled = shouldScroll
+        }
+        return CGSize(width: width, height: min(max(fitted, minimum), maximum))
+    }
+
+    private func applyState(to textView: TerminalComposerPromptTextView) {
+        textView.placeholderLabel.text = placeholder
+        textView.placeholderLabel.isHidden = !textView.text.isEmpty
+        if textView.textColor != textColor {
+            textView.textColor = textColor
+        }
+        textView.isEditable = !isDisabled
+        textView.isUserInteractionEnabled = !isDisabled
+        if isDisabled, textView.isFirstResponder {
+            textView.resignFirstResponder()
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerPromptEditor.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerPromptEditor.swift
@@ -112,7 +112,11 @@ struct TerminalComposerPromptEditor: UIViewRepresentable {
         uiView textView: TerminalComposerPromptTextView,
         context: Context
     ) -> CGSize? {
-        guard let width = proposal.width, width > 0 else { return nil }
+        // An unbounded proposal would measure (and report) an infinite width;
+        // fall back to system sizing until a concrete width arrives.
+        guard let width = proposal.width, width > 0, width.isFinite else {
+            return nil
+        }
         let lineHeight = (textView.font ?? UIFont.preferredFont(forTextStyle: .body)).lineHeight
         let fitted = textView.sizeThatFits(
             CGSize(width: width, height: .greatestFiniteMagnitude)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -5,6 +5,7 @@ import CmuxMobileShellModel
 import CmuxMobileSupport
 import CmuxMobileTerminal
 import PhotosUI
+import QuickLookThumbnailing
 import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
@@ -209,6 +210,13 @@ struct TerminalComposerView: View {
         // (chip-less) layout rather than the stale tall one.
         .onChange(of: pendingAttachments.isEmpty) { _, _ in
             requestHeightRemeasure()
+        }
+        // Thumbnails are carried on the staged attachments themselves, so a
+        // terminal or workspace switch that recreates this view (emptying the
+        // view-side decode cache) re-hydrates the same chip previews instead
+        // of degrading to placeholders.
+        .onChange(of: pendingAttachments.map(\.id), initial: true) { _, _ in
+            warmThumbnailCache()
         }
         .onChange(of: sendStatus) { _, _ in
             requestHeightRemeasure()
@@ -611,8 +619,22 @@ struct TerminalComposerView: View {
                     )
                 }
             }
-            .padding(.leading, controlHeight + 8)
+            // Chips start at the composer's own leading margin (aligned with
+            // the toolbar's leading control), not indented past the attach
+            // button; the container's 12pt padding is the only inset.
             .padding(.trailing, 12)
+        }
+    }
+
+    /// Decode any staged attachment's carried thumbnail into the view-side
+    /// cache. The cache only avoids re-decoding on every body evaluation; the
+    /// bytes themselves live on the attachment (see the `onChange` above).
+    private func warmThumbnailCache() {
+        for attachment in pendingAttachments {
+            guard thumbnailCache.image(for: attachment.id) == nil,
+                  let thumbnailData = attachment.thumbnailData,
+                  let image = UIImage(data: thumbnailData) else { continue }
+            thumbnailCache.set(image, for: attachment.id)
         }
     }
 
@@ -784,6 +806,7 @@ struct TerminalComposerView: View {
                 guard let id = store.addPendingAttachment(
                     prepared.data,
                     format: prepared.format,
+                    thumbnailData: prepared.thumbnailData,
                     forTerminalID: terminalID,
                     ifSessionGeneration: sessionGeneration
                 ) else { continue }
@@ -913,6 +936,7 @@ struct TerminalComposerView: View {
         guard let id = store.addPendingAttachment(
             prepared.data,
             format: prepared.format,
+            thumbnailData: prepared.thumbnailData,
             forTerminalID: terminalID,
             ifSessionGeneration: sessionGeneration
         ) else { return }
@@ -981,6 +1005,10 @@ struct TerminalComposerView: View {
             }
             return
         }
+        // Best-effort inline preview from the still-on-disk pasted file
+        // (Quick Look renders documents it recognizes; unrecognized types
+        // fall back to the chip's document glyph).
+        let thumbnailData = await Self.fileThumbnailData(at: item.url)
         guard !Task.isCancelled else {
             store.recordAppEvent(
                 .attachmentPreparationFailed,
@@ -993,6 +1021,7 @@ struct TerminalComposerView: View {
             data,
             fileExtension: item.url.pathExtension.lowercased(),
             displayName: item.displayName,
+            thumbnailData: thumbnailData,
             forTerminalID: terminalID,
             ifSessionGeneration: sessionGeneration
         ) != nil else { return }
@@ -1001,6 +1030,24 @@ struct TerminalComposerView: View {
             correlationID: terminalID,
             count: data.count
         )
+    }
+
+    /// Render a small Quick Look thumbnail for a pasted file, or `nil` when
+    /// the system has no renderer for the type. `.thumbnail` only — the
+    /// generic icon representation is skipped so unrecognized types keep the
+    /// chip's own themed document glyph.
+    private static func fileThumbnailData(at url: URL) async -> Data? {
+        let request = QLThumbnailGenerator.Request(
+            fileAt: url,
+            size: CGSize(width: 80, height: 80),
+            scale: 3,
+            representationTypes: .thumbnail
+        )
+        guard let representation = try? await QLThumbnailGenerator.shared
+            .generateBestRepresentation(for: request) else {
+            return nil
+        }
+        return representation.uiImage.pngData()
     }
 
     /// Read the materialized file's bytes off the main actor so a multi-MB
@@ -1201,9 +1248,7 @@ private struct AttachmentChip: View {
 
     private var filePill: some View {
         HStack(spacing: 8) {
-            Image(systemName: "doc.fill")
-                .font(.system(size: 20))
-                .foregroundStyle(theme.terminalForegroundColor.opacity(0.55))
+            fileThumbnailOrGlyph
             VStack(alignment: .leading, spacing: 2) {
                 Text(attachment.displayName ?? fileFallbackName)
                     .font(.caption.weight(.medium))
@@ -1215,13 +1260,31 @@ private struct AttachmentChip: View {
                     .foregroundStyle(theme.terminalForegroundColor.opacity(0.6))
             }
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 8)
         .frame(height: side)
         .frame(maxWidth: 190)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(theme.terminalForegroundColor.opacity(0.08))
         )
+    }
+
+    /// Inline document preview when Quick Look rendered one at stage time,
+    /// else the themed document glyph.
+    @ViewBuilder
+    private var fileThumbnailOrGlyph: some View {
+        if let thumbnail {
+            Image(uiImage: thumbnail)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 40, height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        } else {
+            Image(systemName: "doc.fill")
+                .font(.system(size: 20))
+                .foregroundStyle(theme.terminalForegroundColor.opacity(0.55))
+                .frame(width: 40, height: 40)
+        }
     }
 
     private var fileFallbackName: String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -994,7 +994,14 @@ struct TerminalComposerView: View {
                 )
                 return
             }
-            for item in items {
+            // The store re-enforces the caps atomically; bounding the batch
+            // here just avoids materialize/encode work for items that cannot
+            // land once the count cap binds.
+            let remaining = max(
+                0,
+                Self.maxAttachmentCount - pendingAttachments.count
+            )
+            for item in items.prefix(remaining) {
                 guard !Task.isCancelled else { break }
                 switch item.kind {
                 case .image:
@@ -1002,6 +1009,9 @@ struct TerminalComposerView: View {
                 case .file:
                     await stagePastedFile(item, sessionGeneration: sessionGeneration)
                 }
+            }
+            if items.count > remaining {
+                attachmentAlertMessage = Self.attachmentLimitMessage
             }
             // New chips grow the band; ask the host to re-measure.
             requestHeightRemeasure()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -572,23 +572,37 @@ struct TerminalComposerView: View {
 
     /// The attach control offers the same sources as the task composer's
     /// menu: Photo Library, Choose Files (when the paired Mac supports file
-    /// uploads), and Paste. Built exactly like the task composer's "+"
-    /// button — a plain Menu whose label is a flat circle, NOT a
-    /// glass-effect view — because that is the shape iOS 26 morphs into the
-    /// presented menu; a glassEffect label is composited separately and the
-    /// system falls back to a detached overlay.
+    /// uploads), and Paste. On iOS 26 the control is the SYSTEM glass button
+    /// style: the glass look stays, and because the system owns the glass it
+    /// can morph the control into the presented menu — a custom
+    /// `glassEffect` label is composited separately and only overlays.
+    /// Earlier OSes keep the shared material circle with a plain
+    /// presentation.
+    @ViewBuilder
     private var attachMenuButton: some View {
-        attachMenu {
-            Image(systemName: "paperclip")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(
-                    store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+        if #available(iOS 26.0, *) {
+            attachMenu {
+                Image(systemName: "paperclip")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(
+                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                    )
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.glass)
+            .buttonBorderShape(.circle)
+        } else {
+            attachMenu {
+                MobileComposerIconLabel(
+                    systemImage: "paperclip",
+                    foregroundStyle: AnyShapeStyle(
+                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                    ),
+                    size: controlHeight
                 )
-                .frame(width: controlHeight, height: controlHeight)
-                .background(Color.primary.opacity(0.07), in: Circle())
-                .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
     }
 
     private func attachMenu(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -63,6 +63,12 @@ struct TerminalComposerView: View {
     /// Failure feedback for a paste that could not stage (unreadable item,
     /// over-cap file, host without file-attachment support).
     @State private var attachmentAlertMessage: String?
+    /// Whether the attach control is expanded into its in-composer options
+    /// card (iOS 26 only; earlier OSes use a system Menu).
+    @State private var isAttachMenuExpanded = false
+    /// Shared glass identity between the attach circle and its expanded
+    /// options card, so the Liquid Glass morphs one into the other.
+    @Namespace private var attachMenuNamespace
     /// The staged attachment currently open in the Quick Look preview sheet
     /// (a chip's primary tap), mirroring the task composer's chip behavior.
     @State private var previewedAttachment: MobilePendingAttachment?
@@ -220,6 +226,11 @@ struct TerminalComposerView: View {
         .onChange(of: pendingAttachments.map(\.id), initial: true) { _, _ in
             warmThumbnailCache()
         }
+        // The expanded attach card is band content, so its appearance and
+        // collapse change the composer's ideal height.
+        .onChange(of: isAttachMenuExpanded) { _, _ in
+            requestHeightRemeasure()
+        }
         .onChange(of: sendStatus) { _, _ in
             requestHeightRemeasure()
         }
@@ -263,6 +274,11 @@ struct TerminalComposerView: View {
             dictation.cancel()
         }
         .onChange(of: isFieldFocused) { _, focused in
+            // Typing into the field dismisses the expanded attach card the
+            // way tapping elsewhere dismisses a menu.
+            if focused {
+                setAttachMenuExpanded(false)
+            }
             inputFocusChanged(focused)
             // Mirror the field's focus into the store so a terminal switch knows
             // whether the user was mid-compose (and should keep the keyboard up
@@ -327,6 +343,15 @@ struct TerminalComposerView: View {
             // keeps its compact one-line height (and the host's measurement).
             if !pendingAttachments.isEmpty {
                 attachmentChipRow
+            }
+
+            // The attach circle's expanded options card. Real content (not an
+            // overlay) so the band's height measurement includes it — the
+            // composer band grows to host it, exactly like the chip row.
+            if isAttachMenuExpanded {
+                if #available(iOS 26.0, *) {
+                    attachOptionsCard
+                }
             }
 
             if sendStatus == .failed {
@@ -572,42 +597,126 @@ struct TerminalComposerView: View {
 
     /// The attach control offers the same sources as the task composer's
     /// menu: Photo Library, Choose Files (when the paired Mac supports file
-    /// uploads), and Paste. On iOS 26 the control is the SYSTEM glass button
-    /// style: the glass look stays, and because the system owns the glass it
-    /// can morph the control into the presented menu — a custom
-    /// `glassEffect` label is composited separately and only overlays.
-    /// Earlier OSes keep the shared material circle with a plain
-    /// presentation.
+    /// uploads), and Paste. On iOS 26 the circle MORPHS into an in-composer
+    /// options card: circle and card share a `glassEffectID` inside the
+    /// composer's `GlassEffectContainer`, so swapping which one is present
+    /// animates the Liquid Glass from one shape into the other (a system
+    /// `Menu` presents in a detached overlay layer the glass cannot morph
+    /// into). Earlier OSes keep a system Menu.
     @ViewBuilder
     private var attachMenuButton: some View {
         if #available(iOS 26.0, *) {
-            attachMenu {
-                Image(systemName: "paperclip")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(
-                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                    )
-                    .frame(width: 22, height: 22)
+            if isAttachMenuExpanded {
+                // The circle's glass is morphing into the card above; hold
+                // the slot so the mic and field do not shift while expanded.
+                Color.clear
+                    .frame(width: controlHeight, height: controlHeight)
+            } else {
+                Button {
+                    setAttachMenuExpanded(true)
+                } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(
+                            store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                        )
+                        .frame(width: controlHeight, height: controlHeight)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .glassEffect(.regular.interactive(), in: .circle)
+                .glassEffectID(Self.attachGlassID, in: attachMenuNamespace)
+                .accessibilityIdentifier("MobileComposerAttach")
+                .accessibilityLabel(L10n.string(
+                    "mobile.composer.attach.add",
+                    defaultValue: "Add Attachment"
+                ))
             }
-            .buttonStyle(.glass)
-            .buttonBorderShape(.circle)
         } else {
-            attachMenu {
-                MobileComposerIconLabel(
-                    systemImage: "paperclip",
-                    foregroundStyle: AnyShapeStyle(
-                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                    ),
-                    size: controlHeight
-                )
-            }
-            .buttonStyle(.plain)
+            legacyAttachMenu
         }
     }
 
-    private func attachMenu(
-        @ViewBuilder label: () -> some View
+    /// The expanded options the attach circle morphs into.
+    @available(iOS 26.0, *)
+    private var attachOptionsCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            attachOption(
+                systemImage: "photo.on.rectangle",
+                title: L10n.string(
+                    "mobile.composer.attach.photoLibrary",
+                    defaultValue: "Photo Library"
+                )
+            ) {
+                presentPhotoPicker()
+            }
+            if store.supportsComposerFileAttachments {
+                attachOption(
+                    systemImage: "folder",
+                    title: L10n.string(
+                        "mobile.composer.attach.chooseFiles",
+                        defaultValue: "Choose Files"
+                    )
+                ) {
+                    presentFileImporter()
+                }
+            }
+            attachOption(
+                systemImage: "doc.on.clipboard",
+                title: L10n.string(
+                    "mobile.composer.attach.paste",
+                    defaultValue: "Paste"
+                )
+            ) {
+                _ = pasteComposerAttachments()
+            }
+        }
+        .padding(.vertical, 6)
+        .frame(width: 250, alignment: .leading)
+        .glassEffect(
+            .regular,
+            in: RoundedRectangle(cornerRadius: 24, style: .continuous)
+        )
+        .glassEffectID(Self.attachGlassID, in: attachMenuNamespace)
+        .accessibilityIdentifier("MobileComposerAttachOptions")
+    }
+
+    private func attachOption(
+        systemImage: String,
+        title: String,
+        action: @escaping () -> Void
     ) -> some View {
+        Button {
+            setAttachMenuExpanded(false)
+            action()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .frame(width: 24)
+                Text(title)
+                Spacer(minLength: 0)
+            }
+            .font(.body)
+            .foregroundStyle(store.activeTerminalTheme.terminalForegroundColor)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Toggle the expanded card inside one animation so the shared-ID glass
+    /// morph and the band's height change ride the same transaction.
+    private func setAttachMenuExpanded(_ expanded: Bool) {
+        guard isAttachMenuExpanded != expanded else { return }
+        withAnimation(.smooth(duration: 0.35)) {
+            isAttachMenuExpanded = expanded
+        }
+    }
+
+    /// Pre-iOS-26 attach control: the shared material circle with a system
+    /// menu presentation (no glass to morph on those OSes).
+    private var legacyAttachMenu: some View {
         Menu {
             Button {
                 presentPhotoPicker()
@@ -645,14 +754,23 @@ struct TerminalComposerView: View {
                 )
             }
         } label: {
-            label()
+            MobileComposerIconLabel(
+                systemImage: "paperclip",
+                foregroundStyle: AnyShapeStyle(
+                    store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                ),
+                size: controlHeight
+            )
         }
+        .buttonStyle(.plain)
         .accessibilityIdentifier("MobileComposerAttach")
         .accessibilityLabel(L10n.string(
             "mobile.composer.attach.add",
             defaultValue: "Add Attachment"
         ))
     }
+
+    private static let attachGlassID = "composer-attach"
 
     /// Record the modal boundary before changing the PhotosPicker binding. The
     /// surface input session synchronously resigns its actual terminal/composer
@@ -785,6 +903,7 @@ struct TerminalComposerView: View {
     private func send() {
         // Allowed with empty text as long as an attachment is staged.
         guard canSend else { return }
+        setAttachMenuExpanded(false)
         // Hard-cancel dictation before sending, NOT the graceful async stop. Every
         // partial already wrote into `terminalInputText`, so the field holds the
         // latest spoken words at send time. `cancel()` immediately tears down the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -572,35 +572,23 @@ struct TerminalComposerView: View {
 
     /// The attach control offers the same sources as the task composer's
     /// menu: Photo Library, Choose Files (when the paired Mac supports file
-    /// uploads), and Paste. On iOS 26 the control is a system GLASS button —
-    /// not a custom glass background — because that is what lets the system
-    /// morph the button into the presented menu; earlier OSes keep the shared
-    /// material circle with a plain menu presentation.
-    @ViewBuilder
+    /// uploads), and Paste. Built exactly like the task composer's "+"
+    /// button — a plain Menu whose label is a flat circle, NOT a
+    /// glass-effect view — because that is the shape iOS 26 morphs into the
+    /// presented menu; a glassEffect label is composited separately and the
+    /// system falls back to a detached overlay.
     private var attachMenuButton: some View {
-        if #available(iOS 26.0, *) {
-            attachMenu {
-                Image(systemName: "paperclip")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(
-                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                    )
-                    .frame(width: 22, height: 22)
-            }
-            .buttonStyle(.glass)
-            .buttonBorderShape(.circle)
-        } else {
-            attachMenu {
-                MobileComposerIconLabel(
-                    systemImage: "paperclip",
-                    foregroundStyle: AnyShapeStyle(
-                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                    ),
-                    size: controlHeight
+        attachMenu {
+            Image(systemName: "paperclip")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(
+                    store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
                 )
-            }
-            .buttonStyle(.plain)
+                .frame(width: controlHeight, height: controlHeight)
+                .background(Color.primary.opacity(0.07), in: Circle())
+                .contentShape(Circle())
         }
+        .buttonStyle(.plain)
     }
 
     private func attachMenu(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -63,12 +63,6 @@ struct TerminalComposerView: View {
     /// Failure feedback for a paste that could not stage (unreadable item,
     /// over-cap file, host without file-attachment support).
     @State private var attachmentAlertMessage: String?
-    /// Whether the attach control is expanded into its in-composer options
-    /// card (iOS 26 only; earlier OSes use a system Menu).
-    @State private var isAttachMenuExpanded = false
-    /// Shared glass identity between the attach circle and its expanded
-    /// options card, so the Liquid Glass morphs one into the other.
-    @Namespace private var attachMenuNamespace
     /// The staged attachment currently open in the Quick Look preview sheet
     /// (a chip's primary tap), mirroring the task composer's chip behavior.
     @State private var previewedAttachment: MobilePendingAttachment?
@@ -226,11 +220,6 @@ struct TerminalComposerView: View {
         .onChange(of: pendingAttachments.map(\.id), initial: true) { _, _ in
             warmThumbnailCache()
         }
-        // The expanded attach card is band content, so its appearance and
-        // collapse change the composer's ideal height.
-        .onChange(of: isAttachMenuExpanded) { _, _ in
-            requestHeightRemeasure()
-        }
         .onChange(of: sendStatus) { _, _ in
             requestHeightRemeasure()
         }
@@ -274,11 +263,6 @@ struct TerminalComposerView: View {
             dictation.cancel()
         }
         .onChange(of: isFieldFocused) { _, focused in
-            // Typing into the field dismisses the expanded attach card the
-            // way tapping elsewhere dismisses a menu.
-            if focused {
-                setAttachMenuExpanded(false)
-            }
             inputFocusChanged(focused)
             // Mirror the field's focus into the store so a terminal switch knows
             // whether the user was mid-compose (and should keep the keyboard up
@@ -343,15 +327,6 @@ struct TerminalComposerView: View {
             // keeps its compact one-line height (and the host's measurement).
             if !pendingAttachments.isEmpty {
                 attachmentChipRow
-            }
-
-            // The attach circle's expanded options card. Real content (not an
-            // overlay) so the band's height measurement includes it — the
-            // composer band grows to host it, exactly like the chip row.
-            if isAttachMenuExpanded {
-                if #available(iOS 26.0, *) {
-                    attachOptionsCard
-                }
             }
 
             if sendStatus == .failed {
@@ -597,126 +572,10 @@ struct TerminalComposerView: View {
 
     /// The attach control offers the same sources as the task composer's
     /// menu: Photo Library, Choose Files (when the paired Mac supports file
-    /// uploads), and Paste. On iOS 26 the circle MORPHS into an in-composer
-    /// options card: circle and card share a `glassEffectID` inside the
-    /// composer's `GlassEffectContainer`, so swapping which one is present
-    /// animates the Liquid Glass from one shape into the other (a system
-    /// `Menu` presents in a detached overlay layer the glass cannot morph
-    /// into). Earlier OSes keep a system Menu.
-    @ViewBuilder
+    /// uploads), and Paste — a native system Menu over the shared glass
+    /// circle. iOS 26.2+ morphs the presentation out of the control natively;
+    /// earlier OSes present it as a plain overlay.
     private var attachMenuButton: some View {
-        if #available(iOS 26.0, *) {
-            if isAttachMenuExpanded {
-                // The circle's glass is morphing into the card above; hold
-                // the slot so the mic and field do not shift while expanded.
-                Color.clear
-                    .frame(width: controlHeight, height: controlHeight)
-            } else {
-                Button {
-                    setAttachMenuExpanded(true)
-                } label: {
-                    Image(systemName: "paperclip")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(
-                            store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                        )
-                        .frame(width: controlHeight, height: controlHeight)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .glassEffect(.regular.interactive(), in: .circle)
-                .glassEffectID(Self.attachGlassID, in: attachMenuNamespace)
-                .accessibilityIdentifier("MobileComposerAttach")
-                .accessibilityLabel(L10n.string(
-                    "mobile.composer.attach.add",
-                    defaultValue: "Add Attachment"
-                ))
-            }
-        } else {
-            legacyAttachMenu
-        }
-    }
-
-    /// The expanded options the attach circle morphs into.
-    @available(iOS 26.0, *)
-    private var attachOptionsCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            attachOption(
-                systemImage: "photo.on.rectangle",
-                title: L10n.string(
-                    "mobile.composer.attach.photoLibrary",
-                    defaultValue: "Photo Library"
-                )
-            ) {
-                presentPhotoPicker()
-            }
-            if store.supportsComposerFileAttachments {
-                attachOption(
-                    systemImage: "folder",
-                    title: L10n.string(
-                        "mobile.composer.attach.chooseFiles",
-                        defaultValue: "Choose Files"
-                    )
-                ) {
-                    presentFileImporter()
-                }
-            }
-            attachOption(
-                systemImage: "doc.on.clipboard",
-                title: L10n.string(
-                    "mobile.composer.attach.paste",
-                    defaultValue: "Paste"
-                )
-            ) {
-                _ = pasteComposerAttachments()
-            }
-        }
-        .padding(.vertical, 6)
-        .frame(width: 250, alignment: .leading)
-        .glassEffect(
-            .regular,
-            in: RoundedRectangle(cornerRadius: 24, style: .continuous)
-        )
-        .glassEffectID(Self.attachGlassID, in: attachMenuNamespace)
-        .accessibilityIdentifier("MobileComposerAttachOptions")
-    }
-
-    private func attachOption(
-        systemImage: String,
-        title: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button {
-            setAttachMenuExpanded(false)
-            action()
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: systemImage)
-                    .frame(width: 24)
-                Text(title)
-                Spacer(minLength: 0)
-            }
-            .font(.body)
-            .foregroundStyle(store.activeTerminalTheme.terminalForegroundColor)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-
-    /// Toggle the expanded card inside one animation so the shared-ID glass
-    /// morph and the band's height change ride the same transaction.
-    private func setAttachMenuExpanded(_ expanded: Bool) {
-        guard isAttachMenuExpanded != expanded else { return }
-        withAnimation(.smooth(duration: 0.35)) {
-            isAttachMenuExpanded = expanded
-        }
-    }
-
-    /// Pre-iOS-26 attach control: the shared material circle with a system
-    /// menu presentation (no glass to morph on those OSes).
-    private var legacyAttachMenu: some View {
         Menu {
             Button {
                 presentPhotoPicker()
@@ -769,8 +628,6 @@ struct TerminalComposerView: View {
             defaultValue: "Add Attachment"
         ))
     }
-
-    private static let attachGlassID = "composer-attach"
 
     /// Record the modal boundary before changing the PhotosPicker binding. The
     /// surface input session synchronously resigns its actual terminal/composer
@@ -903,7 +760,6 @@ struct TerminalComposerView: View {
     private func send() {
         // Allowed with empty text as long as an attachment is staged.
         guard canSend else { return }
-        setAttachMenuExpanded(false)
         // Hard-cancel dictation before sending, NOT the graceful async stop. Every
         // partial already wrote into `terminalInputText`, so the field holds the
         // latest spoken words at send time. `cancel()` immediately tears down the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -344,60 +344,7 @@ struct TerminalComposerView: View {
             }
 
             HStack(alignment: .bottom, spacing: 8) {
-                // The attach button offers the same sources as the task
-                // composer's menu: Photo Library, Choose Files (when the
-                // paired Mac supports file uploads), and Paste.
-                Menu {
-                    Button {
-                        presentPhotoPicker()
-                    } label: {
-                        Label(
-                            L10n.string(
-                                "mobile.composer.attach.photoLibrary",
-                                defaultValue: "Photo Library"
-                            ),
-                            systemImage: "photo.on.rectangle"
-                        )
-                    }
-                    if store.supportsComposerFileAttachments {
-                        Button {
-                            presentFileImporter()
-                        } label: {
-                            Label(
-                                L10n.string(
-                                    "mobile.composer.attach.chooseFiles",
-                                    defaultValue: "Choose Files"
-                                ),
-                                systemImage: "folder"
-                            )
-                        }
-                    }
-                    Button {
-                        _ = pasteComposerAttachments()
-                    } label: {
-                        Label(
-                            L10n.string(
-                                "mobile.composer.attach.paste",
-                                defaultValue: "Paste"
-                            ),
-                            systemImage: "doc.on.clipboard"
-                        )
-                    }
-                } label: {
-                    MobileComposerIconLabel(
-                        systemImage: "paperclip",
-                        foregroundStyle: AnyShapeStyle(
-                            store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                        ),
-                        size: controlHeight
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("MobileComposerAttach")
-                .accessibilityLabel(L10n.string(
-                    "mobile.composer.attach.add",
-                    defaultValue: "Add Attachment"
-                ))
+                attachMenuButton
 
                 micButton
 
@@ -621,6 +568,88 @@ struct TerminalComposerView: View {
         ) {
             toggleDictation()
         }
+    }
+
+    /// The attach control offers the same sources as the task composer's
+    /// menu: Photo Library, Choose Files (when the paired Mac supports file
+    /// uploads), and Paste. On iOS 26 the control is a system GLASS button —
+    /// not a custom glass background — because that is what lets the system
+    /// morph the button into the presented menu; earlier OSes keep the shared
+    /// material circle with a plain menu presentation.
+    @ViewBuilder
+    private var attachMenuButton: some View {
+        if #available(iOS 26.0, *) {
+            attachMenu {
+                Image(systemName: "paperclip")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(
+                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                    )
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.glass)
+            .buttonBorderShape(.circle)
+        } else {
+            attachMenu {
+                MobileComposerIconLabel(
+                    systemImage: "paperclip",
+                    foregroundStyle: AnyShapeStyle(
+                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                    ),
+                    size: controlHeight
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func attachMenu(
+        @ViewBuilder label: () -> some View
+    ) -> some View {
+        Menu {
+            Button {
+                presentPhotoPicker()
+            } label: {
+                Label(
+                    L10n.string(
+                        "mobile.composer.attach.photoLibrary",
+                        defaultValue: "Photo Library"
+                    ),
+                    systemImage: "photo.on.rectangle"
+                )
+            }
+            if store.supportsComposerFileAttachments {
+                Button {
+                    presentFileImporter()
+                } label: {
+                    Label(
+                        L10n.string(
+                            "mobile.composer.attach.chooseFiles",
+                            defaultValue: "Choose Files"
+                        ),
+                        systemImage: "folder"
+                    )
+                }
+            }
+            Button {
+                _ = pasteComposerAttachments()
+            } label: {
+                Label(
+                    L10n.string(
+                        "mobile.composer.attach.paste",
+                        defaultValue: "Paste"
+                    ),
+                    systemImage: "doc.on.clipboard"
+                )
+            }
+        } label: {
+            label()
+        }
+        .accessibilityIdentifier("MobileComposerAttach")
+        .accessibilityLabel(L10n.string(
+            "mobile.composer.attach.add",
+            defaultValue: "Add Attachment"
+        ))
     }
 
     /// Record the modal boundary before changing the PhotosPicker binding. The

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -69,8 +69,10 @@ struct TerminalComposerView: View {
     /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
     /// each batch is encoded and staged so re-picking the same image fires again.
     @State private var pickerSelection: [PhotosPickerItem] = []
-    /// Drives the photo picker's presentation from the attach button.
+    /// Drives the photo picker's presentation from the attach menu.
     @State private var isPickerPresented = false
+    /// Drives the Files importer's presentation from the attach menu.
+    @State private var isFileImporterPresented = false
     /// Small downsampled thumbnails keyed by attachment id, built ONCE when each
     /// attachment is staged. The chip row renders these instead of decoding the
     /// full multi-MB `Data` from inside the view body on every composer
@@ -342,17 +344,60 @@ struct TerminalComposerView: View {
             }
 
             HStack(alignment: .bottom, spacing: 8) {
-                MobileComposerIconButton(
-                    systemImage: "paperclip",
-                    foregroundStyle: AnyShapeStyle(
-                        store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
-                    ),
-                    size: controlHeight,
-                    accessibilityIdentifier: "MobileComposerAttach",
-                    accessibilityLabel: L10n.string("mobile.composer.attach", defaultValue: "Attach Photo")
-                ) {
-                    presentPhotoPicker()
+                // The attach button offers the same sources as the task
+                // composer's menu: Photo Library, Choose Files (when the
+                // paired Mac supports file uploads), and Paste.
+                Menu {
+                    Button {
+                        presentPhotoPicker()
+                    } label: {
+                        Label(
+                            L10n.string(
+                                "mobile.composer.attach.photoLibrary",
+                                defaultValue: "Photo Library"
+                            ),
+                            systemImage: "photo.on.rectangle"
+                        )
+                    }
+                    if store.supportsComposerFileAttachments {
+                        Button {
+                            presentFileImporter()
+                        } label: {
+                            Label(
+                                L10n.string(
+                                    "mobile.composer.attach.chooseFiles",
+                                    defaultValue: "Choose Files"
+                                ),
+                                systemImage: "folder"
+                            )
+                        }
+                    }
+                    Button {
+                        _ = pasteComposerAttachments()
+                    } label: {
+                        Label(
+                            L10n.string(
+                                "mobile.composer.attach.paste",
+                                defaultValue: "Paste"
+                            ),
+                            systemImage: "doc.on.clipboard"
+                        )
+                    }
+                } label: {
+                    MobileComposerIconLabel(
+                        systemImage: "paperclip",
+                        foregroundStyle: AnyShapeStyle(
+                            store.activeTerminalTheme.terminalChromeForegroundColor.opacity(0.78)
+                        ),
+                        size: controlHeight
+                    )
                 }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("MobileComposerAttach")
+                .accessibilityLabel(L10n.string(
+                    "mobile.composer.attach.add",
+                    defaultValue: "Add Attachment"
+                ))
 
                 micButton
 
@@ -443,6 +488,21 @@ struct TerminalComposerView: View {
                     .photoPickerDismissed,
                     correlationID: terminalID
                 )
+                photoPickerDidDismiss()
+            }
+        }
+        .fileImporter(
+            isPresented: $isFileImporterPresented,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true,
+            onCompletion: stagePickedFiles
+        )
+        .onChange(of: isFileImporterPresented) { _, isPresented in
+            // The Files importer is a modal over the composer like the photo
+            // picker; route the same responder boundary signals.
+            if isPresented {
+                photoPickerDidPresent()
+            } else {
                 photoPickerDidDismiss()
             }
         }
@@ -570,6 +630,59 @@ struct TerminalComposerView: View {
         store.recordAppEvent(.photoPickerOpened, correlationID: terminalID)
         photoPickerWillPresent()
         isPickerPresented = true
+    }
+
+    /// Same modal boundary for the Files importer behind the attach menu's
+    /// Choose Files item.
+    private func presentFileImporter() {
+        guard pendingAttachments.count < Self.maxAttachmentCount else {
+            attachmentAlertMessage = Self.attachmentLimitMessage
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .attachmentCountLimitReached
+            )
+            return
+        }
+        store.recordAppEvent(.taskAttachmentPickerOpened, correlationID: terminalID)
+        photoPickerWillPresent()
+        isFileImporterPresented = true
+    }
+
+    /// Stage files picked from the Files importer through the same flow as
+    /// pasted files: each security-scoped URL is copied into app-owned temp
+    /// storage, thumbnailed, size-gated, and staged as a pending FILE
+    /// attachment that uploads at send time.
+    private func stagePickedFiles(_ result: Result<[URL], any Error>) {
+        guard case .success(let urls) = result else {
+            attachmentAlertMessage = Self.attachmentUnreadableMessage
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .permissionDenied
+            )
+            return
+        }
+        let sessionGeneration = store.currentSessionGeneration
+        stagingTask.task?.cancel()
+        stagingTask.task = Task { @MainActor in
+            let reader = MobilePasteboardReader()
+            for url in urls {
+                guard !Task.isCancelled else { break }
+                guard let item = await reader.materializePickedFile(at: url) else {
+                    store.recordAppEvent(
+                        .attachmentPreparationFailed,
+                        correlationID: terminalID,
+                        failure: .unknown
+                    )
+                    attachmentAlertMessage = Self.attachmentUnreadableMessage
+                    continue
+                }
+                await stagePastedFile(item, sessionGeneration: sessionGeneration)
+                reader.cleanUp([item])
+            }
+            requestHeightRemeasure()
+        }
     }
 
     /// Bridge the support package's fixed dictation vocabulary into the app-wide

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -53,7 +53,15 @@ struct TerminalComposerView: View {
     let photoPickerWillPresent: () -> Void
     let photoPickerDidPresent: () -> Void
     let photoPickerDidDismiss: () -> Void
-    @FocusState private var isFieldFocused: Bool
+    /// Mirror of the UIKit editor's first-responder state, written by the
+    /// editor's coordinator on begin/end editing. Replaces the `@FocusState`
+    /// the SwiftUI `TextField` used; programmatic focus goes through
+    /// ``requestInputFocus`` (the surface input-session owner) instead of this
+    /// value.
+    @State private var isFieldFocused = false
+    /// Failure feedback for a paste that could not stage (unreadable item,
+    /// over-cap file, host without file-attachment support).
+    @State private var attachmentAlertMessage: String?
     /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
     /// each batch is encoded and staged so re-picking the same image fires again.
     @State private var pickerSelection: [PhotosPickerItem] = []
@@ -170,6 +178,10 @@ struct TerminalComposerView: View {
     /// file size, so this is a generous multiple of the 8 MB per-image cap rather
     /// than the cap itself; whatever passes is still downsampled by ImageIO.
     private static let maxRawInputBytes = MobileImageAttachmentPreparer.maximumRawInputBytes
+
+    /// Per-file cap for one pasted FILE attachment, mirrored from the store
+    /// (which re-enforces it atomically at add time).
+    private static let maxFileAttachmentBytes = CMUXMobileShellStore.maxPendingAttachmentFileBytes
 
     var body: some View {
         composerSurface
@@ -337,44 +349,44 @@ struct TerminalComposerView: View {
                 // rendered through the same support component as GUI chat. `.bottom`
                 // alignment pins the button to the field's last line as it grows.
                 MobileComposerFieldContainer(minHeight: composerFieldMinHeight) {
-                    TextField(
-                        L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
+                    // A UIKit-backed editor with the exact TextField(axis:
+                    // .vertical).lineLimit(1...14) geometry, swapped in so the
+                    // system Paste action can stage images/files as attachments
+                    // (SwiftUI's TextField has no paste hook on iOS). It grows
+                    // per line up to 14; the host reserves the height above the
+                    // always-visible toolbar, so the toolbar and keyboard never
+                    // move.
+                    TerminalComposerPromptEditor(
                         text: $store.terminalInputText,
-                        axis: .vertical
+                        isFocused: $isFieldFocused,
+                        placeholder: L10n.string(
+                            "mobile.composer.placeholder",
+                            defaultValue: "Message"
+                        ),
+                        textColor: UIColor(
+                            store.activeTerminalTheme.terminalForegroundColor
+                        ),
+                        // Lock the field while dictation owns the text
+                        // (`.listening` or `.stopping`). Every recognition
+                        // callback rewrites the field as base + transcript, so an
+                        // edit the user made mid-dictation would be silently
+                        // discarded by the next partial/final. Disabling input
+                        // until dictation settles to idle makes that edit
+                        // impossible rather than letting it be clobbered; the
+                        // field stays visible showing the live transcript.
+                        isDisabled: dictation.locksComposerField,
+                        pasteAttachments: pasteComposerAttachments
                     )
-                    // Opens at a single line and grows up to 14 lines so a long message has
-                    // room. Each added line grows this view, which the host reserves above the
-                    // always-visible toolbar; the toolbar and keyboard never move.
-                    .lineLimit(composerLineLimit)
-                    // Natural-language to an agent, so normal iOS text assistance
-                    // is on (autocorrect, sentence-case, spell check). The raw
-                    // terminal input field keeps these OFF; only the composer
-                    // enables them.
-                    .textInputAutocapitalization(.sentences)
-                    .autocorrectionDisabled(false)
-                    .focused($isFieldFocused)
                     .simultaneousGesture(
                         TapGesture().onEnded {
                             guard !dictation.locksComposerField else { return }
                             requestInputFocus()
                         }
                     )
-                    // Lock the field while dictation owns the text (`.listening`
-                    // or `.stopping`). Every recognition callback rewrites the
-                    // field as base + transcript, so an edit the user made
-                    // mid-dictation would be silently discarded by the next
-                    // partial/final. Disabling input until dictation settles to
-                    // idle makes that edit impossible rather than letting it be
-                    // clobbered. The field stays visible showing the live
-                    // transcript; the mic toggle and send stay live (send
-                    // hard-cancels dictation -> idle, re-enabling the field).
-                    .disabled(dictation.locksComposerField)
-                    .foregroundStyle(store.activeTerminalTheme.terminalForegroundColor)
                     // 6pt container padding + 3pt here keeps the text's 9pt inset
                     // from the round-7 layout, and bottom-aligns the single-line text
                     // with the inline button's circle.
                     .padding(.vertical, 3)
-                    .accessibilityIdentifier("MobileComposerField")
 
                 } trailing: {
                     Button {
@@ -422,6 +434,26 @@ struct TerminalComposerView: View {
                 )
                 photoPickerDidDismiss()
             }
+        }
+        .alert(
+            L10n.string(
+                "mobile.composer.attachment.alert.title",
+                defaultValue: "Couldn’t Add Attachment"
+            ),
+            isPresented: Binding(
+                get: { attachmentAlertMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        attachmentAlertMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button(L10n.string("mobile.common.ok", defaultValue: "OK")) {
+                attachmentAlertMessage = nil
+            }
+        } message: {
+            Text(attachmentAlertMessage ?? "")
         }
     }
 
@@ -551,6 +583,7 @@ struct TerminalComposerView: View {
             HStack(spacing: 8) {
                 ForEach(pendingAttachments) { attachment in
                     AttachmentChip(
+                        attachment: attachment,
                         thumbnail: thumbnailCache.image(for: attachment.id),
                         theme: store.activeTerminalTheme
                     ) {
@@ -580,7 +613,9 @@ struct TerminalComposerView: View {
         // an idle controller is a no-op, so a send without active dictation is
         // unchanged.
         dictation.cancel()
-        isFieldFocused = true
+        // Keep the keyboard up across the send through the surface's
+        // input-session owner (the sanctioned focus path for the UIKit editor).
+        requestInputFocus()
         Task { @MainActor in
             // Sends staged images first (in order), then the text. Acknowledged
             // attachments are removed from the staged set; a failed send keeps the
@@ -755,6 +790,244 @@ struct TerminalComposerView: View {
         }
     }
 
+    /// Stage the pasteboard's image/file content as pending attachments for
+    /// this terminal — the action behind the field's system Paste. Images
+    /// encode exactly like picked photos and send through
+    /// `terminal.paste_image`; files stage as pending file attachments that
+    /// upload at send time and land in the message as shell-quoted Mac paths.
+    ///
+    /// - Returns: `true` when the paste was consumed as attachment content,
+    ///   `false` for text-only pasteboards so native text insertion proceeds.
+    private func pasteComposerAttachments() -> Bool {
+        let reader = MobilePasteboardReader()
+        guard reader.hasAttachmentContent(in: .general) else { return false }
+        guard pendingAttachments.count < Self.maxAttachmentCount else {
+            attachmentAlertMessage = Self.attachmentLimitMessage
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .attachmentCountLimitReached
+            )
+            return true
+        }
+        // Captured before the awaits below for the same reasons as the picker
+        // path: a sign-out mid-materialization must not stage stale bytes.
+        let sessionGeneration = store.currentSessionGeneration
+        stagingTask.task?.cancel()
+        stagingTask.task = Task { @MainActor in
+            let items = await reader.materializeAttachments(from: .general)
+            defer { reader.cleanUp(items) }
+            guard !Task.isCancelled else {
+                store.recordAppEvent(
+                    .attachmentPreparationFailed,
+                    correlationID: terminalID,
+                    failure: .cancelled
+                )
+                return
+            }
+            guard !items.isEmpty else {
+                attachmentAlertMessage = Self.attachmentUnreadableMessage
+                store.recordAppEvent(
+                    .attachmentPreparationFailed,
+                    correlationID: terminalID,
+                    failure: .unknown
+                )
+                return
+            }
+            for item in items {
+                guard !Task.isCancelled else { break }
+                switch item.kind {
+                case .image:
+                    await stagePastedImage(item, sessionGeneration: sessionGeneration)
+                case .file:
+                    await stagePastedFile(item, sessionGeneration: sessionGeneration)
+                }
+            }
+            // New chips grow the band; ask the host to re-measure.
+            requestHeightRemeasure()
+        }
+        return true
+    }
+
+    /// Encode one materialized pasted image the same way a picked photo is
+    /// encoded and stage it, mirroring the picker loop's gates and diagnostics.
+    private func stagePastedImage(
+        _ item: MobilePastedAttachment,
+        sessionGeneration: Int
+    ) async {
+        store.recordAppEvent(
+            .attachmentPreparationStarted,
+            correlationID: terminalID
+        )
+        if let fileSize = (try? FileManager.default.attributesOfItem(
+            atPath: item.url.path
+        )[.size]) as? Int,
+           fileSize > Self.maxRawInputBytes {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .payloadTooLarge,
+                count: fileSize
+            )
+            attachmentAlertMessage = Self.attachmentUnreadableMessage
+            return
+        }
+        guard let prepared = await MobileImageAttachmentPreparer()
+            .prepare(url: item.url) else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .unknown
+            )
+            if !Task.isCancelled {
+                attachmentAlertMessage = Self.attachmentUnreadableMessage
+            }
+            return
+        }
+        guard !Task.isCancelled else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .cancelled
+            )
+            return
+        }
+        guard let id = store.addPendingAttachment(
+            prepared.data,
+            format: prepared.format,
+            forTerminalID: terminalID,
+            ifSessionGeneration: sessionGeneration
+        ) else { return }
+        store.recordAppEvent(
+            .attachmentPreparationSucceeded,
+            correlationID: terminalID,
+            count: prepared.data.count
+        )
+        if let thumbnailData = prepared.thumbnailData,
+           let thumbnail = UIImage(data: thumbnailData) {
+            thumbnailCache.set(thumbnail, for: id)
+        }
+    }
+
+    /// Stage one materialized pasted file as a pending FILE attachment, gated
+    /// on the foreground Mac advertising the upload capability its send rides.
+    private func stagePastedFile(
+        _ item: MobilePastedAttachment,
+        sessionGeneration: Int
+    ) async {
+        store.recordAppEvent(
+            .attachmentPreparationStarted,
+            correlationID: terminalID
+        )
+        guard store.supportsComposerFileAttachments else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .unsupportedRoute
+            )
+            attachmentAlertMessage = Self.attachmentFilesUnsupportedMessage
+            return
+        }
+        guard let byteCount = try? item.url.resourceValues(
+            forKeys: [.fileSizeKey]
+        ).fileSize else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .unknown
+            )
+            attachmentAlertMessage = Self.attachmentUnreadableMessage
+            return
+        }
+        guard byteCount <= Self.maxFileAttachmentBytes else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .payloadTooLarge,
+                count: byteCount
+            )
+            attachmentAlertMessage = Self.attachmentFileTooLargeMessage
+            return
+        }
+        let data: Data
+        do {
+            data = try await readPastedFileData(at: item.url)
+        } catch {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: DiagnosticFailureKind.classify(error)
+            )
+            if !Task.isCancelled {
+                attachmentAlertMessage = Self.attachmentUnreadableMessage
+            }
+            return
+        }
+        guard !Task.isCancelled else {
+            store.recordAppEvent(
+                .attachmentPreparationFailed,
+                correlationID: terminalID,
+                failure: .cancelled
+            )
+            return
+        }
+        guard store.addPendingFileAttachment(
+            data,
+            fileExtension: item.url.pathExtension.lowercased(),
+            displayName: item.displayName,
+            forTerminalID: terminalID,
+            ifSessionGeneration: sessionGeneration
+        ) != nil else { return }
+        store.recordAppEvent(
+            .attachmentPreparationSucceeded,
+            correlationID: terminalID,
+            count: data.count
+        )
+    }
+
+    /// Read the materialized file's bytes off the main actor so a multi-MB
+    /// paste never stalls the composer.
+    private func readPastedFileData(at url: URL) async throws -> Data {
+        try await withThrowingTaskGroup(of: Data.self) { group in
+            group.addTask(priority: .utility) {
+                try Task.checkCancellation()
+                return try Data(contentsOf: url)
+            }
+            guard let data = try await group.next() else {
+                throw CancellationError()
+            }
+            return data
+        }
+    }
+
+    static var attachmentLimitMessage: String {
+        L10n.string(
+            "mobile.composer.attachment.limit",
+            defaultValue: "You can attach up to 10 items."
+        )
+    }
+
+    static var attachmentUnreadableMessage: String {
+        L10n.string(
+            "mobile.composer.attachment.unreadable",
+            defaultValue: "That item couldn’t be read."
+        )
+    }
+
+    static var attachmentFileTooLargeMessage: String {
+        L10n.string(
+            "mobile.composer.attachment.tooLarge",
+            defaultValue: "Choose a file smaller than 32 MB."
+        )
+    }
+
+    static var attachmentFilesUnsupportedMessage: String {
+        L10n.string(
+            "mobile.composer.attachment.unsupported",
+            defaultValue: "This Mac doesn’t support file attachments yet. Update cmux on the Mac."
+        )
+    }
+
 }
 
 /// A file-backed `Transferable` for loading a `PhotosPickerItem` as an on-disk
@@ -821,10 +1094,12 @@ final class AttachmentThumbnailCache {
     }
 }
 
-/// A removable thumbnail chip for one staged image attachment. Renders a
-/// pre-built, downsampled thumbnail (cached by the composer at stage time) so
-/// the view body never decodes the full encoded `Data` on a re-render.
+/// A removable chip for one staged attachment: images render a pre-built,
+/// downsampled thumbnail (cached by the composer at stage time, so the view
+/// body never decodes the full encoded `Data` on a re-render); files render a
+/// document glyph with the file name and size.
 private struct AttachmentChip: View {
+    let attachment: MobilePendingAttachment
     let thumbnail: UIImage?
     let theme: TerminalTheme
     let onRemove: () -> Void
@@ -833,8 +1108,7 @@ private struct AttachmentChip: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            thumbnailView
-                .frame(width: side, height: side)
+            chipContent
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -855,6 +1129,17 @@ private struct AttachmentChip: View {
     }
 
     @ViewBuilder
+    private var chipContent: some View {
+        switch attachment.kind {
+        case .image:
+            thumbnailView
+                .frame(width: side, height: side)
+        case .file:
+            filePill
+        }
+    }
+
+    @ViewBuilder
     private var thumbnailView: some View {
         if let thumbnail {
             Image(uiImage: thumbnail)
@@ -868,6 +1153,38 @@ private struct AttachmentChip: View {
                         .foregroundStyle(theme.terminalForegroundColor.opacity(0.5))
                 )
         }
+    }
+
+    private var filePill: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "doc.fill")
+                .font(.system(size: 20))
+                .foregroundStyle(theme.terminalForegroundColor.opacity(0.55))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(attachment.displayName ?? fileFallbackName)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(theme.terminalForegroundColor)
+                Text(Int64(attachment.data.count), format: .byteCount(style: .file))
+                    .font(.caption2)
+                    .foregroundStyle(theme.terminalForegroundColor.opacity(0.6))
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: side)
+        .frame(maxWidth: 190)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(theme.terminalForegroundColor.opacity(0.08))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(fileFallbackName)
+        .accessibilityValue(attachment.displayName ?? "")
+    }
+
+    private var fileFallbackName: String {
+        L10n.string("mobile.composer.attachment.file", defaultValue: "File attachment")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -1260,9 +1260,12 @@ private struct AttachmentChip: View {
                     .foregroundStyle(theme.terminalForegroundColor.opacity(0.6))
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.leading, 8)
+        // Reserve the top-right corner the remove button floats over, so a
+        // long (truncated) file name never runs underneath the ✕.
+        .padding(.trailing, 34)
         .frame(height: side)
-        .frame(maxWidth: 190)
+        .frame(maxWidth: 220)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(theme.terminalForegroundColor.opacity(0.08))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -62,6 +62,9 @@ struct TerminalComposerView: View {
     /// Failure feedback for a paste that could not stage (unreadable item,
     /// over-cap file, host without file-attachment support).
     @State private var attachmentAlertMessage: String?
+    /// The staged attachment currently open in the Quick Look preview sheet
+    /// (a chip's primary tap), mirroring the task composer's chip behavior.
+    @State private var previewedAttachment: MobilePendingAttachment?
     /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
     /// each batch is encoded and staged so re-picking the same image fires again.
     @State private var pickerSelection: [PhotosPickerItem] = []
@@ -455,6 +458,13 @@ struct TerminalComposerView: View {
         } message: {
             Text(attachmentAlertMessage ?? "")
         }
+        .sheet(
+            item: $previewedAttachment,
+            onDismiss: photoPickerDidDismiss
+        ) { attachment in
+            TerminalComposerAttachmentPreviewSheet(attachment: attachment)
+                .onAppear(perform: photoPickerDidPresent)
+        }
     }
 
     @ViewBuilder
@@ -585,12 +595,20 @@ struct TerminalComposerView: View {
                     AttachmentChip(
                         attachment: attachment,
                         thumbnail: thumbnailCache.image(for: attachment.id),
-                        theme: store.activeTerminalTheme
-                    ) {
-                        store.removePendingAttachment(id: attachment.id, forTerminalID: terminalID)
-                        thumbnailCache.remove(attachment.id)
-                        requestHeightRemeasure()
-                    }
+                        theme: store.activeTerminalTheme,
+                        onPreview: {
+                            // The preview sheet is a modal over the composer;
+                            // route the same responder boundary the photo
+                            // picker uses so the keyboard hands off cleanly.
+                            photoPickerWillPresent()
+                            previewedAttachment = attachment
+                        },
+                        onRemove: {
+                            store.removePendingAttachment(id: attachment.id, forTerminalID: terminalID)
+                            thumbnailCache.remove(attachment.id)
+                            requestHeightRemeasure()
+                        }
+                    )
                 }
             }
             .padding(.leading, controlHeight + 8)
@@ -1094,26 +1112,45 @@ final class AttachmentThumbnailCache {
     }
 }
 
-/// A removable chip for one staged attachment: images render a pre-built,
-/// downsampled thumbnail (cached by the composer at stage time, so the view
-/// body never decodes the full encoded `Data` on a re-render); files render a
-/// document glyph with the file name and size.
+/// A staged-attachment chip: images render a pre-built, downsampled thumbnail
+/// (cached by the composer at stage time, so the view body never decodes the
+/// full encoded `Data` on a re-render); files render a document glyph with the
+/// file name and size. The primary tap previews the staged bytes (mirroring
+/// the task composer's chips); removal remains a separate corner action.
 private struct AttachmentChip: View {
     let attachment: MobilePendingAttachment
     let thumbnail: UIImage?
     let theme: TerminalTheme
+    let onPreview: () -> Void
     let onRemove: () -> Void
 
     private let side: CGFloat = 56
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            chipContent
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .strokeBorder(theme.terminalForegroundColor.opacity(0.15), lineWidth: 1)
-                )
+            Button(action: onPreview) {
+                chipContent
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .strokeBorder(theme.terminalForegroundColor.opacity(0.15), lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilityName)
+            .accessibilityHint(L10n.string(
+                "mobile.composer.attachment.preview",
+                defaultValue: "Preview Attachment"
+            ))
+            .accessibilityIdentifier(
+                "MobileComposerAttachmentPreview-\(attachment.id.uuidString)"
+            )
+            .accessibilityAction(named: L10n.string(
+                "mobile.composer.attachment.remove",
+                defaultValue: "Remove Attachment"
+            )) {
+                onRemove()
+            }
 
             Button(action: onRemove) {
                 Image(systemName: "xmark.circle.fill")
@@ -1126,6 +1163,13 @@ private struct AttachmentChip: View {
             .accessibilityIdentifier("MobileComposerAttachmentRemove")
             .accessibilityLabel(L10n.string("mobile.composer.attachment.remove", defaultValue: "Remove Attachment"))
         }
+    }
+
+    private var accessibilityName: String {
+        attachment.displayName ?? L10n.string(
+            "mobile.composer.attachment.image",
+            defaultValue: "Image attachment"
+        )
     }
 
     @ViewBuilder
@@ -1178,9 +1222,6 @@ private struct AttachmentChip: View {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(theme.terminalForegroundColor.opacity(0.08))
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(fileFallbackName)
-        .accessibilityValue(attachment.displayName ?? "")
     }
 
     private var fileFallbackName: String {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1871,6 +1871,27 @@
         }
       }
     },
+    "mobile.composer.attachment.alert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn’t Add Attachment" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "添付ファイルを追加できませんでした" } }
+      }
+    },
+    "mobile.composer.attachment.file": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "File attachment" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ファイル添付" } }
+      }
+    },
+    "mobile.composer.attachment.limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "You can attach up to 10 items." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "添付できるのは最大10個までです。" } }
+      }
+    },
     "mobile.composer.attachment.remove": {
       "extractionState": "manual",
       "localizations": {
@@ -1886,6 +1907,27 @@
             "value": "添付を削除"
           }
         }
+      }
+    },
+    "mobile.composer.attachment.tooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Choose a file smaller than 32 MB." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "32 MB未満のファイルを選択してください。" } }
+      }
+    },
+    "mobile.composer.attachment.unreadable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "That item couldn’t be read." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "その項目を読み込めませんでした。" } }
+      }
+    },
+    "mobile.composer.attachment.unsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This Mac doesn’t support file attachments yet. Update cmux on the Mac." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このMacはファイル添付にまだ対応していません。Macのcmuxをアップデートしてください。" } }
       }
     },
     "mobile.composer.close": {
@@ -10817,6 +10859,13 @@
       "localizations": {
         "en": { "stringUnit": { "state": "translated", "value": "Task attachments can use up to 64 MB in total." } },
         "ja": { "stringUnit": { "state": "translated", "value": "タスクの添付ファイルは合計64 MBまでです。" } }
+      }
+    },
+    "mobile.taskComposer.attachments.paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Paste" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ペースト" } }
       }
     },
     "mobile.taskComposer.attachments.photoLibrary": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1871,6 +1871,34 @@
         }
       }
     },
+    "mobile.composer.attach.add": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Add Attachment" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "添付ファイルを追加" } }
+      }
+    },
+    "mobile.composer.attach.chooseFiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Choose Files" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ファイルを選択" } }
+      }
+    },
+    "mobile.composer.attach.paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Paste" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ペースト" } }
+      }
+    },
+    "mobile.composer.attach.photoLibrary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Photo Library" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真ライブラリ" } }
+      }
+    },
     "mobile.composer.attachment.alert.title": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1885,6 +1885,13 @@
         "ja": { "stringUnit": { "state": "translated", "value": "ファイル添付" } }
       }
     },
+    "mobile.composer.attachment.image": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Image attachment" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像添付" } }
+      }
+    },
     "mobile.composer.attachment.limit": {
       "extractionState": "manual",
       "localizations": {
@@ -1907,6 +1914,20 @@
             "value": "添付を削除"
           }
         }
+      }
+    },
+    "mobile.composer.attachment.preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Preview Attachment" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "添付をプレビュー" } }
+      }
+    },
+    "mobile.composer.attachment.previewFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This attachment couldn’t be previewed." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "この添付はプレビューできませんでした。" } }
       }
     },
     "mobile.composer.attachment.tooLarge": {

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,9 +1,0 @@
-<!-- BEGIN:nextjs-agent-rules -->
-
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
-
-This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
-
-<!-- END:nextjs-agent-rules -->

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Pasting into the Task Composer prompt or the terminal composer previously did nothing for images and files. Both composers now stage pasted content as attachment chips through one shared paste path.

A fresh implementation of what https://github.com/manaflow-ai/cmux/pull/10181 attempted, designed around that PR's unresolved review findings (capability-gate bypass, text paste consumed at the attachment limit, staging tasks outliving cancellation). It supersedes #10181 and deliberately drops that PR's out-of-scope artifact Copy File and chat-composer changes.

**Shared layer.** `MobilePasteInterceptingTextView` overrides `canPerformAction`/`paste(_:)` so every paste entry point (edit menu, hardware Cmd+V, keyboard paste key) routes through one hook; the `canPerformAction` probe reads only pasteboard metadata, so it cannot trigger the iOS paste privacy prompt. `MobilePasteboardReader` classifies items (images, file URLs; plain text and web URLs fall through to native paste) and materializes each through its `NSItemProvider` inside the load completion, preserving Files.app names in app-owned temp wrappers.

**Task Composer.** Pasted items feed the existing stager → chips → chunked-upload pipeline, so previews, caps, and `CMUX_TASK_ATTACHMENTS` referencing come free. The paste action is gated on the exact `showsAttachmentButton` condition (plain-shell templates and Macs without `task.attachments.v1` fall back to native paste), classification happens before the count gate so a full attachment list never swallows a text paste, and staging batches clear their shared task handle generation-checked so a cancelled batch finishing late cannot re-enable submit mid-staging (same fix applied to the photo/file picker batches). The attachment menu gains a Paste item.

**Terminal composer.** The message field's SwiftUI `TextField` becomes a UIKit-backed `TerminalComposerPromptEditor` (SwiftUI offers no paste hook on iOS) reproducing the `TextField(axis: .vertical).lineLimit(1...14)` geometry: zero text-container insets, `sizeThatFits` clamped to 1–14 lines, scrolling only past the cap. `MobilePendingAttachment` gains a `.file` kind staged through the same validated store path with a 32 MB per-file cap. On send, files upload through the existing chunked `mobile.task.attachment.upload` verb to `~/.cache/cmux/task-attachments/...` and the returned paths are prepended shell-quoted (`'…'` with `'\''` escapes) ahead of the message; file chips leave the staged set only after the text send acks, so a failed upload or send keeps chips and text for retry. Image paste keeps the existing `terminal.paste_image` inline transport. File chips render a document glyph with name and size; programmatic send focus now routes through the surface input-session owner (`requestInputFocus`) instead of `@FocusState`.

No Mac-side changes: the upload verb, capability announcement, and attachment store already exist on `main`.

**Tests** (all green locally): `ComposerFileAttachmentSubmitTests` (6 scenarios over real RPC frames: quoted-path prepend, files-only send, upload failure keeps chip+text, mixed image/file transports, missing capability, apostrophe quoting), file-kind staging caps and session-generation guards in `ComposerPendingAttachmentTests`, and `TerminalComposerAttachmentInsertionTests` for the POSIX quoting. `swift build` for the iOS simulator passes for CmuxMobileShellModel, CmuxMobileShell, and CmuxMobileShellUI. Note: `lint-ios-package-conventions.sh` and `test-ios.yml` fail on current `main` for pre-existing files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789942240&installation_model_id=21920&pr_number=10536&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10536&signature=b4777b04e9c0749eb19d3ad6ebd293c4501aa1d97404ba264992f431b7000b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paste images and files into the iOS Task Composer and terminal composer to stage them as attachment chips instead of doing nothing. Files upload on send and their POSIX single‑quoted paths are inserted before the message; images still send inline; previews are consistent and persist across reloads.

- Shared paste path: one `MobilePasteInterceptingTextView` intercepts all Paste entry points; `MobilePasteboardAttachments` classifies/materializes via `NSItemProvider` using metadata only (no paste‑privacy prompt). Files copied from Files.app without `public.file-url` still stage as files.
- Task Composer: adds a Paste item to the attachment menu; availability matches `showsAttachmentButton`/`task.attachments.v1`. Classification runs before count limits and uses a generation token to avoid stale‑batch side effects; pasted batches are bounded to remaining capacity with a limit alert. Previews use `MobileAttachmentQuickLookView`.
- Terminal composer: replaces the SwiftUI TextField with a UIKit editor (same 1–14 line growth; ignores non‑finite width proposals; focus via `requestInputFocus`). The attach control is a native Menu; on iOS 26.2+ it morphs from the button, earlier OSes overlay. Sources are Photo Library, Choose Files (when the Mac supports uploads), and Paste. Chips open in Quick Look; inline file thumbnails render at stage time and persist across view recreations.
- Send pipeline: adds `.file` attachments (32 MB/file). On send, files upload via `mobile.task.attachment.upload`; uploads are idempotent by attachment id so retries reuse the existing path, preventing orphaned copies. Returned paths are POSIX single‑quoted and prepended before the message. Chips clear only after the text ack. Requires `task.attachments.v1` (otherwise alert and native/text paste).
- Limits and fallthroughs: image cap unchanged; text‑only pasteboards fall through to native paste. Alerts cover unreadable, oversized, or unsupported items. Localized strings added for the attachment UX. No Mac‑side changes.

<sup>Written for commit 074c854865826f0c29af43344965afe083fd7c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste images and files directly into task and terminal composers.
  * Preview attachments with thumbnails, file details, or Quick Look.
  * Upload file attachments with safely quoted paths inserted into messages.
  * Added a “Paste” option to attachment controls.
* **Bug Fixes**
  * Improved validation, size-limit handling, cancellation, and stale-session protection.
  * Preserved attachment chips when uploads fail and cleaned up temporary files safely.
  * Improved attachment accessibility and preview updates.
* **Localization**
  * Added English and Japanese messages for attachment errors, limits, and unsupported capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->