### PR TITLE
fix(ssh): verify and repair remote daemon bootstrap

### DIFF
--- a/CLI/CMUXCLI+SSHPTYAttachBridge.swift
+++ b/CLI/CMUXCLI+SSHPTYAttachBridge.swift
@@ -19,7 +19,7 @@ extension CMUXCLI {
               let exitCode = SSHPTYAttachExitCode(rawValue: cliError.exitCode) else {
             return false
         }
-        return exitCode.isWrapperRetryable
+        return sshPTYAttachWrapperWillRetry(exitCode)
     }
 
     /// True when a persistent attach wrapper has another general retry available.

--- a/CLI/CMUXCLI+SSHPTYAttachBridge.swift
+++ b/CLI/CMUXCLI+SSHPTYAttachBridge.swift
@@ -9,6 +9,19 @@ extension CLIError {
 }
 
 extension CMUXCLI {
+    /// Persistent attach launchers own the retry UX.  A retryable bridge
+    /// establishment error is expected while the management supervisor is
+    /// bringing the daemon/proxy back; printing it before the bounded retry
+    /// notice makes a healthy recovery look like a fatal SSH failure.
+    func shouldSuppressSSHPTYAttachRetryError(_ error: Error) -> Bool {
+        guard sshPTYAttachWrapperRetryPending(),
+              let cliError = error as? CLIError,
+              let exitCode = SSHPTYAttachExitCode(rawValue: cliError.exitCode) else {
+            return false
+        }
+        return exitCode.isWrapperRetryable
+    }
+
     /// True when a persistent attach wrapper has another general retry available.
     /// Persistent wrappers export `CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=1`;
     /// direct invocations leave it unset, so failures there always clean up.

--- a/CLI/CMUXCLI+SSHReconnectPrompt.swift
+++ b/CLI/CMUXCLI+SSHReconnectPrompt.swift
@@ -10,6 +10,19 @@ extension CMUXCLI {
         return "\\n\\033[33m\(status)\\033[0m\\n\\033[2m\(stopHint)\\033[0m\\n"
     }
 
+    /// Returns the localized success note printed after a transient SSH
+    /// supervisor retry.  Keeping this beside the retry/error formats makes a
+    /// historical warning in scrollback unambiguous once the bridge is live.
+    func sshAutoReconnectRecoveredNoteFormat() -> String {
+        let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
+        let status = String(
+            localized: "cli.ssh.autoReconnect.recovered",
+            defaultValue: "[cmux] SSH reconnected (attempt %s/%s).",
+            bundle: bundle
+        )
+        return "\\n\\033[32m\(status)\\033[0m\\n"
+    }
+
     func sshManualReconnectExitPromptFormat() -> String {
         let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
         let status = String(localized: "cli.ssh.manualReconnectPrompt.status", defaultValue: "[cmux] ssh exited with status %s.", bundle: bundle)

--- a/CLI/CMUXCLI+SSHStartupScripts.swift
+++ b/CLI/CMUXCLI+SSHStartupScripts.swift
@@ -308,6 +308,7 @@ extension CMUXCLI {
         let backoffBuilder = SSHRetryBackoffScriptBuilder(context: .startup)
         let terminalModeReset = shellQuote(SSHTerminalModeResetSequence().shellPrintfFormat)
         let terminalExitPrompt = shellQuote(sshTerminalExitPromptFormat())
+        let reconnectRecoveredNote = shellQuote(sshAutoReconnectRecoveredNoteFormat())
         let terminalExitPromptCommand = [
             shellQuote(resolvedExecutableURL()?.path ?? (args.first ?? "cmux")),
             "__ssh-terminal-exit-prompt",
@@ -355,9 +356,7 @@ extension CMUXCLI {
             // Keep the supervisor finite even when an old persisted launcher
             // omitted CMUX_SSH_RECONNECT_LIMIT.
             "cmux_ssh_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
-            "case \"$cmux_ssh_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_reconnect_limit=20 ;; esac",
-            "cmux_ssh_reconnect_hard_limit=20; if [ \"$cmux_ssh_reconnect_limit\" -gt \"$cmux_ssh_reconnect_hard_limit\" ]; then cmux_ssh_reconnect_limit=\"$cmux_ssh_reconnect_hard_limit\"; fi",
-            "cmux_ssh_reconnect_unbounded=0",
+            "case \"$cmux_ssh_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_reconnect_limit=20 ;; *) while [ \"${cmux_ssh_reconnect_limit#0}\" != \"$cmux_ssh_reconnect_limit\" ] && [ \"$cmux_ssh_reconnect_limit\" != 0 ]; do cmux_ssh_reconnect_limit=\"${cmux_ssh_reconnect_limit#0}\"; done; case \"$cmux_ssh_reconnect_limit\" in [1-9]|1[0-9]|20) ;; *) cmux_ssh_reconnect_limit=20 ;; esac ;; esac",
             "cmux_ssh_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_reconnect_delay=2 ;; esac",
             "cmux_ssh_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",
@@ -436,7 +435,7 @@ extension CMUXCLI {
             "  wait \"$CMUX_SSH_CHILD_PID\"",
             "  cmux_ssh_status=$?",
             "  CMUX_SSH_CHILD_PID=",
-            "  if [ \"$cmux_ssh_status\" -eq 0 ]; then break; fi",
+            "  if [ \"$cmux_ssh_status\" -eq 0 ]; then if [ \"$cmux_ssh_retry\" -gt 0 ]; then cmux_ssh_note \"$(printf \(reconnectRecoveredNote) \"$cmux_ssh_retry\" \"$cmux_ssh_reconnect_limit\")\"; fi; break; fi",
             "  cmux_ssh_reset_terminal_modes",
             "  case \"$cmux_ssh_status\" in \(retryableStatusPattern)) ;; *) break ;; esac",
         ]
@@ -449,9 +448,8 @@ extension CMUXCLI {
         if hasOneTimeCommand {
             scriptLines += ["  if [ \"$cmux_ssh_status\" -eq 255 ]; then cmux_ssh_reauth_required=1; fi", "  fi"]
         }
-        let retryLimitCondition = retryPTYAttachStatus
-            ? "  if [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
-            : "  if [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
+        let retryLimitCondition =
+            "  if [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
         scriptLines.append(retryLimitCondition)
         scriptLines += [
             "  cmux_ssh_retry=$((cmux_ssh_retry + 1))",

--- a/CLI/CMUXCLI+SSHStartupScripts.swift
+++ b/CLI/CMUXCLI+SSHStartupScripts.swift
@@ -350,8 +350,14 @@ extension CMUXCLI {
             scriptLines.append(authRetryPolicy.processTreeTerminationShellFunction())
         }
         let reconnectConfiguration = retryPTYAttachStatus ? [
-            "cmux_ssh_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-}\"",
-            "case \"$cmux_ssh_reconnect_limit\" in '') cmux_ssh_reconnect_limit='∞'; cmux_ssh_reconnect_unbounded=1 ;; *[!0-9]*) cmux_ssh_reconnect_limit=20; cmux_ssh_reconnect_unbounded=0 ;; *) cmux_ssh_reconnect_unbounded=0 ;; esac",
+            // A missing limit used to mean infinity, which left a corrupt or
+            // permanently unavailable daemon spinning forever in the pane.
+            // Keep the supervisor finite even when an old persisted launcher
+            // omitted CMUX_SSH_RECONNECT_LIMIT.
+            "cmux_ssh_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
+            "case \"$cmux_ssh_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_reconnect_limit=20 ;; esac",
+            "cmux_ssh_reconnect_hard_limit=20; if [ \"$cmux_ssh_reconnect_limit\" -gt \"$cmux_ssh_reconnect_hard_limit\" ]; then cmux_ssh_reconnect_limit=\"$cmux_ssh_reconnect_hard_limit\"; fi",
+            "cmux_ssh_reconnect_unbounded=0",
             "cmux_ssh_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_reconnect_delay=2 ;; esac",
             "cmux_ssh_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",
@@ -406,7 +412,7 @@ extension CMUXCLI {
             // retry is actually pending; see CMUXCLI.sshPTYAttachWrapperRetryPending
             // and SSHPTYAttachRetryScriptBuilder.
             scriptLines += [
-                "  if [ \"$cmux_ssh_reconnect_unbounded\" -eq 1 ] || [ \"$cmux_ssh_retry\" -lt \"$cmux_ssh_reconnect_limit\" ]; then CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=1; else CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=0; fi",
+                "  if [ \"$cmux_ssh_retry\" -lt \"$cmux_ssh_reconnect_limit\" ]; then CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=1; else CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=0; fi",
                 "  export CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY",
             ]
         }
@@ -444,7 +450,7 @@ extension CMUXCLI {
             scriptLines += ["  if [ \"$cmux_ssh_status\" -eq 255 ]; then cmux_ssh_reauth_required=1; fi", "  fi"]
         }
         let retryLimitCondition = retryPTYAttachStatus
-            ? "  if [ \"$cmux_ssh_reconnect_unbounded\" -eq 0 ] && [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
+            ? "  if [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
             : "  if [ \"$cmux_ssh_retry\" -ge \"$cmux_ssh_reconnect_limit\" ]; then break; fi"
         scriptLines.append(retryLimitCondition)
         scriptLines += [

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -36787,7 +36787,9 @@ struct CMUXTermMain {
         do {
             try cli.run()
         } catch {
-            CMUXCLIOutput.writeStandardError("Error: \(error)\n")
+            if !cli.shouldSuppressSSHPTYAttachRetryError(error) {
+                CMUXCLIOutput.writeStandardError("Error: \(error)\n")
+            }
             let exitCode = (error as? CLIError)?.exitCode ?? 1
             exit(exitCode)
         }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
@@ -86,9 +86,7 @@ public enum SSHPTYAttachExitCode: Int32 {
 
         return [
             "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
-            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; esac",
-            "cmux_ssh_attach_reconnect_hard_limit=20; if [ \"$cmux_ssh_attach_reconnect_limit\" -gt \"$cmux_ssh_attach_reconnect_hard_limit\" ]; then cmux_ssh_attach_reconnect_limit=\"$cmux_ssh_attach_reconnect_hard_limit\"; fi",
-            "cmux_ssh_attach_reconnect_unbounded=0",
+            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; *) while [ \"${cmux_ssh_attach_reconnect_limit#0}\" != \"$cmux_ssh_attach_reconnect_limit\" ] && [ \"$cmux_ssh_attach_reconnect_limit\" != 0 ]; do cmux_ssh_attach_reconnect_limit=\"${cmux_ssh_attach_reconnect_limit#0}\"; done; case \"$cmux_ssh_attach_reconnect_limit\" in [1-9]|1[0-9]|20) ;; *) cmux_ssh_attach_reconnect_limit=20 ;; esac ;; esac",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_attach_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_attach_reconnect_delay=2 ;; esac",
             "cmux_ssh_attach_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",
@@ -106,7 +104,7 @@ public enum SSHPTYAttachExitCode: Int32 {
             "    if [ \"$cmux_ssh_attach_status\" -eq 0 ]; then cmux_ssh_attach_reauth_required=0; elif [ \"$cmux_ssh_attach_status\" -ne \(transientStatus) ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  fi",
             "  if [ \"$cmux_ssh_attach_reauth_required\" -eq 0 ]; then",
-            "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 1 ] || [ \"$cmux_ssh_attach_retry\" -lt \"$cmux_ssh_attach_reconnect_limit\" ]; then cmux_ssh_attach_can_retry=1; else cmux_ssh_attach_can_retry=0; fi",
+            "  if [ \"$cmux_ssh_attach_retry\" -lt \"$cmux_ssh_attach_reconnect_limit\" ]; then cmux_ssh_attach_can_retry=1; else cmux_ssh_attach_can_retry=0; fi",
             "  CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=\"$cmux_ssh_attach_can_retry\" CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY=\"$cmux_ssh_attach_no_progress_retry\" CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT=\"$cmux_ssh_attach_no_progress_limit\" \(command)",
             "  cmux_ssh_attach_status=$?",
             "  if [ \"$cmux_ssh_attach_status\" -ne 0 ] && [ -t 2 ]; then printf \(terminalModeReset) >&2 || true; fi",
@@ -118,7 +116,7 @@ public enum SSHPTYAttachExitCode: Int32 {
             "    *) exit \"$cmux_ssh_attach_status\" ;;",
             "  esac",
             "  fi",
-            "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 0 ] && [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
+            "  if [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_retry=$((cmux_ssh_attach_retry + 1))",
             "  if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' \"$(printf \(reattachingFormat) \"$cmux_ssh_attach_retry\" \"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi",
             "  if [ \"$cmux_ssh_attach_reconnect_delay\" -gt 0 ]; then sleep \"$cmux_ssh_attach_reconnect_delay\"; fi",

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
@@ -85,8 +85,10 @@ public enum SSHPTYAttachExitCode: Int32 {
         let terminalModeReset = SSHTerminalModeResetSequence().shellPrintfFormat.remoteCommandShellQuoted
 
         return [
-            "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-}\"",
-            "case \"$cmux_ssh_attach_reconnect_limit\" in '') cmux_ssh_attach_reconnect_limit='∞'; cmux_ssh_attach_reconnect_unbounded=1 ;; *[!0-9]*) cmux_ssh_attach_reconnect_limit=20; cmux_ssh_attach_reconnect_unbounded=0 ;; *) cmux_ssh_attach_reconnect_unbounded=0 ;; esac",
+            "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
+            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; esac",
+            "cmux_ssh_attach_reconnect_hard_limit=20; if [ \"$cmux_ssh_attach_reconnect_limit\" -gt \"$cmux_ssh_attach_reconnect_hard_limit\" ]; then cmux_ssh_attach_reconnect_limit=\"$cmux_ssh_attach_reconnect_hard_limit\"; fi",
+            "cmux_ssh_attach_reconnect_unbounded=0",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_attach_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_attach_reconnect_delay=2 ;; esac",
             "cmux_ssh_attach_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
@@ -33,6 +33,10 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             localized: "cli.sshPtyAttach.bridgeClosedReattaching",
             defaultValue: "[cmux] remote PTY bridge closed; reattaching (attempt %s/%s)."
         ).remoteCommandShellQuoted
+        let reconnectedFormat = String(
+            localized: "cli.sshPtyAttach.reconnected",
+            defaultValue: "[cmux] remote PTY reconnected (attempt %s/%s)."
+        ).remoteCommandShellQuoted
         let retryWithoutReauthenticationStatus =
             SSHPTYAttachExitCode.retryableWithoutReauthentication.rawValue
         let noProgressStatus = SSHPTYAttachExitCode.bridgeClosedWithoutProgress.rawValue
@@ -44,9 +48,7 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             // malformed limit must fail closed to the same finite supervisor
             // used by newly generated SSH startup scripts.
             "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
-            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; esac",
-            "cmux_ssh_attach_reconnect_hard_limit=20; if [ \"$cmux_ssh_attach_reconnect_limit\" -gt \"$cmux_ssh_attach_reconnect_hard_limit\" ]; then cmux_ssh_attach_reconnect_limit=\"$cmux_ssh_attach_reconnect_hard_limit\"; fi",
-            "cmux_ssh_attach_reconnect_unbounded=0",
+            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; *) while [ \"${cmux_ssh_attach_reconnect_limit#0}\" != \"$cmux_ssh_attach_reconnect_limit\" ] && [ \"$cmux_ssh_attach_reconnect_limit\" != 0 ]; do cmux_ssh_attach_reconnect_limit=\"${cmux_ssh_attach_reconnect_limit#0}\"; done; case \"$cmux_ssh_attach_reconnect_limit\" in [1-9]|1[0-9]|20) ;; *) cmux_ssh_attach_reconnect_limit=20 ;; esac ;; esac",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_attach_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_attach_reconnect_delay=2 ;; esac",
             "cmux_ssh_attach_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",
@@ -77,10 +79,11 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             "    \(authenticationResult)",
             "  fi",
             "  if [ \"$cmux_ssh_attach_reauth_required\" -eq 0 ]; then",
-            "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 1 ] || [ \"$cmux_ssh_attach_retry\" -lt \"$cmux_ssh_attach_reconnect_limit\" ]; then cmux_ssh_attach_can_retry=1; else cmux_ssh_attach_can_retry=0; fi",
+            "  if [ \"$cmux_ssh_attach_retry\" -lt \"$cmux_ssh_attach_reconnect_limit\" ]; then cmux_ssh_attach_can_retry=1; else cmux_ssh_attach_can_retry=0; fi",
             "  CMUX_SSH_PTY_ATTACH_WRAPPER_CAN_RETRY=\"$cmux_ssh_attach_can_retry\" CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY=\"$cmux_ssh_attach_no_progress_retry\" CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT=\"$cmux_ssh_attach_no_progress_limit\" \(command)",
             "  cmux_ssh_attach_status=$?",
             "  if [ \"$cmux_ssh_attach_status\" -ne 0 ] && [ -t 2 ]; then printf \(terminalModeReset) >&2 || true; fi",
+            "  if [ \"$cmux_ssh_attach_status\" -eq 0 ] && [ \"$cmux_ssh_attach_retry\" -gt 0 ] && [ -t 2 ]; then printf '\\n\\033[32m%s\\033[0m\\n' \"$(printf \(reconnectedFormat) \"$cmux_ssh_attach_retry\" \"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi",
             "  case \"$cmux_ssh_attach_status\" in",
             "    \(noProgressStatus)) cmux_ssh_attach_no_progress_retry=$((cmux_ssh_attach_no_progress_retry + 1)); cmux_ssh_attach_reconnect_delay=\"$cmux_ssh_attach_reconnect_initial_delay\"; \(noProgressPolicy.limitReachedCommand) ;;",
             "    \(retryWithoutReauthenticationStatus)) cmux_ssh_attach_no_progress_retry=0 ;;",
@@ -89,7 +92,7 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             "    *) exit \"$cmux_ssh_attach_status\" ;;",
             "  esac",
             "  fi",
-            "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 0 ] && [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
+            "  if [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_retry=$((cmux_ssh_attach_retry + 1))",
             "  \(backoffBuilder.terminalInputModeResetLine)",
             "  if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' \"$(printf \(reattachingFormat) \"$cmux_ssh_attach_retry\" \"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi",

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
@@ -40,8 +40,13 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
         let transientStatus = SSHPTYAttachExitCode.retryableTransient.rawValue
         let terminalModeReset = SSHTerminalModeResetSequence().shellPrintfFormat.remoteCommandShellQuoted
         var lines = [
-            "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-}\"",
-            "case \"$cmux_ssh_attach_reconnect_limit\" in '') cmux_ssh_attach_reconnect_limit='∞'; cmux_ssh_attach_reconnect_unbounded=1 ;; *[!0-9]*) cmux_ssh_attach_reconnect_limit=20; cmux_ssh_attach_reconnect_unbounded=0 ;; *) cmux_ssh_attach_reconnect_unbounded=0 ;; esac",
+            // Persisted launchers may predate the retry policy.  A missing or
+            // malformed limit must fail closed to the same finite supervisor
+            // used by newly generated SSH startup scripts.
+            "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
+            "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; esac",
+            "cmux_ssh_attach_reconnect_hard_limit=20; if [ \"$cmux_ssh_attach_reconnect_limit\" -gt \"$cmux_ssh_attach_reconnect_hard_limit\" ]; then cmux_ssh_attach_reconnect_limit=\"$cmux_ssh_attach_reconnect_hard_limit\"; fi",
+            "cmux_ssh_attach_reconnect_unbounded=0",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
             "case \"$cmux_ssh_attach_reconnect_delay\" in ''|*[!0-9]*|0*) cmux_ssh_attach_reconnect_delay=2 ;; esac",
             "cmux_ssh_attach_reconnect_max_delay=\"${CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS:-30}\"",

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -345,6 +345,39 @@ struct SSHPTYAttachRetryScriptBuilderTests {
         }
     }
 
+    @Test(arguments: ["bad", "21", "999999999999999999999999999999"])
+    func malformedOrOversizedReconnectLimitsRemainFinite(_ configuredLimit: String) throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-attach-limit-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        let retryLines = SSHPTYAttachRetryScriptBuilder().lines(
+            command: "cmux_test_attach",
+            reauthenticates: false
+        )
+        let script = ([
+            "cmux_ssh_attach_signal_exit() { exit \"$1\"; }",
+            "sleep() { :; }",
+            "cmux_test_attach() { printf '%s\\n' attach >> \"$CMUX_TEST_LOG\"; return 255; }",
+        ] + retryLines).joined(separator: "\n")
+
+        let result = try run(
+            script,
+            environment: [
+                "CMUX_TEST_LOG": logURL.path,
+                "CMUX_SSH_RECONNECT_LIMIT": configuredLimit,
+            ]
+        )
+        let attempts = try String(contentsOf: logURL, encoding: .utf8)
+            .split(separator: "\n")
+            .count
+
+        #expect(result.status == 255)
+        // One initial attach plus at most the 20 reconnects is the hard
+        // contract, regardless of user-provided limit text.
+        #expect(attempts == 21)
+    }
+
     private func waitForFile(
         at url: URL,
         containing expectedContents: String,

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -378,6 +378,36 @@ struct SSHPTYAttachRetryScriptBuilderTests {
         #expect(attempts == 21)
     }
 
+    @Test
+    func retryableAttachIsCappedAtTwentyReconnects() throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-attach-budget-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        let retryLines = SSHPTYAttachRetryScriptBuilder().lines(
+            command: "cmux_test_attach",
+            reauthenticates: false
+        )
+        let script = ([
+            "cmux_ssh_attach_signal_exit() { exit \"$1\"; }",
+            "sleep() { :; }",
+            "cmux_test_attach() { printf '%s\\n' attach >> \"$CMUX_TEST_LOG\"; return 255; }",
+        ] + retryLines).joined(separator: "\n")
+
+        let result = try run(
+            script,
+            environment: [
+                "CMUX_TEST_LOG": logURL.path,
+                "CMUX_SSH_RECONNECT_LIMIT": "20",
+            ]
+        )
+
+        #expect(result.status == 255)
+        let attempts = try String(contentsOf: logURL, encoding: .utf8)
+            .split(separator: "\n")
+        #expect(attempts == Array(repeating: Substring("attach"), count: 21))
+    }
+
     private func waitForFile(
         at url: URL,
         containing expectedContents: String,

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -84,7 +84,7 @@ struct SSHPTYAttachRetryScriptBuilderTests {
         #expect(try String(contentsOf: logURL, encoding: .utf8) == "attach\nsleep:2\nattach\n")
     }
 
-    @Test func establishedSessionKeepsRetryingUnclassifiedAndTransientAuthenticationFailures() throws {
+    @Test func establishedSessionStopsAfterTheFiniteReconnectBudget() throws {
         let logURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ssh-attach-unclassified-reauth-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: logURL) }
@@ -123,10 +123,10 @@ struct SSHPTYAttachRetryScriptBuilderTests {
             ]
         )
 
-        #expect(result.status == 7)
+        #expect(result.status == 254)
         let events = try String(contentsOf: logURL, encoding: .utf8).split(separator: "\n")
-        #expect(events.filter { $0 == "auth" }.count == 23)
-        #expect(events.filter { $0 == "attach" }.count == 2)
+        #expect(events.filter { $0 == "auth" }.count == 21)
+        #expect(events.filter { $0 == "attach" }.count == 1)
     }
 
     @Test func permanentReauthenticationStillFailsClosedAfterEstablishedSession() throws {

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHPTYAttachRetryScriptBuilderTests.swift
@@ -5,6 +5,16 @@ import Testing
 @testable import CmuxFoundation
 
 struct SSHPTYAttachRetryScriptBuilderTests {
+    @Test func defaultReconnectPolicyIsFinite() {
+        let script = SSHPTYAttachRetryScriptBuilder()
+            .lines(command: "cmux_test_attach", reauthenticates: false)
+            .joined(separator: "\n")
+
+        #expect(script.contains("cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\""))
+        #expect(!script.contains("cmux_ssh_attach_reconnect_limit='∞'"))
+        #expect(!script.contains("cmux_ssh_attach_reconnect_unbounded=1"))
+    }
+
     @Test func retriesInitialAuthenticationBeforeAttaching() throws {
         let logURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ssh-attach-retry-\(UUID().uuidString)")

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Hosting/RemoteSessionStrings.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Hosting/RemoteSessionStrings.swift
@@ -16,6 +16,8 @@ public struct RemoteSessionStrings: Sendable, Equatable {
     public let reverseRelayPortUnavailableRetrying: String
     /// Detail when another cmux process temporarily owns the SSH master.
     public let controlMasterOwnershipUnavailable: String
+    /// Safe product-facing detail for a non-retryable proxy failure.
+    public let remoteProxyUnavailable: String
 
     /// Creates the app-resolved strings bundle.
     ///
@@ -30,7 +32,8 @@ public struct RemoteSessionStrings: Sendable, Equatable {
         suspendedDetailFormat: String,
         reverseRelayUnavailableRetrying: String,
         reverseRelayPortUnavailableRetrying: String,
-        controlMasterOwnershipUnavailable: String
+        controlMasterOwnershipUnavailable: String,
+        remoteProxyUnavailable: String = "Remote proxy unavailable"
     ) {
         self.connectedVMNoProxyFormat = connectedVMNoProxyFormat
         self.suspendedDetailFormat = suspendedDetailFormat
@@ -40,5 +43,6 @@ public struct RemoteSessionStrings: Sendable, Equatable {
             reverseRelayPortUnavailableRetrying
         self.controlMasterOwnershipUnavailable =
             controlMasterOwnershipUnavailable
+        self.remoteProxyUnavailable = remoteProxyUnavailable
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Reachability/RemoteBootstrapRetryPolicy.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Reachability/RemoteBootstrapRetryPolicy.swift
@@ -7,6 +7,7 @@ import Foundation
 /// those decisions separate prevents a reachable host with a corrupt install
 /// from consuming an unbounded reconnect loop.
 struct RemoteBootstrapRetryPolicy: Sendable {
+    static let stableFailureClassKey = "cmux.remote.bootstrap.failureClass"
     /// The decision after one bootstrap failure.
     enum Decision: Equatable, Sendable {
         /// Schedule another centrally-owned reconnect attempt.
@@ -58,27 +59,35 @@ struct RemoteBootstrapRetryPolicy: Sendable {
     /// excluded. A truncated payload must remain the same failure class across
     /// attempts even when each temporary path or diagnostic count changes.
     static func fingerprint(for error: any Error) -> String {
-        let nsError = error as NSError
+        let annotatedError = error as NSError
+        // Bootstrap diagnostics are intentionally appended after the real
+        // failure.  Retry accounting must classify that underlying failure,
+        // never a changing log tail/path/byte count.
+        let nsError = (annotatedError.userInfo[NSUnderlyingErrorKey] as? NSError)
+            ?? annotatedError
         let domain = nsError.domain.trimmingCharacters(in: .whitespacesAndNewlines)
         let code = nsError.code
-        let message = nsError.localizedDescription.lowercased()
-        let className: String
+        let className = (nsError.userInfo[stableFailureClassKey] as? String)
+            ?? failureClass(for: nsError.localizedDescription)
+        return "\(domain):\(code):\(className)"
+    }
+
+    private static func failureClass(for rawMessage: String) -> String {
+        let message = rawMessage.lowercased()
         if message.contains("permission denied") ||
             message.contains("authentication") ||
             message.contains("host key") ||
             message.contains("access denied") {
-            className = "blocked"
+            return "blocked"
         } else if message.contains("verification") || message.contains("checksum") || message.contains("hash") {
-            className = "integrity"
+            return "integrity"
         } else if message.contains("hello") || message.contains("json") {
-            className = "hello"
+            return "hello"
         } else if message.contains("upload") || message.contains("transfer") {
-            className = "transfer"
+            return "transfer"
         } else if message.contains("directory") || message.contains("install") {
-            className = "install"
-        } else {
-            className = "bootstrap"
+            return "install"
         }
-        return "\(domain):\(code):\(className)"
+        return "bootstrap"
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Reachability/RemoteBootstrapRetryPolicy.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Reachability/RemoteBootstrapRetryPolicy.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Bounds automatic retries when the remote daemon bootstrap keeps failing.
+///
+/// Reachability answers whether SSH can reach the host; this policy answers
+/// whether repeating the same bootstrap operation is still useful. Keeping
+/// those decisions separate prevents a reachable host with a corrupt install
+/// from consuming an unbounded reconnect loop.
+struct RemoteBootstrapRetryPolicy: Sendable {
+    /// The decision after one bootstrap failure.
+    enum Decision: Equatable, Sendable {
+        /// Schedule another centrally-owned reconnect attempt.
+        case retry
+        /// Park the connection until the user explicitly reconnects.
+        case suspend
+    }
+
+    /// The counters and decision produced for one failure.
+    struct Evaluation: Equatable, Sendable {
+        let fingerprint: String
+        let consecutiveFailures: Int
+        let totalFailures: Int
+        let decision: Decision
+    }
+
+    /// Number of identical failures tolerated before parking the workspace.
+    let maxConsecutiveFailures = 3
+    /// Total bootstrap failures tolerated during one automatic reconnect run.
+    let maxTotalFailures = 8
+
+    /// Evaluates one failure against the previous retry counters.
+    func evaluate(
+        fingerprint: String,
+        previousFingerprint: String?,
+        previousConsecutiveFailures: Int,
+        previousTotalFailures: Int
+    ) -> Evaluation {
+        let normalizedFingerprint = fingerprint
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let consecutiveFailures = previousFingerprint == normalizedFingerprint
+            ? max(0, previousConsecutiveFailures) + 1
+            : 1
+        let totalFailures = max(0, previousTotalFailures) + 1
+        let shouldSuspend = normalizedFingerprint.contains(":blocked") ||
+            consecutiveFailures >= maxConsecutiveFailures ||
+            totalFailures >= maxTotalFailures
+        return Evaluation(
+            fingerprint: normalizedFingerprint,
+            consecutiveFailures: consecutiveFailures,
+            totalFailures: totalFailures,
+            decision: shouldSuspend ? .suspend : .retry
+        )
+    }
+
+    /// Produces a stable failure class for retry accounting.
+    ///
+    /// Dynamic stderr (paths, byte counts, and elapsed times) is deliberately
+    /// excluded. A truncated payload must remain the same failure class across
+    /// attempts even when each temporary path or diagnostic count changes.
+    static func fingerprint(for error: any Error) -> String {
+        let nsError = error as NSError
+        let domain = nsError.domain.trimmingCharacters(in: .whitespacesAndNewlines)
+        let code = nsError.code
+        let message = nsError.localizedDescription.lowercased()
+        let className: String
+        if message.contains("permission denied") ||
+            message.contains("authentication") ||
+            message.contains("host key") ||
+            message.contains("access denied") {
+            className = "blocked"
+        } else if message.contains("verification") || message.contains("checksum") || message.contains("hash") {
+            className = "integrity"
+        } else if message.contains("hello") || message.contains("json") {
+            className = "hello"
+        } else if message.contains("upload") || message.contains("transfer") {
+            className = "transfer"
+        } else if message.contains("directory") || message.contains("install") {
+            className = "install"
+        } else {
+            className = "bootstrap"
+        }
+        return "\(domain):\(code):\(className)"
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -55,6 +55,10 @@ extension RemoteSessionCoordinator {
             let diagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
             Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: diagnostic)
             guard hadExistingBinary else {
+                // The just-installed artifact passed transport verification but
+                // failed its hello contract; do not leave it to strand the next
+                // reconnect behind a path-only probe.
+                try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
                 throw Self.annotatedRemoteDaemonBootstrapError(
                     error,
                     remotePath: remotePath,
@@ -68,6 +72,7 @@ extension RemoteSessionCoordinator {
                 hello = try helloRemoteDaemonLocked(remotePath: remotePath)
             } catch {
                 let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+                Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: retryDiagnostic)
                 throw Self.annotatedRemoteDaemonBootstrapError(
                     error,
                     remotePath: remotePath,
@@ -92,6 +97,7 @@ extension RemoteSessionCoordinator {
                 hello = try helloRemoteDaemonLocked(remotePath: remotePath)
             } catch {
                 let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+                Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: retryDiagnostic)
                 throw Self.annotatedRemoteDaemonBootstrapError(
                     error,
                     remotePath: remotePath,
@@ -223,7 +229,7 @@ extension RemoteSessionCoordinator {
         let binarySize = lines.first { $0.hasPrefix(Self.remotePlatformProbeSizeMarker) }
             .flatMap { Int64(String($0.dropFirst(Self.remotePlatformProbeSizeMarker.count)).trimmingCharacters(in: .whitespacesAndNewlines)) }
         let binaryExists = binaryExistsMarker.map { marker in
-            marker && (binarySize.map { $0 > 0 } ?? true)
+            marker && (binarySize.map { $0 > 0 } ?? false)
         }
         if result.status != 0, binaryExists == nil {
             let detail = Self.bestErrorLine(stderr: result.stderr, stdout: userFacingStdout) ?? "ssh exited \(result.status)"

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -39,6 +39,7 @@ extension RemoteSessionCoordinator {
         )
 
         let hadExistingBinary = bootstrapState.binaryExists
+        var installedThisAttempt = false
         debugLog(
             "remote.bootstrap.binaryExists remotePath=\(remotePath) exists=\(hadExistingBinary ? 1 : 0) " +
             "size=\(bootstrapState.binarySize.map(String.init) ?? "unknown")"
@@ -46,6 +47,7 @@ extension RemoteSessionCoordinator {
         if forceExplicitOverrideInstall || !hadExistingBinary {
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
+            installedThisAttempt = true
         }
 
         var hello: DaemonHello
@@ -54,9 +56,9 @@ extension RemoteSessionCoordinator {
         } catch {
             let diagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
             Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: diagnostic)
-            guard hadExistingBinary else {
-                // The just-installed artifact passed transport verification but
-                // failed its hello contract; do not leave it to strand the next
+            if installedThisAttempt || !hadExistingBinary {
+                // A just-installed artifact passed transport verification but
+                // failed its hello contract. Never leave it to strand the next
                 // reconnect behind a path-only probe.
                 try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
                 throw Self.annotatedRemoteDaemonBootstrapError(
@@ -65,14 +67,16 @@ extension RemoteSessionCoordinator {
                     diagnostic: diagnostic
                 )
             }
-            try removeRemoteDaemonInstallLocked(remotePath: remotePath)
+            try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
+            installedThisAttempt = true
             do {
                 hello = try helloRemoteDaemonLocked(remotePath: remotePath)
             } catch {
                 let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
                 Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: retryDiagnostic)
+                try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
                 throw Self.annotatedRemoteDaemonBootstrapError(
                     error,
                     remotePath: remotePath,
@@ -80,8 +84,8 @@ extension RemoteSessionCoordinator {
                 )
             }
         }
-        let missingCapabilities = Self.missingRequiredCapabilities(requiredCapabilities, in: hello.capabilities)
-        if hadExistingBinary, !missingCapabilities.isEmpty {
+        var missingCapabilities = Self.missingRequiredCapabilities(requiredCapabilities, in: hello.capabilities)
+        if !missingCapabilities.isEmpty, !installedThisAttempt {
             debugLog(
                 "remote.bootstrap.capabilityMissing remotePath=\(remotePath) " +
                 "missing=\(missingCapabilities.joined(separator: ",")) capabilities=\(hello.capabilities.joined(separator: ","))"
@@ -90,20 +94,39 @@ extension RemoteSessionCoordinator {
             Self.logHelloRetry(remotePath: remotePath, error: NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
                 NSLocalizedDescriptionKey: "remote daemon missing required capabilities: \(missingCapabilities.joined(separator: ","))",
             ]), diagnostic: diagnostic)
-            try removeRemoteDaemonInstallLocked(remotePath: remotePath)
+            try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
+            installedThisAttempt = true
             do {
                 hello = try helloRemoteDaemonLocked(remotePath: remotePath)
             } catch {
                 let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
                 Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: retryDiagnostic)
+                try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
                 throw Self.annotatedRemoteDaemonBootstrapError(
                     error,
                     remotePath: remotePath,
                     diagnostic: retryDiagnostic ?? diagnostic
                 )
             }
+            missingCapabilities = Self.missingRequiredCapabilities(
+                requiredCapabilities,
+                in: hello.capabilities
+            )
+        }
+        if !missingCapabilities.isEmpty {
+            let capabilityError = NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
+                NSLocalizedDescriptionKey: "remote daemon missing required capabilities: \(missingCapabilities.joined(separator: ","))",
+            ])
+            let diagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+            Self.logHelloRetry(remotePath: remotePath, error: capabilityError, diagnostic: diagnostic)
+            try? removeRemoteDaemonInstallLocked(remotePath: remotePath)
+            throw Self.annotatedRemoteDaemonBootstrapError(
+                capabilityError,
+                remotePath: remotePath,
+                diagnostic: diagnostic
+            )
         }
 
         debugLog(
@@ -345,7 +368,7 @@ extension RemoteSessionCoordinator {
             throw NSError(domain: "cmux.remote.daemon", code: 24, userInfo: [
                 NSLocalizedDescriptionKey: String(
                     localized: "remoteDaemon.bootstrap.buildOutputEmpty",
-                    defaultValue: "cmuxd-remote build output is missing or empty"
+                    defaultValue: "remote daemon build output is missing or empty"
                 ),
             ])
         }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -15,6 +15,7 @@ extension RemoteSessionCoordinator {
     static let remotePlatformProbeOSMarker = "__CMUX_REMOTE_OS__="
     static let remotePlatformProbeArchMarker = "__CMUX_REMOTE_ARCH__="
     static let remotePlatformProbeExistsMarker = "__CMUX_REMOTE_EXISTS__="
+    static let remotePlatformProbeSizeMarker = "__CMUX_REMOTE_SIZE__="
 
     func bootstrapDaemonLocked(requiredCapabilities: [String]) throws -> DaemonHello {
         debugLog("remote.bootstrap.begin \(debugConfigSummary())")
@@ -38,7 +39,10 @@ extension RemoteSessionCoordinator {
         )
 
         let hadExistingBinary = bootstrapState.binaryExists
-        debugLog("remote.bootstrap.binaryExists remotePath=\(remotePath) exists=\(hadExistingBinary ? 1 : 0)")
+        debugLog(
+            "remote.bootstrap.binaryExists remotePath=\(remotePath) exists=\(hadExistingBinary ? 1 : 0) " +
+            "size=\(bootstrapState.binarySize.map(String.init) ?? "unknown")"
+        )
         if forceExplicitOverrideInstall || !hadExistingBinary {
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
@@ -48,16 +52,28 @@ extension RemoteSessionCoordinator {
         do {
             hello = try helloRemoteDaemonLocked(remotePath: remotePath)
         } catch {
+            let diagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+            Self.logHelloRetry(remotePath: remotePath, error: error, diagnostic: diagnostic)
             guard hadExistingBinary else {
-                throw error
+                throw Self.annotatedRemoteDaemonBootstrapError(
+                    error,
+                    remotePath: remotePath,
+                    diagnostic: diagnostic
+                )
             }
-            debugLog(
-                "remote.bootstrap.helloRetry remotePath=\(remotePath) " +
-                "detail=\(error.localizedDescription)"
-            )
+            try removeRemoteDaemonInstallLocked(remotePath: remotePath)
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
-            hello = try helloRemoteDaemonLocked(remotePath: remotePath)
+            do {
+                hello = try helloRemoteDaemonLocked(remotePath: remotePath)
+            } catch {
+                let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+                throw Self.annotatedRemoteDaemonBootstrapError(
+                    error,
+                    remotePath: remotePath,
+                    diagnostic: retryDiagnostic ?? diagnostic
+                )
+            }
         }
         let missingCapabilities = Self.missingRequiredCapabilities(requiredCapabilities, in: hello.capabilities)
         if hadExistingBinary, !missingCapabilities.isEmpty {
@@ -65,9 +81,23 @@ extension RemoteSessionCoordinator {
                 "remote.bootstrap.capabilityMissing remotePath=\(remotePath) " +
                 "missing=\(missingCapabilities.joined(separator: ",")) capabilities=\(hello.capabilities.joined(separator: ","))"
             )
+            let diagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+            Self.logHelloRetry(remotePath: remotePath, error: NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
+                NSLocalizedDescriptionKey: "remote daemon missing required capabilities: \(missingCapabilities.joined(separator: ","))",
+            ]), diagnostic: diagnostic)
+            try removeRemoteDaemonInstallLocked(remotePath: remotePath)
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: remoteLocation)
-            hello = try helloRemoteDaemonLocked(remotePath: remotePath)
+            do {
+                hello = try helloRemoteDaemonLocked(remotePath: remotePath)
+            } catch {
+                let retryDiagnostic = remoteDaemonDiagnosticsLocked(remotePath: remotePath, version: version)
+                throw Self.annotatedRemoteDaemonBootstrapError(
+                    error,
+                    remotePath: remotePath,
+                    diagnostic: retryDiagnostic ?? diagnostic
+                )
+            }
         }
 
         debugLog(
@@ -111,10 +141,13 @@ extension RemoteSessionCoordinator {
           *) exit 71 ;;
         esac
         cmux_remote_path="$HOME/.cmux/bin/cmuxd-remote/\(scriptVersion)/${cmux_go_os}-${cmux_go_arch}/cmuxd-remote"
-        if [ -x "$cmux_remote_path" ]; then
+        if [ -x "$cmux_remote_path" ] && [ -s "$cmux_remote_path" ]; then
           printf '%syes\\n' '\(Self.remotePlatformProbeExistsMarker)'
+          cmux_remote_size="$(wc -c < "$cmux_remote_path" 2>/dev/null || printf '0')"
+          printf '%s%s\\n' '\(Self.remotePlatformProbeSizeMarker)' "$cmux_remote_size"
         else
           printf '%sno\\n' '\(Self.remotePlatformProbeExistsMarker)'
+          printf '%s0\\n' '\(Self.remotePlatformProbeSizeMarker)'
         fi
         """
     }
@@ -151,7 +184,8 @@ extension RemoteSessionCoordinator {
         line.hasPrefix(remotePlatformProbeHomeMarker) ||
             line.hasPrefix(remotePlatformProbeOSMarker) ||
             line.hasPrefix(remotePlatformProbeArchMarker) ||
-            line.hasPrefix(remotePlatformProbeExistsMarker)
+            line.hasPrefix(remotePlatformProbeExistsMarker) ||
+            line.hasPrefix(remotePlatformProbeSizeMarker)
     }
 
     func probeRemoteBootstrapStateLocked(version: String) throws -> RemoteBootstrapState {
@@ -184,8 +218,13 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        let binaryExists = lines.first { $0.hasPrefix(Self.remotePlatformProbeExistsMarker) }
+        let binaryExistsMarker: Bool? = lines.first { $0.hasPrefix(Self.remotePlatformProbeExistsMarker) }
             .map { String($0.dropFirst(Self.remotePlatformProbeExistsMarker.count)) == "yes" }
+        let binarySize = lines.first { $0.hasPrefix(Self.remotePlatformProbeSizeMarker) }
+            .flatMap { Int64(String($0.dropFirst(Self.remotePlatformProbeSizeMarker.count)).trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let binaryExists = binaryExistsMarker.map { marker in
+            marker && (binarySize.map { $0 > 0 } ?? true)
+        }
         if result.status != 0, binaryExists == nil {
             let detail = Self.bestErrorLine(stderr: result.stderr, stdout: userFacingStdout) ?? "ssh exited \(result.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 13, userInfo: [
@@ -196,7 +235,8 @@ extension RemoteSessionCoordinator {
         return RemoteBootstrapState(
             platform: RemotePlatform(goOS: goOS, goArch: goArch),
             homeDirectory: homeDirectory,
-            binaryExists: binaryExists ?? false
+            binaryExists: binaryExists ?? false,
+            binarySize: binarySize
         )
     }
 
@@ -223,7 +263,8 @@ extension RemoteSessionCoordinator {
 
     func buildLocalDaemonBinary(goOS: String, goArch: String, version: String) throws -> URL {
         if let explicitBinary = Self.explicitRemoteDaemonBinaryURL(),
-           FileManager.default.isExecutableFile(atPath: explicitBinary.path) {
+           FileManager.default.isExecutableFile(atPath: explicitBinary.path),
+           Self.fileSize(at: explicitBinary) > 0 {
             debugLog("remote.build.explicit path=\(explicitBinary.path)")
             return explicitBinary
         }
@@ -293,13 +334,22 @@ extension RemoteSessionCoordinator {
                 NSLocalizedDescriptionKey: "failed to build cmuxd-remote: \(detail)",
             ])
         }
-        guard FileManager.default.isExecutableFile(atPath: output.path) else {
+        guard FileManager.default.isExecutableFile(atPath: output.path),
+              Self.fileSize(at: output) > 0 else {
             throw NSError(domain: "cmux.remote.daemon", code: 24, userInfo: [
-                NSLocalizedDescriptionKey: "cmuxd-remote build output is not executable",
+                NSLocalizedDescriptionKey: String(
+                    localized: "remoteDaemon.bootstrap.buildOutputEmpty",
+                    defaultValue: "cmuxd-remote build output is missing or empty"
+                ),
             ])
         }
         debugLog("remote.build.output path=\(output.path)")
         return output
+    }
+
+    private static func fileSize(at url: URL) -> Int64 {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return Int64(values?.fileSize ?? 0)
     }
 
     func helloRemoteDaemonLocked(remotePath: String) throws -> DaemonHello {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
@@ -29,10 +29,11 @@ extension RemoteSessionCoordinator {
         guard result.status == 0 else {
             let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ??
                 "ssh exited \(result.status)"
+            debugLog("remote.bootstrap.repair.removeFailed detail=\(detail)")
             throw NSError(domain: "cmux.remote.daemon", code: 34, userInfo: [
                 NSLocalizedDescriptionKey: String(
                     localized: "remoteDaemon.bootstrap.removeCorruptFailedWithDetail",
-                    defaultValue: "failed to remove corrupt remote daemon install: \(detail)"
+                    defaultValue: "failed to remove corrupt remote daemon install"
                 ),
             ])
         }
@@ -56,7 +57,12 @@ extension RemoteSessionCoordinator {
         }
         let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !output.isEmpty else { return nil }
-        return String(output.prefix(6_000))
+        #if DEBUG
+        debugLog(
+            "remote.bootstrap.diagnostics raw=\(String(output.prefix(6_000)))"
+        )
+        #endif
+        return Self.sanitizedRemoteDaemonDiagnostic(output, fallbackPath: remotePath)
     }
 
     /// Builds the remote diagnostic probe used on bootstrap/hello failures.
@@ -85,7 +91,7 @@ extension RemoteSessionCoordinator {
         printf 'remote_path=%s\\nremote_size=%s\\n' "$remote_path" "$remote_size"
         if [ -n "$log_path" ] && [ -r "$log_path" ]; then
           printf '%s\\n' 'daemon_log_tail:'
-          tail -n 80 "$log_path" 2>/dev/null || true
+          tail -n 80 "$log_path" 2>/dev/null | tail -c 6000 || true
         else
           printf '%s\\n' 'daemon_log_tail: unavailable'
         fi
@@ -100,12 +106,18 @@ extension RemoteSessionCoordinator {
     ) -> NSError {
         let nsError = error as NSError
         var detail = nsError.localizedDescription
-        detail += " (remote path: \(remotePath)"
+        detail += " (remote path: \(sanitizedRemoteDaemonPath(remotePath))"
         if let diagnostic, !diagnostic.isEmpty {
             detail += "; diagnostics: \(diagnostic)"
         }
         detail += ")"
         var userInfo: [String: Any] = [NSLocalizedDescriptionKey: detail]
+        if let stableClass = RemoteBootstrapRetryPolicy
+            .fingerprint(for: nsError)
+            .split(separator: ":")
+            .last {
+            userInfo[RemoteBootstrapRetryPolicy.stableFailureClassKey] = String(stableClass)
+        }
         if let underlying = nsError.userInfo[NSUnderlyingErrorKey] {
             userInfo[NSUnderlyingErrorKey] = underlying
         }
@@ -118,8 +130,47 @@ extension RemoteSessionCoordinator {
     /// Emits hello-retry diagnostics through the release-visible bootstrap logger.
     static func logHelloRetry(remotePath: String, error: any Error, diagnostic: String?) {
         let diagnosticText = diagnostic?.replacingOccurrences(of: "\n", with: "\\n") ?? "none"
+        let errorClass = RemoteBootstrapRetryPolicy.fingerprint(for: error)
+            .split(separator: ":")
+            .last
+            .map(String.init) ?? "bootstrap"
         remoteBootstrapLogger.error(
-            "remote.bootstrap.helloRetry remotePath=\(remotePath) detail=\(error.localizedDescription) diagnostic=\(diagnosticText)"
+            "remote.bootstrap.helloRetry class=\(errorClass, privacy: .public) remotePath=\(sanitizedRemoteDaemonPath(remotePath), privacy: .private(mask: .hash)) diagnostic=\(diagnosticText, privacy: .private(mask: .hash))"
         )
+    }
+
+    /// Keeps user-visible diagnostics useful without exposing a home path,
+    /// host-specific username, or arbitrary daemon-log content.
+    private static func sanitizedRemoteDaemonPath(_ path: String) -> String {
+        let normalized = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let marker = normalized.range(of: "/.cmux/bin/cmuxd-remote/") else {
+            return "~/.cmux/bin/cmuxd-remote"
+        }
+        return "~/.cmux/bin/cmuxd-remote/" + normalized[marker.upperBound...]
+    }
+
+    private static func sanitizedRemoteDaemonDiagnostic(
+        _ output: String,
+        fallbackPath: String
+    ) -> String {
+        var path = sanitizedRemoteDaemonPath(fallbackPath)
+        var size = "unknown"
+        var hasLogTail = false
+        for line in output.split(whereSeparator: \.isNewline) {
+            let value = String(line)
+            if value.hasPrefix("remote_path=") {
+                path = sanitizedRemoteDaemonPath(String(value.dropFirst("remote_path=".count)))
+            } else if value.hasPrefix("remote_size=") {
+                let candidate = String(value.dropFirst("remote_size=".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if Int64(candidate) != nil || candidate == "missing" || candidate == "unknown" {
+                    size = candidate
+                }
+            } else if value == "daemon_log_tail:" {
+                hasLogTail = true
+            }
+        }
+        let logSummary = hasLogTail ? "daemon log tail captured" : "daemon log unavailable"
+        return "remote path: \(path); remote size: \(size) bytes; \(logSummary)"
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
@@ -1,0 +1,123 @@
+internal import Foundation
+internal import OSLog
+
+nonisolated private let remoteBootstrapLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "RemoteDaemonBootstrap"
+)
+
+extension RemoteSessionCoordinator {
+    /// Removes a known versioned install before a repair upload.
+    func removeRemoteDaemonInstallLocked(remotePath: String) throws {
+        let script = "rm -f -- \(remotePath.shellSingleQuoted)"
+        let command = "sh -c \(script.shellSingleQuoted)"
+        let result: RemoteCommandResult
+        do {
+            result = try sshExec(
+                arguments: daemonBootstrapSSHArguments() + [configuration.destination, command],
+                timeout: 12
+            )
+        } catch {
+            throw NSError(domain: "cmux.remote.daemon", code: 34, userInfo: [
+                NSLocalizedDescriptionKey: String(
+                    localized: "remoteDaemon.bootstrap.removeCorruptFailed",
+                    defaultValue: "failed to remove corrupt remote daemon install"
+                ),
+                NSUnderlyingErrorKey: error,
+            ])
+        }
+        guard result.status == 0 else {
+            let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ??
+                "ssh exited \(result.status)"
+            throw NSError(domain: "cmux.remote.daemon", code: 34, userInfo: [
+                NSLocalizedDescriptionKey: String(
+                    localized: "remoteDaemon.bootstrap.removeCorruptFailedWithDetail",
+                    defaultValue: "failed to remove corrupt remote daemon install: \(detail)"
+                ),
+            ])
+        }
+        debugLog("remote.bootstrap.repair.removed remotePath=\(remotePath)")
+    }
+
+    /// Collects bounded remote path/size/log-tail diagnostics without masking
+    /// the bootstrap failure that triggered the query.
+    func remoteDaemonDiagnosticsLocked(remotePath: String, version: String) -> String? {
+        let script = Self.remoteDaemonDiagnosticsScript(
+            remotePath: remotePath,
+            version: version,
+            persistentDaemonSlot: configuration.persistentDaemonSlot
+        )
+        let command = "sh -c \(script.shellSingleQuoted)"
+        guard let result = try? sshExec(
+            arguments: daemonBootstrapSSHArguments() + [configuration.destination, command],
+            timeout: 8
+        ), result.status == 0 else {
+            return nil
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else { return nil }
+        return String(output.prefix(6_000))
+    }
+
+    /// Builds the remote diagnostic probe used on bootstrap/hello failures.
+    static func remoteDaemonDiagnosticsScript(
+        remotePath: String,
+        version: String,
+        persistentDaemonSlot: String?
+    ) -> String {
+        let safeVersion = normalizedRemotePlatformProbeVersion(version)
+        let logPathAssignment: String
+        if let slot = normalizedPersistentDaemonSlotForRemoteCleanup(persistentDaemonSlot) {
+            logPathAssignment = "log_path=\"$HOME/.cmux/daemon/\(safeVersion)/\(slot)/daemon.log\""
+        } else {
+            logPathAssignment = "log_path=''"
+        }
+        return """
+        remote_path=\(remotePath.shellSingleQuoted)
+        \(logPathAssignment)
+        if [ -e "$remote_path" ]; then
+          remote_size="$(wc -c < "$remote_path" 2>/dev/null || printf 'unknown')"
+          set -- $remote_size
+          remote_size="${1:-unknown}"
+        else
+          remote_size=missing
+        fi
+        printf 'remote_path=%s\\nremote_size=%s\\n' "$remote_path" "$remote_size"
+        if [ -n "$log_path" ] && [ -r "$log_path" ]; then
+          printf '%s\\n' 'daemon_log_tail:'
+          tail -n 80 "$log_path" 2>/dev/null || true
+        else
+          printf '%s\\n' 'daemon_log_tail: unavailable'
+        fi
+        """
+    }
+
+    static func annotatedRemoteDaemonBootstrapError(
+        _ error: any Error,
+        remotePath: String,
+        diagnostic: String?
+    ) -> NSError {
+        let nsError = error as NSError
+        var detail = nsError.localizedDescription
+        detail += " (remote path: \(remotePath)"
+        if let diagnostic, !diagnostic.isEmpty {
+            detail += "; diagnostics: \(diagnostic)"
+        }
+        detail += ")"
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: detail]
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] {
+            userInfo[NSUnderlyingErrorKey] = underlying
+        }
+        if let debugDescription = nsError.userInfo[NSDebugDescriptionErrorKey] {
+            userInfo[NSDebugDescriptionErrorKey] = debugDescription
+        }
+        return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
+    }
+
+    static func logHelloRetry(remotePath: String, error: any Error, diagnostic: String?) {
+        let diagnosticText = diagnostic?.replacingOccurrences(of: "\n", with: "\\n") ?? "none"
+        remoteBootstrapLogger.error(
+            "remote.bootstrap.helloRetry remotePath=\(remotePath) detail=\(error.localizedDescription) diagnostic=\(diagnosticText)"
+        )
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
@@ -27,9 +27,10 @@ extension RemoteSessionCoordinator {
             ])
         }
         guard result.status == 0 else {
-            let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ??
-                "ssh exited \(result.status)"
-            debugLog("remote.bootstrap.repair.removeFailed detail=\(detail)")
+            debugLog(
+                "remote.bootstrap.repair.removeFailed status=\(result.status) " +
+                    "\(debugConfigSummary())"
+            )
             throw NSError(domain: "cmux.remote.daemon", code: 34, userInfo: [
                 NSLocalizedDescriptionKey: String(
                     localized: "remoteDaemon.bootstrap.removeCorruptFailedWithDetail",
@@ -57,12 +58,14 @@ extension RemoteSessionCoordinator {
         }
         let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !output.isEmpty else { return nil }
-        #if DEBUG
-        debugLog(
-            "remote.bootstrap.diagnostics raw=\(String(output.prefix(6_000)))"
+        let sanitized = Self.sanitizedRemoteDaemonDiagnostic(
+            output,
+            fallbackPath: remotePath
         )
+        #if DEBUG
+        debugLog("remote.bootstrap.diagnostics \(sanitized)")
         #endif
-        return Self.sanitizedRemoteDaemonDiagnostic(output, fallbackPath: remotePath)
+        return sanitized
     }
 
     /// Builds the remote diagnostic probe used on bootstrap/hello failures.

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapDiagnostics.swift
@@ -92,6 +92,7 @@ extension RemoteSessionCoordinator {
         """
     }
 
+    /// Adds the resolved remote path and bounded diagnostics to a bootstrap error.
     static func annotatedRemoteDaemonBootstrapError(
         _ error: any Error,
         remotePath: String,
@@ -114,6 +115,7 @@ extension RemoteSessionCoordinator {
         return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
     }
 
+    /// Emits hello-retry diagnostics through the release-visible bootstrap logger.
     static func logHelloRetry(remotePath: String, error: any Error, diagnostic: String?) {
         let diagnosticText = diagnostic?.replacingOccurrences(of: "\n", with: "\\n") ?? "none"
         remoteBootstrapLogger.error(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapFailureTracking.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+BootstrapFailureTracking.swift
@@ -1,0 +1,11 @@
+internal import Foundation
+
+extension RemoteSessionCoordinator {
+    /// Clears bootstrap retry accounting after a transport reaches a healthy
+    /// ready state or the coordinator is explicitly stopped/re-armed.
+    func resetBootstrapFailureTrackingLocked() {
+        bootstrapFailureFingerprint = nil
+        bootstrapFailureCount = 0
+        bootstrapFailureTotal = 0
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -293,8 +293,13 @@ extension RemoteSessionCoordinator {
     }
 
     private static func isRemoteDaemonIntegrityFailure(_ result: RemoteCommandResult) -> Bool {
-        result.status == 74 || result.status == 75 ||
-            result.stderr.localizedCaseInsensitiveContains("cmux daemon verification failed")
+        let stderr = result.stderr.lowercased()
+        return result.status == 74 || result.status == 75 ||
+            stderr.contains("cmux daemon verification failed") ||
+            stderr.contains("sha256") ||
+            stderr.contains("sha-256") ||
+            stderr.contains("checksum") ||
+            stderr.contains("size mismatch")
     }
 
     private static func remoteDaemonIntegrityFailureMessage(detail: String?) -> String {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -59,6 +59,7 @@ extension RemoteSessionCoordinator {
             )
         } catch {
             let detail = Self.safeRemoteProcessFailureDetail(error)
+            debugLog("remote.bootstrap.upload.failed detail=\(detail ?? "unknown")")
             let message: String
             if let detail {
                 message = String(
@@ -142,22 +143,16 @@ extension RemoteSessionCoordinator {
             )
         } catch {
             let detail = Self.safeRemoteProcessFailureDetail(error)
+            debugLog("remote.bootstrap.upload.failed detail=\(detail ?? "unknown")")
             cleanupRemoteDaemonTemporaryUploadsLocked(
                 remotePath: remotePath,
                 currentTemporaryPath: remoteTempPath
             )
             let message: String
-            if let detail {
-                message = String(
-                    localized: "remoteDaemon.upload.transferFailedWithDetail",
-                    defaultValue: "failed to upload cmuxd-remote: \(detail)"
-                )
-            } else {
-                message = String(
-                    localized: "remoteDaemon.upload.transferFailed",
-                    defaultValue: "failed to upload cmuxd-remote"
-                )
-            }
+            message = String(
+                localized: "remoteDaemon.upload.transferFailed",
+                defaultValue: "failed to upload remote daemon"
+            )
             throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
                 NSLocalizedDescriptionKey: message,
             ])
@@ -169,10 +164,11 @@ extension RemoteSessionCoordinator {
             )
             let detail = Self.bestErrorLine(stderr: uploadResult.stderr, stdout: uploadResult.stdout) ??
                 "ssh exited \(uploadResult.status)"
+            debugLog("remote.bootstrap.upload.failed status=\(uploadResult.status) detail=\(detail)")
             throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
                 NSLocalizedDescriptionKey: String(
-                    localized: "remoteDaemon.upload.transferFailedWithDetail",
-                    defaultValue: "failed to upload cmuxd-remote: \(detail)"
+                    localized: "remoteDaemon.upload.transferFailed",
+                    defaultValue: "failed to upload remote daemon"
                 ),
             ])
         }
@@ -192,11 +188,12 @@ extension RemoteSessionCoordinator {
             )
         } catch {
             let detail = Self.safeRemoteProcessFailureDetail(error)
+            debugLog("remote.bootstrap.install.failed detail=\(detail ?? "unknown")")
             cleanupRemoteDaemonTemporaryUploadsLocked(
                 remotePath: remotePath,
                 currentTemporaryPath: remoteTempPath
             )
-            let message = Self.remoteDaemonInstallFailureMessage(detail: detail)
+            let message = Self.remoteDaemonInstallFailureMessage(detail: nil)
             throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
                 NSLocalizedDescriptionKey: message,
             ])
@@ -208,10 +205,11 @@ extension RemoteSessionCoordinator {
             )
             let detail = Self.bestErrorLine(stderr: finalizeResult.stderr, stdout: finalizeResult.stdout) ??
                 "ssh exited \(finalizeResult.status)"
+            debugLog("remote.bootstrap.install.failed status=\(finalizeResult.status) detail=\(detail)")
             let integrityFailure = Self.isRemoteDaemonIntegrityFailure(finalizeResult)
             let message = integrityFailure
-                ? Self.remoteDaemonIntegrityFailureMessage(detail: detail)
-                : Self.remoteDaemonInstallFailureMessage(detail: detail)
+                ? Self.remoteDaemonIntegrityFailureMessage(detail: nil)
+                : Self.remoteDaemonInstallFailureMessage(detail: nil)
             throw NSError(domain: "cmux.remote.daemon", code: integrityFailure ? 33 : 32, userInfo: [
                 NSLocalizedDescriptionKey: message,
             ])
@@ -286,9 +284,9 @@ extension RemoteSessionCoordinator {
         return LocalDaemonArtifact(byteCount: Int64(data.count), sha256: digest)
     }
 
-    private static func remoteDaemonIntegrityFailure(detail: String) -> NSError {
+    private static func remoteDaemonIntegrityFailure(detail _: String) -> NSError {
         NSError(domain: "cmux.remote.daemon", code: 33, userInfo: [
-            NSLocalizedDescriptionKey: remoteDaemonIntegrityFailureMessage(detail: detail),
+            NSLocalizedDescriptionKey: remoteDaemonIntegrityFailureMessage(detail: nil),
         ])
     }
 
@@ -316,15 +314,15 @@ extension RemoteSessionCoordinator {
     }
 
     private static func remoteDaemonInstallFailureMessage(detail: String?) -> String {
-        if let detail {
+        if detail != nil {
             return String(
                 localized: "remoteDaemon.upload.installFailedWithDetail",
-                defaultValue: "failed to install remote daemon binary: \(detail)"
+                defaultValue: "failed to install remote daemon"
             )
         }
         return String(
             localized: "remoteDaemon.upload.installFailed",
-            defaultValue: "failed to install remote daemon binary"
+            defaultValue: "failed to install remote daemon"
         )
     }
 

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -1,4 +1,5 @@
 internal import CmuxFoundation
+internal import CryptoKit
 internal import Foundation
 
 // Installs cmuxd-remote through the same SSH exec channel used by bootstrap.
@@ -6,6 +7,11 @@ internal import Foundation
 // streamed to `cat`, then the existing chmod-and-rename step publishes it
 // atomically at the versioned destination.
 extension RemoteSessionCoordinator {
+    private struct LocalDaemonArtifact {
+        let byteCount: Int64
+        let sha256: String
+    }
+
     // A daemon binary is small enough that a bounded throughput estimate is
     // more useful than a fixed wall clock. The floor handles SSH setup and the
     // cap bounds how long a stalled transfer can hold the coordinator.
@@ -13,6 +19,8 @@ extension RemoteSessionCoordinator {
     static let daemonUploadMinimumTimeout: TimeInterval = 90
     static let daemonUploadTimeoutGrace: TimeInterval = 30
     static let daemonUploadMaximumTimeout: TimeInterval = 15 * 60
+    static let daemonUploadStallCheckIntervalSeconds = 5
+    static let daemonUploadStallCheckLimit = 12
 
     static func daemonUploadTimeout(for localBinary: URL) -> TimeInterval {
         let resourceValues = try? localBinary.resourceValues(forKeys: [.fileSizeKey])
@@ -30,6 +38,7 @@ extension RemoteSessionCoordinator {
     }
 
     func uploadRemoteDaemonBinaryLocked(localBinary: URL, location: RemoteDaemonInstallLocation) throws {
+        let artifact = try localDaemonArtifact(for: localBinary)
         let remotePath = location.absolutePath
         let remoteDirectory = location.directory
         let remoteTempPath = "\(remotePath).tmp-\(UUID().uuidString.prefix(8))"
@@ -81,16 +90,43 @@ extension RemoteSessionCoordinator {
         let quotedRemoteTempPIDPath = remoteTempPIDPath.shellSingleQuoted
         let uploadScript = """
         cat_pid=
+        watchdog_pid=
         temp_path=\(quotedRemoteTempPath)
         pid_path=\(quotedRemoteTempPIDPath)
         printf '%s\\n' "$$" > "$pid_path"
-        trap 'if [ -n "$cat_pid" ]; then kill "$cat_pid" 2>/dev/null || true; fi; rm -f -- "$temp_path" "$pid_path"; exit 1' HUP INT TERM
+        trap 'if [ -n "$cat_pid" ]; then kill "$cat_pid" 2>/dev/null || true; fi; if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; fi; rm -f -- "$temp_path" "$pid_path"; exit 1' HUP INT TERM
         cat > "$temp_path" &
         cat_pid=$!
         printf '%s\\n' "$cat_pid" > "$pid_path"
+        (
+          stall_checks=0
+          previous_size=0
+          while kill -0 "$cat_pid" 2>/dev/null; do
+            current_size="$(wc -c < "$temp_path" 2>/dev/null || printf '0')"
+            set -- $current_size
+            current_size="${1:-0}"
+            if [ "$current_size" -ge \(artifact.byteCount) ]; then exit 0; fi
+            if [ "$current_size" -gt "$previous_size" ]; then
+              previous_size="$current_size"
+              stall_checks=0
+            else
+              stall_checks=$((stall_checks + 1))
+            fi
+            if [ "$stall_checks" -ge \(Self.daemonUploadStallCheckLimit) ]; then
+              printf 'cmux daemon upload stalled after %ss without byte progress (received=%s expected=%s)\\n' \
+                \(Self.daemonUploadStallCheckIntervalSeconds * Self.daemonUploadStallCheckLimit) "$current_size" \(artifact.byteCount) >&2
+              kill "$cat_pid" 2>/dev/null || true
+              exit 0
+            fi
+            sleep \(Self.daemonUploadStallCheckIntervalSeconds)
+          done
+        ) &
+        watchdog_pid=$!
         wait "$cat_pid"
         cat_status=$?
         cat_pid=
+        if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; fi
+        watchdog_pid=
         rm -f -- "$pid_path"
         if [ "$cat_status" -ne 0 ]; then rm -f -- "$temp_path"; fi
         trap - HUP INT TERM
@@ -102,7 +138,7 @@ extension RemoteSessionCoordinator {
             uploadResult = try sshExec(
                 arguments: daemonBootstrapSSHArguments() + [configuration.destination, uploadCommand],
                 stdinFile: localBinary,
-                timeout: Self.daemonUploadTimeout(for: localBinary)
+                timeout: Self.daemonUploadTimeout(forByteCount: artifact.byteCount)
             )
         } catch {
             let detail = Self.safeRemoteProcessFailureDetail(error)
@@ -141,10 +177,12 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        let finalizeScript = """
-        chmod 755 \(remoteTempPath.shellSingleQuoted) && \
-        mv \(remoteTempPath.shellSingleQuoted) \(remotePath.shellSingleQuoted)
-        """
+        let finalizeScript = Self.remoteDaemonFinalizeScript(
+            remoteTempPath: remoteTempPath,
+            remotePath: remotePath,
+            expectedByteCount: artifact.byteCount,
+            expectedSHA256: artifact.sha256
+        )
         let finalizeCommand = "sh -c \(finalizeScript.shellSingleQuoted)"
         let finalizeResult: RemoteCommandResult
         do {
@@ -158,18 +196,7 @@ extension RemoteSessionCoordinator {
                 remotePath: remotePath,
                 currentTemporaryPath: remoteTempPath
             )
-            let message: String
-            if let detail {
-                message = String(
-                    localized: "remoteDaemon.upload.installFailedWithDetail",
-                    defaultValue: "failed to install remote daemon binary: \(detail)"
-                )
-            } else {
-                message = String(
-                    localized: "remoteDaemon.upload.installFailed",
-                    defaultValue: "failed to install remote daemon binary"
-                )
-            }
+            let message = Self.remoteDaemonInstallFailureMessage(detail: detail)
             throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
                 NSLocalizedDescriptionKey: message,
             ])
@@ -181,13 +208,119 @@ extension RemoteSessionCoordinator {
             )
             let detail = Self.bestErrorLine(stderr: finalizeResult.stderr, stdout: finalizeResult.stdout) ??
                 "ssh exited \(finalizeResult.status)"
-            throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
-                NSLocalizedDescriptionKey: String(
-                    localized: "remoteDaemon.upload.installFailedWithDetail",
-                    defaultValue: "failed to install remote daemon binary: \(detail)"
-                ),
+            let integrityFailure = Self.isRemoteDaemonIntegrityFailure(finalizeResult)
+            let message = integrityFailure
+                ? Self.remoteDaemonIntegrityFailureMessage(detail: detail)
+                : Self.remoteDaemonInstallFailureMessage(detail: detail)
+            throw NSError(domain: "cmux.remote.daemon", code: integrityFailure ? 33 : 32, userInfo: [
+                NSLocalizedDescriptionKey: message,
             ])
         }
+    }
+
+    /// Builds the fail-closed remote verification and atomic promotion script.
+    /// The temporary file is never renamed until both byte count and SHA-256
+    /// match the local artifact; missing hash utilities are an explicit error.
+    static func remoteDaemonFinalizeScript(
+        remoteTempPath: String,
+        remotePath: String,
+        expectedByteCount: Int64,
+        expectedSHA256: String
+    ) -> String {
+        let expectedSize = String(max(0, expectedByteCount))
+        return """
+        temp_path=\(remoteTempPath.shellSingleQuoted)
+        final_path=\(remotePath.shellSingleQuoted)
+        expected_size=\(expectedSize.shellSingleQuoted)
+        expected_sha=\(expectedSHA256.shellSingleQuoted)
+        if [ ! -s "$temp_path" ]; then
+          printf '%s\\n' 'cmux daemon verification failed: temporary payload is empty' >&2
+          exit 74
+        fi
+        set -- $(wc -c < "$temp_path" 2>/dev/null)
+        actual_size="${1:-}"
+        case "$actual_size" in
+          ''|*[!0-9]*)
+            printf '%s\\n' 'cmux daemon verification failed: could not read temporary payload size' >&2
+            exit 74
+            ;;
+        esac
+        if [ "$actual_size" != "$expected_size" ]; then
+          printf 'cmux daemon verification failed: size mismatch expected=%s actual=%s\\n' "$expected_size" "$actual_size" >&2
+          exit 74
+        fi
+        actual_sha=
+        if command -v sha256sum >/dev/null 2>&1; then
+          set -- $(sha256sum "$temp_path" 2>/dev/null)
+          actual_sha="${1:-}"
+        elif command -v shasum >/dev/null 2>&1; then
+          set -- $(shasum -a 256 "$temp_path" 2>/dev/null)
+          actual_sha="${1:-}"
+        else
+          printf '%s\\n' 'cmux daemon verification failed: remote host has no SHA-256 utility (sha256sum or shasum)' >&2
+          exit 75
+        fi
+        if [ "$actual_sha" != "$expected_sha" ]; then
+          printf 'cmux daemon verification failed: SHA-256 mismatch expected=%s actual=%s\\n' "$expected_sha" "${actual_sha:-missing}" >&2
+          exit 74
+        fi
+        chmod 755 "$temp_path" && mv -f "$temp_path" "$final_path"
+        """
+    }
+
+    private func localDaemonArtifact(for localBinary: URL) throws -> LocalDaemonArtifact {
+        let data: Data
+        do {
+            data = try Data(contentsOf: localBinary, options: [.mappedIfSafe])
+        } catch {
+            throw Self.remoteDaemonIntegrityFailure(
+                detail: "could not read local cmuxd-remote: \(error.localizedDescription)"
+            )
+        }
+        guard !data.isEmpty else {
+            throw Self.remoteDaemonIntegrityFailure(detail: "local cmuxd-remote is empty")
+        }
+        let digest = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return LocalDaemonArtifact(byteCount: Int64(data.count), sha256: digest)
+    }
+
+    private static func remoteDaemonIntegrityFailure(detail: String) -> NSError {
+        NSError(domain: "cmux.remote.daemon", code: 33, userInfo: [
+            NSLocalizedDescriptionKey: remoteDaemonIntegrityFailureMessage(detail: detail),
+        ])
+    }
+
+    private static func isRemoteDaemonIntegrityFailure(_ result: RemoteCommandResult) -> Bool {
+        result.status == 74 || result.status == 75 ||
+            result.stderr.localizedCaseInsensitiveContains("cmux daemon verification failed")
+    }
+
+    private static func remoteDaemonIntegrityFailureMessage(detail: String?) -> String {
+        guard let detail, !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return String(
+                localized: "remoteDaemon.upload.verifyFailed",
+                defaultValue: "remote daemon integrity verification failed"
+            )
+        }
+        return String(
+            localized: "remoteDaemon.upload.verifyFailedWithDetail",
+            defaultValue: "remote daemon integrity verification failed: \(detail)"
+        )
+    }
+
+    private static func remoteDaemonInstallFailureMessage(detail: String?) -> String {
+        if let detail {
+            return String(
+                localized: "remoteDaemon.upload.installFailedWithDetail",
+                defaultValue: "failed to install remote daemon binary: \(detail)"
+            )
+        }
+        return String(
+            localized: "remoteDaemon.upload.installFailed",
+            defaultValue: "failed to install remote daemon binary"
+        )
     }
 
     private func cleanupRemoteDaemonTemporaryUploadsLocked(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Lifecycle.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Lifecycle.swift
@@ -19,6 +19,9 @@ extension RemoteSessionCoordinator {
         cancelReconnectRetryLocked()
         reconnectRetryCount = 0
         consecutiveUnreachableProbeCount = 0
+        bootstrapFailureFingerprint = nil
+        bootstrapFailureCount = 0
+        bootstrapFailureTotal = 0
         reconnectSuspended = false
         reachabilityProbeGeneration &+= 1
         cancelControlMasterReapObservationLocked()

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Lifecycle.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Lifecycle.swift
@@ -15,13 +15,12 @@ extension RemoteSessionCoordinator {
     func stopAllLocked(cleanupScope: RemoteRelayCleanupScope) -> Bool {
         debugLog("remote.session.stop \(debugConfigSummary())")
         isStopping = true
+        proxyConnectionDesired = false
         cancelConnectionAttemptLocked()
         cancelReconnectRetryLocked()
         reconnectRetryCount = 0
         consecutiveUnreachableProbeCount = 0
-        bootstrapFailureFingerprint = nil
-        bootstrapFailureCount = 0
-        bootstrapFailureTotal = 0
+        resetBootstrapFailureTrackingLocked()
         reconnectSuspended = false
         reachabilityProbeGeneration &+= 1
         cancelControlMasterReapObservationLocked()

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
@@ -28,6 +28,11 @@ extension RemoteSessionCoordinator {
         guard reverseRelayControlMasterForwardSpec == nil else { return }
         guard controlMasterReapState.startupPhase
             .allowsRelayLaunch else { return }
+        // A new relay attempt owns readiness from this point forward.  The
+        // daemon hello may already be valid, but the local proxy cannot use
+        // the remote listener until the forward and metadata transaction
+        // complete.
+        reverseRelayReady = false
 
         cancelReverseRelayRestartLocked()
         launchReverseRelayLocked(
@@ -87,8 +92,13 @@ extension RemoteSessionCoordinator {
                     scheduleReverseRelayRestartLocked(remotePath: remotePath, delay: 2.0)
                     return
                 }
+                reverseRelayReady = true
                 restoreReadyDaemonStatusLocked()
                 recordHeartbeatActivityLocked()
+                // A relay restart can happen after the original bootstrap
+                // caller has returned; reacquire the proxy/PTY bridge now
+                // that the forward and metadata invariant is restored.
+                startProxyLocked()
                 debugLog(
                     "remote.relay.start relayPort=\(relayPort) localRelayPort=\(localRelayPort) " +
                     "target=\(configuration.displayTarget) controlMaster=1"
@@ -192,8 +202,12 @@ extension RemoteSessionCoordinator {
             scheduleReverseRelayRestartLocked(remotePath: remotePath, delay: 2.0)
             return
         }
+        reverseRelayReady = true
         restoreReadyDaemonStatusLocked()
         recordHeartbeatActivityLocked()
+        // The relay is now a usable transport.  This is the first point at
+        // which a proxy/PTY bridge may be acquired for a standalone fallback.
+        startProxyLocked()
         debugLog(
             "remote.relay.start relayPort=\(relayPort) localRelayPort=\(localRelayPort) " +
             "target=\(configuration.displayTarget) controlMaster=0"
@@ -206,6 +220,7 @@ extension RemoteSessionCoordinator {
     ) {
         guard reverseRelayProcess === process else { return }
         reverseRelayProcess = nil
+        reverseRelayReady = false
 
         guard !isStopping else { return }
         guard let remotePath = daemonRemotePath,
@@ -220,10 +235,11 @@ extension RemoteSessionCoordinator {
         remotePath: String
     ) {
         let retryDelay = 2.0
-        publishDaemonStatus(
-            .error,
-            detail: strings.reverseRelayUnavailableRetrying
-        )
+        // Relay startup is itself retryable.  Keep the sidebar in the
+        // reconnecting phase until the bounded supervisor gives up; otherwise
+        // a short ControlMaster handoff paints a false daemon error.
+        publishDaemonStatus(.bootstrapping, detail: nil)
+        publishState(.reconnecting, detail: nil)
         scheduleReverseRelayRestartLocked(remotePath: remotePath, delay: retryDelay)
     }
 
@@ -272,6 +288,7 @@ extension RemoteSessionCoordinator {
             reverseRelayProcess.terminate()
         }
         reverseRelayProcess = nil
+        reverseRelayReady = false
         stopReverseRelayViaControlMasterLocked()
         cliRelayServer?.stop()
         cliRelayServer = nil
@@ -289,6 +306,7 @@ extension RemoteSessionCoordinator {
         }
         reverseRelayProcess = nil
         reverseRelayControlMasterForwardSpec = nil
+        reverseRelayReady = false
         cliRelayServer?.stop()
         cliRelayServer = nil
     }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelayStartup.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelayStartup.swift
@@ -192,10 +192,8 @@ extension RemoteSessionCoordinator {
         resetTransportForReconnectLocked(
             preservePersistentRelayMetadata: true
         )
-        publishDaemonStatus(
-            .error,
-            detail: strings.reverseRelayUnavailableRetrying
-        )
+        publishDaemonStatus(.bootstrapping, detail: nil)
+        publishState(.reconnecting, detail: nil)
         _ = scheduleReconnectLocked(baseDelay: 2.0)
     }
 
@@ -243,9 +241,7 @@ extension RemoteSessionCoordinator {
     }
 
     private func publishReverseRelayPortUnavailableLocked() {
-        publishDaemonStatus(
-            .error,
-            detail: strings.reverseRelayPortUnavailableRetrying
-        )
+        publishDaemonStatus(.bootstrapping, detail: nil)
+        publishState(.reconnecting, detail: nil)
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
@@ -44,9 +44,7 @@ extension RemoteSessionCoordinator {
         cancelReconnectRetryLocked()
         reconnectRetryCount = 0
         consecutiveUnreachableProbeCount = 0
-        bootstrapFailureFingerprint = nil
-        bootstrapFailureCount = 0
-        bootstrapFailureTotal = 0
+        resetBootstrapFailureTrackingLocked()
         reconnectSuspended = false
         reachabilityProbeGeneration &+= 1
         debugLog(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
@@ -44,6 +44,9 @@ extension RemoteSessionCoordinator {
         cancelReconnectRetryLocked()
         reconnectRetryCount = 0
         consecutiveUnreachableProbeCount = 0
+        bootstrapFailureFingerprint = nil
+        bootstrapFailureCount = 0
+        bootstrapFailureTotal = 0
         reconnectSuspended = false
         reachabilityProbeGeneration &+= 1
         debugLog(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SystemPower.swift
@@ -66,7 +66,10 @@ extension RemoteSessionCoordinator {
         } else {
             stopReverseRelayLocked()
         }
-        failPendingPTYBridgeStartsLocked("remote daemon is not ready")
+        // Wait-for-ready bridge requests belong to the persistent remote PTY,
+        // not to this particular local transport lease. Leave them parked so
+        // a sleep/wake or transient reconnect does not manufacture a failed
+        // attach that the pane immediately has to retry.
         releaseProxyLeaseLocked()
         proxyEndpoint = nil
         daemonReady = false

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -76,6 +76,10 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var isStopping = false
     var proxyLease: RemoteProxyLease?
     var proxyLeaseGeneration: UInt64 = 0
+    /// Whether this connection attempt still needs a proxy tunnel.  Keeping
+    /// the intent separate from relay readiness lets a standalone relay start
+    /// asynchronously without losing the eventual proxy acquisition.
+    var proxyConnectionDesired = false
     var proxyEndpoint: BrowserProxyEndpoint?
     var daemonReady = false
     var daemonBootstrapVersion: String?
@@ -84,6 +88,12 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var controlMasterReapState = ControlMasterReapState()
     var reverseRelayProcess: (any RemoteReverseRelayProcess)?
     var reverseRelayControlMasterForwardSpec: String?
+    /// True only after the reverse listener and its authenticated remote
+    /// metadata are both installed.  The proxy/PTY bridge must not be
+    /// advertised before this invariant holds: a ControlMaster recovery can
+    /// leave the daemon hello ready while the old reverse port is still
+    /// draining.
+    var reverseRelayReady = false
     var resolvedControlMasterSSHOptions: [String]?
     var cliRelayServer: RemoteCLIRelayServer?
     var remotePortScanTTYNames: [UUID: String] = [:]
@@ -282,6 +292,8 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         publishDaemonStatus(.bootstrapping, detail: bootstrapDetail)
         do {
             try prepareControlMasterOwnershipLocked()
+            proxyConnectionDesired = !configuration.skipDaemonBootstrap ||
+                configuration.daemonWebSocketEndpoint != nil
             let requiredCapabilities = requiredDaemonCapabilities
             let hello: DaemonHello
             if configuration.skipDaemonBootstrap {
@@ -326,6 +338,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
                 } else {
                     // SSH-only cloud VM fallback cannot use ssh-exec or local socket forwarding
                     // through provider gateways. Keep the shell connected and leave proxy off.
+                    resetBootstrapFailureTrackingLocked()
                     publishState(
                         .connected,
                         detail: String(format: strings.connectedVMNoProxyFormat, configuration.displayTarget)
@@ -353,10 +366,17 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             switch evaluation.decision {
             case .retry:
                 let retrySchedule = scheduleReconnectLocked(baseDelay: 4.0)
-                let retrySuffix = Self.retrySuffix(retry: retrySchedule.retry, delay: retrySchedule.delay)
-                let detail = "Remote daemon bootstrap failed: \(failureMessage)\(retrySuffix)"
-                publishDaemonStatus(.error, detail: detail)
-                publishState(.error, detail: detail)
+                // A retryable bootstrap failure is supervisor state, not a
+                // user-visible terminal error.  Publishing `.error` here
+                // makes the sidebar flash red even when the very next retry
+                // succeeds; the bounded `.suspend` branch below is the only
+                // place that parks and surfaces a bootstrap failure.
+                debugLog(
+                    "remote.session.bootstrap.retry failure=\(failureMessage.debugLogSnippet(limit: 240)) " +
+                    "retry=\(retrySchedule.retry) delay=\(Int(retrySchedule.delay))"
+                )
+                publishDaemonStatus(.bootstrapping, detail: nil)
+                publishState(.reconnecting, detail: nil)
             case .suspend:
                 cancelReconnectRetryLocked()
                 reconnectSuspended = true
@@ -379,14 +399,20 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     func startProxyLocked() {
         guard !isStopping else { return }
         guard daemonReady else { return }
+        guard proxyConnectionDesired else { return }
+        guard configuration.relayPort == nil || reverseRelayReady else {
+            debugLog(
+                "remote.proxy.waitingForRelay \(debugConfigSummary())"
+            )
+            return
+        }
         guard proxyLease == nil else { return }
         guard let remotePath = daemonRemotePath,
               !remotePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            let retrySchedule = scheduleReconnectLocked(baseDelay: 4.0)
-            let retrySuffix = Self.retrySuffix(retry: retrySchedule.retry, delay: retrySchedule.delay)
-            let detail = "Remote daemon did not provide a valid remote path\(retrySuffix)"
-            publishDaemonStatus(.error, detail: detail)
-            publishState(.error, detail: detail)
+            _ = scheduleReconnectLocked(baseDelay: 4.0)
+            debugLog("remote.session.proxy.missingPath \(debugConfigSummary())")
+            publishDaemonStatus(.bootstrapping, detail: nil)
+            publishState(.reconnecting, detail: nil)
             return
         }
 
@@ -424,9 +450,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             cancelReconnectRetryLocked()
             reconnectRetryCount = 0
             consecutiveUnreachableProbeCount = 0
-            bootstrapFailureFingerprint = nil
-            bootstrapFailureCount = 0
-            bootstrapFailureTotal = 0
+            resetBootstrapFailureTrackingLocked()
             // A live connection ends any suspension; without this a future
             // failure would hit the suspended guard and never reschedule.
             reconnectSuspended = false
@@ -467,24 +491,36 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             proxyEndpoint = nil
             publishProxyEndpoint(nil)
             publishPortsSnapshotLocked()
-            publishState(.error, detail: "Remote proxy to \(configuration.displayTarget) unavailable: \(detail)")
+            let shouldEscalate = Self.shouldEscalateProxyErrorToBootstrap(detail)
+            let brokerWillRetry = shouldEscalate || detail.lowercased().contains("retry in")
+            if brokerWillRetry {
+                // Keep transient tunnel churn out of the sidebar.  The
+                // supervisor owns the retry and the eventual parked state
+                // carries the actionable failure if it cannot recover.
+                publishDaemonStatus(.bootstrapping, detail: nil)
+                publishState(.reconnecting, detail: nil)
+            } else {
+                publishState(.error, detail: "Remote proxy to \(configuration.displayTarget) unavailable: \(detail)")
+            }
             // Keep wait-for-ready PTY requests parked across a transient
             // transport bounce.  The remote PTY is persistent; failing the
             // local bridge here forces a noisy shell retry even though the
             // supervisor is already reconnecting the daemon/proxy.
-            guard Self.shouldEscalateProxyErrorToBootstrap(detail) else { return }
+            guard shouldEscalate else { return }
 
+            // The proxy broker can lose its daemon tunnel while the reverse
+            // relay's local state still claims ownership of the old forward.
+            // Clear that transport lease before the next bootstrap; otherwise
+            // `startReverseRelayLocked` sees a non-nil forward spec and the
+            // proxy/PTY bridge remains parked forever after a reconnect.
+            _ = stopReverseRelayLocked(cleanupScope: .transport)
             releaseProxyLeaseLocked()
             daemonReady = false
             daemonBootstrapVersion = nil
             daemonRemotePath = nil
 
-            let retrySchedule = scheduleReconnectLocked(baseDelay: 2.0)
-            let retrySuffix = Self.retrySuffix(retry: retrySchedule.retry, delay: retrySchedule.delay)
-            publishDaemonStatus(
-                .error,
-                detail: "Remote daemon transport needs re-bootstrap after proxy failure\(retrySuffix)"
-            )
+            _ = scheduleReconnectLocked(baseDelay: 2.0)
+            publishDaemonStatus(.bootstrapping, detail: nil)
         }
     }
 
@@ -571,7 +607,8 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         _ error: any Error,
         strings: RemoteDaemonStrings
     ) -> String {
-        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nsError = error as NSError
+        let message = nsError.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowered = message.lowercased()
         if lowered.contains("missing required capability") ||
             lowered.contains(RemoteDaemonRPCClient.requiredPTYSessionCapability) ||
@@ -581,7 +618,43 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
                 RemoteDaemonRPCClient.requiredPTYSessionCapability,
             ])
         }
-        return message.isEmpty ? "remote daemon bootstrap failed" : message
+        switch nsError.code {
+        case 24:
+            return String(
+                localized: "remoteDaemon.bootstrap.buildOutputEmpty",
+                defaultValue: "Remote daemon build output is missing or empty"
+            )
+        case 31:
+            return String(
+                localized: "remoteDaemon.upload.transferFailed",
+                defaultValue: "Failed to upload remote daemon"
+            )
+        case 33:
+            return String(
+                localized: "remoteDaemon.upload.verifyFailed",
+                defaultValue: "Remote daemon integrity verification failed"
+            )
+        case 32, 34:
+            return String(
+                localized: "remoteDaemon.upload.installFailed",
+                defaultValue: "Failed to install remote daemon"
+            )
+        case 41:
+            return String(
+                localized: "remoteDaemon.bootstrap.helloFailed",
+                defaultValue: "Remote daemon did not return a valid readiness response"
+            )
+        case 13:
+            return String(
+                localized: "remoteDaemon.bootstrap.probeFailed",
+                defaultValue: "Could not inspect the remote daemon installation"
+            )
+        default:
+            return String(
+                localized: "remoteDaemon.bootstrap.failed",
+                defaultValue: "Remote daemon bootstrap failed"
+            )
+        }
     }
 
     // MARK: - Debug logging

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -362,10 +362,10 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
                 reconnectSuspended = true
                 let pausedSuffix = String(
                     localized: "remoteDaemon.bootstrap.reconnectPaused",
-                    defaultValue: "Automatic reconnect paused after %d identical failures; repair the remote install and use Reconnect to try again."
+                    defaultValue: "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again."
                 )
                 let detail = "Remote daemon bootstrap failed: \(failureMessage). " +
-                    String(format: pausedSuffix, evaluation.consecutiveFailures)
+                    pausedSuffix
                 debugLog(
                     "remote.session.bootstrap.suspended consecutive=\(evaluation.consecutiveFailures) " +
                     "total=\(evaluation.totalFailures) fingerprint=\(evaluation.fingerprint) \(debugConfigSummary())"

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -68,6 +68,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     /// relay restart, bootstrap-TTY retry, port-scan coalesce and burst).
     let clock: any RemoteProxyRetryClock
     let reconnectPolicy = RemoteReconnectPolicy()
+    let bootstrapRetryPolicy = RemoteBootstrapRetryPolicy()
     // MARK: - Queue-confined state
     //
     // Every var below is confined to `queue` (see the isolation essay).
@@ -116,6 +117,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var reconnectRetryCount = 0
     var reconnectTask: Task<Void, Never>?
     var reconnectToken: UUID?
+    var bootstrapFailureFingerprint: String?
+    var bootstrapFailureCount = 0
+    var bootstrapFailureTotal = 0
     var connectionAttemptTask: Task<Void, Never>?
     var connectionAttemptToken: UUID?
     var consecutiveUnreachableProbeCount = 0
@@ -336,11 +340,39 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             daemonReady = false
             daemonBootstrapVersion = nil
             daemonRemotePath = nil
-            let retrySchedule = scheduleReconnectLocked(baseDelay: 4.0)
-            let retrySuffix = Self.retrySuffix(retry: retrySchedule.retry, delay: retrySchedule.delay)
-            let detail = "Remote daemon bootstrap failed: \(Self.userFacingRemoteDaemonBootstrapErrorMessage(error, strings: daemonStrings))\(retrySuffix)"
-            publishDaemonStatus(.error, detail: detail)
-            publishState(.error, detail: detail)
+            let failureMessage = Self.userFacingRemoteDaemonBootstrapErrorMessage(error, strings: daemonStrings)
+            let evaluation = bootstrapRetryPolicy.evaluate(
+                fingerprint: RemoteBootstrapRetryPolicy.fingerprint(for: error),
+                previousFingerprint: bootstrapFailureFingerprint,
+                previousConsecutiveFailures: bootstrapFailureCount,
+                previousTotalFailures: bootstrapFailureTotal
+            )
+            bootstrapFailureFingerprint = evaluation.fingerprint
+            bootstrapFailureCount = evaluation.consecutiveFailures
+            bootstrapFailureTotal = evaluation.totalFailures
+            switch evaluation.decision {
+            case .retry:
+                let retrySchedule = scheduleReconnectLocked(baseDelay: 4.0)
+                let retrySuffix = Self.retrySuffix(retry: retrySchedule.retry, delay: retrySchedule.delay)
+                let detail = "Remote daemon bootstrap failed: \(failureMessage)\(retrySuffix)"
+                publishDaemonStatus(.error, detail: detail)
+                publishState(.error, detail: detail)
+            case .suspend:
+                cancelReconnectRetryLocked()
+                reconnectSuspended = true
+                let pausedSuffix = String(
+                    localized: "remoteDaemon.bootstrap.reconnectPaused",
+                    defaultValue: "Automatic reconnect paused after %d identical failures; repair the remote install and use Reconnect to try again."
+                )
+                let detail = "Remote daemon bootstrap failed: \(failureMessage). " +
+                    String(format: pausedSuffix, evaluation.consecutiveFailures)
+                debugLog(
+                    "remote.session.bootstrap.suspended consecutive=\(evaluation.consecutiveFailures) " +
+                    "total=\(evaluation.totalFailures) fingerprint=\(evaluation.fingerprint) \(debugConfigSummary())"
+                )
+                publishDaemonStatus(.error, detail: detail)
+                publishState(.suspended, detail: detail)
+            }
         }
     }
 
@@ -392,6 +424,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             cancelReconnectRetryLocked()
             reconnectRetryCount = 0
             consecutiveUnreachableProbeCount = 0
+            bootstrapFailureFingerprint = nil
+            bootstrapFailureCount = 0
+            bootstrapFailureTotal = 0
             // A live connection ends any suspension; without this a future
             // failure would hit the suspended guard and never reschedule.
             reconnectSuspended = false

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -468,7 +468,10 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             publishProxyEndpoint(nil)
             publishPortsSnapshotLocked()
             publishState(.error, detail: "Remote proxy to \(configuration.displayTarget) unavailable: \(detail)")
-            failPendingPTYBridgeStartsLocked("remote daemon is not ready")
+            // Keep wait-for-ready PTY requests parked across a transient
+            // transport bounce.  The remote PTY is persistent; failing the
+            // local bridge here forces a noisy shell retry even though the
+            // supervisor is already reconnecting the daemon/proxy.
             guard Self.shouldEscalateProxyErrorToBootstrap(detail) else { return }
 
             releaseProxyLeaseLocked()

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -476,7 +476,6 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             requestBootstrapRemoteTTYIfNeededLocked()
             recordHeartbeatActivityLocked()
         case .error(let detail):
-            debugLog("remote.proxy.error detail=\(detail) \(debugConfigSummary())")
             remotePortScanGeneration &+= 1
             remotePortScanBurstTask?.cancel()
             remotePortScanBurstTask = nil
@@ -493,6 +492,10 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             publishPortsSnapshotLocked()
             let shouldEscalate = Self.shouldEscalateProxyErrorToBootstrap(detail)
             let brokerWillRetry = shouldEscalate || detail.lowercased().contains("retry in")
+            debugLog(
+                "remote.proxy.error escalated=\(shouldEscalate ? 1 : 0) " +
+                    "brokerRetry=\(brokerWillRetry ? 1 : 0) \(debugConfigSummary())"
+            )
             if brokerWillRetry {
                 // Keep transient tunnel churn out of the sidebar.  The
                 // supervisor owns the retry and the eventual parked state
@@ -500,7 +503,10 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
                 publishDaemonStatus(.bootstrapping, detail: nil)
                 publishState(.reconnecting, detail: nil)
             } else {
-                publishState(.error, detail: "Remote proxy to \(configuration.displayTarget) unavailable: \(detail)")
+                publishState(
+                    .error,
+                    detail: "\(strings.remoteProxyUnavailable) (\(configuration.displayTarget))"
+                )
             }
             // Keep wait-for-ready PTY requests parked across a transient
             // transport bounce.  The remote PTY is persistent; failing the
@@ -622,7 +628,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         case 24:
             return String(
                 localized: "remoteDaemon.bootstrap.buildOutputEmpty",
-                defaultValue: "Remote daemon build output is missing or empty"
+                defaultValue: "The remote daemon files are missing or empty"
             )
         case 31:
             return String(
@@ -642,7 +648,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         case 41:
             return String(
                 localized: "remoteDaemon.bootstrap.helloFailed",
-                defaultValue: "Remote daemon did not return a valid readiness response"
+                defaultValue: "Could not confirm that the remote daemon is ready"
             )
         case 13:
             return String(
@@ -652,7 +658,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         default:
             return String(
                 localized: "remoteDaemon.bootstrap.failed",
-                defaultValue: "Remote daemon bootstrap failed"
+                defaultValue: "Could not prepare the remote daemon"
             )
         }
     }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/RemoteBootstrapState.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/RemoteBootstrapState.swift
@@ -5,4 +5,5 @@ struct RemoteBootstrapState {
     let platform: RemotePlatform
     let homeDirectory: String
     let binaryExists: Bool
+    let binarySize: Int64?
 }

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -76,7 +76,7 @@ extension RemoteDaemonUploadTests {
         #expect(largeUpload.timeout > smallUpload.timeout)
     }
 
-    @Test("Upload timeout exposes the process detail and cleans remote temporary files directly")
+    @Test("Upload timeout reports a safe error and cleans remote temporary files directly")
     func uploadTimeoutSurfacesDetailAndCleansRemoteTemporaryFiles() throws {
         let fileManager = FileManager.default
         let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
@@ -122,7 +122,7 @@ extension RemoteDaemonUploadTests {
             }
             Issue.record("Expected the timed-out upload to fail")
         } catch {
-            #expect(error.localizedDescription.contains("ssh timed out after 222s"))
+            #expect(error.localizedDescription == "failed to upload remote daemon")
         }
 
         let requests = runner.requests

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -1,9 +1,44 @@
 import CmuxCore
+import CryptoKit
 import Foundation
 import Testing
 @testable import CmuxRemoteSession
 
 extension RemoteDaemonUploadTests {
+    @Test("Finalize script promotes only a byte-and-hash-matching payload")
+    func finalizeScriptIsFailClosed() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-finalize-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let tempURL = root.appendingPathComponent("cmuxd-remote.tmp", isDirectory: false)
+        let finalURL = root.appendingPathComponent("cmuxd-remote", isDirectory: false)
+        let payload = Data("healthy remote daemon".utf8)
+        try payload.write(to: tempURL)
+        let hash = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        let script = RemoteSessionCoordinator.remoteDaemonFinalizeScript(
+            remoteTempPath: tempURL.path,
+            remotePath: finalURL.path,
+            expectedByteCount: Int64(payload.count),
+            expectedSHA256: hash
+        )
+
+        let success = try Self.runShell(script)
+        #expect(success == 0)
+        #expect(fileManager.fileExists(atPath: finalURL.path))
+        #expect(!fileManager.fileExists(atPath: tempURL.path))
+        #expect(try Data(contentsOf: finalURL) == payload)
+
+        try Data("truncated".utf8).write(to: tempURL)
+        let mismatch = try Self.runShell(script)
+        #expect(mismatch == 74)
+        #expect(fileManager.fileExists(atPath: tempURL.path))
+    }
+
     @Test("Bootstrap uploads bypass wedged ControlMasters and scale their deadline with payload size")
     func uploadUsesStandaloneTransportAndScaledDeadline() throws {
         let fileManager = FileManager.default
@@ -100,6 +135,8 @@ extension RemoteDaemonUploadTests {
         )
         #expect(uploadRequest.arguments.last?.contains("trap") == true)
         #expect(uploadRequest.arguments.last?.contains("kill") == true)
+        #expect(uploadRequest.arguments.last?.contains("stall_checks") == true)
+        #expect(uploadRequest.arguments.last?.contains("without byte progress") == true)
         #expect(cleanupRequest.arguments.last?.contains(".tmp-*") == true)
         #expect(Self.consecutive(cleanupRequest.arguments, "-o", "ControlPath=none"))
         #expect(!cleanupRequest.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
@@ -230,5 +267,17 @@ extension RemoteDaemonUploadTests {
             stdout: "",
             stderr: "unexpected request: \(request.executable) \(request.arguments.last ?? "<missing>")"
         )
+    }
+
+    private static func runShell(_ script: String) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -269,6 +269,117 @@ struct RemoteDaemonUploadTests {
         #expect(runner.requests.map(Self.uploadStep) == [.createDirectory, .upload, .finalize, .cleanup])
     }
 
+    @Test("Bootstrap repairs an executable install whose probe reports zero bytes")
+    func bootstrapRepairsZeroByteInstall() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-bootstrap-repair-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        try fileManager.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let payload = Data("cached daemon payload".utf8)
+        let hash = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        let manifestJSON = """
+        {"schemaVersion":1,"appVersion":"test-version","releaseTag":"test","releaseURL":"https://example.invalid","checksumsAssetName":"checksums","checksumsURL":"https://example.invalid/checksums","entries":[{"goOS":"linux","goArch":"amd64","assetName":"cmuxd-remote-linux-amd64","downloadURL":"https://example.invalid/cmuxd-remote","sha256":"\(hash)"}]}
+        """
+        let manifest = try #require(
+            WorkspaceRemoteDaemonManifest(
+                infoDictionary: [WorkspaceRemoteDaemonManifest.infoDictionaryKey: manifestJSON]
+            )
+        )
+        let repository = RemoteDaemonManifestRepository(homeDirectory: home)
+        let cachedURL = try repository.cachedBinaryURL(
+            version: "test-version",
+            goOS: "linux",
+            goArch: "amd64"
+        )
+        try fileManager.createDirectory(
+            at: cachedURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try payload.write(to: cachedURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cachedURL.path)
+
+        let runner = RecordingProcessRunner { request in
+            let command = request.arguments.last ?? ""
+            if command.contains(RemoteSessionCoordinator.remotePlatformProbeHomeMarker) {
+                return RemoteCommandResult(
+                    status: 0,
+                    stdout: """
+                    \(RemoteSessionCoordinator.remotePlatformProbeHomeMarker)\(home.path)
+                    \(RemoteSessionCoordinator.remotePlatformProbeOSMarker)Linux
+                    \(RemoteSessionCoordinator.remotePlatformProbeArchMarker)x86_64
+                    \(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes
+                    \(RemoteSessionCoordinator.remotePlatformProbeSizeMarker)0
+                    """,
+                    stderr: ""
+                )
+            }
+            switch Self.uploadStep(for: request) {
+            case .createDirectory, .upload, .finalize:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .cleanup:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .unknown:
+                if command.contains("hello") {
+                    return RemoteCommandResult(
+                        status: 0,
+                        stdout: #"{"ok":true,"result":{"name":"cmuxd-remote","version":"test-version","capabilities":[]}}"#,
+                        stderr: ""
+                    )
+                }
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "test@repair.example",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil,
+            preserveAfterTerminalExit: false,
+            persistentDaemonSlot: nil
+        )
+        let coordinator = RemoteSessionCoordinator(
+            host: NoopRemoteSessionHost(),
+            configuration: configuration,
+            proxyBroker: SSHOverrideUnusedRemoteProxyBroker(),
+            connectionBroker: NativeSSHConnectionBroker(),
+            manifestRepository: repository,
+            processRunner: runner,
+            reachabilityProbe: SSHOverrideNoopReachabilityProbe(),
+            relayCommandRewriter: SSHOverridePassthroughRelayCommandRewriter(),
+            buildInfo: ManifestBuildInfo(version: "test-version", manifest: manifest),
+            daemonStrings: RemoteDaemonStrings(
+                missingPersistentPTYCapability: "",
+                missingRequiredFunctionality: ""
+            ),
+            strings: RemoteSessionStrings(
+                connectedVMNoProxyFormat: "%@",
+                suspendedDetailFormat: "%@",
+                reverseRelayUnavailableRetrying: "",
+                reverseRelayPortUnavailableRetrying: "",
+                controlMasterOwnershipUnavailable: ""
+            )
+        )
+        defer { coordinator.stop() }
+
+        let hello = try coordinator.queue.sync {
+            try coordinator.bootstrapDaemonLocked(requiredCapabilities: [])
+        }
+        #expect(hello.version == "test-version")
+        #expect(runner.requests.contains { Self.uploadStep(for: $0) == .upload })
+        #expect(runner.requests.contains { Self.uploadStep(for: $0) == .finalize })
+    }
+
     @Test("Upload process failures do not expose arbitrary local error text")
     func uploadProcessFailureSanitizesLocalDetail() throws {
         try assertProcessFailureIsSanitized(
@@ -441,4 +552,13 @@ struct RemoteDaemonUploadTests {
             )
         )
     }
+}
+
+private struct ManifestBuildInfo: RemoteSessionBuildInfoProviding {
+    let version: String
+    let manifest: WorkspaceRemoteDaemonManifest
+
+    func appVersion() -> String? { version }
+    func embeddedDaemonManifest() -> WorkspaceRemoteDaemonManifest? { manifest }
+    func executableDirectoryURL() -> URL? { nil }
 }

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -73,7 +73,7 @@ struct RemoteDaemonUploadTests {
         #expect(finalizeRequest.arguments.last?.contains(location.absolutePath) == true)
     }
 
-    @Test("Upload reports SSH exec failures with their remote detail")
+    @Test("Upload reports SSH exec failures with a safe transfer error")
     func uploadReportsExecFailureDetail() throws {
         let fileManager = FileManager.default
         let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
@@ -117,8 +117,7 @@ struct RemoteDaemonUploadTests {
             #expect(nsError.domain == "cmux.remote.daemon")
             #expect(nsError.code == 31)
             #expect(
-                nsError.localizedDescription ==
-                    "failed to upload cmuxd-remote: cat: remote path: Permission denied"
+                nsError.localizedDescription == "failed to upload remote daemon"
             )
         }
 
@@ -141,7 +140,7 @@ struct RemoteDaemonUploadTests {
         #expect(cleanupRequest.arguments.last?.contains(location.absolutePath) == true)
     }
 
-    @Test("Finalization failure cleans the temporary upload and reports install detail")
+    @Test("Finalization failure cleans the temporary upload and reports a safe install error")
     func finalizationFailureCleansTemporaryUpload() throws {
         let fileManager = FileManager.default
         let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
@@ -185,8 +184,7 @@ struct RemoteDaemonUploadTests {
             #expect(nsError.domain == "cmux.remote.daemon")
             #expect(nsError.code == 32)
             #expect(
-                nsError.localizedDescription ==
-                    "failed to install remote daemon binary: chmod: remote helper: Operation not permitted"
+                nsError.localizedDescription == "failed to install remote daemon"
             )
         }
 
@@ -254,8 +252,8 @@ struct RemoteDaemonUploadTests {
             let nsError = error as NSError
             #expect(nsError.domain == "cmux.remote.daemon")
             #expect(nsError.code == 33)
-            #expect(nsError.localizedDescription.contains("verification"))
-            #expect(nsError.localizedDescription.contains("size mismatch"))
+            #expect(nsError.localizedDescription == "remote daemon integrity verification failed")
+            #expect(!nsError.localizedDescription.contains("size mismatch"))
         }
 
         let finalizeRequest = try #require(
@@ -385,7 +383,7 @@ struct RemoteDaemonUploadTests {
         try assertProcessFailureIsSanitized(
             at: .upload,
             expectedCode: 31,
-            expectedDescription: "failed to upload cmuxd-remote"
+            expectedDescription: "failed to upload remote daemon"
         )
     }
 
@@ -403,7 +401,7 @@ struct RemoteDaemonUploadTests {
         try assertProcessFailureIsSanitized(
             at: .finalize,
             expectedCode: 32,
-            expectedDescription: "failed to install remote daemon binary"
+            expectedDescription: "failed to install remote daemon"
         )
     }
 

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -1,6 +1,7 @@
 import CmuxCore
 import CmuxRemoteDaemon
 import CmuxRemoteWorkspace
+import CryptoKit
 import Foundation
 import Testing
 @testable import CmuxRemoteSession
@@ -206,6 +207,66 @@ struct RemoteDaemonUploadTests {
         )
         #expect(cleanupRequest.arguments.last?.contains(temporaryPathMarker) == true)
         #expect(cleanupRequest.arguments.last?.contains(location.absolutePath) == true)
+    }
+
+    @Test("A truncated remote payload is rejected before daemon promotion")
+    func truncatedPayloadIsRejectedBeforePromotion() throws {
+        let fileManager = FileManager.default
+        let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-integrity-\(UUID().uuidString)",
+            isDirectory: false
+        )
+        let payload = Data("verified daemon payload".utf8)
+        try payload.write(to: localBinary)
+        defer { try? fileManager.removeItem(at: localBinary) }
+
+        let expectedHash = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        let runner = RecordingProcessRunner { request in
+            switch Self.uploadStep(for: request) {
+            case .createDirectory, .upload, .cleanup:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .finalize:
+                return RemoteCommandResult(
+                    status: 74,
+                    stdout: "",
+                    stderr: "cmux daemon verification failed: size mismatch expected=23 actual=0"
+                )
+            case .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(runner: runner)
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
+            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
+        )
+
+        do {
+            try coordinator.queue.sync {
+                try coordinator.uploadRemoteDaemonBinaryLocked(
+                    localBinary: localBinary,
+                    location: location
+                )
+            }
+            Issue.record("Expected remote integrity verification to reject the truncated payload")
+        } catch {
+            let nsError = error as NSError
+            #expect(nsError.domain == "cmux.remote.daemon")
+            #expect(nsError.code == 33)
+            #expect(nsError.localizedDescription.contains("verification"))
+            #expect(nsError.localizedDescription.contains("size mismatch"))
+        }
+
+        let finalizeRequest = try #require(
+            runner.requests.first { Self.uploadStep(for: $0) == .finalize }
+        )
+        let finalizeCommand = finalizeRequest.arguments.last ?? ""
+        #expect(finalizeCommand.contains("wc -c"))
+        #expect(finalizeCommand.contains("sha256sum"))
+        #expect(finalizeCommand.contains(expectedHash))
+        #expect(finalizeCommand.contains("mv"))
+        #expect(runner.requests.map(Self.uploadStep) == [.createDirectory, .upload, .finalize, .cleanup])
     }
 
     @Test("Upload process failures do not expose arbitrary local error text")

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
@@ -113,6 +113,59 @@ struct RemotePlatformProbeScriptTests {
         )
     }
 
+    @Test("A zero-byte executable is reported as not installed")
+    func zeroByteExecutableIsNotInstalled() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-platform-probe-empty-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        let daemonURL = home
+            .appendingPathComponent(".cmux/bin/cmuxd-remote/test-version/linux-amd64", isDirectory: true)
+            .appendingPathComponent("cmuxd-remote", isDirectory: false)
+        try fileManager.createDirectory(at: daemonURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: bin, withIntermediateDirectories: true)
+        try Data().write(to: daemonURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: daemonURL.path)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try Self.writeExecutableShellFile(
+            at: bin.appendingPathComponent("uname"),
+            body: """
+            #!/bin/sh
+            case "${1:-}" in
+              -s) printf '%s\\n' Linux ;;
+              -m) printf '%s\\n' x86_64 ;;
+              *) exit 1 ;;
+            esac
+            """
+        )
+
+        let result = try Self.runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: [
+                "HOME=\(home.path)",
+                "PATH=\(bin.path):/usr/bin:/bin",
+                "/bin/sh",
+                "-c",
+                RemoteSessionCoordinator.remotePlatformProbeScript(version: "test-version"),
+            ]
+        )
+
+        let outputComment = Comment(rawValue: result.stdout + result.stderr)
+        #expect(result.status == 0, outputComment)
+        #expect(
+            result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)no"),
+            outputComment
+        )
+        #expect(
+            !result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes"),
+            outputComment
+        )
+    }
+
     @Test("Probe sanitizes the version before shell interpolation")
     func probeScriptSanitizesVersionBeforeShellInterpolation() throws {
         let fileManager = FileManager.default

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
@@ -166,6 +166,45 @@ struct RemotePlatformProbeScriptTests {
         )
     }
 
+    @Test("Bootstrap diagnostics include remote size and the persistent daemon log tail")
+    func diagnosticsIncludeSizeAndLogTail() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-diagnostics-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let remotePath = home.appendingPathComponent(".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote")
+        let logURL = home.appendingPathComponent(".cmux/daemon/test/repair-slot/daemon.log")
+        try fileManager.createDirectory(at: remotePath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("abc".utf8).write(to: remotePath)
+        try Data("daemon_ready\nrepair_reason=integrity\n".utf8).write(to: logURL)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let result = try Self.runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: [
+                "HOME=\(home.path)",
+                "PATH=/usr/bin:/bin",
+                "/bin/sh",
+                "-c",
+                RemoteSessionCoordinator.remoteDaemonDiagnosticsScript(
+                    remotePath: remotePath.path,
+                    version: "test",
+                    persistentDaemonSlot: "repair-slot"
+                ),
+            ]
+        )
+
+        let outputComment = Comment(rawValue: result.stdout + result.stderr)
+        #expect(result.status == 0, outputComment)
+        #expect(result.stdout.contains("remote_path=\(remotePath.path)"), outputComment)
+        #expect(result.stdout.contains("remote_size=3"), outputComment)
+        #expect(result.stdout.contains("daemon_log_tail:"), outputComment)
+        #expect(result.stdout.contains("repair_reason=integrity"), outputComment)
+    }
+
     @Test("Probe sanitizes the version before shell interpolation")
     func probeScriptSanitizesVersionBeforeShellInterpolation() throws {
         let fileManager = FileManager.default

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteReconnectPolicyTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteReconnectPolicyTests.swift
@@ -105,6 +105,68 @@ struct RemoteReconnectPolicyTests {
         )
     }
 
+    @Test("Repeated identical bootstrap failures eventually park reconnect")
+    func repeatedBootstrapFailuresAreBounded() {
+        let policy = RemoteBootstrapRetryPolicy()
+        var previousFingerprint: String?
+        var consecutive = 0
+        var total = 0
+        var decisions: [RemoteBootstrapRetryPolicy.Decision] = []
+
+        for _ in 0..<policy.maxConsecutiveFailures {
+            let evaluation = policy.evaluate(
+                fingerprint: "cmux.remote.daemon:33",
+                previousFingerprint: previousFingerprint,
+                previousConsecutiveFailures: consecutive,
+                previousTotalFailures: total
+            )
+            previousFingerprint = evaluation.fingerprint
+            consecutive = evaluation.consecutiveFailures
+            total = evaluation.totalFailures
+            decisions.append(evaluation.decision)
+        }
+
+        #expect(decisions.dropLast().allSatisfy { $0 == .retry })
+        #expect(decisions.last == .suspend)
+        #expect(consecutive == policy.maxConsecutiveFailures)
+        #expect(total == policy.maxConsecutiveFailures)
+    }
+
+    @Test("A changed bootstrap failure fingerprint resets the consecutive budget")
+    func changedBootstrapFailureResetsConsecutiveBudget() {
+        let policy = RemoteBootstrapRetryPolicy()
+        let first = policy.evaluate(
+            fingerprint: "cmux.remote.daemon:33",
+            previousFingerprint: nil,
+            previousConsecutiveFailures: 0,
+            previousTotalFailures: 0
+        )
+        let changed = policy.evaluate(
+            fingerprint: "cmux.remote.daemon:31",
+            previousFingerprint: first.fingerprint,
+            previousConsecutiveFailures: first.consecutiveFailures,
+            previousTotalFailures: first.totalFailures
+        )
+
+        #expect(changed.decision == .retry)
+        #expect(changed.consecutiveFailures == 1)
+        #expect(changed.totalFailures == 2)
+    }
+
+    @Test("Blocked bootstrap failures park immediately")
+    func blockedBootstrapFailureDoesNotSpin() {
+        let policy = RemoteBootstrapRetryPolicy()
+        let evaluation = policy.evaluate(
+            fingerprint: "cmux.remote.daemon:31:blocked",
+            previousFingerprint: nil,
+            previousConsecutiveFailures: 0,
+            previousTotalFailures: 0
+        )
+
+        #expect(evaluation.decision == .suspend)
+        #expect(evaluation.consecutiveFailures == 1)
+    }
+
     @Test("System wake re-arms a suspended coordinator with fresh backoff")
     func systemWakeRearmsSuspendedCoordinator() {
         let provider = IntentionalCleanupTestTunnelProvider()

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteReconnectPolicyTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteReconnectPolicyTests.swift
@@ -153,6 +153,36 @@ struct RemoteReconnectPolicyTests {
         #expect(changed.totalFailures == 2)
     }
 
+    @Test("Bootstrap diagnostics do not change retry fingerprints")
+    func bootstrapDiagnosticsDoNotAffectFingerprint() {
+        let underlying = NSError(
+            domain: "cmux.remote.daemon",
+            code: 41,
+            userInfo: [
+                NSLocalizedDescriptionKey: "remote daemon hello returned invalid JSON",
+            ]
+        )
+        let first = RemoteSessionCoordinator.annotatedRemoteDaemonBootstrapError(
+            underlying,
+            remotePath: "/home/test/.cmux/bin/cmuxd-remote/1/linux-amd64/cmuxd-remote",
+            diagnostic: "daemon log tail: authentication failed"
+        )
+        let second = RemoteSessionCoordinator.annotatedRemoteDaemonBootstrapError(
+            underlying,
+            remotePath: "/home/test/.cmux/bin/cmuxd-remote/1/linux-amd64/cmuxd-remote",
+            diagnostic: "daemon log tail: checksum mismatch"
+        )
+
+        #expect(
+            RemoteBootstrapRetryPolicy.fingerprint(for: first) ==
+                "cmux.remote.daemon:41:hello"
+        )
+        #expect(
+            RemoteBootstrapRetryPolicy.fingerprint(for: second) ==
+                "cmux.remote.daemon:41:hello"
+        )
+    }
+
     @Test("Blocked bootstrap failures park immediately")
     func blockedBootstrapFailureDoesNotSpin() {
         let policy = RemoteBootstrapRetryPolicy()

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionInheritedForwardRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionInheritedForwardRecoveryTests.swift
@@ -295,9 +295,11 @@ struct RemoteSessionInheritedForwardRecoveryTests {
         #expect(await statuses.next() == readyStatus)
         #expect(await clock.nextRequestedDelay() == 2_000)
         await clock.resumeNextSleep()
-        #expect(await statuses.next()?.state != .error)
+        let firstRecoveryStatus = try #require(await statuses.next())
+        #expect(firstRecoveryStatus.state != .error)
         #expect(await clock.nextRequestedDelay() == 2_000)
-        #expect(await statuses.next()?.state != .error)
+        let secondRecoveryStatus = try #require(await statuses.next())
+        #expect(secondRecoveryStatus.state != .error)
 
         let requests = runner.requests
         #expect(

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionInheritedForwardRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionInheritedForwardRecoveryTests.swift
@@ -295,9 +295,9 @@ struct RemoteSessionInheritedForwardRecoveryTests {
         #expect(await statuses.next() == readyStatus)
         #expect(await clock.nextRequestedDelay() == 2_000)
         await clock.resumeNextSleep()
-        #expect(await statuses.next()?.state == .error)
+        #expect(await statuses.next()?.state != .error)
         #expect(await clock.nextRequestedDelay() == 2_000)
-        #expect(await statuses.next()?.state == .error)
+        #expect(await statuses.next()?.state != .error)
 
         let requests = runner.requests
         #expect(

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionReverseRelayTransportTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionReverseRelayTransportTests.swift
@@ -55,6 +55,28 @@ struct RemoteSessionReverseRelayTransportTests {
         )
     }
 
+    @Test("A duplicate relay start does not downgrade a ready forward")
+    func duplicateRelayStartPreservesReadiness() async throws {
+        let runner = RecordingProcessRunner()
+        let fixture = try await RemoteSessionReverseRelayStartupTests.makeCoordinator(
+            runner: runner
+        )
+        let coordinator = fixture.coordinator
+        defer { try? FileManager.default.removeItem(at: fixture.scratchDirectory) }
+
+        coordinator.queue.sync {
+            coordinator.daemonReady = true
+            coordinator.daemonRemotePath = "/tmp/cmuxd-remote"
+            coordinator.reverseRelayControlMasterForwardSpec =
+                "127.0.0.1:64044:127.0.0.1:55001"
+            coordinator.reverseRelayReady = true
+            coordinator.startReverseRelayLocked(remotePath: "/tmp/cmuxd-remote")
+        }
+
+        #expect(coordinator.queue.sync { coordinator.reverseRelayReady })
+        _ = await coordinator.stopAndWait(cleanupScope: .transport)
+    }
+
     @Test("Connection preparation retains an already-resolved path")
     func connectionPreparationRetainsResolvedPath() async throws {
         let runner = RecordingProcessRunner()
@@ -159,6 +181,7 @@ struct RemoteSessionReverseRelayTransportTests {
         }
 
         let launch = try #require(await launches.next())
+        #expect(coordinator.queue.sync { coordinator.reverseRelayReady == false })
         #expect(launch.arguments.starts(with: ["-N", "-T", "-S", "none"]))
         #expect(!runner.requests.contains(where: {
             Self.isControlCommand("forward", in: $0.arguments)
@@ -167,6 +190,9 @@ struct RemoteSessionReverseRelayTransportTests {
             coordinator.reverseRelayControlMasterForwardSpec == nil &&
                 coordinator.reverseRelayProcess === launcher.process
         })
+        launcher.emitStartupReady()
+        coordinator.queue.sync {}
+        #expect(coordinator.queue.sync { coordinator.reverseRelayReady })
         _ = await coordinator.stopAndWait(cleanupScope: .transport)
     }
 
@@ -325,8 +351,8 @@ struct RemoteSessionReverseRelayTransportTests {
         launcher.emitTermination(detail: rawFailure)
 
         let status = try #require(await statuses.next())
-        #expect(status.detail == "test relay unavailable")
-        #expect(status.detail?.contains(rawFailure) == false)
+        #expect(status.state == .bootstrapping)
+        #expect(status.detail == nil)
         #expect(await clock.nextRequestedDelay() == 2_000)
         _ = await coordinator.stopAndWait(cleanupScope: .transport)
     }

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Manifest/RemoteDaemonManifestRepository.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Manifest/RemoteDaemonManifestRepository.swift
@@ -72,6 +72,11 @@ public struct RemoteDaemonManifestRepository: Sendable {
     public func validatedCachedBinary(entry: WorkspaceRemoteDaemonManifest.Entry, version: String) throws -> URL? {
         let cacheURL = try cachedBinaryURL(version: version, goOS: entry.goOS, goArch: entry.goArch)
         guard fileManager.fileExists(atPath: cacheURL.path) else { return nil }
+        let fileSize = (try? cacheURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard fileSize > 0 else {
+            try? fileManager.removeItem(at: cacheURL)
+            return nil
+        }
         let cachedSHA = try sha256Hex(forFile: cacheURL)
         if cachedSHA == entry.sha256.lowercased(),
            fileManager.isExecutableFile(atPath: cacheURL.path) {

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteDaemonManifestRepositoryTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemoteDaemonManifestRepositoryTests.swift
@@ -291,7 +291,15 @@ struct RemoteDaemonManifestRepositoryTests {
         #expect(try repository.validatedCachedBinary(entry: entry, version: "0.99.0") == cacheURL)
         #expect(FileManager.default.fileExists(atPath: cacheURL.path), "a valid hit is not deleted")
 
+        // Present + executable but empty: treated as corrupt and removed.
+        try Data().write(to: cacheURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cacheURL.path)
+        #expect(try repository.validatedCachedBinary(entry: entry, version: "0.99.0") == nil)
+        #expect(!FileManager.default.fileExists(atPath: cacheURL.path))
+
         // Present + stale bytes: removed, nil.
+        try binary.write(to: cacheURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cacheURL.path)
         try Data("tampered".utf8).write(to: cacheURL)
         #expect(try repository.validatedCachedBinary(entry: entry, version: "0.99.0") == nil)
         #expect(!FileManager.default.fileExists(atPath: cacheURL.path))

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -145432,26 +145432,62 @@
             "state": "translated",
             "value": "cmuxd-remote のビルド出力がないか空です"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "bs": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "da": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "de": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "es": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "fr": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "it": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "km": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "ko": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "nb": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "pl": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "ru": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "th": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "tr": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "uk": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } }
         }
-      }
-    },
+      },
     "remoteDaemon.bootstrap.reconnectPaused": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Automatic reconnect paused after %d identical failures; repair the remote install and use Reconnect to try again."
+            "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "同じ失敗が %d 回続いたため自動再接続を一時停止しました。リモートインストールを修復して「再接続」を実行してください。"
+            "value": "ブートストラップを続行できないため自動再接続を一時停止しました。表示されたリモートの問題を修復して「再接続」を実行してください。"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "bs": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "da": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "de": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "es": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "fr": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "it": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "km": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "ko": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "nb": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "pl": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "ru": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "th": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "tr": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "uk": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } }
         }
-      }
-    },
+      },
     "remoteDaemon.bootstrap.removeCorruptFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -145466,9 +145502,27 @@
             "state": "translated",
             "value": "破損したリモートデーモンのインストールを削除できませんでした"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "bs": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "da": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "de": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "es": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "fr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "it": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "km": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "ko": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "nb": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "pl": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "ru": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "th": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "tr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "uk": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } }
         }
-      }
-    },
+      },
     "remoteDaemon.bootstrap.removeCorruptFailedWithDetail": {
       "extractionState": "manual",
       "localizations": {
@@ -145483,9 +145537,27 @@
             "state": "translated",
             "value": "破損したリモートデーモンのインストールを削除できませんでした：%@"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "bs": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "da": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "de": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "es": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "fr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "it": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "km": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "ko": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "nb": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "pl": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "ru": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "th": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "tr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "uk": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } }
         }
-      }
-    },
+      },
     "remoteDaemon.upload.createDirectoryFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -145568,9 +145640,27 @@
             "state": "translated",
             "value": "リモートデーモンの整合性検証に失敗しました"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "bs": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "da": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "de": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "es": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "fr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "it": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "km": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "ko": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "nb": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "pl": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "ru": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "th": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "tr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "uk": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } }
         }
-      }
-    },
+      },
     "remoteDaemon.upload.verifyFailedWithDetail": {
       "extractionState": "manual",
       "localizations": {
@@ -145585,9 +145675,27 @@
             "state": "translated",
             "value": "リモートデーモンの整合性検証に失敗しました：%@"
           }
+        },
+        "ar": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "bs": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "da": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "de": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "es": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "fr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "it": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "km": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "ko": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "nb": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "pl": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "pt-BR": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "ru": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "th": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "tr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "uk": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "zh-Hans": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
+        "zh-Hant": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } }
         }
-      }
-    },
+      },
     "remoteDaemon.upload.transferFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -145418,6 +145418,74 @@
         }
       }
     },
+    "remoteDaemon.bootstrap.buildOutputEmpty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxd-remote build output is missing or empty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxd-remote のビルド出力がないか空です"
+          }
+        }
+      }
+    },
+    "remoteDaemon.bootstrap.reconnectPaused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic reconnect paused after %d identical failures; repair the remote install and use Reconnect to try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同じ失敗が %d 回続いたため自動再接続を一時停止しました。リモートインストールを修復して「再接続」を実行してください。"
+          }
+        }
+      }
+    },
+    "remoteDaemon.bootstrap.removeCorruptFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failed to remove corrupt remote daemon install"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "破損したリモートデーモンのインストールを削除できませんでした"
+          }
+        }
+      }
+    },
+    "remoteDaemon.bootstrap.removeCorruptFailedWithDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failed to remove corrupt remote daemon install: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "破損したリモートデーモンのインストールを削除できませんでした：%@"
+          }
+        }
+      }
+    },
     "remoteDaemon.upload.createDirectoryFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -145482,6 +145550,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "リモートデーモンのバイナリをインストールできませんでした：%@"
+          }
+        }
+      }
+    },
+    "remoteDaemon.upload.verifyFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remote daemon integrity verification failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンの整合性検証に失敗しました"
+          }
+        }
+      }
+    },
+    "remoteDaemon.upload.verifyFailedWithDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remote daemon integrity verification failed: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンの整合性検証に失敗しました：%@"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53858,6 +53858,23 @@
         }
       }
     },
+    "cli.ssh.autoReconnect.recovered": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH reconnected (attempt %s/%s)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH が再接続されました（試行 %s/%s）。"
+          }
+        }
+      }
+    },
     "cli.ssh.autoReconnect.stopHint": {
       "extractionState": "manual",
       "localizations": {
@@ -55280,6 +55297,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "[cmux] リモート PTY ブリッジが閉じました。再接続しています（試行 %s/%s）。"
+          }
+        }
+      }
+    },
+    "cli.sshPtyAttach.reconnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] remote PTY reconnected (attempt %s/%s)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] リモート PTY が再接続されました（試行 %s/%s）。"
           }
         }
       }
@@ -145424,35 +145458,17 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxd-remote build output is missing or empty"
+            "value": "Remote daemon build output is missing or empty"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxd-remote のビルド出力がないか空です"
+            "value": "リモートデーモンのビルド出力がないか空です"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "bs": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "da": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "de": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "es": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "fr": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "it": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "km": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "ko": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "nb": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "pl": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "ru": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "th": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "tr": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "uk": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "cmuxd-remote build output is missing or empty" } }
         }
-      },
+      }
+    },
     "remoteDaemon.bootstrap.reconnectPaused": {
       "extractionState": "manual",
       "localizations": {
@@ -145467,27 +145483,60 @@
             "state": "translated",
             "value": "ブートストラップを続行できないため自動再接続を一時停止しました。表示されたリモートの問題を修復して「再接続」を実行してください。"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "bs": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "da": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "de": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "es": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "fr": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "it": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "km": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "ko": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "nb": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "pl": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "ru": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "th": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "tr": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "uk": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "Automatic reconnect paused because bootstrap cannot proceed; repair the reported remote failure and use Reconnect to try again." } }
         }
-      },
+      }
+    },
+    "remoteDaemon.bootstrap.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote daemon bootstrap failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンのブートストラップに失敗しました"
+          }
+        }
+      }
+    },
+    "remoteDaemon.bootstrap.helloFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote daemon did not return a valid readiness response"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンが有効な準備完了応答を返しませんでした"
+          }
+        }
+      }
+    },
+    "remoteDaemon.bootstrap.probeFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not inspect the remote daemon installation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンのインストールを検査できませんでした"
+          }
+        }
+      }
+    },
     "remoteDaemon.bootstrap.removeCorruptFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -145502,27 +145551,9 @@
             "state": "translated",
             "value": "破損したリモートデーモンのインストールを削除できませんでした"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "bs": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "da": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "de": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "es": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "fr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "it": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "km": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "ko": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "nb": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "pl": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "ru": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "th": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "tr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "uk": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install" } }
         }
-      },
+      }
+    },
     "remoteDaemon.bootstrap.removeCorruptFailedWithDetail": {
       "extractionState": "manual",
       "localizations": {
@@ -145537,27 +145568,9 @@
             "state": "translated",
             "value": "破損したリモートデーモンのインストールを削除できませんでした：%@"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "bs": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "da": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "de": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "es": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "fr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "it": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "km": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "ko": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "nb": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "pl": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "ru": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "th": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "tr": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "uk": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "failed to remove corrupt remote daemon install: %@" } }
         }
-      },
+      }
+    },
     "remoteDaemon.upload.createDirectoryFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -145598,13 +145611,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "failed to install remote daemon binary"
+            "value": "failed to install remote daemon"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "リモートデーモンのバイナリをインストールできませんでした"
+            "value": "リモートデーモンをインストールできませんでした"
           }
         }
       }
@@ -145640,27 +145653,9 @@
             "state": "translated",
             "value": "リモートデーモンの整合性検証に失敗しました"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "bs": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "da": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "de": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "es": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "fr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "it": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "km": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "ko": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "nb": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "pl": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "ru": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "th": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "tr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "uk": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed" } }
         }
-      },
+      }
+    },
     "remoteDaemon.upload.verifyFailedWithDetail": {
       "extractionState": "manual",
       "localizations": {
@@ -145675,40 +145670,22 @@
             "state": "translated",
             "value": "リモートデーモンの整合性検証に失敗しました：%@"
           }
-        },
-        "ar": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "bs": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "da": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "de": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "es": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "fr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "it": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "km": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "ko": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "nb": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "pl": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "pt-BR": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "ru": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "th": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "tr": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "uk": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "zh-Hans": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } },
-        "zh-Hant": { "stringUnit": { "state": "new", "value": "remote daemon integrity verification failed: %@" } }
         }
-      },
+      }
+    },
     "remoteDaemon.upload.transferFailed": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "failed to upload cmuxd-remote"
+            "value": "failed to upload remote daemon"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxd-remote をアップロードできませんでした"
+            "value": "リモートデーモンをアップロードできませんでした"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -145458,13 +145458,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Remote daemon build output is missing or empty"
+            "value": "The remote daemon files are missing or empty"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "リモートデーモンのビルド出力がないか空です"
+            "value": "リモートデーモンのファイルがないか空です"
           }
         }
       }
@@ -145492,13 +145492,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Remote daemon bootstrap failed"
+            "value": "Could not prepare the remote daemon"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "リモートデーモンのブートストラップに失敗しました"
+            "value": "リモートデーモンを準備できませんでした"
           }
         }
       }
@@ -145509,13 +145509,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Remote daemon did not return a valid readiness response"
+            "value": "Could not confirm that the remote daemon is ready"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "リモートデーモンが有効な準備完了応答を返しませんでした"
+            "value": "リモートデーモンが準備完了したことを確認できませんでした"
           }
         }
       }
@@ -146358,6 +146358,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "別の cmux プロセスが SSH 接続を使用しています。"
+          }
+        }
+      }
+    },
+    "remoteSession.proxy.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote proxy unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートプロキシを利用できません"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1990,7 +1990,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let markedForKill = remoteTmuxController.windowsMarkedForKillOnClose()
         let simulatorCleanupTasks = SimulatorPanel.beginApplicationTerminationCleanup()
         let hasOwnedRuntimeCleanup = !markedForKill.isEmpty || !simulatorCleanupTasks.isEmpty
-        let ttyDeviceBindings = currentSurfaceTTYDeviceBindings()
         if !isAwaitingTerminateCleanup {
             isAwaitingTerminateCleanup = true
             terminateCleanupPhase = .ownedRuntimeCleanup
@@ -2021,6 +2020,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     return
                 }
                 self.terminateCleanupPhase = .freshSnapshot
+                let ttyDeviceBindings = self.currentSurfaceTTYDeviceBindings()
                 let resumeIndexes = await ProcessDetectedResumeIndexes.loadFresh(
                     ttyDeviceBindings: ttyDeviceBindings
                 )
@@ -4636,9 +4636,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Synchronous lifecycle backstops cannot wait for the authoritative off-main load.
         // Revalidate only the already-cached process generations and argv, and fail closed
         // with an empty index when startup has not populated that cache yet.
-        let resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously(
-            cachedRestorableAgentIndex: SharedLiveAgentIndex.shared.index ?? .empty,
-            ttyDeviceBindings: currentSurfaceTTYDeviceBindings()
+        let resumeIndexes = ProcessDetectedResumeIndexes.cached(
+            restorableAgentIndex: SharedLiveAgentIndex.shared.index ?? .empty
         )
         return saveSessionSnapshot(
             includeScrollback: includeScrollback,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1990,6 +1990,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let markedForKill = remoteTmuxController.windowsMarkedForKillOnClose()
         let simulatorCleanupTasks = SimulatorPanel.beginApplicationTerminationCleanup()
         let hasOwnedRuntimeCleanup = !markedForKill.isEmpty || !simulatorCleanupTasks.isEmpty
+        let ttyDeviceBindings = currentSurfaceTTYDeviceBindings()
         if !isAwaitingTerminateCleanup {
             isAwaitingTerminateCleanup = true
             terminateCleanupPhase = .ownedRuntimeCleanup
@@ -2020,7 +2021,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     return
                 }
                 self.terminateCleanupPhase = .freshSnapshot
-                let resumeIndexes = await ProcessDetectedResumeIndexes.loadFresh()
+                let resumeIndexes = await ProcessDetectedResumeIndexes.loadFresh(
+                    ttyDeviceBindings: ttyDeviceBindings
+                )
                 guard !Task.isCancelled else { return }
                 _ = self.saveSessionSnapshot(
                     includeScrollback: true,
@@ -4131,7 +4134,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.isTerminatingApp = true
-                let resumeIndexes = await ProcessDetectedResumeIndexes.loadFresh()
+                let ttyDeviceBindings = self.currentSurfaceTTYDeviceBindings()
+                let resumeIndexes = await ProcessDetectedResumeIndexes.loadFresh(
+                    ttyDeviceBindings: ttyDeviceBindings
+                )
                 _ = self.saveSessionSnapshot(
                     includeScrollback: true,
                     removeWhenEmpty: false,
@@ -4516,7 +4522,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         let loadStart = ProcessInfo.processInfo.systemUptime
 #endif
-        let resumeIndexes = await ProcessDetectedResumeIndexes.load()
+        let ttyDeviceBindings = currentSurfaceTTYDeviceBindings()
+        let resumeIndexes = await ProcessDetectedResumeIndexes.load(
+            ttyDeviceBindings: ttyDeviceBindings
+        )
 #if DEBUG
         loadMs = (ProcessInfo.processInfo.systemUptime - loadStart) * 1000.0
         let fingerprintStart = ProcessInfo.processInfo.systemUptime
@@ -4591,6 +4600,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// Captures the live pane-to-PTY identity before the process scan leaves
+    /// the main actor.  Plain `ssh` commonly drops the CMUX_* environment when
+    /// it is exec'd by a user's shell, so process detection cannot safely use
+    /// environment scope alone.  The terminal surface owns the controlling
+    /// TTY and is the authoritative mapping for this save pass.
+    @MainActor
+    private func currentSurfaceTTYDeviceBindings()
+        -> [SurfaceResumeBindingIndex.PanelKey: Int64] {
+        var bindings: [SurfaceResumeBindingIndex.PanelKey: Int64] = [:]
+        for context in mainWindowContexts.values {
+            for workspace in context.tabManager.tabs {
+                for (panelID, panel) in workspace.panels {
+                    guard let terminal = panel as? TerminalPanel else { continue }
+                    let device = workspace.surfaceTTYDevices[panelID]
+                        ?? terminal.surface.controllingTTYDeviceIdentifier
+                    guard let device, device > 0 else { continue }
+                    bindings[
+                        SurfaceResumeBindingIndex.PanelKey(
+                            workspaceId: workspace.id,
+                            panelId: panelID
+                        )
+                    ] = device
+                }
+            }
+        }
+        return bindings
+    }
+
     @discardableResult
     private func saveSessionSnapshotIncludingProcessDetectedIndexes(
         includeScrollback: Bool,
@@ -4600,7 +4637,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Revalidate only the already-cached process generations and argv, and fail closed
         // with an empty index when startup has not populated that cache yet.
         let resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously(
-            cachedRestorableAgentIndex: SharedLiveAgentIndex.shared.index ?? .empty
+            cachedRestorableAgentIndex: SharedLiveAgentIndex.shared.index ?? .empty,
+            ttyDeviceBindings: currentSurfaceTTYDeviceBindings()
         )
         return saveSessionSnapshot(
             includeScrollback: includeScrollback,
@@ -4616,8 +4654,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         preserveManualRestoreBackupOnMissingPrimary: Bool = false
     ) {
         let generation = nextProcessDetectedSessionSaveGeneration()
+        let ttyDeviceBindings = currentSurfaceTTYDeviceBindings()
         Task { @MainActor [weak self] in
-            let resumeIndexes = await ProcessDetectedResumeIndexes.load()
+            let resumeIndexes = await ProcessDetectedResumeIndexes.load(
+                ttyDeviceBindings: ttyDeviceBindings
+            )
             guard let self,
                   !self.isTerminatingApp,
                   self.isCurrentProcessDetectedSessionSaveGeneration(generation) else { return }

--- a/Sources/ProcessDetectedResumeIndexes.swift
+++ b/Sources/ProcessDetectedResumeIndexes.swift
@@ -6,20 +6,31 @@ struct ProcessDetectedResumeIndexes: Sendable {
 
     static func load(
         homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        ttyDeviceBindings: [SurfaceResumeBindingIndex.PanelKey: Int64] = [:]
     ) async -> ProcessDetectedResumeIndexes {
         await Task.detached(priority: .utility) {
-            loadSynchronously(homeDirectory: homeDirectory, fileManager: fileManager, maximumSnapshotAge: 5)
+            loadSynchronously(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager,
+                maximumSnapshotAge: 5,
+                ttyDeviceBindings: ttyDeviceBindings
+            )
         }.value
     }
 
     /// Loads current hook stores and captures an uncached process snapshot off-main.
     static func loadFresh(
         homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        ttyDeviceBindings: [SurfaceResumeBindingIndex.PanelKey: Int64] = [:]
     ) async -> ProcessDetectedResumeIndexes {
         await Task.detached(priority: .utility) {
-            loadFreshSynchronously(homeDirectory: homeDirectory, fileManager: fileManager)
+            loadFreshSynchronously(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager,
+                ttyDeviceBindings: ttyDeviceBindings
+            )
         }.value
     }
 
@@ -27,9 +38,14 @@ struct ProcessDetectedResumeIndexes: Sendable {
     /// Main-actor lifecycle paths must call ``loadFresh(homeDirectory:fileManager:)``.
     static func loadFreshSynchronously(
         homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        ttyDeviceBindings: [SurfaceResumeBindingIndex.PanelKey: Int64] = [:]
     ) -> ProcessDetectedResumeIndexes {
-        loadSynchronously(homeDirectory: homeDirectory, fileManager: fileManager)
+        loadSynchronously(
+            homeDirectory: homeDirectory,
+            fileManager: fileManager,
+            ttyDeviceBindings: ttyDeviceBindings
+        )
     }
 
     /// Returns the last published agent index without filesystem or process capture.
@@ -49,7 +65,8 @@ struct ProcessDetectedResumeIndexes: Sendable {
         homeDirectory: String = NSHomeDirectory(),
         fileManager: FileManager = .default,
         maximumSnapshotAge: TimeInterval? = nil,
-        cachedRestorableAgentIndex: RestorableAgentSessionIndex? = nil
+        cachedRestorableAgentIndex: RestorableAgentSessionIndex? = nil,
+        ttyDeviceBindings: [SurfaceResumeBindingIndex.PanelKey: Int64] = [:]
     ) -> ProcessDetectedResumeIndexes {
         let capturedAt = Date().timeIntervalSince1970
         let processSnapshot = if let maximumSnapshotAge {
@@ -83,7 +100,8 @@ struct ProcessDetectedResumeIndexes: Sendable {
         let detectedBindings = SurfaceResumeBindingIndex.processDetectedTmuxBindings(
             fileManager: fileManager,
             processSnapshot: processSnapshot,
-            capturedAt: capturedAt
+            capturedAt: capturedAt,
+            ttyDeviceBindings: ttyDeviceBindings
         )
         return ProcessDetectedResumeIndexes(
             restorableAgentIndex: restorableAgentIndex,

--- a/Sources/RemoteSessionStrings+App.swift
+++ b/Sources/RemoteSessionStrings+App.swift
@@ -33,6 +33,10 @@ extension RemoteSessionStrings {
                     "remoteSession.controlMaster.ownershipUnavailable",
                 defaultValue:
                     "SSH connection is busy in another cmux process."
+            ),
+            remoteProxyUnavailable: String(
+                localized: "remoteSession.proxy.unavailable",
+                defaultValue: "Remote proxy unavailable"
             )
         )
     }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -366,6 +366,14 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         source == "process-detected"
     }
 
+    /// Plain interactive SSH bindings are intentionally durable across a
+    /// restore pass.  Their process is expected to be absent while the new
+    /// local PTY is starting, so a transiently empty process scan must not
+    /// erase the command before the next autosave can observe it again.
+    var isPlainSSHProcessDetectedBinding: Bool {
+        isProcessDetected && kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "ssh"
+    }
+
     var isAgentHookBinding: Bool {
         source == "agent-hook"
     }

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -303,12 +303,6 @@ extension TerminalController {
                     defaultValue: "Artifact transfer is temporarily unavailable.",
                     path: nil
                 )
-            case .permissionDenied:
-                return mobileArtifactReadFailure(.permissionDenied, path: v2RawString(params, "path"))
-            case .notRegularFile:
-                return mobileArtifactReadFailure(.notRegularFile, path: v2RawString(params, "path"))
-            case .readFailed:
-                return mobileArtifactReadFailure(.readFailed, path: v2RawString(params, "path"))
             }
         } catch ArtifactByteReader.Error.fileNotFound {
             return mobilePanelArtifactFileError(

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -445,7 +445,7 @@ enum TerminalSSHSessionDetector {
     /// process. Managed `cmux ssh` wrappers are excluded because their stable
     /// remote PTY binding is authoritative; this path is only the muscle-memory
     /// `ssh host` command typed into a local pane.
-    static func resumeBindingForTesting(
+    static func resumeBinding(
         processName: String,
         processPath: String?,
         arguments: [String],

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -441,6 +441,53 @@ enum TerminalSSHSessionDetector {
         return nil
     }
 
+    /// Builds a restore binding for a foreground, interactive plain-SSH
+    /// process. Managed `cmux ssh` wrappers are excluded because their stable
+    /// remote PTY binding is authoritative; this path is only the muscle-memory
+    /// `ssh host` command typed into a local pane.
+    static func resumeBindingForTesting(
+        processName: String,
+        processPath: String?,
+        arguments: [String],
+        environment: [String: String],
+        capturedAt: TimeInterval = Date().timeIntervalSince1970
+    ) -> SurfaceResumeBindingSnapshot? {
+        let executableName = processPath ?? processName
+        guard let transport = RemoteShellTransport(executableName: executableName),
+              case .ssh = transport,
+              !isManagedSSHWrapper(environment: environment),
+              isInteractiveSSHArguments(arguments),
+              let session = parseSSHCommandLine(arguments) else {
+            return nil
+        }
+
+        let command = arguments
+            .map(SurfaceResumeBindingSnapshot.shellSingleQuoted)
+            .joined(separator: " ")
+        guard SurfaceResumeCommandCanonicalizer.isShellExpansionSafeCommand(command) else {
+            return nil
+        }
+        let cwd = environment["CMUX_AGENT_LAUNCH_CWD"] ?? environment["PWD"]
+        return SurfaceResumeBindingSnapshot(
+            name: "ssh \(session.destination)",
+            kind: "ssh",
+            command: command,
+            cwd: cwd,
+            source: "process-detected",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: nil,
+                executablePath: arguments.first,
+                arguments: arguments,
+                workingDirectory: cwd,
+                environment: nil,
+                capturedAt: capturedAt,
+                source: "process-detected"
+            ),
+            autoResume: true,
+            updatedAt: capturedAt
+        )
+    }
+
     private static let psPath = "/bin/ps"
     private static let noArgumentFlags = Set("46AaCfGgKkMNnqsTtVvXxYy")
     private static let valueArgumentFlags = Set("BbcDEeFIiJLlmOopQRSWw")
@@ -460,6 +507,58 @@ enum TerminalSSHSessionDetector {
             process.pgid > 0 &&
             process.tpgid > 0 &&
             process.pgid == process.tpgid
+    }
+
+    private static func isManagedSSHWrapper(environment: [String: String]) -> Bool {
+        [
+            "CMUX_SSH_PTY_SESSION_ID",
+            "CMUX_REMOTE_PTY_SESSION_ID",
+            "CMUX_SSH_ATTEMPT_ID",
+            "CMUX_SSH_STARTUP_PID",
+        ].contains { key in
+            guard let value = environment[key] else { return false }
+            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private static func isInteractiveSSHArguments(_ arguments: [String]) -> Bool {
+        guard !arguments.isEmpty else { return false }
+        var index = RemoteShellSessionParsing.normalizedExecutableName(arguments[0]) == "ssh" ? 1 : 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--" {
+                return index + 2 >= arguments.count
+            }
+            if !argument.hasPrefix("-") || argument == "-" {
+                return index == arguments.count - 1
+            }
+
+            if argument.count > 2,
+               let option = argument.dropFirst().first,
+               valueArgumentFlags.contains(option) {
+                // -W host:port is a stream forward, not an interactive shell.
+                if option == "W" { return false }
+                index += 1
+                continue
+            }
+            if argument.count == 2,
+               let option = argument.dropFirst().first,
+               valueArgumentFlags.contains(option) {
+                if option == "W" { return false }
+                index += 2
+                continue
+            }
+
+            let flags = Array(argument.dropFirst())
+            guard !flags.isEmpty, flags.allSatisfy({ noArgumentFlags.contains($0) }) else {
+                return false
+            }
+            if flags.contains("N") {
+                return false
+            }
+            index += 1
+        }
+        return false
     }
 
     private static func processSnapshots(forTTY ttyName: String) -> [ProcessSnapshot] {

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -461,7 +461,18 @@ enum TerminalSSHSessionDetector {
             return nil
         }
 
-        let command = arguments
+        // libproc's argv[0] is often the bare `ssh` name even when the
+        // process was launched from a company wrapper or an absolute path.
+        // Preserve the resolved executable path so restore does not silently
+        // switch binaries (or fail when that bare name is not on PATH).
+        let resolvedExecutable = processPath?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+        let launchArguments: [String] = {
+            guard let resolvedExecutable, !arguments.isEmpty else { return arguments }
+            return [resolvedExecutable] + arguments.dropFirst()
+        }()
+        let command = launchArguments
             .map(SurfaceResumeBindingSnapshot.shellSingleQuoted)
             .joined(separator: " ")
         guard SurfaceResumeCommandCanonicalizer.isShellExpansionSafeCommand(command) else {
@@ -476,8 +487,8 @@ enum TerminalSSHSessionDetector {
             source: "process-detected",
             launchCommand: AgentLaunchCommandSnapshot(
                 launcher: nil,
-                executablePath: arguments.first,
-                arguments: arguments,
+                executablePath: resolvedExecutable ?? launchArguments.first,
+                arguments: launchArguments,
                 workingDirectory: cwd,
                 environment: nil,
                 capturedAt: capturedAt,
@@ -490,6 +501,7 @@ enum TerminalSSHSessionDetector {
 
     private static let psPath = "/bin/ps"
     private static let noArgumentFlags = Set("46AaCfGgKkMNnqsTtVvXxYy")
+    private static let nonInteractiveFlags = Set("nTGV")
     private static let valueArgumentFlags = Set("BbcDEeFIiJLlmOopQRSWw")
 
     private static func normalizeTTYName(_ ttyName: String) -> String {
@@ -562,7 +574,7 @@ enum TerminalSSHSessionDetector {
             guard !flags.isEmpty, flags.allSatisfy({ noArgumentFlags.contains($0) }) else {
                 return false
             }
-            if flags.contains("N") {
+            if flags.contains(where: { nonInteractiveFlags.contains($0) }) {
                 return false
             }
             index += 1
@@ -571,13 +583,26 @@ enum TerminalSSHSessionDetector {
     }
 
     private static func isNonInteractiveSSHOption(_ rawOption: String) -> Bool {
-        let key = rawOption
+        let parts = rawOption
             .split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-            .first?
+        let key = parts.first?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        return key == "remotecommand" ||
-            (key == "sessiontype" && rawOption.lowercased().contains("none"))
+        let value = parts.count == 2
+            ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            : nil
+        if key == "remotecommand" {
+            // `RemoteCommand=none` is OpenSSH's explicit request for the
+            // normal interactive shell and is safe to resume.
+            return value != "none"
+        }
+        if key == "requesttty" {
+            return value == "no" || value == "false"
+        }
+        if key == "stdinnull" {
+            return value == "yes" || value == "true"
+        }
+        return key == "sessiontype" && value == "none"
     }
 
     private static func processSnapshots(forTTY ttyName: String) -> [ProcessSnapshot] {

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -538,6 +538,10 @@ enum TerminalSSHSessionDetector {
                valueArgumentFlags.contains(option) {
                 // -W host:port is a stream forward, not an interactive shell.
                 if option == "W" { return false }
+                if option == "o",
+                   isNonInteractiveSSHOption(String(argument.dropFirst(2))) {
+                    return false
+                }
                 index += 1
                 continue
             }
@@ -545,6 +549,11 @@ enum TerminalSSHSessionDetector {
                let option = argument.dropFirst().first,
                valueArgumentFlags.contains(option) {
                 if option == "W" { return false }
+                if option == "o",
+                   index + 1 < arguments.count,
+                   isNonInteractiveSSHOption(arguments[index + 1]) {
+                    return false
+                }
                 index += 2
                 continue
             }
@@ -559,6 +568,16 @@ enum TerminalSSHSessionDetector {
             index += 1
         }
         return false
+    }
+
+    private static func isNonInteractiveSSHOption(_ rawOption: String) -> Bool {
+        let key = rawOption
+            .split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return key == "remotecommand" ||
+            (key == "sessiontype" && rawOption.lowercased().contains("none"))
     }
 
     private static func processSnapshots(forTTY ttyName: String) -> [ProcessSnapshot] {

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -649,16 +649,31 @@ extension SurfaceResumeBindingIndex {
     static func processDetectedTmuxBindings(
         fileManager: FileManager,
         processSnapshot: CmuxTopProcessSnapshot,
-        capturedAt: TimeInterval
+        capturedAt: TimeInterval,
+        ttyDeviceBindings: [PanelKey: Int64] = [:],
+        processArgumentsProvider: @Sendable (Int) -> CmuxTopProcessArguments? = {
+            CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: $0)
+        }
     ) -> [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] {
         _ = fileManager
         var resolved: [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] = [:]
 
-        for process in processSnapshot.cmuxScopedProcesses() {
-            guard let workspaceId = process.cmuxWorkspaceID,
-                  let panelId = process.cmuxSurfaceID,
-                  process.isTerminalForegroundProcessGroup,
-                  let processArguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: process.pid) else {
+        // A child such as `/usr/bin/ssh` is not guaranteed to retain the
+        // CMUX_* environment after the user's shell/launch tooling runs it.
+        // The terminal's controlling TTY is the authoritative pane identity,
+        // so use it as a fail-closed fallback when exactly one live panel owns
+        // the device. This keeps process detection scoped without guessing
+        // from titles or global process names.
+        let panelKeysByTTYDevice = Dictionary(grouping: ttyDeviceBindings) { $0.value }
+            .mapValues { $0.map(\.key) }
+
+        for process in processSnapshot.processesByPID.values.sorted(by: { $0.pid < $1.pid }) {
+            guard process.isTerminalForegroundProcessGroup,
+                  let panelKey = processDetectedPanelKey(
+                      for: process,
+                      panelKeysByTTYDevice: panelKeysByTTYDevice
+                  ),
+                  let processArguments = processArgumentsProvider(process.pid) else {
                 continue
             }
             if let binding = TmuxResumeParser.binding(
@@ -668,7 +683,7 @@ extension SurfaceResumeBindingIndex {
                 environment: processArguments.environment,
                 capturedAt: capturedAt
             ) {
-                resolved[PanelKey(workspaceId: workspaceId, panelId: panelId)] = (binding: binding, updatedAt: capturedAt)
+                resolved[panelKey] = (binding: binding, updatedAt: capturedAt)
                 continue
             }
             guard let binding = TerminalSSHSessionDetector.resumeBinding(
@@ -680,10 +695,26 @@ extension SurfaceResumeBindingIndex {
             ) else {
                 continue
             }
-            resolved[PanelKey(workspaceId: workspaceId, panelId: panelId)] = (binding: binding, updatedAt: capturedAt)
+            resolved[panelKey] = (binding: binding, updatedAt: capturedAt)
         }
 
         return resolved
+    }
+
+    private static func processDetectedPanelKey(
+        for process: CmuxTopProcessInfo,
+        panelKeysByTTYDevice: [Int64: [PanelKey]]
+    ) -> PanelKey? {
+        if let workspaceId = process.cmuxWorkspaceID,
+           let panelId = process.cmuxSurfaceID {
+            return PanelKey(workspaceId: workspaceId, panelId: panelId)
+        }
+        guard let ttyDevice = process.ttyDevice,
+              let candidates = panelKeysByTTYDevice[ttyDevice],
+              candidates.count == 1 else {
+            return nil
+        }
+        return candidates[0]
     }
 
     static func tmuxResumeBindingForTesting(

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -657,6 +657,7 @@ extension SurfaceResumeBindingIndex {
     ) -> [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] {
         _ = fileManager
         var resolved: [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] = [:]
+        var selectedPIDByPanel: [PanelKey: Int] = [:]
 
         // A child such as `/usr/bin/ssh` is not guaranteed to retain the
         // CMUX_* environment after the user's shell/launch tooling runs it.
@@ -667,7 +668,10 @@ extension SurfaceResumeBindingIndex {
         let panelKeysByTTYDevice = Dictionary(grouping: ttyDeviceBindings) { $0.value }
             .mapValues { $0.map(\.key) }
 
-        for process in processSnapshot.processesByPID.values.sorted(by: { $0.pid < $1.pid }) {
+        // The process snapshot is already indexed by PID.  Select the newest
+        // candidate per panel in one pass instead of sorting the entire system
+        // process table on every autosave.
+        for process in processSnapshot.processesByPID.values {
             guard process.isTerminalForegroundProcessGroup,
                   let panelKey = processDetectedPanelKey(
                       for: process,
@@ -676,25 +680,29 @@ extension SurfaceResumeBindingIndex {
                   let processArguments = processArgumentsProvider(process.pid) else {
                 continue
             }
-            if let binding = TmuxResumeParser.binding(
+            let binding: SurfaceResumeBindingSnapshot?
+            if let tmuxBinding = TmuxResumeParser.binding(
                 processName: process.name,
                 processPath: process.path,
                 arguments: processArguments.arguments,
                 environment: processArguments.environment,
                 capturedAt: capturedAt
             ) {
-                resolved[panelKey] = (binding: binding, updatedAt: capturedAt)
+                binding = tmuxBinding
+            } else {
+                binding = TerminalSSHSessionDetector.resumeBinding(
+                    processName: process.name,
+                    processPath: process.path,
+                    arguments: processArguments.arguments,
+                    environment: processArguments.environment,
+                    capturedAt: capturedAt
+                )
+            }
+            guard let binding else { continue }
+            guard process.pid > (selectedPIDByPanel[panelKey] ?? Int.min) else {
                 continue
             }
-            guard let binding = TerminalSSHSessionDetector.resumeBinding(
-                processName: process.name,
-                processPath: process.path,
-                arguments: processArguments.arguments,
-                environment: processArguments.environment,
-                capturedAt: capturedAt
-            ) else {
-                continue
-            }
+            selectedPIDByPanel[panelKey] = process.pid
             resolved[panelKey] = (binding: binding, updatedAt: capturedAt)
         }
 

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -661,7 +661,17 @@ extension SurfaceResumeBindingIndex {
                   let processArguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: process.pid) else {
                 continue
             }
-            guard let binding = TmuxResumeParser.binding(
+            if let binding = TmuxResumeParser.binding(
+                processName: process.name,
+                processPath: process.path,
+                arguments: processArguments.arguments,
+                environment: processArguments.environment,
+                capturedAt: capturedAt
+            ) {
+                resolved[PanelKey(workspaceId: workspaceId, panelId: panelId)] = (binding: binding, updatedAt: capturedAt)
+                continue
+            }
+            guard let binding = TerminalSSHSessionDetector.resumeBindingForTesting(
                 processName: process.name,
                 processPath: process.path,
                 arguments: processArguments.arguments,
@@ -684,6 +694,22 @@ extension SurfaceResumeBindingIndex {
         capturedAt: TimeInterval = 1_777_777_777
     ) -> SurfaceResumeBindingSnapshot? {
         TmuxResumeParser.binding(
+            processName: processName,
+            processPath: processPath,
+            arguments: arguments,
+            environment: environment,
+            capturedAt: capturedAt
+        )
+    }
+
+    static func sshResumeBindingForTesting(
+        processName: String,
+        processPath: String?,
+        arguments: [String],
+        environment: [String: String],
+        capturedAt: TimeInterval = Date().timeIntervalSince1970
+    ) -> SurfaceResumeBindingSnapshot? {
+        TerminalSSHSessionDetector.resumeBindingForTesting(
             processName: processName,
             processPath: processPath,
             arguments: arguments,

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -702,21 +702,6 @@ extension SurfaceResumeBindingIndex {
         )
     }
 
-    static func sshResumeBindingForTesting(
-        processName: String,
-        processPath: String?,
-        arguments: [String],
-        environment: [String: String],
-        capturedAt: TimeInterval = Date().timeIntervalSince1970
-    ) -> SurfaceResumeBindingSnapshot? {
-        TerminalSSHSessionDetector.resumeBinding(
-            processName: processName,
-            processPath: processPath,
-            arguments: arguments,
-            environment: environment,
-            capturedAt: capturedAt
-        )
-    }
 }
 
 private struct VaultAgentSessionIDResolution {

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -671,7 +671,7 @@ extension SurfaceResumeBindingIndex {
                 resolved[PanelKey(workspaceId: workspaceId, panelId: panelId)] = (binding: binding, updatedAt: capturedAt)
                 continue
             }
-            guard let binding = TerminalSSHSessionDetector.resumeBindingForTesting(
+            guard let binding = TerminalSSHSessionDetector.resumeBinding(
                 processName: process.name,
                 processPath: process.path,
                 arguments: processArguments.arguments,
@@ -709,7 +709,7 @@ extension SurfaceResumeBindingIndex {
         environment: [String: String],
         capturedAt: TimeInterval = Date().timeIntervalSince1970
     ) -> SurfaceResumeBindingSnapshot? {
-        TerminalSSHSessionDetector.resumeBindingForTesting(
+        TerminalSSHSessionDetector.resumeBinding(
             processName: processName,
             processPath: processPath,
             arguments: arguments,

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -525,6 +525,9 @@ extension Workspace {
         surfaceTTYNames.removeValue(forKey: panelId)
         discardRemotePTYSessionID(panelId: panelId)
         surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+        pendingPlainSSHRestorePanelIds.remove(panelId)
+        observedPlainSSHPanelIds.remove(panelId)
+        plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
         surfaceListeningPorts.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
 #if DEBUG

--- a/Sources/Workspace+RemoteTerminalLiveness.swift
+++ b/Sources/Workspace+RemoteTerminalLiveness.swift
@@ -374,6 +374,7 @@ extension Workspace {
         remoteConnectionState = .connected
         remoteConnectionDetail = nil
         clearProxyOnlyRemoteSidebarArtifacts()
+        clearRecoveredRemoteDaemonSidebarArtifacts()
         applyBrowserRemoteWorkspaceStatusToPanels()
         postRemoteConnectionPresentationDidChange()
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1312,7 +1312,14 @@ extension Workspace {
             }
             guard let detectedBinding else {
                 if storedBinding.isProcessDetected {
-                    surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                    // A plain SSH process is expected to disappear while the
+                    // app is restoring its local PTY. Keep its safe,
+                    // process-detected command through that observation gap;
+                    // otherwise the first post-restore autosave erases the
+                    // only instruction that could reconnect it next time.
+                    if !storedBinding.isPlainSSHProcessDetectedBinding {
+                        surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                    }
                 } else if isStaleAgentHookBinding(
                     storedBinding,
                     panelId: panelId,
@@ -1348,7 +1355,11 @@ extension Workspace {
 
         let detectedBinding = surfaceResumeBindingIndex.binding(workspaceId: id, panelId: panelId)
         guard let storedBinding else { return detectedBinding }
-        guard let detectedBinding else { return storedBinding.isProcessDetected ? nil : storedBinding }
+        guard let detectedBinding else {
+            return storedBinding.isPlainSSHProcessDetectedBinding
+                ? storedBinding
+                : (storedBinding.isProcessDetected ? nil : storedBinding)
+        }
         if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) { return detectedBinding }
         if storedBinding.isProcessDetected { return nil }
         return storedBinding

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -218,6 +218,9 @@ extension Workspace {
 #endif
         terminalStartupRestoreCoordinator.removeAllRestores()
         surfaceResumeBindingsByPanelId.removeAll(keepingCapacity: false)
+        pendingPlainSSHRestorePanelIds.removeAll(keepingCapacity: false)
+        observedPlainSSHPanelIds.removeAll(keepingCapacity: false)
+        plainSSHDetectionMissesByPanelId.removeAll(keepingCapacity: false)
         restoredGuardedWorkingDirectoriesByPanelId.removeAll(keepingCapacity: false)
         restoredPanelTitleBoundariesByPanelId.removeAll(keepingCapacity: false)
         panelShellActivityStates.removeAll(keepingCapacity: false)
@@ -1304,6 +1307,16 @@ extension Workspace {
             let storedBinding = surfaceResumeBindingsByPanelId[panelId]
             let detectedBinding = surfaceResumeBindingIndex.binding(workspaceId: id, panelId: panelId)
 
+            if let detectedBinding, detectedBinding.isPlainSSHProcessDetectedBinding {
+                // A fresh process observation is authoritative evidence that
+                // the SSH child is still alive.  It also closes the restore
+                // observation gap so later misses can be interpreted as an
+                // actual exit rather than startup churn.
+                observedPlainSSHPanelIds.insert(panelId)
+                pendingPlainSSHRestorePanelIds.remove(panelId)
+                plainSSHDetectionMissesByPanelId[panelId] = 0
+            }
+
             guard let storedBinding else {
                 if let detectedBinding, detectedBinding.isProcessDetected {
                     surfaceResumeBindingsByPanelId[panelId] = detectedBinding
@@ -1311,15 +1324,32 @@ extension Workspace {
                 continue
             }
             guard let detectedBinding else {
-                if storedBinding.isProcessDetected {
-                    // A plain SSH process is expected to disappear while the
-                    // app is restoring its local PTY. Keep its safe,
-                    // process-detected command through that observation gap;
-                    // otherwise the first post-restore autosave erases the
-                    // only instruction that could reconnect it next time.
-                    if !storedBinding.isPlainSSHProcessDetectedBinding {
-                        surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                if storedBinding.isPlainSSHProcessDetectedBinding {
+                    if pendingPlainSSHRestorePanelIds.contains(panelId) {
+                        // The restored PTY may not have exec'd `ssh` yet. Keep
+                        // the binding for a bounded restore observation gap;
+                        // the shell activity transition below retires it if
+                        // SSH never starts.
+                        let restoreMisses = (plainSSHDetectionMissesByPanelId[panelId] ?? 0) + 1
+                        plainSSHDetectionMissesByPanelId[panelId] = restoreMisses
+                        if restoreMisses >= Self.plainSSHRestoreObservationMissLimit {
+                            surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                            pendingPlainSSHRestorePanelIds.remove(panelId)
+                            plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
+                        }
+                        continue
                     }
+                    let misses = (plainSSHDetectionMissesByPanelId[panelId] ?? 0) + 1
+                    plainSSHDetectionMissesByPanelId[panelId] = misses
+                    if misses >= 2 {
+                        surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                        observedPlainSSHPanelIds.remove(panelId)
+                        plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
+                    }
+                    continue
+                }
+                if storedBinding.isProcessDetected {
+                    surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                 } else if isStaleAgentHookBinding(
                     storedBinding,
                     panelId: panelId,
@@ -1340,6 +1370,9 @@ extension Workspace {
                 surfaceResumeBindingsByPanelId[panelId] = detectedBinding
             } else if storedBinding.isProcessDetected {
                 surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                observedPlainSSHPanelIds.remove(panelId)
+                pendingPlainSSHRestorePanelIds.remove(panelId)
+                plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
             }
         }
     }
@@ -1356,9 +1389,14 @@ extension Workspace {
         let detectedBinding = surfaceResumeBindingIndex.binding(workspaceId: id, panelId: panelId)
         guard let storedBinding else { return detectedBinding }
         guard let detectedBinding else {
-            return storedBinding.isPlainSSHProcessDetectedBinding
-                ? storedBinding
-                : (storedBinding.isProcessDetected ? nil : storedBinding)
+            if storedBinding.isPlainSSHProcessDetectedBinding {
+                let misses = plainSSHDetectionMissesByPanelId[panelId] ?? 0
+                if pendingPlainSSHRestorePanelIds.contains(panelId) || misses < 2 {
+                    return storedBinding
+                }
+                return nil
+            }
+            return storedBinding.isProcessDetected ? nil : storedBinding
         }
         if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) { return detectedBinding }
         if storedBinding.isProcessDetected { return nil }
@@ -1680,13 +1718,20 @@ extension Workspace {
                 )
             }
             if let storedResumeBinding = effectiveResumeBindingForStartup ?? resumeBinding {
-                surfaceResumeBindingsByPanelId[terminalPanel.id] = storedResumeBinding.retargetingRemoteOwner(
+                let restoredBinding = storedResumeBinding.retargetingRemoteOwner(
                     expectedWorkspaceID: restoredResumeSnapshotWorkspaceID,
                     expectedSurfaceID: snapshot.id,
                     workspaceID: id,
                     surfaceID: terminalPanel.id,
                     persistentPTYSessionID: restoredRemotePTYSessionID
                 )
+                surfaceResumeBindingsByPanelId[terminalPanel.id] = restoredBinding
+                if restoredBinding.isPlainSSHProcessDetectedBinding,
+                   restoredBindingLaunch != nil {
+                    pendingPlainSSHRestorePanelIds.insert(terminalPanel.id)
+                    observedPlainSSHPanelIds.remove(terminalPanel.id)
+                    plainSSHDetectionMissesByPanelId[terminalPanel.id] = 0
+                }
             } else {
                 surfaceResumeBindingsByPanelId.removeValue(forKey: terminalPanel.id)
             }
@@ -2642,6 +2687,15 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         restoredAgentLifecycle.snapshotsByPanelId
     }
     var surfaceResumeBindingsByPanelId: [UUID: SurfaceResumeBindingSnapshot] = [:]
+    /// Plain SSH restore bindings survive the short interval in which a new
+    /// local PTY exists but its `ssh` child has not become foreground yet.
+    /// These indexes make that exception explicit and bounded: once a shell
+    /// has been observed after SSH exits, the binding is retired instead of
+    /// being replayed forever.
+    var pendingPlainSSHRestorePanelIds: Set<UUID> = []
+    var observedPlainSSHPanelIds: Set<UUID> = []
+    var plainSSHDetectionMissesByPanelId: [UUID: Int] = [:]
+    private static let plainSSHRestoreObservationMissLimit = 3
     var restoredGuardedWorkingDirectoriesByPanelId: [UUID: RestoredWorkingDirectoryGuard] = [:]
     /// The session directory each restored auto-resume launcher targets, kept
     /// for the resumed run so split/new-tab cwd inheritance can rescue a
@@ -5141,6 +5195,26 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
         guard panels[panelId] != nil else { return }
         let previousState = panelShellActivityStates[panelId] ?? .unknown
+
+        if surfaceResumeBindingsByPanelId[panelId]?.isPlainSSHProcessDetectedBinding == true {
+            switch state {
+            case .commandRunning:
+                // The restored/manual SSH command reached the foreground.
+                observedPlainSSHPanelIds.insert(panelId)
+                pendingPlainSSHRestorePanelIds.remove(panelId)
+                plainSSHDetectionMissesByPanelId[panelId] = 0
+            case .promptIdle where observedPlainSSHPanelIds.contains(panelId)
+                && !pendingPlainSSHRestorePanelIds.contains(panelId):
+                // The SSH child has exited and the pane is back at its local
+                // shell.  Retaining this binding would relaunch a connection
+                // the user has intentionally left.
+                surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+                observedPlainSSHPanelIds.remove(panelId)
+                plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
+            default:
+                break
+            }
+        }
         if previousState == state {
             if let terminalPanel = panels[panelId] as? TerminalPanel {
                 terminalPanel.updateShellActivityState(state)
@@ -5313,12 +5387,25 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
         }
         surfaceResumeBindingsByPanelId[panelId] = binding
+        if binding.isPlainSSHProcessDetectedBinding {
+            observedPlainSSHPanelIds.insert(panelId)
+            pendingPlainSSHRestorePanelIds.remove(panelId)
+            plainSSHDetectionMissesByPanelId[panelId] = 0
+        } else {
+            observedPlainSSHPanelIds.remove(panelId)
+            pendingPlainSSHRestorePanelIds.remove(panelId)
+            plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
+        }
         return true
     }
 
     @discardableResult
     func clearSurfaceResumeBinding(panelId: UUID) -> Bool {
-        surfaceResumeBindingsByPanelId.removeValue(forKey: panelId) != nil
+        let removed = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId) != nil
+        pendingPlainSSHRestorePanelIds.remove(panelId)
+        observedPlainSSHPanelIds.remove(panelId)
+        plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
+        return removed
     }
 
     func surfaceResumeBinding(panelId: UUID) -> SurfaceResumeBindingSnapshot? {
@@ -5579,6 +5666,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             refreshTrackedAgentPorts()
         }
         surfaceResumeBindingsByPanelId = surfaceResumeBindingsByPanelId.filter {
+            validSurfaceIds.contains($0.key)
+        }
+        pendingPlainSSHRestorePanelIds = pendingPlainSSHRestorePanelIds.intersection(validSurfaceIds)
+        observedPlainSSHPanelIds = observedPlainSSHPanelIds.intersection(validSurfaceIds)
+        plainSSHDetectionMissesByPanelId = plainSSHDetectionMissesByPanelId.filter {
             validSurfaceIds.contains($0.key)
         }
         restoredAgentLifecycle.retainSessionRestores(for: validSurfaceIds)
@@ -7009,6 +7101,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         remoteControllerConnectionDetail = detail
         remoteConnectionState = effectiveState
         remoteConnectionDetail = detail
+        if effectiveState == .connecting || effectiveState == .reconnecting {
+            // A retry has ownership of the failure now.  Retract any prior
+            // red sidebar entry immediately; only a bounded parked state may
+            // recreate it.
+            clearRecoveredRemoteDaemonSidebarArtifacts()
+        }
         if state == .connected,
            (remoteSessionController != nil || !reconnectWasInFlight) {
             _ = reattachPersistentRemotePTYPanels()
@@ -9951,6 +10049,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             panelDirectoryDisplayLabels.removeValue(forKey: detached.panelId)
             surfaceTTYNames.removeValue(forKey: detached.panelId)
             surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
+            pendingPlainSSHRestorePanelIds.remove(detached.panelId)
+            observedPlainSSHPanelIds.remove(detached.panelId)
+            plainSSHDetectionMissesByPanelId.removeValue(forKey: detached.panelId)
             restoredResumeSessionWorkingDirectoriesByPanelId.removeValue(forKey: detached.panelId)
             syncRemotePortScanTTYs()
             panelTitles.removeValue(forKey: detached.panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2749,12 +2749,25 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
-    /// Removes proxy-only daemon log entries appended by
-    /// `applyRemoteDaemonStatusUpdate`, without touching the connection-state
-    /// artifacts owned by `applyRemoteConnectionStateUpdate`.
-    func clearProxyOnlyRemoteDaemonSidebarArtifacts() {
-        logEntries.removeAll { entry in
-            entry.source == "remote-daemon" && Self.isProxyOnlyRemoteError(entry.message)
+    /// Retracts daemon/bootstrap failures after the daemon has become healthy.
+    ///
+    /// Bootstrap failures are published through both the daemon-status and
+    /// connection-state seams.  A persistent PTY can reattach as soon as the
+    /// daemon is ready, before the proxy publishes `.connected`, so leaving
+    /// either seam's old entry in place makes the sidebar report a failure
+    /// after recovery.  Keep an active `.error`/`.suspended` connection state
+    /// visible until the proxy confirms that the transport is healthy.
+    func clearRecoveredRemoteDaemonSidebarArtifacts() {
+        guard remoteConnectionState != .error,
+              remoteConnectionState != .suspended else {
+            return
+        }
+        logEntries.removeAll { $0.source == "remote-daemon" }
+        statusEntries.removeValue(forKey: Self.remoteErrorStatusKey)
+        remoteLastErrorFingerprint = nil
+        remoteLastDaemonErrorFingerprint = nil
+        if let key = remoteNotificationCooldownKey(target: remoteDisplayTarget ?? "") {
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, correlationKey: key)
         }
     }
 
@@ -7074,6 +7087,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
         if state == .connected {
             clearProxyOnlyRemoteSidebarArtifacts()
+            clearRecoveredRemoteDaemonSidebarArtifacts()
         }
     }
 
@@ -7083,10 +7097,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         guard status.state == .error else {
             remoteLastDaemonErrorFingerprint = nil
             if status.state == .ready {
-                // #8917: a transport bounce that re-bootstrapped successfully is
-                // not a workspace failure, so retract its sidebar error the same
-                // way the connection-state path retracts on `.connected`.
-                clearProxyOnlyRemoteDaemonSidebarArtifacts()
+                // #8917/#10541: a transport bounce or bootstrap retry that
+                // succeeds is not a workspace failure.  Retract both the
+                // daemon log and any stale connection-state entry; a live
+                // `.error`/`.suspended` state remains until proxy readiness.
+                clearRecoveredRemoteDaemonSidebarArtifacts()
             }
             return
         }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -5125,7 +5125,8 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             XCTAssertTrue(
                 retryStatuses.allSatisfy { initialCommand.contains($0) }
                     && initialCommand.contains("CMUX_SSH_RECONNECT_MAX_DELAY_SECONDS")
-                    && initialCommand.contains("∞"),
+                    && !initialCommand.contains("∞")
+                    && initialCommand.contains("CMUX_SSH_RECONNECT_LIMIT"),
                 initialCommand
             )
             XCTAssertEqual(initialCommand.components(separatedBy: "/usr/bin/uuidgen").count - 1, 2, initialCommand)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7155,6 +7155,17 @@ extension SessionPersistenceTests {
         XCTAssertNil(binding)
     }
 
+    func testPlainSSHProcessDetectedResumeBindingRejectsRemoteCommandOption() {
+        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+            processName: "ssh",
+            processPath: "/usr/bin/ssh",
+            arguments: ["ssh", "-o", "RemoteCommand=uname -a", "tinybox"],
+            environment: [:]
+        )
+
+        XCTAssertNil(binding)
+    }
+
     func testTmuxProcessDetectedResumeBindingPreservesTmuxTmpdir() throws {
         let binding = try XCTUnwrap(
             SurfaceResumeBindingIndex.tmuxResumeBindingForTesting(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7133,6 +7133,21 @@ extension SessionPersistenceTests {
         XCTAssertEqual(binding.startupInput, binding.command + "\n")
     }
 
+    func testPlainSSHProcessDetectedResumeBindingUsesResolvedExecutablePath() throws {
+        let binding = try XCTUnwrap(
+            TerminalSSHSessionDetector.resumeBinding(
+                processName: "ssh",
+                processPath: "/opt/company/bin/ssh",
+                arguments: ["ssh", "tinybox"],
+                environment: [:]
+            )
+        )
+
+        XCTAssertEqual(binding.command, "'/opt/company/bin/ssh' 'tinybox'")
+        XCTAssertEqual(binding.launchCommand?.executablePath, "/opt/company/bin/ssh")
+        XCTAssertEqual(binding.launchCommand?.arguments, ["/opt/company/bin/ssh", "tinybox"])
+    }
+
     func testPlainSSHProcessDetectedResumeBindingRejectsRemoteCommand() {
         let binding = TerminalSSHSessionDetector.resumeBinding(
             processName: "ssh",
@@ -7164,6 +7179,43 @@ extension SessionPersistenceTests {
         )
 
         XCTAssertNil(binding)
+    }
+
+    func testPlainSSHProcessDetectedResumeBindingRejectsNonInteractiveSSHFlags() {
+        let invocations = [
+            ["ssh", "-n", "tinybox"],
+            ["ssh", "-T", "tinybox"],
+            ["ssh", "-G", "tinybox"],
+            ["ssh", "-V"],
+            ["ssh", "-o", "RequestTTY=no", "tinybox"],
+            ["ssh", "-o", "StdinNull=yes", "tinybox"],
+        ]
+
+        for arguments in invocations {
+            XCTAssertNil(
+                TerminalSSHSessionDetector.resumeBinding(
+                    processName: "ssh",
+                    processPath: "/usr/bin/ssh",
+                    arguments: arguments,
+                    environment: [:]
+                ),
+                "Expected non-interactive invocation to be rejected: \(arguments)"
+            )
+        }
+    }
+
+    func testPlainSSHProcessDetectedResumeBindingAllowsRemoteCommandNone() throws {
+        let binding = try XCTUnwrap(
+            TerminalSSHSessionDetector.resumeBinding(
+                processName: "ssh",
+                processPath: "/usr/bin/ssh",
+                arguments: ["ssh", "-o", "RemoteCommand=none", "tinybox"],
+                environment: [:]
+            )
+        )
+
+        XCTAssertEqual(binding.kind, "ssh")
+        XCTAssertEqual(binding.command, "'/usr/bin/ssh' '-o' 'RemoteCommand=none' 'tinybox'")
     }
 
     func testPlainSSHProcessDetectedBindingFallsBackToPaneTTYWhenScopeIsMissing() throws {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7107,6 +7107,54 @@ extension SessionPersistenceTests {
         XCTAssertEqual(binding.command, "'/opt/homebrew/bin/tmux' '-L' 'dev' 'attach' '-t' 'work'")
     }
 
+    func testPlainSSHProcessDetectedResumeBindingRerunsInteractiveCommand() throws {
+        let binding = try XCTUnwrap(
+            SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+                processName: "ssh",
+                processPath: "/usr/bin/ssh",
+                arguments: [
+                    "/usr/bin/ssh",
+                    "-p", "2222",
+                    "-i", "/Users/test/.ssh/id_ed25519",
+                    "tinybox",
+                ],
+                environment: ["PWD": "/Users/test/project"]
+            )
+        )
+
+        XCTAssertEqual(binding.kind, "ssh")
+        XCTAssertEqual(binding.source, "process-detected")
+        XCTAssertTrue(binding.allowsAutomaticResume)
+        XCTAssertEqual(binding.cwd, "/Users/test/project")
+        XCTAssertEqual(
+            binding.command,
+            "'/usr/bin/ssh' '-p' '2222' '-i' '/Users/test/.ssh/id_ed25519' 'tinybox'"
+        )
+        XCTAssertEqual(binding.startupInput, binding.command + "\n")
+    }
+
+    func testPlainSSHProcessDetectedResumeBindingRejectsRemoteCommand() {
+        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+            processName: "ssh",
+            processPath: "/usr/bin/ssh",
+            arguments: ["ssh", "tinybox", "uname", "-a"],
+            environment: [:]
+        )
+
+        XCTAssertNil(binding)
+    }
+
+    func testPlainSSHProcessDetectedResumeBindingDoesNotReplaceManagedPTYBinding() {
+        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+            processName: "ssh",
+            processPath: "/usr/bin/ssh",
+            arguments: ["ssh", "tinybox"],
+            environment: ["CMUX_SSH_PTY_SESSION_ID": "ssh-managed"]
+        )
+
+        XCTAssertNil(binding)
+    }
+
     func testTmuxProcessDetectedResumeBindingPreservesTmuxTmpdir() throws {
         let binding = try XCTUnwrap(
             SurfaceResumeBindingIndex.tmuxResumeBindingForTesting(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7166,6 +7166,53 @@ extension SessionPersistenceTests {
         XCTAssertNil(binding)
     }
 
+    func testPlainSSHProcessDetectedBindingFallsBackToPaneTTYWhenScopeIsMissing() throws {
+        let workspaceID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let panelID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let process = CmuxTopProcessInfo(
+            pid: 4242,
+            parentPID: 1,
+            name: "ssh",
+            path: "/usr/bin/ssh",
+            ttyDevice: 9876,
+            cmuxWorkspaceID: nil,
+            cmuxSurfaceID: nil,
+            cmuxAttributionReason: nil,
+            processGroupID: 4242,
+            terminalProcessGroupID: 4242,
+            cpuPercent: 0,
+            residentBytes: 1,
+            virtualBytes: 1,
+            threadCount: 1
+        )
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [process],
+            sampledAt: Date(timeIntervalSince1970: 1_777_777_777),
+            includesProcessDetails: true
+        )
+        let key = SurfaceResumeBindingIndex.PanelKey(
+            workspaceId: workspaceID,
+            panelId: panelID
+        )
+        let detected = SurfaceResumeBindingIndex.processDetectedTmuxBindings(
+            fileManager: .default,
+            processSnapshot: snapshot,
+            capturedAt: 1_777_777_777,
+            ttyDeviceBindings: [key: 9876],
+            processArgumentsProvider: { _ in
+                CmuxTopProcessArguments(
+                    arguments: ["/usr/bin/ssh", "tinybox"],
+                    environment: [:]
+                )
+            }
+        )
+
+        let binding = try XCTUnwrap(detected[key]?.binding)
+        XCTAssertEqual(binding.kind, "ssh")
+        XCTAssertEqual(binding.source, "process-detected")
+        XCTAssertEqual(binding.command, "'/usr/bin/ssh' 'tinybox'")
+    }
+
     func testTmuxProcessDetectedResumeBindingPreservesTmuxTmpdir() throws {
         let binding = try XCTUnwrap(
             SurfaceResumeBindingIndex.tmuxResumeBindingForTesting(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7109,7 +7109,7 @@ extension SessionPersistenceTests {
 
     func testPlainSSHProcessDetectedResumeBindingRerunsInteractiveCommand() throws {
         let binding = try XCTUnwrap(
-            SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+            TerminalSSHSessionDetector.resumeBinding(
                 processName: "ssh",
                 processPath: "/usr/bin/ssh",
                 arguments: [
@@ -7134,7 +7134,7 @@ extension SessionPersistenceTests {
     }
 
     func testPlainSSHProcessDetectedResumeBindingRejectsRemoteCommand() {
-        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+        let binding = TerminalSSHSessionDetector.resumeBinding(
             processName: "ssh",
             processPath: "/usr/bin/ssh",
             arguments: ["ssh", "tinybox", "uname", "-a"],
@@ -7145,7 +7145,7 @@ extension SessionPersistenceTests {
     }
 
     func testPlainSSHProcessDetectedResumeBindingDoesNotReplaceManagedPTYBinding() {
-        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+        let binding = TerminalSSHSessionDetector.resumeBinding(
             processName: "ssh",
             processPath: "/usr/bin/ssh",
             arguments: ["ssh", "tinybox"],
@@ -7156,7 +7156,7 @@ extension SessionPersistenceTests {
     }
 
     func testPlainSSHProcessDetectedResumeBindingRejectsRemoteCommandOption() {
-        let binding = SurfaceResumeBindingIndex.sshResumeBindingForTesting(
+        let binding = TerminalSSHSessionDetector.resumeBinding(
             processName: "ssh",
             processPath: "/usr/bin/ssh",
             arguments: ["ssh", "-o", "RemoteCommand=uname -a", "tinybox"],

--- a/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
+++ b/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
@@ -115,6 +115,34 @@ struct WorkspaceIsStaleAgentHookBindingTests {
     }
 
     @Test
+    func plainSSHProcessBindingSurvivesATransientMissedProcessScan() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "ssh",
+            command: "'/usr/bin/ssh' 'tinybox'",
+            cwd: "/Users/test",
+            source: "process-detected",
+            autoResume: true
+        )
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        workspace.reconcileSurfaceResumeBindings(
+            using: .empty,
+            restorableAgentIndex: .empty
+        )
+
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) == binding)
+        #expect(
+            workspace.effectiveSurfaceResumeBinding(
+                panelId: panelId,
+                surfaceResumeBindingIndex: .empty
+            ) == binding
+        )
+    }
+
+    @Test
     func reconciliationKeepsPiBindingAfterResumeScannerResolvesUUIDToSessionPath() throws {
         let workspace = Workspace()
         let panelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
+++ b/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
@@ -138,8 +138,47 @@ struct WorkspaceIsStaleAgentHookBindingTests {
             workspace.effectiveSurfaceResumeBinding(
                 panelId: panelId,
                 surfaceResumeBindingIndex: .empty
-            ) == binding
+        ) == binding
         )
+    }
+
+    @Test
+    func plainSSHProcessBindingIsRetiredAfterTheSSHChildExits() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "ssh",
+            command: "'/usr/bin/ssh' 'tinybox'",
+            source: "process-detected",
+            autoResume: true
+        )
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        // One empty scan is a process-scan hiccup; the second is authoritative
+        // absence after the observed SSH process has ended.
+        workspace.reconcileSurfaceResumeBindings(using: .empty, restorableAgentIndex: .empty)
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) != nil)
+        workspace.reconcileSurfaceResumeBindings(using: .empty, restorableAgentIndex: .empty)
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) == nil)
+    }
+
+    @Test
+    func plainSSHProcessBindingIsClearedWhenShellReturnsToPrompt() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "ssh",
+            command: "'/usr/bin/ssh' 'tinybox'",
+            source: "process-detected",
+            autoResume: true
+        )
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .commandRunning)
+        workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) == nil)
     }
 
     @Test

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -773,7 +773,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             strings: .appLocalized
         )
 
-        XCTAssertEqual(message, "Remote daemon did not return a valid readiness response")
+        XCTAssertEqual(message, "Could not confirm that the remote daemon is ready")
         XCTAssertFalse(message.contains("/private/home"))
         XCTAssertFalse(message.contains("/secret/token"))
         XCTAssertFalse(message.contains("raw stderr"))

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -763,6 +763,22 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertFalse(bootstrapMessage.contains("pty.write.notification"))
     }
 
+    func testRemoteDaemonBootstrapErrorsDoNotExposeUpstreamDetails() {
+        let rawError = NSError(domain: "cmux.remote.daemon", code: 41, userInfo: [
+            NSLocalizedDescriptionKey: "provider=/private/home/austin/.cmuxd path=/secret/token raw stderr",
+        ])
+
+        let message = RemoteSessionCoordinator.userFacingRemoteDaemonBootstrapErrorMessage(
+            rawError,
+            strings: .appLocalized
+        )
+
+        XCTAssertEqual(message, "Remote daemon did not return a valid readiness response")
+        XCTAssertFalse(message.contains("/private/home"))
+        XCTAssertFalse(message.contains("/secret/token"))
+        XCTAssertFalse(message.contains("raw stderr"))
+    }
+
     @MainActor
     func testWebSocketVMWithDaemonEndpointStartsProxyCapableConnection() {
         let workspace = Workspace()

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -98,6 +98,14 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             target: target
         )
 
+        // The reconnect supervisor has started a new attempt; the old error
+        // is still the sidebar's latest detail while the proxy comes up.
+        workspace.applyRemoteConnectionStateUpdate(
+            .reconnecting,
+            detail: "Reconnecting to \(target) (retry 1)",
+            target: target
+        )
+
         #expect(workspace.statusEntries["remote.error"] != nil)
         #expect(workspace.logEntries.contains { $0.source == "remote-daemon" })
 

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -61,4 +61,60 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             "The workspace row must not keep rendering the recovered daemon error"
         )
     }
+
+    /// A bootstrap failure is published through both the connection-state and
+    /// daemon-status seams.  The PTY can subsequently reattach as soon as the
+    /// daemon is ready, before a separate proxy `.connected` update arrives.
+    /// That recovery ordering must retract the old connection error too.
+    @Test
+    func daemonReadyClearsBootstrapErrorBeforeProxyConnected() {
+        let workspace = Workspace()
+        let target = "dev@example.com"
+        let config = WorkspaceRemoteConfiguration(
+            destination: target,
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_022,
+            relayID: String(repeating: "e", count: 16),
+            relayToken: String(repeating: "f", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test-bootstrap.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        let failureDetail =
+            "Remote daemon bootstrap failed: remote daemon is not ready (retry 1 in 4s)"
+        workspace.applyRemoteConnectionStateUpdate(
+            .error,
+            detail: failureDetail,
+            target: target
+        )
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .error, detail: failureDetail),
+            target: target
+        )
+
+        #expect(workspace.statusEntries["remote.error"] != nil)
+        #expect(workspace.logEntries.contains { $0.source == "remote-daemon" })
+
+        // The daemon is healthy again, but the proxy/connection presentation
+        // has not published `.connected` yet.
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: target
+        )
+
+        #expect(
+            workspace.statusEntries["remote.error"] == nil,
+            "A recovered bootstrap error must not remain in the sidebar"
+        )
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote-daemon" }) == nil,
+            "A recovered bootstrap log must not remain the sidebar's latest error"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/10541 by making remote daemon bootstrap fail closed, self-healing, bounded, and diagnosable, while persisting eligible plain interactive SSH sessions across app restore.

## Reliability core

- Computes the local daemon byte count and SHA-256, streams over the existing SSH exec channel, and verifies both values remotely before chmod/atomic promotion. Empty, truncated, mismatched, or unverifiable payloads never become the versioned install.
- Adds a remote byte-progress watchdog and cleans temporary payloads, PID markers, and stale writers on every failed transfer/finalize path.
- Probes daemon installs with executable and non-empty checks, repairs corrupt/nonresponsive installs, and removes artifacts installed during the current attempt when hello/capability validation fails.
- Captures a sanitized versioned path, remote byte size, and bounded daemon-log-tail indicator at failure time. Raw provider paths, command text, and stderr remain in redacted internal diagnostics only.
- Separates bootstrap failure accounting from host reachability. Blocked failures park immediately; repeated identical failures park after three; all automatic bootstrap failures are capped at eight. Retry fingerprints are stable even when diagnostics change.
- Keeps persistent PTY attach requests parked through transport recovery, gates proxy/PTY bridges on a ready reverse relay, clears stale relay state before a fresh transport, and suppresses transient red sidebar errors until recovery is confirmed.
- Makes both generated and legacy persistent-PTY launchers finite (20 reconnects), validates malformed/over-limit limits, and prints an explicit green recovery note after a successful retry.

## Plain SSH restore

Foreground interactive ssh host processes are detected by the pane's controlling TTY, saved with the resolved executable path and safely quoted argv, and re-run on every restore. Managed cmux ssh, remote-command invocations, stream-forwarding modes, and noninteractive options are excluded. Bindings survive a bounded startup observation gap and are retired when the shell is authoritatively back at a prompt or the SSH child has exited.

## Architecture boundary

This PR lands the integrity/repair/diagnostics/retry boundary and the plain-SSH on-ramp. The larger t3code-style migration—one managed ssh -N -L tunnel, one remote owner for PTYs/scrollback, one client supervisor for every entrypoint, and no pane-local retry loop—remains an explicit follow-up. Keeping that migration separate avoids shipping a second partially-wired transport while making the current stack safe to migrate.

## Validation

- swift test --package-path Packages/macOS/CmuxRemoteSession — 163 tests passed.
- Focused retry/relay/upload/reconnect tests — 9 CmuxFoundation tests and 55 CmuxRemoteSession tests passed.
- swiftc -parse passed for every changed Swift file.
- swift_warning_budget.py on the final tagged build log — 6 pre-existing cmux-owned warnings, 221 allowed; no new warning bucket.
- Package-resolved policy, localization JSON parsing, and git diff --check passed.
- Tagged Debug build on pushed commit 605a6927fb succeeded with reload.sh --tag issue-10541-ssh-daemon-upload-verify (no untagged app launch).
- Live Tailscale validation on tinybox: plain ssh returned SSH_OK; cmux ssh reached daemon-ready/proxy-ready/PTY-ready; a controlled SSH transport drop recovered through bootstrap → relay → proxy → PTY, cleared the sidebar failure, and repeated plain-SSH restore relaunched /usr/bin/ssh tinybox.
- Remote hosts need sha256sum or shasum; missing hash tooling fails closed with an actionable install error.

Closes https://github.com/manaflow-ai/cmux/issues/10541
