### PR TITLE
Fix non-exhaustive AgentHookFailureStage switch breaking nightly build

### DIFF
--- a/CLI/CMUXCLI+AgentHookFailureReporting.swift
+++ b/CLI/CMUXCLI+AgentHookFailureReporting.swift
@@ -57,6 +57,15 @@ extension CMUXCLI {
                 agentName,
                 event
             )
+        case .journalAppend:
+            failureDescription = String.localizedStringWithFormat(
+                String(
+                    localized: "cli.agentHook.error.journalAppend",
+                    defaultValue: "Agent hook journal append failed for %@ %@."
+                ),
+                agentName,
+                event
+            )
         }
         let userInfo: [String: Any] = [
             NSLocalizedDescriptionKey: failureDescription,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4141,8 +4141,26 @@
     "cli.agentHook.error.journalAppend": {
       "extractionState": "manual",
       "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "فشل إلحاق سجل خطاف الوكيل لـ %@ %@." } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Dodavanje agentske kuke u dnevnik nije uspjelo za %@ %@." } },
+        "da": { "stringUnit": { "state": "translated", "value": "Tilføjelse af agent-hook til journalen mislykkedes for %@ %@." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Das Anhängen des Agent-Hooks an das Journal ist für %@ %@ fehlgeschlagen." } },
         "en": { "stringUnit": { "state": "translated", "value": "Agent hook journal append failed for %@ %@." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフックのジャーナル追記に失敗しました。" } }
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo añadir el hook del agente al diario para %@ %@." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échec de l’ajout du hook d’agent au journal pour %@ %@." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Impossibile aggiungere l’hook dell’agente al diario per %@ %@." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフックのジャーナル追記に失敗しました。" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ការបន្ថែម agent hook ទៅក្នុងកំណត់ហេតុបានបរាជ័យសម្រាប់ %@ %@។" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 저널 추가에 실패했습니다." } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Det oppstod en feil ved å legge agent-hooken til journalen for %@ %@." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się dodać haka agenta do dziennika dla %@ %@." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao adicionar o hook do agente ao diário para %@ %@." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось добавить хук агента в журнал для %@ %@." } },
+        "th": { "stringUnit": { "state": "translated", "value": "เพิ่ม agent hook ลงในบันทึกประจำวันสำหรับ %@ %@ ไม่สำเร็จ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancasını günlüğe ekleme başarısız oldu." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося додати хук агента до журналу для %@ %@." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法将 %@ %@ 的代理钩子追加到日志。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法將 %@ %@ 的代理程式掛鉤追加到日誌。" } }
       }
     },
     "cli.agentHook.error.targetResolution": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4138,6 +4138,13 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法傳遞 %@ %@ 的代理程式掛鉤通知。" } }
       }
     },
+    "cli.agentHook.error.journalAppend": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Agent hook journal append failed for %@ %@." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフックのジャーナル追記に失敗しました。" } }
+      }
+    },
     "cli.agentHook.error.targetResolution": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary

- Handle `.journalAppend` explicitly in the agent-hook failure reporting switch.
- Add the localized `cli.agentHook.error.journalAppend` message in English and Japanese.

## Root cause

PR https://github.com/manaflow-ai/cmux/pull/10490 added `journalAppend` to `AgentHookFailureStage`, while PR https://github.com/manaflow-ai/cmux/pull/10551 rewrote the reporting switch without that case. The combined change made the Release `cmux-cli` build fail with a non-exhaustive switch. The failing nightly run is https://github.com/manaflow-ai/cmux/actions/runs/32548349860.

This patch keeps the switch explicit (no default case), so future enum additions continue to fail at compile time until handled.

## Verification

- Focused `swiftc -warnings-as-errors -typecheck` passed for the enum and reporting sources.
- Repository-wide grep confirms the reporting switch handles all three enum cases.
- `Resources/Localizable.xcstrings` JSON and English/Japanese placeholder parity validated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789962384&installation_model_id=21920&pr_number=10565&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10565&signature=02cab10c6b03247c738ffadc96ea948c06751081c2a9eb3fad2e21bbb430067b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a non-exhaustive `AgentHookFailureStage` switch by handling `journalAppend`, restoring the Release `cmux-cli` build and emitting a localized error. Previously the switch omitted `journalAppend` and failed to compile.

- Keeps the switch exhaustive with no default case to enforce compile-time coverage.
- Adds `cli.agentHook.error.journalAppend` to `Resources/Localizable.xcstrings` with translations across supported locales.
- No migrations or API changes.

<sup>Written for commit b6c467b6b8e811a581a81bc6792916e7940566db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when agent hook journal updates fail.
  * Failure messages now identify the affected agent and event.

* **Localization**
  * Added translated journal update failure messages across 19 locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->