### PR TITLE
Prevent WebKit navigation decision handler crashes

### DIFF
--- a/Sources/Panels/AgentSessionWebRendererCoordinator.swift
+++ b/Sources/Panels/AgentSessionWebRendererCoordinator.swift
@@ -217,7 +217,7 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationActionDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationActionPolicy.cancel,
             label: "AgentSessionWebRendererCoordinator.navigationAction"

--- a/Sources/Panels/AgentSessionWebRendererCoordinator.swift
+++ b/Sources/Panels/AgentSessionWebRendererCoordinator.swift
@@ -217,6 +217,12 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationActionPolicy.cancel,
+            label: "AgentSessionWebRendererCoordinator.navigationAction"
+        ).closure
+
         guard let url = navigationAction.request.url else {
             decisionHandler(.allow)
             return

--- a/Sources/Panels/BrowserAuthCallbackNavigationPolicy.swift
+++ b/Sources/Panels/BrowserAuthCallbackNavigationPolicy.swift
@@ -104,19 +104,22 @@ struct BrowserAuthCallbackNavigationPolicy {
         switch disposition {
         case .passThrough:
             return false
-        case .block:
+        case .block, .deliverInApp:
+            // Every consumed disposition must close WebKit's policy decision
+            // before any follow-up work can run. Keeping this outside the
+            // delivery-specific branch prevents a new consumed case from
+            // accidentally returning with an uncalled handler.
             cancelNavigation()
             reportTerminalCancellation()
-            return true
-        case .deliverInApp:
+        }
+
+        if case .deliverInApp = disposition {
             let returnURL = Self.webReturnURL(fromPageURL: sourcePageURL)
-            cancelNavigation()
-            reportTerminalCancellation()
             Task { @MainActor in
                 completion(await deliver(callbackURL), returnURL)
             }
-            return true
         }
+        return true
     }
 
     /// Completes a consumed callback consistently across browser surfaces.

--- a/Sources/Panels/BrowserNavigationDecisionHandler.swift
+++ b/Sources/Panels/BrowserNavigationDecisionHandler.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Guarantees that a WebKit navigation policy callback is completed at most once.
+///
+/// WebKit invokes navigation policy delegates on the main thread and requires
+/// the supplied callback to be completed synchronously. Keeping this state in a
+/// small synchronous wrapper lets `deinit` cancel an abandoned callback without
+/// introducing an async hop that could outlive WebKit's policy decision.
+final class BrowserNavigationDecisionHandler<Policy> {
+    private var pendingHandler: ((Policy) -> Void)?
+    private let fallbackPolicy: Policy
+    private let label: String
+
+    init(
+        _ decisionHandler: @escaping (Policy) -> Void,
+        fallbackPolicy: Policy,
+        label: String
+    ) {
+        pendingHandler = decisionHandler
+        self.fallbackPolicy = fallbackPolicy
+        self.label = label
+    }
+
+    /// Returns a closure view that keeps this guard alive while a policy path is pending.
+    var closure: (Policy) -> Void {
+        { [self] policy in
+            self(policy)
+        }
+    }
+
+    func callAsFunction(_ policy: Policy) {
+        guard let pendingHandler else {
+            log("decision callback invoked more than once")
+            return
+        }
+        self.pendingHandler = nil
+        pendingHandler(policy)
+    }
+
+    deinit {
+        guard let pendingHandler else { return }
+        log("decision callback was dropped; applying fallback policy")
+        pendingHandler(fallbackPolicy)
+    }
+
+    private func log(_ message: String) {
+        NSLog("Browser navigation decision handler (%@): %@", label, message)
+    }
+}

--- a/Sources/Panels/BrowserNavigationDecisionHandler.swift
+++ b/Sources/Panels/BrowserNavigationDecisionHandler.swift
@@ -1,4 +1,10 @@
 import Foundation
+import OSLog
+
+nonisolated private let browserNavigationDecisionHandlerLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "BrowserNavigationDecision"
+)
 
 /// Guarantees that a WebKit navigation policy callback is completed at most once.
 ///
@@ -44,6 +50,8 @@ final class BrowserNavigationDecisionHandler<Policy> {
     }
 
     private func log(_ message: String) {
-        NSLog("Browser navigation decision handler (%@): %@", label, message)
+        browserNavigationDecisionHandlerLogger.error(
+            "\(message, privacy: .public) label=\(self.label, privacy: .public)"
+        )
     }
 }

--- a/Sources/Panels/BrowserNavigationDecisionHandler.swift
+++ b/Sources/Panels/BrowserNavigationDecisionHandler.swift
@@ -1,10 +1,19 @@
 import Foundation
 import OSLog
+import WebKit
 
 nonisolated private let browserNavigationDecisionHandlerLogger = Logger(
     subsystem: "com.cmuxterm.app",
     category: "BrowserNavigationDecision"
 )
+
+/// Guards a WebKit action-policy callback with a cancellation fallback.
+typealias BrowserNavigationActionDecisionHandler =
+    BrowserNavigationDecisionHandler<WKNavigationActionPolicy>
+
+/// Guards a WebKit response-policy callback with a cancellation fallback.
+typealias BrowserNavigationResponseDecisionHandler =
+    BrowserNavigationDecisionHandler<WKNavigationResponsePolicy>
 
 /// Guarantees that a WebKit navigation policy callback is completed at most once.
 ///

--- a/Sources/Panels/BrowserNavigationDecisionHandler.swift
+++ b/Sources/Panels/BrowserNavigationDecisionHandler.swift
@@ -17,6 +17,7 @@ final class BrowserNavigationDecisionHandler<Policy> {
     private let fallbackPolicy: Policy
     private let label: String
 
+    /// Creates a guard that forwards the first policy and cancels an abandoned one.
     init(
         _ decisionHandler: @escaping (Policy) -> Void,
         fallbackPolicy: Policy,
@@ -34,6 +35,7 @@ final class BrowserNavigationDecisionHandler<Policy> {
         }
     }
 
+    /// Forwards one policy decision and ignores any later completion attempts.
     func callAsFunction(_ policy: Policy) {
         guard let pendingHandler else {
             log("decision callback invoked more than once")
@@ -49,6 +51,7 @@ final class BrowserNavigationDecisionHandler<Policy> {
         pendingHandler(fallbackPolicy)
     }
 
+    /// Emits a diagnostic without coupling callback cleanup to an actor.
     private func log(_ message: String) {
         browserNavigationDecisionHandlerLogger.error(
             "\(message, privacy: .public) label=\(self.label, privacy: .public)"

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -608,7 +608,8 @@ import WebKit
         let replacedNavigation = activeMainFrameNavigation
         let reportReplacementWillStart = willReplaceNavigationForUserAgentPolicy
         return webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
-            navigationAction,
+            request: navigationAction.request,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
             decisionHandler: decisionHandler,
             willRestart: {
                 reportReplacementWillStart?(webView, replacedNavigation)

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -282,7 +282,7 @@ import WebKit
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationActionDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationActionPolicy.cancel,
             label: "BrowserNavigationDelegate.navigationAction"
@@ -708,7 +708,7 @@ import WebKit
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationResponseDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationResponsePolicy.cancel,
             label: "BrowserNavigationDelegate.navigationResponse"

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -282,6 +282,12 @@ import WebKit
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationActionPolicy.cancel,
+            label: "BrowserNavigationDelegate.navigationAction"
+        ).closure
+
         if let url = navigationAction.request.url,
            url.scheme == "cmux-browser-action",
            url.host == "bypass-ssl" {
@@ -701,6 +707,12 @@ import WebKit
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationResponsePolicy.cancel,
+            label: "BrowserNavigationDelegate.navigationResponse"
+        ).closure
+
         if let url = navigationResponse.response.url {
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             if !isTrustedInternal,

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -205,10 +205,7 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
             }
         }
         urlObservation = webView.observe(\.url, options: [.new]) { [weak self, weak navDel] _, change in
-            let observedDisplayURL = navDel?.activePolicyBlockedURL
-                .map { BrowserURLAllowlistBlockedPage.safeDisplayOrigin(for: $0) }
-                ?? change.newValue??.absoluteString
-                ?? ""
+            let observedDisplayURL = change.newValue??.absoluteString ?? ""
             Task { @MainActor [weak self, weak navDel] in
                 self?.urlLabel.stringValue = navDel?.activePolicyBlockedURL
                     .map { BrowserURLAllowlistBlockedPage.safeDisplayOrigin(for: $0) }

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -849,7 +849,8 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         }
 
         return webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
-            navigationAction,
+            request: navigationAction.request,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
             decisionHandler: decisionHandler,
             startReplacement: { restartRequest in
                 controller.requestNavigation(restartRequest, in: webView)

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -693,6 +693,12 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationActionPolicy.cancel,
+            label: "PopupNavigationDelegate.navigationAction"
+        ).closure
+
         if let url = navigationAction.request.url,
            url.scheme == "cmux-browser-action",
            url.host == "bypass-ssl" {
@@ -785,7 +791,11 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
             #if DEBUG
             cmuxDebugLog("popup.nav.insecureHTTP url=\(url.absoluteString)")
             #endif
-            controller?.presentInsecureHTTPAlert(for: url, in: webView) { policy in
+            guard let controller else {
+                decisionHandler(.cancel)
+                return
+            }
+            controller.presentInsecureHTTPAlert(for: url, in: webView) { policy in
                 if policy == .allow,
                    self.restartNavigationForUserAgentPolicyIfNeeded(
                        navigationAction,
@@ -895,6 +905,12 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationResponsePolicy.cancel,
+            label: "PopupNavigationDelegate.navigationResponse"
+        ).closure
+
         if let url = navigationResponse.response.url,
            !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
             decisionHandler(.cancel)

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -693,7 +693,7 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationActionDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationActionPolicy.cancel,
             label: "PopupNavigationDelegate.navigationAction"
@@ -906,7 +906,7 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationResponseDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationResponsePolicy.cancel,
             label: "PopupNavigationDelegate.navigationResponse"

--- a/Sources/Panels/BrowserPrewarmedWebViewPool.swift
+++ b/Sources/Panels/BrowserPrewarmedWebViewPool.swift
@@ -215,7 +215,7 @@ extension BrowserPrewarmedWebViewPool: WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationActionDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationActionPolicy.cancel,
             label: "BrowserPrewarmedWebViewPool.navigationAction"
@@ -235,7 +235,7 @@ extension BrowserPrewarmedWebViewPool: WKNavigationDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationResponseDecisionHandler(
             decisionHandler,
             fallbackPolicy: WKNavigationResponsePolicy.cancel,
             label: "BrowserPrewarmedWebViewPool.navigationResponse"

--- a/Sources/Panels/BrowserPrewarmedWebViewPool.swift
+++ b/Sources/Panels/BrowserPrewarmedWebViewPool.swift
@@ -215,6 +215,12 @@ extension BrowserPrewarmedWebViewPool: WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationActionPolicy.cancel,
+            label: "BrowserPrewarmedWebViewPool.navigationAction"
+        ).closure
+
         if let url = navigationAction.request.url,
            !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
             decisionHandler(.cancel)
@@ -229,6 +235,12 @@ extension BrowserPrewarmedWebViewPool: WKNavigationDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            decisionHandler,
+            fallbackPolicy: WKNavigationResponsePolicy.cancel,
+            label: "BrowserPrewarmedWebViewPool.navigationResponse"
+        ).closure
+
         if let url = navigationResponse.response.url,
            !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
             decisionHandler(.cancel)

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -797,6 +797,12 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
         ) {
+            let decisionHandler = BrowserNavigationDecisionHandler(
+                decisionHandler,
+                fallbackPolicy: WKNavigationActionPolicy.cancel,
+                label: "MarkdownWebRenderer.Coordinator.navigationAction"
+            ).closure
+
             // The first load (loadHTMLString) has navigationType = .other —
             // allow it. Anything the user clicks (links, anchors, ...) we
             // route through the cmux tab/browser machinery.

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -797,7 +797,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
         ) {
-            let decisionHandler = BrowserNavigationDecisionHandler(
+            let decisionHandler = BrowserNavigationActionDecisionHandler(
                 decisionHandler,
                 fallbackPolicy: WKNavigationActionPolicy.cancel,
                 label: "MarkdownWebRenderer.Coordinator.navigationAction"

--- a/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
+++ b/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
@@ -40,24 +40,7 @@ extension WKWebView {
         return browserUserAgentPolicyRestartRequest(for: request)
     }
 
-    @MainActor
-    func restartNavigationForBrowserUserAgentPolicyIfNeeded(
-        _ navigationAction: WKNavigationAction,
-        decisionHandler: (WKNavigationActionPolicy) -> Void,
-        willRestart: () -> Void = {},
-        startReplacement: (URLRequest) -> Void
-    ) -> Bool {
-        restartNavigationForBrowserUserAgentPolicyIfNeeded(
-            request: navigationAction.request,
-            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
-            decisionHandler: decisionHandler,
-            willRestart: willRestart,
-            startReplacement: startReplacement
-        )
-    }
-
-    /// Testable policy seam for the WebKit adapter; callers pass the action's
-    /// request and frame identity after extracting those values from WebKit.
+    /// Applies a changed user-agent policy to a main-frame request and starts its replacement.
     @MainActor
     @discardableResult
     func restartNavigationForBrowserUserAgentPolicyIfNeeded(

--- a/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
+++ b/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
@@ -47,9 +47,29 @@ extension WKWebView {
         willRestart: () -> Void = {},
         startReplacement: (URLRequest) -> Void
     ) -> Bool {
+        restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            request: navigationAction.request,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
+            decisionHandler: decisionHandler,
+            willRestart: willRestart,
+            startReplacement: startReplacement
+        )
+    }
+
+    /// Testable policy seam for the WebKit adapter; callers pass the action's
+    /// request and frame identity after extracting those values from WebKit.
+    @MainActor
+    @discardableResult
+    func restartNavigationForBrowserUserAgentPolicyIfNeeded(
+        request: URLRequest,
+        targetFrameIsMainFrame: Bool?,
+        decisionHandler: (WKNavigationActionPolicy) -> Void,
+        willRestart: () -> Void = {},
+        startReplacement: (URLRequest) -> Void
+    ) -> Bool {
         guard let restartRequest = browserUserAgentPolicyRestartRequest(
-            for: navigationAction.request,
-            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+            for: request,
+            targetFrameIsMainFrame: targetFrameIsMainFrame
         ) else {
             return false
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A500MR01 /* BrowserMediaPlaybackReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MR00 /* BrowserMediaPlaybackReport.swift */; };
 		A85970000000000000000001 /* BrowserNavigableURLPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85970000000000000000002 /* BrowserNavigableURLPasteTests.swift */; };
 		C67540080000000000000001 /* BrowserNavigationDebugURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540080000000000000002 /* BrowserNavigationDebugURL.swift */; };
+		BABA25000000000000000010 /* BrowserNavigationDecisionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABA25000000000000000011 /* BrowserNavigationDecisionHandler.swift */; };
 		BABA25000000000000000009 /* BrowserNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABA2500000000000000000A /* BrowserNavigationDelegate.swift */; };
 		B424PWNP000000000000PW01 /* BrowserNavigationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */; };
 		C67540100000000000000001 /* BrowserNavigationPopupPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540100000000000000002 /* BrowserNavigationPopupPolicy.swift */; };
@@ -3279,6 +3280,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A500MR00 /* BrowserMediaPlaybackReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserMediaPlaybackReport.swift; sourceTree = "<group>"; };
 		A85970000000000000000002 /* BrowserNavigableURLPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigableURLPasteTests.swift; sourceTree = "<group>"; };
 		C67540080000000000000002 /* BrowserNavigationDebugURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationDebugURL.swift; sourceTree = "<group>"; };
+		BABA25000000000000000011 /* BrowserNavigationDecisionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationDecisionHandler.swift; sourceTree = "<group>"; };
 		BABA2500000000000000000A /* BrowserNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationDelegate.swift; sourceTree = "<group>"; };
 		B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationPolicy.swift; sourceTree = "<group>"; };
 		C67540100000000000000002 /* BrowserNavigationPopupPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationPopupPolicy.swift; sourceTree = "<group>"; };
@@ -7121,6 +7123,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				BABA2500000000000000000C /* BrowserHTTPBasicAuthProtectionSpaceKey.swift */,
 				BABA2500000000000000000E /* BrowserHTTPBasicAuthPromptRequest.swift */,
 				BABA2500000000000000000A /* BrowserNavigationDelegate.swift */,
+				BABA25000000000000000011 /* BrowserNavigationDecisionHandler.swift */,
 				C67540080000000000000002 /* BrowserNavigationDebugURL.swift */,
 				D93410010000000000000002 /* BrowserChromePopoverAppearance.swift */,
 				C67540110000000000000002 /* BrowserDownloadRecord.swift */,
@@ -9324,6 +9327,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A500MH01 /* BrowserMediaPlaybackMessageHandler.swift in Sources */,
 				A500MR01 /* BrowserMediaPlaybackReport.swift in Sources */,
 				C67540080000000000000001 /* BrowserNavigationDebugURL.swift in Sources */,
+				BABA25000000000000000010 /* BrowserNavigationDecisionHandler.swift in Sources */,
 				BABA25000000000000000009 /* BrowserNavigationDelegate.swift in Sources */,
 				B424PWNP000000000000PW01 /* BrowserNavigationPolicy.swift in Sources */,
 				C67540100000000000000001 /* BrowserNavigationPopupPolicy.swift in Sources */,

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -139,7 +139,7 @@ struct BrowserNavigationDecisionHandlerTests {
     @Test
     func navigationDecisionHandlerInvokesUnderlyingHandlerAtMostOnce() {
         var policies: [WKNavigationActionPolicy] = []
-        let decisionHandler = BrowserNavigationDecisionHandler(
+        let decisionHandler = BrowserNavigationActionDecisionHandler(
             { policies.append($0) },
             fallbackPolicy: WKNavigationActionPolicy.cancel,
             label: "test.double-call"
@@ -156,7 +156,7 @@ struct BrowserNavigationDecisionHandlerTests {
     func navigationDecisionHandlerCancelsWhenConsumedPathDropsHandler() {
         var policies: [WKNavigationActionPolicy] = []
         var droppedHandler: ((WKNavigationActionPolicy) -> Void)? =
-            BrowserNavigationDecisionHandler(
+            BrowserNavigationActionDecisionHandler(
                 { policies.append($0) },
                 fallbackPolicy: .cancel,
                 label: "test.dropped-consumed-path"
@@ -173,7 +173,7 @@ struct BrowserNavigationDecisionHandlerTests {
     func navigationResponseDecisionHandlerUsesCancelFallback() {
         var policies: [WKNavigationResponsePolicy] = []
         var droppedHandler: ((WKNavigationResponsePolicy) -> Void)? =
-            BrowserNavigationDecisionHandler(
+            BrowserNavigationResponseDecisionHandler(
                 { policies.append($0) },
                 fallbackPolicy: .cancel,
                 label: "test.dropped-response-path"

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -97,3 +97,39 @@ struct BrowserUserAgentPolicyWebKitTests {
         #expect(webView.customUserAgent?.isEmpty != false)
     }
 }
+
+@MainActor
+@Suite
+struct BrowserNavigationDecisionHandlerTests {
+    @Test
+    func navigationDecisionHandlerInvokesUnderlyingHandlerAtMostOnce() {
+        var policies: [WKNavigationActionPolicy] = []
+        let decisionHandler = BrowserNavigationDecisionHandler(
+            { policies.append($0) },
+            fallbackPolicy: WKNavigationActionPolicy.cancel,
+            label: "test.double-call"
+        )
+
+        decisionHandler(.allow)
+        decisionHandler(.download)
+
+        #expect(policies.count == 1)
+        #expect(policies.first == .allow)
+    }
+
+    @Test
+    func navigationDecisionHandlerCancelsWhenConsumedPathDropsHandler() {
+        var policies: [WKNavigationActionPolicy] = []
+        var droppedHandler: ((WKNavigationActionPolicy) -> Void)? =
+            BrowserNavigationDecisionHandler(
+                { policies.append($0) },
+                fallbackPolicy: .cancel,
+                label: "test.dropped-consumed-path"
+            ).closure
+
+        droppedHandler = nil
+
+        #expect(policies.count == 1)
+        #expect(policies.first == .cancel)
+    }
+}

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -96,6 +96,41 @@ struct BrowserUserAgentPolicyWebKitTests {
         #expect(webView.browserUserAgentPolicyRestartRequest(for: request) == nil)
         #expect(webView.customUserAgent?.isEmpty != false)
     }
+
+    @Test func restartPolicyCancelsOnceBeforeStartingReplacement() throws {
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let request = URLRequest(url: URL(string: "https://workspace.google.com/")!)
+        var policies: [WKNavigationActionPolicy] = []
+        var replacementRequests: [URLRequest] = []
+        var willRestartCount = 0
+
+        let restarted = webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            request: request,
+            targetFrameIsMainFrame: true,
+            decisionHandler: { policies.append($0) },
+            willRestart: { willRestartCount += 1 },
+            startReplacement: { replacementRequests.append($0) }
+        )
+
+        #expect(restarted)
+        #expect(policies.count == 1)
+        #expect(policies.first == .cancel)
+        #expect(willRestartCount == 1)
+        #expect(replacementRequests.count == 1)
+        #expect(replacementRequests.first?.value(forHTTPHeaderField: "User-Agent") == nil)
+
+        let replacementRequest = try #require(replacementRequests.first)
+        let restartedAgain = webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            request: replacementRequest,
+            targetFrameIsMainFrame: true,
+            decisionHandler: { policies.append($0) },
+            startReplacement: { replacementRequests.append($0) }
+        )
+
+        #expect(!restartedAgain)
+        #expect(policies.count == 1)
+        #expect(replacementRequests.count == 1)
+    }
 }
 
 @MainActor
@@ -127,6 +162,24 @@ struct BrowserNavigationDecisionHandlerTests {
                 label: "test.dropped-consumed-path"
             ).closure
 
+        withExtendedLifetime(droppedHandler) {}
+        droppedHandler = nil
+
+        #expect(policies.count == 1)
+        #expect(policies.first == .cancel)
+    }
+
+    @Test
+    func navigationResponseDecisionHandlerUsesCancelFallback() {
+        var policies: [WKNavigationResponsePolicy] = []
+        var droppedHandler: ((WKNavigationResponsePolicy) -> Void)? =
+            BrowserNavigationDecisionHandler(
+                { policies.append($0) },
+                fallbackPolicy: .cancel,
+                label: "test.dropped-response-path"
+            ).closure
+
+        withExtendedLifetime(droppedHandler) {}
         droppedHandler = nil
 
         #expect(policies.count == 1)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -84,8 +84,8 @@ struct BrowserWebContentProcessTests {
         let sourcePageURL = URL(
             string: "https://cmux.test/handler/after-sign-in?web_return_to=%2Fapp-pricing%3Fcmux_app%3D1"
         )!
-        var cancelled = false
-        var reportedTerminalCancellation = false
+        var cancellationCount = 0
+        var terminalCancellationReportCount = 0
 
         let completion = await withCheckedContinuation {
             (continuation: CheckedContinuation<(Bool, URL?), Never>) in
@@ -93,16 +93,16 @@ struct BrowserWebContentProcessTests {
                 disposition: .deliverInApp,
                 callbackURL: callbackURL,
                 sourcePageURL: sourcePageURL,
-                cancelNavigation: { cancelled = true },
-                reportTerminalCancellation: { reportedTerminalCancellation = true },
+                cancelNavigation: { cancellationCount += 1 },
+                reportTerminalCancellation: { terminalCancellationReportCount += 1 },
                 deliver: { _ in false },
                 completion: { delivered, returnURL in
                     continuation.resume(returning: (delivered, returnURL))
                 }
             )
             #expect(consumed)
-            #expect(cancelled)
-            #expect(reportedTerminalCancellation)
+            #expect(cancellationCount == 1)
+            #expect(terminalCancellationReportCount == 1)
         }
 
         #expect(!completion.0)
@@ -136,15 +136,15 @@ struct BrowserWebContentProcessTests {
             callbackScheme: "cmux-dev-test"
         )
         let callbackURL = URL(string: "cmux-nightly://auth-callback?refresh_token=secret")!
-        var cancelled = false
-        var reportedTerminalCancellation = false
+        var cancellationCount = 0
+        var terminalCancellationReportCount = 0
 
         let consumed = policy.consume(
             disposition: .block,
             callbackURL: callbackURL,
             sourcePageURL: nil,
-            cancelNavigation: { cancelled = true },
-            reportTerminalCancellation: { reportedTerminalCancellation = true },
+            cancelNavigation: { cancellationCount += 1 },
+            reportTerminalCancellation: { terminalCancellationReportCount += 1 },
             deliver: { _ in
                 Issue.record("Blocked callbacks must never be delivered")
                 return false
@@ -155,8 +155,8 @@ struct BrowserWebContentProcessTests {
         )
 
         #expect(consumed)
-        #expect(cancelled)
-        #expect(reportedTerminalCancellation)
+        #expect(cancellationCount == 1)
+        #expect(terminalCancellationReportCount == 1)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a synchronous exactly-once guard around every `WKNavigationDelegate` action/response decision handler.
- Cancel and unified-log an unexpected dropped callback, and ignore duplicate completions.
- Fix popup teardown where a missing controller previously returned from insecure-navigation policy without deciding the navigation.
- Centralize auth-callback cancellation and expose a request/frame seam for deterministic user-agent restart tests.

WebKit aborts when its navigation-policy completion handler is destroyed without being called. The guard preserves every existing decision on correct paths and safely cancels/logs an unexpected drop. The concrete popup teardown path is now explicitly cancelled as well.

Closes #10566

Issue: https://github.com/manaflow-ai/cmux/issues/10566

## Testing

- `swift build` in `Packages/macOS/CmuxBrowser` (pass).
- Swift syntax/type checks for all changed Swift files (pass).
- `./scripts/check-pbxproj.sh`, `./scripts/lint-pbxproj-test-wiring.sh`, `python3 scripts/check-package-resolved-policy.py`, and `python3 scripts/check-test-determinism.py --strict` (pass).
- Hosted `ci.yml` run `32554055288` passed all completed guard/package/web jobs; the macOS app-host shards reached compilation and are running the unit suites.
- No local Xcode or UI build was run, per the issue instructions.

## Demo Video

Not applicable: this is a crash-safety and policy-control-flow fix with no user-visible UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally with targeted non-Xcode validation.
- [x] I added or updated behavior tests for duplicate, dropped, auth-consumed, and user-agent-restart paths.
- [x] I updated docs/changelog if needed (no user-facing behavior or release notes changed).
- [x] Automated review bots ran after the latest implementation commit.
- [x] All actionable automated review comments are resolved.
- [ ] Human review comments remain pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling browser navigation, popups, redirects, and authentication callbacks.
  * Prevented navigation decisions from being applied more than once.
  * Added safe cancellation when navigation decisions cannot be completed.
  * Ensured blocked or failed authentication callbacks are cancelled and reported consistently.
  * Improved handling of insecure HTTP popups when required presentation is unavailable.
  * Improved browser user-agent updates during navigation restarts.
  * Preserved reliable routing for in-page, trusted, and external destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->