### PR TITLE
fix(ios): pin the New Task button outside the keyboard safe area

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -76,6 +76,14 @@ struct MobilePrimaryTabScaffold<
                     )
                     .padding(.trailing, iOS26BottomControlInset)
                     .padding(.bottom, iOS26TaskComposerBottomPadding)
+                    // Compose anchors to the screen, not the keyboard. The
+                    // only keyboard that can appear while it is visible
+                    // belongs to an overlaying sheet (the composer's
+                    // auto-focused prompt), whose inset dragged the button
+                    // toward mid-screen and stranded it there whenever the
+                    // hide update was missed.
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
                 }
             }
             .ignoresSafeArea(.container, edges: .bottom)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListSearchHost.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListSearchHost.swift
@@ -47,6 +47,10 @@ struct WorkspaceListSearchHost<Content: View>: View {
                         TaskComposerButton(action: taskComposerAction)
                             .padding(.trailing, 20)
                             .padding(.bottom, 6)
+                            // Same keyboard exemption as the iOS 26 scaffold:
+                            // a sheet keyboard must not drag the button up.
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                            .ignoresSafeArea(.keyboard, edges: .bottom)
                     }
                 }
         }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6056,6 +6056,77 @@ final class cmuxUITests: XCTestCase {
         )
     }
 
+    /// Regression: the floating New Task button must not track the keyboard's
+    /// safe-area inset. The composer sheet auto-focuses its prompt, and that
+    /// sheet keyboard used to shrink the tab scaffold underneath it, dragging
+    /// the bottom-anchored compose button toward mid-screen. The shift showed
+    /// through during sheet dismissal and stranded the button mid-screen
+    /// whenever the keyboard-hide update was missed.
+    @MainActor
+    func testTaskComposerButtonIgnoresComposerKeyboardInset() async throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The floating compose control requires iOS 26.")
+        }
+        let server = try MobileSyncMockHostServer(
+            supportsManualAttachTicket: true,
+            workspaceCreateSelectsCreatedWorkspace: false
+        )
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedAppViaManualPairing(port: port)
+        defer { app.terminate() }
+
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 4))
+        tap(backButton, in: app)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["MobileWorkspaceRow-workspace-main"]
+                .waitForExistence(timeout: 4)
+        )
+
+        let composerButton = app.buttons["MobileTaskComposerButton"]
+        XCTAssertTrue(composerButton.waitForExistence(timeout: 4))
+        guard let restingFrame = waitForUsableFrame(of: composerButton, timeout: 3) else {
+            XCTFail("New Task button had no usable frame before the composer opened")
+            return
+        }
+        tap(composerButton, in: app)
+
+        let prompt = taskComposerPrompt(in: app)
+        XCTAssertTrue(prompt.waitForExistence(timeout: 4))
+        XCTAssertTrue(
+            waitForKeyboardFocus(of: prompt, timeout: 3),
+            "Opening New Task must focus the prompt without an extra tap."
+        )
+        XCTAssertTrue(
+            waitForSoftwareKeyboardKeyPlane(in: app, minimumOverlap: 120, timeout: 3) != nil,
+            "Opening New Task must raise the software keyboard without an extra tap."
+        )
+
+        // The button sits behind the sheet but stays in the element tree; the
+        // sheet keyboard must not have dragged it up.
+        guard let coveredFrame = waitForUsableFrame(of: composerButton, timeout: 3) else {
+            XCTFail("New Task button left the element tree while the composer was presented")
+            return
+        }
+        XCTAssertEqual(
+            coveredFrame.midY, restingFrame.midY, accuracy: 2,
+            "New Task moved from \(restingFrame) to \(coveredFrame) while the composer keyboard was up"
+        )
+
+        tap(app.buttons["MobileTaskComposerCancelButton"], in: app)
+        XCTAssertTrue(prompt.waitForNonExistence(timeout: 4))
+        guard let settledFrame = waitForUsableFrame(of: composerButton, timeout: 3) else {
+            XCTFail("New Task button had no usable frame after the composer dismissed")
+            return
+        }
+        XCTAssertEqual(
+            settledFrame.midY, restingFrame.midY, accuracy: 2,
+            "New Task must settle back to \(restingFrame), got \(settledFrame)"
+        )
+    }
+
     /// Regression: the production composer must route a Claude task through
     /// the connected host and select the exact workspace returned by that RPC.
     @MainActor


### PR DESCRIPTION
Fixes the floating New Task (compose) button jumping to mid-screen on the workspaces tab.

The button is bottom-aligned in the primary tab scaffold, and the scaffold ignores only the container safe-area region. Opening the task composer sheet auto-focuses its prompt and raises the keyboard; the keyboard's safe-area inset shrinks the scaffold underneath the sheet and drags the bottom-anchored button up by keyboard height. The shift shows through during sheet dismissal, and when a keyboard-hide update is missed the button stays stranded mid-screen with no keyboard visible until the next keyboard cycle.

The fix gives the button a full-size alignment frame that ignores the keyboard safe-area region, on both the iOS 26 scaffold (`MobilePrimaryTabScaffold`) and the pre-26 search-host overlay (`WorkspaceListSearchHost`), so no keyboard, and no stale keyboard inset, can move it. On the workspaces tab the only keyboard that can appear while the button is visible belongs to an overlaying sheet, so the button never legitimately needs to avoid one.

Commit 1 adds the regression UI test only (red): the button's frame must not move while the composer sheet's keyboard is up. Commit 2 adds the fix (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790020620&installation_model_id=21920&pr_number=10573&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10573&signature=6252b479539a6344ef03f9188ed5509665c081465a402714cccb7d6fccc01dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the floating New Task button outside the keyboard safe area so it no longer rides up when the composer sheet raises the keyboard. Before: the button tracked the keyboard inset and could remain mid-screen after dismissal; now: it stays bottom-aligned regardless of keyboard state.

- Implemented in `MobilePrimaryTabScaffold` (iOS 26) and `WorkspaceListSearchHost` (pre-26) by adding a full-size alignment frame and `.ignoresSafeArea(.keyboard, edges: .bottom)` to the compose control.
- Adds a regression UI test that asserts the button’s Y position does not change while the composer keyboard is visible and after dismissal.

<sup>Written for commit a277d5815aafb273ed739cc05648bf076675bb5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the floating New Task button moving upward when the on-screen keyboard is displayed in the task composer.
  * Kept the button anchored to the bottom-right corner while the composer is open.

* **Tests**
  * Added coverage to verify the button remains in position during task creation and returns correctly after cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->