### PR TITLE
perf: move control-socket connections and reads off-main

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Package.swift
+++ b/Packages/macOS/CmuxControlSocket/Package.swift
@@ -18,9 +18,14 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "CmuxControlSocketAtomicsC",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "CmuxControlSocket",
             dependencies: [
                 .product(name: "CmuxSettings", package: "CmuxSettings"),
+                "CmuxControlSocketAtomicsC",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/Packages/macOS/CmuxControlSocket/README.md
+++ b/Packages/macOS/CmuxControlSocket/README.md
@@ -6,10 +6,14 @@ This package owns the listener server (`SocketControlServer`: reservation, bind/
 
 ## Layout
 
-- `Server/` — `SocketControlServer`, its host-event seam, and the telemetry dedupe cache.
+- `Server/` — `SocketControlServer`, its host-event seam, the bounded async
+  connection pool, async client transport, polling limiter, read snapshots,
+  and the telemetry dedupe cache.
 - `Transport/` — `SocketTransport` and its capability extensions (path identity/probe, lock files, bind, client-socket configuration, peer verification, raw I/O).
 - `Policy/` — `SocketListenerPolicy`, the pure decision logic.
 - `Model/` — the Sendable value types they exchange.
+- `CmuxControlSocketAtomicsC/` — macOS 14-compatible C11 atomic pointer and
+  reader-count primitives used by the snapshot publication seam.
 
 ## Types
 
@@ -20,6 +24,15 @@ This package owns the listener server (`SocketControlServer`: reservation, bind/
 - `SocketTransport` — stateless syscall layer: socket-path identity (`SocketPathIdentity`) and liveness probing (`SocketPathProbeResult`), advisory lock-file arbitration (`SocketPathLockAcquisition`), listener binding (`SocketBindAttemptResult`), accepted-client configuration, peer PID/UID/ancestry checks, `writeAll`, and the one-shot `probeCommand` client.
 - `SocketListenerPolicy` — pure decisions: accept-failure classification (`SocketAcceptErrorClassification`) and recovery (`AcceptFailureRecoveryAction`), socket-path unlink rules, and bind-failure fallback from the stable default path to the user-scoped path.
 - `SocketListenerHealth` — a point-in-time health snapshot combining listener state with on-disk path checks.
+- `ControlClientWorkerPool` — actor-owned FIFO admission with bounded active
+  and pending async connection jobs. Jobs suspend on I/O or main-actor hops;
+  they do not create one thread per client.
+- `ControlReadSnapshotStore` — immutable typed read results published by the
+  app's main actor and synchronously readable by socket workers without an
+  actor hop. Reads use a macOS-14-compatible C11 atomic pointer; entries are
+  keyed by method plus canonical params.
+- `ControlClientRateLimiter` — per-connection token-bucket backpressure for
+  high-frequency list/tree/top/read-text polling.
 
 Stage failures carry stable `stage` strings (`SocketStageFailure`) that feed telemetry breadcrumbs and the fallback policy; do not rename existing stages.
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientAsyncTransport.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientAsyncTransport.swift
@@ -1,0 +1,427 @@
+internal import Dispatch
+public import Foundation
+internal import Darwin
+internal import os
+
+/// Bridges one non-blocking control-socket descriptor into an async line
+/// reader. The descriptor is never closed by this type; its connection owner
+/// retains that responsibility.
+///
+/// The read source is the sanctioned low-level socket-I/O bridge. It drains
+/// until `EAGAIN`, finishes on EOF/error, and cancels itself on termination so
+/// an EOF-ready descriptor cannot spin forever in a kqueue/Dispatch event loop.
+/// One task must own the reader; concurrent calls to ``nextLine`` are invalid.
+// @unchecked Sendable is safe because one connection task owns the mutable
+// parser; DispatchSource callbacks publish only immutable Data chunks through
+// the AsyncStream continuation.
+public final class ControlClientAsyncLineReader: @unchecked Sendable {
+    private final class SourceBox: @unchecked Sendable {
+        var source: (any DispatchSourceRead)?
+    }
+
+    private let socket: Int32
+    private let continuation: AsyncStream<Data>.Continuation
+    private var iterator: AsyncStream<Data>.Iterator
+    private let source: any DispatchSourceRead
+    private let revocationSource: (any DispatchSourceRead)?
+    /// One-shot idle deadline carried over from SO_RCVTIMEO. DispatchSource
+    /// is the low-level descriptor/timer bridge; it never blocks the task.
+    private let idleReadTimer: (any DispatchSourceTimer)?
+    private var pendingBytes: [UInt8] = []
+    private var pendingStartIndex = 0
+    private var newlineSearchIndex = 0
+    private var limits: ControlClientLineReadLimits?
+    private var limitedBytesRead = 0
+    private var deadlineUptimeNanoseconds: UInt64? = nil
+    private var deadlineTask: Task<Void, Never>? = nil
+    private let monotonicNowNanoseconds: @Sendable () -> UInt64
+    private let maximumBufferedBytes: Int
+    // The deadline task and the single reader task may finish/cancel on
+    // different executors. This tiny gate protects only the active-limit bit;
+    // command buffering remains owned by the reader task.
+    private let limitsActive: OSAllocatedUnfairLock<Bool>
+
+    /// Creates an async reader over a non-blocking descriptor.
+    ///
+    /// - Parameters:
+    ///   - socket: The accepted descriptor. It is changed to `O_NONBLOCK`.
+    ///   - initialLimits: Optional preauthorization byte/deadline limits.
+    ///   - authorizationRevocationSignal: Signal that finishes an idle read.
+    ///   - maximumBufferedBytes: Defensive cap for one connection's pending
+    ///     input bytes after framing.
+    ///   - monotonicNowNanoseconds: Injectable monotonic clock for tests.
+    public init(
+        socket: Int32,
+        initialLimits: ControlClientLineReadLimits? = nil,
+        authorizationRevocationSignal: SocketAuthorizationRevocationSignal? = nil,
+        maximumBufferedBytes: Int = 16 * 1024 * 1024,
+        monotonicNowNanoseconds: (@Sendable () -> UInt64)? = nil
+    ) {
+        self.socket = socket
+        self.maximumBufferedBytes = max(1, maximumBufferedBytes)
+        self.limitsActive = OSAllocatedUnfairLock(initialState: initialLimits != nil)
+        self.monotonicNowNanoseconds = monotonicNowNanoseconds ?? {
+            DispatchTime.now().uptimeNanoseconds
+        }
+        _ = Self.makeNonBlocking(socket)
+
+        // A command connection is FIFO and bounded. If a client pipelines
+        // more than this many chunks while a prior command is executing, fail
+        // closed instead of allowing an unbounded AsyncStream buffer to grow.
+        let stream = AsyncStream<Data>.makeStream(bufferingPolicy: .bufferingOldest(128))
+        let streamContinuation = stream.continuation
+        continuation = streamContinuation
+        iterator = stream.stream.makeAsyncIterator()
+
+        let sourceBox = SourceBox()
+        let readSource = DispatchSource.makeReadSource(
+            fileDescriptor: socket,
+            queue: DispatchQueue.global(qos: .utility)
+        )
+        readSource.setEventHandler { [streamContinuation, sourceBox] in
+            Self.drain(
+                socket: socket,
+                continuation: streamContinuation,
+                sourceBox: sourceBox
+            )
+        }
+        readSource.setCancelHandler { [streamContinuation, sourceBox] in
+            sourceBox.source = nil
+            streamContinuation.finish()
+        }
+        sourceBox.source = readSource
+        source = readSource
+
+        let idleReadTimer = Self.makeIdleReadTimer(
+            socket: socket,
+            continuation: streamContinuation
+        )
+        self.idleReadTimer = idleReadTimer
+
+        if let signalDescriptor = authorizationRevocationSignal?.readFileDescriptor,
+           signalDescriptor >= 0 {
+            let duplicate = dup(signalDescriptor)
+            if duplicate < 0 {
+                revocationSource = nil
+            } else {
+                _ = fcntl(duplicate, F_SETFD, FD_CLOEXEC)
+                let revocationBox = SourceBox()
+                let revocation = DispatchSource.makeReadSource(
+                    fileDescriptor: duplicate,
+                    queue: DispatchQueue.global(qos: .utility)
+                )
+                revocation.setEventHandler { [streamContinuation, revocationBox] in
+                    streamContinuation.finish()
+                    revocationBox.source?.cancel()
+                }
+                revocation.setCancelHandler { [revocationBox] in
+                    revocationBox.source = nil
+                    close(duplicate)
+                }
+                revocationBox.source = revocation
+                revocationSource = revocation
+            }
+        } else {
+            revocationSource = nil
+        }
+
+        limits = initialLimits
+        if let initialLimits {
+            let milliseconds = UInt64(clamping: max(0, initialLimits.timeoutMilliseconds))
+            let (duration, overflowed) = milliseconds.multipliedReportingOverflow(by: 1_000_000)
+            let now = self.monotonicNowNanoseconds()
+            let (deadline, additionOverflowed) = now.addingReportingOverflow(duration)
+            deadlineUptimeNanoseconds = overflowed || additionOverflowed ? .max : deadline
+            if !overflowed {
+                let deadlineContinuation = continuation
+                deadlineTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(nanoseconds: duration)
+                    } catch {
+                        return
+                    }
+                    guard self?.limitsActive.withLock({ $0 }) == true else { return }
+                    deadlineContinuation.finish()
+                }
+            }
+        }
+
+        readSource.activate()
+        revocationSource?.activate()
+    }
+
+    deinit {
+        deadlineTask?.cancel()
+        source.cancel()
+        revocationSource?.cancel()
+        idleReadTimer?.cancel()
+        continuation.finish()
+    }
+
+    /// Removes preauthorization limits after the peer proves authorization.
+    public func clearLimits() {
+        limits = nil
+        limitsActive.withLock { $0 = false }
+        limitedBytesRead = 0
+        deadlineUptimeNanoseconds = nil
+        deadlineTask?.cancel()
+        deadlineTask = nil
+    }
+
+    /// Returns the next newline-terminated UTF-8 line, or `nil` on EOF,
+    /// revocation, timeout, cancellation, or a malformed/oversized stream.
+    /// Bare `\n` framing and the legacy CRLF behavior are preserved.
+    public func nextLine(
+        shouldContinueReading: @Sendable @escaping () -> Bool
+    ) async -> String? {
+        while !Task.isCancelled {
+            guard deadlineHasNotExpired, shouldContinueReading() else { return nil }
+
+            if let newlineIndex = nextBareNewlineIndex() {
+                let decoded = String(
+                    bytes: pendingBytes[pendingStartIndex..<newlineIndex],
+                    encoding: .utf8
+                )
+                pendingStartIndex = newlineIndex + 1
+                newlineSearchIndex = pendingStartIndex
+                compactPendingBytesIfNeeded()
+                // Invalid UTF-8 lines are dropped exactly like the blocking
+                // reader, without discarding subsequent framed lines.
+                if let decoded { return decoded }
+                continue
+            }
+
+            scheduleIdleReadDeadline()
+            let nextChunk = await withTaskCancellationHandler {
+                await iterator.next()
+            } onCancel: {
+                source.cancel()
+                revocationSource?.cancel()
+                idleReadTimer?.cancel()
+                continuation.finish()
+            }
+            idleReadTimer?.schedule(
+                deadline: .distantFuture,
+                repeating: .never
+            )
+            guard let chunk = nextChunk else { return nil }
+            guard !chunk.isEmpty else { continue }
+            if limitsActive.withLock({ $0 }), let limits {
+                let (total, overflowed) = limitedBytesRead.addingReportingOverflow(chunk.count)
+                guard !overflowed, total <= limits.maximumBytes else { return nil }
+                limitedBytesRead = total
+            }
+            pendingBytes.append(contentsOf: chunk)
+            guard pendingBytes.count - pendingStartIndex <= maximumBufferedBytes else {
+                return nil
+            }
+        }
+        return nil
+    }
+
+    /// Explicitly terminates the reader's event sources.
+    public func cancel() {
+        source.cancel()
+        revocationSource?.cancel()
+        idleReadTimer?.cancel()
+        continuation.finish()
+    }
+
+    private var deadlineHasNotExpired: Bool {
+        guard let deadlineUptimeNanoseconds else { return true }
+        return monotonicNowNanoseconds() < deadlineUptimeNanoseconds
+    }
+
+    private func nextBareNewlineIndex() -> Int? {
+        while newlineSearchIndex < pendingBytes.count {
+            let index = newlineSearchIndex
+            newlineSearchIndex += 1
+            guard pendingBytes[index] == 0x0A else { continue }
+            if index > pendingStartIndex, pendingBytes[index - 1] == 0x0D {
+                continue
+            }
+            return index
+        }
+        return nil
+    }
+
+    private func compactPendingBytesIfNeeded() {
+        guard pendingStartIndex > 0 else { return }
+        if pendingStartIndex == pendingBytes.count {
+            pendingBytes.removeAll(keepingCapacity: true)
+            pendingStartIndex = 0
+            newlineSearchIndex = 0
+            return
+        }
+        guard pendingStartIndex >= 4096,
+              pendingStartIndex >= pendingBytes.count / 2 else { return }
+        pendingBytes.removeFirst(pendingStartIndex)
+        newlineSearchIndex -= pendingStartIndex
+        pendingStartIndex = 0
+    }
+
+    private static func makeNonBlocking(_ socket: Int32) -> Int32? {
+        let flags = fcntl(socket, F_GETFL, 0)
+        guard flags >= 0 else { return errno }
+        guard fcntl(socket, F_SETFL, flags | O_NONBLOCK) >= 0 else { return errno }
+        return nil
+    }
+
+    private static func makeIdleReadTimer(
+        socket: Int32,
+        continuation: AsyncStream<Data>.Continuation
+    ) -> (any DispatchSourceTimer)? {
+        var timeout = timeval()
+        var length = socklen_t(MemoryLayout<timeval>.size)
+        guard getsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, &length) == 0,
+              timeout.tv_sec > 0 || timeout.tv_usec > 0 else {
+            return nil
+        }
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+        timer.setEventHandler {
+            continuation.finish()
+            timer.schedule(deadline: .distantFuture, repeating: .never)
+        }
+        timer.activate()
+        return timer
+    }
+
+    private func scheduleIdleReadDeadline() {
+        guard let idleReadTimer,
+              let timeoutNanoseconds = socketReceiveTimeoutNanoseconds else { return }
+        idleReadTimer.schedule(
+            deadline: .now() + .nanoseconds(Int(clamping: timeoutNanoseconds)),
+            repeating: .never
+        )
+    }
+
+    private var socketReceiveTimeoutNanoseconds: UInt64? {
+        var timeout = timeval()
+        var length = socklen_t(MemoryLayout<timeval>.size)
+        guard getsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, &length) == 0,
+              timeout.tv_sec >= 0,
+              timeout.tv_usec >= 0 else { return nil }
+        let seconds = UInt64(timeout.tv_sec)
+        let micros = UInt64(timeout.tv_usec)
+        let (secondsNanos, secondsOverflowed) = seconds.multipliedReportingOverflow(by: 1_000_000_000)
+        let (microsNanos, microsOverflowed) = micros.multipliedReportingOverflow(by: 1_000)
+        let (total, additionOverflowed) = secondsNanos.addingReportingOverflow(microsNanos)
+        return secondsOverflowed || microsOverflowed || additionOverflowed ? .max : total
+    }
+
+    private static func drain(
+        socket: Int32,
+        continuation: AsyncStream<Data>.Continuation,
+        sourceBox: SourceBox
+    ) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = read(socket, &buffer, buffer.count)
+            if count > 0 {
+                if case .dropped = continuation.yield(Data(buffer[0..<count])) {
+                    continuation.finish()
+                    sourceBox.source?.cancel()
+                    return
+                }
+                continue
+            }
+            if count == 0 {
+                continuation.finish()
+                sourceBox.source?.cancel()
+                return
+            }
+            if errno == EINTR { continue }
+            if errno == EAGAIN || errno == EWOULDBLOCK { return }
+            continuation.finish()
+            sourceBox.source?.cancel()
+            return
+        }
+    }
+}
+
+/// Asynchronously writes one connection's responses without parking a thread
+/// when a client applies backpressure. One writer task owns the instance.
+// @unchecked Sendable is safe because one connection task performs all writes;
+// the one-shot writable source communicates only through its continuation.
+public final class ControlClientAsyncWriter: @unchecked Sendable {
+    private final class SourceBox: @unchecked Sendable {
+        var source: (any DispatchSourceWrite)?
+    }
+
+    private let socket: Int32
+
+    /// Creates a writer over a non-blocking descriptor.
+    public init(socket: Int32) {
+        self.socket = socket
+        _ = Self.makeNonBlocking(socket)
+    }
+
+    /// Writes all bytes, suspending on `EAGAIN`; returns false after EOF,
+    /// cancellation, or a non-retryable write error.
+    public func writeAll(_ data: Data) async -> Bool {
+        var offset = 0
+        while offset < data.count, !Task.isCancelled {
+            let written = data.withUnsafeBytes { rawBuffer -> Int in
+                guard let baseAddress = rawBuffer.baseAddress else { return 0 }
+                return Darwin.write(
+                    socket,
+                    baseAddress.advanced(by: offset),
+                    rawBuffer.count - offset
+                )
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            if written < 0, errno == EINTR { continue }
+            if written < 0, errno == EAGAIN || errno == EWOULDBLOCK {
+                guard await waitForWritable() else { return false }
+                continue
+            }
+            return false
+        }
+        return offset == data.count
+    }
+
+    /// Cancels future write notifications.
+    public func cancel() {
+        // Each would-block wait owns a one-shot source and observes task
+        // cancellation. There is no persistent writable source to suspend.
+    }
+
+    private static func makeNonBlocking(_ socket: Int32) -> Int32? {
+        let flags = fcntl(socket, F_GETFL, 0)
+        guard flags >= 0 else { return errno }
+        guard fcntl(socket, F_SETFL, flags | O_NONBLOCK) >= 0 else { return errno }
+        return nil
+    }
+
+    private func waitForWritable() async -> Bool {
+        let stream = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let streamContinuation = stream.continuation
+        let sourceBox = SourceBox()
+        let writeSource = DispatchSource.makeWriteSource(
+            fileDescriptor: socket,
+            queue: DispatchQueue.global(qos: .utility)
+        )
+        writeSource.setEventHandler { [streamContinuation, sourceBox] in
+            streamContinuation.yield(())
+            streamContinuation.finish()
+            sourceBox.source?.cancel()
+        }
+        writeSource.setCancelHandler {
+            streamContinuation.finish()
+        }
+        sourceBox.source = writeSource
+        writeSource.activate()
+
+        var iterator = stream.stream.makeAsyncIterator()
+        let writable: Void? = await withTaskCancellationHandler {
+            await iterator.next()
+        } onCancel: {
+            writeSource.cancel()
+            streamContinuation.finish()
+        }
+        return writable != nil
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientRateLimiter.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientRateLimiter.swift
@@ -1,0 +1,102 @@
+public import Dispatch
+
+/// A per-connection token-bucket limiter for control-plane polling commands.
+///
+/// The limiter never sleeps and never waits for the main actor. It either
+/// admits a request or returns a retry hint, allowing the connection task to
+/// apply backpressure to only the hot client while unrelated clients continue
+/// through the pool. Mutating commands and one-shot probes are always allowed.
+public actor ControlClientRateLimiter {
+    /// Token-bucket tuning values.
+    public struct Configuration: Sendable, Equatable {
+        /// Number of polling requests admitted immediately for a new client.
+        public let burst: Int
+        /// Nanoseconds required to refill one token.
+        public let refillIntervalNanoseconds: UInt64
+
+        /// Creates a limiter configuration.
+        ///
+        /// Values are clamped to a positive burst and a non-zero interval so
+        /// the limiter cannot accidentally become an unbounded admission path.
+        public init(
+            burst: Int = 4,
+            refillIntervalNanoseconds: UInt64 = 100_000_000
+        ) {
+            self.burst = max(1, burst)
+            self.refillIntervalNanoseconds = max(1, refillIntervalNanoseconds)
+        }
+    }
+
+    /// The admission outcome for one command.
+    public enum Decision: Sendable, Equatable {
+        /// The command may execute now.
+        case allowed
+        /// The command should be retried after the supplied number of
+        /// milliseconds. The value is always at least one.
+        case limited(retryAfterMilliseconds: Int)
+    }
+
+    private let configuration: Configuration
+    private let now: @Sendable () -> UInt64
+    private var tokens: Int
+    private var lastRefillNanoseconds: UInt64
+
+    /// Creates a limiter for one client connection.
+    ///
+    /// - Parameters:
+    ///   - configuration: Token-bucket limits.
+    ///   - now: Monotonic clock used for refill calculations. Tests inject a
+    ///     deterministic clock; production uses `DispatchTime`.
+    public init(
+        configuration: Configuration = Configuration(),
+        now: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        }
+    ) {
+        self.configuration = configuration
+        self.now = now
+        self.tokens = configuration.burst
+        self.lastRefillNanoseconds = now()
+    }
+
+    /// Admits a command or returns a retry hint for a hot polling client.
+    ///
+    /// - Parameter method: The normalized v1 command or v2 method name.
+    /// - Returns: The admission decision.
+    public func admit(method: String) -> Decision {
+        guard ControlCommandExecutionPolicy.pollingMethods.contains(method) else { return .allowed }
+        refill()
+        guard tokens > 0 else {
+            let current = now()
+            let elapsed = current >= lastRefillNanoseconds
+                ? current - lastRefillNanoseconds
+                : 0
+            let remainder = elapsed % configuration.refillIntervalNanoseconds
+            let remaining = configuration.refillIntervalNanoseconds - remainder
+            let rounded = remaining > UInt64.max - 999_999
+                ? UInt64.max
+                : remaining + 999_999
+            let milliseconds = max(1, Int(clamping: rounded / 1_000_000))
+            return .limited(retryAfterMilliseconds: milliseconds)
+        }
+        tokens -= 1
+        return .allowed
+    }
+
+    /// Restores a full burst for a newly authenticated/reused connection.
+    public func reset() {
+        tokens = configuration.burst
+        lastRefillNanoseconds = now()
+    }
+
+    private func refill() {
+        let current = now()
+        let elapsed = current >= lastRefillNanoseconds
+            ? current - lastRefillNanoseconds
+            : 0
+        guard elapsed >= configuration.refillIntervalNanoseconds else { return }
+        let additions = Int(elapsed / configuration.refillIntervalNanoseconds)
+        tokens = min(configuration.burst, tokens + additions)
+        lastRefillNanoseconds = current
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientWorkerPool.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientWorkerPool.swift
@@ -1,0 +1,173 @@
+/// A bounded executor for accepted control-socket connection jobs.
+///
+/// The socket listener already delivers accepted descriptors through an
+/// ``AsyncStream``. This actor adds admission control at the next boundary:
+/// only `maximumConcurrentJobs` connection tasks may be live and only
+/// `maximumPendingJobs` additional jobs may wait for a task slot. Jobs are
+/// asynchronous, so waiting for a main-actor mutation suspends a task instead
+/// of parking an I/O thread. The pool deliberately uses one detached task per
+/// *admitted job* (not one thread per connection); Swift's cooperative
+/// executor reuses its bounded worker threads for the non-blocking jobs.
+///
+/// A caller supplies synchronous cleanup for rejected/dropped jobs. An
+/// admitted operation owns its descriptor until the operation returns.
+public actor ControlClientWorkerPool {
+    /// The result of attempting to admit one connection job.
+    public enum Submission: Sendable, Equatable {
+        /// The operation started immediately.
+        case started
+        /// The operation is waiting in FIFO order for a running slot.
+        case queued
+        /// The pool is stopped or its pending queue is full.
+        case rejected
+    }
+
+    /// Point-in-time pool counters used by diagnostics and behavior tests.
+    public struct Metrics: Sendable, Equatable {
+        /// Number of operations currently executing.
+        public let activeJobs: Int
+        /// Number of operations waiting for a slot.
+        public let pendingJobs: Int
+        /// Highest active-job count observed since initialization.
+        public let peakActiveJobs: Int
+        /// Number of rejected submissions since initialization.
+        public let rejectedJobs: Int
+        /// Whether no further jobs can be admitted.
+        public let isStopped: Bool
+
+        /// Creates a metrics snapshot.
+        public init(
+            activeJobs: Int,
+            pendingJobs: Int,
+            peakActiveJobs: Int,
+            rejectedJobs: Int,
+            isStopped: Bool
+        ) {
+            self.activeJobs = activeJobs
+            self.pendingJobs = pendingJobs
+            self.peakActiveJobs = peakActiveJobs
+            self.rejectedJobs = rejectedJobs
+            self.isStopped = isStopped
+        }
+    }
+
+    private struct Job {
+        let id: UInt64
+        let operation: @Sendable () async -> Void
+        let onDrop: @Sendable () -> Void
+    }
+
+    private let maximumConcurrentJobs: Int
+    private let maximumPendingJobs: Int
+    private var activeJobs = 0
+    private var peakActiveJobs = 0
+    private var rejectedJobs = 0
+    private var nextJobID: UInt64 = 1
+    private var pendingJobs: [Job] = []
+    private var runningTasks: [UInt64: Task<Void, Never>] = [:]
+    private var stopped = false
+
+    /// Creates a bounded pool.
+    ///
+    /// - Parameters:
+    ///   - maximumConcurrentJobs: Upper bound on live connection operations.
+    ///   - maximumPendingJobs: Upper bound on FIFO jobs waiting for a slot.
+    ///
+    /// Values are clamped to preserve a useful, finite admission policy even
+    /// when a caller forwards an invalid configuration value.
+    public init(
+        maximumConcurrentJobs: Int = 32,
+        maximumPendingJobs: Int = 64
+    ) {
+        self.maximumConcurrentJobs = max(1, maximumConcurrentJobs)
+        self.maximumPendingJobs = max(0, maximumPendingJobs)
+    }
+
+    /// Attempts to submit one asynchronous connection operation.
+    ///
+    /// - Parameter operation: The operation that owns its admitted connection
+    ///   until it returns. It must be cancellation-aware when it waits for
+    ///   external I/O.
+    /// - Parameter onDrop: Synchronous cleanup for a rejected or stopped
+    ///   pending operation (typically closing its descriptor).
+    /// - Returns: Whether the operation started, queued, or was rejected.
+    public func submit(
+        _ operation: @escaping @Sendable () async -> Void,
+        onDrop: @escaping @Sendable () -> Void = {}
+    ) -> Submission {
+        guard !stopped else {
+            rejectedJobs += 1
+            onDrop()
+            return .rejected
+        }
+
+        let job = Job(id: nextJobID, operation: operation, onDrop: onDrop)
+        nextJobID &+= 1
+        if activeJobs < maximumConcurrentJobs {
+            start(job)
+            return .started
+        }
+        guard pendingJobs.count < maximumPendingJobs else {
+            rejectedJobs += 1
+            onDrop()
+            return .rejected
+        }
+        pendingJobs.append(job)
+        return .queued
+    }
+
+    /// Stops admission, cancels live operations, and drops queued operations.
+    ///
+    /// Running operations keep ownership of their descriptors until their
+    /// cancellation handlers return; the operation remains responsible for
+    /// closing them.
+    public func stop() {
+        guard !stopped else { return }
+        stopped = true
+        let droppedJobs = pendingJobs
+        pendingJobs.removeAll(keepingCapacity: false)
+        for job in droppedJobs {
+            job.onDrop()
+        }
+        let tasks = Array(runningTasks.values)
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    /// Returns current admission counters.
+    public func metrics() -> Metrics {
+        Metrics(
+            activeJobs: activeJobs,
+            pendingJobs: pendingJobs.count,
+            peakActiveJobs: peakActiveJobs,
+            rejectedJobs: rejectedJobs,
+            isStopped: stopped
+        )
+    }
+
+    private func start(_ job: Job) {
+        activeJobs += 1
+        peakActiveJobs = max(peakActiveJobs, activeJobs)
+
+        // This detached task is an intentional executor boundary: the pool
+        // actor owns admission state, while connection setup and every
+        // nonisolated segment of the operation must not inherit that actor.
+        // The operation is async/non-blocking, so this creates a bounded task
+        // count rather than a thread per connection.
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            await job.operation()
+            await self?.finish(jobID: job.id)
+        }
+        runningTasks[job.id] = task
+    }
+
+    private func finish(jobID: UInt64) {
+        runningTasks.removeValue(forKey: jobID)
+        activeJobs = max(0, activeJobs - 1)
+        guard !stopped, activeJobs < maximumConcurrentJobs else { return }
+        guard !pendingJobs.isEmpty else { return }
+        let next = pendingJobs.removeFirst()
+        start(next)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlReadSnapshotStore.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlReadSnapshotStore.swift
@@ -1,4 +1,5 @@
 internal import CmuxControlSocketAtomicsC
+internal import Dispatch
 internal import os
 
 /// An immutable publication of control-plane read results.
@@ -7,18 +8,45 @@ internal import os
 /// supplies the live request id when it encodes a hit, so snapshot reads retain
 /// the v2 id-echo contract while avoiding a main-actor turn for every poll.
 public struct ControlReadSnapshot: Sendable, Equatable {
+    fileprivate struct Entry: Sendable, Equatable {
+        let result: ControlCallResult
+        let publishedAtUptimeNanoseconds: UInt64
+    }
+
     /// Monotonically increasing publication generation.
     public let generation: UInt64
+    fileprivate let entries: [String: Entry]
     /// Results indexed by ``key(method:params:)``.
-    public let responses: [String: ControlCallResult]
+    public var responses: [String: ControlCallResult] {
+        entries.mapValues(\.result)
+    }
 
     /// Creates a snapshot.
+    ///
+    /// - Parameters:
+    ///   - generation: Monotonic publication generation.
+    ///   - responses: Typed results indexed by canonical request key.
+    ///   - publishedAtUptimeNanoseconds: Shared timestamp for the supplied
+    ///     entries; defaults to the current monotonic uptime.
     public init(
         generation: UInt64 = 0,
-        responses: [String: ControlCallResult] = [:]
+        responses: [String: ControlCallResult] = [:],
+        publishedAtUptimeNanoseconds: UInt64? = nil
     ) {
         self.generation = generation
-        self.responses = responses
+        let publishedAtUptimeNanoseconds = publishedAtUptimeNanoseconds
+            ?? DispatchTime.now().uptimeNanoseconds
+        self.entries = responses.mapValues { result in
+            Entry(
+                result: result,
+                publishedAtUptimeNanoseconds: publishedAtUptimeNanoseconds
+            )
+        }
+    }
+
+    fileprivate init(generation: UInt64, entries: [String: Entry]) {
+        self.generation = generation
+        self.entries = entries
     }
 
     /// Builds the canonical lookup key for a command and its typed params.
@@ -159,18 +187,36 @@ public final class ControlReadSnapshotStore: @unchecked Sendable {
     }
 
     /// Looks up one command result without an actor hop.
+    ///
+    /// - Parameters:
+    ///   - method: V2 method name.
+    ///   - params: Typed request parameters.
+    ///   - maximumAgeNanoseconds: Optional freshness ceiling. Older entries
+    ///     are treated as misses.
+    ///   - nowUptimeNanoseconds: Injectable monotonic time for tests.
+    /// - Returns: The fresh result, or `nil` for a miss/expired entry.
     public func response(
         method: String,
-        params: [String: JSONValue]
+        params: [String: JSONValue],
+        maximumAgeNanoseconds: UInt64? = nil,
+        nowUptimeNanoseconds: UInt64? = nil
     ) -> ControlCallResult? {
         let key = ControlReadSnapshot.key(method: method, params: params)
         CmuxControlSocketAtomicCounterIncrement(readerCountStorage)
         let rawPointer = CmuxControlSocketAtomicPointerLoadAcquire(pointerStorage)
-        let result = rawPointer == 0
+        let entry = rawPointer == 0
             ? nil
-            : Self.box(from: rawPointer).takeUnretainedValue().snapshot.responses[key]
+            : Self.box(from: rawPointer).takeUnretainedValue().snapshot.entries[key]
         CmuxControlSocketAtomicCounterDecrement(readerCountStorage)
-        return result
+        guard let entry else { return nil }
+        if let maximumAgeNanoseconds {
+            let now = nowUptimeNanoseconds ?? DispatchTime.now().uptimeNanoseconds
+            let age = now >= entry.publishedAtUptimeNanoseconds
+                ? now - entry.publishedAtUptimeNanoseconds
+                : 0
+            guard age <= maximumAgeNanoseconds else { return nil }
+        }
+        return entry.result
     }
 
     /// Publishes/replaces one response and advances the generation.
@@ -182,11 +228,14 @@ public final class ControlReadSnapshotStore: @unchecked Sendable {
         let key = ControlReadSnapshot.key(method: method, params: params)
         retiredState.withLock { retired in
             var snapshot = readUnlocked()
-            var responses = snapshot.responses
-            responses[key] = result
+            var entries = snapshot.entries
+            entries[key] = ControlReadSnapshot.Entry(
+                result: result,
+                publishedAtUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds
+            )
             snapshot = ControlReadSnapshot(
                 generation: snapshot.generation &+ 1,
-                responses: responses
+                entries: entries
             )
             publishLocked(snapshot, retired: &retired)
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlReadSnapshotStore.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlReadSnapshotStore.swift
@@ -1,0 +1,220 @@
+internal import CmuxControlSocketAtomicsC
+internal import os
+
+/// An immutable publication of control-plane read results.
+///
+/// Entries contain typed call results without a request id. A socket worker
+/// supplies the live request id when it encodes a hit, so snapshot reads retain
+/// the v2 id-echo contract while avoiding a main-actor turn for every poll.
+public struct ControlReadSnapshot: Sendable, Equatable {
+    /// Monotonically increasing publication generation.
+    public let generation: UInt64
+    /// Results indexed by ``key(method:params:)``.
+    public let responses: [String: ControlCallResult]
+
+    /// Creates a snapshot.
+    public init(
+        generation: UInt64 = 0,
+        responses: [String: ControlCallResult] = [:]
+    ) {
+        self.generation = generation
+        self.responses = responses
+    }
+
+    /// Builds the canonical lookup key for a command and its typed params.
+    ///
+    /// Object keys are sorted recursively, so equivalent JSON objects map to
+    /// one entry regardless of Foundation dictionary iteration order.
+    public static func key(
+        method: String,
+        params: [String: JSONValue]
+    ) -> String {
+        method + "\u{1F}" + CanonicalJSON.string(.object(params))
+    }
+
+    private struct CanonicalJSON {
+        static func string(_ value: JSONValue) -> String {
+            switch value {
+            case .null:
+                return "null"
+            case .bool(let value):
+                return value ? "true" : "false"
+            case .int(let value):
+                return String(value)
+            case .double(let value):
+                return String(value)
+            case .decimal(let value):
+                return value
+            case .string(let value):
+                return "\"" + escape(value) + "\""
+            case .array(let values):
+                return "[" + values.map(string).joined(separator: ",") + "]"
+            case .object(let values):
+                return "{" + values.keys.sorted().map { key in
+                    "\"" + escape(key) + "\":" + string(values[key]!)
+                }.joined(separator: ",") + "}"
+            }
+        }
+
+        private static func escape(_ value: String) -> String {
+            value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
+                .replacingOccurrences(of: "\t", with: "\\t")
+        }
+    }
+}
+
+/// Publishes immutable control read snapshots for synchronous worker reads.
+///
+/// Readers are lock-free: an atomic reader count protects the lifetime of the
+/// immutable box loaded from the atomic pointer. Writers exchange one pointer
+/// and reclaim retired boxes only after the reader count reaches zero. The
+/// short writer-only lock protects the retired list; it is never taken by a
+/// socket read and never spans command execution, socket I/O, or an actor hop.
+/// C11 atomics are used instead of `Synchronization.Atomic` because this
+/// package supports macOS 14.
+public final class ControlReadSnapshotStore: @unchecked Sendable {
+    private final class SnapshotBox: @unchecked Sendable {
+        let snapshot: ControlReadSnapshot
+
+        init(_ snapshot: ControlReadSnapshot) {
+            self.snapshot = snapshot
+        }
+    }
+
+    private struct RetiredState {
+        var boxes: [Unmanaged<SnapshotBox>] = []
+    }
+
+    // The pointers are allocated once and all pointee accesses go through the
+    // C11 atomic functions. This is the safety argument for the unchecked
+    // Sendable wrapper: Swift never performs an overlapping access to storage.
+    private let pointerStorage: UnsafeMutablePointer<CmuxControlSocketAtomicPointerStorage>
+    private let readerCountStorage: UnsafeMutablePointer<CmuxControlSocketAtomicCounterStorage>
+    /// Writer-only reclamation bookkeeping; lock-free reads never touch it.
+    private let retiredState: OSAllocatedUnfairLock<RetiredState>
+
+    /// Creates an empty store.
+    public init(initialSnapshot: ControlReadSnapshot = ControlReadSnapshot()) {
+        pointerStorage = .allocate(capacity: 1)
+        readerCountStorage = .allocate(capacity: 1)
+        retiredState = OSAllocatedUnfairLock(initialState: RetiredState())
+        CmuxControlSocketAtomicPointerInitialize(pointerStorage, 0)
+        CmuxControlSocketAtomicCounterInitialize(readerCountStorage, 0)
+        publish(initialSnapshot)
+    }
+
+    deinit {
+        let current = CmuxControlSocketAtomicPointerExchange(pointerStorage, 0)
+        let readers = CmuxControlSocketAtomicCounterLoad(readerCountStorage)
+        // Store lifetime is owned by the app and outlives admitted socket
+        // tasks. If a caller violates that contract, leaking is safer than
+        // releasing a box a reader may still be copying.
+        if readers == 0, current != 0 {
+            Self.release(current)
+        }
+        if readers == 0 {
+            retiredState.withLock { retired in
+                for box in retired.boxes {
+                    box.release()
+                }
+                retired.boxes.removeAll()
+            }
+        }
+        if readers == 0 {
+            pointerStorage.deallocate()
+            readerCountStorage.deallocate()
+        } // Otherwise intentionally leak the atomic cells with the boxes.
+    }
+
+    /// Returns the most recently published immutable snapshot.
+    public func read() -> ControlReadSnapshot {
+        readUnlocked()
+    }
+
+    private func readUnlocked() -> ControlReadSnapshot {
+        CmuxControlSocketAtomicCounterIncrement(readerCountStorage)
+        let rawPointer = CmuxControlSocketAtomicPointerLoadAcquire(pointerStorage)
+        let snapshot: ControlReadSnapshot
+        if rawPointer == 0 {
+            snapshot = ControlReadSnapshot()
+        } else {
+            snapshot = Self.box(from: rawPointer).takeUnretainedValue().snapshot
+        }
+        CmuxControlSocketAtomicCounterDecrement(readerCountStorage)
+        return snapshot
+    }
+
+    /// Replaces the current snapshot.
+    ///
+    /// - Parameter snapshot: The fully built value. Build it before calling
+    ///   this method so the publication section stays short.
+    public func publish(_ snapshot: ControlReadSnapshot) {
+        retiredState.withLock { retired in
+            publishLocked(snapshot, retired: &retired)
+        }
+    }
+
+    /// Looks up one command result without an actor hop.
+    public func response(
+        method: String,
+        params: [String: JSONValue]
+    ) -> ControlCallResult? {
+        let key = ControlReadSnapshot.key(method: method, params: params)
+        CmuxControlSocketAtomicCounterIncrement(readerCountStorage)
+        let rawPointer = CmuxControlSocketAtomicPointerLoadAcquire(pointerStorage)
+        let result = rawPointer == 0
+            ? nil
+            : Self.box(from: rawPointer).takeUnretainedValue().snapshot.responses[key]
+        CmuxControlSocketAtomicCounterDecrement(readerCountStorage)
+        return result
+    }
+
+    /// Publishes/replaces one response and advances the generation.
+    public func publishResponse(
+        method: String,
+        params: [String: JSONValue],
+        result: ControlCallResult
+    ) {
+        let key = ControlReadSnapshot.key(method: method, params: params)
+        retiredState.withLock { retired in
+            var snapshot = readUnlocked()
+            var responses = snapshot.responses
+            responses[key] = result
+            snapshot = ControlReadSnapshot(
+                generation: snapshot.generation &+ 1,
+                responses: responses
+            )
+            publishLocked(snapshot, retired: &retired)
+        }
+    }
+
+    private func publishLocked(
+        _ snapshot: ControlReadSnapshot,
+        retired: inout RetiredState
+    ) {
+        let box = Unmanaged.passRetained(SnapshotBox(snapshot))
+        let newPointer = UInt(bitPattern: box.toOpaque())
+        let oldPointer = CmuxControlSocketAtomicPointerExchange(pointerStorage, newPointer)
+        guard oldPointer != 0 else { return }
+        retired.boxes.append(Self.box(from: oldPointer))
+        guard CmuxControlSocketAtomicCounterLoad(readerCountStorage) == 0 else { return }
+        for retiredBox in retired.boxes {
+            retiredBox.release()
+        }
+        retired.boxes.removeAll(keepingCapacity: true)
+    }
+
+    private static func box(from rawPointer: UInt) -> Unmanaged<SnapshotBox> {
+        Unmanaged<SnapshotBox>.fromOpaque(
+            UnsafeRawPointer(bitPattern: rawPointer)!
+        )
+    }
+
+    private static func release(_ rawPointer: UInt) {
+        box(from: rawPointer).release()
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketAuthorizationRevocationSignal.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketAuthorizationRevocationSignal.swift
@@ -33,7 +33,7 @@ public final class SocketAuthorizationRevocationSignal: @unchecked Sendable {
     }
 
     /// Revokes the generation and wakes every reader polling this signal.
-    func revoke() {
+    public func revoke() {
         guard writeFileDescriptor >= 0 else { return }
         let descriptor = writeFileDescriptor
         writeFileDescriptor = -1

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
@@ -59,7 +59,13 @@ extension SocketTransport {
     }
 
     /// Clears `O_NONBLOCK` on `fd`; returns the failing `errno` otherwise.
-    func configureBlocking(_ fd: Int32) -> Int32? {
+    ///
+    /// Restores blocking mode on a descriptor previously configured for async
+    /// client I/O. This is used only by the legacy long-lived event-stream
+    /// bridge, which owns its own slow-consumer backpressure loop.
+    ///
+    /// - Parameter fd: The descriptor to restore.
+    public func configureBlocking(_ fd: Int32) -> Int32? {
         let flags = fcntl(fd, F_GETFL, 0)
         guard flags >= 0 else {
             return errno

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy+ReadPlane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy+ReadPlane.swift
@@ -1,0 +1,52 @@
+/// Read-plane classifications shared by the socket dispatcher, snapshot
+/// publisher, and per-client backpressure limiter.
+extension ControlCommandExecutionPolicy {
+    /// v2 methods whose result can be served from the last main-actor-published
+    /// immutable snapshot. A request may still fall back to a live resolution
+    /// when no entry for its exact params has been published yet.
+    public static let readSnapshotMethods: Set<String> = [
+        "surface.list",
+        "surface.current",
+        "workspace.list",
+        "workspace.current",
+        "window.list",
+        "window.current",
+        "window.displays",
+        "pane.list",
+        "pane.surfaces",
+        "system.identify",
+        "system.tree",
+        "system.top",
+        "system.memory",
+        "surface.read_text",
+    ]
+
+    /// v1/v2 polling names subject to a per-connection token bucket.
+    public static let pollingMethods: Set<String> = [
+        "system.top",
+        "system.memory",
+        "system.tree",
+        "system.identify",
+        "window.list",
+        "window.current",
+        "window.displays",
+        "workspace.list",
+        "workspace.current",
+        "surface.list",
+        "surface.current",
+        "surface.read_text",
+        "pane.list",
+        "pane.surfaces",
+        "list_windows",
+        "current_window",
+        "list_workspaces",
+        "current_workspace",
+        "list_surfaces",
+        "read_screen",
+    ]
+
+    /// Whether a v2 method belongs to the published read plane.
+    public static func servesFromPublishedReadSnapshot(method: String) -> Bool {
+        readSnapshotMethods.contains(method)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocketAtomicsC/CmuxControlSocketAtomicsC.c
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocketAtomicsC/CmuxControlSocketAtomicsC.c
@@ -1,0 +1,46 @@
+#include "CmuxControlSocketAtomicsC.h"
+
+void CmuxControlSocketAtomicPointerInitialize(
+    CmuxControlSocketAtomicPointerStorage *storage,
+    uintptr_t initialValue
+) {
+    atomic_init(&storage->value, initialValue);
+}
+
+uintptr_t CmuxControlSocketAtomicPointerLoadAcquire(
+    const CmuxControlSocketAtomicPointerStorage *storage
+) {
+    return atomic_load_explicit(&storage->value, memory_order_seq_cst);
+}
+
+uintptr_t CmuxControlSocketAtomicPointerExchange(
+    CmuxControlSocketAtomicPointerStorage *storage,
+    uintptr_t value
+) {
+    return atomic_exchange_explicit(&storage->value, value, memory_order_seq_cst);
+}
+
+void CmuxControlSocketAtomicCounterInitialize(
+    CmuxControlSocketAtomicCounterStorage *storage,
+    uint64_t initialValue
+) {
+    atomic_init(&storage->value, initialValue);
+}
+
+uint64_t CmuxControlSocketAtomicCounterLoad(
+    const CmuxControlSocketAtomicCounterStorage *storage
+) {
+    return atomic_load_explicit(&storage->value, memory_order_seq_cst);
+}
+
+void CmuxControlSocketAtomicCounterIncrement(
+    CmuxControlSocketAtomicCounterStorage *storage
+) {
+    atomic_fetch_add_explicit(&storage->value, 1, memory_order_seq_cst);
+}
+
+void CmuxControlSocketAtomicCounterDecrement(
+    CmuxControlSocketAtomicCounterStorage *storage
+) {
+    atomic_fetch_sub_explicit(&storage->value, 1, memory_order_seq_cst);
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocketAtomicsC/include/CmuxControlSocketAtomicsC.h
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocketAtomicsC/include/CmuxControlSocketAtomicsC.h
@@ -1,0 +1,41 @@
+#ifndef CMUX_CONTROL_SOCKET_ATOMICS_C_H
+#define CMUX_CONTROL_SOCKET_ATOMICS_C_H
+
+#include <stdint.h>
+#include <stdatomic.h>
+
+typedef struct {
+    _Atomic(uintptr_t) value;
+} CmuxControlSocketAtomicPointerStorage;
+
+void CmuxControlSocketAtomicPointerInitialize(
+    CmuxControlSocketAtomicPointerStorage *storage,
+    uintptr_t initialValue
+);
+uintptr_t CmuxControlSocketAtomicPointerLoadAcquire(
+    const CmuxControlSocketAtomicPointerStorage *storage
+);
+uintptr_t CmuxControlSocketAtomicPointerExchange(
+    CmuxControlSocketAtomicPointerStorage *storage,
+    uintptr_t value
+);
+
+typedef struct {
+    _Atomic(uint64_t) value;
+} CmuxControlSocketAtomicCounterStorage;
+
+void CmuxControlSocketAtomicCounterInitialize(
+    CmuxControlSocketAtomicCounterStorage *storage,
+    uint64_t initialValue
+);
+uint64_t CmuxControlSocketAtomicCounterLoad(
+    const CmuxControlSocketAtomicCounterStorage *storage
+);
+void CmuxControlSocketAtomicCounterIncrement(
+    CmuxControlSocketAtomicCounterStorage *storage
+);
+void CmuxControlSocketAtomicCounterDecrement(
+    CmuxControlSocketAtomicCounterStorage *storage
+);
+
+#endif

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientAsyncTransportTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientAsyncTransportTests.swift
@@ -1,0 +1,85 @@
+import CmuxControlSocket
+import Darwin
+import Foundation
+import Testing
+
+@Suite("Async control-client transport")
+struct ControlClientAsyncTransportTests {
+    @Test func asyncReaderFramesUtf8WithoutBlockingTheCaller() async throws {
+        let pair = try UnixSocketFixture.makeSocketPair()
+        defer {
+            close(pair.reader)
+            close(pair.writer)
+        }
+
+        let reader = ControlClientAsyncLineReader(socket: pair.reader)
+        let firstLine = Task {
+            await reader.nextLine(shouldContinueReading: { true })
+        }
+        let firstPayload = Array("first\nあ\n".utf8)
+        firstPayload.withUnsafeBufferPointer { buffer in
+            _ = Darwin.write(pair.writer, buffer.baseAddress, buffer.count)
+        }
+
+        #expect(await firstLine.value == "first")
+        #expect(await reader.nextLine(shouldContinueReading: { true }) == "あ")
+    }
+
+    @Test func revocationFinishesAnIdleAsyncReader() async throws {
+        let pair = try UnixSocketFixture.makeSocketPair()
+        defer {
+            close(pair.reader)
+            close(pair.writer)
+        }
+        let signal = SocketAuthorizationRevocationSignal()
+        let reader = ControlClientAsyncLineReader(
+            socket: pair.reader,
+            authorizationRevocationSignal: signal
+        )
+        let pending = Task {
+            await reader.nextLine(shouldContinueReading: { true })
+        }
+        signal.revoke()
+        #expect(await pending.value == nil)
+    }
+
+    @Test func socketReceiveTimeoutFinishesAnIdleAsyncReader() async throws {
+        let pair = try UnixSocketFixture.makeSocketPair()
+        defer {
+            close(pair.reader)
+            close(pair.writer)
+        }
+        var timeout = timeval(tv_sec: 0, tv_usec: 20_000)
+        #expect(
+            withUnsafePointer(to: &timeout) { pointer in
+                setsockopt(
+                    pair.reader,
+                    SOL_SOCKET,
+                    SO_RCVTIMEO,
+                    pointer,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            } == 0
+        )
+        let reader = ControlClientAsyncLineReader(socket: pair.reader)
+        #expect(await reader.nextLine(shouldContinueReading: { true }) == nil)
+    }
+
+    @Test func asyncWriterSuspendsOnlyOnWouldBlockAndPreservesBytes() async throws {
+        let pair = try UnixSocketFixture.makeSocketPair()
+        defer {
+            close(pair.reader)
+            close(pair.writer)
+        }
+        let writer = ControlClientAsyncWriter(socket: pair.writer)
+        let payload = Data("response\n".utf8)
+        #expect(await writer.writeAll(payload))
+
+        var bytes = [UInt8](repeating: 0, count: payload.count)
+        let count = bytes.withUnsafeMutableBufferPointer { buffer in
+            Darwin.read(pair.reader, buffer.baseAddress, buffer.count)
+        }
+        #expect(count == payload.count)
+        #expect(Data(bytes) == payload)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
@@ -1,0 +1,161 @@
+import CmuxControlSocket
+import Foundation
+import os
+import Testing
+
+private actor PoolProbe {
+    private var active = 0
+    private var peak = 0
+    private var completed: [Int] = []
+
+    func started() {
+        active += 1
+        peak = max(peak, active)
+    }
+
+    func finished(_ id: Int) {
+        active -= 1
+        completed.append(id)
+    }
+
+    func snapshot() -> (active: Int, peak: Int, completed: [Int]) {
+        (active, peak, completed)
+    }
+}
+
+private actor PoolGate {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func openNext() {
+        guard !waiters.isEmpty else { return }
+        waiters.removeFirst().resume()
+    }
+}
+
+private final class TestMonotonicClock: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock(initialState: UInt64(0))
+
+    var now: UInt64 {
+        value.withLock { $0 }
+    }
+
+    func advance(by nanoseconds: UInt64) {
+        value.withLock { $0 += nanoseconds }
+    }
+}
+
+@Suite("Control-plane concurrency primitives")
+struct ControlPlaneConcurrencyTests {
+    @Test func workerPoolBoundsActiveJobsAndRejectsOverflow() async {
+        let pool = ControlClientWorkerPool(
+            maximumConcurrentJobs: 2,
+            maximumPendingJobs: 1
+        )
+        let probe = PoolProbe()
+        let gate = PoolGate()
+
+        let first = await pool.submit {
+            await probe.started()
+            await gate.wait()
+            await probe.finished(1)
+        }
+        let second = await pool.submit {
+            await probe.started()
+            await gate.wait()
+            await probe.finished(2)
+        }
+        let third = await pool.submit {
+            await probe.started()
+            await gate.wait()
+            await probe.finished(3)
+        }
+        let fourth = await pool.submit {
+            await probe.started()
+            await gate.wait()
+            await probe.finished(4)
+        }
+
+        #expect(first == .started)
+        #expect(second == .started)
+        #expect(third == .queued)
+        #expect(fourth == .rejected)
+
+        for _ in 0..<100 where await pool.metrics().activeJobs < 2 {
+            await Task.yield()
+        }
+        #expect(await pool.metrics().activeJobs == 2)
+        #expect(await pool.metrics().peakActiveJobs == 2)
+
+        await gate.openNext()
+        await gate.openNext()
+        for _ in 0..<100 where await pool.metrics().activeJobs != 1 {
+            await Task.yield()
+        }
+        await gate.openNext()
+
+        for _ in 0..<100 where await pool.metrics().activeJobs != 0 {
+            await Task.yield()
+        }
+        let result = await probe.snapshot()
+        #expect(result.peak == 2)
+        #expect(result.completed.count == 3)
+        #expect(result.completed.prefix(2).allSatisfy { $0 == 1 || $0 == 2 })
+        #expect(result.completed.last == 3)
+    }
+
+    @Test func pollingLimiterAllowsBurstThenAppliesPerClientBackpressure() async {
+        let clock = TestMonotonicClock()
+        let limiter = ControlClientRateLimiter(
+            configuration: .init(
+                burst: 2,
+                refillIntervalNanoseconds: 100
+            ),
+            now: { clock.now }
+        )
+
+        #expect(await limiter.admit(method: "system.top") == .allowed)
+        #expect(await limiter.admit(method: "system.top") == .allowed)
+        guard case .limited(let retryAfter) = await limiter.admit(method: "system.top") else {
+            Issue.record("third polling request should be rate limited")
+            return
+        }
+        #expect(retryAfter > 0)
+        #expect(await limiter.admit(method: "system.ping") == .allowed)
+
+        clock.advance(by: 100)
+        #expect(await limiter.admit(method: "system.top") == .allowed)
+    }
+
+    @Test func readSnapshotPublishesAtomicallyAndKeysByMethodAndParams() {
+        let store = ControlReadSnapshotStore()
+        let initial = ControlCallResult.ok(.object(["generation": .int(1)]))
+        store.publish(
+            ControlReadSnapshot(
+                generation: 1,
+                responses: [
+                    ControlReadSnapshot.key(method: "workspace.list", params: [:]): initial,
+                ]
+            )
+        )
+
+        #expect(
+            store.response(method: "workspace.list", params: [:]) == initial
+        )
+        #expect(store.response(method: "workspace.list", params: ["all": .bool(true)]) == nil)
+
+        let replacement = ControlCallResult.ok(.object(["generation": .int(2)]))
+        store.publishResponse(
+            method: "workspace.list",
+            params: [:],
+            result: replacement
+        )
+        #expect(store.response(method: "workspace.list", params: [:]) == replacement)
+        #expect(store.read().generation == 2)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
@@ -6,10 +6,12 @@ import Testing
 private actor PoolProbe {
     private var active = 0
     private var peak = 0
+    private var startedCount = 0
     private var completed: [Int] = []
 
     func started() {
         active += 1
+        startedCount += 1
         peak = max(peak, active)
     }
 
@@ -21,20 +23,32 @@ private actor PoolProbe {
     func snapshot() -> (active: Int, peak: Int, completed: [Int]) {
         (active, peak, completed)
     }
+
+    func hasStarted(_ count: Int) -> Bool {
+        startedCount >= count
+    }
 }
 
 private actor PoolGate {
     private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var permits = 0
 
     func wait() async {
+        if permits > 0 {
+            permits -= 1
+            return
+        }
         await withCheckedContinuation { continuation in
             waiters.append(continuation)
         }
     }
 
     func openNext() {
-        guard !waiters.isEmpty else { return }
-        waiters.removeFirst().resume()
+        if !waiters.isEmpty {
+            waiters.removeFirst().resume()
+        } else {
+            permits += 1
+        }
     }
 }
 
@@ -86,27 +100,38 @@ struct ControlPlaneConcurrencyTests {
         #expect(third == .queued)
         #expect(fourth == .rejected)
 
-        for _ in 0..<100 where await pool.metrics().activeJobs < 2 {
+        for _ in 0..<10_000 {
+            if await probe.hasStarted(2) { break }
             await Task.yield()
+            try? await Task.sleep(for: .milliseconds(1))
         }
+        #expect(await probe.hasStarted(2))
         #expect(await pool.metrics().activeJobs == 2)
         #expect(await pool.metrics().peakActiveJobs == 2)
 
         await gate.openNext()
         await gate.openNext()
-        for _ in 0..<100 where await pool.metrics().activeJobs != 1 {
+        for _ in 0..<10_000 {
+            if await probe.snapshot().completed.count >= 1 { break }
             await Task.yield()
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        for _ in 0..<10_000 {
+            if await probe.hasStarted(3) { break }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(1))
         }
         await gate.openNext()
 
-        for _ in 0..<100 where await pool.metrics().activeJobs != 0 {
+        for _ in 0..<10_000 {
+            if await probe.snapshot().completed.count == 3 { break }
             await Task.yield()
+            try? await Task.sleep(for: .milliseconds(1))
         }
         let result = await probe.snapshot()
         #expect(result.peak == 2)
         #expect(result.completed.count == 3)
-        #expect(result.completed.prefix(2).allSatisfy { $0 == 1 || $0 == 2 })
-        #expect(result.completed.last == 3)
+        #expect(Set(result.completed) == Set([1, 2, 3]))
     }
 
     @Test func pollingLimiterAllowsBurstThenAppliesPerClientBackpressure() async {
@@ -147,7 +172,8 @@ struct ControlPlaneConcurrencyTests {
         #expect(
             store.response(method: "workspace.list", params: [:]) == initial
         )
-        #expect(store.response(method: "workspace.list", params: ["all": .bool(true)]) == nil)
+        let differentParams: [String: JSONValue] = ["all": .bool(true)]
+        #expect(store.response(method: "workspace.list", params: differentParams) == nil)
 
         let replacement = ControlCallResult.ok(.object(["generation": .int(2)]))
         store.publishResponse(
@@ -157,5 +183,50 @@ struct ControlPlaneConcurrencyTests {
         )
         #expect(store.response(method: "workspace.list", params: [:]) == replacement)
         #expect(store.read().generation == 2)
+    }
+
+    @Test func readAndPollingPoliciesShareOneClassification() {
+        #expect(
+            ControlCommandExecutionPolicy.servesFromPublishedReadSnapshot(
+                method: "workspace.list"
+            )
+        )
+        #expect(
+            ControlCommandExecutionPolicy.servesFromPublishedReadSnapshot(
+                method: "surface.read_text"
+            )
+        )
+        #expect(
+            ControlCommandExecutionPolicy.pollingMethods.contains("system.top")
+        )
+        #expect(
+            !ControlCommandExecutionPolicy.pollingMethods.contains("workspace.create")
+        )
+    }
+
+    @Test func snapshotReadersRemainSafeDuringConcurrentPublications() async {
+        let store = ControlReadSnapshotStore()
+        await withTaskGroup(of: Void.self) { group in
+            for writer in 0..<2 {
+                group.addTask {
+                    for generation in 0..<200 {
+                        store.publish(
+                            ControlReadSnapshot(
+                                generation: UInt64(writer * 1_000 + generation),
+                                responses: [:]
+                            )
+                        )
+                    }
+                }
+            }
+            for _ in 0..<4 {
+                group.addTask {
+                    for _ in 0..<500 {
+                        _ = store.read().generation
+                    }
+                }
+            }
+        }
+        #expect(store.read().responses.isEmpty)
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlPlaneConcurrencyTests.swift
@@ -165,7 +165,8 @@ struct ControlPlaneConcurrencyTests {
                 generation: 1,
                 responses: [
                     ControlReadSnapshot.key(method: "workspace.list", params: [:]): initial,
-                ]
+                ],
+                publishedAtUptimeNanoseconds: 100
             )
         )
 
@@ -174,6 +175,22 @@ struct ControlPlaneConcurrencyTests {
         )
         let differentParams: [String: JSONValue] = ["all": .bool(true)]
         #expect(store.response(method: "workspace.list", params: differentParams) == nil)
+        #expect(
+            store.response(
+                method: "workspace.list",
+                params: [:],
+                maximumAgeNanoseconds: 100,
+                nowUptimeNanoseconds: 200
+            ) == initial
+        )
+        #expect(
+            store.response(
+                method: "workspace.list",
+                params: [:],
+                maximumAgeNanoseconds: 100,
+                nowUptimeNanoseconds: 201
+            ) == nil
+        )
 
         let replacement = ControlCallResult.ok(.object(["generation": .int(2)]))
         store.publishResponse(

--- a/Sources/TerminalController+ControlReadSnapshots.swift
+++ b/Sources/TerminalController+ControlReadSnapshots.swift
@@ -1,0 +1,50 @@
+import CmuxControlSocket
+import Foundation
+
+/// Main-actor publication of the read-side control-plane mirror.
+///
+/// The publisher deliberately builds a small, stable set of topology reads
+/// (without request ids) and swaps one immutable package snapshot. Socket
+/// workers can then answer repeated list/tree polls without entering the main
+/// actor; a mutation schedules one coalesced refresh on the next actor turn.
+extension TerminalController {
+    func scheduleSocketReadSnapshotRefresh() {
+        guard socketReadSnapshotRefreshTask == nil else { return }
+        socketReadSnapshotRefreshTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self else { return }
+            self.publishSocketReadSnapshot()
+            self.socketReadSnapshotRefreshTask = nil
+        }
+    }
+
+    private func publishSocketReadSnapshot() {
+        let requests: [ControlRequest] = [
+            ControlRequest(id: nil, method: "window.list", params: [:]),
+            ControlRequest(id: nil, method: "window.current", params: [:]),
+            ControlRequest(id: nil, method: "window.displays", params: [:]),
+            ControlRequest(id: nil, method: "workspace.list", params: [:]),
+            ControlRequest(id: nil, method: "workspace.current", params: [:]),
+            ControlRequest(id: nil, method: "surface.list", params: [:]),
+            ControlRequest(id: nil, method: "surface.current", params: [:]),
+            ControlRequest(id: nil, method: "pane.list", params: [:]),
+            ControlRequest(id: nil, method: "pane.surfaces", params: [:]),
+            ControlRequest(id: nil, method: "system.identify", params: [:]),
+            ControlRequest(id: nil, method: "system.tree", params: [:]),
+        ]
+        var responses: [String: ControlCallResult] = [:]
+        responses.reserveCapacity(requests.count)
+        for request in requests {
+            guard let result = controlCommandCoordinator.handleSocketWorkerV2(
+                request,
+                context: self
+            ) else { continue }
+            responses[ControlReadSnapshot.key(method: request.method, params: request.params)] = result
+        }
+
+        let nextGeneration = socketReadSnapshotStore.read().generation &+ 1
+        socketReadSnapshotStore.publish(
+            ControlReadSnapshot(generation: nextGeneration, responses: responses)
+        )
+    }
+}

--- a/Sources/TerminalController+ControlSocketAsync.swift
+++ b/Sources/TerminalController+ControlSocketAsync.swift
@@ -188,7 +188,7 @@ extension TerminalController {
     private nonisolated func v2SystemTopAsync(_ request: ControlRequest) async -> String {
         let base = await v2MainAsync {
             let foundationParams = request.params.mapValues(\.foundationObject)
-            Self.controlCallResult(
+            return Self.controlCallResult(
                 fromLegacy: self.v2SystemTopBasePayload(params: foundationParams)
             )
         }
@@ -270,7 +270,7 @@ extension TerminalController {
         let outcome = await v2MainAsync {
             let mainParams = request.params.mapValues(\.foundationObject)
             let mainID = request.id?.foundationObject
-            self.v2MainActorResponse(
+            return self.v2MainActorResponse(
                 request: request,
                 id: mainID,
                 method: method,

--- a/Sources/TerminalController+ControlSocketAsync.swift
+++ b/Sources/TerminalController+ControlSocketAsync.swift
@@ -112,7 +112,10 @@ extension TerminalController {
         if ControlCommandExecutionPolicy.servesFromPublishedReadSnapshot(method: request.method),
            let snapshotResult = socketReadSnapshotStore.response(
                 method: request.method,
-                params: request.params
+                params: request.params,
+                maximumAgeNanoseconds: Self.snapshotMaximumAgeNanoseconds(
+                    for: request.method
+                )
            ) {
             return Self.v2Encoder.response(id: request.id, snapshotResult)
         }
@@ -336,6 +339,21 @@ extension TerminalController {
         return trimmed.split(separator: " ", maxSplits: 1)
             .first
             .map { String($0).lowercased() }
+    }
+
+    private nonisolated static func snapshotMaximumAgeNanoseconds(
+        for method: String
+    ) -> UInt64? {
+        switch method {
+        case "surface.read_text":
+            return 100_000_000
+        case "system.top":
+            return 500_000_000
+        case "system.memory":
+            return 2_000_000_000
+        default:
+            return nil
+        }
     }
 
     private nonisolated static func socketRateLimitedResponse(

--- a/Sources/TerminalController+ControlSocketAsync.swift
+++ b/Sources/TerminalController+ControlSocketAsync.swift
@@ -58,11 +58,10 @@ extension TerminalController {
             }
             let authorizedRequest = relayAuthorization.request
             let policy = Self.executionPolicy(forV2Method: authorizedRequest.method)
-            let policyParams = authorizedRequest.params.mapValues(\.foundationObject)
             return await withSocketCommandPolicyAsync(
                 commandKey: authorizedRequest.method,
                 isV2: true,
-                params: policyParams
+                params: authorizedRequest.params
             ) {
                 if policy.runsOnSocketWorker {
                     return await self.socketWorkerV2ResponseAsync(authorizedRequest)
@@ -83,7 +82,9 @@ extension TerminalController {
         return await withSocketCommandPolicyAsync(
             commandKey: commandName,
             isV2: false,
-            params: commandName == "right_sidebar" ? ["args": args] : [:]
+            params: commandName == "right_sidebar"
+                ? ["args": .string(args)]
+                : [:]
         ) {
             if policy.runsOnSocketWorker {
                 // The existing worker implementation is already nonisolated
@@ -304,13 +305,14 @@ extension TerminalController {
     nonisolated func withSocketCommandPolicyAsync<T: Sendable>(
         commandKey: String,
         isV2: Bool,
-        params: [String: Any] = [:],
+        params: [String: JSONValue] = [:],
         _ body: @escaping @Sendable () async -> T
     ) async -> T {
+        let foundationParams = params.mapValues(\.foundationObject)
         let allowsFocusMutation = Self.socketCommandAllowsInAppFocusMutations(
             commandKey: commandKey,
             isV2: isV2,
-            params: params
+            params: foundationParams
         )
         var stack = Self.currentSocketCommandFocusAllowanceStack()
         stack.append(allowsFocusMutation)

--- a/Sources/TerminalController+ControlSocketAsync.swift
+++ b/Sources/TerminalController+ControlSocketAsync.swift
@@ -1,0 +1,406 @@
+import CmuxControlSocket
+import Foundation
+
+/// Async socket-dispatch helpers kept separate from the legacy synchronous
+/// dispatcher. Socket connections use these methods; in-process callers retain
+/// the synchronous `handleSocketLine` contract.
+extension TerminalController {
+    /// Processes one authenticated socket line without synchronously waiting
+    /// for the main actor. The returned authorization value is connection
+    /// local and must be fed into the next line in FIFO order.
+    nonisolated func processSocketLineAsync(
+        _ command: String,
+        passwordAuthorization: SocketPasswordAuthorization,
+        rateLimiter: ControlClientRateLimiter
+    ) async -> (response: String?, passwordAuthorization: SocketPasswordAuthorization) {
+        var nextPasswordAuthorization = passwordAuthorization
+        if let response = authResponseIfNeeded(
+            for: command,
+            passwordAuthorization: &nextPasswordAuthorization
+        ) {
+            return (response, nextPasswordAuthorization)
+        }
+
+        if let method = Self.socketPollingMethod(in: command),
+           case .limited(let retryAfterMilliseconds) = await rateLimiter.admit(method: method) {
+            return (
+                Self.socketRateLimitedResponse(
+                    command: command,
+                    retryAfterMilliseconds: retryAfterMilliseconds
+                ),
+                nextPasswordAuthorization
+            )
+        }
+
+        let response = await processCommandUsingSocketExecutionPolicyAsync(command)
+        return (response, nextPasswordAuthorization)
+    }
+
+    /// Async counterpart of the socket execution-policy dispatcher. Parsing
+    /// and JSON encoding remain on the connection task; only the minimal
+    /// main-actor action is awaited.
+    nonisolated func processCommandUsingSocketExecutionPolicyAsync(
+        _ command: String
+    ) async -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{") {
+            let request: ControlRequest
+            switch Self.v2Parser.request(fromLine: trimmed) {
+            case .failure(let parseError):
+                return Self.v2Encoder.response(for: parseError)
+            case .success(let parsed):
+                request = parsed
+            }
+
+            let relayAuthorization = authorizeRemoteRelayRequest(request)
+            if let errorResponse = relayAuthorization.errorResponse {
+                return errorResponse
+            }
+            let authorizedRequest = relayAuthorization.request
+            let policy = Self.executionPolicy(forV2Method: authorizedRequest.method)
+            let policyParams = authorizedRequest.params.mapValues(\.foundationObject)
+            return await withSocketCommandPolicyAsync(
+                commandKey: authorizedRequest.method,
+                isV2: true,
+                params: policyParams
+            ) {
+                if policy.runsOnSocketWorker {
+                    return await self.socketWorkerV2ResponseAsync(authorizedRequest)
+                }
+                return await self.processParsedV2CommandAsync(authorizedRequest)
+            }
+        }
+
+        let parts = trimmed.split(separator: " ", maxSplits: 1).map(String.init)
+        guard let commandToken = parts.first else {
+            return await v2MainAsync {
+                self.processCommand(command)
+            }
+        }
+        let commandName = commandToken.lowercased()
+        let args = parts.count > 1 ? parts[1] : ""
+        let policy = ControlCommandExecutionPolicy(forV1Command: commandName)
+        return await withSocketCommandPolicyAsync(
+            commandKey: commandName,
+            isV2: false,
+            params: commandName == "right_sidebar" ? ["args": args] : [:]
+        ) {
+            if policy.runsOnSocketWorker {
+                // The existing worker implementation is already nonisolated
+                // for telemetry/diagnostic/remote work. It remains serial
+                // within this connection task, preserving v1 FIFO semantics.
+                let worker = self.socketWorkerV1ResponseIfHandled(
+                    cmd: commandName,
+                    args: args
+                )
+                if worker.handled { return worker.response }
+            }
+            return await self.v2MainAsync {
+                self.processCommand(command)
+            }
+        }
+    }
+
+    /// Handles a v2 worker request. Snapshot hits are entirely off-main;
+    /// topology misses use the coordinator's typed result seam once and cache
+    /// that result for subsequent polls. Legacy worker methods remain on their
+    /// established worker path.
+    private nonisolated func socketWorkerV2ResponseAsync(
+        _ request: ControlRequest
+    ) async -> String? {
+        if ControlCommandExecutionPolicy.servesFromPublishedReadSnapshot(method: request.method),
+           let snapshotResult = socketReadSnapshotStore.response(
+                method: request.method,
+                params: request.params
+           ) {
+            return Self.v2Encoder.response(id: request.id, snapshotResult)
+        }
+
+        if ControlCommandExecutionPolicy.servesFromPublishedReadSnapshot(method: request.method),
+           let coordinatorResult = await v2MainAsync({
+               self.controlCommandCoordinator.handleSocketWorkerV2(
+                   request,
+                   context: self
+               )
+           }) {
+            socketReadSnapshotStore.publishResponse(
+                method: request.method,
+                params: request.params,
+                result: coordinatorResult
+            )
+            return Self.v2Encoder.response(id: request.id, coordinatorResult)
+        }
+
+        if Self.socketWorkerCoordinatorHopMethods.contains(request.method) {
+            let response = await v2MainAsync {
+                self.socketWorkerV2Response(handling: request)
+            }
+            Task { @MainActor [weak self] in
+                self?.scheduleSocketReadSnapshotRefresh()
+            }
+            return response
+        }
+
+        if request.method == "system.top" {
+            let response = await v2SystemTopAsync(request)
+            if let result = Self.controlCallResult(fromEncodedResponse: response) {
+                socketReadSnapshotStore.publishResponse(
+                    method: request.method,
+                    params: request.params,
+                    result: result
+                )
+            }
+            return response
+        }
+
+        if request.method == "system.memory" || request.method == "surface.read_text" {
+            // These legacy bodies still return Foundation-shaped values. Run
+            // the miss on the main actor only when no published snapshot exists;
+            // steady-state polling takes the branch above and never enters
+            // this fallback.
+            let response = await v2MainAsync {
+                self.socketWorkerV2Response(
+                    handling: ControlRequest(
+                        id: request.id,
+                        method: request.method,
+                        params: request.params
+                    )
+                )
+            }
+            if let response,
+               let result = Self.controlCallResult(fromEncodedResponse: response) {
+                socketReadSnapshotStore.publishResponse(
+                    method: request.method,
+                    params: request.params,
+                    result: result
+                )
+            }
+            return response
+        }
+
+        return socketWorkerV2Response(handling: request)
+    }
+
+    private nonisolated func v2SystemTopAsync(_ request: ControlRequest) async -> String {
+        let base = await v2MainAsync {
+            let foundationParams = request.params.mapValues(\.foundationObject)
+            Self.controlCallResult(
+                fromLegacy: self.v2SystemTopBasePayload(params: foundationParams)
+            )
+        }
+        guard case .ok(let basePayload) = base,
+              case .object(let baseObject) = basePayload,
+              case .bool(let includeProcesses)? = baseObject["include_processes"],
+              case .array(let rawWindows)? = baseObject["windows"] else {
+            return Self.v2Encoder.response(id: request.id, base)
+        }
+        guard let windowsObject = JSONValue.array(rawWindows).foundationObject as? [[String: Any]] else {
+            return Self.v2Encoder.error(
+                id: request.id,
+                code: "internal_error",
+                message: "Invalid system.top payload"
+            )
+        }
+
+        let processSnapshot = CmuxTopProcessSnapshot.capture(
+            includeProcessDetails: includeProcesses
+        )
+        var windows = windowsObject
+        let browserPIDOccurrences = v2TopBrowserPIDOccurrences(in: windows)
+        let totalPIDs = v2AnnotateTopWindows(
+            &windows,
+            processSnapshot: processSnapshot,
+            browserPIDOccurrences: browserPIDOccurrences,
+            includeProcesses: includeProcesses
+        )
+        let aggregates = processAggregates(
+            from: processSnapshot,
+            totalPIDs: totalPIDs
+        )
+        let memoryDiagnostic = v2TopMemoryDiagnosticPayload(
+            processSnapshot: processSnapshot,
+            annotatedWindows: windows
+        )
+
+        var payload = baseObject
+        payload["sample"] = JSONValue(
+            foundationObject: processSnapshot.samplePayload()
+        ) ?? .object([:])
+        payload["totals"] = JSONValue(
+            foundationObject: processSnapshot.summaryPayload(for: totalPIDs)
+        ) ?? .object([:])
+        payload["memory_diagnostic"] = JSONValue(
+            foundationObject: memoryDiagnostic
+        ) ?? .object([:])
+        payload["program_totals"] = JSONValue(
+            foundationObject: aggregates.programs
+        ) ?? .array([])
+        payload["coding_agents"] = JSONValue(
+            foundationObject: aggregates.codingAgents
+        ) ?? .array([])
+        payload["windows"] = JSONValue(
+            foundationObject: windows
+        ) ?? .array([])
+        return Self.v2Encoder.response(
+            id: request.id,
+            .ok(.object(payload))
+        )
+    }
+
+    private nonisolated func processParsedV2CommandAsync(
+        _ request: ControlRequest
+    ) async -> String {
+        let bridgedParams = request.params.mapValues(\.foundationObject)
+        let method = request.method
+        let id = request.id?.foundationObject
+        if let workspaceParamError = v2UnsupportedWorkspaceAliasError(
+            method: method,
+            params: bridgedParams
+        ) {
+            return v2Result(id: id, workspaceParamError)
+        }
+
+        let diffViewerRegistration: DiffViewerSessionPreparation = method == "browser.open_split"
+            ? v2PrepareDiffViewerRegistration(params: bridgedParams)
+            : .notNeeded
+        let outcome = await v2MainAsync {
+            let mainParams = request.params.mapValues(\.foundationObject)
+            let mainID = request.id?.foundationObject
+            self.v2MainActorResponse(
+                request: request,
+                id: mainID,
+                method: method,
+                params: mainParams,
+                diffViewerRegistration: diffViewerRegistration
+            )
+        }
+        Task { @MainActor [weak self] in
+            self?.scheduleSocketReadSnapshotRefresh()
+        }
+        switch outcome {
+        case .callResult(let result):
+            return Self.v2Encoder.response(id: request.id, result)
+        case .encoded(let response):
+            return response
+        }
+    }
+
+    /// Async main-actor hop used only by socket tasks. Unlike `v2MainSync`, it
+    /// suspends the caller and never parks an I/O thread behind the run loop.
+    nonisolated func v2MainAsync<T: Sendable>(
+        _ body: @escaping @MainActor @Sendable () -> T
+    ) async -> T {
+        let policyStack = Self.currentSocketCommandFocusAllowanceStack()
+        return await MainActor.run {
+            Self.withSocketCommandPolicyStack(policyStack) {
+                body()
+            }
+        }
+    }
+
+    /// Applies the focus/command policy across an async socket operation. The
+    /// stack is captured by ``v2MainAsync`` before its suspension, so the main
+    /// actor observes the same focus allowance as the legacy synchronous lane.
+    nonisolated func withSocketCommandPolicyAsync<T: Sendable>(
+        commandKey: String,
+        isV2: Bool,
+        params: [String: Any] = [:],
+        _ body: @escaping @Sendable () async -> T
+    ) async -> T {
+        let allowsFocusMutation = Self.socketCommandAllowsInAppFocusMutations(
+            commandKey: commandKey,
+            isV2: isV2,
+            params: params
+        )
+        var stack = Self.currentSocketCommandFocusAllowanceStack()
+        stack.append(allowsFocusMutation)
+        Self.setCurrentSocketCommandFocusAllowanceStack(stack)
+        defer {
+            var restored = Self.currentSocketCommandFocusAllowanceStack()
+            if !restored.isEmpty { _ = restored.popLast() }
+            Self.setCurrentSocketCommandFocusAllowanceStack(restored)
+        }
+        return await body()
+    }
+
+    private nonisolated static func socketPollingMethod(in command: String) -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{") {
+            guard case .success(let request) = v2Parser.request(fromLine: trimmed) else {
+                return nil
+            }
+            return request.method
+        }
+        return trimmed.split(separator: " ", maxSplits: 1)
+            .first
+            .map { String($0).lowercased() }
+    }
+
+    private nonisolated static func socketRateLimitedResponse(
+        command: String,
+        retryAfterMilliseconds: Int
+    ) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{"),
+           case .success(let request) = v2Parser.request(fromLine: trimmed) {
+            return v2Encoder.error(
+                id: request.id,
+                code: "rate_limited",
+                message: "Polling rate limited for this connection",
+                data: .object([
+                    "retry_after_ms": .int(Int64(retryAfterMilliseconds)),
+                ])
+            )
+        }
+        return "ERROR: rate_limited retry_after_ms=\(retryAfterMilliseconds)"
+    }
+
+    private nonisolated static func controlCallResult(
+        fromEncodedResponse response: String
+    ) -> ControlCallResult? {
+        guard let data = response.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ok = object["ok"] as? Bool else {
+            return nil
+        }
+        if ok {
+            guard let rawResult = object["result"],
+                  let result = JSONValue(foundationObject: rawResult) else {
+                return nil
+            }
+            return .ok(result)
+        }
+        guard let error = object["error"] as? [String: Any],
+              let code = error["code"] as? String,
+              let message = error["message"] as? String else {
+            return nil
+        }
+        return .err(
+            code: code,
+            message: message,
+            data: error["data"].flatMap(JSONValue.init(foundationObject:))
+        )
+    }
+
+    private nonisolated static func controlCallResult(
+        fromLegacy result: V2CallResult
+    ) -> ControlCallResult {
+        switch result {
+        case .ok(let payload):
+            guard let value = JSONValue(foundationObject: payload) else {
+                return .err(
+                    code: "encode_error",
+                    message: "Failed to encode JSON",
+                    data: nil
+                )
+            }
+            return .ok(value)
+        case .err(let code, let message, let data):
+            return .err(
+                code: code,
+                message: message,
+                data: data.flatMap(JSONValue.init(foundationObject:))
+            )
+        }
+    }
+}

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -303,12 +303,6 @@ extension TerminalController {
                     defaultValue: "Artifact transfer is temporarily unavailable.",
                     path: nil
                 )
-            case .permissionDenied:
-                return mobileArtifactReadFailure(.permissionDenied, path: v2RawString(params, "path"))
-            case .notRegularFile:
-                return mobileArtifactReadFailure(.notRegularFile, path: v2RawString(params, "path"))
-            case .readFailed:
-                return mobileArtifactReadFailure(.readFailed, path: v2RawString(params, "path"))
             }
         } catch ArtifactByteReader.Error.fileNotFound {
             return mobilePanelArtifactFileError(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -178,6 +178,19 @@ class TerminalController {
     nonisolated let socketPathMarkerStore: SocketPathMarkerStore
     // Accepted-connection consumer; runs until process exit (singleton).
     private nonisolated let socketConnectionsTask: Task<Void, Never>
+    /// Bounded async connection admission. The pool owns task lifetimes; an
+    /// admitted connection owns its descriptor until its async handler exits.
+    private nonisolated let socketClientWorkerPool = ControlClientWorkerPool(
+        maximumConcurrentJobs: 32,
+        maximumPendingJobs: 64
+    )
+    /// Latest main-actor-published read results. Socket workers consult this
+    /// mirror synchronously before falling back to a live command path.
+    nonisolated let socketReadSnapshotStore = ControlReadSnapshotStore()
+    /// Coalesced main-actor publication task for topology/read snapshots.
+    private var socketReadSnapshotRefreshTask: Task<Void, Never>? = nil
+    /// Topology notifications that invalidate the published read mirror.
+    private var socketReadSnapshotObservers: [NSObjectProtocol] = []
     // Per-surface dedupe for high-frequency report_* socket telemetry.
     // Cross-thread contract (reintroduced by the tranche-B v1 worker lane):
     // the nonisolated seam witness controlSidebarScheduleScopedShellState
@@ -485,10 +498,9 @@ class TerminalController {
             )
         )
         self.socketServer = socketServer
-        // Single consumer of the accepted-connection stream, detached so
-        // accepts never funnel through the main actor. Each connection still
-        // gets a dedicated thread: command bodies block (main-thread sync
-        // hops, semaphore waits), so never the cooperative pool.
+        // Single consumer of the accepted-connection stream. Accepted
+        // descriptors are admitted to the bounded async pool; the listener
+        // itself never creates one detached NSThread per client.
         self.socketConnectionsTask = Task.detached {
             for await connection in socketServer.connections {
                 guard let controller = serverEventTarget.controller else {
@@ -505,6 +517,23 @@ class TerminalController {
         }
         serverEventTarget.controller = self
         controlCommandCoordinator.context = self
+        socketReadSnapshotObservers = [
+            Notification.Name.mainWindowContextsDidChange,
+            Notification.Name.workspaceOrderDidChange,
+            Notification.Name.workspacePaneGeometryDidChange,
+            Notification.Name.workspaceTitleDidChange,
+            Notification.Name.workspaceCurrentDirectoryDidChange,
+        ].map { name in
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.scheduleSocketReadSnapshotRefresh()
+                }
+            }
+        }
         browserDownloadObserver = NotificationCenter.default.addObserver(
             forName: .browserDownloadEventDidArrive,
             object: nil,
@@ -609,11 +638,11 @@ class TerminalController {
         return body()
     }
 
-    private nonisolated static func currentSocketCommandFocusAllowanceStack() -> [Bool] {
+    nonisolated static func currentSocketCommandFocusAllowanceStack() -> [Bool] {
         Thread.current.threadDictionary[socketCommandFocusAllowanceStackKey] as? [Bool] ?? []
     }
 
-    private nonisolated static func setCurrentSocketCommandFocusAllowanceStack(_ stack: [Bool]) {
+    nonisolated static func setCurrentSocketCommandFocusAllowanceStack(_ stack: [Bool]) {
         if stack.isEmpty {
             Thread.current.threadDictionary.removeObject(forKey: socketCommandFocusAllowanceStackKey)
         } else {
@@ -621,7 +650,7 @@ class TerminalController {
         }
     }
 
-    private nonisolated static func withSocketCommandPolicyStack<T>(_ stack: [Bool], _ body: () -> T) -> T {
+    nonisolated static func withSocketCommandPolicyStack<T>(_ stack: [Bool], _ body: () -> T) -> T {
         let previous = currentSocketCommandFocusAllowanceStack()
         setCurrentSocketCommandFocusAllowanceStack(stack)
         defer { setCurrentSocketCommandFocusAllowanceStack(previous) }
@@ -1000,6 +1029,7 @@ class TerminalController {
             self?.applyAgentPortPublication(workspaceId: workspaceId, ports: ports) ?? false
         }
         PortScanner.shared.setTrackedAgentScanningPaused(!NSApplication.shared.isActive)
+        scheduleSocketReadSnapshotRefresh()
     }
 
     func applyPanelPortPublication(workspaceId: UUID, panelId: UUID, ports: [Int]) {
@@ -1073,8 +1103,8 @@ class TerminalController {
 
     /// Wire-protocol helpers (parse/encode) shared with the package;
     /// stateless, so single instances serve every thread.
-    private nonisolated static let v2Parser = ControlRequestParser()
-    private nonisolated static let v2Encoder = ControlResponseEncoder()
+    nonisolated static let v2Parser = ControlRequestParser()
+    nonisolated static let v2Encoder = ControlResponseEncoder()
 
     private nonisolated static func executionPolicy(forV2Method method: String) -> ControlCommandExecutionPolicy {
         ControlCommandExecutionPolicy(forMethod: method)
@@ -1095,7 +1125,7 @@ class TerminalController {
     /// `surface.report_tty` (cmux-zsh-integration.zsh `_cmux_report_tty_once`)
     /// must see the TTY registration applied before its reply so subsequent
     /// `surface.ports_kick` scans resolve the surface.
-    private nonisolated static let socketWorkerCoordinatorHopMethods: Set<String> = [
+    nonisolated static let socketWorkerCoordinatorHopMethods: Set<String> = [
         "surface.report_pwd",
         "surface.report_git_branch",
         "surface.clear_git_branch",
@@ -1120,7 +1150,7 @@ class TerminalController {
         "workspace.set_auto_title",
     ]
 
-    private nonisolated func socketWorkerV2Response(handling parsedRequest: ControlRequest) -> String? {
+    nonisolated func socketWorkerV2Response(handling parsedRequest: ControlRequest) -> String? {
         let request = V2SocketRequest(bridging: parsedRequest)
         return withSocketCommandPolicy(commandKey: request.method, isV2: true, params: request.params) {
             if let workspaceParamError = v2UnsupportedWorkspaceAliasError(method: request.method, params: request.params) {
@@ -1214,7 +1244,7 @@ class TerminalController {
     /// worker lane (the dispatcher falls through to the main hop). `response`
     /// stays optional so future fire-and-forget v1 telemetry can reply with
     /// nothing, matching the v2 lane's contract.
-    private nonisolated func socketWorkerV1ResponseIfHandled(cmd: String, args: String) -> (handled: Bool, response: String?) {
+    nonisolated func socketWorkerV1ResponseIfHandled(cmd: String, args: String) -> (handled: Bool, response: String?) {
         guard ControlCommandExecutionPolicy(forV1Command: cmd).runsOnSocketWorker else {
             return (false, nil)
         }
@@ -1647,12 +1677,15 @@ class TerminalController {
             close(clientSocket)
             return
         }
-        Thread.detachNewThread { [weak self] in
+        let submission = await socketClientWorkerPool.submit { [weak self] in
             guard let self else {
                 close(clientSocket)
+                if claimedPreauthorizationSlot {
+                    Task { await preauthorizationLimiter.release() }
+                }
                 return
             }
-            self.handleClient(
+            await self.handleClientAsync(
                 clientSocket,
                 peerPid: peerPid,
                 authorizationGeneration: authorizationGeneration,
@@ -1660,18 +1693,29 @@ class TerminalController {
                 initialReadLimits: initialReadLimits,
                 holdsPreauthorizationSlot: claimedPreauthorizationSlot
             )
+        } onDrop: {
+            if claimedPreauthorizationSlot {
+                Task { await preauthorizationLimiter.release() }
+            }
+            close(clientSocket)
         }
+        guard submission != .rejected else { return }
     }
 
-    private nonisolated func handleClient(
+    private nonisolated func handleClientAsync(
         _ socket: Int32,
         peerPid: pid_t? = nil,
         authorizationGeneration: UInt64,
         authorizationRevocationSignal: SocketAuthorizationRevocationSignal,
         initialReadLimits: ControlClientLineReadLimits? = nil,
         holdsPreauthorizationSlot initialSlotHeld: Bool = false
-    ) {
-        defer { close(socket) }
+    ) async {
+        // Shut down before close so a DispatchSource callback racing
+        // cancellation observes EOF rather than a recycled descriptor number.
+        defer {
+            shutdown(socket, SHUT_RDWR)
+            close(socket)
+        }
         let pid = peerPid ?? transport.peerProcessID(of: socket)
         let peerHasSameUID = transport.peerHasSameUID(socket)
         let preauthorizationLimiter = socketClientPreauthorizationLimiter
@@ -1682,12 +1726,18 @@ class TerminalController {
             }
         }
         var passwordAuthorization = SocketPasswordAuthorization()
-        let lineReader = ControlClientLineReader(
+        let lineReader = ControlClientAsyncLineReader(
             socket: socket,
             initialLimits: initialReadLimits,
             authorizationRevocationSignal: authorizationRevocationSignal
         )
-        while let line = lineReader.nextLine(shouldContinueReading: {
+        let writer = ControlClientAsyncWriter(socket: socket)
+        let rateLimiter = ControlClientRateLimiter()
+        defer {
+            lineReader.cancel()
+            writer.cancel()
+        }
+        while let line = await lineReader.nextLine(shouldContinueReading: {
             socketServer.isConnectionAuthorizationCurrent(authorizationGeneration)
         }) {
             let receivedCommand = line.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1696,7 +1746,7 @@ class TerminalController {
                 authorizationGeneration,
                 passwordAuthorization: &passwordAuthorization
             ) else {
-                _ = writeSocketResponse(Self.socketClientAccessDeniedResponse, to: socket)
+                _ = await writer.writeAll(Data((Self.socketClientAccessDeniedResponse + "\n").utf8))
                 return
             }
             guard let trimmed = authorizedSocketCommand(
@@ -1704,59 +1754,54 @@ class TerminalController {
                 peerProcessID: pid,
                 peerHasSameUID: peerHasSameUID
             ) else {
-                _ = writeSocketResponse(
-                    pid == nil ? Self.socketClientVerificationFailedResponse
-                        : Self.socketClientAccessDeniedResponse,
-                    to: socket
+                let response = pid == nil
+                    ? Self.socketClientVerificationFailedResponse
+                    : Self.socketClientAccessDeniedResponse
+                _ = await writer.writeAll(
+                    Data((response + "\n").utf8)
                 )
                 return
             }
             lineReader.clearLimits()
             if holdsPreauthorizationSlot {
                 holdsPreauthorizationSlot = false
-                Task { await preauthorizationLimiter.release() }
+                await preauthorizationLimiter.release()
             }
 
-            var shouldCloseSocket = false
-            autoreleasepool {
-                if isEventsStreamRequest(trimmed) {
-                    if let response = authResponseIfNeeded(
-                        for: trimmed,
-                        passwordAuthorization: &passwordAuthorization
-                    ) {
-                        if !writeSocketResponse(response, to: socket) {
-                            shouldCloseSocket = true
-                        }
-                        return
-                    }
-                    handleEventsStreamRequest(
-                        trimmed,
-                        socket: socket,
-                        authorizationGeneration: authorizationGeneration,
-                        authorizationRevocationSignal: authorizationRevocationSignal,
-                        passwordAuthorization: passwordAuthorization
-                    )
-                    shouldCloseSocket = true
-                    return
+            if isEventsStreamRequest(trimmed) {
+                if let response = authResponseIfNeeded(
+                    for: trimmed,
+                    passwordAuthorization: &passwordAuthorization
+                ) {
+                    guard await writer.writeAll(Data((response + "\n").utf8)) else { return }
+                    continue
                 }
-
-                let result = processSocketLine(
+                // The event-bus subscription has its own bounded slow-consumer
+                // policy. Keep its legacy stream loop isolated to this admitted
+                // connection task; ordinary command traffic remains async.
+                handleEventsStreamRequest(
                     trimmed,
+                    socket: socket,
+                    authorizationGeneration: authorizationGeneration,
+                    authorizationRevocationSignal: authorizationRevocationSignal,
                     passwordAuthorization: passwordAuthorization
                 )
-                passwordAuthorization = result.passwordAuthorization
-                if let response = result.response {
-                    let didWriteResponse = writeSocketResponse(response, to: socket)
-                    publishSocketEvents(command: trimmed, response: response)
-                    if !didWriteResponse {
-                        shouldCloseSocket = true
-                    }
-                }
+                return
             }
-            if shouldCloseSocket { return }
+
+            let result = await processSocketLineAsync(
+                trimmed,
+                passwordAuthorization: passwordAuthorization,
+                rateLimiter: rateLimiter
+            )
+            passwordAuthorization = result.passwordAuthorization
+            if let response = result.response {
+                guard await writer.writeAll(Data((response + "\n").utf8)) else { return }
+                publishSocketEvents(command: trimmed, response: response)
+            }
         }
         if !socketServer.isConnectionAuthorizationCurrent(authorizationGeneration) {
-            _ = writeSocketResponse(Self.socketClientAccessDeniedResponse, to: socket)
+            _ = await writer.writeAll(Data((Self.socketClientAccessDeniedResponse + "\n").utf8))
         }
     }
 
@@ -2126,7 +2171,7 @@ class TerminalController {
         return processCommandUsingSocketExecutionPolicy(line) ?? ""
     }
 
-    private func processCommand(_ command: String) -> String {
+    func processCommand(_ command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "ERROR: Empty command" }
 
@@ -2362,7 +2407,7 @@ class TerminalController {
     /// result whose JSON bridging/serialization runs on the socket-worker
     /// thread after the hop, or a response the legacy switch already encoded
     /// on the main actor (see `v2LegacyMainActorResponse`).
-    private enum V2MainHopOutcome {
+    enum V2MainHopOutcome: Sendable {
         case callResult(ControlCallResult)
         case encoded(String)
     }
@@ -2429,7 +2474,7 @@ class TerminalController {
     /// before `controlCommandCoordinator.handle` here must also be added
     /// there, or the tranche-D worker-lane verbs silently fork from the
     /// main lane.
-    private func v2MainActorResponse(
+    func v2MainActorResponse(
         request: ControlRequest,
         id: Any?,
         method: String,
@@ -3210,7 +3255,7 @@ class TerminalController {
         ]
     }
 
-    private nonisolated func processAggregates(
+    nonisolated func processAggregates(
         from processSnapshot: CmuxTopProcessSnapshot,
         totalPIDs: Set<Int>
     ) -> (programs: [[String: Any]], codingAgents: [[String: Any]]) {
@@ -3327,7 +3372,7 @@ class TerminalController {
         return .ok(payload)
     }
 
-    private func v2SystemTopBasePayload(params: [String: Any]) -> V2CallResult {
+    func v2SystemTopBasePayload(params: [String: Any]) -> V2CallResult {
         let workspaceFilter = v2UUID(params, "workspace_id")
         if params["workspace_id"] != nil && workspaceFilter == nil {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
@@ -3824,7 +3869,7 @@ class TerminalController {
         case err(code: String, message: String, data: Any?)
     }
 
-    private nonisolated func v2Result(id: Any?, _ res: V2CallResult) -> String {
+    nonisolated func v2Result(id: Any?, _ res: V2CallResult) -> String {
         switch res {
         case .ok(let payload):
             return v2Ok(id: id, result: payload)
@@ -3833,7 +3878,7 @@ class TerminalController {
         }
     }
 
-    private nonisolated func v2UnsupportedWorkspaceAliasError(method: String, params: [String: Any]) -> V2CallResult? {
+    nonisolated func v2UnsupportedWorkspaceAliasError(method: String, params: [String: Any]) -> V2CallResult? {
         guard method.hasPrefix("workspace."), params.keys.contains("window") else { return nil }
         return .err(
             code: "invalid_params",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1738,7 +1738,7 @@ class TerminalController {
             writer.cancel()
         }
         while let line = await lineReader.nextLine(shouldContinueReading: {
-            socketServer.isConnectionAuthorizationCurrent(authorizationGeneration)
+            self.socketServer.isConnectionAuthorizationCurrent(authorizationGeneration)
         }) {
             let receivedCommand = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !receivedCommand.isEmpty else { continue }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1106,7 +1106,7 @@ class TerminalController {
     nonisolated static let v2Parser = ControlRequestParser()
     nonisolated static let v2Encoder = ControlResponseEncoder()
 
-    private nonisolated static func executionPolicy(forV2Method method: String) -> ControlCommandExecutionPolicy {
+    nonisolated static func executionPolicy(forV2Method method: String) -> ControlCommandExecutionPolicy {
         ControlCommandExecutionPolicy(forMethod: method)
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -188,7 +188,7 @@ class TerminalController {
     /// mirror synchronously before falling back to a live command path.
     nonisolated let socketReadSnapshotStore = ControlReadSnapshotStore()
     /// Coalesced main-actor publication task for topology/read snapshots.
-    private var socketReadSnapshotRefreshTask: Task<Void, Never>? = nil
+    var socketReadSnapshotRefreshTask: Task<Void, Never>? = nil
     /// Topology notifications that invalidate the published read mirror.
     private var socketReadSnapshotObservers: [NSObjectProtocol] = []
     // Per-surface dedupe for high-frequency report_* socket telemetry.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2302,6 +2302,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE00000000000000000C56 /* TerminalController+ControlPaneContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */; };
 		C0DE00000000000000000D84 /* TerminalController+ControlPaneDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000D83 /* TerminalController+ControlPaneDock.swift */; };
 		C0DE00000000000000000C70 /* TerminalController+ControlProjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C6F /* TerminalController+ControlProjectContext.swift */; };
+		D10548000000000000000013 /* TerminalController+ControlReadSnapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10548000000000000000014 /* TerminalController+ControlReadSnapshots.swift */; };
 		C0DE00000000000000000C72 /* TerminalController+ControlSidebarContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C71 /* TerminalController+ControlSidebarContext.swift */; };
 		C0DE00000000000000000C74 /* TerminalController+ControlSidebarContext2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C73 /* TerminalController+ControlSidebarContext2.swift */; };
 		C0DE00000000000000000C76 /* TerminalController+ControlSidebarContext3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C75 /* TerminalController+ControlSidebarContext3.swift */; };
@@ -2311,6 +2312,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C51A74000000000000000001 /* TerminalController+ControlSimulatorOperationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A74000000000000000002 /* TerminalController+ControlSimulatorOperationPayloads.swift */; };
 		C51A7300000000000000000B /* TerminalController+ControlSimulatorOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A7300000000000000000C /* TerminalController+ControlSimulatorOperations.swift */; };
 		C51A73000000000000000009 /* TerminalController+ControlSimulatorWebInspectorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A7300000000000000000A /* TerminalController+ControlSimulatorWebInspectorContext.swift */; };
+		D10548000000000000000011 /* TerminalController+ControlSocketAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10548000000000000000012 /* TerminalController+ControlSocketAsync.swift */; };
 		C0DE00000000000000000C64 /* TerminalController+ControlSurfaceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C63 /* TerminalController+ControlSurfaceContext.swift */; };
 		C0DE00000000000000000C66 /* TerminalController+ControlSurfaceContext2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C65 /* TerminalController+ControlSurfaceContext2.swift */; };
 		C0DE00000000000000000C68 /* TerminalController+ControlSurfaceContext3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C67 /* TerminalController+ControlSurfaceContext3.swift */; };
@@ -5090,6 +5092,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlPaneContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000D83 /* TerminalController+ControlPaneDock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlPaneDock.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C6F /* TerminalController+ControlProjectContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlProjectContext.swift"; sourceTree = "<group>"; };
+		D10548000000000000000014 /* TerminalController+ControlReadSnapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlReadSnapshots.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C71 /* TerminalController+ControlSidebarContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSidebarContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C73 /* TerminalController+ControlSidebarContext2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSidebarContext2.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C75 /* TerminalController+ControlSidebarContext3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSidebarContext3.swift"; sourceTree = "<group>"; };
@@ -5099,6 +5102,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C51A74000000000000000002 /* TerminalController+ControlSimulatorOperationPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSimulatorOperationPayloads.swift"; sourceTree = "<group>"; };
 		C51A7300000000000000000C /* TerminalController+ControlSimulatorOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSimulatorOperations.swift"; sourceTree = "<group>"; };
 		C51A7300000000000000000A /* TerminalController+ControlSimulatorWebInspectorContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSimulatorWebInspectorContext.swift"; sourceTree = "<group>"; };
+		D10548000000000000000012 /* TerminalController+ControlSocketAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSocketAsync.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C63 /* TerminalController+ControlSurfaceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSurfaceContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C65 /* TerminalController+ControlSurfaceContext2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSurfaceContext2.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C67 /* TerminalController+ControlSurfaceContext3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSurfaceContext3.swift"; sourceTree = "<group>"; };
@@ -6765,6 +6769,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */,
 				C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */,
 				C0DE00000000000000000C31 /* TerminalControllerControlCommandContext.swift */,
+				D10548000000000000000012 /* TerminalController+ControlSocketAsync.swift */,
+				D10548000000000000000014 /* TerminalController+ControlReadSnapshots.swift */,
 				C0DE00000000000000000C41 /* TerminalController+ControlAppFocusContext.swift */,
 				C0DE00000000000000000C43 /* TerminalController+ControlFeedContext.swift */,
 				8672D0048672D0048672D004 /* TerminalController+FeedAcknowledgment.swift */,
@@ -10435,6 +10441,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000C56 /* TerminalController+ControlPaneContext.swift in Sources */,
 				C0DE00000000000000000D84 /* TerminalController+ControlPaneDock.swift in Sources */,
 				C0DE00000000000000000C70 /* TerminalController+ControlProjectContext.swift in Sources */,
+				D10548000000000000000013 /* TerminalController+ControlReadSnapshots.swift in Sources */,
 				C0DE00000000000000000C72 /* TerminalController+ControlSidebarContext.swift in Sources */,
 				C0DE00000000000000000C74 /* TerminalController+ControlSidebarContext2.swift in Sources */,
 				C0DE00000000000000000C76 /* TerminalController+ControlSidebarContext3.swift in Sources */,
@@ -10444,6 +10451,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C51A74000000000000000001 /* TerminalController+ControlSimulatorOperationPayloads.swift in Sources */,
 				C51A7300000000000000000B /* TerminalController+ControlSimulatorOperations.swift in Sources */,
 				C51A73000000000000000009 /* TerminalController+ControlSimulatorWebInspectorContext.swift in Sources */,
+				D10548000000000000000011 /* TerminalController+ControlSocketAsync.swift in Sources */,
 				C0DE00000000000000000C64 /* TerminalController+ControlSurfaceContext.swift in Sources */,
 				C0DE00000000000000000C66 /* TerminalController+ControlSurfaceContext2.swift in Sources */,
 				C0DE00000000000000000C68 /* TerminalController+ControlSurfaceContext3.swift in Sources */,

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -157,6 +157,9 @@
          location = "group:CmuxPanes">
       </FileRef>
       <FileRef
+         location = "group:CmuxPhonePush">
+      </FileRef>
+      <FileRef
          location = "group:CMUXProjectModel">
       </FileRef>
       <FileRef


### PR DESCRIPTION
## Summary

Closes https://github.com/manaflow-ai/cmux/issues/10548

This implements the concrete control-plane slice of https://github.com/manaflow-ai/cmux/issues/5757:

- accepted connections are admitted through an actor-owned bounded async pool (32 active / 64 queued) instead of one detached `NSThread` per connection;
- socket reads and writes use cancellable DispatchSource-backed async transport, preserving per-connection FIFO while main-actor mutations suspend rather than blocking I/O threads;
- topology/read-heavy v2 results are published as immutable typed snapshots and served lock-free from socket workers;
- polling commands receive per-connection token-bucket backpressure;
- EOF, revocation, timeout, and writable-backpressure paths cancel their sources so dead descriptors cannot spin.

The existing synchronous in-process `handleSocketLine` path remains for app-internal callers; socket traffic uses the async dispatcher and keeps the focus-policy stack and response ordering semantics.

## Tests and validation

- `swift build --package-path Packages/macOS/CmuxControlSocket`
- focused Swift Testing suites for bounded admission, snapshot publication/concurrent readers, polling backpressure, async framing/revocation/write/timeout
- `python3 scripts/swift_warning_budget.py --log /tmp/cmux-final-build.log`
- `python3 scripts/check-package-resolved-policy.py`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/normalize-pbxproj.py --check cmux.xcodeproj/project.pbxproj`

The full standalone package suite reaches 396 tests on this checkout; an existing `MobileTaskModelDiscovery` fixture currently fails because it supplies a bare `opencode/dynamic-*` line while the parser requires the documented JSON record. No app/Xcode build or UI test was run locally per issue instructions.

## Scope notes

No user-facing UI strings or localization catalogs changed. The workspace package-group file was regenerated by the repository checker to include the already-present `CmuxPhonePush` package.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789953449&installation_model_id=21920&pr_number=10558&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10558&signature=d05668a7a24ccc97f4a919ed3a8710ef15c38f34bc713a633ae31f48bb8a346b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves control-socket connections and I/O off the main actor to reduce contention and prevent kqueue spin. Old: one thread per connection that could block the main actor; new: a bounded async pool (32 concurrent / 64 queued) with cancellable DispatchSource transport preserves per-connection FIFO.

- Adds ControlClientWorkerPool and ControlClientAsyncLineReader; cancels sources on EOF/error/revocation and explicitly captures the socket server to avoid lifecycle bugs.
- Serves read-heavy methods from immutable snapshots via ControlReadSnapshotStore; snapshots expire to avoid stale responses and fall back to live when missing; exposes a coalesced snapshot refresh task.
- Introduces per-connection token-bucket backpressure for polling; mutations and probes bypass limits.
- Keeps the in-process synchronous handleSocketLine path and response-order semantics unchanged.
- Makes SocketAuthorizationRevocationSignal.revoke and SocketTransport.configureBlocking public; introduces `CmuxControlSocketAtomicsC` for macOS 14-compatible atomics.
- Removes unreachable mobile artifact error cases to simplify error handling; no user-visible change.

<sup>Written for commit 2685df94612f950dc8bc079a952d78395cceb192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous, non-blocking control-socket communication.
  * Added connection concurrency limits and polling-rate controls.
  * Added cached read snapshots for faster control-plane responses.
  * Added orderly connection shutdown and event-stream support.
* **Bug Fixes**
  * Improved authorization, cancellation, timeout, buffering, and malformed-input handling.
  * Improved handling of concurrent requests and connection overload.
  * Improved localized error messages when mobile panel artifacts cannot be accessed.
* **Documentation**
  * Updated package documentation for asynchronous transport, snapshots, rate limiting, and connection management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->