### PR TITLE
fix(cli): keep Sentry telemetry off the exit hot path

### DIFF
--- a/CLI/CLISocketSentryTelemetry.swift
+++ b/CLI/CLISocketSentryTelemetry.swift
@@ -174,9 +174,10 @@ final class CLISocketSentryTelemetry {
         let envelopeItem = SentryEnvelopeItem(event: scrubbedEvent)
         let envelope = SentryEnvelope(id: scrubbedEvent.eventId, singleItem: envelopeItem)
         PrivateSentrySDKOnly.store(envelope)
-        // `store` is the durable step. A zero-timeout flush only schedules the
-        // SDK's cached-envelope sender without waiting for network completion.
-        SentrySDK.flush(timeout: 0)
+        // `store` is the durable handoff. Calling SentrySDK.flush here—even
+        // with a zero timeout—still enters SentryHttpTransport's synchronous
+        // coordination path. The app's Sentry client will pick up the cached
+        // envelope on its next transport pass.
 #if DEBUG
         recordStoreProbe(eventId: scrubbedEvent.eventId.sentryIdString)
 #endif
@@ -392,6 +393,7 @@ final class CLISocketSentryTelemetry {
         defer { startupLock.unlock() }
         guard !started else { return }
         SentrySDK.start { options in
+            CLISentryRuntimePolicy().configure(options)
             options.dsn = dsn
             options.releaseName = currentSentryReleaseName()
 #if DEBUG
@@ -405,11 +407,7 @@ final class CLISocketSentryTelemetry {
             options.sendDefaultPii = false
             options.attachStacktrace = true
             options.tracesSampleRate = 0.0
-            options.enableAppHangTracking = false
-            options.enableWatchdogTerminationTracking = false
-            options.enableAutoSessionTracking = false
             options.enableCaptureFailedRequests = false
-            options.enableMetricKit = false
             // Redact file paths, emails, and secrets from every outgoing event
             // and breadcrumb before it leaves the device.
             let scrubber = SentryEventScrubber()

--- a/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/CLISentryRuntimePolicy.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/CLISentryRuntimePolicy.swift
@@ -1,0 +1,26 @@
+public import Sentry
+
+/// Configures Sentry for telemetry emitted by a short-lived CLI process.
+///
+/// A CLI invocation has no application lifecycle during which a synchronous
+/// transport drain is useful. Its events are persisted before the process
+/// exits, so SDK shutdown must never add a network wait to the command path.
+public struct CLISentryRuntimePolicy: Sendable {
+    /// Creates the short-lived CLI policy.
+    public init() {}
+
+    /// Applies the CLI lifecycle and shutdown settings to Sentry options.
+    ///
+    /// - Parameter options: The options that will be passed to
+    ///   `SentrySDK.start(options:)`.
+    public func configure(_ options: Options) {
+        // SentrySDK.close() always asks its transport to flush. Keep that
+        // shutdown path bounded even if a future CLI teardown calls close().
+        options.shutdownTimeInterval = 0
+        options.enableAppHangTracking = false
+        options.enableWatchdogTerminationTracking = false
+        options.enableAutoSessionTracking = false
+        options.enableLogs = false
+        options.enableMetricKit = false
+    }
+}

--- a/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/CLISentryRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/CLISentryRuntimePolicyTests.swift
@@ -1,0 +1,18 @@
+import Sentry
+import Testing
+
+@testable import CmuxSentryReporting
+
+@Suite struct CLISentryRuntimePolicyTests {
+    @Test func shortLivedCLIProfileDoesNotWaitForSentryShutdown() {
+        let options = Options()
+
+        CLISentryRuntimePolicy().configure(options)
+
+        #expect(options.shutdownTimeInterval == 0)
+        #expect(options.enableAppHangTracking == false)
+        #expect(options.enableWatchdogTerminationTracking == false)
+        #expect(options.enableAutoSessionTracking == false)
+        #expect(options.enableLogs == false)
+    }
+}

--- a/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/CLISentryRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/CLISentryRuntimePolicyTests.swift
@@ -14,5 +14,6 @@ import Testing
         #expect(options.enableWatchdogTerminationTracking == false)
         #expect(options.enableAutoSessionTracking == false)
         #expect(options.enableLogs == false)
+        #expect(options.enableMetricKit == false)
     }
 }


### PR DESCRIPTION
## Summary

Fixes [cmux issue #10543](https://github.com/manaflow-ai/cmux/issues/10543), where short-lived `cmux` CLI invocations could spend 2+ seconds in Sentry's `SentryHttpTransport.flush` while exiting. The CLI was already persisting a manually-built envelope, but it still called `SentrySDK.flush(timeout: 0)`; Sentry enters its synchronous transport coordination path even for that zero timeout. Sentry also defaults its shutdown flush interval to two seconds.

This change makes the short-lived process contract explicit:

- persist the scrubbed envelope and return without invoking Sentry transport flush from the CLI error path;
- configure a reusable `CLISentryRuntimePolicy` with `shutdownTimeInterval = 0` so a future `SentrySDK.close()` cannot reintroduce the two-second shutdown wait;
- keep app-hang, watchdog-termination, auto-session, MetricKit, and log lifecycle integrations off for the CLI profile.

The durable envelope may be uploaded by a later Sentry transport pass (for example, when the host app starts or its transport becomes reachable). CLI command latency and correctness take precedence over best-effort immediate delivery.

## Regression coverage

Two commits intentionally preserve the repository's red/green regression shape:

1. `test: require non-blocking CLI Sentry shutdown policy` adds a runtime test against a real Sentry `Options` instance.
2. `fix: keep CLI Sentry teardown non-blocking` adds and wires the policy and removes the transport flush call.

Checks run:

- `swift build` in `Packages/Shared/CmuxSentryTelemetry` — passed.
- `swift test --filter CLISentryRuntimePolicyTests` — the Swift Testing test passed; this Intel host reports the existing SwiftPM XCTest helper arm64/x86_64 bundle mismatch after running the tests, so the command's final exit status is environment-limited.
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (698 test files).
- `./scripts/check-pbxproj.sh` — passed.
- `python3 scripts/check-package-resolved-policy.py` — passed.
- `git diff --check origin/main...HEAD` — passed.

No app build or launch was performed, per the task contract.

Closes https://github.com/manaflow-ai/cmux/issues/10543

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789951469&installation_model_id=21920&pr_number=10553&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10553&signature=e3d328cd8fa1d08d117a9feabc2d8840cc30ad20e926329346b70992ebff5be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates 2+ second CLI exit delays by removing `SentrySDK.flush(timeout: 0)` from the error path. Short-lived `cmux` commands now persist a scrubbed Sentry envelope and exit; a later process uploads the cached envelope.

- Introduces `CLISentryRuntimePolicy` and applies it at CLI Sentry startup to keep teardown non-blocking (`shutdownTimeInterval = 0`) and disable app-hang, watchdog-termination, auto-session, logs, and MetricKit integrations.
- Removes the explicit transport flush after `PrivateSentrySDKOnly.store(...)`; storage is the durable handoff.
- Adds a test to assert the policy settings.
- Scope: CLI only; the app profile is unchanged. Events may be delivered later instead of immediately, but command latency improves.

<sup>Written for commit 780a3b313a3b852d5583cd123f11cce69f8f621b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

