### PR TITLE
Fix sanitized Grok agent-hook target resolution

### DIFF
--- a/CLI/CMUXCLI+AgentHookFailureReporting.swift
+++ b/CLI/CMUXCLI+AgentHookFailureReporting.swift
@@ -37,21 +37,27 @@ extension CMUXCLI {
         }
         let shortSessionId = String(sessionId.prefix(12))
         let errorType = error.map { String(reflecting: type(of: $0)) } ?? "unresolved-target"
-        let messageKey: String
-        let defaultMessage: String
+        let failureDescription: String
         switch stage {
         case .targetResolution:
-            messageKey = "cli.agentHook.error.targetResolution"
-            defaultMessage = "Agent hook target resolution failed for %@ %@."
+            failureDescription = String.localizedStringWithFormat(
+                String(
+                    localized: "cli.agentHook.error.targetResolution",
+                    defaultValue: "Agent hook target resolution failed for %@ %@."
+                ),
+                agentName,
+                event
+            )
         case .notificationDelivery:
-            messageKey = "cli.agentHook.error.notificationDelivery"
-            defaultMessage = "Agent hook notification delivery failed for %@ %@."
+            failureDescription = String.localizedStringWithFormat(
+                String(
+                    localized: "cli.agentHook.error.notificationDelivery",
+                    defaultValue: "Agent hook notification delivery failed for %@ %@."
+                ),
+                agentName,
+                event
+            )
         }
-        let failureDescription = String.localizedStringWithFormat(
-            String(localized: messageKey, defaultValue: defaultMessage),
-            agentName,
-            event
-        )
         let userInfo: [String: Any] = [
             NSLocalizedDescriptionKey: failureDescription,
             NSDebugDescriptionErrorKey: failureDescription,

--- a/CLI/CMUXCLI+AgentHookFailureReporting.swift
+++ b/CLI/CMUXCLI+AgentHookFailureReporting.swift
@@ -37,13 +37,33 @@ extension CMUXCLI {
         }
         let shortSessionId = String(sessionId.prefix(12))
         let errorType = error.map { String(reflecting: type(of: $0)) } ?? "unresolved-target"
+        let messageKey: String
+        let defaultMessage: String
+        switch stage {
+        case .targetResolution:
+            messageKey = "cli.agentHook.error.targetResolution"
+            defaultMessage = "Agent hook target resolution failed for %@ %@."
+        case .notificationDelivery:
+            messageKey = "cli.agentHook.error.notificationDelivery"
+            defaultMessage = "Agent hook notification delivery failed for %@ %@."
+        }
+        let failureDescription = String.localizedStringWithFormat(
+            String(localized: messageKey, defaultValue: defaultMessage),
+            agentName,
+            event
+        )
+        let userInfo: [String: Any] = [
+            NSLocalizedDescriptionKey: failureDescription,
+            NSDebugDescriptionErrorKey: failureDescription,
+            "underlying_error_type": errorType,
+        ]
         let reportableError = NSError(
             domain: "com.cmuxterm.cli.agent-hook.\(stage.rawValue)",
             code: 1,
-            userInfo: ["underlying_error_type": errorType]
+            userInfo: userInfo
         )
         agentHookDeliveryLogger.error(
-            "Agent hook failed stage=\(stage.rawValue, privacy: .public) event=\(event, privacy: .public) agent=\(agentName, privacy: .public) session=\(shortSessionId, privacy: .private(mask: .hash)) errorType=\(errorType, privacy: .private(mask: .hash))"
+            "Agent hook failed stage=\(stage.rawValue, privacy: .public) event=\(event, privacy: .public) agent=\(agentName, privacy: .public) session=\(shortSessionId, privacy: .private(mask: .hash)) errorType=\(errorType, privacy: .private(mask: .hash)) description=\(failureDescription, privacy: .public)"
         )
         telemetry.captureError(
             stage: "agent-hook-\(stage.rawValue)",
@@ -53,6 +73,7 @@ extension CMUXCLI {
                 "hook_event": event,
                 "has_session_id": !sessionId.isEmpty,
                 "underlying_error_type": errorType,
+                "failure_description": failureDescription,
             ]
         )
     }

--- a/CLI/CMUXCLI+AgentHookProcessBinding.swift
+++ b/CLI/CMUXCLI+AgentHookProcessBinding.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 extension CMUXCLI {
@@ -43,7 +44,19 @@ extension CMUXCLI {
         client: SocketClient
     ) -> AgentHookProcessBindingResult {
         guard resolution == .controllingTTY else {
-            return corroboratedAgentHookProcessBinding(pid: pid, client: client)
+            switch liveAgentHookProcessBinding(pid: pid, client: client) {
+            case .resolved(let binding):
+                return AgentHookProcessBindingResult(binding: binding, source: .liveProcess, rejectsAmbientClaim: false)
+            case .unsupported:
+                return corroboratedAgentHookProcessBinding(pid: pid, client: client)
+            case .failed:
+                // Keep the pre-live-resolver process-tree evidence as a
+                // compatibility path for nested PTYs whose controlling TTY
+                // is not visible in the app's surface registry yet.
+                return corroboratedAgentHookProcessBinding(pid: pid, client: client)
+            case .notAttempted:
+                return corroboratedAgentHookProcessBinding(pid: pid, client: client)
+            }
         }
 
         switch liveAgentControllingTTYBinding(pid: pid, client: client) {
@@ -60,6 +73,88 @@ extension CMUXCLI {
                 rejectsAmbientClaim: false
             )
         }
+    }
+
+    /// Resolves the hook process through the same live PID probe used by
+    /// Claude hooks. A sanitized agent hook has no ambient CMUX identity; the
+    /// CLI process itself still carries the live controlling TTY, so it is a
+    /// safe second candidate when an agent's parent is hidden behind a runner.
+    private func liveAgentHookProcessBinding(
+        pid: Int?,
+        client: SocketClient
+    ) -> AgentHookProcessBindingProbe {
+        guard !client.isRelayBacked else { return .notAttempted }
+
+        var candidates: [Int] = []
+        if let pid, pid > 0 {
+            candidates.append(pid)
+        }
+        let hookPID = Int(getpid())
+        if hookPID > 0, !candidates.contains(hookPID) {
+            candidates.append(hookPID)
+        }
+        guard !candidates.isEmpty else { return .notAttempted }
+
+        var sawUnsupported = false
+        var sawFailure = false
+        for candidate in candidates {
+            switch liveAgentPidDeliveryTarget(pid: candidate, client: client) {
+            case .resolved(let target):
+                return .resolved(
+                    CallerTerminalBinding(
+                        workspaceId: target.workspaceId,
+                        surfaceId: target.surfaceId
+                    )
+                )
+            case .unsupported:
+                sawUnsupported = true
+            case .failed:
+                sawFailure = true
+            case .notAttempted:
+                continue
+            }
+        }
+        if sawFailure {
+            return .failed
+        }
+        if sawUnsupported {
+            return .unsupported
+        }
+        return .notAttempted
+    }
+
+    /// Re-homes a persisted or ambient surface through the shared live owner
+    /// map. This keeps moved-pane recovery identical for Claude and generic
+    /// hooks without trusting a stale workspace claim.
+    func liveAgentHookSurfaceBinding(
+        mappedSurfaceId: String?,
+        directSurfaceId: String?,
+        claimedWorkspaceId: String?,
+        client: SocketClient
+    ) -> CallerTerminalBinding? {
+        var candidates: [String] = []
+        if let mappedSurfaceId = nonEmptyClaudeHookIdentifier(mappedSurfaceId) {
+            candidates.append(mappedSurfaceId)
+        }
+        if let directSurfaceId = nonEmptyClaudeHookIdentifier(directSurfaceId),
+           !candidates.contains(directSurfaceId) {
+            candidates.append(directSurfaceId)
+        }
+        let claimedWorkspace = nonEmptyClaudeHookIdentifier(claimedWorkspaceId)
+        for surfaceId in candidates {
+            guard case .resolved(let target) = liveAgentSurfaceDeliveryTarget(
+                surfaceId: surfaceId,
+                claimedWorkspaceId: claimedWorkspace,
+                client: client
+            ) else {
+                continue
+            }
+            return CallerTerminalBinding(
+                workspaceId: target.workspaceId,
+                surfaceId: target.surfaceId
+            )
+        }
+        return nil
     }
 
     private func corroboratedAgentHookProcessBinding(

--- a/CLI/CMUXCLI+AgentHookProcessBinding.swift
+++ b/CLI/CMUXCLI+AgentHookProcessBinding.swift
@@ -38,6 +38,7 @@ extension CMUXCLI {
         return .resolved(CallerTerminalBinding(workspaceId: workspaceId, surfaceId: surfaceId))
     }
 
+    /// Resolves a generic hook's process identity with live evidence first.
     func resolveAgentHookProcessBinding(
         pid: Int?,
         resolution: AgentProcessBindingResolution,
@@ -50,10 +51,11 @@ extension CMUXCLI {
             case .unsupported:
                 return corroboratedAgentHookProcessBinding(pid: pid, client: client)
             case .failed:
-                // Keep the pre-live-resolver process-tree evidence as a
-                // compatibility path for nested PTYs whose controlling TTY
-                // is not visible in the app's surface registry yet.
-                return corroboratedAgentHookProcessBinding(pid: pid, client: client)
+                return AgentHookProcessBindingResult(
+                    binding: nil,
+                    source: nil,
+                    rejectsAmbientClaim: true
+                )
             case .notAttempted:
                 return corroboratedAgentHookProcessBinding(pid: pid, client: client)
             }

--- a/CLI/CMUXCLI+ClaudeHookDeliveryTarget.swift
+++ b/CLI/CMUXCLI+ClaudeHookDeliveryTarget.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 extension CMUXCLI {
-    struct ClaudeHookDeliveryTarget {
+    struct AgentHookDeliveryTarget {
         let workspaceId: String
         let surfaceId: String
         /// Resolved from the hook's own identity (live pid target, session
@@ -53,18 +53,19 @@ extension CMUXCLI {
         var allowsPidProbe: Bool = true
     }
 
-    private enum LiveAgentDeliveryTargetProbeResult {
+    /// Shared live-identity probe result used by Claude and generic agent hooks.
+    enum LiveAgentDeliveryTargetProbeResult {
         case notAttempted
         case unsupported
         case failed
-        case resolved(ClaudeHookDeliveryTarget)
+        case resolved(AgentHookDeliveryTarget)
     }
 
     func resolveClaudeHookDeliveryTarget(
         mappedSession: ClaudeHookSessionRecord?,
         routing: ClaudeHookRoutingContext,
         client: SocketClient
-    ) throws -> ClaudeHookDeliveryTarget? {
+    ) throws -> AgentHookDeliveryTarget? {
         let pidProbeAllowed = routing.allowsPidProbe && routing.preferCallerTTYRouting
         let rehomeAllowed = routing.preferCallerTTYRouting
         if pidProbeAllowed {
@@ -190,7 +191,7 @@ extension CMUXCLI {
                 return rehomed
             }
         }
-        return ClaudeHookDeliveryTarget(
+        return AgentHookDeliveryTarget(
             workspaceId: workspaceId,
             surfaceId: resolvedSurface.surfaceId,
             isAuthoritative: resolvedSurface.isAuthoritative
@@ -201,7 +202,7 @@ extension CMUXCLI {
     /// to live identity. An older app may fall back; a present resolver's
     /// rejection must fail closed unless the caller supplies corroborated
     /// surface identity (handled by the caller).
-    private func liveAgentPidDeliveryTarget(
+    func liveAgentPidDeliveryTarget(
         pid: Int?,
         client: SocketClient
     ) -> LiveAgentDeliveryTargetProbeResult {
@@ -233,7 +234,7 @@ extension CMUXCLI {
               isUUID(surfaceId) else {
             return .failed
         }
-        return .resolved(ClaudeHookDeliveryTarget(
+        return .resolved(AgentHookDeliveryTarget(
             workspaceId: workspaceId,
             surfaceId: surfaceId,
             isAuthoritative: true
@@ -246,7 +247,7 @@ extension CMUXCLI {
         surfaceId: String?,
         claimedWorkspaceId: String?,
         client: SocketClient
-    ) -> ClaudeHookDeliveryTarget? {
+    ) -> AgentHookDeliveryTarget? {
         guard case .resolved(let target) = liveAgentSurfaceDeliveryTarget(
             surfaceId: surfaceId,
             claimedWorkspaceId: claimedWorkspaceId,
@@ -255,7 +256,7 @@ extension CMUXCLI {
         return target
     }
 
-    private func liveAgentSurfaceDeliveryTarget(
+    func liveAgentSurfaceDeliveryTarget(
         surfaceId: String?,
         claimedWorkspaceId: String?,
         client: SocketClient
@@ -286,7 +287,7 @@ extension CMUXCLI {
               isUUID(workspaceId) else {
             return .failed
         }
-        return .resolved(ClaudeHookDeliveryTarget(
+        return .resolved(AgentHookDeliveryTarget(
             workspaceId: workspaceId,
             surfaceId: surfaceId,
             isAuthoritative: true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31422,6 +31422,14 @@ export default CMUXSessionRestore;
             }
             if hookWsFlag == nil, explicitSurfaceFlag == nil,
                processBindingResolution().rejectsAmbientClaim {
+                if let liveSurfaceTarget = liveAgentHookSurfaceBinding(
+                    mappedSurfaceId: mapped?.surfaceId,
+                    directSurfaceId: directSurfaceArg,
+                    claimedWorkspaceId: mapped?.workspaceId ?? directWorkspaceArg,
+                    client: client
+                ) {
+                    return (liveSurfaceTarget.workspaceId, liveSurfaceTarget.surfaceId)
+                }
 #if DEBUG
                 agentHookDebugLog(
                     "agentHook.target.nil agent=\(def.name) subcommand=\(subcommand) session=\(agentHookDebugShort(sessionId)) reason=processBindingRejected mapped=\(mapped == nil ? 0 : 1)",
@@ -31471,6 +31479,15 @@ export default CMUXSessionRestore;
 #endif
                     return (workspaceId, surfaceId)
                 }
+            }
+
+            if let liveSurfaceTarget = liveAgentHookSurfaceBinding(
+                mappedSurfaceId: mapped?.surfaceId,
+                directSurfaceId: directSurfaceArg,
+                claimedWorkspaceId: mapped?.workspaceId ?? directWorkspaceArg,
+                client: client
+            ) {
+                return (liveSurfaceTarget.workspaceId, liveSurfaceTarget.surfaceId)
             }
 
             if let workspaceId = resolvedDirectWorkspaceArg {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31420,14 +31420,22 @@ export default CMUXSessionRestore;
             if let strictPiTarget {
                 return strictPiTarget
             }
+            /// Re-homes a known surface only when the hook supplied no explicit target.
+            func tryLiveSurfaceBinding() -> (workspaceId: String, surfaceId: String)? {
+                guard hookWsFlag == nil, explicitSurfaceFlag == nil,
+                      let liveSurfaceTarget = liveAgentHookSurfaceBinding(
+                          mappedSurfaceId: mapped?.surfaceId,
+                          directSurfaceId: directSurfaceArg,
+                          claimedWorkspaceId: mapped?.workspaceId ?? directWorkspaceArg,
+                          client: client
+                      ) else {
+                    return nil
+                }
+                return (liveSurfaceTarget.workspaceId, liveSurfaceTarget.surfaceId)
+            }
             if hookWsFlag == nil, explicitSurfaceFlag == nil,
                processBindingResolution().rejectsAmbientClaim {
-                if let liveSurfaceTarget = liveAgentHookSurfaceBinding(
-                    mappedSurfaceId: mapped?.surfaceId,
-                    directSurfaceId: directSurfaceArg,
-                    claimedWorkspaceId: mapped?.workspaceId ?? directWorkspaceArg,
-                    client: client
-                ) {
+                if let liveSurfaceTarget = tryLiveSurfaceBinding() {
                     return (liveSurfaceTarget.workspaceId, liveSurfaceTarget.surfaceId)
                 }
 #if DEBUG
@@ -31481,12 +31489,7 @@ export default CMUXSessionRestore;
                 }
             }
 
-            if let liveSurfaceTarget = liveAgentHookSurfaceBinding(
-                mappedSurfaceId: mapped?.surfaceId,
-                directSurfaceId: directSurfaceArg,
-                claimedWorkspaceId: mapped?.workspaceId ?? directWorkspaceArg,
-                client: client
-            ) {
+            if let liveSurfaceTarget = tryLiveSurfaceBinding() {
                 return (liveSurfaceTarget.workspaceId, liveSurfaceTarget.surfaceId)
             }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4116,35 +4116,51 @@
     "cli.agentHook.error.notificationDelivery": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agent hook notification delivery failed for %@ %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ %@ のエージェントフック通知を配信できませんでした。"
-          }
-        }
+        "ar": { "stringUnit": { "state": "translated", "value": "فشل تسليم إشعار خطاف الوكيل لـ %@ %@." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Dostava obavijesti agentske kuke nije uspjela za %@ %@." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Levering af agent-hook-notifikationen mislykkedes for %@ %@." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Die Zustellung der Agent-Hook-Benachrichtigung ist für %@ %@ fehlgeschlagen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Agent hook notification delivery failed for %@ %@." } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo entregar la notificación del hook del agente para %@ %@." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échec de la livraison de la notification du hook d’agent pour %@ %@." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Impossibile recapitare la notifica dell’hook dell’agente per %@ %@." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフック通知を配信できませんでした。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ការបញ្ជូនការជូនដំណឹង agent hook បានបរាជ័យសម្រាប់ %@ %@។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 알림을 전달하지 못했습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Levering av agent-hook-varslingen mislyktes for %@ %@." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się dostarczyć powiadomienia haka agenta dla %@ %@." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao entregar a notificação do hook do agente para %@ %@." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось доставить уведомление хука агента для %@ %@." } },
+        "th": { "stringUnit": { "state": "translated", "value": "ส่งการแจ้งเตือน agent hook สำหรับ %@ %@ ไม่สำเร็จ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancası bildirimi teslim edilemedi." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося доставити сповіщення хуку агента для %@ %@." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法传递 %@ %@ 的代理钩子通知。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法傳遞 %@ %@ 的代理程式掛鉤通知。" } }
       }
     },
     "cli.agentHook.error.targetResolution": {
       "extractionState": "manual",
       "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agent hook target resolution failed for %@ %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ %@ のエージェントフック配信先を解決できませんでした。"
-          }
-        }
+        "ar": { "stringUnit": { "state": "translated", "value": "فشل حل هدف خطاف الوكيل لـ %@ %@." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Rješavanje odredišta agentske kuke nije uspjelo za %@ %@." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Agent-hook-målløsning mislykkedes for %@ %@." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Die Zielauflösung des Agent-Hooks ist für %@ %@ fehlgeschlagen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Agent hook target resolution failed for %@ %@." } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo resolver el destino del hook del agente para %@ %@." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échec de la résolution de la cible du hook d’agent pour %@ %@." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Risoluzione della destinazione dell’hook dell’agente non riuscita per %@ %@." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフック配信先を解決できませんでした。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ការដោះស្រាយគោលដៅ agent hook បានបរាជ័យសម្រាប់ %@ %@។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 대상을 확인하지 못했습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Fant ikke målet for agent-hooken for %@ %@." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się rozpoznać celu haka agenta dla %@ %@." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao resolver o destino do hook do agente para %@ %@." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось определить цель хука агента для %@ %@." } },
+        "th": { "stringUnit": { "state": "translated", "value": "ไม่สามารถแก้ไขปลายทาง agent hook สำหรับ %@ %@ ได้" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancası hedefi çözülemedi." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося визначити ціль хуку агента для %@ %@." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法解析 %@ %@ 的代理钩子目标。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法解析 %@ %@ 的代理程式掛鉤目標。" } }
       }
     },
     "agent.generic.notification.body.approvalNeeded": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4113,6 +4113,40 @@
         }
       }
     },
+    "cli.agentHook.error.notificationDelivery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent hook notification delivery failed for %@ %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ のエージェントフック通知を配信できませんでした。"
+          }
+        }
+      }
+    },
+    "cli.agentHook.error.targetResolution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent hook target resolution failed for %@ %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ のエージェントフック配信先を解決できませんでした。"
+          }
+        }
+      }
+    },
     "agent.generic.notification.body.approvalNeeded": {
       "extractionState": "manual",
       "localizations": {

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -157,6 +157,9 @@
          location = "group:CmuxPanes">
       </FileRef>
       <FileRef
+         location = "group:CmuxPhonePush">
+      </FileRef>
+      <FileRef
          location = "group:CMUXProjectModel">
       </FileRef>
       <FileRef

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -2217,6 +2217,132 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    func testGrokSessionStartUsesLiveTargetWithoutHookEnvironmentAndDescribesResolutionFailures() throws {
+        let cliPath = try bundledCLIPath()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-live-target-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        func environment(socketPath: String, probePath: String? = nil) -> [String: String] {
+            var values: [String: String] = [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "PWD": root.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+                "CMUX_CLI_SENTRY_DISABLED": probePath == nil ? "1" : "0",
+                "GROK_HOME": root.appendingPathComponent("grok-home", isDirectory: true).path,
+            ]
+            values["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath
+            return values
+        }
+
+        let successSocketPath = makeSocketPath("grok-live-target")
+        let successListenerFD = try bindUnixSocket(at: successSocketPath)
+        let successState = MockSocketServerState()
+        defer {
+            Darwin.close(successListenerFD)
+            unlink(successSocketPath)
+        }
+        startDetachedMockServer(listenerFD: successListenerFD, state: successState) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return "OK"
+            }
+            switch method {
+            case "agent.resolve_delivery_target":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "workspace_id": workspaceId,
+                        "surface_id": surfaceId,
+                        "source": "pid",
+                    ]
+                )
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["resume_binding": [:]])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return "OK"
+            }
+        }
+
+        let liveStart = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "grok", "session-start"],
+            environment: environment(socketPath: successSocketPath),
+            standardInput: #"{"sessionId":"grok-live-session","cwd":"\#(root.path)","hookEventName":"SessionStart"}"#,
+            timeout: 5
+        )
+        XCTAssertFalse(liveStart.timedOut, liveStart.stderr)
+        XCTAssertEqual(liveStart.status, 0, liveStart.stderr)
+        XCTAssertEqual(liveStart.stdout, "{}\n")
+
+        let liveRequests = successState.snapshot().compactMap { self.jsonObject($0) }
+        XCTAssertTrue(
+            liveRequests.contains {
+                ($0["method"] as? String) == "agent.resolve_delivery_target"
+                    && (((($0["params"] as? [String: Any])?["pid"] as? NSNumber)?.intValue ?? 0) > 0)
+            },
+            "A sanitized Grok hook must resolve its live process identity, saw \(successState.snapshot())"
+        )
+        XCTAssertTrue(
+            liveRequests.contains { ($0["method"] as? String) == "surface.resume.set" },
+            "A resolved Grok SessionStart must persist the live target, saw \(successState.snapshot())"
+        )
+
+        let failureSocketPath = makeSocketPath("grok-live-failure")
+        let failureListenerFD = try bindUnixSocket(at: failureSocketPath)
+        let failureState = MockSocketServerState()
+        let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false).path
+        defer {
+            Darwin.close(failureListenerFD)
+            unlink(failureSocketPath)
+        }
+        startDetachedMockServer(listenerFD: failureListenerFD, state: failureState) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return "OK"
+            }
+            guard method == "agent.resolve_delivery_target" else {
+                return "OK"
+            }
+            return self.v2Response(
+                id: id,
+                ok: false,
+                error: ["code": "not_found", "message": "No live delivery target"]
+            )
+        }
+
+        let failedStart = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "grok", "session-start"],
+            environment: environment(
+                socketPath: failureSocketPath,
+                probePath: probePath
+            ),
+            standardInput: #"{"sessionId":"grok-failed-session","cwd":"\#(root.path)","hookEventName":"SessionStart"}"#,
+            timeout: 5
+        )
+        XCTAssertFalse(failedStart.timedOut, failedStart.stderr)
+        XCTAssertEqual(failedStart.status, 0, failedStart.stderr)
+        XCTAssertEqual(failedStart.stdout, "{}\n")
+        let capturedError = try String(contentsOfFile: probePath, encoding: .utf8)
+        XCTAssertTrue(
+            capturedError.contains("Agent hook target resolution failed for Grok session-start."),
+            "Target-resolution telemetry must describe the failure, saw \(capturedError)"
+        )
+    }
+
     func testGrokStopFallbackCompletionsFireForTwoConcurrentThreads() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("grok-two-threads")

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -2298,6 +2298,20 @@ extension CLINotifyProcessIntegrationRegressionTests {
             liveRequests.contains { ($0["method"] as? String) == "surface.resume.set" },
             "A resolved Grok SessionStart must persist the live target, saw \(successState.snapshot())"
         )
+        let resumeRequest = try XCTUnwrap(
+            liveRequests.first { ($0["method"] as? String) == "surface.resume.set" }
+        )
+        let resumeParams = try XCTUnwrap(resumeRequest["params"] as? [String: Any])
+        XCTAssertEqual(resumeParams["workspace_id"] as? String, workspaceId)
+        XCTAssertEqual(resumeParams["surface_id"] as? String, surfaceId)
+        let storeURL = root.appendingPathComponent("grok-hook-sessions.json", isDirectory: false)
+        let storeJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: storeURL)) as? [String: Any]
+        )
+        let sessions = try XCTUnwrap(storeJSON["sessions"] as? [String: Any])
+        let liveRecord = try XCTUnwrap(sessions["grok-live-session"] as? [String: Any])
+        XCTAssertEqual(liveRecord["workspaceId"] as? String, workspaceId)
+        XCTAssertEqual(liveRecord["surfaceId"] as? String, surfaceId)
 
         let failureSocketPath = makeSocketPath("grok-live-failure")
         let failureListenerFD = try bindUnixSocket(at: failureSocketPath)
@@ -2338,9 +2352,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(failedStart.stdout, "{}\n")
         let capturedError = try String(contentsOfFile: probePath, encoding: .utf8)
         XCTAssertTrue(
-            capturedError.contains("Agent hook target resolution failed for Grok session-start."),
+            capturedError.contains("Grok") && capturedError.contains("session-start"),
             "Target-resolution telemetry must describe the failure, saw \(capturedError)"
         )
+        XCTAssertFalse(capturedError.contains("(null)"), capturedError)
     }
 
     func testGrokStopFallbackCompletionsFireForTwoConcurrentThreads() throws {


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/10545.

Fresh Grok session-start hooks run from a pinned command that strips CMUX_* identity variables. Generic hooks were still using the legacy TTY/process-tree resolver, so a fresh callback could connect successfully but have no positively resolved target. The failure telemetry also constructed an NSError with no debug description, which Sentry rendered as bare Code: 1.

## Root cause

Claude hooks had adopted the live `agent.resolve_delivery_target` path, while generic hooks (including Grok) had not. Grok session-start has no persisted session record yet and no ambient workspace/surface identity.

## Fix

- Share the live PID and surface-owner probes between Claude and generic hooks.
- Use the hook process PID as a live identity fallback when an agent runner hides the parent PID.
- Fail closed when a supported live resolver rejects identity; retain the legacy chain only for older apps that do not expose the resolver.
- Preserve explicit `--workspace`/`--surface` target precedence.
- Re-home persisted/ambient surface identities through the live owner map.
- Add localized `NSLocalizedDescriptionKey` and `NSDebugDescriptionErrorKey` values plus telemetry context so Sentry reports a useful message.
- Normalize the existing workspace package-group manifest so the required repository guard is green.

## Tests

- Added a behavior regression test for a sanitized, fresh Grok session-start, exact persisted target, and descriptive target-resolution telemetry.
- The regression test and fix are separate commits as required.
- Ran Swift parse checks, localization JSON validation, pbxproj/test-wiring lint, package-resolved policy, workspace-group normalization, and diff checks.
- Dispatched the full CI workflow on the branch; its routed checks are being verified remotely.
- Dispatched the focused macOS E2E test on the Blacksmith macOS runner (the first Warp attempt reached an unrelated test-bundle linker failure before executing tests).
- Did not run local xcodebuild tests or build/launch the app per task instructions.

## Localization

Audited the changed CLI error surface and added translations for all 20 locales present in `Resources/Localizable.xcstrings`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789952774&installation_model_id=21920&pr_number=10551&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10551&signature=8d32775886d38a18299527396d8aec79ac1b8f995a3596bd81bdd35c91cc9dbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->