### PR TITLE
Fix SF Symbol materialization during window layout

### DIFF
--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -138,6 +138,25 @@ enum RenderableSystemSymbol {
         renderabilityCache.isRenderable(symbol)
     }
 
+    /// Resolves a bounded set of symbols before a view enters an AppKit
+    /// window's constraint/layout cycle.
+    @MainActor
+    static func prewarmAppKitImages(
+        systemNames: [String],
+        pointSizes: [CGFloat],
+        weight: Font.Weight? = nil
+    ) {
+        for systemName in systemNames {
+            for pointSize in pointSizes {
+                _ = configuredAppKitImage(
+                    systemName: systemName,
+                    pointSize: pointSize,
+                    weight: weight
+                )
+            }
+        }
+    }
+
     static func clampedRasterPointSize(_ pointSize: CGFloat) -> CGFloat {
         guard pointSize.isFinite else {
             return minimumRasterPointSize
@@ -186,15 +205,70 @@ enum RenderableSystemSymbol {
             weight: fontWeight
         )
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
-        let image = (configuredImage.copy() as? NSImage) ?? configuredImage
+        let imageSize = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
+        guard let image = materializedImage(configuredImage, size: imageSize) else {
+            renderabilityCache.cacheRenderability(false, for: systemName)
+            return nil
+        }
+        // Keep the template contract used by the SwiftUI and AppKit callers,
+        // while replacing AppKit's lazy symbol representation with a bitmap
+        // that cannot be materialized again from an NSWindow layout pass.
         image.isTemplate = true
-        image.size = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
             let evictedKey = appKitImageCacheInsertionOrder.removeFirst()
             appKitImageCache.removeValue(forKey: evictedKey)
         }
+        return image
+    }
+
+    /// Draws a symbol into an owned bitmap before handing it to AppKit views.
+    ///
+    /// `NSImage(systemSymbolName:)` stores a lazy symbol representation. If
+    /// that representation reaches an `NSImageView` while AppKit is solving
+    /// window constraints, the first provider lookup can block the main
+    /// thread for several seconds. A bitmap representation makes all later
+    /// intrinsic-size and layout queries constant-time.
+    @MainActor
+    private static func materializedImage(_ source: NSImage, size: NSSize) -> NSImage? {
+        let pixelScale: CGFloat = 2
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: max(1, Int(ceil(size.width * pixelScale))),
+            pixelsHigh: max(1, Int(ceil(size.height * pixelScale))),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ),
+        let graphicsContext = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            return nil
+        }
+
+        bitmap.size = size
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        graphicsContext.imageInterpolation = .high
+        source.draw(
+            in: NSRect(origin: .zero, size: size),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1,
+            respectFlipped: true,
+            hints: nil
+        )
+
+        let image = NSImage(size: size)
+        image.addRepresentation(bitmap)
+        image.cacheMode = .never
         return image
     }
 

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -207,7 +207,6 @@ enum RenderableSystemSymbol {
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let imageSize = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
         guard let image = materializedImage(configuredImage, size: imageSize) else {
-            renderabilityCache.cacheRenderability(false, for: systemName)
             return nil
         }
         // Keep the template contract used by the SwiftUI and AppKit callers,

--- a/Sources/Update/TitlebarCloudVMButton.swift
+++ b/Sources/Update/TitlebarCloudVMButton.swift
@@ -163,8 +163,7 @@ struct TitlebarNewWorkspaceCloudSplitButton: View {
     var body: some View {
         HStack(spacing: 0) {
             Button(action: onNewTab) {
-                Image(systemName: "plus")
-                    .font(.system(size: config.iconSize, weight: .medium))
+                CmuxSystemSymbolImage(systemName: "plus", pointSize: config.iconSize, weight: .medium)
                     .padding(plusIconPadding)
                     .frame(width: primaryWidth, height: config.buttonSize)
             }
@@ -200,11 +199,11 @@ struct TitlebarNewWorkspaceCloudSplitButton: View {
                 ZStack {
                     Rectangle()
                         .fill(Color.clear)
-                    Image(systemName: "chevron.down")
-                        .font(.system(
-                            size: TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: config),
-                            weight: .bold
-                        ))
+                    CmuxSystemSymbolImage(
+                        systemName: "chevron.down",
+                        pointSize: TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: config),
+                        weight: .bold
+                    )
                         .padding(caretIconPadding)
                 }
                 .frame(width: dropdownWidth, height: config.buttonSize)
@@ -354,8 +353,7 @@ struct TitlebarCloudVMButton: View {
                 Self.showCloudVMMenu(anchorView: anchorView, event: event)
             }
         ) {
-            Image(systemName: "cloud")
-                .font(.system(size: config.iconSize, weight: .medium))
+            CmuxSystemSymbolImage(systemName: "cloud", pointSize: config.iconSize, weight: .medium)
                 .frame(width: config.buttonSize, height: config.buttonSize)
         }
         .safeHelp(String(localized: "titlebar.cloudVM.tooltip", defaultValue: "Open Base"))

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2759,6 +2759,31 @@ final class UpdateTitlebarAccessoryController {
             pointSizes: dropdownSizes,
             weight: .bold
         )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["arrow.down.to.line"],
+            pointSizes: [10],
+            weight: .semibold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["iphone"],
+            pointSizes: [12],
+            weight: .medium
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["chevron.right"],
+            pointSizes: [9],
+            weight: .semibold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["xmark"],
+            pointSizes: [9],
+            weight: .bold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["bell.slash", "bell.badge"],
+            pointSizes: [30],
+            weight: .light
+        )
     }
 
     func attach(to window: NSWindow) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2732,10 +2732,33 @@ final class UpdateTitlebarAccessoryController {
 
     func start() {
         guard !didStart else { return }
+        prewarmTitlebarSymbols()
         didStart = true
         attachToExistingWindows()
         installObservers()
         scheduleStartupWindowScans()
+    }
+
+    private func prewarmTitlebarSymbols() {
+        let iconSizes = TitlebarControlsStyle.allCases.map { $0.config.iconSize }
+        let dropdownSizes = TitlebarControlsStyle.allCases.map {
+            TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: $0.config)
+        }
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["bell", "arrow.left", "arrow.right"],
+            pointSizes: iconSizes,
+            weight: .regular
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["plus", "cloud"],
+            pointSizes: iconSizes,
+            weight: .medium
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["chevron.down"],
+            pointSizes: dropdownSizes,
+            weight: .bold
+        )
     }
 
     func attach(to window: NSWindow) {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -56,6 +56,21 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == clampedImage.size)
     }
 
+    @Test @MainActor func configuredAppKitImageIsEagerlyMaterializedForLayout() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+
+        let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "folder.fill",
+            pointSize: 14,
+            weight: .regular
+        ))
+
+        #expect(image.isTemplate)
+        #expect(image.representations.count == 1)
+        #expect(image.representations.first is NSBitmapImageRep)
+        #expect(image.tiffRepresentation != nil)
+    }
+
     @Test @MainActor func configuredAppKitImagePreservesConfiguredSizeForNonSquareSymbols() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let baseImage = try #require(NSImage(systemSymbolName: "arrow.left.and.right", accessibilityDescription: nil))


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/10547.

`NSImage(systemSymbolName:)` keeps a lazy `NSImageSymbolRepProvider`. When that image reaches an AppKit-constrained view during an `NSWindow` layout pass, the provider can block the main thread for 8+ seconds. The shared AppKit symbol cache now rasterizes each configured symbol into an owned 2x bitmap before returning it, preserving template/tint behavior while making intrinsic-size queries constant-time. The titlebar accessory prewarms all configured icon sizes and replaces its remaining direct `Image(systemName:)` call sites before attaching to windows.

## Tests

- Added a runtime regression test requiring bitmap-backed, template-preserving symbol images.
- Two commits intentionally separate the failing regression test from the fix.
- `swiftc -parse` passed for all changed Swift files.
- `./scripts/lint-pbxproj-test-wiring.sh` passed.
- `./scripts/check-pbxproj.sh` passed.
- `python3 scripts/check-package-resolved-policy.py` passed.

Per task instructions, no local app build, launch, or Xcode test run was performed; CI is the validation environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789950685&installation_model_id=21920&pr_number=10549&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10549&signature=7336961dbeb7e24d5e34180ddc7d86ba73e8e78be6bd9191c7605a161d88c93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AppKit window layout hangs by eliminating lazy SF Symbol materialization. Previously NSImage(systemSymbolName:) could block during window layout; now symbols are rasterized into a single 2x bitmap in configuredAppKitImage and common titlebar and notification icon variants are prewarmed, making intrinsic-size queries constant-time while preserving template/tint behavior.

- Replaces remaining titlebar Image(systemName:) uses with `CmuxSystemSymbolImage`.
- Prewarms plus, cloud, chevron.down, bell and variants, navigation arrows, and other small controls at configured sizes/weights during accessory startup.

**Migration**
- When adding titlebar or notification-popover icons, use `CmuxSystemSymbolImage` and update `prewarmTitlebarSymbols()` with the symbol name, sizes, and weight.

<sup>Written for commit 540d1a69d641eaecc1c0997e3d3a28077ec2879a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency of system-symbol images in titlebar controls.
  * Preserved symbol appearance, sizing, weight, and template behavior when rendering images.
  * Preloaded titlebar and workspace icons to help prevent delays or missing images when controls appear.

* **Tests**
  * Added coverage verifying that configured template images are materialized correctly for layout and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->