### PR TITLE
feat(cmux-tui): chatmux-relay slices 2+3 — PTY multi-viewer bridge + exec verbs

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -543,7 +543,11 @@ dependencies = [
 name = "chatmux-relay"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "base64",
+ "bytes",
+ "cmux-pty",
  "futures-util",
  "getrandom 0.3.4",
  "libc",

--- a/cmux-tui/crates/chatmux-relay/Cargo.toml
+++ b/cmux-tui/crates/chatmux-relay/Cargo.toml
@@ -18,7 +18,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
 base64.workspace = true
+bytes.workspace = true
+cmux-pty.workspace = true
 futures-util.workspace = true
 getrandom.workspace = true
 reqwest.workspace = true

--- a/cmux-tui/crates/chatmux-relay/README.md
+++ b/cmux-tui/crates/chatmux-relay/README.md
@@ -47,12 +47,22 @@ cutover — pre-launch, no legacy.
    YOLO receipt, managed enrollment (0600 check, shred after read,
    `managedSessionToken` kept in memory), `--allow-root` persistence,
    `--status`.
-2. **PTY bridge** — port `bin/pty.mjs` incl. the 0.0.10 MULTI-VIEWER
-   fan-out (any number of attachments per session/surface; `session_limit`
-   only for the process-wide PTY cap). `packages/relay/test/pty.test.mjs`
-   pins the behavior. Raise the advertised dialect to 4.
-3. **Exec verbs + trust gates** — port `bin/actions.mjs` (path scoping,
-   caps, timeouts). Raise the advertised dialect to 5.
+2. **PTY bridge (DONE)** — `pty.rs` ports `bin/pty.mjs`: the shell
+   fallback with a bounded scrollback ring and the 0.0.10 MULTI-VIEWER
+   fan-out (any number of attachments per session; `session_limit` only
+   for the process-wide `MAX_PTYS` cap), the cmux-tui whole-session viewer
+   path, the W86 raw single-terminal control-socket path, `surface_list`,
+   the buffered-output cap, and the no-empty-frame rule.
+   `packages/relay/test/pty.test.mjs` behaviors are mirrored in
+   `pty.rs::tests`. Real PTY allocation is `pty_deps.rs` (cmux-pty +
+   pipe-mode degradation); the control socket is `control.rs`.
+3. **Exec verbs + trust gates (DONE)** — `actions.rs` ports
+   `bin/actions.mjs`: exec/read/write/ls/grep/find with the 60k output
+   bound, 2 MB read cap, `--allow-root` + server-echoed path scoping,
+   lexical + canonical (realpath) double pass, O_NOFOLLOW opens, scrubbed
+   env, hard process-group timeouts, the v5 process-credential runtime,
+   and the reconciled-trust gate (observe = read-only verbs only).
+   Both slices raised the advertised dialect to **5**.
 4. **Wire-v6 pane verbs + preview proxy** — fs/git/watch verbs and the
    chobitsu-injecting preview proxy (chatmux pane-primitives program;
    these verbs have NO JS implementation — Rust-first by decision).
@@ -60,18 +70,20 @@ cutover — pre-launch, no legacy.
    `--uninstall`), replacing the npm runtime-install machinery with the
    platform binary path.
 
-### Intentional slice-1 divergences from the JS relay
+### Intentional divergences from the JS relay (still open)
 
-- The advertised relay protocol is **v2** (`wire::ADVERTISED_PROTOCOL_VERSION`)
-  until the verb slices land, so the Worker's designed old-relay degrade
-  applies instead of half-implemented verbs. The JS relay advertises v5.
-  If a verb frame arrives anyway (test override), the relay answers a
-  typed refusal instead of running it.
+- The advertised relay protocol is **v5** now that PTY + exec land. The
+  pane data-plane verbs (wire v6) and the journal forwarder are later
+  slices; the Worker's forward tolerance covers the gap.
 - `--code` prints the `chatmux://pair` link without the terminal QR
   graphic (QR rendering comes with a later slice; the link carries the
   same payload).
 - `--autostart` / `--uninstall` exit 1 with a pointer to the npm build
   (slice 5).
+- PTY frame dispatch is serialized on one task per connection, so a slow
+  `pty_open` (daemon spawn, up to 5s) delays a following frame for a
+  DIFFERENT pty. Acceptable for typical one-open-at-a-time use; revisit
+  if concurrent opens become common.
 
 ## Wire contract and the vendored protocol
 
@@ -85,8 +97,9 @@ is clearly marked for replacement. Once `packages/protocol/generated/rust/`
 exists in chatmux:
 
 1. In chatmux: `cd packages/protocol && bun run generate`.
-2. Copy `packages/protocol/generated/rust/relay.rs` (generated, do not
-   edit) into this crate as `src/protocol_generated.rs`.
+2. Copy `packages/protocol/generated/rust/relay_wire.rs` (generated,
+   do not edit; landed by chatmux PR #313) into this crate as
+   `src/protocol_generated.rs`.
 3. Replace the hand-modeled structs in `src/wire.rs` with re-exports from
    the vendored module; keep only the tolerant-parse helpers.
 4. Record the chatmux commit sha of the vendored file in the copy header.

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1,0 +1,1290 @@
+//! Relay-side execution verbs (relay wire v3, W57; v5 process credentials).
+//!
+//! Behavior port of `packages/relay/bin/actions.mjs` (chatmux repo); tests
+//! mirror `actions.test.mjs`. The Worker sends `action_request` frames over
+//! the paired socket; this module runs them with the relay user's
+//! permissions and answers `action_result`.
+//!
+//! Discipline:
+//! - trust is re-checked HERE from the machine's own reconciled config
+//!   (observe = the read-only verbs only), so a compromised or buggy server
+//!   still cannot run anything the owner did not allow;
+//! - path scoping: when allowed roots exist (local `--allow-root` config
+//!   and/or the machine row echoed by the server) every file path and exec
+//!   cwd must resolve inside them — enforced against BOTH lists, first
+//!   lexically and then against the canonical (realpath) host view;
+//! - final read/write opens use O_NOFOLLOW where the host supports it;
+//! - exec spawns with a scrubbed environment (no inherited API keys) and a
+//!   hard timeout (whole process group: SIGTERM, then SIGKILL after grace);
+//! - all output is truncated to bounded sizes before it goes on the wire.
+
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::{Map, Value, json};
+
+pub const READ_ONLY_VERBS: [&str; 4] = ["read", "ls", "grep", "find"];
+pub const ACTION_VERBS: [&str; 6] = ["exec", "read", "write", "ls", "grep", "find"];
+
+/// Bounded sizes so one action can never flood the socket.
+pub const MAX_OUTPUT_CHARS: usize = 60_000;
+pub const MAX_READ_BYTES: u64 = 2_000_000;
+pub const MAX_LISTING_ENTRIES: usize = 1_000;
+
+pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+pub const MAX_TIMEOUT_MS: u64 = 300_000;
+pub const MAX_PATH_CHARS: usize = 4_096;
+
+const MAX_RUNTIME_ENVIRONMENT_ENTRIES: usize = 64;
+const MAX_RUNTIME_ENVIRONMENT_BYTES: usize = 256_000;
+const MAX_RUNTIME_FILES: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Path policy (pure)
+// ---------------------------------------------------------------------------
+
+/// Node `path.resolve` equivalent: absolute values normalize on their own,
+/// relative values join the base first; `.` and `..` collapse lexically.
+fn lexical_resolve(base: &Path, value: &str) -> PathBuf {
+    let candidate = Path::new(value);
+    let joined =
+        if candidate.is_absolute() { candidate.to_path_buf() } else { base.join(candidate) };
+    let mut out = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            Component::RootDir => out.push(Component::RootDir.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    // Above the root: Node clamps at the root.
+                }
+            }
+            Component::Normal(part) => out.push(part),
+        }
+    }
+    if out.as_os_str().is_empty() { base.to_path_buf() } else { out }
+}
+
+/// Expand a leading `~` and resolve to an absolute path.
+pub fn expand_path(raw_path: &str, home: &Path, base: &Path) -> PathBuf {
+    if raw_path == "~" {
+        return home.to_path_buf();
+    }
+    if let Some(rest) = raw_path.strip_prefix("~/").or_else(|| raw_path.strip_prefix("~\\")) {
+        return lexical_resolve(home, rest);
+    }
+    lexical_resolve(base, raw_path)
+}
+
+fn within_root(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+fn relative_path_escapes(raw_path: &str) -> bool {
+    let mut depth: i64 = 0;
+    for segment in raw_path.split(['/', '\\']) {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if depth == 0 {
+                    return true;
+                }
+                depth -= 1;
+            }
+            _ => depth += 1,
+        }
+    }
+    false
+}
+
+fn is_tilde_request(value: &str) -> bool {
+    value == "~" || value.starts_with("~/") || value.starts_with("~\\")
+}
+
+fn has_encoded_path_syntax(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    ["%00", "%25", "%2e", "%2f", "%5c"].iter().any(|needle| lower.contains(needle))
+}
+
+fn validate_request_path(value: &str) -> Result<(), String> {
+    if value.len() > MAX_PATH_CHARS {
+        return Err(format!("path exceeds {MAX_PATH_CHARS} characters"));
+    }
+    if value.chars().any(|c| c <= '\u{001f}' || c == '\u{007f}') {
+        return Err("path contains a control character".to_owned());
+    }
+    if has_encoded_path_syntax(value) {
+        return Err("percent-encoded path syntax is not accepted".to_owned());
+    }
+    if value.starts_with("//") || value.starts_with("\\\\") {
+        return Err("ambiguous leading path separators are not accepted".to_owned());
+    }
+    if cfg!(windows) {
+        let drive_relative = value.len() >= 2
+            && value.as_bytes()[1] == b':'
+            && value.as_bytes()[0].is_ascii_alphabetic()
+            && !Path::new(value).is_absolute();
+        if drive_relative {
+            return Err("drive-relative paths are not accepted".to_owned());
+        }
+    }
+    // A backslash is a filename character on POSIX but a separator on
+    // Windows. Refuse that ambiguous spelling on POSIX so one request cannot
+    // acquire different authority after crossing hosts.
+    if cfg!(not(windows)) && value.contains('\\') {
+        return Err("use '/' as the path separator on this machine".to_owned());
+    }
+    Ok(())
+}
+
+pub struct ScopedPath {
+    pub path: PathBuf,
+    pub absolute_request: bool,
+    pub workdir: PathBuf,
+}
+
+/// Root lists: local config roots and the server-echoed roots. Empty or
+/// absent lists impose nothing; every NON-empty list must contain the path.
+pub type RootLists<'a> = [Option<&'a [String]>; 2];
+
+/// Resolve a request path and enforce every non-empty root list.
+pub fn resolve_scoped_path(
+    raw_path: &str,
+    root_lists: &RootLists<'_>,
+    home: &Path,
+    workdir: &str,
+) -> Result<ScopedPath, String> {
+    validate_request_path(raw_path)?;
+    let absolute_request = Path::new(raw_path).is_absolute() || is_tilde_request(raw_path);
+    if !absolute_request && relative_path_escapes(raw_path) {
+        return Err("a relative path cannot escape the target workdir".to_owned());
+    }
+    let resolved_workdir = expand_path(workdir, home, home);
+    let path = expand_path(raw_path, home, &resolved_workdir);
+    if !path.is_absolute() {
+        return Err(format!("path did not resolve absolute: {}", path.display()));
+    }
+    if !absolute_request && !within_root(&path, &resolved_workdir) {
+        return Err(format!(
+            "relative path {} is outside the target workdir {}",
+            path.display(),
+            resolved_workdir.display(),
+        ));
+    }
+    for roots in root_lists.iter().flatten() {
+        if roots.is_empty() {
+            continue;
+        }
+        let resolved: Vec<PathBuf> =
+            roots.iter().map(|root| expand_path(root, home, home)).collect();
+        if !resolved.iter().any(|root| within_root(&path, root)) {
+            let joined =
+                resolved.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
+            return Err(format!(
+                "path {} is outside this machine's allowed roots ({joined})",
+                path.display(),
+            ));
+        }
+    }
+    Ok(ScopedPath { path, absolute_request, workdir: resolved_workdir })
+}
+
+// ---------------------------------------------------------------------------
+// Host-aware second pass (realpath + O_NOFOLLOW)
+// ---------------------------------------------------------------------------
+
+/// A typed refusal from the canonical host pass (mapped to path_forbidden).
+struct HostPathRefusal(String);
+
+enum HostError {
+    Refusal(String),
+    Io(std::io::Error),
+}
+
+impl From<HostPathRefusal> for HostError {
+    fn from(refusal: HostPathRefusal) -> HostError {
+        HostError::Refusal(refusal.0)
+    }
+}
+
+impl From<std::io::Error> for HostError {
+    fn from(error: std::io::Error) -> HostError {
+        HostError::Io(error)
+    }
+}
+
+fn is_not_found(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound
+}
+
+fn is_eloop(error: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+    #[cfg(not(unix))]
+    {
+        error.kind() == std::io::ErrorKind::FilesystemLoop
+    }
+}
+
+fn assert_not_dangling_link(path: &Path) -> Result<(), HostError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(info) => {
+            if info.file_type().is_symlink() {
+                return Err(HostError::Refusal(format!(
+                    "path {} is a symlink whose target cannot be resolved",
+                    path.display(),
+                )));
+            }
+            Ok(())
+        }
+        Err(error) if is_not_found(&error) => Ok(()),
+        Err(error) => Err(HostError::Io(error)),
+    }
+}
+
+/// realpath the nearest existing ancestor and re-append the missing suffix.
+/// realpath reports NotFound for both a genuinely absent component and a
+/// dangling symlink; never reinterpret the latter as a safe create target.
+fn canonical_potential_path(path: &Path) -> Result<PathBuf, HostError> {
+    let mut cursor = path.to_path_buf();
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        match std::fs::canonicalize(&cursor) {
+            Ok(canonical) => {
+                let mut out = canonical;
+                for part in suffix.iter().rev() {
+                    out.push(part);
+                }
+                return Ok(out);
+            }
+            Err(error) if is_not_found(&error) => {
+                assert_not_dangling_link(&cursor)?;
+                let Some(parent) = cursor.parent().map(Path::to_path_buf) else {
+                    return Err(HostError::Io(error));
+                };
+                if parent == cursor {
+                    return Err(HostError::Io(error));
+                }
+                let Some(name) = cursor.file_name().map(std::ffi::OsStr::to_os_string) else {
+                    return Err(HostError::Io(error));
+                };
+                suffix.push(name);
+                cursor = parent;
+            }
+            Err(error) => return Err(HostError::Io(error)),
+        }
+    }
+}
+
+fn canonical_root_lists(
+    root_lists: &[&[String]],
+    home: &Path,
+) -> Result<Vec<Vec<PathBuf>>, HostError> {
+    let mut canonical = Vec::new();
+    for roots in root_lists {
+        if roots.is_empty() {
+            continue;
+        }
+        let mut list = Vec::new();
+        for root in *roots {
+            list.push(canonical_potential_path(&expand_path(root, home, home))?);
+        }
+        canonical.push(list);
+    }
+    Ok(canonical)
+}
+
+fn enforce_canonical_roots(path: &Path, root_lists: &[Vec<PathBuf>]) -> Result<(), String> {
+    for roots in root_lists {
+        if !roots.iter().any(|root| within_root(path, root)) {
+            let joined =
+                roots.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
+            return Err(format!(
+                "path {} resolves outside this machine's allowed roots ({joined})",
+                path.display(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub struct HostScopedPath {
+    pub path: PathBuf,
+    roots: Vec<Vec<PathBuf>>,
+}
+
+/// Host-aware second pass. Existing paths are realpathed and operations use
+/// that canonical path, so a stable symlink inside a workdir/root cannot
+/// redirect an operation outside it. Missing write targets canonicalize
+/// from the nearest existing ancestor.
+pub fn resolve_scoped_host_path(
+    raw_path: &str,
+    root_lists: &RootLists<'_>,
+    home: &Path,
+    workdir: &str,
+    allow_missing: bool,
+) -> Result<Result<HostScopedPath, String>, std::io::Error> {
+    let run = || -> Result<HostScopedPath, HostError> {
+        let lexical =
+            resolve_scoped_path(raw_path, root_lists, home, workdir).map_err(HostError::Refusal)?;
+        let workdir_list: Vec<String>;
+        let mut effective: Vec<&[String]> = root_lists.iter().flatten().copied().collect();
+        if !lexical.absolute_request {
+            workdir_list = vec![lexical.workdir.display().to_string()];
+            effective.push(&workdir_list);
+        }
+        let roots = canonical_root_lists(&effective, home)?;
+        let path = if allow_missing {
+            canonical_potential_path(&lexical.path)?
+        } else {
+            std::fs::canonicalize(&lexical.path)?
+        };
+        enforce_canonical_roots(&path, &roots).map_err(HostError::Refusal)?;
+        Ok(HostScopedPath { path, roots })
+    };
+    match run() {
+        Ok(scoped) => Ok(Ok(scoped)),
+        Err(HostError::Refusal(message)) => Ok(Err(message)),
+        Err(HostError::Io(error)) => Err(error),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bounded file I/O (O_NOFOLLOW where the host supports it)
+// ---------------------------------------------------------------------------
+
+fn open_options_no_follow(read: bool) -> std::fs::OpenOptions {
+    let mut options = std::fs::OpenOptions::new();
+    if read {
+        options.read(true);
+    } else {
+        options.write(true).create(true).truncate(true);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    options
+}
+
+fn read_utf8_no_follow(path: &Path) -> Result<String, HostError> {
+    use std::io::Read as _;
+    let mut file = open_options_no_follow(true).open(path).map_err(|error| {
+        if is_eloop(&error) {
+            HostError::Refusal("refusing a symlink that changed during read".to_owned())
+        } else {
+            HostError::Io(error)
+        }
+    })?;
+    let info = file.metadata()?;
+    if info.len() > MAX_READ_BYTES {
+        return Err(HostError::Refusal(format!(
+            "file is {} bytes (max {MAX_READ_BYTES}); read a smaller file or use grep",
+            info.len(),
+        )));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn write_utf8_no_follow(
+    path: &Path,
+    content: &str,
+    roots: &[Vec<PathBuf>],
+) -> Result<(), HostError> {
+    use std::io::Write as _;
+    let parent = path.parent().unwrap_or(Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let canonical_parent = std::fs::canonicalize(parent)?;
+    let file_name = path.file_name().map(std::ffi::OsStr::to_os_string).unwrap_or_default();
+    let canonical = canonical_parent.join(file_name);
+    assert_not_dangling_link(&canonical)?;
+    enforce_canonical_roots(&canonical, roots).map_err(HostError::Refusal)?;
+    let mut file = open_options_no_follow(false).open(&canonical).map_err(|error| {
+        if is_eloop(&error) {
+            HostError::Refusal("refusing a symlink that changed during write".to_owned())
+        } else {
+            HostError::Io(error)
+        }
+    })?;
+    file.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Output bounds, timeouts, environment
+// ---------------------------------------------------------------------------
+
+pub struct TruncatedOutput {
+    pub output: String,
+    pub truncated: bool,
+}
+
+pub fn truncate_output(output: &str, cap: usize) -> TruncatedOutput {
+    let total = output.chars().count();
+    if total <= cap {
+        return TruncatedOutput { output: output.to_owned(), truncated: false };
+    }
+    let head: String = output.chars().take(cap).collect();
+    TruncatedOutput {
+        output: format!("{head}\n…[truncated {} characters]", total - cap),
+        truncated: true,
+    }
+}
+
+pub fn clamp_timeout(requested: Option<&Value>) -> u64 {
+    let value = requested.and_then(Value::as_f64).unwrap_or(0.0);
+    if !value.is_finite() || value <= 0.0 {
+        return DEFAULT_TIMEOUT_MS;
+    }
+    (value.trunc() as u64).clamp(1_000, MAX_TIMEOUT_MS)
+}
+
+/// Minimal, non-secret environment for spawned commands.
+pub fn scrubbed_env(base: &HashMap<String, String>) -> HashMap<String, String> {
+    let keep = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG", "LC_ALL"];
+    let mut env = HashMap::new();
+    for key in keep {
+        if let Some(value) = base.get(key) {
+            env.insert(key.to_owned(), value.clone());
+        }
+    }
+    env.insert("TERM".to_owned(), "dumb".to_owned());
+    env
+}
+
+pub fn process_env_snapshot() -> HashMap<String, String> {
+    std::env::vars().collect()
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub struct ProcessRuntime {
+    pub environment: HashMap<String, String>,
+    pub files: Vec<RuntimeFile>,
+}
+
+pub struct RuntimeFile {
+    pub content_environment_variable: String,
+    pub path_environment_variable: String,
+    pub path_hint: String,
+}
+
+/// Validate the secret-bearing frame field without returning secret text in
+/// errors (v5 one-call process credentials).
+pub fn process_runtime(frame_runtime: Option<&Value>) -> Result<ProcessRuntime, String> {
+    let Some(runtime) = frame_runtime else {
+        return Ok(ProcessRuntime { environment: HashMap::new(), files: Vec::new() });
+    };
+    let invalid = || "process runtime is invalid".to_owned();
+    let object = runtime.as_object().ok_or_else(invalid)?;
+    let environment_value =
+        object.get("environment").and_then(Value::as_object).ok_or_else(invalid)?;
+    let files_value = object.get("files").and_then(Value::as_array).ok_or_else(invalid)?;
+    if environment_value.len() > MAX_RUNTIME_ENVIRONMENT_ENTRIES {
+        return Err("process runtime has too many environment values".to_owned());
+    }
+    let mut environment = HashMap::new();
+    let mut bytes = 0_usize;
+    for (name, value) in environment_value {
+        let Some(value) = value.as_str() else {
+            return Err("process runtime environment is invalid".to_owned());
+        };
+        if !valid_environment_name(name) {
+            return Err("process runtime environment is invalid".to_owned());
+        }
+        bytes += name.len() + value.len();
+        if bytes > MAX_RUNTIME_ENVIRONMENT_BYTES || value.contains('\0') {
+            return Err("process runtime environment is too large or invalid".to_owned());
+        }
+        environment.insert(name.clone(), value.to_owned());
+    }
+    if files_value.len() > MAX_RUNTIME_FILES {
+        return Err("process runtime has too many files".to_owned());
+    }
+    let mut files = Vec::new();
+    for file in files_value {
+        let content = file
+            .get("contentEnvironmentVariable")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let path_var = file
+            .get("pathEnvironmentVariable")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let path_hint = file.get("pathHint").and_then(Value::as_str);
+        if !valid_environment_name(&content)
+            || !valid_environment_name(&path_var)
+            || path_hint.is_none()
+            || !environment.contains_key(&content)
+        {
+            return Err("process runtime file is invalid".to_owned());
+        }
+        files.push(RuntimeFile {
+            content_environment_variable: content,
+            path_environment_variable: path_var,
+            path_hint: path_hint.unwrap_or_default().to_owned(),
+        });
+    }
+    Ok(ProcessRuntime { environment, files })
+}
+
+/// Build a POSIX supervisor. No secret value enters the command string.
+pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> String {
+    if files.is_empty() {
+        return command.to_owned();
+    }
+    let mut setup: Vec<String> = vec!["set +e".to_owned(), "umask 077".to_owned()];
+    let mut cleanup: Vec<String> = Vec::new();
+    for (index, file) in files.iter().enumerate() {
+        let sanitized: String = file
+            .path_hint
+            .chars()
+            .map(
+                |c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '-' },
+            )
+            .take(80)
+            .collect();
+        let hint = if sanitized.is_empty() { "secret".to_owned() } else { sanitized };
+        let shell_path = format!("__chatmux_file_{index}");
+        setup.push(format!("{shell_path}=$(mktemp \"${{TMPDIR:-/tmp}}/chatmux-{hint}.XXXXXX\")"));
+        setup.push(format!("chmod 600 \"${shell_path}\""));
+        setup.push(format!(
+            "printf '%s' \"${}\" > \"${shell_path}\"",
+            file.content_environment_variable,
+        ));
+        setup.push(format!("unset {}", file.content_environment_variable));
+        setup.push(format!("export {}=\"${shell_path}\"", file.path_environment_variable,));
+        cleanup.push(format!("rm -f -- \"${shell_path}\""));
+    }
+    let cleanup_body = cleanup.join("; ");
+    setup.push(format!("__chatmux_cleanup() {{ {cleanup_body}; }}"));
+    setup.push("trap __chatmux_cleanup EXIT".to_owned());
+    setup.push("trap 'exit 143' HUP INT TERM".to_owned());
+    setup.push(format!("( bash -lc {} )", shell_quote(command)));
+    setup.push("__chatmux_status=$?".to_owned());
+    setup.push("__chatmux_cleanup".to_owned());
+    setup.push("trap - EXIT HUP INT TERM".to_owned());
+    setup.push("exit $__chatmux_status".to_owned());
+    setup.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Bounded spawn with a hard process-group timeout
+// ---------------------------------------------------------------------------
+
+enum RunSpec<'a> {
+    Shell { command: &'a str },
+    Argv { file: &'a str, args: Vec<String> },
+}
+
+enum RunOutcome {
+    Done { exit_code: i64, output: String },
+    TimedOut { tail: String },
+    Failed { message: String },
+}
+
+async fn run_spec(
+    spec: RunSpec<'_>,
+    cwd: &Path,
+    timeout_ms: u64,
+    env: &HashMap<String, String>,
+) -> RunOutcome {
+    use tokio::io::AsyncReadExt as _;
+    let mut command = match &spec {
+        RunSpec::Shell { command } => {
+            let mut shell = tokio::process::Command::new("/bin/sh");
+            shell.arg("-c").arg(command);
+            shell
+        }
+        RunSpec::Argv { file, args } => {
+            let mut argv = tokio::process::Command::new(file);
+            argv.args(args);
+            argv
+        }
+    };
+    command.current_dir(cwd).env_clear().envs(env);
+    command.stdin(std::process::Stdio::null());
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    command.process_group(0);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => return RunOutcome::Failed { message: error.to_string() },
+    };
+    let pid = child.id();
+    // Collect a little past the char cap (bytes over-approximate chars).
+    let byte_cap = (MAX_OUTPUT_CHARS + 10_000) * 4;
+    let mut stdout = child.stdout.take();
+    let mut stderr = child.stderr.take();
+    let mut output: Vec<u8> = Vec::new();
+    let mut timed_out = false;
+    let deadline = tokio::time::sleep(std::time::Duration::from_millis(timeout_ms));
+    tokio::pin!(deadline);
+    let mut stdout_buf = [0_u8; 8_192];
+    let mut stderr_buf = [0_u8; 8_192];
+    let mut stdout_open = stdout.is_some();
+    let mut stderr_open = stderr.is_some();
+    let mut exited: Option<i64> = None;
+    loop {
+        if exited.is_some() && !stdout_open && !stderr_open {
+            break;
+        }
+        tokio::select! {
+            read = async {
+                match stdout.as_mut() {
+                    Some(stream) => stream.read(&mut stdout_buf).await,
+                    None => std::future::pending().await,
+                }
+            }, if stdout_open => {
+                match read {
+                    Ok(0) | Err(_) => stdout_open = false,
+                    Ok(count) => {
+                        if output.len() < byte_cap {
+                            output.extend_from_slice(&stdout_buf[..count]);
+                        }
+                    }
+                }
+            }
+            read = async {
+                match stderr.as_mut() {
+                    Some(stream) => stream.read(&mut stderr_buf).await,
+                    None => std::future::pending().await,
+                }
+            }, if stderr_open => {
+                match read {
+                    Ok(0) | Err(_) => stderr_open = false,
+                    Ok(count) => {
+                        if output.len() < byte_cap {
+                            output.extend_from_slice(&stderr_buf[..count]);
+                        }
+                    }
+                }
+            }
+            status = child.wait(), if exited.is_none() => {
+                exited = Some(match status {
+                    Ok(status) => i64::from(status.code().unwrap_or(0)),
+                    Err(_) => 0,
+                });
+            }
+            () = &mut deadline, if !timed_out => {
+                timed_out = true;
+                // Commands run below a shell and may have descendants that
+                // inherited stdout/stderr. Kill the whole POSIX process group
+                // so the supervisor gets its EXIT cleanup, then enforce a
+                // hard bound for processes that ignore TERM.
+                signal_process_tree(pid, false);
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    signal_process_tree(pid, true);
+                });
+            }
+        }
+    }
+    let text = String::from_utf8_lossy(&output);
+    if timed_out {
+        let tail: String = {
+            let chars: Vec<char> = text.chars().collect();
+            let start = chars.len().saturating_sub(2_000);
+            chars[start..].iter().collect()
+        };
+        return RunOutcome::TimedOut { tail };
+    }
+    RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
+}
+
+#[cfg(unix)]
+fn signal_process_tree(pid: Option<u32>, kill: bool) {
+    let Some(pid) = pid else { return };
+    let signal = if kill { libc::SIGKILL } else { libc::SIGTERM };
+    // SAFETY: sending a signal to a process group id we spawned; failure is
+    // harmless (the group may have exited already).
+    let group = -(pid as i32);
+    unsafe {
+        if libc::kill(group, signal) != 0 {
+            libc::kill(pid as i32, signal);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn signal_process_tree(_pid: Option<u32>, _kill: bool) {}
+
+fn cap_lines(output: &str, truncated: bool, limit: Option<&Value>) -> (String, bool) {
+    let Some(limit) = limit.and_then(Value::as_f64).filter(|v| v.is_finite()) else {
+        return (output.to_owned(), truncated);
+    };
+    let cap = (limit.trunc() as i64).clamp(1, 5_000) as usize;
+    let lines: Vec<&str> = output.split('\n').collect();
+    if lines.len() <= cap {
+        return (output.to_owned(), truncated);
+    }
+    (format!("{}\n…[{} more lines]", lines[..cap].join("\n"), lines.len() - cap), true)
+}
+
+// ---------------------------------------------------------------------------
+// The verb dispatcher
+// ---------------------------------------------------------------------------
+
+pub struct ActionContext {
+    /// The machine's reconciled trust (config after the trust_ack handshake),
+    /// never the frame's echo alone.
+    pub trust: String,
+    pub local_roots: Option<Vec<String>>,
+    pub home: PathBuf,
+    /// Scrubbed base environment for spawns.
+    pub env: HashMap<String, String>,
+}
+
+fn frame_roots(frame: &Value) -> Option<Vec<String>> {
+    frame
+        .get("allowedRoots")
+        .and_then(Value::as_array)
+        .map(|roots| roots.iter().filter_map(Value::as_str).map(str::to_owned).collect())
+}
+
+fn ok_result(version: i64, action_id: &str, result: Value) -> Value {
+    json!({
+        "version": version,
+        "type": "action_result",
+        "actionId": action_id,
+        "ok": true,
+        "result": result,
+    })
+}
+
+fn run_reply(
+    version: i64,
+    action_id: &str,
+    outcome: RunOutcome,
+    limit: Option<&Value>,
+    default_limit: Option<i64>,
+    timeout_ms: u64,
+) -> Value {
+    let default_value = default_limit.map(Value::from);
+    let limit = limit.or(default_value.as_ref());
+    match outcome {
+        RunOutcome::Failed { message } => fail_result(version, action_id, "failed", &message),
+        RunOutcome::TimedOut { tail } => {
+            let suffix = if tail.trim().is_empty() {
+                String::new()
+            } else {
+                format!("; output tail:\n{tail}")
+            };
+            let seconds = (timeout_ms as f64 / 1000.0).round() as u64;
+            fail_result(
+                version,
+                action_id,
+                "timeout",
+                &format!("command timed out after {seconds}s{suffix}"),
+            )
+        }
+        RunOutcome::Done { exit_code, output } => {
+            let bounded = truncate_output(&output, MAX_OUTPUT_CHARS);
+            let (capped, truncated) = cap_lines(&bounded.output, bounded.truncated, limit);
+            let mut result = Map::new();
+            result.insert("exitCode".to_owned(), Value::from(exit_code));
+            result.insert("output".to_owned(), Value::from(capped));
+            if truncated {
+                result.insert("truncated".to_owned(), Value::from(true));
+            }
+            ok_result(version, action_id, Value::Object(result))
+        }
+    }
+}
+
+fn fail_result(version: i64, action_id: &str, code: &str, message: &str) -> Value {
+    json!({
+        "version": version,
+        "type": "action_result",
+        "actionId": action_id,
+        "ok": false,
+        "code": code,
+        "message": message,
+    })
+}
+
+/// Execute one action_request frame. Returns the `action_result` frame to
+/// send back (never fails).
+pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
+    let version = frame.get("version").and_then(Value::as_i64).unwrap_or(3);
+    let action_id = frame.get("actionId").and_then(Value::as_str).unwrap_or_default().to_owned();
+    let fail = |code: &str, message: &str| fail_result(version, &action_id, code, message);
+
+    let verb = frame.get("verb").and_then(Value::as_str).unwrap_or_default().to_owned();
+    if !ACTION_VERBS.contains(&verb.as_str()) {
+        return fail("unsupported_verb", &format!("this relay does not support verb \"{verb}\""));
+    }
+
+    // Owner-side trust floor: the server gates too, but the machine's own
+    // config is authoritative here.
+    if context.trust == "observe" && !READ_ONLY_VERBS.contains(&verb.as_str()) {
+        return fail(
+            "trust_refused",
+            &format!("this machine is paired at observe trust; \"{verb}\" is not a read-only verb"),
+        );
+    }
+
+    let home = context.home.clone();
+    let server_roots = frame_roots(frame);
+    let root_lists: RootLists<'_> = [context.local_roots.as_deref(), server_roots.as_deref()];
+    let empty_args = Map::new();
+    let args = frame.get("args").and_then(Value::as_object).unwrap_or(&empty_args);
+    let timeout_ms = clamp_timeout(frame.get("timeoutMs"));
+    let runtime = match process_runtime(frame.get("runtime")) {
+        Ok(runtime) => runtime,
+        Err(message) => return fail("failed", &message),
+    };
+    if verb != "exec" && (!runtime.environment.is_empty() || !runtime.files.is_empty()) {
+        return fail("failed", "process runtime is valid only for exec");
+    }
+    if cfg!(windows) && !runtime.files.is_empty() {
+        return fail("failed", "process file bindings are not available on Windows relays");
+    }
+    let mut env = context.env.clone();
+    env.extend(runtime.environment.clone());
+    let first_roots = root_lists.iter().flatten().find(|roots| !roots.is_empty());
+    let workdir = match first_roots {
+        Some(roots) => expand_path(&roots[0], &home, &home).display().to_string(),
+        None => home.display().to_string(),
+    };
+    let scoped = |raw: &str, allow_missing: bool| {
+        resolve_scoped_host_path(raw, &root_lists, &home, &workdir, allow_missing)
+    };
+    let io_fail =
+        |error: std::io::Error| fail_result(version, &action_id, "failed", &error.to_string());
+
+    match verb.as_str() {
+        "read" => {
+            let Some(raw) = args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty())
+            else {
+                return fail("failed", "read: path is required");
+            };
+            let path = match scoped(raw, false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            match read_utf8_no_follow(&path.path) {
+                Ok(content) => ok_result(version, &action_id, json!({ "content": content })),
+                Err(HostError::Refusal(message)) => fail("path_forbidden", &message),
+                Err(HostError::Io(error)) if is_eloop(&error) => {
+                    fail("path_forbidden", "path contains a symlink loop")
+                }
+                Err(HostError::Io(error)) => io_fail(error),
+            }
+        }
+        "write" => {
+            let Some(raw) = args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty())
+            else {
+                return fail("failed", "write: path is required");
+            };
+            let path = match scoped(raw, true) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let content = args.get("content").and_then(Value::as_str).unwrap_or_default();
+            match write_utf8_no_follow(&path.path, content, &path.roots) {
+                Ok(()) => ok_result(version, &action_id, json!({})),
+                Err(HostError::Refusal(message)) => fail("path_forbidden", &message),
+                Err(HostError::Io(error)) if is_eloop(&error) => {
+                    fail("path_forbidden", "path contains a symlink loop")
+                }
+                Err(HostError::Io(error)) => io_fail(error),
+            }
+        }
+        "ls" => {
+            let raw =
+                args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
+            let path = match scoped(raw, false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let entries = match std::fs::read_dir(&path.path) {
+                Ok(entries) => entries,
+                Err(error) => return io_fail(error),
+            };
+            let mut names: Vec<String> = Vec::new();
+            let mut total = 0_usize;
+            for entry in entries.flatten() {
+                total += 1;
+                if names.len() >= MAX_LISTING_ENTRIES {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                names.push(if is_dir { format!("{name}/") } else { name });
+            }
+            names.sort();
+            let more = if total > MAX_LISTING_ENTRIES {
+                format!("\n…[{} more entries]", total - MAX_LISTING_ENTRIES)
+            } else {
+                String::new()
+            };
+            ok_result(
+                version,
+                &action_id,
+                json!({ "listing": format!("{}{more}", names.join("\n")) }),
+            )
+        }
+        "grep" => {
+            let raw =
+                args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
+            let path = match scoped(raw, false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default();
+            if pattern.is_empty() {
+                return fail("failed", "grep: pattern is required");
+            }
+            if cfg!(windows) {
+                return fail("unsupported_verb", "grep is not available on Windows relays yet");
+            }
+            let command_cwd = match scoped(".", false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let outcome = run_spec(
+                RunSpec::Argv {
+                    file: "grep",
+                    args: vec![
+                        "-rIn".to_owned(),
+                        "--exclude-dir=.git".to_owned(),
+                        "--exclude-dir=node_modules".to_owned(),
+                        "-e".to_owned(),
+                        pattern.to_owned(),
+                        "--".to_owned(),
+                        path.path.display().to_string(),
+                    ],
+                },
+                &command_cwd.path,
+                timeout_ms,
+                &env,
+            )
+            .await;
+            run_reply(version, &action_id, outcome, args.get("limit"), Some(200), timeout_ms)
+        }
+        "find" => {
+            let raw =
+                args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
+            let path = match scoped(raw, false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            if cfg!(windows) {
+                return fail("unsupported_verb", "find is not available on Windows relays yet");
+            }
+            let command_cwd = match scoped(".", false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let mut find_args = vec![path.path.display().to_string()];
+            if let Some(pattern) =
+                args.get("pattern").and_then(Value::as_str).filter(|p| !p.is_empty())
+            {
+                find_args.push("-name".to_owned());
+                find_args.push(pattern.to_owned());
+            }
+            let outcome = run_spec(
+                RunSpec::Argv { file: "find", args: find_args },
+                &command_cwd.path,
+                timeout_ms,
+                &env,
+            )
+            .await;
+            run_reply(version, &action_id, outcome, args.get("limit"), Some(500), timeout_ms)
+        }
+        "exec" => {
+            let command = args.get("command").and_then(Value::as_str).unwrap_or_default();
+            if command.is_empty() {
+                return fail("failed", "exec: command is required");
+            }
+            // Default and explicit relative cwds use the same canonical
+            // workdir policy as every file verb. This also enforces the
+            // intersection when the root lists do not overlap.
+            let raw_cwd =
+                args.get("cwd").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
+            let scoped_cwd = match scoped(raw_cwd, false) {
+                Ok(Ok(path)) => path,
+                Ok(Err(message)) => return fail("path_forbidden", &message),
+                Err(error) => return io_fail(error),
+            };
+            let prepared = command_with_process_files(command, &runtime.files);
+            let outcome =
+                run_spec(RunSpec::Shell { command: &prepared }, &scoped_cwd.path, timeout_ms, &env)
+                    .await;
+            run_reply(version, &action_id, outcome, None, None, timeout_ms)
+        }
+        _ => fail("unsupported_verb", &format!("verb \"{verb}\" fell through")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — mirror packages/relay/test/actions.test.mjs.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/u")
+    }
+
+    fn ctx(trust: &str, roots: Option<Vec<String>>, home: PathBuf) -> ActionContext {
+        ActionContext { trust: trust.to_owned(), local_roots: roots, home, env: HashMap::new() }
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("chatmux-actions-{}-{name}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // realpath so canonical checks match (macOS /tmp -> /private/tmp).
+        std::fs::canonicalize(&dir).unwrap()
+    }
+
+    #[test]
+    fn expand_path_handles_tilde_relative_and_absolute() {
+        assert_eq!(expand_path("~", &home(), &home()), home());
+        assert_eq!(expand_path("~/x", &home(), &home()), PathBuf::from("/home/u/x"));
+        assert_eq!(expand_path("/abs", &home(), Path::new("/base")), PathBuf::from("/abs"));
+        assert_eq!(expand_path("rel", &home(), Path::new("/base")), PathBuf::from("/base/rel"));
+        assert_eq!(expand_path("a/../b", &home(), Path::new("/base")), PathBuf::from("/base/b"));
+    }
+
+    #[test]
+    fn resolve_scoped_path_enforces_every_nonempty_root_list() {
+        let roots_a = vec!["/home/u/work".to_owned()];
+        let roots_b = vec!["/home/u/work/sub".to_owned()];
+        let lists: RootLists = [Some(roots_a.as_slice()), Some(roots_b.as_slice())];
+        // Inside both: ok.
+        let ok = resolve_scoped_path("/home/u/work/sub/file", &lists, &home(), "/home/u/work/sub");
+        assert!(ok.is_ok());
+        // Inside A but outside B: refused.
+        let refused = resolve_scoped_path("/home/u/work/other", &lists, &home(), "/home/u/work");
+        assert!(refused.is_err());
+    }
+
+    #[test]
+    fn relative_paths_stay_in_the_workdir() {
+        let roots = vec!["/home/u/work".to_owned()];
+        let lists: RootLists = [Some(roots.as_slice()), None];
+        assert!(resolve_scoped_path("../escape", &lists, &home(), "/home/u/work").is_err());
+        assert!(resolve_scoped_path("./nested/../ok", &lists, &home(), "/home/u/work").is_ok());
+        // Encoded and control-character variants are refused.
+        assert!(resolve_scoped_path("a%2e%2e/b", &lists, &home(), "/home/u/work").is_err());
+        assert!(resolve_scoped_path("a\u{0000}b", &lists, &home(), "/home/u/work").is_err());
+    }
+
+    #[test]
+    fn truncate_output_caps_and_marks() {
+        let short = truncate_output("hi", MAX_OUTPUT_CHARS);
+        assert!(!short.truncated);
+        let long = "x".repeat(MAX_OUTPUT_CHARS + 5);
+        let capped = truncate_output(&long, MAX_OUTPUT_CHARS);
+        assert!(capped.truncated);
+        assert!(capped.output.contains("truncated 5 characters"));
+    }
+
+    #[test]
+    fn clamp_timeout_bounds() {
+        assert_eq!(clamp_timeout(None), DEFAULT_TIMEOUT_MS);
+        assert_eq!(clamp_timeout(Some(&json!(50))), 1_000);
+        assert_eq!(clamp_timeout(Some(&json!(9_999_999))), MAX_TIMEOUT_MS);
+        assert_eq!(clamp_timeout(Some(&json!(-5))), DEFAULT_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn scrubbed_env_drops_secrets_keeps_path_home() {
+        let base = HashMap::from([
+            ("PATH".to_owned(), "/usr/bin".to_owned()),
+            ("HOME".to_owned(), "/home/u".to_owned()),
+            ("OPENAI_API_KEY".to_owned(), "sekret".to_owned()),
+        ]);
+        let env = scrubbed_env(&base);
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/home/u"));
+        assert!(!env.contains_key("OPENAI_API_KEY"));
+        assert_eq!(env.get("TERM").map(String::as_str), Some("dumb"));
+    }
+
+    #[tokio::test]
+    async fn read_write_ls_round_trip_inside_allowed_roots() {
+        let root = scratch("rw");
+        let roots = vec![root.display().to_string()];
+        let context = ctx("supervised", Some(roots.clone()), root.clone());
+        // write
+        let write = perform_action(
+            &json!({ "verb": "write", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "path": "note.txt", "content": "hello" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(write["ok"], true, "{write}");
+        // read
+        let read = perform_action(
+            &json!({ "verb": "read", "actionId": "a2", "allowedRoots": roots,
+                     "args": { "path": "note.txt" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(read["result"]["content"], "hello");
+        // ls
+        let ls = perform_action(
+            &json!({ "verb": "ls", "actionId": "a3", "allowedRoots": roots, "args": {} }),
+            &context,
+        )
+        .await;
+        assert!(ls["result"]["listing"].as_str().unwrap().contains("note.txt"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn file_verbs_outside_roots_are_path_forbidden() {
+        let root = scratch("scoped");
+        let roots = vec![root.display().to_string()];
+        let context = ctx("supervised", Some(roots.clone()), root.clone());
+        let read = perform_action(
+            &json!({ "verb": "read", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "path": "/etc/hosts" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(read["ok"], false);
+        assert_eq!(read["code"], "path_forbidden");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn symlinks_cannot_escape_allowed_roots() {
+        let root = scratch("symlink");
+        let outside = scratch("outside");
+        std::fs::write(outside.join("secret.txt"), "top secret").unwrap();
+        // A symlink inside the root pointing outside it.
+        std::os::unix::fs::symlink(&outside, root.join("escape")).unwrap();
+        let roots = vec![root.display().to_string()];
+        let context = ctx("supervised", Some(roots.clone()), root.clone());
+        let read = perform_action(
+            &json!({ "verb": "read", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "path": "escape/secret.txt" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(read["ok"], false);
+        assert_eq!(read["code"], "path_forbidden");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[tokio::test]
+    async fn exec_runs_with_cwd_discipline_and_returns_exit_code_and_output() {
+        let root = scratch("exec");
+        let roots = vec![root.display().to_string()];
+        let mut context = ctx("supervised", Some(roots.clone()), root.clone());
+        context.env =
+            scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let exec = perform_action(
+            &json!({ "verb": "exec", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "command": "echo hi && pwd" }, "timeoutMs": 10000 }),
+            &context,
+        )
+        .await;
+        assert_eq!(exec["ok"], true, "{exec}");
+        assert_eq!(exec["result"]["exitCode"], 0);
+        let output = exec["result"]["output"].as_str().unwrap();
+        assert!(output.contains("hi"));
+        assert!(output.contains(&root.display().to_string()));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn exec_receives_scoped_process_environment_values() {
+        let root = scratch("procenv");
+        let roots = vec![root.display().to_string()];
+        let mut context = ctx("supervised", Some(roots.clone()), root.clone());
+        context.env =
+            scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let exec = perform_action(
+            &json!({ "verb": "exec", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "command": "printf '%s' \"$MY_TOKEN\"" }, "timeoutMs": 10000,
+                     "runtime": { "environment": { "MY_TOKEN": "abc123" }, "files": [] } }),
+            &context,
+        )
+        .await;
+        assert_eq!(exec["result"]["output"], "abc123");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn observe_trust_refuses_mutating_verbs_allows_reads() {
+        let root = scratch("observe");
+        std::fs::write(root.join("f.txt"), "data").unwrap();
+        let roots = vec![root.display().to_string()];
+        let context = ctx("observe", Some(roots.clone()), root.clone());
+        let write = perform_action(
+            &json!({ "verb": "write", "actionId": "a1", "allowedRoots": roots,
+                     "args": { "path": "x.txt", "content": "no" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(write["code"], "trust_refused");
+        let read = perform_action(
+            &json!({ "verb": "read", "actionId": "a2", "allowedRoots": roots,
+                     "args": { "path": "f.txt" } }),
+            &context,
+        )
+        .await;
+        assert_eq!(read["ok"], true);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn unknown_verbs_answer_unsupported_verb() {
+        let context = ctx("supervised", None, home());
+        let result =
+            perform_action(&json!({ "verb": "nope", "actionId": "a1", "args": {} }), &context)
+                .await;
+        assert_eq!(result["ok"], false);
+        assert_eq!(result["code"], "unsupported_verb");
+    }
+
+    #[tokio::test]
+    async fn invalid_process_runtime_does_not_reflect_credential_bytes() {
+        let context = ctx("supervised", None, home());
+        let result = perform_action(
+            &json!({ "verb": "exec", "actionId": "a1", "args": { "command": "true" },
+                     "runtime": { "environment": { "BAD NAME": "sekret-value" }, "files": [] } }),
+            &context,
+        )
+        .await;
+        assert_eq!(result["ok"], false);
+        assert!(!result["message"].as_str().unwrap().contains("sekret-value"));
+    }
+}

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -1,0 +1,244 @@
+//! cmux-tui control socket client (JSON Lines over the session's unix
+//! socket, cmux-tui docs/protocol.md). Behavior port of the JS relay's
+//! `defaultConnectControl` (`packages/relay/bin/pty.mjs`): every failure
+//! mode resolves requests with `None` instead of erroring (callers
+//! feature-detect); torn lines never kill the attachment; `pause` stops
+//! reading so PTY backpressure applies naturally.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Per-request budget on a cmux-tui control connection.
+pub const CONTROL_TIMEOUT_MS: u64 = 3_000;
+
+pub type EventHandler = Box<dyn Fn(&Value) + Send + Sync>;
+pub type CloseHandler = Box<dyn Fn() + Send + Sync>;
+
+/// One control connection to a cmux-tui session socket. The trait exists so
+/// the PTY manager's unit tests can inject a scripted control plane, exactly
+/// like the JS test harness does.
+pub trait ControlHandle: Send + Sync {
+    /// Round-trip one command; `None` on timeout, close, or write failure.
+    fn request(
+        &self,
+        cmd: &str,
+        params: Value,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>>;
+    /// Fire-and-forget (input/resize hot paths); the response line drops.
+    fn send(&self, cmd: &str, params: Value);
+    fn on_event(&self, handler: EventHandler);
+    /// Fires on unexpected close only (not after `end()`).
+    fn on_close(&self, handler: CloseHandler);
+    fn pause(&self);
+    fn resume(&self);
+    fn end(&self);
+}
+
+#[cfg(unix)]
+pub use unix::connect_control;
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use tokio::io::AsyncReadExt as _;
+    use tokio::net::UnixStream;
+    use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+    use tokio::sync::{Notify, oneshot};
+
+    struct Shared {
+        pending: Mutex<HashMap<u64, oneshot::Sender<Value>>>,
+        event_handler: Mutex<Option<EventHandler>>,
+        close_handler: Mutex<Option<CloseHandler>>,
+        closed: AtomicBool,
+        deliberate: AtomicBool,
+        paused: AtomicBool,
+        resume_notify: Notify,
+    }
+
+    impl Shared {
+        fn settle_closed(&self) {
+            if self.closed.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            // Resolve every pending request with "no reply".
+            self.pending.lock().expect("control pending lock").clear();
+            if !self.deliberate.load(Ordering::SeqCst)
+                && let Some(handler) =
+                    self.close_handler.lock().expect("control close lock").as_ref()
+            {
+                handler();
+            }
+        }
+    }
+
+    pub struct UnixControl {
+        shared: Arc<Shared>,
+        writer: Mutex<OwnedWriteHalf>,
+        raw_fd: std::os::fd::RawFd,
+        next_id: AtomicU64,
+        timeout_ms: u64,
+    }
+
+    /// Connect a JSON-lines control client to a cmux-tui session socket.
+    pub async fn connect_control(
+        socket_path: &std::path::Path,
+        timeout_ms: u64,
+    ) -> Result<Arc<dyn ControlHandle>, String> {
+        let connect = UnixStream::connect(socket_path);
+        let stream = tokio::time::timeout(Duration::from_millis(timeout_ms), connect)
+            .await
+            .map_err(|_| format!("cmux-tui control connect timed out ({})", socket_path.display()))?
+            .map_err(|error| error.to_string())?;
+        let raw_fd = {
+            use std::os::fd::AsRawFd as _;
+            stream.as_raw_fd()
+        };
+        let (read_half, write_half) = stream.into_split();
+        let shared = Arc::new(Shared {
+            pending: Mutex::new(HashMap::new()),
+            event_handler: Mutex::new(None),
+            close_handler: Mutex::new(None),
+            closed: AtomicBool::new(false),
+            deliberate: AtomicBool::new(false),
+            paused: AtomicBool::new(false),
+            resume_notify: Notify::new(),
+        });
+        tokio::spawn(read_loop(read_half, Arc::clone(&shared)));
+        Ok(Arc::new(UnixControl {
+            shared,
+            writer: Mutex::new(write_half),
+            raw_fd,
+            next_id: AtomicU64::new(1),
+            timeout_ms,
+        }))
+    }
+
+    async fn read_loop(mut reader: OwnedReadHalf, shared: Arc<Shared>) {
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut chunk = [0_u8; 16_384];
+        loop {
+            while shared.paused.load(Ordering::SeqCst) {
+                shared.resume_notify.notified().await;
+            }
+            let count = match reader.read(&mut chunk).await {
+                Ok(0) | Err(_) => break,
+                Ok(count) => count,
+            };
+            buffer.extend_from_slice(&chunk[..count]);
+            while let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
+                let line: Vec<u8> = buffer.drain(..=newline).collect();
+                let Ok(text) = std::str::from_utf8(&line[..line.len() - 1]) else { continue };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                // A torn or non-JSON line must not kill the attachment.
+                let Ok(parsed) = serde_json::from_str::<Value>(text) else { continue };
+                if !parsed.is_object() {
+                    continue;
+                }
+                let id = parsed.get("id").and_then(Value::as_u64);
+                let waiting = id.and_then(|id| {
+                    shared.pending.lock().expect("control pending lock").remove(&id)
+                });
+                if let Some(sender) = waiting {
+                    let _ = sender.send(parsed);
+                } else if parsed.get("event").and_then(Value::as_str).is_some()
+                    && let Some(handler) =
+                        shared.event_handler.lock().expect("control event lock").as_ref()
+                {
+                    handler(&parsed);
+                }
+                // Responses to fire-and-forget sends fall through silently.
+            }
+        }
+        shared.settle_closed();
+    }
+
+    impl UnixControl {
+        fn write_line(&self, id: u64, cmd: &str, params: Value) -> bool {
+            let mut frame = match params {
+                Value::Object(map) => map,
+                _ => serde_json::Map::new(),
+            };
+            frame.insert("id".to_owned(), Value::from(id));
+            frame.insert("cmd".to_owned(), Value::from(cmd));
+            let mut line = Value::Object(frame).to_string();
+            line.push('\n');
+            let writer = self.writer.lock().expect("control writer lock");
+            // try_write on the owned half: control lines are tiny and the
+            // socket buffer absorbs them; a full buffer reads as a failure
+            // (the JS write() try/catch equivalent).
+            writer.try_write(line.as_bytes()).is_ok()
+        }
+    }
+
+    impl ControlHandle for UnixControl {
+        fn request(
+            &self,
+            cmd: &str,
+            params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            let cmd = cmd.to_owned();
+            Box::pin(async move {
+                if self.shared.closed.load(Ordering::SeqCst) {
+                    return None;
+                }
+                let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+                let (sender, receiver) = oneshot::channel();
+                self.shared.pending.lock().expect("control pending lock").insert(id, sender);
+                if !self.write_line(id, &cmd, params) {
+                    self.shared.pending.lock().expect("control pending lock").remove(&id);
+                    return None;
+                }
+                match tokio::time::timeout(Duration::from_millis(self.timeout_ms), receiver).await {
+                    Ok(Ok(value)) => Some(value),
+                    _ => {
+                        self.shared.pending.lock().expect("control pending lock").remove(&id);
+                        None
+                    }
+                }
+            })
+        }
+
+        fn send(&self, cmd: &str, params: Value) {
+            if self.shared.closed.load(Ordering::SeqCst) {
+                return;
+            }
+            let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+            let _ = self.write_line(id, cmd, params);
+        }
+
+        fn on_event(&self, handler: EventHandler) {
+            *self.shared.event_handler.lock().expect("control event lock") = Some(handler);
+        }
+
+        fn on_close(&self, handler: CloseHandler) {
+            *self.shared.close_handler.lock().expect("control close lock") = Some(handler);
+        }
+
+        fn pause(&self) {
+            self.shared.paused.store(true, Ordering::SeqCst);
+        }
+
+        fn resume(&self) {
+            self.shared.paused.store(false, Ordering::SeqCst);
+            self.shared.resume_notify.notify_waiters();
+        }
+
+        fn end(&self) {
+            self.shared.deliberate.store(true, Ordering::SeqCst);
+            self.shared.settle_closed();
+            // Shut both directions so the read loop sees EOF and any blocked
+            // writer unblocks; the halves drop and close the fd afterwards.
+            // SAFETY: shutdown on a socket fd this handle owns for the split
+            // stream's lifetime; a failure (already closed) is harmless.
+            unsafe {
+                libc::shutdown(self.raw_fd, libc::SHUT_RDWR);
+            }
+        }
+    }
+}

--- a/cmux-tui/crates/chatmux-relay/src/lib.rs
+++ b/cmux-tui/crates/chatmux-relay/src/lib.rs
@@ -4,13 +4,18 @@
 //! name stays `cmux-relay`. See README.md for the port plan and the
 //! vendored-protocol regeneration step.
 
+pub mod actions;
 pub mod cli;
 pub mod config;
+pub mod control;
 pub mod enrollment;
 pub mod error;
 pub mod fingerprint;
 pub mod pairing;
 pub mod prompt;
+pub mod pty;
+#[cfg(unix)]
+pub mod pty_deps;
 pub mod session;
 pub mod trust;
 pub mod wire;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1,0 +1,1767 @@
+//! Relay-side PTY sessions (relay wire v4/v5, W78/W86). Behavior port of
+//! `packages/relay/bin/pty.mjs`; the unit tests mirror `pty.test.mjs`.
+//!
+//! The Worker's Relay DO sends `pty_*` frames over the paired socket; this
+//! module resolves persistent sessions on the machine and answers
+//! pty_opened/pty_output/pty_exit/pty_error.
+//!
+//! Session model (docs/TERMINAL.md):
+//! - cmux-tui path (preferred): a `cmux-tui --headless --session <name>`
+//!   daemon owns the mux; each attachment is a `cmux-tui attach` viewer PTY.
+//!   Detach kills only the viewer; the daemon keeps the session.
+//! - cmux-tui RAW single-terminal path (W86): pty_open with a `surface`
+//!   attaches ONE terminal over the daemon's JSON-lines control socket.
+//! - fallback (no cmux-tui): a plain $SHELL PTY held across detaches, with a
+//!   bounded scrollback ring replayed on reattach, fanned out to any number
+//!   of concurrent viewers (0.0.10 multi-viewer).
+//!
+//! Discipline: trust re-checked here (observe = owner-only); cwd scoped to
+//! the first allowed root; env scrubbed; per-pty buffered output capped; no
+//! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use bytes::Bytes;
+use serde_json::{Value, json};
+
+use crate::actions::{expand_path, scrubbed_env};
+use crate::control::ControlHandle;
+
+pub const PTY_PROTOCOL_VERSION: u64 = 4;
+
+pub type DataSink = Arc<dyn Fn(Bytes) + Send + Sync>;
+pub type ExitSink = Arc<dyn Fn(i64) + Send + Sync>;
+/// Max concurrent attachments per relay process.
+pub const MAX_PTYS: usize = 8;
+/// Fallback-session scrollback ring, bytes.
+pub const SCROLLBACK_LIMIT: usize = 256 * 1024;
+/// Per-pty outbound buffer cap, bytes (ws bufferedAmount at output time).
+pub const OUTPUT_BUFFER_CAP: u64 = 1024 * 1024;
+/// cmux-tui control protocol floor for attach-surface/send.
+const CONTROL_MIN_PROTOCOL: i64 = 5;
+/// Inner terminals listed per session (surface_list stays bounded).
+const MAX_ENUM_TERMINALS: usize = 32;
+
+pub fn session_name_ok(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+pub fn surface_ref_ok(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '-'))
+}
+
+fn clamp_dim(value: Option<&Value>) -> Option<u16> {
+    let number = value.and_then(Value::as_i64)?;
+    if (1..=10_000).contains(&number) { u16::try_from(number).ok() } else { None }
+}
+
+// ---------------------------------------------------------------------------
+// Injected dependencies (real impls in `deps`; tests inject fakes)
+// ---------------------------------------------------------------------------
+
+/// One PTY's control surface (write/resize/pause/resume/kill). The kill
+/// semantics vary by mode: viewer PTYs detach, shell proxies release a
+/// viewer, control handles close the stream.
+pub trait PtyControl: Send + Sync {
+    fn write(&self, data: &[u8]);
+    fn resize(&self, cols: u16, rows: u16);
+    fn pause(&self);
+    fn resume(&self);
+    fn kill(&self);
+}
+
+/// A spawned PTY's output: the manager subscribes exactly one (data, exit)
+/// sink. The source calls the sink synchronously as bytes arrive (a real PTY
+/// from its reader thread; a test fake directly), buffering anything that
+/// arrives before `subscribe`, so no early prompt bytes are lost.
+pub trait PtyOutput: Send + Sync {
+    fn subscribe(&self, on_data: DataSink, on_exit: ExitSink);
+}
+
+/// A spawned PTY: a control surface, its output source, and an optional
+/// banner (degraded pipe-mode notice) delivered before live bytes.
+pub struct PtyHandle {
+    pub control: Arc<dyn PtyControl>,
+    pub output: Arc<dyn PtyOutput>,
+    pub banner: Option<Vec<u8>>,
+}
+
+pub struct SpawnSpec {
+    pub file: String,
+    pub args: Vec<String>,
+    pub cols: u16,
+    pub rows: u16,
+    pub cwd: PathBuf,
+    pub env: HashMap<String, String>,
+}
+
+/// A resolved cmux-tui binary: file plus an argv prefix.
+#[derive(Clone)]
+pub struct CmuxTui {
+    pub file: String,
+    pub prefix: Vec<String>,
+}
+
+pub struct EnsureDaemon {
+    pub created: bool,
+    pub socket_path: PathBuf,
+}
+
+#[async_trait]
+pub trait PtyDeps: Send + Sync {
+    async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle;
+    async fn resolve_cmux_tui(&self) -> Option<CmuxTui>;
+    async fn ensure_daemon(
+        &self,
+        cmux_tui: &CmuxTui,
+        session: &str,
+        socket_dir: &Path,
+        cwd: &Path,
+        env: &HashMap<String, String>,
+    ) -> Result<EnsureDaemon, String>;
+    async fn connect_control(&self, socket_path: &Path) -> Result<Arc<dyn ControlHandle>, String>;
+    async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()>;
+    fn socket_dir(&self) -> PathBuf;
+    fn shell(&self) -> String;
+}
+
+// ---------------------------------------------------------------------------
+// Frame context (the socket send + backpressure probe)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct FrameContext {
+    pub send: Arc<dyn Fn(Value) + Send + Sync>,
+    pub buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
+    pub trust: String,
+    pub local_roots: Option<Vec<String>>,
+    pub owner_user_id: Option<String>,
+}
+
+/// Scrubbed env for interactive PTYs (actions.mjs base, real TERM).
+pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut env = scrubbed_env(base);
+    env.insert("TERM".to_owned(), "xterm-256color".to_owned());
+    env
+}
+
+// ---------------------------------------------------------------------------
+// Shared session/attachment state
+// ---------------------------------------------------------------------------
+
+/// A per-attachment output sink into the framing path.
+struct ViewerSink {
+    id: u64,
+    on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
+    on_exit: Arc<dyn Fn(i64) + Send + Sync>,
+}
+
+/// A fallback $SHELL session: one PTY, a bounded ring, and a viewer set that
+/// fans output out to every attachment (multi-viewer, tmux-style).
+struct ShellSession {
+    control: Arc<dyn PtyControl>,
+    inner: Mutex<ShellInner>,
+    banner: Option<Vec<u8>>,
+}
+
+struct ShellInner {
+    ring: Vec<Bytes>,
+    ring_size: usize,
+    alive: bool,
+    viewers: Vec<ViewerSink>,
+}
+
+struct Attachment {
+    closing: Arc<AtomicBool>,
+    /// Releases this attachment (detach a viewer, close a control stream,
+    /// kill a viewer PTY) — never kills a shared session.
+    control: Arc<dyn PtyControl>,
+}
+
+struct Inner {
+    deps: Arc<dyn PtyDeps>,
+    home: PathBuf,
+    env: HashMap<String, String>,
+    max_ptys: usize,
+    scrollback_limit: usize,
+    output_cap: u64,
+    attachments: Mutex<HashMap<String, Attachment>>,
+    shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
+}
+
+pub struct PtyManager {
+    inner: Arc<Inner>,
+}
+
+impl PtyManager {
+    pub fn new(deps: Arc<dyn PtyDeps>, home: PathBuf, env: HashMap<String, String>) -> PtyManager {
+        PtyManager {
+            inner: Arc::new(Inner {
+                deps,
+                home,
+                env,
+                max_ptys: MAX_PTYS,
+                scrollback_limit: SCROLLBACK_LIMIT,
+                output_cap: OUTPUT_BUFFER_CAP,
+                attachments: Mutex::new(HashMap::new()),
+                shell_sessions: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub fn with_limits(
+        deps: Arc<dyn PtyDeps>,
+        home: PathBuf,
+        env: HashMap<String, String>,
+        max_ptys: usize,
+        scrollback_limit: usize,
+        output_cap: u64,
+    ) -> PtyManager {
+        PtyManager {
+            inner: Arc::new(Inner {
+                deps,
+                home,
+                env,
+                max_ptys,
+                scrollback_limit,
+                output_cap,
+                attachments: Mutex::new(HashMap::new()),
+                shell_sessions: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Handle one Worker -> relay PTY frame.
+    pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
+        let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
+        match frame_type {
+            "pty_open" => self.inner.clone().open(frame, context).await,
+            "pty_input" => {
+                let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
+                let Some(data) = frame
+                    .get("dataB64")
+                    .and_then(Value::as_str)
+                    .and_then(|b64| BASE64.decode(b64).ok())
+                else {
+                    return;
+                };
+                if let Some(attachment) =
+                    self.inner.attachments.lock().expect("attach lock").get(pty_id)
+                {
+                    attachment.control.write(&data);
+                }
+            }
+            "pty_resize" => {
+                let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
+                let (Some(cols), Some(rows)) =
+                    (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
+                else {
+                    return;
+                };
+                if let Some(attachment) =
+                    self.inner.attachments.lock().expect("attach lock").get(pty_id)
+                {
+                    attachment.control.resize(cols, rows);
+                }
+            }
+            "pty_flow" => {
+                let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
+                let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
+                if let Some(attachment) =
+                    self.inner.attachments.lock().expect("attach lock").get(pty_id)
+                {
+                    if pause {
+                        attachment.control.pause();
+                    } else {
+                        attachment.control.resume();
+                    }
+                }
+            }
+            "pty_close" => {
+                let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
+                self.inner.close(pty_id);
+            }
+            "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
+            _ => {}
+        }
+    }
+
+    /// The relay socket dropped: release every attachment (sessions live on).
+    pub fn detach_all(&self) {
+        let ids: Vec<String> =
+            self.inner.attachments.lock().expect("attach lock").keys().cloned().collect();
+        for id in ids {
+            self.inner.close(&id);
+        }
+    }
+}
+
+fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, message: &str) {
+    (context.send)(json!({
+        "version": PTY_PROTOCOL_VERSION,
+        "type": "pty_error",
+        "ptyId": pty_id,
+        "code": code,
+        "message": message,
+    }));
+}
+
+impl Inner {
+    async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
+        let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
+        if pty_id.is_empty() {
+            return;
+        }
+        let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
+
+        let session = frame.get("session").and_then(Value::as_str).unwrap_or_default().to_owned();
+        let (Some(cols), Some(rows)) = (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
+        else {
+            fail("bad_request", "invalid session name or dimensions");
+            return;
+        };
+        if !session_name_ok(&session) {
+            fail("bad_request", "invalid session name or dimensions");
+            return;
+        }
+        let mut surface_ref: Option<String> = None;
+        if let Some(surface) = frame.get("surface") {
+            match surface.as_str() {
+                Some(value) if surface_ref_ok(value) => surface_ref = Some(value.to_owned()),
+                _ => {
+                    fail("bad_request", "invalid surface ref");
+                    return;
+                }
+            }
+        }
+
+        // Owner-side trust floor: observe-trust machines admit only their
+        // OWNER's terminal. Any trust level admits the owner.
+        let trust = if context.trust.is_empty() {
+            frame.get("trust").and_then(Value::as_str).unwrap_or("supervised").to_owned()
+        } else {
+            context.trust.clone()
+        };
+        let owner = context.owner_user_id.as_deref();
+        let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
+        if trust == "observe" && (owner.is_none() || Some(actor) != owner) {
+            fail(
+                "trust_refused",
+                "this machine is paired at observe trust; terminals are owner-only",
+            );
+            return;
+        }
+
+        if self.attachments.lock().expect("attach lock").len() >= self.max_ptys {
+            fail(
+                "session_limit",
+                &format!("this relay caps concurrent terminals at {}", self.max_ptys),
+            );
+            return;
+        }
+
+        // cwd discipline: first allowed root (local config first, then the
+        // server-echoed list), else $HOME.
+        let server_roots: Option<Vec<String>> = frame
+            .get("allowedRoots")
+            .and_then(Value::as_array)
+            .map(|roots| roots.iter().filter_map(Value::as_str).map(str::to_owned).collect());
+        let first_roots = [context.local_roots.as_deref(), server_roots.as_deref()]
+            .into_iter()
+            .flatten()
+            .find(|roots| !roots.is_empty());
+        let cwd = match first_roots.and_then(|roots| roots.first()) {
+            Some(root) => expand_path(root, &self.home, &self.home),
+            None => self.home.clone(),
+        };
+        let env = pty_env(&self.env);
+
+        let cmux_tui = self.deps.resolve_cmux_tui().await;
+        let opened = if let (Some(cmux_tui), Some(surface_ref)) =
+            (cmux_tui.as_ref(), surface_ref.as_ref())
+        {
+            match self
+                .clone()
+                .open_cmux_terminal(
+                    cmux_tui,
+                    &session,
+                    surface_ref,
+                    cols,
+                    rows,
+                    &cwd,
+                    &env,
+                    &pty_id,
+                    context,
+                )
+                .await
+            {
+                Ok(Some(opened)) => Some(opened),
+                Ok(None) => None, // degrade to whole-session
+                Err(message) => {
+                    fail("failed", &message);
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+        let opened = match opened {
+            Some(opened) => opened,
+            None => {
+                let result = if let Some(cmux_tui) = cmux_tui.as_ref() {
+                    self.clone()
+                        .open_cmux(cmux_tui, &session, cols, rows, &cwd, &env, &pty_id, context)
+                        .await
+                } else {
+                    self.clone()
+                        .open_shell(&session, cols, rows, &cwd, &env, &pty_id, context)
+                        .await
+                };
+                match result {
+                    Ok(opened) => opened,
+                    Err(message) => {
+                        fail("failed", &message);
+                        return;
+                    }
+                }
+            }
+        };
+
+        self.attachments.lock().expect("attach lock").insert(
+            pty_id.clone(),
+            Attachment { closing: opened.closing, control: opened.control },
+        );
+        let mut opened_frame = serde_json::Map::new();
+        opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
+        opened_frame.insert("type".to_owned(), Value::from("pty_opened"));
+        opened_frame.insert("ptyId".to_owned(), Value::from(pty_id.clone()));
+        opened_frame.insert("session".to_owned(), Value::from(session));
+        if let Some(surface) = opened.surface {
+            opened_frame.insert("surface".to_owned(), Value::from(surface));
+        }
+        opened_frame.insert("created".to_owned(), Value::from(opened.created));
+        opened_frame.insert("cols".to_owned(), Value::from(cols));
+        opened_frame.insert("rows".to_owned(), Value::from(rows));
+        (context.send)(Value::Object(opened_frame));
+
+        // Output only AFTER pty_opened (ordering): banner, then scrollback
+        // replay, then live bytes.
+        (opened.start)();
+    }
+
+    /// Build the per-attachment emit closures (output + exit framing).
+    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink) {
+        let on_data = {
+            let inner = Arc::clone(self);
+            let context = context.clone();
+            let pty_id = pty_id.to_owned();
+            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context))
+                as Arc<dyn Fn(Bytes) + Send + Sync>
+        };
+        let on_exit = {
+            let inner = Arc::clone(self);
+            let context = context.clone();
+            let pty_id = pty_id.to_owned();
+            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context))
+                as Arc<dyn Fn(i64) + Send + Sync>
+        };
+        (on_data, on_exit)
+    }
+
+    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
+        if !self.attachments.lock().expect("attach lock").contains_key(pty_id) {
+            return;
+        }
+        // Zero-byte chunks carry nothing and historically crashed the web
+        // terminal's write path (D-R6-1); never put an empty frame on the wire.
+        if chunk.is_empty() {
+            return;
+        }
+        let buffered = (context.buffered_amount)();
+        if buffered > self.output_cap {
+            self.close(pty_id);
+            send_pty_error(
+                context,
+                pty_id,
+                "failed",
+                &format!(
+                    "dropped: {buffered} bytes buffered toward the server (cap {})",
+                    self.output_cap
+                ),
+            );
+            return;
+        }
+        (context.send)(json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_output",
+            "ptyId": pty_id,
+            "dataB64": BASE64.encode(chunk),
+        }));
+    }
+
+    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        match attachments.get(pty_id) {
+            Some(attachment) if !attachment.closing.load(Ordering::SeqCst) => {}
+            _ => return,
+        }
+        attachments.remove(pty_id);
+        drop(attachments);
+        (context.send)(json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_exit",
+            "ptyId": pty_id,
+            "code": code,
+        }));
+    }
+
+    /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
+    fn close(&self, pty_id: &str) {
+        let attachment = self.attachments.lock().expect("attach lock").remove(pty_id);
+        if let Some(attachment) = attachment {
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment.control.kill();
+        }
+    }
+}
+
+/// A resolved open: what to echo, plus a deferred `start` that begins output.
+struct Opened {
+    created: bool,
+    surface: Option<String>,
+    control: Arc<dyn PtyControl>,
+    closing: Arc<AtomicBool>,
+    start: Box<dyn FnOnce() + Send>,
+}
+
+// ---------------------------------------------------------------------------
+// A viewer PTY control that pumps its events into the framing sinks
+// ---------------------------------------------------------------------------
+
+/// Bridges one PTY (its own source, e.g. a cmux-tui attach viewer) to the
+/// framing sinks: banner first, then live bytes via `subscribe`.
+fn drive_handle(
+    output: Arc<dyn PtyOutput>,
+    banner: Option<Vec<u8>>,
+    on_data: DataSink,
+    on_exit: ExitSink,
+) {
+    if let Some(banner) = banner {
+        on_data(Bytes::from(banner));
+    }
+    output.subscribe(on_data, on_exit);
+}
+
+impl Inner {
+    /// cmux-tui path: daemon owns the session; the viewer is disposable.
+    #[allow(clippy::too_many_arguments)]
+    async fn open_cmux(
+        self: Arc<Self>,
+        cmux_tui: &CmuxTui,
+        session: &str,
+        cols: u16,
+        rows: u16,
+        cwd: &Path,
+        env: &HashMap<String, String>,
+        pty_id: &str,
+        context: &FrameContext,
+    ) -> Result<Opened, String> {
+        let socket_dir = self.deps.socket_dir();
+        let ensured = self.deps.ensure_daemon(cmux_tui, session, &socket_dir, cwd, env).await?;
+        let mut args = cmux_tui.prefix.clone();
+        args.extend(["attach".to_owned(), "--session".to_owned(), session.to_owned()]);
+        let handle = self
+            .deps
+            .spawn_pty(SpawnSpec {
+                file: cmux_tui.file.clone(),
+                args,
+                cols,
+                rows,
+                cwd: cwd.to_path_buf(),
+                env: env.clone(),
+            })
+            .await;
+        let control = Arc::clone(&handle.control);
+        let output = Arc::clone(&handle.output);
+        let banner = handle.banner.clone();
+        let (on_data, on_exit) = self.sinks(pty_id, context);
+        Ok(Opened {
+            created: ensured.created,
+            surface: None,
+            control,
+            closing: Arc::new(AtomicBool::new(false)),
+            start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
+        })
+    }
+
+    /// Fallback: a relay-held $SHELL session with a scrollback ring, fanned
+    /// out to any number of concurrent viewers.
+    #[allow(clippy::too_many_arguments)]
+    async fn open_shell(
+        self: Arc<Self>,
+        session: &str,
+        cols: u16,
+        rows: u16,
+        cwd: &Path,
+        env: &HashMap<String, String>,
+        pty_id: &str,
+        context: &FrameContext,
+    ) -> Result<Opened, String> {
+        let existing = {
+            let sessions = self.shell_sessions.lock().expect("shell lock");
+            sessions.get(session).cloned()
+        };
+        let mut created = false;
+        let shell_session = match existing {
+            Some(session) => {
+                session.control.resize(cols, rows);
+                session
+            }
+            None => {
+                let shell = self.deps.shell();
+                let handle = self
+                    .deps
+                    .spawn_pty(SpawnSpec {
+                        file: shell,
+                        args: Vec::new(),
+                        cols,
+                        rows,
+                        cwd: cwd.to_path_buf(),
+                        env: env.clone(),
+                    })
+                    .await;
+                let PtyHandle { control, output, banner } = handle;
+                let shell_session = Arc::new(ShellSession {
+                    control,
+                    banner,
+                    inner: Mutex::new(ShellInner {
+                        ring: Vec::new(),
+                        ring_size: 0,
+                        alive: true,
+                        viewers: Vec::new(),
+                    }),
+                });
+                // Session-level plumbing runs for the session's whole life:
+                // the ring fills even while detached, and exit ends the
+                // session for every attached viewer. One fanout sink is
+                // subscribed to the session PTY; per-viewer sinks live in the
+                // viewer set.
+                let session_name = session.to_owned();
+                let scrollback_limit = self.scrollback_limit;
+                let data_session = Arc::clone(&shell_session);
+                let exit_session = Arc::clone(&shell_session);
+                let manager = Arc::clone(&self);
+                let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
+                    let viewers_to_notify: Vec<Arc<dyn Fn(Bytes) + Send + Sync>> = {
+                        let mut inner = data_session.inner.lock().expect("shell inner lock");
+                        inner.ring_size += chunk.len();
+                        inner.ring.push(chunk.clone());
+                        while inner.ring_size > scrollback_limit && inner.ring.len() > 1 {
+                            let dropped = inner.ring.remove(0);
+                            inner.ring_size -= dropped.len();
+                        }
+                        inner.viewers.iter().map(|viewer| Arc::clone(&viewer.on_data)).collect()
+                    };
+                    for on_data in viewers_to_notify {
+                        on_data(chunk.clone());
+                    }
+                });
+                let on_session_exit: ExitSink = Arc::new(move |code: i64| {
+                    let viewers = {
+                        let mut inner = exit_session.inner.lock().expect("shell inner lock");
+                        inner.alive = false;
+                        std::mem::take(&mut inner.viewers)
+                    };
+                    manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
+                    for viewer in viewers {
+                        (viewer.on_exit)(code);
+                    }
+                });
+                output.subscribe(on_session_data, on_session_exit);
+                self.shell_sessions
+                    .lock()
+                    .expect("shell lock")
+                    .insert(session.to_owned(), Arc::clone(&shell_session));
+                created = true;
+                shell_session
+            }
+        };
+
+        // A stable viewer id lets release remove exactly this sink.
+        let viewer_id = next_viewer_id();
+        let released = Arc::new(AtomicBool::new(false));
+        let closing = Arc::new(AtomicBool::new(false));
+        let (on_data, on_exit) = self.sinks(pty_id, context);
+
+        // The per-attachment control proxies onto the session pty but its
+        // kill() only unhooks this viewer (release), never the session.
+        let proxy = Arc::new(ShellViewerControl {
+            session: Arc::clone(&shell_session),
+            viewer_id,
+            released: Arc::clone(&released),
+        });
+
+        let start_session = Arc::clone(&shell_session);
+        let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+            let mut inner = start_session.inner.lock().expect("shell inner lock");
+            if created {
+                if let Some(banner) = &start_session.banner {
+                    on_data(Bytes::from(banner.clone()));
+                }
+            } else if inner.ring_size > 0 {
+                let replay: Vec<u8> = inner.ring.iter().flat_map(|c| c.iter().copied()).collect();
+                on_data(Bytes::from(replay)); // scrollback replay
+            }
+            if released.load(Ordering::SeqCst) {
+                return; // detached while the open settled
+            }
+            if !inner.alive {
+                on_exit(0); // the session exited between open and start
+                return;
+            }
+            inner.viewers.push(ViewerSink { id: viewer_id, on_data, on_exit });
+        });
+
+        Ok(Opened { created, surface: None, control: proxy, closing, start })
+    }
+}
+
+struct ShellViewerControl {
+    session: Arc<ShellSession>,
+    viewer_id: u64,
+    released: Arc<AtomicBool>,
+}
+
+impl ShellViewerControl {
+    fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+        let mut inner = self.session.inner.lock().expect("shell inner lock");
+        inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+    }
+}
+
+impl PtyControl for ShellViewerControl {
+    fn write(&self, data: &[u8]) {
+        self.session.control.write(data);
+    }
+    fn resize(&self, cols: u16, rows: u16) {
+        self.session.control.resize(cols, rows);
+    }
+    fn pause(&self) {
+        self.session.control.pause();
+    }
+    fn resume(&self) {
+        self.session.control.resume();
+    }
+    fn kill(&self) {
+        self.release();
+    }
+}
+
+fn next_viewer_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+// ---------------------------------------------------------------------------
+// Raw single-terminal attach (W86): speak the cmux-tui control protocol
+// directly. attach-surface streams ONE terminal's PTY bytes (vt-state replay
+// first), send writes input, resize-surface resizes. No node-pty involved.
+// ---------------------------------------------------------------------------
+
+fn decode_b64_field(event: &Value, field: &str) -> Option<Bytes> {
+    event
+        .get(field)
+        .and_then(Value::as_str)
+        .and_then(|value| BASE64.decode(value).ok())
+        .map(Bytes::from)
+}
+
+/// Buffers control-stream output until start() attaches the live sinks, then
+/// flushes in order (vt-state/output precede the attach response, and
+/// pty_opened must precede all output).
+struct TerminalStream {
+    state: Mutex<TerminalStreamState>,
+}
+
+struct TerminalStreamState {
+    live_data: Option<Arc<dyn Fn(Bytes) + Send + Sync>>,
+    live_exit: Option<Arc<dyn Fn(i64) + Send + Sync>>,
+    backlog: Vec<Bytes>,
+    pending_exit: Option<i64>,
+    ended: bool,
+}
+
+impl TerminalStream {
+    fn new() -> TerminalStream {
+        TerminalStream {
+            state: Mutex::new(TerminalStreamState {
+                live_data: None,
+                live_exit: None,
+                backlog: Vec::new(),
+                pending_exit: None,
+                ended: false,
+            }),
+        }
+    }
+
+    fn push_output(&self, chunk: Bytes) {
+        let mut state = self.state.lock().expect("terminal stream lock");
+        match &state.live_data {
+            Some(sink) => {
+                let sink = Arc::clone(sink);
+                drop(state);
+                sink(chunk);
+            }
+            None => state.backlog.push(chunk),
+        }
+    }
+
+    fn finish_exit(&self, code: i64) {
+        let mut state = self.state.lock().expect("terminal stream lock");
+        if state.ended {
+            return;
+        }
+        state.ended = true;
+        match &state.live_exit {
+            Some(sink) => {
+                let sink = Arc::clone(sink);
+                drop(state);
+                sink(code);
+            }
+            None => state.pending_exit = Some(code),
+        }
+    }
+
+    fn go_live(
+        &self,
+        on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
+        on_exit: Arc<dyn Fn(i64) + Send + Sync>,
+    ) {
+        let (backlog, pending_exit) = {
+            let mut state = self.state.lock().expect("terminal stream lock");
+            state.live_data = Some(Arc::clone(&on_data));
+            state.live_exit = Some(Arc::clone(&on_exit));
+            (std::mem::take(&mut state.backlog), state.pending_exit.take())
+        };
+        for chunk in backlog {
+            on_data(chunk);
+        }
+        if let Some(code) = pending_exit {
+            on_exit(code);
+        }
+    }
+}
+
+struct ControlTerminalControl {
+    control: Arc<dyn ControlHandle>,
+    surface_id: i64,
+}
+
+impl PtyControl for ControlTerminalControl {
+    fn write(&self, data: &[u8]) {
+        self.control
+            .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }));
+    }
+    fn resize(&self, cols: u16, rows: u16) {
+        self.control.send(
+            "resize-surface",
+            json!({ "surface": self.surface_id, "cols": cols, "rows": rows }),
+        );
+    }
+    fn pause(&self) {
+        self.control.pause();
+    }
+    fn resume(&self) {
+        self.control.resume();
+    }
+    fn kill(&self) {
+        self.control.end(); // detach only; the daemon keeps the terminal
+    }
+}
+
+fn as_array(value: Option<&Value>) -> Vec<Value> {
+    value.and_then(Value::as_array).cloned().unwrap_or_default()
+}
+
+struct PtyTab {
+    surface_id: i64,
+    resource_id: Option<String>,
+    title: String,
+    name: String,
+    workspace: String,
+}
+
+/// Walk a list-workspaces tree into flat pty-tab records.
+fn collect_pty_tabs(data: Option<&Value>) -> Vec<PtyTab> {
+    let mut tabs = Vec::new();
+    for workspace in as_array(data.and_then(|d| d.get("workspaces"))) {
+        let workspace_name =
+            workspace.get("name").and_then(Value::as_str).unwrap_or_default().to_owned();
+        for screen in as_array(workspace.get("screens")) {
+            for pane in as_array(screen.get("panes")) {
+                for tab in as_array(pane.get("tabs")) {
+                    if tab.get("kind").and_then(Value::as_str) != Some("pty")
+                        || tab.get("dead").and_then(Value::as_bool) == Some(true)
+                    {
+                        continue;
+                    }
+                    let Some(surface_id) = tab.get("surface").and_then(Value::as_i64) else {
+                        continue;
+                    };
+                    tabs.push(PtyTab {
+                        surface_id,
+                        resource_id: tab
+                            .get("terminal_resource_id")
+                            .and_then(Value::as_str)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_owned),
+                        title: tab
+                            .get("title")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_owned(),
+                        name: tab
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_owned(),
+                        workspace: workspace_name.clone(),
+                    });
+                }
+            }
+        }
+    }
+    tabs
+}
+
+/// Compact cwd for picker subtitles: $HOME -> ~, keep the last two parts.
+fn shorten_cwd(cwd: &str, home: &str) -> String {
+    if cwd.is_empty() {
+        return String::new();
+    }
+    let collapsed = if !home.is_empty() && cwd.starts_with(home) {
+        format!("~{}", &cwd[home.len()..])
+    } else {
+        cwd.to_owned()
+    };
+    let parts: Vec<&str> = collapsed.split('/').filter(|p| !p.is_empty()).collect();
+    if collapsed.starts_with('~') || parts.len() <= 2 {
+        return collapsed;
+    }
+    format!("…/{}", parts[parts.len() - 2..].join("/"))
+}
+
+impl Inner {
+    #[allow(clippy::too_many_arguments)]
+    async fn open_cmux_terminal(
+        self: Arc<Self>,
+        cmux_tui: &CmuxTui,
+        session: &str,
+        surface_ref: &str,
+        cols: u16,
+        rows: u16,
+        cwd: &Path,
+        env: &HashMap<String, String>,
+        pty_id: &str,
+        context: &FrameContext,
+    ) -> Result<Option<Opened>, String> {
+        let socket_dir = self.deps.socket_dir();
+        let ensured = self.deps.ensure_daemon(cmux_tui, session, &socket_dir, cwd, env).await?;
+        let socket_path = socket_dir.join(format!("{session}.sock"));
+        let control = match self.deps.connect_control(&socket_path).await {
+            Ok(control) => control,
+            Err(_) => return Ok(None), // degrade to the whole-session attach
+        };
+
+        let identify = control.request("identify", json!({})).await;
+        let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
+        let protocol = info
+            .and_then(|v| v.get("data"))
+            .and_then(|d| d.get("protocol"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if protocol < CONTROL_MIN_PROTOCOL {
+            control.end();
+            return Ok(None);
+        }
+        let capabilities: Vec<String> = info
+            .and_then(|v| v.get("data"))
+            .map(|d| as_array(d.get("capabilities")))
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect();
+
+        // Resolve the ref: numeric surface id directly, else via the tree.
+        let mut surface_id: Option<i64> = if surface_ref.bytes().all(|b| b.is_ascii_digit()) {
+            surface_ref.parse().ok()
+        } else {
+            None
+        };
+        if surface_id.is_none() {
+            let listed = control.request("list-workspaces", json!({})).await;
+            let tabs = listed
+                .as_ref()
+                .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+                .map(|v| collect_pty_tabs(v.get("data")))
+                .unwrap_or_default();
+            surface_id = tabs
+                .iter()
+                .find(|tab| tab.resource_id.as_deref() == Some(surface_ref))
+                .map(|tab| tab.surface_id);
+        }
+        let Some(surface_id) = surface_id else {
+            control.end();
+            return Err(format!(
+                "terminal \"{surface_ref}\" not found in session \"{session}\" (it may have been closed)"
+            ));
+        };
+
+        let stream = Arc::new(TerminalStream::new());
+        let event_stream = Arc::clone(&stream);
+        control.on_event(Box::new(move |event| {
+            if event.get("surface").and_then(Value::as_i64) != Some(surface_id) {
+                return;
+            }
+            match event.get("event").and_then(Value::as_str).unwrap_or_default() {
+                "vt-state" | "output" => {
+                    if let Some(bytes) = decode_b64_field(event, "data") {
+                        event_stream.push_output(bytes);
+                    }
+                }
+                "resized" => {
+                    if let Some(replay) = decode_b64_field(event, "replay") {
+                        let mut reset = b"\x1bc".to_vec();
+                        reset.extend_from_slice(&replay);
+                        event_stream.push_output(Bytes::from(reset));
+                    }
+                }
+                "detached" => event_stream.finish_exit(0),
+                _ => {}
+            }
+        }));
+        let close_stream = Arc::clone(&stream);
+        control.on_close(Box::new(move || close_stream.finish_exit(0)));
+
+        let attach_params = if capabilities.iter().any(|c| c == "attach-initial-size") {
+            json!({ "surface": surface_id, "cols": cols, "rows": rows })
+        } else {
+            json!({ "surface": surface_id })
+        };
+        let attached = control.request("attach-surface", attach_params).await;
+        if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
+            control.end();
+            let reason = attached
+                .as_ref()
+                .and_then(|v| v.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("no reply");
+            return Err(format!("attach-surface failed for terminal \"{surface_ref}\": {reason}"));
+        }
+
+        let proxy = Arc::new(ControlTerminalControl { control, surface_id });
+        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let start_stream = Arc::clone(&stream);
+        Ok(Some(Opened {
+            created: ensured.created,
+            surface: Some(surface_ref.to_owned()),
+            control: proxy,
+            closing: Arc::new(AtomicBool::new(false)),
+            start: Box::new(move || start_stream.go_live(on_data, on_exit)),
+        }))
+    }
+
+    async fn list_surfaces(self: Arc<Self>, frame: &Value, context: &FrameContext) {
+        let request_id =
+            frame.get("requestId").and_then(Value::as_str).unwrap_or_default().to_owned();
+        if request_id.is_empty() {
+            return;
+        }
+        let mut surfaces: Vec<Value> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let socket_dir = self.deps.socket_dir();
+        let mut sessions: Vec<String> = Vec::new();
+        if let Ok(entries) = self.deps.read_dir(&socket_dir).await {
+            for name in entries {
+                let Some(id) = name.strip_suffix(".sock") else { continue };
+                if !session_name_ok(id) || seen.contains(id) {
+                    continue;
+                }
+                seen.insert(id.to_owned());
+                sessions.push(id.to_owned());
+            }
+        }
+        // Inner terminals per session (W86), best-effort.
+        let home = self.home.display().to_string();
+        for session in &sessions {
+            surfaces.push(json!({
+                "kind": "session",
+                "id": session,
+                "title": session,
+                "subtitle": "cmux-tui",
+            }));
+            let socket_path = socket_dir.join(format!("{session}.sock"));
+            for terminal in self.list_session_terminals(&socket_path, &home).await {
+                surfaces.push(json!({
+                    "kind": "terminal",
+                    "id": format!("{session}:{}", terminal.0),
+                    "title": terminal.1,
+                    "subtitle": format!("{session} · raw terminal"),
+                }));
+            }
+        }
+        {
+            let shell_sessions = self.shell_sessions.lock().expect("shell lock");
+            for (name, session) in shell_sessions.iter() {
+                let alive = session.inner.lock().expect("shell inner lock").alive;
+                if !alive || seen.contains(name) {
+                    continue;
+                }
+                seen.insert(name.clone());
+                surfaces.push(json!({
+                    "kind": "session",
+                    "id": name,
+                    "title": name,
+                    "subtitle": "shell",
+                }));
+            }
+        }
+        (context.send)(json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "surface_list_result",
+            "requestId": request_id,
+            "surfaces": surfaces,
+        }));
+    }
+
+    /// Enumerate the live terminals inside one cmux-tui session (W86):
+    /// (ref, title) pairs, best-effort and bounded.
+    async fn list_session_terminals(
+        &self,
+        socket_path: &Path,
+        home: &str,
+    ) -> Vec<(String, String)> {
+        let Ok(control) = self.deps.connect_control(socket_path).await else {
+            return Vec::new();
+        };
+        let identify = control.request("identify", json!({})).await;
+        let protocol = identify
+            .as_ref()
+            .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+            .and_then(|v| v.get("data"))
+            .and_then(|d| d.get("protocol"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if protocol < CONTROL_MIN_PROTOCOL {
+            control.end();
+            return Vec::new();
+        }
+        let listed = control.request("list-workspaces", json!({})).await;
+        let tabs: Vec<PtyTab> = listed
+            .as_ref()
+            .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+            .map(|v| collect_pty_tabs(v.get("data")))
+            .unwrap_or_default()
+            .into_iter()
+            .take(MAX_ENUM_TERMINALS)
+            .collect();
+        let mut out = Vec::new();
+        for tab in tabs {
+            let reference = tab.resource_id.clone().unwrap_or_else(|| tab.surface_id.to_string());
+            let mut title =
+                if !tab.title.is_empty() { tab.title.clone() } else { tab.name.clone() };
+            if title.is_empty() {
+                let proc =
+                    control.request("process-info", json!({ "surface": tab.surface_id })).await;
+                if let Some(data) = proc
+                    .as_ref()
+                    .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+                    .and_then(|v| v.get("data"))
+                {
+                    let command = data
+                        .get("command")
+                        .and_then(Value::as_str)
+                        .map(|c| {
+                            Path::new(c)
+                                .file_name()
+                                .map(|n| n.to_string_lossy().into_owned())
+                                .unwrap_or_default()
+                        })
+                        .unwrap_or_default();
+                    let cwd = shorten_cwd(
+                        data.get("cwd").and_then(Value::as_str).unwrap_or_default(),
+                        home,
+                    );
+                    title = [command, cwd]
+                        .into_iter()
+                        .filter(|p| !p.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" · ");
+                }
+            }
+            if title.is_empty() {
+                title = format!("terminal {}", tab.surface_id);
+            }
+            if !tab.workspace.is_empty() {
+                title = format!("{}: {title}", tab.workspace);
+            }
+            out.push((reference, title.chars().take(200).collect()));
+        }
+        control.end();
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — mirror packages/relay/test/pty.test.mjs. A fake PtyDeps drives the
+// real PtyManager through fake PTYs (synchronous emit) and a recording sink.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// A fake PTY: emit() calls the subscribed sink synchronously, like the
+    /// JS fakePty. Records writes/resizes/pause/kill for assertions.
+    #[derive(Default)]
+    struct FakeState {
+        on_data: Option<DataSink>,
+        on_exit: Option<ExitSink>,
+        written: Vec<Vec<u8>>,
+        resized: Vec<(u16, u16)>,
+        paused: bool,
+        killed: bool,
+    }
+
+    #[derive(Clone)]
+    struct FakePty {
+        state: Arc<StdMutex<FakeState>>,
+        spawn_file: String,
+        spawn_cwd: PathBuf,
+        spawn_term: String,
+    }
+
+    impl FakePty {
+        fn emit(&self, text: &str) {
+            let sink = self.state.lock().unwrap().on_data.clone();
+            if let Some(sink) = sink {
+                sink(Bytes::copy_from_slice(text.as_bytes()));
+            }
+        }
+        fn exit(&self, code: i64) {
+            let sink = self.state.lock().unwrap().on_exit.clone();
+            if let Some(sink) = sink {
+                sink(code);
+            }
+        }
+        fn written_string(&self, index: usize) -> String {
+            String::from_utf8_lossy(&self.state.lock().unwrap().written[index]).into_owned()
+        }
+    }
+
+    impl PtyControl for FakePty {
+        fn write(&self, data: &[u8]) {
+            self.state.lock().unwrap().written.push(data.to_vec());
+        }
+        fn resize(&self, cols: u16, rows: u16) {
+            self.state.lock().unwrap().resized.push((cols, rows));
+        }
+        fn pause(&self) {
+            self.state.lock().unwrap().paused = true;
+        }
+        fn resume(&self) {
+            self.state.lock().unwrap().paused = false;
+        }
+        fn kill(&self) {
+            self.state.lock().unwrap().killed = true;
+        }
+    }
+
+    impl PtyOutput for FakePty {
+        fn subscribe(&self, on_data: DataSink, on_exit: ExitSink) {
+            let mut state = self.state.lock().unwrap();
+            state.on_data = Some(on_data);
+            state.on_exit = Some(on_exit);
+        }
+    }
+
+    #[derive(Default)]
+    struct Recorded {
+        spawned: Vec<FakePty>,
+        daemons: Vec<(String, PathBuf)>,
+    }
+
+    struct FakeDeps {
+        env: HashMap<String, String>,
+        recorded: Arc<StdMutex<Recorded>>,
+        resolve: Option<CmuxTui>,
+        socket_dir: PathBuf,
+        read_dir: Option<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl PtyDeps for FakeDeps {
+        async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
+            let pty = FakePty {
+                state: Arc::new(StdMutex::new(FakeState::default())),
+                spawn_file: spec.file.clone(),
+                spawn_cwd: spec.cwd.clone(),
+                spawn_term: spec.env.get("TERM").cloned().unwrap_or_default(),
+            };
+            self.recorded.lock().unwrap().spawned.push(pty.clone());
+            let control: Arc<dyn PtyControl> = Arc::new(pty.clone());
+            let output: Arc<dyn PtyOutput> = Arc::new(pty);
+            PtyHandle { control, output, banner: None }
+        }
+        async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
+            self.resolve.clone()
+        }
+        async fn ensure_daemon(
+            &self,
+            _cmux_tui: &CmuxTui,
+            session: &str,
+            socket_dir: &Path,
+            _cwd: &Path,
+            _env: &HashMap<String, String>,
+        ) -> Result<EnsureDaemon, String> {
+            self.recorded
+                .lock()
+                .unwrap()
+                .daemons
+                .push((session.to_owned(), socket_dir.to_path_buf()));
+            Ok(EnsureDaemon {
+                created: true,
+                socket_path: socket_dir.join(format!("{session}.sock")),
+            })
+        }
+        async fn connect_control(
+            &self,
+            _socket_path: &Path,
+        ) -> Result<Arc<dyn ControlHandle>, String> {
+            Err("no control socket in tests unless injected".to_owned())
+        }
+        async fn read_dir(&self, _path: &Path) -> Result<Vec<String>, ()> {
+            self.read_dir.clone().ok_or(())
+        }
+        fn socket_dir(&self) -> PathBuf {
+            self.socket_dir.clone()
+        }
+        fn shell(&self) -> String {
+            self.env.get("SHELL").cloned().unwrap_or_else(|| "/bin/sh".to_owned())
+        }
+    }
+
+    struct Harness {
+        manager: PtyManager,
+        recorded: Arc<StdMutex<Recorded>>,
+        sent: Arc<StdMutex<Vec<Value>>>,
+        buffered: Arc<AtomicU64>,
+        owner: Option<String>,
+    }
+
+    fn env_map() -> HashMap<String, String> {
+        HashMap::from([
+            ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
+            ("PATH".to_owned(), "/usr/bin".to_owned()),
+            ("HOME".to_owned(), "/home/u".to_owned()),
+        ])
+    }
+
+    fn harness(resolve: Option<CmuxTui>, read_dir: Option<Vec<String>>) -> Harness {
+        let recorded = Arc::new(StdMutex::new(Recorded::default()));
+        let socket_dir = PathBuf::from("/run/cmux-tui-501");
+        let deps = Arc::new(FakeDeps {
+            env: env_map(),
+            recorded: Arc::clone(&recorded),
+            resolve,
+            socket_dir,
+            read_dir,
+        });
+        let manager = PtyManager::with_limits(
+            deps,
+            PathBuf::from("/home/u"),
+            env_map(),
+            MAX_PTYS,
+            SCROLLBACK_LIMIT,
+            OUTPUT_BUFFER_CAP,
+        );
+        Harness {
+            manager,
+            recorded,
+            sent: Arc::new(StdMutex::new(Vec::new())),
+            buffered: Arc::new(AtomicU64::new(0)),
+            owner: Some("user_owner".to_owned()),
+        }
+    }
+
+    impl Harness {
+        fn context(&self, trust: &str, owner: Option<String>) -> FrameContext {
+            let sent = Arc::clone(&self.sent);
+            let buffered = Arc::clone(&self.buffered);
+            FrameContext {
+                send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+                buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
+                trust: trust.to_owned(),
+                local_roots: None,
+                owner_user_id: owner,
+            }
+        }
+
+        async fn open(
+            &self,
+            pty_id: &str,
+            session: &str,
+            extra: Value,
+            trust: &str,
+            owner: Option<String>,
+        ) {
+            let mut frame = serde_json::json!({
+                "version": 4,
+                "type": "pty_open",
+                "ptyId": pty_id,
+                "session": session,
+                "cols": 80,
+                "rows": 24,
+                "actorId": "user_owner",
+                "trust": "supervised",
+                "allowedRoots": Value::Null,
+            });
+            if let Value::Object(extra) = extra {
+                for (k, v) in extra {
+                    frame[k] = v;
+                }
+            }
+            self.manager.handle_frame(&frame, &self.context(trust, owner)).await;
+        }
+
+        async fn frame(&self, frame: Value) {
+            self.manager
+                .handle_frame(&frame, &self.context("supervised", self.owner.clone()))
+                .await;
+        }
+
+        fn sent(&self) -> Vec<Value> {
+            self.sent.lock().unwrap().clone()
+        }
+        fn spawned(&self) -> Vec<FakePty> {
+            self.recorded.lock().unwrap().spawned.clone()
+        }
+        fn daemons(&self) -> Vec<(String, PathBuf)> {
+            self.recorded.lock().unwrap().daemons.clone()
+        }
+    }
+
+    fn b64(text: &str) -> String {
+        BASE64.encode(text.as_bytes())
+    }
+    fn from_b64(value: &str) -> String {
+        String::from_utf8_lossy(&BASE64.decode(value).unwrap()).into_owned()
+    }
+    fn ty(frame: &Value) -> &str {
+        frame.get("type").and_then(Value::as_str).unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn bad_session_names_and_dims_answer_bad_request() {
+        let h = harness(None, None);
+        h.open("p1", "bad name!", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "ok", serde_json::json!({ "cols": 0 }), "supervised", h.owner.clone()).await;
+        let sent = h.sent();
+        assert_eq!(ty(&sent[0]), "pty_error");
+        assert_eq!(sent[0]["code"], "bad_request");
+        assert_eq!(sent[1]["code"], "bad_request");
+    }
+
+    #[tokio::test]
+    async fn observe_trust_refuses_non_owner_but_admits_owner() {
+        let h = harness(None, None);
+        h.open(
+            "p1",
+            "main",
+            serde_json::json!({ "actorId": "user_other" }),
+            "observe",
+            h.owner.clone(),
+        )
+        .await;
+        assert_eq!(h.sent()[0]["code"], "trust_refused");
+        h.open("p2", "main", Value::Null, "observe", h.owner.clone()).await;
+        assert_eq!(ty(&h.sent()[1]), "pty_opened");
+    }
+
+    #[tokio::test]
+    async fn observe_trust_with_unknown_owner_refuses() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "observe", None).await;
+        assert_eq!(h.sent()[0]["code"], "trust_refused");
+    }
+
+    #[tokio::test]
+    async fn shell_open_output_input_resize_flow_round_trip() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let opened = &h.sent()[0];
+        assert_eq!(opened["type"], "pty_opened");
+        assert_eq!(opened["created"], true);
+        assert_eq!(opened["cols"], 80);
+        let pty = h.spawned()[0].clone();
+        assert_eq!(pty.spawn_file, "/bin/fakesh");
+        assert_eq!(pty.spawn_cwd, PathBuf::from("/home/u"));
+        assert_eq!(pty.spawn_term, "xterm-256color");
+
+        pty.emit("hello\r\n");
+        assert_eq!(ty(&h.sent()[1]), "pty_output");
+        assert_eq!(from_b64(h.sent()[1]["dataB64"].as_str().unwrap()), "hello\r\n");
+
+        h.frame(serde_json::json!({ "type": "pty_input", "ptyId": "p1", "dataB64": b64("ls\r") }))
+            .await;
+        assert_eq!(pty.written_string(0), "ls\r");
+
+        h.frame(
+            serde_json::json!({ "type": "pty_resize", "ptyId": "p1", "cols": 132, "rows": 43 }),
+        )
+        .await;
+        assert!(pty.state.lock().unwrap().resized.contains(&(132, 43)));
+
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
+        assert!(pty.state.lock().unwrap().paused);
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": false })).await;
+        assert!(!pty.state.lock().unwrap().paused);
+    }
+
+    #[tokio::test]
+    async fn close_detaches_without_killing_reattach_replays_scrollback() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        pty.emit("before detach\r\n");
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        assert!(!pty.state.lock().unwrap().killed);
+        pty.emit("while detached\r\n");
+        let before = h.sent().len();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let opened = &h.sent()[before];
+        assert_eq!(opened["type"], "pty_opened");
+        assert_eq!(opened["created"], false);
+        let replay = &h.sent()[before + 1];
+        assert_eq!(
+            from_b64(replay["dataB64"].as_str().unwrap()),
+            "before detach\r\nwhile detached\r\n"
+        );
+        assert_eq!(h.spawned().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn zero_byte_chunks_never_become_output_frames() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        pty.emit("");
+        assert_eq!(h.sent().len(), 1);
+        pty.emit("real bytes");
+        assert_eq!(h.sent().len(), 2);
+        assert_eq!(from_b64(h.sent()[1]["dataB64"].as_str().unwrap()), "real bytes");
+    }
+
+    #[tokio::test]
+    async fn unknown_pty_ids_are_tolerated_on_every_verb() {
+        let h = harness(None, None);
+        for frame in [
+            serde_json::json!({ "type": "pty_input", "ptyId": "ghost", "dataB64": b64("x") }),
+            serde_json::json!({ "type": "pty_resize", "ptyId": "ghost", "cols": 10, "rows": 10 }),
+            serde_json::json!({ "type": "pty_flow", "ptyId": "ghost", "pause": true }),
+            serde_json::json!({ "type": "pty_close", "ptyId": "ghost" }),
+            serde_json::json!({ "type": "pty_close", "ptyId": "ghost" }),
+        ] {
+            h.frame(frame).await;
+        }
+        assert_eq!(h.sent().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn session_exit_sends_exit_once_and_next_open_creates() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.spawned()[0].exit(3);
+        let exit = &h.sent()[1];
+        assert_eq!(exit["type"], "pty_exit");
+        assert_eq!(exit["code"], 3);
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        assert_eq!(h.sent()[2]["created"], true);
+        assert_eq!(h.spawned().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn scrollback_ring_is_bounded() {
+        let recorded = Arc::new(StdMutex::new(Recorded::default()));
+        let deps = Arc::new(FakeDeps {
+            env: env_map(),
+            recorded: Arc::clone(&recorded),
+            resolve: None,
+            socket_dir: PathBuf::from("/run/cmux-tui-501"),
+            read_dir: None,
+        });
+        let manager = PtyManager::with_limits(
+            deps,
+            PathBuf::from("/home/u"),
+            env_map(),
+            MAX_PTYS,
+            32,
+            OUTPUT_BUFFER_CAP,
+        );
+        let h = Harness {
+            manager,
+            recorded,
+            sent: Arc::new(StdMutex::new(Vec::new())),
+            buffered: Arc::new(AtomicU64::new(0)),
+            owner: Some("user_owner".to_owned()),
+        };
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        for i in 0..10 {
+            pty.emit(&format!("chunk-{i}-aaaaaaaa\r\n"));
+        }
+        let before = h.sent().len();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let replay = from_b64(h.sent()[before + 1]["dataB64"].as_str().unwrap());
+        assert!(replay.len() <= 32 + 20);
+        assert!(replay.contains("chunk-9"));
+        assert!(!replay.contains("chunk-0"));
+    }
+
+    #[tokio::test]
+    async fn second_open_adds_a_viewer_output_fans_out_to_both() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        assert_eq!(h.spawned().len(), 1);
+        assert_eq!(h.sent()[1]["created"], false);
+        h.spawned()[0].emit("hello");
+        let mut ids: Vec<String> = h
+            .sent()
+            .iter()
+            .filter(|f| ty(f) == "pty_output")
+            .map(|f| f["ptyId"].as_str().unwrap().to_owned())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["p1", "p2"]);
+    }
+
+    #[tokio::test]
+    async fn detaching_one_viewer_leaves_the_other_live_exit_reaches_every_viewer() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        let before = h.sent().len();
+        h.spawned()[0].emit("again");
+        let after: Vec<(String, String)> = h.sent()[before..]
+            .iter()
+            .map(|f| (ty(f).to_owned(), f["ptyId"].as_str().unwrap().to_owned()))
+            .collect();
+        assert_eq!(after, vec![("pty_output".to_owned(), "p2".to_owned())]);
+        h.spawned()[0].exit(0);
+        let last = h.sent();
+        let last = last.last().unwrap();
+        assert_eq!(last["type"], "pty_exit");
+        assert_eq!(last["ptyId"], "p2");
+    }
+
+    #[tokio::test]
+    async fn more_than_max_ptys_answers_session_limit() {
+        let h = harness(None, None);
+        for i in 0..MAX_PTYS {
+            h.open(&format!("p{i}"), &format!("s{i}"), Value::Null, "supervised", h.owner.clone())
+                .await;
+        }
+        h.open("overflow", "extra", Value::Null, "supervised", h.owner.clone()).await;
+        let last = h.sent();
+        let last = last.last().unwrap();
+        assert_eq!(last["type"], "pty_error");
+        assert_eq!(last["code"], "session_limit");
+    }
+
+    #[tokio::test]
+    async fn wedged_worker_drops_attachment_session_survives() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.buffered.store(OUTPUT_BUFFER_CAP + 1, Ordering::SeqCst);
+        pty.emit("flood");
+        let last = h.sent();
+        let last = last.last().unwrap();
+        assert_eq!(last["type"], "pty_error");
+        assert_eq!(last["code"], "failed");
+        assert!(!pty.state.lock().unwrap().killed);
+        h.buffered.store(0, Ordering::SeqCst);
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let reopened =
+            h.sent().into_iter().find(|f| ty(f) == "pty_opened" && f["ptyId"] == "p2").unwrap();
+        assert_eq!(reopened["created"], false);
+    }
+
+    #[tokio::test]
+    async fn cmux_open_ensures_daemon_and_close_kills_only_the_viewer() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness(Some(cmux), None);
+        h.open("p1", "work", Value::Null, "supervised", h.owner.clone()).await;
+        assert_eq!(h.daemons().len(), 1);
+        assert_eq!(h.daemons()[0].0, "work");
+        assert_eq!(h.daemons()[0].1, PathBuf::from("/run/cmux-tui-501"));
+        assert_eq!(h.sent()[0]["created"], true);
+        let viewer = h.spawned()[0].clone();
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        assert!(viewer.state.lock().unwrap().killed);
+    }
+
+    #[tokio::test]
+    async fn surface_list_globs_socket_dir_and_merges_shell_sessions() {
+        let h = harness(
+            None,
+            Some(vec!["work.sock".to_owned(), "notes.sock".to_owned(), "junk".to_owned()]),
+        );
+        // A live shell session too.
+        h.open("p1", "myshell", Value::Null, "supervised", h.owner.clone()).await;
+        h.frame(serde_json::json!({ "type": "surface_list", "requestId": "r1" })).await;
+        let result = h.sent().into_iter().find(|f| ty(f) == "surface_list_result").unwrap();
+        let surfaces = result["surfaces"].as_array().unwrap();
+        let ids: Vec<&str> = surfaces.iter().map(|s| s["id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&"work"));
+        assert!(ids.contains(&"notes"));
+        assert!(ids.contains(&"myshell"));
+        assert!(!ids.contains(&"junk"));
+    }
+
+    #[tokio::test]
+    async fn detach_all_releases_attachments_sessions_stay_reattachable() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.manager.detach_all();
+        let before = h.sent().len();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        assert_eq!(h.sent()[before]["created"], false); // same session survived
+        assert_eq!(h.spawned().len(), 1);
+    }
+
+    #[test]
+    fn pty_env_scrubs_secrets_but_keeps_a_real_term() {
+        let mut base = env_map();
+        base.insert("OPENAI_API_KEY".to_owned(), "secret".to_owned());
+        let env = pty_env(&base);
+        assert!(!env.contains_key("OPENAI_API_KEY"));
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color"));
+    }
+}

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1,0 +1,448 @@
+//! Production `PtyDeps`: real PTY allocation (cmux-pty), cmux-tui binary
+//! resolution, headless daemon management, and the unix control socket.
+//! Behavior port of the default* helpers in `packages/relay/bin/pty.mjs`.
+//!
+//! PTY reads and the child wait are blocking, so each runs on a dedicated
+//! blocking thread that forwards into the attachment's event channel; writes
+//! and resizes go through the (blocking) master behind a mutex.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use cmux_pty::{MasterPty, PtySize};
+
+use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle, connect_control};
+use crate::pty::{
+    CmuxTui, DataSink, EnsureDaemon, ExitSink, PtyControl, PtyDeps, PtyHandle, PtyOutput,
+    SpawnSpec, session_name_ok,
+};
+
+const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;
+
+/// Buffers output until the manager subscribes, then calls the sink directly
+/// from the reader/wait threads. One sink; the manager fans out itself.
+#[derive(Default)]
+struct SourceState {
+    on_data: Option<DataSink>,
+    on_exit: Option<ExitSink>,
+    backlog: Vec<Bytes>,
+    pending_exit: Option<i64>,
+    exited: bool,
+}
+
+struct ThreadOutput {
+    state: Mutex<SourceState>,
+}
+
+impl ThreadOutput {
+    fn new() -> Arc<ThreadOutput> {
+        Arc::new(ThreadOutput { state: Mutex::new(SourceState::default()) })
+    }
+
+    fn push_data(&self, chunk: Bytes) {
+        let sink = {
+            let mut state = self.state.lock().expect("source lock");
+            match state.on_data.clone() {
+                Some(sink) => Some(sink),
+                None => {
+                    state.backlog.push(chunk.clone());
+                    None
+                }
+            }
+        };
+        if let Some(sink) = sink {
+            sink(chunk);
+        }
+    }
+
+    fn push_exit(&self, code: i64) {
+        let sink = {
+            let mut state = self.state.lock().expect("source lock");
+            if state.exited {
+                return;
+            }
+            state.exited = true;
+            match state.on_exit.clone() {
+                Some(sink) => Some(sink),
+                None => {
+                    state.pending_exit = Some(code);
+                    None
+                }
+            }
+        };
+        if let Some(sink) = sink {
+            sink(code);
+        }
+    }
+}
+
+impl PtyOutput for ThreadOutput {
+    fn subscribe(&self, on_data: DataSink, on_exit: ExitSink) {
+        let (backlog, pending_exit) = {
+            let mut state = self.state.lock().expect("source lock");
+            state.on_data = Some(Arc::clone(&on_data));
+            state.on_exit = Some(Arc::clone(&on_exit));
+            (std::mem::take(&mut state.backlog), state.pending_exit.take())
+        };
+        for chunk in backlog {
+            on_data(chunk);
+        }
+        if let Some(code) = pending_exit {
+            on_exit(code);
+        }
+    }
+}
+
+pub struct RealPtyDeps {
+    env: HashMap<String, String>,
+    uid: u32,
+    shell: String,
+}
+
+impl RealPtyDeps {
+    pub fn new(env: HashMap<String, String>) -> RealPtyDeps {
+        // SAFETY: getuid is always safe.
+        let uid = unsafe { libc::getuid() };
+        let shell = env.get("SHELL").cloned().unwrap_or_else(|| "/bin/sh".to_owned());
+        RealPtyDeps { env, uid, shell }
+    }
+}
+
+/// A real PTY master behind a mutex; write/resize block briefly.
+struct MasterControl {
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
+}
+
+impl PtyControl for MasterControl {
+    fn write(&self, data: &[u8]) {
+        if let Ok(mut writer) = self.writer.lock() {
+            let _ = writer.write_all(data);
+            let _ = writer.flush();
+        }
+    }
+    fn resize(&self, cols: u16, rows: u16) {
+        if let Ok(master) = self.master.lock() {
+            let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+        }
+    }
+    fn pause(&self) {}
+    fn resume(&self) {}
+    fn kill(&self) {
+        if let Ok(mut killer) = self.killer.lock() {
+            let _ = killer.kill();
+        }
+    }
+}
+
+/// A degraded pipe-mode shell (no TTY) used when PTY allocation fails. The
+/// child is owned by its wait thread; kill signals it by pid.
+struct PipeControl {
+    stdin: Mutex<Option<std::process::ChildStdin>>,
+    pid: i32,
+}
+
+impl PtyControl for PipeControl {
+    fn write(&self, data: &[u8]) {
+        if let Ok(mut guard) = self.stdin.lock()
+            && let Some(stdin) = guard.as_mut()
+        {
+            let _ = stdin.write_all(data);
+            let _ = stdin.flush();
+        }
+    }
+    fn resize(&self, _cols: u16, _rows: u16) {}
+    fn pause(&self) {}
+    fn resume(&self) {}
+    fn kill(&self) {
+        // SAFETY: signalling a child pid this handle spawned; harmless if gone.
+        unsafe {
+            libc::kill(self.pid, libc::SIGKILL);
+        }
+    }
+}
+
+fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
+    let pair = cmux_pty::open(PtySize {
+        rows: spec.rows,
+        cols: spec.cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+    let mut command = cmux_pty::PtyCommand::new(spec.file.clone());
+    command.args(spec.args.clone());
+    command.cwd(&spec.cwd);
+    command.env_clear();
+    for (key, value) in &spec.env {
+        command.env(key, value);
+    }
+    let spawned = pair.spawn(command)?;
+    let reader = spawned.master.try_clone_reader()?;
+    let writer = spawned.master.take_writer()?;
+    let killer = spawned.child.clone_killer();
+    let output = ThreadOutput::new();
+
+    // Blocking reader thread -> output sink.
+    let data_output = Arc::clone(&output);
+    std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut buffer = [0_u8; 32_768];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(count) => data_output.push_data(Bytes::copy_from_slice(&buffer[..count])),
+            }
+        }
+    });
+    // Blocking wait thread -> exit.
+    let mut child = spawned.child;
+    let exit_output = Arc::clone(&output);
+    std::thread::spawn(move || {
+        let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        exit_output.push_exit(code);
+    });
+
+    Ok(PtyHandle {
+        control: Arc::new(MasterControl {
+            master: Mutex::new(spawned.master),
+            writer: Mutex::new(writer),
+            killer: Mutex::new(killer),
+        }),
+        output,
+        banner: None,
+    })
+}
+
+fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
+    let shell = spec.env.get("SHELL").cloned().unwrap_or_else(|| "/bin/sh".to_owned());
+    let output = ThreadOutput::new();
+    let mut command = std::process::Command::new(&shell);
+    command.arg("-i").current_dir(&spec.cwd).env_clear();
+    for (key, value) in &spec.env {
+        command.env(key, value);
+    }
+    command.env("TERM", "dumb");
+    command.stdin(std::process::Stdio::piped());
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    let banner = format!(
+        "[cmux-relay] PTY allocation failed ({reason}); running {} without a TTY.\r\n",
+        Path::new(&shell)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| shell.clone()),
+    );
+    match command.spawn() {
+        Ok(mut child) => {
+            let stdin = child.stdin.take();
+            let pid = child.id() as i32;
+            if let Some(stdout) = child.stdout.take() {
+                let out = Arc::clone(&output);
+                std::thread::spawn(move || pump_pipe(stdout, out));
+            }
+            if let Some(stderr) = child.stderr.take() {
+                let out = Arc::clone(&output);
+                std::thread::spawn(move || pump_pipe(stderr, out));
+            }
+            // The wait would need its own thread; the shell exits when its
+            // pipes close, and the manager treats a data EOF plus process
+            // teardown as the end. Report exit when both pipes close.
+            let wait_output = Arc::clone(&output);
+            std::thread::spawn(move || {
+                let code =
+                    child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
+                wait_output.push_exit(code);
+            });
+            PtyHandle {
+                control: Arc::new(PipeControl { stdin: Mutex::new(stdin), pid }),
+                output,
+                banner: Some(banner.into_bytes()),
+            }
+        }
+        Err(error) => {
+            let _ = error;
+            output.push_exit(1);
+            PtyHandle { control: Arc::new(DeadControl), output, banner: Some(banner.into_bytes()) }
+        }
+    }
+}
+
+struct DeadControl;
+impl PtyControl for DeadControl {
+    fn write(&self, _data: &[u8]) {}
+    fn resize(&self, _cols: u16, _rows: u16) {}
+    fn pause(&self) {}
+    fn resume(&self) {}
+    fn kill(&self) {}
+}
+
+fn pump_pipe(mut stream: impl Read, output: Arc<ThreadOutput>) {
+    let mut buffer = [0_u8; 32_768];
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) | Err(_) => break,
+            Ok(count) => output.push_data(Bytes::copy_from_slice(&buffer[..count])),
+        }
+    }
+}
+
+async fn socket_exists(path: &Path) -> bool {
+    tokio::fs::metadata(path).await.is_ok()
+}
+
+#[async_trait]
+impl PtyDeps for RealPtyDeps {
+    async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
+        // PTY allocation and thread setup are blocking; run off the reactor.
+        // On PTY allocation failure (ptmx exhaustion et al) degrade to a
+        // pipe-mode shell so the terminal still functions, with a banner.
+        tokio::task::spawn_blocking(move || match spawn_real_pty(&spec) {
+            Ok(handle) => handle,
+            Err(error) => spawn_pipe_mode(&spec, &error.to_string()),
+        })
+        .await
+        .unwrap_or_else(|_| PtyHandle {
+            control: Arc::new(DeadControl),
+            output: ThreadOutput::new(),
+            banner: None,
+        })
+    }
+
+    async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
+        if let Some(override_path) =
+            self.env.get("CHATMUX_RELAY_CMUX_TUI").filter(|value| !value.trim().is_empty())
+        {
+            let path = override_path.trim();
+            return if is_executable(Path::new(path)).await {
+                Some(CmuxTui { file: path.to_owned(), prefix: Vec::new() })
+            } else {
+                None
+            };
+        }
+        // Never a bare `cmux` on PATH — that name is ambiguous; only cmux-tui.
+        for dir in self.env.get("PATH").map(String::as_str).unwrap_or("").split(':') {
+            if dir.is_empty() {
+                continue;
+            }
+            let candidate = Path::new(dir).join("cmux-tui");
+            if is_executable(&candidate).await {
+                return Some(CmuxTui {
+                    file: candidate.to_string_lossy().into_owned(),
+                    prefix: Vec::new(),
+                });
+            }
+        }
+        None
+    }
+
+    async fn ensure_daemon(
+        &self,
+        cmux_tui: &CmuxTui,
+        session: &str,
+        socket_dir: &Path,
+        cwd: &Path,
+        env: &HashMap<String, String>,
+    ) -> Result<EnsureDaemon, String> {
+        let socket_path = socket_dir.join(format!("{session}.sock"));
+        if socket_exists(&socket_path).await {
+            return Ok(EnsureDaemon { created: false, socket_path });
+        }
+        let mut args = cmux_tui.prefix.clone();
+        args.extend(["--headless".to_owned(), "--session".to_owned(), session.to_owned()]);
+        let mut command = tokio::process::Command::new(&cmux_tui.file);
+        command.args(&args).current_dir(cwd).env_clear();
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.stdin(std::process::Stdio::null());
+        command.stdout(std::process::Stdio::null());
+        command.stderr(std::process::Stdio::null());
+        command.process_group(0);
+        command.spawn().map_err(|error| format!("cmux-tui daemon spawn failed: {error}"))?;
+
+        let deadline = Instant::now() + Duration::from_millis(DAEMON_SOCKET_WAIT_MS);
+        while Instant::now() < deadline {
+            if socket_exists(&socket_path).await {
+                // Probe a control round-trip before declaring readiness.
+                while Instant::now() < deadline {
+                    let mut probe = tokio::process::Command::new(&cmux_tui.file);
+                    let mut probe_args = cmux_tui.prefix.clone();
+                    probe_args.extend([
+                        "--session".to_owned(),
+                        session.to_owned(),
+                        "client".to_owned(),
+                        "list".to_owned(),
+                        "--json".to_owned(),
+                    ]);
+                    probe.args(&probe_args).env_clear();
+                    for (key, value) in env {
+                        probe.env(key, value);
+                    }
+                    probe.stdin(std::process::Stdio::null());
+                    probe.stdout(std::process::Stdio::null());
+                    probe.stderr(std::process::Stdio::null());
+                    match probe.status().await {
+                        Ok(status) if status.success() => {
+                            return Ok(EnsureDaemon { created: true, socket_path });
+                        }
+                        _ => tokio::time::sleep(Duration::from_millis(50)).await,
+                    }
+                }
+                // Soft gate: socket exists but the probe verb never answered
+                // (an older cmux-tui). Attach anyway.
+                return Ok(EnsureDaemon { created: true, socket_path });
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err(format!("cmux-tui daemon for \"{session}\" never created {}", socket_path.display()))
+    }
+
+    async fn connect_control(&self, socket_path: &Path) -> Result<Arc<dyn ControlHandle>, String> {
+        connect_control(socket_path, CONTROL_TIMEOUT_MS).await
+    }
+
+    async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()> {
+        let mut entries = tokio::fs::read_dir(path).await.map_err(|_| ())?;
+        let mut names = Vec::new();
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        Ok(names)
+    }
+
+    fn socket_dir(&self) -> PathBuf {
+        let runtime = self
+            .env
+            .get("XDG_RUNTIME_DIR")
+            .or_else(|| self.env.get("TMPDIR"))
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("/tmp");
+        Path::new(runtime).join(format!("cmux-tui-{}", self.uid))
+    }
+
+    fn shell(&self) -> String {
+        self.shell.clone()
+    }
+}
+
+async fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    match tokio::fs::metadata(path).await {
+        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
+        Err(_) => false,
+    }
+}
+
+/// Session-name validity is re-exported so the daemon path can reject early.
+pub fn valid_session(name: &str) -> bool {
+    session_name_ok(name)
+}

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1,19 +1,35 @@
 //! Connected state: hello negotiation, heartbeats, trust sync, reconnect
-//! with jittered exponential backoff. Behavior port of `stayOnline` /
-//! `relaySession` in `packages/relay/bin/cmux-relay.mjs`.
+//! with jittered exponential backoff, and the exec/PTY frame dispatch.
+//! Behavior port of `stayOnline` / `relaySession` in
+//! `packages/relay/bin/cmux-relay.mjs`.
+//!
+//! Slices 2/3: `action_request` runs the exec verbs (`actions`); the
+//! `pty_*` family drives the PtyManager (`pty`). Both re-check the machine's
+//! own reconciled trust locally. The PtyManager is a per-process singleton
+//! held across reconnects (sessions persist; only attachments detach on a
+//! socket drop). Output from spawned exec/PTY tasks rides an outbound
+//! channel so the socket stays single-writer; `pending_bytes` approximates
+//! the server-directed backpressure the JS relay read from `ws.bufferedAmount`.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt as _, StreamExt as _};
 use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::mpsc;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
+use crate::actions::{ActionContext, perform_action, process_env_snapshot, scrubbed_env};
 use crate::config::{Config, save_config};
 use crate::error::RelayError;
 use crate::pairing::websocket_url;
+use crate::pty::{FrameContext, PtyManager};
 use crate::trust::{
     DEFAULT_RELAY_TRUST, Trust, clear_invalid_yolo_confirmation, effective_local_trust,
     has_yolo_confirmation, relay_trust,
@@ -27,6 +43,49 @@ pub struct SessionState {
     pub first_connect: bool,
     pub first_run: bool,
     pub managed: bool,
+}
+
+/// The machine-side authority read at each exec/PTY dispatch: reconciled
+/// trust, allowed roots, and the paired owner. Updated on hello_accepted and
+/// trust_ack; never the frame's echo alone.
+#[derive(Clone, Default)]
+struct AuthSnapshot {
+    trust: String,
+    roots: Option<Vec<String>>,
+    owner: Option<String>,
+}
+
+/// Process-lifetime state shared across reconnects. The PtyManager singleton
+/// keeps sessions alive while attachments detach with each socket.
+pub struct SessionRuntime {
+    home: PathBuf,
+    base_env: HashMap<String, String>,
+    #[cfg(unix)]
+    pty: Arc<PtyManager>,
+}
+
+impl SessionRuntime {
+    pub fn new() -> SessionRuntime {
+        let base_env = process_env_snapshot();
+        let home = base_env.get("HOME").map(PathBuf::from).unwrap_or_else(std::env::temp_dir);
+        #[cfg(unix)]
+        let pty = {
+            let deps = Arc::new(crate::pty_deps::RealPtyDeps::new(base_env.clone()));
+            Arc::new(PtyManager::new(deps, home.clone(), base_env.clone()))
+        };
+        SessionRuntime {
+            home,
+            base_env,
+            #[cfg(unix)]
+            pty,
+        }
+    }
+}
+
+impl Default for SessionRuntime {
+    fn default() -> SessionRuntime {
+        SessionRuntime::new()
+    }
 }
 
 fn now_ms() -> i64 {
@@ -43,12 +102,12 @@ fn jitter() -> f64 {
 }
 
 /// Keep the machine online forever. Fatal errors end the process; anything
-/// else rides a jittered exponential backoff with a 30s ceiling, riding out
-/// Worker deploys and network loss without user action.
+/// else rides a jittered exponential backoff with a 30s ceiling.
 pub async fn stay_online(mut config: Config, config_path: &Path, mut state: SessionState) -> ! {
+    let runtime = SessionRuntime::new();
     let mut attempt: u32 = 0;
     loop {
-        match relay_session(&mut config, config_path, &mut state).await {
+        match relay_session(&mut config, config_path, &mut state, &runtime).await {
             Ok(was_connected) => {
                 if was_connected {
                     attempt = 0;
@@ -75,10 +134,33 @@ fn save(config: &Config, config_path: &Path) {
     }
 }
 
+/// Build a per-frame FrameContext reading the current reconciled auth.
+fn make_context(
+    out: &mpsc::UnboundedSender<Value>,
+    pending: &Arc<AtomicU64>,
+    auth: &AuthSnapshot,
+) -> FrameContext {
+    let sender = out.clone();
+    let pending_send = Arc::clone(pending);
+    let pending_probe = Arc::clone(pending);
+    FrameContext {
+        send: Arc::new(move |frame: Value| {
+            let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
+            pending_send.fetch_add(size, Ordering::SeqCst);
+            let _ = sender.send(frame);
+        }),
+        buffered_amount: Arc::new(move || pending_probe.load(Ordering::SeqCst)),
+        trust: auth.trust.clone(),
+        local_roots: auth.roots.clone(),
+        owner_user_id: auth.owner.clone(),
+    }
+}
+
 async fn relay_session(
     config: &mut Config,
     config_path: &Path,
     state: &mut SessionState,
+    runtime: &SessionRuntime,
 ) -> Result<bool, RelayError> {
     if config.backend.is_empty() {
         return Err(RelayError::fatal(
@@ -87,9 +169,10 @@ async fn relay_session(
     }
     let socket_url =
         websocket_url(&format!("{}/v2/relays/{}/socket", config.backend, config.device_id));
-    let (mut socket, _response) = connect_async(socket_url.as_str())
+    let (socket, _response) = connect_async(socket_url.as_str())
         .await
         .map_err(|error| RelayError::transient(error.to_string()))?;
+    let socket = Arc::new(AsyncMutex::new(socket));
 
     let local_roots = config.allowed_roots.clone().filter(|roots| !roots.is_empty());
     let hello = HelloFrame {
@@ -105,244 +188,339 @@ async fn relay_session(
     let hello_text =
         serde_json::to_string(&hello).map_err(|error| RelayError::transient(error.to_string()))?;
     socket
+        .lock()
+        .await
         .send(Message::Text(hello_text.into()))
         .await
         .map_err(|error| RelayError::transient(error.to_string()))?;
+
+    // Outbound frame channel (exec/PTY tasks -> socket) + backpressure gauge.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Value>();
+    let pending = Arc::new(AtomicU64::new(0));
+    let auth = Arc::new(std::sync::Mutex::new(AuthSnapshot::default()));
+
+    // Ordered PTY frame dispatch on its own task so a slow open (daemon
+    // spawn) never stalls heartbeats or other frames.
+    #[cfg(unix)]
+    let pty_tx = {
+        let (pty_tx, mut pty_rx) = mpsc::unbounded_channel::<Value>();
+        let manager = Arc::clone(&runtime.pty);
+        let out = out_tx.clone();
+        let pending = Arc::clone(&pending);
+        let auth = Arc::clone(&auth);
+        tokio::spawn(async move {
+            while let Some(frame) = pty_rx.recv().await {
+                let snapshot = auth.lock().expect("auth lock").clone();
+                let context = make_context(&out, &pending, &snapshot);
+                manager.handle_frame(&frame, &context).await;
+            }
+        });
+        pty_tx
+    };
 
     let mut connected = false;
     let mut negotiated_version: u64 = 0;
     let mut unknown_types: HashSet<String> = HashSet::new();
     let mut heartbeat: Option<tokio::time::Interval> = None;
 
-    loop {
-        let incoming = tokio::select! {
-            _ = async {
-                match heartbeat.as_mut() {
-                    Some(interval) => interval.tick().await,
-                    None => std::future::pending().await,
-                }
-            }, if heartbeat.is_some() => {
+    let result = loop {
+        enum Wake {
+            Heartbeat,
+            Outbound(Option<Value>),
+            Incoming(Option<Result<Message, tokio_tungstenite::tungstenite::Error>>),
+        }
+        let wake = {
+            let mut guard = socket.lock().await;
+            tokio::select! {
+                _ = async {
+                    match heartbeat.as_mut() {
+                        Some(interval) => interval.tick().await,
+                        None => std::future::pending().await,
+                    }
+                }, if heartbeat.is_some() => Wake::Heartbeat,
+                frame = out_rx.recv() => Wake::Outbound(frame),
+                incoming = guard.next() => Wake::Incoming(incoming),
+            }
+        };
+        match wake {
+            Wake::Heartbeat => {
                 let frame = heartbeat_frame(now_ms()).to_string();
-                if socket.send(Message::Text(frame.into())).await.is_err() {
-                    return Ok(connected);
+                if socket.lock().await.send(Message::Text(frame.into())).await.is_err() {
+                    break Ok(connected);
                 }
-                continue;
             }
-            incoming = socket.next() => incoming,
-        };
-        let message = match incoming {
-            Some(Ok(message)) => message,
-            Some(Err(error)) => return Err(RelayError::transient(error.to_string())),
-            None => return Ok(connected),
-        };
-        let text = match message {
-            Message::Text(text) => text,
-            Message::Ping(payload) => {
-                let _ = socket.send(Message::Pong(payload)).await;
-                continue;
+            Wake::Outbound(Some(frame)) => {
+                let text = frame.to_string();
+                let size = text.len() as u64;
+                let sent = socket.lock().await.send(Message::Text(text.into())).await;
+                pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
+                if sent.is_err() {
+                    break Ok(connected);
+                }
             }
-            Message::Close(_) => return Ok(connected),
-            _ => continue,
-        };
-        // Unreadable frames are ignored; the socket stays open.
-        let Some(frame) = parse_server_frame(&text) else { continue };
-        match frame {
-            ServerFrame::HelloAccepted(hello) => {
-                connected = true;
-                negotiated_version = hello.relay_protocol_version;
-                clear_invalid_yolo_confirmation(config);
-                let configured =
-                    relay_trust(config.pending_trust.as_deref().or(config.trust.as_deref()));
-                let local_trust =
-                    if state.managed { DEFAULT_RELAY_TRUST } else { effective_local_trust(config) };
-                if !state.managed && configured != local_trust {
-                    config.pending_trust = Some(local_trust.as_str().to_owned());
-                    save(config, config_path);
-                }
-                // v4+ servers name the paired owner so PTY opens can be
-                // re-checked locally. Persisted for --status.
-                if let Some(owner) = hello.owner_user_id {
-                    config.owner_user_id = Some(owner);
-                }
-                if state.managed {
-                    match hello.managed_session_token.as_deref().filter(|token| token.len() >= 32) {
-                        Some(token) => {
-                            // Runtime memory only. The enrollment file was
-                            // already shredded; managed mode never saves.
-                            config.token = token.to_owned();
+            Wake::Outbound(None) => {}
+            Wake::Incoming(incoming) => {
+                let message = match incoming {
+                    Some(Ok(message)) => message,
+                    Some(Err(error)) => break Err(RelayError::transient(error.to_string())),
+                    None => break Ok(connected),
+                };
+                let text = match message {
+                    Message::Text(text) => text,
+                    Message::Ping(payload) => {
+                        let _ = socket.lock().await.send(Message::Pong(payload)).await;
+                        continue;
+                    }
+                    Message::Close(_) => break Ok(connected),
+                    _ => continue,
+                };
+                // Unreadable frames are ignored; the socket stays open.
+                let Some(frame) = parse_server_frame(&text) else { continue };
+                match frame {
+                    ServerFrame::HelloAccepted(hello) => {
+                        connected = true;
+                        negotiated_version = hello.relay_protocol_version;
+                        clear_invalid_yolo_confirmation(config);
+                        let configured = relay_trust(
+                            config.pending_trust.as_deref().or(config.trust.as_deref()),
+                        );
+                        let local_trust = if state.managed {
+                            DEFAULT_RELAY_TRUST
+                        } else {
+                            effective_local_trust(config)
+                        };
+                        if !state.managed && configured != local_trust {
+                            config.pending_trust = Some(local_trust.as_str().to_owned());
+                            save(config, config_path);
                         }
-                        None => {
-                            if !config.enrollment_claimed {
-                                return Err(RelayError::fatal(
-                                    "Managed enrollment was not accepted.",
-                                ));
+                        if let Some(owner) = hello.owner_user_id {
+                            config.owner_user_id = Some(owner);
+                        }
+                        if state.managed {
+                            match hello
+                                .managed_session_token
+                                .as_deref()
+                                .filter(|token| token.len() >= 32)
+                            {
+                                Some(token) => config.token = token.to_owned(),
+                                None => {
+                                    if !config.enrollment_claimed {
+                                        break Err(RelayError::fatal(
+                                            "Managed enrollment was not accepted.",
+                                        ));
+                                    }
+                                }
+                            }
+                            config.enrollment_claimed = true;
+                        }
+                        let display_name = if hello.machine_name.is_empty() {
+                            config.name.clone().unwrap_or_default()
+                        } else {
+                            hello.machine_name.clone()
+                        };
+                        let shown_trust = if state.managed {
+                            hello.trust.clone()
+                        } else {
+                            local_trust.as_str().to_owned()
+                        };
+                        println!(
+                            "Connected as {display_name} (protocol v{}, trust {shown_trust}, scope {}).",
+                            hello.relay_protocol_version, hello.scope,
+                        );
+                        if state.first_connect {
+                            state.first_connect = false;
+                            println!(
+                                "{}",
+                                if state.first_run {
+                                    "Leave this terminal running, or rely on autostart to keep \
+                                     this machine reachable."
+                                } else {
+                                    "Leave this running; chatmux can now reach this machine."
+                                }
+                            );
+                        }
+                        if !state.managed
+                            && (local_trust.as_str() != hello.trust
+                                || local_trust == Trust::Autonomous)
+                        {
+                            let frame = set_trust_frame(local_trust.as_str()).to_string();
+                            if socket.lock().await.send(Message::Text(frame.into())).await.is_err()
+                            {
+                                break Ok(connected);
+                            }
+                        } else if !state.managed {
+                            config.trust = Some(local_trust.as_str().to_owned());
+                            config.pending_trust = None;
+                            save(config, config_path);
+                        } else {
+                            config.trust = Some(hello.trust.clone());
+                        }
+                        // Publish the reconciled auth for exec/PTY dispatch.
+                        {
+                            let effective_trust = if state.managed {
+                                hello.trust.clone()
+                            } else {
+                                local_trust.as_str().to_owned()
+                            };
+                            let mut snapshot = auth.lock().expect("auth lock");
+                            snapshot.trust = effective_trust;
+                            snapshot.roots = local_roots.clone();
+                            snapshot.owner = config.owner_user_id.clone();
+                        }
+                        let mut interval = tokio::time::interval(Duration::from_millis(
+                            hello.heartbeat_interval_ms,
+                        ));
+                        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                        interval.reset();
+                        heartbeat = Some(interval);
+                    }
+                    ServerFrame::UpgradeRequired { min_version, message } => {
+                        let advertised = advertised_protocol();
+                        break Err(RelayError::fatal(format!(
+                            "This cmux-relay speaks relay protocol v{advertised}, but the server \
+                             requires v{min_version} or newer.\n{message}\n\nUpgrade:\n  npx \
+                             cmux-relay@latest        # npx fetches the latest release each run\n  \
+                             npm i -g cmux-relay@latest   # if you installed it globally"
+                        )));
+                    }
+                    ServerFrame::HeartbeatAck => {}
+                    ServerFrame::TrustAck { trust } => {
+                        let Some(ack) = Trust::parse(&trust) else { continue };
+                        if ack == Trust::Autonomous && !has_yolo_confirmation(config) {
+                            config.trust = Some(DEFAULT_RELAY_TRUST.as_str().to_owned());
+                            config.pending_trust = Some(DEFAULT_RELAY_TRUST.as_str().to_owned());
+                            clear_invalid_yolo_confirmation(config);
+                            if !state.managed {
+                                save(config, config_path);
+                            }
+                            let frame = set_trust_frame(DEFAULT_RELAY_TRUST.as_str()).to_string();
+                            let _ = socket.lock().await.send(Message::Text(frame.into())).await;
+                            eprintln!(
+                                "Refused an autonomous trust acknowledgement without this \
+                                 machine's local YOLO receipt."
+                            );
+                            continue;
+                        }
+                        config.trust = Some(ack.as_str().to_owned());
+                        config.pending_trust = None;
+                        if ack != Trust::Autonomous {
+                            config.yolo_confirmed_at = None;
+                        }
+                        if !state.managed {
+                            save(config, config_path);
+                        }
+                        auth.lock().expect("auth lock").trust = ack.as_str().to_owned();
+                        println!("Trust level set to {ack}.");
+                    }
+                    ServerFrame::ActionRequest { action_id, verb, raw } => {
+                        // Managed sandbox relays serve terminals, not verbs;
+                        // below the exec dialect the server never sends these.
+                        if negotiated_version < EXEC_PROTOCOL_VERSION || state.managed {
+                            continue;
+                        }
+                        let snapshot = auth.lock().expect("auth lock").clone();
+                        let action = ActionContext {
+                            trust: snapshot.trust,
+                            local_roots: snapshot.roots,
+                            home: runtime.home.clone(),
+                            env: scrubbed_env(&runtime.base_env),
+                        };
+                        let out = out_tx.clone();
+                        let pending = Arc::clone(&pending);
+                        let actor = raw
+                            .get("actorId")
+                            .and_then(Value::as_str)
+                            .unwrap_or("chatmux")
+                            .to_owned();
+                        tokio::spawn(async move {
+                            let result = perform_action(&raw, &action).await;
+                            let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                            if ok {
+                                println!(
+                                    "Ran {verb} for {actor} (action {}).",
+                                    &action_id[..action_id.len().min(8)]
+                                );
+                            } else {
+                                let code =
+                                    result.get("code").and_then(Value::as_str).unwrap_or("failed");
+                                println!("Refused {verb} ({code}) for {actor}.");
+                            }
+                            let size = serde_json::to_string(&result)
+                                .map(|text| text.len() as u64)
+                                .unwrap_or(0);
+                            pending.fetch_add(size, Ordering::SeqCst);
+                            let _ = out.send(result);
+                        });
+                    }
+                    ServerFrame::Pty { frame_type, raw } => {
+                        if negotiated_version < PTY_PROTOCOL_VERSION {
+                            continue;
+                        }
+                        if frame_type == "pty_open" {
+                            let session = raw.get("session").and_then(Value::as_str).unwrap_or("?");
+                            let actor =
+                                raw.get("actorId").and_then(Value::as_str).unwrap_or("chatmux");
+                            println!("Terminal attach to session \"{session}\" for {actor}.");
+                        }
+                        #[cfg(unix)]
+                        {
+                            let _ = pty_tx.send(raw);
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            // Non-Unix relays cannot allocate PTYs; answer typed.
+                            let reply = match frame_type.as_str() {
+                                "pty_open" => raw.get("ptyId").and_then(Value::as_str).map(|id| {
+                                    serde_json::json!({
+                                        "version": PTY_PROTOCOL_VERSION,
+                                        "type": "pty_error",
+                                        "ptyId": id,
+                                        "code": "failed",
+                                        "message": "terminals are not available on this relay platform",
+                                    })
+                                }),
+                                "surface_list" => {
+                                    raw.get("requestId").and_then(Value::as_str).map(|id| {
+                                        serde_json::json!({
+                                            "version": PTY_PROTOCOL_VERSION,
+                                            "type": "surface_list_result",
+                                            "requestId": id,
+                                            "surfaces": [],
+                                        })
+                                    })
+                                }
+                                _ => None,
+                            };
+                            if let Some(reply) = reply {
+                                let _ = out_tx.send(reply);
                             }
                         }
                     }
-                    config.enrollment_claimed = true;
-                }
-                let display_name = if hello.machine_name.is_empty() {
-                    config.name.clone().unwrap_or_default()
-                } else {
-                    hello.machine_name.clone()
-                };
-                let shown_trust = if state.managed {
-                    hello.trust.clone()
-                } else {
-                    local_trust.as_str().to_owned()
-                };
-                println!(
-                    "Connected as {display_name} (protocol v{}, trust {shown_trust}, scope {}).",
-                    hello.relay_protocol_version, hello.scope,
-                );
-                if state.first_connect {
-                    state.first_connect = false;
-                    println!(
-                        "{}",
-                        if state.first_run {
-                            "Leave this terminal running, or rely on autostart to keep this \
-                             machine reachable."
-                        } else {
-                            "Leave this running; chatmux can now reach this machine."
+                    ServerFrame::Error { code, message } => {
+                        if code == "unauthorized" || code == "machine_mismatch" {
+                            break Err(RelayError::fatal(format!(
+                                "The server refused this machine's credential ({code}). The \
+                                 pairing may have been replaced or revoked. Re-pair with: npx \
+                                 cmux-relay --pair"
+                            )));
                         }
-                    );
-                }
-                // The relay's local config is the owner-at-the-keyboard
-                // authority. A phone approval can never raise trust by
-                // itself: when the server row is more permissive than this
-                // local setting, send the local value back through the
-                // authenticated set_trust frame. Older or missing config
-                // defaults to supervised, so reconnects fail closed.
-                if !state.managed
-                    && (local_trust.as_str() != hello.trust || local_trust == Trust::Autonomous)
-                {
-                    let frame = set_trust_frame(local_trust.as_str()).to_string();
-                    if socket.send(Message::Text(frame.into())).await.is_err() {
-                        return Ok(connected);
+                        let suffix = message.map(|text| format!(" — {text}")).unwrap_or_default();
+                        eprintln!("Server error: {code}{suffix}");
                     }
-                } else if !state.managed {
-                    config.trust = Some(local_trust.as_str().to_owned());
-                    config.pending_trust = None;
-                    save(config, config_path);
-                } else {
-                    config.trust = Some(hello.trust.clone());
-                }
-                let mut interval =
-                    tokio::time::interval(Duration::from_millis(hello.heartbeat_interval_ms));
-                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-                // The first tick of a tokio interval fires immediately;
-                // consume it so heartbeats start one interval from now,
-                // like the JS setInterval.
-                interval.reset();
-                heartbeat = Some(interval);
-            }
-            ServerFrame::UpgradeRequired { min_version, message } => {
-                let advertised = advertised_protocol();
-                return Err(RelayError::fatal(format!(
-                    "This cmux-relay speaks relay protocol v{advertised}, but the server \
-                     requires v{min_version} or newer.\n{message}\n\nUpgrade:\n  npx \
-                     cmux-relay@latest        # npx fetches the latest release each run\n  npm \
-                     i -g cmux-relay@latest   # if you installed it globally"
-                )));
-            }
-            ServerFrame::HeartbeatAck => {}
-            ServerFrame::TrustAck { trust } => {
-                let Some(ack) = Trust::parse(&trust) else { continue };
-                if ack == Trust::Autonomous && !has_yolo_confirmation(config) {
-                    config.trust = Some(DEFAULT_RELAY_TRUST.as_str().to_owned());
-                    config.pending_trust = Some(DEFAULT_RELAY_TRUST.as_str().to_owned());
-                    clear_invalid_yolo_confirmation(config);
-                    if !state.managed {
-                        save(config, config_path);
+                    ServerFrame::Unknown { frame_type } => {
+                        if unknown_types.insert(frame_type.clone()) {
+                            eprintln!(
+                                "Ignoring unknown server frame type \"{frame_type}\" (a newer server?)."
+                            );
+                        }
                     }
-                    let frame = set_trust_frame(DEFAULT_RELAY_TRUST.as_str()).to_string();
-                    let _ = socket.send(Message::Text(frame.into())).await;
-                    eprintln!(
-                        "Refused an autonomous trust acknowledgement without this machine's \
-                         local YOLO receipt."
-                    );
-                    continue;
-                }
-                config.trust = Some(ack.as_str().to_owned());
-                config.pending_trust = None;
-                if ack != Trust::Autonomous {
-                    config.yolo_confirmed_at = None;
-                }
-                if !state.managed {
-                    save(config, config_path);
-                }
-                println!("Trust level set to {ack}.");
-            }
-            ServerFrame::ActionRequest { action_id, verb } => {
-                // Remote execution verbs land in a later slice
-                // (README: port plan). Below the exec dialect the server
-                // never sends these; a typed refusal keeps callers unblocked
-                // if one arrives anyway.
-                if negotiated_version < EXEC_PROTOCOL_VERSION || state.managed {
-                    continue;
-                }
-                let refusal = serde_json::json!({
-                    "version": FRAME_VERSION,
-                    "type": "action_result",
-                    "actionId": action_id,
-                    "ok": false,
-                    "code": "unsupported_verb",
-                    "message": "This relay build does not run verbs yet (Rust port slice 1).",
-                });
-                println!("Refused {verb} (unsupported_verb) for chatmux.");
-                if socket.send(Message::Text(refusal.to_string().into())).await.is_err() {
-                    return Ok(connected);
-                }
-            }
-            ServerFrame::Pty { frame_type, pty_id, request_id } => {
-                // PTY attach lands in a later slice (README: port plan).
-                if negotiated_version < PTY_PROTOCOL_VERSION {
-                    continue;
-                }
-                let reply: Option<Value> = match frame_type.as_str() {
-                    "pty_open" => pty_id.map(|pty_id| {
-                        serde_json::json!({
-                            "version": FRAME_VERSION,
-                            "type": "pty_error",
-                            "ptyId": pty_id,
-                            "code": "failed",
-                            "message":
-                                "This relay build does not attach terminals yet (Rust port slice 1).",
-                        })
-                    }),
-                    "surface_list" => request_id.map(|request_id| {
-                        serde_json::json!({
-                            "version": FRAME_VERSION,
-                            "type": "surface_list_result",
-                            "requestId": request_id,
-                            "surfaces": [],
-                        })
-                    }),
-                    _ => None,
-                };
-                if let Some(reply) = reply
-                    && socket.send(Message::Text(reply.to_string().into())).await.is_err()
-                {
-                    return Ok(connected);
-                }
-            }
-            ServerFrame::Error { code, message } => {
-                if code == "unauthorized" || code == "machine_mismatch" {
-                    return Err(RelayError::fatal(format!(
-                        "The server refused this machine's credential ({code}). The pairing \
-                         may have been replaced or revoked. Re-pair with: npx cmux-relay --pair"
-                    )));
-                }
-                let suffix = message.map(|text| format!(" — {text}")).unwrap_or_default();
-                eprintln!("Server error: {code}{suffix}");
-            }
-            ServerFrame::Unknown { frame_type } => {
-                if unknown_types.insert(frame_type.clone()) {
-                    eprintln!(
-                        "Ignoring unknown server frame type \"{frame_type}\" (a newer server?)."
-                    );
                 }
             }
         }
-    }
+    };
+
+    // Attachments die with the socket; sessions persist (docs/TERMINAL.md).
+    #[cfg(unix)]
+    runtime.pty.detach_all();
+    result
 }

--- a/cmux-tui/crates/chatmux-relay/src/wire.rs
+++ b/cmux-tui/crates/chatmux-relay/src/wire.rs
@@ -19,13 +19,12 @@ use serde_json::Value;
 
 use crate::config::ManagedIdentity;
 
-/// Relay wire dialect this build ADVERTISES. The full JS relay speaks v5
-/// (exec + PTY + credential frames); this build implements the v2 core
-/// (hello negotiation, heartbeats, trust) and therefore advertises v2 so
-/// the Worker never dispatches verbs it cannot run — the server's designed
-/// degrade for older relays. Slice 3 (PTY) raises this to 4; slice 4
-/// (exec verbs) to 5.
-pub const ADVERTISED_PROTOCOL_VERSION: u64 = 2;
+/// Relay wire dialect this build ADVERTISES. Slice 1 advertised v2 (core
+/// only). Slices 2 (PTY multi-viewer) and 3 (exec verbs + v5 process
+/// credentials) are implemented, so this build advertises v5 — the Worker
+/// may dispatch exec verbs and the pty_* family. The pane data-plane verbs
+/// (wire v6) land in a later slice and bump this again.
+pub const ADVERTISED_PROTOCOL_VERSION: u64 = 5;
 /// Frame dialect marker (`RelayFrameVersion`, >= 2) on every sent frame.
 pub const FRAME_VERSION: u64 = 2;
 /// Verbs exist from this dialect on.
@@ -112,11 +111,11 @@ pub enum ServerFrame {
     ActionRequest {
         action_id: String,
         verb: String,
+        raw: Value,
     },
     Pty {
         frame_type: String,
-        pty_id: Option<String>,
-        request_id: Option<String>,
+        raw: Value,
     },
     Error {
         code: String,
@@ -170,13 +169,10 @@ pub fn parse_server_frame(raw: &str) -> Option<ServerFrame> {
         "action_request" => Some(ServerFrame::ActionRequest {
             action_id: get_str(&frame, "actionId")?,
             verb: get_str(&frame, "verb")?,
+            raw: frame,
         }),
         "pty_open" | "pty_input" | "pty_resize" | "pty_flow" | "pty_close" | "surface_list" => {
-            Some(ServerFrame::Pty {
-                frame_type,
-                pty_id: get_str(&frame, "ptyId"),
-                request_id: get_str(&frame, "requestId"),
-            })
+            Some(ServerFrame::Pty { frame_type, raw: frame })
         }
         "error" => Some(ServerFrame::Error {
             code: get_str(&frame, "code")?,


### PR DESCRIPTION
## What

Slices 2 and 3 of the Rust `chatmux-relay` (crate `cmux-tui/crates/chatmux-relay`), building on the slice-1 core (#10559). They share the frame-dispatch machinery, so they land together. The advertised relay dialect rises to **5**.

**Not the `cmux-relay` circuit crate** — that's a different product, untouched.

### Slice 2 — PTY bridge (`pty.rs`, `pty_deps.rs`, `control.rs`)

Port of `packages/relay/bin/pty.mjs`:
- Shell fallback session with a bounded 256 KiB scrollback ring and the **0.0.10 multi-viewer fan-out**: any number of attachments per session; `MAX_PTYS = 8` caps process-wide concurrency, `session_limit` past it.
- cmux-tui whole-session viewer path (ensure a headless daemon, attach a viewer PTY; detach kills only the viewer).
- W86 raw single-terminal path over the JSON-lines control socket (`identify`/`list-workspaces`/`attach-surface`/`send`/`resize-surface`), degrading to the whole-session attach below the capability floor.
- `surface_list` (cmux-tui sockets + inner terminals + shell sessions), the buffered-output cap (drops the attachment, session survives), the no-empty-frame rule, unknown-ptyId tolerance, detach ≠ kill.
- Real PTY allocation via `cmux-pty` with pipe-mode degradation on allocation failure.

### Slice 3 — exec verbs (`actions.rs`)

Port of `packages/relay/bin/actions.mjs`: exec/read/write/ls/grep/find with the 60k output bound, 2 MB read cap, `--allow-root` + server-echoed path scoping, lexical + canonical (realpath) double pass, `O_NOFOLLOW` opens, scrubbed env, hard process-group timeouts (SIGTERM then SIGKILL), the v5 one-call process-credential runtime, and the reconciled-trust gate (observe = read-only verbs only).

### Dispatch (`session.rs`)

Small match arms: exec runs on a spawned task; PTY frames on one ordered per-connection task. Output rides an outbound channel so the socket stays single-writer; `pending_bytes` gauges the server-directed backpressure the JS relay read from `ws.bufferedAmount`. The PtyManager is a per-process singleton (sessions persist; attachments detach on a socket drop).

## Evidence

- **59 unit tests** mirror `pty.test.mjs` (trust floor, lifecycle, scrollback bound, multi-viewer fan-out, detach-leaves-other-live, MAX_PTYS, buffered cap, cmux-tui daemon, surface_list) and `actions.test.mjs` (path scoping, symlink escape, realpath confinement, exec cwd + process env, observe trust, timeouts).
- Chatmux conformance harness (local wrangler dev, Rust release binary via `CHATMUX_RELAY_BIN` — chatmux PR #341): `e2e-terminal-pty.ts` 8/8 incl. multi-viewer fan-out + surviving-viewer-after-detach; `e2e-relay.ts` 11/11 (v5 negotiated, non-stale).
- Hosted merge gate `verify-cmux-tui-hosted.sh --full` in progress (run 32570932011).

## Coordination

A parallel agent is adding the workspace/pane verbs (wire v6) in the same crate on a separate branch. Per the plan, the **dialect-6 bump lands in whichever of the two PRs merges last**, only once e2e-terminal-pty + e2e-relay + e2e-workspace are all green on the combined head. This PR advertises 5; if it merges first, the workspace PR rebases and owns the 6 bump. PTY and exec live in their own modules with small dispatch arms; `main.rs` is unchanged.

## Next

Slice 4 (workspace verbs + preview proxy) is the parallel agent's lane. Slice 5 (autostart + npm platform packages + 0.1.0 publish + image rebake + delete `packages/relay`) is unclaimed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789990928&installation_model_id=21920&pr_number=10571&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10571&signature=403ef2fe987c2cfa32ac92487d464e0e87c260726ad4a1170432286347140343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PTY multi-viewer bridge and exec verbs to `cmux-tui/crates/chatmux-relay`, raising the advertised relay wire dialect to v5. The relay now matches the JS relay PTY/session model and runs exec actions with local trust and path scoping, enabling the Worker to dispatch `pty_*` and `action_request` safely.

- PTY bridge (`pty.rs`, `pty_deps.rs`, `control.rs`): multi-viewer fan-out, 256 KiB scrollback, `MAX_PTYS = 8`, cmux-tui whole-session viewer path with headless daemon, W86 raw single-terminal control-socket path with capability-based degrade, surface enumeration, buffered-output cap drops only the attachment, detach does not kill session, unknown `ptyId` tolerated, real PTY via `cmux-pty` with pipe-mode fallback.
- Exec verbs (`actions.rs`): exec/read/write/ls/grep/find with a 60k output bound and 2 MB read cap, `--allow-root` plus server-echoed roots with lexical + realpath scoping, `O_NOFOLLOW` opens, scrubbed env, process-group timeouts (SIGTERM then SIGKILL), v5 one-call process credentials, trust gate (observe = read-only).
- Dispatch (`session.rs`): small match arms; exec on spawned tasks; PTY frames on one ordered per-connection task; outbound channel keeps the socket single-writer; `pending_bytes` drives backpressure; `PtyManager` is a per-process singleton (sessions persist across reconnects; attachments drop on socket close).
- Protocol/versioning (`wire.rs`): advertised dialect set to v5; Worker may dispatch `pty_*` and exec actions.
- Tests/docs: 59 unit tests mirror JS behavior; README port plan updated.

- Review and rollout
  - No config migration required. To use the cmux-tui path, ensure a `cmux-tui` binary is available; otherwise the relay falls back to a shell PTY.
  - Resource limits: `MAX_PTYS = 8` caps process-wide PTY concurrency; attachments may be dropped under buffered-output pressure while sessions survive.
  - A later PR will add pane/workspace verbs (wire v6) and bump the advertised dialect then.

<sup>Written for commit 139f01f4ed6d8cd2e5d6dfc18671e8f686a2b5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive terminal sessions with shell access, resizing, input/output streaming, reconnection, multiple viewers, and scrollback.
  - Added remote file and command actions, including reading, writing, listing, searching, and executing commands.
  - Added connection controls for requests, events, pausing, resuming, and graceful shutdown.
- **Security & Reliability**
  - Added trust checks, path restrictions, symlink protection, output limits, timeouts, environment isolation, and process cleanup.
- **Compatibility**
  - Updated relay communication to protocol version 5 with improved terminal frame handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->