### PR TITLE
Fix iOS default surface fallback

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileStateSyncRecords.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileStateSyncRecords.swift
@@ -43,6 +43,8 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
         public let kind: String
         /// User-facing surface title.
         public let title: String
+        /// Whether the surface currently holds focus on the owning Mac.
+        public let isFocused: Bool
         /// Backing file path for file-based surfaces, when reported.
         public let filePath: String?
         /// Bounded checklist/status payload for todo surfaces.
@@ -54,19 +56,32 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
             kind: String,
             title: String,
             filePath: String?,
-            todo: MobileTodoSnapshot? = nil
+            todo: MobileTodoSnapshot? = nil,
+            isFocused: Bool = false
         ) {
             self.surfaceID = surfaceID
             self.kind = kind
             self.title = title
+            self.isFocused = isFocused
             self.filePath = filePath
             self.todo = todo
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            surfaceID = try container.decode(String.self, forKey: .surfaceID)
+            kind = try container.decode(String.self, forKey: .kind)
+            title = try container.decode(String.self, forKey: .title)
+            isFocused = try container.decodeIfPresent(Bool.self, forKey: .isFocused) ?? false
+            filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
+            todo = try container.decodeIfPresent(MobileTodoSnapshot.self, forKey: .todo)
         }
 
         private enum CodingKeys: String, CodingKey {
             case surfaceID = "surface_id"
             case kind
             case title
+            case isFocused = "is_focused"
             case filePath = "file_path"
             case todo
         }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileStateSyncFrameCodingTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileStateSyncFrameCodingTests.swift
@@ -35,7 +35,8 @@ struct MobileStateSyncFrameCodingTests {
                     surfaceID: "surface-future",
                     kind: "simulator",
                     title: "iPhone 17 Pro",
-                    filePath: nil
+                    filePath: nil,
+                    isFocused: true
                 ),
                 WorkspaceSyncRecord.Surface(
                     surfaceID: "surface-todo",
@@ -81,6 +82,7 @@ struct MobileStateSyncFrameCodingTests {
         #expect(surfaces?.first?["surface_id"] as? String == "surface-future")
         #expect(surfaces?.first?["kind"] as? String == "simulator")
         #expect(surfaces?.first?["file_path"] == nil)
+        #expect(surfaces?.first?["is_focused"] as? Bool == true)
         let todo = surfaces?[1]["todo"] as? [String: Any]
         #expect(todo?["status"] as? String == "needs-attention")
         #expect(todo?["status_hidden"] as? Bool == false)

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamStore.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamStore.swift
@@ -10,6 +10,7 @@ public import Observation
 @Observable
 public final class BrowserStreamStore: BrowserStreamEventReceiving {
     private var descriptorsByWorkspace: [String: [MobileBrowserPanelDescriptor]] = [:]
+    private var panelDiscoveryRevisionsByWorkspace: [String: UInt64] = [:]
     private var statesByPanel: [String: BrowserStreamSurfaceState] = [:]
     private var activePanelByWorkspace: [String: String] = [:]
     private var pendingDialogsByPanel: [String: MobileBrowserDialogEvent] = [:]
@@ -71,12 +72,22 @@ public final class BrowserStreamStore: BrowserStreamEventReceiving {
         descriptorsByWorkspace[workspaceID] ?? []
     }
 
+    /// Monotonic discovery token for a workspace's browser panel list.
+    ///
+    /// SwiftUI uses this instead of scanning the full descriptor list during
+    /// body evaluation, so selection refreshes still run when panels arrive or
+    /// disappear without turning render passes into O(P) work.
+    public func panelDiscoveryRevision(in workspaceID: String) -> UInt64 {
+        panelDiscoveryRevisionsByWorkspace[workspaceID, default: 0]
+    }
+
     /// Replaces the discovered panels for a workspace while preserving existing stream state.
     /// - Parameters:
     ///   - workspaceID: The Mac-local workspace identifier.
     ///   - descriptors: The current browser panel descriptors.
     public func replacePanels(in workspaceID: String, with descriptors: [MobileBrowserPanelDescriptor]) {
         descriptorsByWorkspace[workspaceID] = descriptors
+        panelDiscoveryRevisionsByWorkspace[workspaceID, default: 0] &+= 1
         let currentIDs = Set(descriptors.map(\.panelID))
         for descriptor in descriptors {
             if let state = statesByPanel[descriptor.panelID] {
@@ -329,7 +340,10 @@ public final class BrowserStreamStore: BrowserStreamEventReceiving {
             activePanelByWorkspace[workspaceID] = nil
         }
         for (workspaceID, descriptors) in descriptorsByWorkspace {
-            descriptorsByWorkspace[workspaceID] = descriptors.filter { $0.panelID != event.panelID }
+            let filtered = descriptors.filter { $0.panelID != event.panelID }
+            guard filtered.count != descriptors.count else { continue }
+            descriptorsByWorkspace[workspaceID] = filtered
+            panelDiscoveryRevisionsByWorkspace[workspaceID, default: 0] &+= 1
         }
         return event.panelID
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -147,6 +147,8 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         public let kind: String
         /// User-facing surface title.
         public let title: String
+        /// Whether the surface currently holds focus on the owning Mac.
+        public let isFocused: Bool
         /// Backing path for file-oriented surfaces, when present.
         public let filePath: String?
         /// Bounded checklist/status payload for todo surfaces.
@@ -156,6 +158,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             case surfaceID = "surface_id"
             case kind
             case title
+            case isFocused = "is_focused"
             case filePath = "file_path"
             case todo
         }
@@ -166,13 +169,25 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             kind: String,
             title: String,
             filePath: String?,
-            todo: MobileTodoSnapshot? = nil
+            todo: MobileTodoSnapshot? = nil,
+            isFocused: Bool = false
         ) {
             self.surfaceID = surfaceID
             self.kind = kind
             self.title = title
+            self.isFocused = isFocused
             self.filePath = filePath
             self.todo = todo
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            surfaceID = try container.decode(String.self, forKey: .surfaceID)
+            kind = try container.decode(String.self, forKey: .kind)
+            title = try container.decode(String.self, forKey: .title)
+            isFocused = try container.decodeIfPresent(Bool.self, forKey: .isFocused) ?? false
+            filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
+            todo = try container.decodeIfPresent(MobileTodoSnapshot.self, forKey: .todo)
         }
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -35,7 +35,8 @@ extension MobileSurfacePreview {
             kind: Kind(rawValue: remote.kind),
             title: remote.title,
             filePath: remote.filePath,
-            todo: remote.todo
+            todo: remote.todo,
+            isFocused: remote.isFocused
         )
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileSurfaceInventoryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileSurfaceInventoryTests.swift
@@ -12,11 +12,12 @@ import Testing
     }
 
     @Test func unknownKindSurvivesProjection() throws {
-        let response = try MobileSyncWorkspaceListResponse.decode(Data(#"{"workspaces":[{"id":"w","title":"W","is_selected":true,"terminals":[],"surfaces":[{"surface_id":"s","kind":"future.canvas","title":"Canvas","file_path":"/tmp/a"}]}]}"#.utf8))
+        let response = try MobileSyncWorkspaceListResponse.decode(Data(#"{"workspaces":[{"id":"w","title":"W","is_selected":true,"terminals":[],"surfaces":[{"surface_id":"s","kind":"future.canvas","title":"Canvas","file_path":"/tmp/a","is_focused":true}]}]}"#.utf8))
         let surface = try #require(MobileWorkspacePreview(remote: response.workspaces[0]).surfaces.first)
         #expect(surface.kind == .other("future.canvas"))
         #expect(surface.filePath == "/tmp/a")
         #expect(surface.todo == nil)
+        #expect(surface.isFocused)
     }
 
     @Test func todoSnapshotSurvivesLegacyWorkspaceProjection() throws {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10852,8 +10852,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// empty terminal frame when only Mac surfaces or streamed panels exist.
     private func syncDefaultSurfaceForWorkspace() {
         guard let selectedWorkspace else { return }
-        if selectedMacSurfaceID != nil {
+        if let selectedMacSurfaceID,
+           selectedWorkspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID }) {
             return
+        } else if selectedMacSurfaceID != nil {
+            self.selectedMacSurfaceID = nil
         }
         let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
         if simulatorStreamStore?.activeState(in: workspaceID) != nil {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1804,6 +1804,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await self?.forceRestartMobileBrowserStream(panelID: panelID)
         }
         startObservingConnectionMethodChanges()
+        syncSelectedTerminalForWorkspace()
     }
 
     isolated deinit {
@@ -10833,6 +10834,40 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         selectedTerminalID = selectedWorkspace.preferredTerminal?.id
+        if selectedTerminalID == nil {
+            syncDefaultSurfaceForWorkspace()
+        }
+    }
+
+    /// Re-evaluates the default surface after the workspace's panel lists
+    /// finish loading. Panel discovery can arrive after the workspace is
+    /// already selected, so this lets the shell promote the first available
+    /// non-terminal once it exists.
+    public func refreshWorkspaceSelection() {
+        syncSelectedTerminalForWorkspace()
+    }
+
+    /// Promotes the first available non-terminal surface when the workspace has
+    /// no terminal to show. Keeps the default-open workspace from landing on an
+    /// empty terminal frame when only Mac surfaces or streamed panels exist.
+    private func syncDefaultSurfaceForWorkspace() {
+        guard let selectedWorkspace else { return }
+        if selectedMacSurfaceID != nil {
+            return
+        }
+        let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
+        if let selectedSurface = selectedWorkspace.selectedMacSurface(id: nil) {
+            selectedMacSurfaceID = selectedSurface.id
+            return
+        }
+        if let simulatorPanelID = simulatorStreamStore?.panels(in: workspaceID).first?.panelID {
+            _ = simulatorStreamStore?.activate(panelID: simulatorPanelID, in: workspaceID)
+            return
+        }
+        if let browserStore = browserStreamEvents as? BrowserStreamStore,
+           let browserPanelID = browserStore.panels(in: workspaceID).first?.panelID {
+            _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
+        }
     }
 
     // MARK: - Per-terminal composer drafts

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10852,13 +10852,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// empty terminal frame when only Mac surfaces or streamed panels exist.
     private func syncDefaultSurfaceForWorkspace() {
         guard let selectedWorkspace else { return }
+        let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
         if let selectedMacSurfaceID,
-           selectedWorkspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID }) {
-            return
-        } else if selectedMacSurfaceID != nil {
+           !selectedWorkspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID }) {
             self.selectedMacSurfaceID = nil
         }
-        let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
         if simulatorStreamStore?.activeState(in: workspaceID) != nil {
             return
         }
@@ -10866,9 +10864,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            browserStore.activeState(in: workspaceID) != nil {
             return
         }
-        if let selectedSurface = selectedWorkspace.selectedMacSurface(id: nil) {
-            selectedMacSurfaceID = selectedSurface.id
-            return
+        if let selectedMacSurfaceID {
+            if let simulatorPanelID = simulatorStreamStore?.panels(in: workspaceID)
+                .first(where: { $0.panelID == selectedMacSurfaceID.rawValue })?.panelID {
+                _ = simulatorStreamStore?.activate(panelID: simulatorPanelID, in: workspaceID)
+                return
+            }
+            if let browserStore = browserStreamEvents as? BrowserStreamStore,
+               let browserPanelID = browserStore.panels(in: workspaceID)
+                .first(where: { $0.panelID == selectedMacSurfaceID.rawValue })?.panelID {
+                _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
+                return
+            }
+            if selectedWorkspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID }) {
+                return
+            }
         }
         if let simulatorPanelID = simulatorStreamStore?.panels(in: workspaceID).first?.panelID {
             _ = simulatorStreamStore?.activate(panelID: simulatorPanelID, in: workspaceID)
@@ -10877,6 +10887,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if let browserStore = browserStreamEvents as? BrowserStreamStore,
            let browserPanelID = browserStore.panels(in: workspaceID).first?.panelID {
             _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
+            return
+        }
+        if let selectedSurface = selectedWorkspace.selectedMacSurface(id: nil) {
+            selectedMacSurfaceID = selectedSurface.id
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10856,6 +10856,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
+        if simulatorStreamStore?.activeState(in: workspaceID) != nil {
+            return
+        }
+        if let browserStore = browserStreamEvents as? BrowserStreamStore,
+           browserStore.activeState(in: workspaceID) != nil {
+            return
+        }
         if let selectedSurface = selectedWorkspace.selectedMacSurface(id: nil) {
             selectedMacSurfaceID = selectedSurface.id
             return

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1712,7 +1712,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.activeRoute = nil
         self.activeMacInstanceTag = nil
         self.selectedWorkspaceID = workspaces.first?.id
-        self.selectedTerminalID = workspaces.first?.terminals.first?.id
+        // Let the final synchronizer apply the same focus-aware priority used
+        // when a workspace changes after initialization.
+        self.selectedTerminalID = nil
         self.remoteClient = nil
         self.terminalEventListenerTask = nil
         self.terminalEventListenerID = nil
@@ -1804,6 +1806,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await self?.forceRestartMobileBrowserStream(panelID: panelID)
         }
         startObservingConnectionMethodChanges()
+        selectedTerminalID = nil
+        selectedMacSurfaceID = nil
         syncSelectedTerminalForWorkspace()
     }
 
@@ -10833,6 +10837,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            selectedTerminal.isReady || !selectedWorkspace.hasReadyTerminal {
             return
         }
+        if selectedMacSurfaceID == nil,
+           selectedWorkspace.focusedNonTerminalSurface != nil {
+            syncDefaultSurfaceForWorkspace()
+            let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
+            if selectedMacSurfaceID != nil
+                || simulatorStreamStore?.activeState(in: workspaceID) != nil
+                || (browserStreamEvents as? BrowserStreamStore)?.activeState(in: workspaceID) != nil {
+                return
+            }
+        }
         selectedTerminalID = selectedWorkspace.preferredTerminal?.id
         if selectedTerminalID == nil {
             syncDefaultSurfaceForWorkspace()
@@ -10841,15 +10855,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Re-evaluates the default surface after the workspace's panel lists
     /// finish loading. Panel discovery can arrive after the workspace is
-    /// already selected, so this lets the shell promote the first available
-    /// non-terminal once it exists.
+    /// already selected, so this lets the shell promote the Mac-focused
+    /// non-terminal, then fall back to the first available one.
     public func refreshWorkspaceSelection() {
         syncSelectedTerminalForWorkspace()
     }
 
-    /// Promotes the first available non-terminal surface when the workspace has
-    /// no terminal to show. Keeps the default-open workspace from landing on an
-    /// empty terminal frame when only Mac surfaces or streamed panels exist.
+    /// Promotes the Mac-focused non-terminal surface when no explicit terminal
+    /// selection is active. Keeps the default-open workspace from landing on
+    /// an empty terminal frame when only Mac surfaces or streamed panels exist.
     private func syncDefaultSurfaceForWorkspace() {
         guard let selectedWorkspace else { return }
         let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
@@ -10864,22 +10878,40 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            browserStore.activeState(in: workspaceID) != nil {
             return
         }
-        if let selectedMacSurfaceID {
+
+        func activateStream(for surfaceID: MobileSurfacePreview.ID) -> Bool {
             if let simulatorPanelID = simulatorStreamStore?.panels(in: workspaceID)
-                .first(where: { $0.panelID == selectedMacSurfaceID.rawValue })?.panelID {
+                .first(where: { $0.panelID == surfaceID.rawValue })?.panelID {
                 _ = simulatorStreamStore?.activate(panelID: simulatorPanelID, in: workspaceID)
-                return
+                return true
             }
             if let browserStore = browserStreamEvents as? BrowserStreamStore,
                let browserPanelID = browserStore.panels(in: workspaceID)
-                .first(where: { $0.panelID == selectedMacSurfaceID.rawValue })?.panelID {
+                .first(where: { $0.panelID == surfaceID.rawValue })?.panelID {
                 _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
+                return true
+            }
+            return false
+        }
+
+        if let selectedMacSurfaceID {
+            if activateStream(for: selectedMacSurfaceID) {
                 return
             }
             if selectedWorkspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID }) {
                 return
             }
         }
+
+        if let selectedSurface = selectedWorkspace.focusedNonTerminalSurface
+            ?? selectedWorkspace.selectedMacSurface(id: nil) {
+            if activateStream(for: selectedSurface.id) {
+                return
+            }
+            selectedMacSurfaceID = selectedSurface.id
+            return
+        }
+
         if let simulatorPanelID = simulatorStreamStore?.panels(in: workspaceID).first?.panelID {
             _ = simulatorStreamStore?.activate(panelID: simulatorPanelID, in: workspaceID)
             return
@@ -10888,9 +10920,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            let browserPanelID = browserStore.panels(in: workspaceID).first?.panelID {
             _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
             return
-        }
-        if let selectedSurface = selectedWorkspace.selectedMacSurface(id: nil) {
-            selectedMacSurfaceID = selectedSurface.id
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10837,15 +10837,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            selectedTerminal.isReady || !selectedWorkspace.hasReadyTerminal {
             return
         }
-        if selectedMacSurfaceID == nil,
-           selectedWorkspace.focusedNonTerminalSurface != nil {
-            syncDefaultSurfaceForWorkspace()
-            let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
-            if selectedMacSurfaceID != nil
-                || simulatorStreamStore?.activeState(in: workspaceID) != nil
-                || (browserStreamEvents as? BrowserStreamStore)?.activeState(in: workspaceID) != nil {
-                return
-            }
+        // Clear stale Mac selections and promote an active or Mac-focused
+        // non-terminal before assigning a preferred terminal fallback.
+        syncDefaultSurfaceForWorkspace()
+        let workspaceID = selectedWorkspace.rpcWorkspaceID.rawValue
+        if selectedMacSurfaceID != nil
+            || simulatorStreamStore?.activeState(in: workspaceID) != nil
+            || (browserStreamEvents as? BrowserStreamStore)?.activeState(in: workspaceID) != nil {
+            return
         }
         selectedTerminalID = selectedWorkspace.preferredTerminal?.id
         if selectedTerminalID == nil {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
@@ -93,9 +93,36 @@ import CmuxMobileShellModel
         #expect(!composite.startedMobileSimulatorPanelIDs.contains("sim-1"))
     }
 
+    @Test func existingSimulatorSelectionSurvivesDefaultSurfaceRefresh() {
+        let workspaceID = "workspace-1"
+        let selectedDescriptor = Self.descriptor(panelID: "sim-2")
+        let workspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: [],
+            simulators: [Self.descriptor(), selectedDescriptor]
+        )
+        let store = MobileSimulatorStreamStore()
+        store.replaceSimulatorPanels(in: workspaceID, with: [Self.descriptor(), selectedDescriptor])
+        store.activate(panelID: selectedDescriptor.panelID, in: workspaceID)
+        let composite = MobileShellComposite(
+            workspaces: [workspace],
+            simulatorStreamStore: store
+        )
+
+        composite.selectedWorkspaceID = nil
+        composite.selectedWorkspaceID = workspace.id
+
+        #expect(store.activeState(in: workspaceID)?.id == selectedDescriptor.panelID)
+    }
+
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
+        descriptor(panelID: "sim-1")
+    }
+
+    private static func descriptor(panelID: String) -> MobileSimulatorPanelDescriptor {
         MobileSimulatorPanelDescriptor(
-            panelID: "sim-1",
+            panelID: panelID,
             workspaceID: "workspace-1",
             title: "Simulator",
             selectedDeviceName: "iPhone 17",

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
@@ -161,6 +161,27 @@ import CmuxMobileShellModel
         #expect(composite.selectedMacSurfaceID == focusedSurface.id)
     }
 
+    @Test func staleMacSelectionDoesNotBlockFocusedNonTerminalFallback() {
+        let focusedSurface = MobileSurfacePreview(
+            id: "browser-1",
+            kind: .browser,
+            title: "Browser",
+            isFocused: true
+        )
+        let workspace = MobileWorkspacePreview(
+            id: .init(rawValue: "workspace-1"),
+            name: "Workspace",
+            terminals: [MobileTerminalPreview(id: "terminal-1", name: "zsh")],
+            surfaces: [focusedSurface]
+        )
+        let composite = MobileShellComposite(workspaces: [workspace])
+        composite.selectedMacSurfaceID = .init(rawValue: "removed-surface")
+
+        composite.selectedWorkspaceID = workspace.id
+
+        #expect(composite.selectedMacSurfaceID == focusedSurface.id)
+    }
+
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
         descriptor(panelID: "sim-1")
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
@@ -116,6 +116,28 @@ import CmuxMobileShellModel
         #expect(store.activeState(in: workspaceID)?.id == selectedDescriptor.panelID)
     }
 
+    @Test func staleMacSelectionFallsBackToAvailableSimulatorPanel() {
+        let workspaceID = "workspace-1"
+        let workspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: [],
+            surfaces: []
+        )
+        let store = MobileSimulatorStreamStore()
+        store.replaceSimulatorPanels(in: workspaceID, with: [Self.descriptor()])
+        let composite = MobileShellComposite(
+            workspaces: [workspace],
+            simulatorStreamStore: store
+        )
+        composite.selectedMacSurfaceID = .init(rawValue: "stale-surface")
+
+        composite.selectedWorkspaceID = workspace.id
+
+        #expect(composite.selectedMacSurfaceID == nil)
+        #expect(store.activeState(in: workspaceID)?.id == Self.descriptor().panelID)
+    }
+
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
         descriptor(panelID: "sim-1")
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeSimulatorStreamTests.swift
@@ -138,6 +138,29 @@ import CmuxMobileShellModel
         #expect(store.activeState(in: workspaceID)?.id == Self.descriptor().panelID)
     }
 
+    @Test func focusedNonTerminalSelectionWinsWhenWorkspaceAlsoHasTerminal() {
+        let focusedSurface = MobileSurfacePreview(
+            id: "browser-1",
+            kind: .browser,
+            title: "Browser",
+            isFocused: true
+        )
+        let terminal = MobileTerminalPreview(id: "terminal-1", name: "zsh")
+        let workspace = MobileWorkspacePreview(
+            id: .init(rawValue: "workspace-1"),
+            name: "Workspace",
+            terminals: [terminal],
+            surfaces: [focusedSurface]
+        )
+        let composite = MobileShellComposite(workspaces: [workspace])
+
+        #expect(workspace.focusedNonTerminalSurface?.id == focusedSurface.id)
+        #expect(composite.selectedWorkspace?.focusedNonTerminalSurface?.id == focusedSurface.id)
+        composite.selectedWorkspaceID = workspace.id
+
+        #expect(composite.selectedMacSurfaceID == focusedSurface.id)
+    }
+
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
         descriptor(panelID: "sim-1")
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileSurfacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileSurfacePreview.swift
@@ -67,6 +67,8 @@ public struct MobileSurfacePreview: Identifiable, Equatable, Sendable {
     public let kind: Kind
     /// User-facing surface title.
     public let title: String
+    /// Whether the surface currently holds focus on the owning Mac.
+    public let isFocused: Bool
     /// Backing path for file-oriented surfaces, when supplied by the Mac.
     public let filePath: String?
     /// Bounded checklist/status data for a todo surface.
@@ -78,11 +80,13 @@ public struct MobileSurfacePreview: Identifiable, Equatable, Sendable {
         kind: Kind,
         title: String,
         filePath: String? = nil,
-        todo: MobileTodoSnapshot? = nil
+        todo: MobileTodoSnapshot? = nil,
+        isFocused: Bool = false
     ) {
         self.id = id
         self.kind = kind
         self.title = title
+        self.isFocused = isFocused
         self.filePath = filePath
         self.todo = todo
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -180,6 +180,13 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
 }
 
 extension MobileWorkspacePreview {
+    /// The non-terminal surface the owning Mac currently has focused, when it
+    /// reports one. This is separate from the terminal fallback because an
+    /// explicitly selected terminal on iOS must remain authoritative.
+    public var focusedNonTerminalSurface: MobileSurfacePreview? {
+        surfaces.first { !$0.kind.isTerminal && $0.isFocused }
+    }
+
     /// The non-terminal Mac surface to present, honoring the picker selection.
     ///
     /// Terminal-kinded rows are never a Mac-surface selection (terminals have
@@ -198,6 +205,7 @@ extension MobileWorkspacePreview {
 
     private var defaultMacSurface: MobileSurfacePreview? {
         guard terminals.isEmpty else { return nil }
-        return surfaces.first { !$0.kind.isTerminal }
+        return surfaces.first { !$0.kind.isTerminal && $0.isFocused }
+            ?? surfaces.first { !$0.kind.isTerminal }
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspacePreviewDefaultSurfaceTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspacePreviewDefaultSurfaceTests.swift
@@ -10,9 +10,16 @@ struct MobileWorkspacePreviewDefaultSurfaceTests {
     private func surface(
         id: MobileSurfacePreview.ID,
         kind: MobileSurfacePreview.Kind,
-        todo: MobileTodoSnapshot? = nil
+        todo: MobileTodoSnapshot? = nil,
+        isFocused: Bool = false
     ) -> MobileSurfacePreview {
-        MobileSurfacePreview(id: id, kind: kind, title: "Surface", todo: todo)
+        MobileSurfacePreview(
+            id: id,
+            kind: kind,
+            title: "Surface",
+            todo: todo,
+            isFocused: isFocused
+        )
     }
 
     private func workspace(
@@ -50,6 +57,12 @@ struct MobileWorkspacePreviewDefaultSurfaceTests {
         let browserSurface = surface(id: "surface-browser", kind: .browser)
         let workspace = workspace(terminals: [], surfaces: [browserSurface, todoSurface])
         #expect(workspace.selectedMacSurface(id: nil) == browserSurface)
+    }
+
+    @Test func fallbackPrefersTheFocusedNonTerminalSurfaceOverSpatialOrder() {
+        let focusedSurface = surface(id: "surface-focused", kind: .browser, isFocused: true)
+        let workspace = workspace(terminals: [], surfaces: [todoSurface, focusedSurface])
+        #expect(workspace.selectedMacSurface(id: nil) == focusedSurface)
     }
 
     @Test func staleSelectionFallsBackWhenTerminalless() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+AgentChat.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+AgentChat.swift
@@ -108,15 +108,7 @@ extension WorkspaceDetailView {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .mobileChatTopScrollEdgeLayout(legacyTopPadding: terminalTopPadding)
         } else {
-            waitingSurfacePlaceholder(
-                title: L10n.string("mobile.chat.waiting", defaultValue: "Waiting for Chat"),
-                detail: L10n.string(
-                    "mobile.chat.waitingDetail",
-                    defaultValue: "The conversation will appear when it is ready."
-                ),
-                symbol: "bubble.left.and.bubble.right",
-                accessibilityIdentifier: "WorkspaceChatPlaceholder"
-            )
+            chatWaitingSurfacePlaceholder()
                 .task(id: session.id) {
                     _ = ensureChatConversationStore(for: session)
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+AgentChat.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+AgentChat.swift
@@ -108,7 +108,15 @@ extension WorkspaceDetailView {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .mobileChatTopScrollEdgeLayout(legacyTopPadding: terminalTopPadding)
         } else {
-            Color.clear
+            waitingSurfacePlaceholder(
+                title: L10n.string("mobile.chat.waiting", defaultValue: "Waiting for Chat"),
+                detail: L10n.string(
+                    "mobile.chat.waitingDetail",
+                    defaultValue: "The conversation will appear when it is ready."
+                ),
+                symbol: "bubble.left.and.bubble.right",
+                accessibilityIdentifier: "WorkspaceChatPlaceholder"
+            )
                 .task(id: session.id) {
                     _ = ensureChatConversationStore(for: session)
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+SurfacePlaceholder.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+SurfacePlaceholder.swift
@@ -1,0 +1,29 @@
+#if os(iOS)
+import SwiftUI
+
+extension WorkspaceDetailView {
+    @ViewBuilder
+    func waitingSurfacePlaceholder(
+        title: String,
+        detail: String,
+        symbol: String,
+        accessibilityIdentifier: String
+    ) -> some View {
+        ZStack {
+            Color.black.opacity(0.72)
+            VStack(spacing: 12) {
+                Image(systemName: symbol)
+                    .font(.system(size: 36))
+                Text(title)
+                    .font(.headline)
+                Text(detail)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(.white)
+            .padding(28)
+        }
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+SurfacePlaceholder.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+SurfacePlaceholder.swift
@@ -1,7 +1,22 @@
 #if os(iOS)
+import CMUXMobileCore
+import CmuxMobileSupport
 import SwiftUI
 
 extension WorkspaceDetailView {
+    @ViewBuilder
+    func chatWaitingSurfacePlaceholder() -> some View {
+        waitingSurfacePlaceholder(
+            title: L10n.string("mobile.chat.waiting", defaultValue: "Waiting for Chat"),
+            detail: L10n.string(
+                "mobile.chat.waitingDetail",
+                defaultValue: "The conversation will appear when it is ready."
+            ),
+            symbol: "bubble.left.and.bubble.right",
+            accessibilityIdentifier: "WorkspaceChatPlaceholder"
+        )
+    }
+
     @ViewBuilder
     func waitingSurfacePlaceholder(
         title: String,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
@@ -31,15 +31,7 @@ extension WorkspaceDetailView {
                 chatContent(session)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)
             } else if surface == .chat {
-                waitingSurfacePlaceholder(
-                    title: L10n.string("mobile.chat.waiting", defaultValue: "Waiting for Chat"),
-                    detail: L10n.string(
-                        "mobile.chat.waitingDetail",
-                        defaultValue: "The conversation will appear when it is ready."
-                    ),
-                    symbol: "bubble.left.and.bubble.right",
-                    accessibilityIdentifier: "WorkspaceChatPlaceholder"
-                )
+                chatWaitingSurfacePlaceholder()
             } else if surface == .browser, let browser = activeBrowser {
                 browserContent(browser)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
@@ -3,6 +3,7 @@ import CmuxMobileBrowser
 import CmuxMobileBrowserStream
 import CmuxMobileShell
 import CmuxMobileShellModel
+import CmuxMobileSupport
 import CmuxMobileTerminal
 import SwiftUI
 
@@ -29,15 +30,55 @@ extension WorkspaceDetailView {
             if surface == .chat, let session = chosenChatSession {
                 chatContent(session)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)
+            } else if surface == .chat {
+                waitingSurfacePlaceholder(
+                    title: L10n.string("mobile.chat.waiting", defaultValue: "Waiting for Chat"),
+                    detail: L10n.string(
+                        "mobile.chat.waitingDetail",
+                        defaultValue: "The conversation will appear when it is ready."
+                    ),
+                    symbol: "bubble.left.and.bubble.right",
+                    accessibilityIdentifier: "WorkspaceChatPlaceholder"
+                )
             } else if surface == .browser, let browser = activeBrowser {
                 browserContent(browser)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)
+            } else if surface == .browser {
+                waitingSurfacePlaceholder(
+                    title: L10n.string("mobile.browser.waiting", defaultValue: "Waiting for Browser"),
+                    detail: L10n.string(
+                        "mobile.browser.waitingDetail",
+                        defaultValue: "The browser will appear when the Mac is ready."
+                    ),
+                    symbol: "globe",
+                    accessibilityIdentifier: "MobileBrowserPlaceholder"
+                )
             } else if surface == .browserStream, let browser = activeBrowserStream {
                 browserStreamContent(browser)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)
+            } else if surface == .browserStream {
+                waitingSurfacePlaceholder(
+                    title: L10n.string("mobile.browserStream.waiting", defaultValue: "Waiting for Browser"),
+                    detail: L10n.string(
+                        "mobile.browserStream.waitingDetail",
+                        defaultValue: "The first frame will appear when the Mac is ready."
+                    ),
+                    symbol: "globe",
+                    accessibilityIdentifier: "BrowserStreamPlaceholder"
+                )
             } else if surface == .simulatorStream, let simulator = activeSimulatorStream {
                 simulatorStreamContent(simulator)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)
+            } else if surface == .simulatorStream {
+                waitingSurfacePlaceholder(
+                    title: L10n.string("mobile.simulatorStream.waiting", defaultValue: "Waiting for Simulator"),
+                    detail: L10n.string(
+                        "mobile.simulatorStream.waitingDetail",
+                        defaultValue: "The first frame will appear when the Mac is ready."
+                    ),
+                    symbol: "iphone",
+                    accessibilityIdentifier: "SimulatorStreamPlaceholder"
+                )
             } else if case let .macSurface(macSurface) = surface {
                 macSurfaceContent(macSurface)
                     .background(store.activeTerminalTheme.terminalBackgroundColor)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -196,8 +196,12 @@ struct WorkspaceDetailView: View {
             .task(id: workspace.rpcWorkspaceID.rawValue) {
                 await store.refreshMobileBrowserPanels(workspaceID: workspace.rpcWorkspaceID.rawValue)
                 syncSimulatorStreamPanels()
+                store.refreshWorkspaceSelection()
             }
-            .onChange(of: workspace.simulators) { _, _ in syncSimulatorStreamPanels() }
+            .onChange(of: workspace.simulators) { _, _ in
+                syncSimulatorStreamPanels()
+                store.refreshWorkspaceSelection()
+            }
             .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
             // Structural removal drops the item's retained measurement so a
             // returning item takes the fail-safe unmeasured reserve instead of

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -198,7 +198,7 @@ struct WorkspaceDetailView: View {
                 syncSimulatorStreamPanels()
                 store.refreshWorkspaceSelection()
             }
-            .onChange(of: browserStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(\.panelID)) { _, _ in
+            .onChange(of: browserStreamStore.panelDiscoveryRevision(in: workspace.rpcWorkspaceID.rawValue)) { _, _ in
                 store.refreshWorkspaceSelection()
             }
             .onChange(of: workspace.simulators) { _, _ in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -198,6 +198,9 @@ struct WorkspaceDetailView: View {
                 syncSimulatorStreamPanels()
                 store.refreshWorkspaceSelection()
             }
+            .onChange(of: browserStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(\.panelID)) { _, _ in
+                store.refreshWorkspaceSelection()
+            }
             .onChange(of: workspace.simulators) { _, _ in
                 syncSimulatorStreamPanels()
                 store.refreshWorkspaceSelection()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewChatPlaceholderTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewChatPlaceholderTests.swift
@@ -1,0 +1,67 @@
+#if os(iOS)
+import CMUXMobileCore
+import CmuxAgentChat
+import CmuxMobileShell
+import CmuxMobileShellModel
+import SwiftUI
+import Testing
+@preconcurrency import UIKit
+@testable import CmuxMobileShellUI
+
+@MainActor
+@Suite struct WorkspaceDetailViewChatPlaceholderTests {
+    @Test func chatContentShowsAWaitingPlaceholderBeforeTheConversationStoreArrives() {
+        let workspace = MobileWorkspacePreview(
+            id: "workspace-1",
+            name: "Workspace",
+            terminals: []
+        )
+        let detail = WorkspaceDetailView(
+            host: "Mac",
+            connectionStatus: .connected,
+            workspace: workspace,
+            store: MobileShellComposite(workspaces: [workspace]),
+            createWorkspace: {},
+            canCreateWorkspace: false,
+            createTerminal: {},
+            renameWorkspace: nil,
+            customizeWorkspace: nil,
+            setWorkspaceUnread: nil,
+            closeWorkspace: nil,
+            reportTerminalViewport: { _, _, _ in },
+            sendTerminalInput: { _ in },
+            safeAreaContext: .fullWidth,
+            backButtonConfiguration: nil,
+            signOut: nil
+        )
+        let session = ChatSessionDescriptor(
+            id: "session-1",
+            agentKind: .claude,
+            workspaceID: workspace.id.rawValue,
+            terminalID: nil,
+            state: .idle
+        )
+
+        let controller = UIHostingController(rootView: detail.chatContent(session))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        #expect(viewContainsAccessibilityIdentifier(controller.view, "WorkspaceChatPlaceholder"))
+        window.isHidden = true
+    }
+
+    private func viewContainsAccessibilityIdentifier(
+        _ view: UIView,
+        _ identifier: String
+    ) -> Bool {
+        if view.accessibilityIdentifier == identifier {
+            return true
+        }
+        return view.subviews.contains {
+            viewContainsAccessibilityIdentifier($0, identifier)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -61,7 +61,10 @@ import Testing
 
         model.workspace = updatedWorkspace
         controller.view.layoutIfNeeded()
-        await Task.yield()
+        await Self.waitForActivePanel(
+            expectedID: Self.descriptor().panelID,
+            activeID: { simulatorStore.activeState(in: workspaceID)?.id }
+        )
         controller.view.layoutIfNeeded()
 
         #expect(simulatorStore.activeState(in: workspaceID)?.id == Self.descriptor().panelID)
@@ -115,11 +118,26 @@ import Testing
         model.workspace = updatedWorkspace
         browserStreamStore.replaceBrowserPanels(in: workspaceID, with: [Self.browserDescriptor()])
         controller.view.layoutIfNeeded()
-        await Task.yield()
+        await Self.waitForActivePanel(
+            expectedID: Self.browserDescriptor().panelID,
+            activeID: { browserStreamStore.activeState(in: workspaceID)?.id }
+        )
         controller.view.layoutIfNeeded()
 
         #expect(browserStreamStore.activeState(in: workspaceID)?.id == Self.browserDescriptor().panelID)
         window.isHidden = true
+    }
+
+    private static func waitForActivePanel(
+        expectedID: String,
+        activeID: @escaping @MainActor () -> String?
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while activeID() != expectedID, clock.now < deadline {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
     }
 
     private static func descriptor() -> MobileSimulatorPanelDescriptor {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -16,15 +16,22 @@ import Testing
 @Suite struct WorkspaceDetailViewDefaultSurfaceSelectionTests {
     @Test func simulatorOnlyWorkspaceAutoSelectsItsFirstPanelWhenPanelsArrive() async {
         let workspaceID = "workspace-1"
+        let simulatorSurface = MobileSurfacePreview(
+            id: .init(rawValue: Self.descriptor().panelID),
+            kind: .other("simulator"),
+            title: "Simulator"
+        )
         let initialWorkspace = MobileWorkspacePreview(
             id: .init(rawValue: workspaceID),
             name: "Workspace",
-            terminals: []
+            terminals: [],
+            surfaces: [simulatorSurface]
         )
         let updatedWorkspace = MobileWorkspacePreview(
             id: .init(rawValue: workspaceID),
             name: "Workspace",
             terminals: [],
+            surfaces: [simulatorSurface],
             simulators: [Self.descriptor()]
         )
         let simulatorStore = MobileSimulatorStreamStore()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -28,12 +28,13 @@ import Testing
             simulators: [Self.descriptor()]
         )
         let simulatorStore = MobileSimulatorStreamStore()
+        let browserStreamStore = BrowserStreamStore()
         let shell = MobileShellComposite(
             workspaces: [initialWorkspace],
+            browserStreamEvents: browserStreamStore,
             simulatorStreamStore: simulatorStore
         )
         let browserStore = BrowserSurfaceStore()
-        let browserStreamStore = BrowserStreamStore()
         let displaySettings = MobileDisplaySettings(
             defaults: UserDefaults(suiteName: "cmux.tests.\(UUID().uuidString)")!
         )
@@ -67,6 +68,60 @@ import Testing
         window.isHidden = true
     }
 
+    @Test func browserOnlyWorkspaceAutoSelectsItsFirstStreamPanelWhenPanelsArrive() async {
+        let workspaceID = "workspace-1"
+        let initialWorkspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: []
+        )
+        let updatedWorkspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: []
+        )
+        let browserStore = BrowserSurfaceStore()
+        let browserStreamStore = BrowserStreamStore()
+        let simulatorStore = MobileSimulatorStreamStore()
+        let shell = MobileShellComposite(
+            workspaces: [initialWorkspace],
+            browserStreamEvents: browserStreamStore,
+            simulatorStreamStore: simulatorStore
+        )
+        let displaySettings = MobileDisplaySettings(
+            defaults: UserDefaults(suiteName: "cmux.tests.\(UUID().uuidString)")!
+        )
+        let toasts = ToastCenter()
+        let model = WorkspaceDetailHarnessModel(workspace: initialWorkspace)
+
+        let controller = UIHostingController(
+            rootView: WorkspaceDetailHarness(
+                model: model,
+                store: shell,
+                browserStore: browserStore,
+                browserStreamStore: browserStreamStore,
+                simulatorStore: simulatorStore,
+                displaySettings: displaySettings,
+                toasts: toasts
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        #expect(browserStreamStore.activeState(in: workspaceID) == nil)
+
+        model.workspace = updatedWorkspace
+        browserStreamStore.replaceBrowserPanels(in: workspaceID, with: [Self.browserDescriptor()])
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        controller.view.layoutIfNeeded()
+
+        #expect(browserStreamStore.activeState(in: workspaceID)?.id == Self.browserDescriptor().panelID)
+        window.isHidden = true
+    }
+
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
         MobileSimulatorPanelDescriptor(
             panelID: "sim-1",
@@ -82,6 +137,20 @@ import Testing
             supportsRotation: true,
             ownerConnectionID: nil,
             isOwnedByCurrentConnection: nil
+        )
+    }
+
+    private static func browserDescriptor() -> MobileBrowserPanelDescriptor {
+        MobileBrowserPanelDescriptor(
+            panelID: "browser-1",
+            workspaceID: "workspace-1",
+            url: nil,
+            title: "Browser",
+            pageWidth: 800,
+            pageHeight: 600,
+            canGoBack: false,
+            canGoForward: false,
+            isLoading: false
         )
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -1,0 +1,134 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import CmuxMobileBrowser
+import CmuxMobileBrowserStream
+import CmuxMobileShell
+import CmuxMobileShellModel
+import CmuxMobileToast
+import Foundation
+import Observation
+import SwiftUI
+import Testing
+@preconcurrency import UIKit
+@testable import CmuxMobileShellUI
+
+@MainActor
+@Suite struct WorkspaceDetailViewDefaultSurfaceSelectionTests {
+    @Test func simulatorOnlyWorkspaceAutoSelectsItsFirstPanelWhenPanelsArrive() async {
+        let workspaceID = "workspace-1"
+        let initialWorkspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: []
+        )
+        let updatedWorkspace = MobileWorkspacePreview(
+            id: .init(rawValue: workspaceID),
+            name: "Workspace",
+            terminals: [],
+            simulators: [Self.descriptor()]
+        )
+        let simulatorStore = MobileSimulatorStreamStore()
+        let shell = MobileShellComposite(
+            workspaces: [initialWorkspace],
+            simulatorStreamStore: simulatorStore
+        )
+        let browserStore = BrowserSurfaceStore()
+        let browserStreamStore = BrowserStreamStore()
+        let displaySettings = MobileDisplaySettings(
+            defaults: UserDefaults(suiteName: "cmux.tests.\(UUID().uuidString)")!
+        )
+        let toasts = ToastCenter()
+        let model = WorkspaceDetailHarnessModel(workspace: initialWorkspace)
+
+        let controller = UIHostingController(
+            rootView: WorkspaceDetailHarness(
+                model: model,
+                store: shell,
+                browserStore: browserStore,
+                browserStreamStore: browserStreamStore,
+                simulatorStore: simulatorStore,
+                displaySettings: displaySettings,
+                toasts: toasts
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        #expect(simulatorStore.activeState(in: workspaceID) == nil)
+
+        model.workspace = updatedWorkspace
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        controller.view.layoutIfNeeded()
+
+        #expect(simulatorStore.activeState(in: workspaceID)?.id == Self.descriptor().panelID)
+        window.isHidden = true
+    }
+
+    private static func descriptor() -> MobileSimulatorPanelDescriptor {
+        MobileSimulatorPanelDescriptor(
+            panelID: "sim-1",
+            workspaceID: "workspace-1",
+            title: "Simulator",
+            selectedDeviceName: "iPhone 17",
+            selectedDeviceState: "Booted",
+            status: "streaming",
+            isReady: true,
+            supportsTouch: true,
+            supportsKeyboard: true,
+            supportsHardwareButtons: true,
+            supportsRotation: true,
+            ownerConnectionID: nil,
+            isOwnedByCurrentConnection: nil
+        )
+    }
+}
+
+private struct WorkspaceDetailHarness: View {
+    @Bindable var model: WorkspaceDetailHarnessModel
+    let store: MobileShellComposite
+    let browserStore: BrowserSurfaceStore
+    let browserStreamStore: BrowserStreamStore
+    let simulatorStore: MobileSimulatorStreamStore
+    let displaySettings: MobileDisplaySettings
+    let toasts: ToastCenter
+
+    var body: some View {
+        WorkspaceDetailView(
+            host: "Mac",
+            connectionStatus: .connected,
+            workspace: model.workspace,
+            store: store,
+            createWorkspace: {},
+            canCreateWorkspace: false,
+            createTerminal: {},
+            renameWorkspace: nil,
+            customizeWorkspace: nil,
+            setWorkspaceUnread: nil,
+            closeWorkspace: nil,
+            reportTerminalViewport: { _, _, _ in },
+            sendTerminalInput: { _ in },
+            safeAreaContext: .fullWidth,
+            backButtonConfiguration: nil,
+            signOut: nil
+        )
+        .environment(browserStore)
+        .environment(browserStreamStore)
+        .environment(simulatorStore)
+        .environment(displaySettings)
+        .environment(toasts)
+    }
+}
+
+@MainActor
+@Observable
+private final class WorkspaceDetailHarnessModel {
+    var workspace: MobileWorkspacePreview
+
+    init(workspace: MobileWorkspacePreview) {
+        self.workspace = workspace
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -155,8 +155,12 @@ import Testing
     }
 
     private static func descriptor() -> MobileSimulatorPanelDescriptor {
+        descriptor(panelID: "sim-1")
+    }
+
+    private static func descriptor(panelID: String) -> MobileSimulatorPanelDescriptor {
         MobileSimulatorPanelDescriptor(
-            panelID: "sim-1",
+            panelID: panelID,
             workspaceID: "workspace-1",
             title: "Simulator",
             selectedDeviceName: "iPhone 17",

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -143,7 +143,6 @@ import Testing
         let deadline = clock.now.advanced(by: .seconds(1))
         while activeID() != expectedID, clock.now < deadline {
             await Task.yield()
-            try? await Task.sleep(for: .milliseconds(10))
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceDetailViewDefaultSurfaceSelectionTests.swift
@@ -14,25 +14,33 @@ import Testing
 
 @MainActor
 @Suite struct WorkspaceDetailViewDefaultSurfaceSelectionTests {
-    @Test func simulatorOnlyWorkspaceAutoSelectsItsFirstPanelWhenPanelsArrive() async {
+    @Test func simulatorOnlyWorkspaceAutoSelectsItsFocusedPanelWhenPanelsArrive() async {
         let workspaceID = "workspace-1"
-        let simulatorSurface = MobileSurfacePreview(
-            id: .init(rawValue: Self.descriptor().panelID),
+        let firstDescriptor = Self.descriptor(panelID: "sim-1")
+        let focusedDescriptor = Self.descriptor(panelID: "sim-2")
+        let firstSimulatorSurface = MobileSurfacePreview(
+            id: .init(rawValue: firstDescriptor.panelID),
             kind: .other("simulator"),
-            title: "Simulator"
+            title: "First Simulator"
+        )
+        let focusedSimulatorSurface = MobileSurfacePreview(
+            id: .init(rawValue: focusedDescriptor.panelID),
+            kind: .other("simulator"),
+            title: "Focused Simulator",
+            isFocused: true
         )
         let initialWorkspace = MobileWorkspacePreview(
             id: .init(rawValue: workspaceID),
             name: "Workspace",
             terminals: [],
-            surfaces: [simulatorSurface]
+            surfaces: [firstSimulatorSurface, focusedSimulatorSurface]
         )
         let updatedWorkspace = MobileWorkspacePreview(
             id: .init(rawValue: workspaceID),
             name: "Workspace",
             terminals: [],
-            surfaces: [simulatorSurface],
-            simulators: [Self.descriptor()]
+            surfaces: [firstSimulatorSurface, focusedSimulatorSurface],
+            simulators: [firstDescriptor, focusedDescriptor]
         )
         let simulatorStore = MobileSimulatorStreamStore()
         let browserStreamStore = BrowserStreamStore()
@@ -69,12 +77,12 @@ import Testing
         model.workspace = updatedWorkspace
         controller.view.layoutIfNeeded()
         await Self.waitForActivePanel(
-            expectedID: Self.descriptor().panelID,
+            expectedID: focusedDescriptor.panelID,
             activeID: { simulatorStore.activeState(in: workspaceID)?.id }
         )
         controller.view.layoutIfNeeded()
 
-        #expect(simulatorStore.activeState(in: workspaceID)?.id == Self.descriptor().panelID)
+        #expect(simulatorStore.activeState(in: workspaceID)?.id == focusedDescriptor.panelID)
         window.isHidden = true
     }
 

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -74,7 +74,8 @@ extension TerminalController {
                 kind: mobileSurfaceKind(for: panel.panelType).rawValue,
                 title: workspace.panelTitle(panelId: panel.id) ?? panel.displayTitle,
                 filePath: filePath,
-                todo: panel.panelType == .workspaceTodo ? mobileTodoSnapshot(in: workspace) : nil
+                todo: panel.panelType == .workspaceTodo ? mobileTodoSnapshot(in: workspace) : nil,
+                isFocused: panel.id == workspace.focusedPanelId
             )
         }
     }

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -254,6 +254,7 @@ extension TerminalController {
                 "surface_id": surface.surfaceID,
                 "kind": surface.kind,
                 "title": surface.title,
+                "is_focused": surface.isFocused,
                 "file_path": v2OrNull(surface.filePath),
             ]
             if let todo = surface.todo {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1735,6 +1735,40 @@
         }
       }
     },
+    "mobile.browser.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザを待機中"
+          }
+        }
+      }
+    },
+    "mobile.browser.waitingDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The browser will appear when the Mac is ready."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac の準備ができるとブラウザが表示されます。"
+          }
+        }
+      }
+    },
     "mobile.browser.reload": {
       "extractionState": "manual",
       "localizations": {
@@ -3737,6 +3771,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "何が起きましたか？"
+          }
+        }
+      }
+    },
+    "mobile.chat.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for Chat"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チャットを待機中"
+          }
+        }
+      }
+    },
+    "mobile.chat.waitingDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The conversation will appear when it is ready."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "準備ができると会話が表示されます。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add regressions for simulator-only workspaces auto-selecting a late-arriving first panel and for empty non-terminal surface branches showing placeholders.
- Add the iOS default-surface fallback and nil-stream waiting placeholders for chat, browser, browser stream, and simulator stream.

## Testing
- `swift test --filter MobileShellCompositeSimulatorStreamTests` in `Packages/iOS/CmuxMobileShell` passed.
- `swift test list --disable-xctest --enable-swift-testing --triple arm64-apple-ios18.0-simulator --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"` in `Packages/iOS/CmuxMobileShellUI` built the iOS test target, then failed in `swiftpm-testing-helper` with the known macOS-vs-iOS-simulator bundle load mismatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789943539&installation_model_id=21920&pr_number=10539&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10539&signature=fb59968fb12be826fae2bc5288469f1d7455dbb6b5957a7d8ccaee2fee4c49e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS default surface selection so new or refreshed workspaces no longer land on an empty terminal. Old behavior: could select an empty terminal or a stale Mac surface; new behavior: prefers the Mac‑focused non‑terminal, preserves any active non‑terminal selection, falls back to the first available simulator or browser stream, and clears stale Mac selections before falling back.

- Data model/RPC (`CMUXMobileCore`, `CmuxMobileRPC`): add is_focused to surface records and list responses; encode the field; decode defaults to false for back‑compat. The server now sets is_focused from the workspace’s focused panel.
- Shell (`CmuxMobileShell`): reset terminal/Mac selections on start; syncSelectedTerminalForWorkspace() defers to syncDefaultSurfaceForWorkspace() to promote the focused non‑terminal, then a selected Mac surface, then first simulator, then first browser. Expose refreshWorkspaceSelection() to re‑evaluate after panel discovery; preserve any active non‑terminal selection; clear stale Mac selections before fallback.
- Browser stream: add BrowserStreamStore.panelDiscoveryRevision(in:) and bump it on replace/remove to trigger selection refresh without O(P) scans.
- UI (`CmuxMobileShellUI`): WorkspaceDetailView refreshes selection on initial load, on browser panel discovery changes, and when simulator lists change. Add waiting placeholders for chat, browser, browser stream, and simulator stream with localized strings and accessibility IDs.
- Tests: add regressions for focused non‑terminal priority (even with terminals), preserving active non‑terminal selection, clearing stale Mac selections, auto‑selecting late‑arriving panels, and chat/browser/simulator placeholders; replace fixed waits with polling.

<sup>Written for commit 51b9456b1fae731f4208eac76e06bd6897c1608f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear waiting screens for chat, browser, browser streaming, and simulator streaming surfaces while content loads.
  * Added localized English and Japanese messaging for browser and chat waiting states.
  * Automatically selects available surfaces as they become available, prioritizing the currently focused surface.

* **Bug Fixes**
  * Preserved valid simulator selections when workspace selections are cleared and restored.
  * Improved selection updates as panels and content become available.
  * Added fallback selection when a previously selected surface is no longer available.

* **Tests**
  * Added coverage for loading placeholders and automatic surface selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->