### PR TITLE
Simulator stream v2: quality presets and simulator switching from the phone

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorRPCDTOs.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorRPCDTOs.swift
@@ -25,6 +25,56 @@ public struct MobileSimulatorStreamStartParameters: Codable, Equatable, Sendable
     }
 }
 
+public struct MobileSimulatorDeviceSelectParameters: Codable, Equatable, Sendable {
+    public let panelID: String
+    public let workspaceID: String
+    public let udid: String
+
+    public init(panelID: String, workspaceID: String, udid: String) {
+        self.panelID = panelID
+        self.workspaceID = workspaceID
+        self.udid = udid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case panelID = "panel_id"
+        case workspaceID = "workspace_id"
+        case udid
+    }
+}
+
+/// One installed simulator a panel can stream, as reported by the Mac.
+public struct MobileSimulatorDeviceDescriptor: Codable, Equatable, Sendable, Identifiable {
+    public var id: String { udid }
+    public let udid: String
+    public let name: String
+    public let runtimeName: String
+    public let family: String
+    public let state: String
+    public let isSelected: Bool
+
+    public init(
+        udid: String, name: String, runtimeName: String, family: String,
+        state: String, isSelected: Bool
+    ) {
+        self.udid = udid
+        self.name = name
+        self.runtimeName = runtimeName
+        self.family = family
+        self.state = state
+        self.isSelected = isSelected
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case udid
+        case name
+        case runtimeName = "runtime_name"
+        case family
+        case state
+        case isSelected = "is_selected"
+    }
+}
+
 public struct MobileSimulatorPanelParameters: Codable, Equatable, Sendable {
     public let panelID: String
     public let workspaceID: String

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorStreamCapability.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorStreamCapability.swift
@@ -14,18 +14,24 @@ public struct MobileSimulatorStreamCapability: Sendable {
     /// `CmuxSimulatorStreamKit.SimStreamProtocol` (same literal, duplicated
     /// so this base DTO package does not link VideoToolbox).
     public let streamV2Identifier: String
+    /// The host serves `mobile.simulator.devices.list` and
+    /// `mobile.simulator.device.select`, so phones can switch which
+    /// simulator a panel streams.
+    public let devicesIdentifier: String
 
     public init(
         identifier: String = "simulator.stream.v1",
         inputIdentifier: String = "simulator.input.v1",
         ownershipIdentifier: String = "simulator.ownership.v1",
         keepaliveIdentifier: String = "simulator.keepalive.v1",
-        streamV2Identifier: String = "simulator.stream.v2"
+        streamV2Identifier: String = "simulator.stream.v2",
+        devicesIdentifier: String = "simulator.devices.v1"
     ) {
         self.identifier = identifier
         self.inputIdentifier = inputIdentifier
         self.ownershipIdentifier = ownershipIdentifier
         self.keepaliveIdentifier = keepaliveIdentifier
         self.streamV2Identifier = streamV2Identifier
+        self.devicesIdentifier = devicesIdentifier
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+SimulatorStream.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+SimulatorStream.swift
@@ -50,6 +50,29 @@ extension MobileCoreRPCClient {
         try await sendSimulatorCommand(method: "mobile.simulator.input.button", parameters: input)
     }
 
+    public func listMobileSimulatorDevices(
+        panelID: String,
+        workspaceID: String
+    ) async throws -> [MobileSimulatorDeviceDescriptor] {
+        let data = try await sendSimulatorRequest(
+            method: "mobile.simulator.devices.list",
+            parameters: MobileSimulatorPanelParameters(panelID: panelID, workspaceID: workspaceID)
+        )
+        return try MobileSimulatorDevicesResponse.decode(data).devices
+    }
+
+    public func selectMobileSimulatorDevice(
+        panelID: String,
+        workspaceID: String,
+        udid: String
+    ) async throws -> MobileSimulatorCommandResponse {
+        try await sendSimulatorCommand(
+            method: "mobile.simulator.device.select",
+            parameters: MobileSimulatorDeviceSelectParameters(
+                panelID: panelID, workspaceID: workspaceID, udid: udid)
+        )
+    }
+
     private func sendSimulatorCommand<Parameters: Encodable>(
         method: String,
         parameters: Parameters

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSimulatorRPCDTOs.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSimulatorRPCDTOs.swift
@@ -9,6 +9,14 @@ struct MobileSimulatorListResponse: Decodable, Sendable {
     }
 }
 
+struct MobileSimulatorDevicesResponse: Decodable, Sendable {
+    let devices: [MobileSimulatorDeviceDescriptor]
+
+    static func decode(_ data: Data) throws -> MobileSimulatorDevicesResponse {
+        try JSONDecoder().decode(Self.self, from: data)
+    }
+}
+
 public struct MobileSimulatorCommandResponse: Decodable, Sendable {
     public let ok: Bool?
     public let stopped: Bool?

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
@@ -26,6 +26,38 @@ extension MobileShellComposite {
             && activeRoute?.kind == .iroh
     }
 
+    /// Whether the connected Mac can list and switch a panel's simulator.
+    public var supportsSimulatorDeviceSwitching: Bool {
+        supportedHostCapabilities.contains(
+            MobileSimulatorStreamCapability.current.devicesIdentifier)
+    }
+
+    /// Installed simulators the panel can stream; empty on any failure so
+    /// the picker simply hides against older or unreachable hosts.
+    public func listSimulatorDevices(
+        panelID: String, workspaceID: String
+    ) async -> [MobileSimulatorDeviceDescriptor] {
+        guard supportsSimulatorDeviceSwitching, let client = remoteClient else { return [] }
+        return (try? await client.listMobileSimulatorDevices(
+            panelID: panelID, workspaceID: workspaceID)) ?? []
+    }
+
+    /// Asks the Mac to switch the panel's simulator. Fire-and-forget: the
+    /// v2 stream's own status/config/keyframe flow shows the transition,
+    /// and a cold boot outlives any reasonable RPC deadline.
+    public func selectSimulatorDevice(
+        panelID: String, workspaceID: String, udid: String
+    ) async -> Bool {
+        guard supportsSimulatorDeviceSwitching, let client = remoteClient else { return false }
+        do {
+            _ = try await client.selectMobileSimulatorDevice(
+                panelID: panelID, workspaceID: workspaceID, udid: udid)
+            return true
+        } catch {
+            return false
+        }
+    }
+
     public func simulatorStreamV2Access(panelID: String) -> SimulatorStreamV2Access? {
         guard let provider = runtime?.simulatorStreamLaneProvider else { return nil }
         return SimulatorStreamV2Access(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
@@ -1,4 +1,4 @@
-import CMUXMobileCore
+public import CMUXMobileCore
 public import CmuxMobileRPC
 import Foundation
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import CMUXMobileCore
 import CmuxMobileShell
 import CmuxMobileSimulatorStream
 import CmuxMobileSupport
@@ -14,13 +15,24 @@ import UIKit
 /// remount or route change unable to strand a session.
 struct SimulatorStreamV2Pane: View {
     let panelID: String
+    let workspaceID: String
     let access: SimulatorStreamV2Access
     let isTransportReady: Bool
+    let supportsDeviceSwitching: Bool
+    let listDevices: @MainActor () async -> [MobileSimulatorDeviceDescriptor]
+    let selectDevice: @MainActor (String) async -> Bool
 
     @State private var store: SimulatorStreamV2Store?
     @State private var pendingText = ""
+    @State private var devices: [MobileSimulatorDeviceDescriptor] = []
+    @AppStorage("cmux.simulatorStream.quality")
+    private var qualityRaw = SimStreamQualityPreset.default.rawValue
     @FocusState private var textFocused: Bool
     @Environment(\.scenePhase) private var scenePhase
+
+    private var quality: SimStreamQualityPreset {
+        SimStreamQualityPreset(rawValue: qualityRaw) ?? .default
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -42,10 +54,18 @@ struct SimulatorStreamV2Pane: View {
                 ?? SimulatorStreamV2Store(
                     panelID: panelID,
                     opener: access.opener,
-                    transportReady: access.transportReady
+                    transportReady: access.transportReady,
+                    maximumLongSidePixels: quality.maximumLongSidePixels
                 )
             self.store = store
             store.activate()
+        }
+        .task {
+            guard supportsDeviceSwitching else { return }
+            devices = await listDevices()
+        }
+        .onChange(of: qualityRaw) { _, _ in
+            store?.setQuality(maximumLongSidePixels: quality.maximumLongSidePixels)
         }
         .onDisappear {
             store?.deactivate()
@@ -190,6 +210,10 @@ struct SimulatorStreamV2Pane: View {
                 menuButton(
                     .siri, systemImage: "waveform",
                     label: L10n.string("mobile.simulatorStream.siri", defaultValue: "Siri"))
+                qualityMenu
+                if supportsDeviceSwitching, !devices.isEmpty {
+                    deviceMenu
+                }
             } label: {
                 Image(systemName: "ellipsis.circle").frame(width: 24, height: 24)
             }
@@ -207,6 +231,63 @@ struct SimulatorStreamV2Pane: View {
         .clipShape(Capsule())
         .padding(.horizontal, 12)
         .padding(.bottom, 10)
+    }
+
+    private var qualityMenu: some View {
+        Picker(
+            L10n.string("mobile.simulatorStream.quality", defaultValue: "Stream Quality"),
+            selection: $qualityRaw
+        ) {
+            Text(L10n.string("mobile.simulatorStream.qualityHigh", defaultValue: "High"))
+                .tag(SimStreamQualityPreset.high.rawValue)
+            Text(
+                L10n.string(
+                    "mobile.simulatorStream.qualityBalanced", defaultValue: "Balanced")
+            )
+            .tag(SimStreamQualityPreset.balanced.rawValue)
+            Text(
+                L10n.string(
+                    "mobile.simulatorStream.qualityDataSaver", defaultValue: "Data Saver")
+            )
+            .tag(SimStreamQualityPreset.dataSaver.rawValue)
+        }
+        .pickerStyle(.menu)
+        .accessibilityIdentifier("SimulatorStreamV2QualityPicker")
+    }
+
+    private var deviceMenu: some View {
+        Menu {
+            ForEach(devices) { device in
+                Button {
+                    switchDevice(to: device.udid)
+                } label: {
+                    if device.isSelected {
+                        Label(deviceLabel(device), systemImage: "checkmark")
+                    } else {
+                        Text(deviceLabel(device))
+                    }
+                }
+                .disabled(device.isSelected)
+            }
+        } label: {
+            Label(
+                L10n.string(
+                    "mobile.simulatorStream.switchSimulator", defaultValue: "Switch Simulator"),
+                systemImage: "iphone.gen3"
+            )
+        }
+        .accessibilityIdentifier("SimulatorStreamV2DeviceMenu")
+    }
+
+    private func deviceLabel(_ device: MobileSimulatorDeviceDescriptor) -> String {
+        "\(device.name) · \(device.runtimeName)"
+    }
+
+    private func switchDevice(to udid: String) {
+        Task {
+            _ = await selectDevice(udid)
+            devices = await listDevices()
+        }
     }
 
     private func chromeButton(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -25,6 +25,7 @@ struct SimulatorStreamV2Pane: View {
     @State private var store: SimulatorStreamV2Store?
     @State private var pendingText = ""
     @State private var devices: [MobileSimulatorDeviceDescriptor] = []
+    @State private var deviceFetchTask: Task<Void, Never>?
     @AppStorage("cmux.simulatorStream.quality")
     private var qualityRaw = SimStreamQualityPreset.default.rawValue
     @FocusState private var textFocused: Bool
@@ -61,8 +62,11 @@ struct SimulatorStreamV2Pane: View {
             store.activate()
         }
         .task {
-            guard supportsDeviceSwitching else { return }
-            devices = await listDevices()
+            refreshDevices()
+        }
+        .onDisappear {
+            deviceFetchTask?.cancel()
+            deviceFetchTask = nil
         }
         .onChange(of: qualityRaw) { _, _ in
             store?.setQuality(maximumLongSidePixels: quality.maximumLongSidePixels)
@@ -214,6 +218,13 @@ struct SimulatorStreamV2Pane: View {
                 if supportsDeviceSwitching, !devices.isEmpty {
                     deviceMenu
                 }
+                // Menu content materializes when the menu opens, so this
+                // refreshes the device inventory (and stale checkmarks from
+                // Mac-side switches) right before the user can reach the
+                // Switch Simulator submenu.
+                Color.clear
+                    .frame(width: 0, height: 0)
+                    .onAppear { refreshDevices() }
             } label: {
                 Image(systemName: "ellipsis.circle").frame(width: 24, height: 24)
             }
@@ -283,10 +294,25 @@ struct SimulatorStreamV2Pane: View {
         "\(device.name) · \(device.runtimeName)"
     }
 
+    /// One owned fetch at a time; a superseded fetch's result is discarded
+    /// so a slow older response can never overwrite a newer inventory.
+    private func refreshDevices() {
+        guard supportsDeviceSwitching else { return }
+        deviceFetchTask?.cancel()
+        deviceFetchTask = Task {
+            let fetched = await listDevices()
+            guard !Task.isCancelled else { return }
+            devices = fetched
+        }
+    }
+
     private func switchDevice(to udid: String) {
-        Task {
+        deviceFetchTask?.cancel()
+        deviceFetchTask = Task {
             _ = await selectDevice(udid)
-            devices = await listDevices()
+            let fetched = await listDevices()
+            guard !Task.isCancelled else { return }
+            devices = fetched
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -268,6 +268,13 @@ struct SimulatorStreamV2Pane: View {
 
     private var deviceMenu: some View {
         Menu {
+            // Rows live-update in place: entering the submenu re-fetches, so
+            // an inventory raced ahead of the menu-open refresh corrects
+            // itself, and stale selects already fail safe on the host
+            // (unknown devices reject, the current device is a no-op).
+            Color.clear
+                .frame(width: 0, height: 0)
+                .onAppear { refreshDevices() }
             ForEach(devices) { device in
                 Button {
                     switchDevice(to: device.udid)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
@@ -262,10 +262,21 @@ extension WorkspaceDetailView {
         if store.supportsSimulatorStreamV2,
             let access = store.simulatorStreamV2Access(panelID: simulator.id)
         {
+            let workspaceID = workspace.rpcWorkspaceID.rawValue
             SimulatorStreamV2Pane(
                 panelID: simulator.id,
+                workspaceID: workspaceID,
                 access: access,
-                isTransportReady: store.connectionState == .connected
+                isTransportReady: store.connectionState == .connected,
+                supportsDeviceSwitching: store.supportsSimulatorDeviceSwitching,
+                listDevices: { [weak store] in
+                    await store?.listSimulatorDevices(
+                        panelID: simulator.id, workspaceID: workspaceID) ?? []
+                },
+                selectDevice: { [weak store] udid in
+                    await store?.selectSimulatorDevice(
+                        panelID: simulator.id, workspaceID: workspaceID, udid: udid) ?? false
+                }
             )
             .task {
                 await store.stopLegacySimulatorStream(

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimStreamQualityPreset.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimStreamQualityPreset.swift
@@ -1,0 +1,25 @@
+/// Viewer-selectable resolution caps for the stream.
+///
+/// The cap bounds the encode size on the Mac; bitrate keeps adapting to the
+/// link separately. Lower caps trade sharpness for less data and faster
+/// per-frame encode/decode; end-to-end latency is otherwise unchanged
+/// because pacing (encode-on-credit) already prevents queue buildup at any
+/// resolution.
+public enum SimStreamQualityPreset: String, CaseIterable, Sendable {
+    /// Near-native pixels; sharpest text, most data.
+    case high
+    /// Fits modern phone screens; visually close to high at half the data.
+    case balanced
+    /// For constrained links; soft text, lowest data and decode cost.
+    case dataSaver
+
+    public var maximumLongSidePixels: UInt16 {
+        switch self {
+        case .high: 2_000
+        case .balanced: 1_280
+        case .dataSaver: 800
+        }
+    }
+
+    public static let `default` = SimStreamQualityPreset.high
+}

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimStreamViewerEngine.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimStreamViewerEngine.swift
@@ -43,7 +43,7 @@ public actor SimStreamViewerEngine {
 
     private let presenter: any SimStreamFramePresenting
     private let onEvent: @Sendable (SimStreamViewerEvent) -> Void
-    private let maximumLongSidePixels: UInt16
+    private var maximumLongSidePixels: UInt16
     private let epoch: UInt64
 
     private var lane: (any MobileSimulatorStreamLaneConnection)?
@@ -95,6 +95,22 @@ public actor SimStreamViewerEngine {
             await closeLane()
             onEvent(.ended(clean: false))
         }
+    }
+
+    /// Applies a new resolution cap by re-sending `start` on the live lane.
+    /// The host treats any `start` as a fresh stream begin (new encoder
+    /// size, config, keyframe), so a quality change repaints in one frame
+    /// without touching the lane or lifecycle.
+    public func updateQuality(maximumLongSidePixels: UInt16) async {
+        guard maximumLongSidePixels != self.maximumLongSidePixels else { return }
+        self.maximumLongSidePixels = maximumLongSidePixels
+        guard let lane else { return }
+        let start = SimStreamStartRequest(
+            epoch: epoch,
+            maximumLongSidePixels: maximumLongSidePixels,
+            codecPreferences: [.hevc, .h264]
+        )
+        try? await lane.send(SimStreamWireCodec.encodeFramed(.start(start)))
     }
 
     /// Sends `stop` and closes; used for deliberate viewer-initiated stops

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
@@ -42,7 +42,7 @@ public final class SimulatorStreamV2Store {
     @ObservationIgnored private var presenter: (any SimStreamFramePresenting)?
     @ObservationIgnored private let opener: SimStreamViewerEngine.LaneOpener
     @ObservationIgnored private let transportReady: @MainActor () -> Bool
-    @ObservationIgnored private let maximumLongSidePixels: UInt16
+    @ObservationIgnored private var maximumLongSidePixels: UInt16
     @ObservationIgnored private let clock: any Clock<Duration>
     /// Streaming with no presented frame for this long means the pipeline is
     /// wedged somewhere invisible; rebuild it.
@@ -128,6 +128,18 @@ public final class SimulatorStreamV2Store {
 
     public func sendButton(_ button: SimStreamHardwareButton) {
         send(.button(button))
+    }
+
+    // MARK: - Quality
+
+    /// Applies a new resolution cap: live sessions renegotiate in place
+    /// (start -> config -> keyframe on the same lane) and future attaches
+    /// use the new value.
+    public func setQuality(maximumLongSidePixels: UInt16) {
+        guard maximumLongSidePixels != self.maximumLongSidePixels else { return }
+        self.maximumLongSidePixels = maximumLongSidePixels
+        guard let engine else { return }
+        Task { await engine.updateQuality(maximumLongSidePixels: maximumLongSidePixels) }
     }
 
     // MARK: - Machine execution

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
@@ -134,12 +134,21 @@ public final class SimulatorStreamV2Store {
 
     /// Applies a new resolution cap: live sessions renegotiate in place
     /// (start -> config -> keyframe on the same lane) and future attaches
-    /// use the new value.
+    /// use the new value. Rides the same lifecycle-owned relay chain as
+    /// input, so renegotiation serializes with in-flight events, cancels on
+    /// teardown, and can never target a superseded engine.
     public func setQuality(maximumLongSidePixels: UInt16) {
         guard maximumLongSidePixels != self.maximumLongSidePixels else { return }
         self.maximumLongSidePixels = maximumLongSidePixels
         guard let engine else { return }
-        Task { await engine.updateQuality(maximumLongSidePixels: maximumLongSidePixels) }
+        let previous = inputRelayTask
+        inputRelayTask = Task { [weak self] in
+            await previous?.value
+            guard let self, await MainActor.run(body: { self.engine === engine }) else {
+                return
+            }
+            await engine.updateQuality(maximumLongSidePixels: maximumLongSidePixels)
+        }
     }
 
     // MARK: - Machine execution

--- a/Packages/iOS/CmuxMobileSimulatorStream/Tests/CmuxMobileSimulatorStreamTests/SimStreamViewerEngineTests.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Tests/CmuxMobileSimulatorStreamTests/SimStreamViewerEngineTests.swift
@@ -326,6 +326,31 @@ struct SimStreamViewerEngineTests {
     }
 
     @Test
+    func qualityChangeRenegotiatesOnTheLiveLane() async throws {
+        let lane = FakeLane()
+        let presenter = FakePresenter()
+        let engine = SimStreamViewerEngine(
+            presenter: presenter, maximumLongSidePixels: 2_000, epoch: 1
+        ) { _ in }
+        let runTask = Task { await engine.run(opener: { lane }) }
+        _ = await lane.waitForSent(count: 1)
+
+        await engine.updateQuality(maximumLongSidePixels: 800)
+        // Same value again must not renegotiate.
+        await engine.updateQuality(maximumLongSidePixels: 800)
+
+        let sent = await lane.waitForSent(count: 2)
+        let starts = sent.compactMap { message -> SimStreamStartRequest? in
+            guard case .start(let request) = message else { return nil }
+            return request
+        }
+        #expect(starts.map(\.maximumLongSidePixels) == [2_000, 800])
+        #expect(starts.map(\.epoch) == [1, 1])
+        await lane.hostFinishes()
+        await runTask.value
+    }
+
+    @Test
     func frameBeforeConfigFailsClosed() async throws {
         let fixture = try await Self.encodedFixture()
         let lane = FakeLane()

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -45,6 +45,8 @@ extension MobileHostService {
         "mobile.events.unsubscribe",
         "mobile.host.status",
         "mobile.rpc.methods",
+        "mobile.simulator.device.select",
+        "mobile.simulator.devices.list",
         "mobile.simulator.input.button",
         "mobile.simulator.input.pointer",
         "mobile.simulator.input.text",
@@ -179,6 +181,7 @@ extension MobileHostService {
             MobileSimulatorStreamCapability.current.ownershipIdentifier,
             MobileSimulatorStreamCapability.current.keepaliveIdentifier,
             MobileSimulatorStreamCapability.current.streamV2Identifier,
+            MobileSimulatorStreamCapability.current.devicesIdentifier,
             "events.v1",
             "notification.badge.v1",
             "notification.dismiss.v1",
@@ -243,6 +246,7 @@ extension MobileHostService {
                 MobileSimulatorStreamCapability.current.ownershipIdentifier,
                 MobileSimulatorStreamCapability.current.keepaliveIdentifier,
                 MobileSimulatorStreamCapability.current.streamV2Identifier,
+                MobileSimulatorStreamCapability.current.devicesIdentifier,
             ]
             capabilities.removeAll { simulatorCapabilities.contains($0) }
         }

--- a/Sources/TerminalController+MobileSimulator.swift
+++ b/Sources/TerminalController+MobileSimulator.swift
@@ -98,6 +98,10 @@ extension TerminalController {
             return v2MobileSimulatorTextInput(params: params, connectionID: connectionID)
         case "mobile.simulator.input.button":
             return v2MobileSimulatorButtonInput(params: params, connectionID: connectionID)
+        case "mobile.simulator.devices.list":
+            return v2MobileSimulatorDevicesList(params: params, connectionID: connectionID)
+        case "mobile.simulator.device.select":
+            return v2MobileSimulatorDeviceSelect(params: params, connectionID: connectionID)
         default:
             return .err(code: "method_not_found", message: "Unknown mobile method", data: ["method": method])
         }
@@ -105,6 +109,60 @@ extension TerminalController {
 
     func mobileSimulatorPanels(in workspace: Workspace) -> [SimulatorPanel] {
         orderedPanels(in: workspace).compactMap { $0 as? SimulatorPanel }
+    }
+
+    /// Installed simulators a panel can stream. No ownership gate: every
+    /// admitted connection is the same account, and the v2 stream's
+    /// last-writer-wins model already lets any of the user's devices steer.
+    private func v2MobileSimulatorDevicesList(
+        params: [String: Any],
+        connectionID: UUID?
+    ) -> V2CallResult {
+        guard CmuxFeatureFlags.shared.isSimulatorEnabled else {
+            return .err(code: "capability_disabled", message: "Simulator panes are disabled", data: nil)
+        }
+        guard let panelIDString = v2RawString(params, "panel_id"),
+              let workspaceID = v2UUID(params, "workspace_id"),
+              let resolved = mobileSimulatorPanel(id: panelIDString, workspaceID: workspaceID) else {
+            return mobileSimulatorPanelResolutionError(params: params)
+        }
+        let coordinator = resolved.panel.coordinator
+        let selectedID = coordinator.selectedDeviceID
+        let devices = coordinator.devices.map { device -> [String: Any] in
+            [
+                "udid": device.id,
+                "name": device.name,
+                "runtime_name": device.runtimeName,
+                "family": device.family.rawValue,
+                "state": device.state.rawValue,
+                "is_selected": device.id == selectedID,
+            ]
+        }
+        return .ok(["devices": devices])
+    }
+
+    /// Selects (and boots when needed) another simulator for the panel.
+    /// Fire-and-forget like the Mac pane's picker: the stream's own status
+    /// and config/keyframe flow report progress, and a cold boot can take
+    /// far longer than any sane RPC deadline.
+    private func v2MobileSimulatorDeviceSelect(
+        params: [String: Any],
+        connectionID: UUID?
+    ) -> V2CallResult {
+        guard CmuxFeatureFlags.shared.isSimulatorEnabled else {
+            return .err(code: "capability_disabled", message: "Simulator panes are disabled", data: nil)
+        }
+        guard let panelIDString = v2RawString(params, "panel_id"),
+              let workspaceID = v2UUID(params, "workspace_id"),
+              let udid = v2RawString(params, "udid"), !udid.isEmpty,
+              let resolved = mobileSimulatorPanel(id: panelIDString, workspaceID: workspaceID) else {
+            return mobileSimulatorPanelResolutionError(params: params)
+        }
+        guard resolved.panel.coordinator.devices.contains(where: { $0.id == udid }) else {
+            return .err(code: "not_found", message: "Simulator device not found", data: ["udid": udid])
+        }
+        resolved.panel.coordinator.selectDevice(id: udid)
+        return .ok(["ok": true, "panel_id": resolved.panel.id.uuidString, "udid": udid])
     }
 
     private func v2MobileSimulatorList(params: [String: Any], connectionID: UUID?) -> V2CallResult {

--- a/Sources/TerminalController+MobileSimulator.swift
+++ b/Sources/TerminalController+MobileSimulator.swift
@@ -99,7 +99,7 @@ extension TerminalController {
         case "mobile.simulator.input.button":
             return v2MobileSimulatorButtonInput(params: params, connectionID: connectionID)
         case "mobile.simulator.devices.list":
-            return v2MobileSimulatorDevicesList(params: params, connectionID: connectionID)
+            return await v2MobileSimulatorDevicesList(params: params, connectionID: connectionID)
         case "mobile.simulator.device.select":
             return v2MobileSimulatorDeviceSelect(params: params, connectionID: connectionID)
         default:
@@ -117,7 +117,7 @@ extension TerminalController {
     private func v2MobileSimulatorDevicesList(
         params: [String: Any],
         connectionID: UUID?
-    ) -> V2CallResult {
+    ) async -> V2CallResult {
         guard CmuxFeatureFlags.shared.isSimulatorEnabled else {
             return .err(code: "capability_disabled", message: "Simulator panes are disabled", data: nil)
         }
@@ -127,6 +127,10 @@ extension TerminalController {
             return mobileSimulatorPanelResolutionError(params: params)
         }
         let coordinator = resolved.panel.coordinator
+        // The inventory is discovery-time state; refresh it like the Mac
+        // pane's picker does on open, so simulators created after the panel
+        // started still appear.
+        await coordinator.reloadDevices()
         let selectedID = coordinator.selectedDeviceID
         let devices = coordinator.devices.map { device -> [String: Any] in
             [

--- a/docs/ios-simulator-streaming-v2.md
+++ b/docs/ios-simulator-streaming-v2.md
@@ -113,6 +113,22 @@ Capability `simulator.stream.v2` is advertised by the host
 use this pipeline and gate v1 off, others keep v1. v1 host code stays until
 the capability has shipped in a release, then dies.
 
+Viewer-side quality control reuses `start`: picking a preset re-sends
+`start` on the live lane with a new `max_long_side`, and the host answers
+with a resized encoder, fresh `config`, and a keyframe, so quality switches
+repaint in one frame with no lane or lifecycle churn. Presets cap encode
+resolution only (High 2000 / Balanced 1280 / Data Saver 800 long-side
+pixels); pacing already bounds latency at any resolution, so lower presets
+trade sharpness for bandwidth and a slightly cheaper encode/decode, not for
+responsiveness.
+
+Device switching is discovery-plane, not lane-plane: capability
+`simulator.devices.v1` advertises `mobile.simulator.devices.list` and
+`mobile.simulator.device.select`. Selecting reuses the Mac pane's own
+`selectDevice` path; the running stream absorbs the switch through the same
+worker-restart flow as any capture change (status updates, replaced ring,
+new config + keyframe).
+
 ## Lifecycle
 
 One state machine on each side, event-driven:

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1344,6 +1344,74 @@
         }
       }
     },
+    "mobile.simulatorStream.quality": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stream Quality"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストリーム画質"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.qualityBalanced": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balanced"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バランス"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.qualityDataSaver": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data Saver"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データセーバー"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.qualityHigh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高画質"
+          }
+        }
+      }
+    },
     "mobile.simulatorStream.sendText": {
       "extractionState": "manual",
       "localizations": {
@@ -1425,6 +1493,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "別のデバイスがこのSimulatorストリームを引き継ぎました。"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.switchSimulator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch Simulator"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulatorを切り替え"
           }
         }
       }


### PR DESCRIPTION
Follow-ups to https://github.com/manaflow-ai/cmux/pull/10563: viewer-side stream quality and simulator switching, both from the stream pane's More menu.

**Stream Quality.** A picker with High (2000px long side), Balanced (1280), and Data Saver (800), persisted across launches. Picking a preset re-sends `start` on the live lane; the host answers with a resized encoder, fresh `config`, and a keyframe, so the switch repaints in one frame with no lane or lifecycle churn. Speed tradeoffs: none for responsiveness — encode-on-credit already bounds latency at any resolution — lower presets trade text sharpness for less bandwidth and slightly cheaper per-frame encode/decode, which mainly helps sustained frame rate on slow links.

**Switch Simulator.** New capability `simulator.devices.v1` advertises `mobile.simulator.devices.list` and `mobile.simulator.device.select`; the More menu lists the Mac's installed simulators (active one checked) and selecting reuses the Mac pane's own `selectDevice` path, including boot-if-needed. Select is fire-and-forget because a cold boot outlives any sane RPC deadline; the running stream absorbs the switch through the same worker-restart flow as any capture change (status updates, replaced ring, new config + keyframe). Phones against older Macs hide the menu.

en/ja strings for the new menu items. An engine test pins the live-lane quality renegotiation (new `start` with the new cap, same epoch, no duplicate for a same-value change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790022232&installation_model_id=21920&pr_number=10574&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10574&signature=2f7731b54b2e2e7d6d0a6cf9d2cdad670a2bc73190e00bc550c4ccf32c053163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stream v2 quality presets and phone-side simulator switching to control bandwidth and remove Mac-only switching. Before: fixed resolution cap and no phone-side switching. Now: the More menu offers Stream Quality (High 2000, Balanced 1280, Data Saver 800) and Switch Simulator; selections persist and apply immediately.

- Quality changes re-send start on the live lane (same epoch); the host resizes the encoder and returns config + keyframe for a one-frame repaint. No-op changes are ignored; renegotiation serializes with input and cancels on teardown.
- Adds capability `simulator.devices.v1` with RPCs `mobile.simulator.devices.list` and `mobile.simulator.device.select`. The host refreshes device discovery before listing; selection is fire-and-forget and progress surfaces via status/config/keyframe.
- The UI shows the device menu only when the capability is present and the list is non-empty. It refreshes the inventory when the More menu opens and again on entering the Switch Simulator submenu, keeps one in-flight fetch, and drops superseded results.
- Publicly exports the device descriptor via `CMUXMobileCore`; adds iOS RPC client and shell helpers; the host advertises the capability; docs and en/ja strings updated.

No migration required; older hosts continue unchanged and omit the device menu.

<sup>Written for commit ecfc58049829052dd79e07de268c847beaa23388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulator switching from Simulator Stream controls.
  * Added High, Balanced, and Data Saver quality options.
  * Quality changes apply to active streams without disconnecting.
  * Device listings show simulator metadata and selection status.
  * Added capability detection for supported hosts.
* **Documentation**
  * Updated simulator streaming documentation.
* **Localization**
  * Added English and Japanese translations for quality controls and simulator switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->