### PR TITLE
Fix duplicate iOS streamed surface picker rows

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
@@ -6,6 +6,8 @@ struct TerminalPickerMenuValue: Equatable {
     let selectedID: MobileTerminalPreview.ID?
     let selectedMacSurfaceID: MobileSurfacePreview.ID?
     let selectedName: String?
+    let checkedRowID: TerminalPickerMenuRow.ID?
+    let macSurfaceRows: [TerminalPickerMenuRow]
     let canCreateWorkspace: Bool
     let hasActiveBrowser: Bool
     let isChatMode: Bool
@@ -52,35 +54,30 @@ struct TerminalPickerMenuValue: Equatable {
         self.simulatorStreamRows = simulatorStreamRows
         self.supportsSimulatorStream = supportsSimulatorStream
         self.activeSimulatorStreamPanelID = activeSimulatorStreamPanelID
-    }
 
-    /// The single row that carries the checkmark. Nil while the phone-local
-    /// browser or a Mac browser stream overlays the workspace (the stream row
-    /// draws its own check from `activeBrowserStreamPanelID`); a Mac-surface
-    /// selection whose row has disappeared falls back to the resolved
-    /// terminal, matching `selectedName`.
-    var checkedRowID: TerminalPickerMenuRow.ID? {
-        if hasActiveBrowser || activeBrowserStreamPanelID != nil || activeSimulatorStreamPanelID != nil { return nil }
-        if let selectedMacSurfaceID,
-           rows.contains(where: { $0.id == .macSurface(selectedMacSurfaceID) }) {
-            return .macSurface(selectedMacSurfaceID)
+        var streamBackedSurfaceIDs: Set<MobileSurfacePreview.ID> = []
+        if supportsBrowserStream {
+            streamBackedSurfaceIDs.formUnion(browserStreamRows.map { .init(rawValue: $0.id) })
         }
-        return selectedID.map(TerminalPickerMenuRow.ID.terminal)
+        if supportsSimulatorStream {
+            streamBackedSurfaceIDs.formUnion(simulatorStreamRows.map { .init(rawValue: $0.id) })
+        }
+        let filteredMacSurfaceRows = resolvedRows.filter {
+            guard let surfaceID = $0.macSurfaceID else { return false }
+            return !streamBackedSurfaceIDs.contains(surfaceID)
+        }
+        macSurfaceRows = filteredMacSurfaceRows
+        if hasActiveBrowser || activeBrowserStreamPanelID != nil || activeSimulatorStreamPanelID != nil {
+            checkedRowID = nil
+        } else if let selectedMacSurfaceID,
+                  filteredMacSurfaceRows.contains(where: { $0.id == .macSurface(selectedMacSurfaceID) }) {
+            checkedRowID = .macSurface(selectedMacSurfaceID)
+        } else {
+            checkedRowID = selection.map { .terminal($0.id) }
+        }
     }
 
     var terminalRows: [TerminalPickerMenuRow] {
         rows.filter { if case .terminal = $0.id { true } else { false } }
-    }
-
-    /// Mac-surface rows for the "Mac Surfaces" section. Browser panes are
-    /// excluded whenever the Mac supports browser streaming — they get their
-    /// own "Mac Browsers" section — and only fall back to a surface row on
-    /// Macs without streaming. Filtered here (not at row construction) so
-    /// snapshot-built rows obey the same policy as live ones.
-    var macSurfaceRows: [TerminalPickerMenuRow] {
-        rows.filter {
-            guard case .macSurface = $0.id else { return false }
-            return !(supportsBrowserStream && $0.surfaceKind == .browser)
-        }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileShellModel
 import Testing
 @testable import CmuxMobileShellUI
@@ -136,7 +137,12 @@ import Testing
     @Test func browserSurfacesLeaveMacSurfacesWhenTheMacStreamsBrowsers() {
         let browser = MobileSurfacePreview(id: "surface-web", kind: .browser, title: "cmux.com")
         let markdown = MobileSurfacePreview(id: "surface-md", kind: .markdown, title: "README")
-        func value(snapshotRows: [TerminalPickerMenuRow], supportsBrowserStream: Bool) -> TerminalPickerMenuValue {
+        let browserPanel = BrowserStreamPickerRow(Self.browserDescriptor(panelID: browser.id.rawValue))
+        func value(
+            snapshotRows: [TerminalPickerMenuRow],
+            supportsBrowserStream: Bool,
+            browserStreamRows: [BrowserStreamPickerRow] = []
+        ) -> TerminalPickerMenuValue {
             TerminalPickerMenuValue(
                 liveTerminals: [],
                 liveSurfaces: [browser, markdown],
@@ -145,19 +151,120 @@ import Testing
                 canCreateWorkspace: true,
                 hasActiveBrowser: false,
                 isChatMode: false,
+                browserStreamRows: browserStreamRows,
                 supportsBrowserStream: supportsBrowserStream
             )
         }
 
         // Live rows and snapshot rows must obey the same policy: with browser
-        // streaming, the pane lives in "Mac Browsers", not "Mac Surfaces".
+        // streaming, a discovered pane lives in "Mac Browsers", not "Mac Surfaces".
         let snapshot = [TerminalPickerMenuRow(browser), TerminalPickerMenuRow(markdown)]
         for rows in [[], snapshot] {
-            let streaming = value(snapshotRows: rows, supportsBrowserStream: true)
+            let streaming = value(
+                snapshotRows: rows,
+                supportsBrowserStream: true,
+                browserStreamRows: [browserPanel]
+            )
             #expect(streaming.macSurfaceRows.map(\.id) == [.macSurface(markdown.id)])
             let legacyMac = value(snapshotRows: rows, supportsBrowserStream: false)
             #expect(legacyMac.macSurfaceRows.map(\.id) == [.macSurface(browser.id), .macSurface(markdown.id)])
         }
+    }
+
+    @Test func simulatorSurfacesLeaveMacSurfacesWhenTheMacStreamsSimulators() {
+        let simulator = MobileSurfacePreview(
+            id: "surface-simulator",
+            kind: .other("simulator"),
+            title: "Simulator"
+        )
+        let markdown = MobileSurfacePreview(id: "surface-md", kind: .markdown, title: "README")
+        let simulatorPanel = SimulatorStreamPickerRow(Self.simulatorDescriptor(panelID: simulator.id.rawValue))
+        func value(
+            snapshotRows: [TerminalPickerMenuRow],
+            supportsSimulatorStream: Bool,
+            simulatorStreamRows: [SimulatorStreamPickerRow] = []
+        ) -> TerminalPickerMenuValue {
+            TerminalPickerMenuValue(
+                liveTerminals: [],
+                liveSurfaces: [simulator, markdown],
+                snapshotRows: snapshotRows,
+                selectedID: nil,
+                canCreateWorkspace: true,
+                hasActiveBrowser: false,
+                isChatMode: false,
+                simulatorStreamRows: simulatorStreamRows,
+                supportsSimulatorStream: supportsSimulatorStream
+            )
+        }
+
+        let snapshot = [TerminalPickerMenuRow(simulator), TerminalPickerMenuRow(markdown)]
+        for rows in [[], snapshot] {
+            let streaming = value(
+                snapshotRows: rows,
+                supportsSimulatorStream: true,
+                simulatorStreamRows: [simulatorPanel]
+            )
+            #expect(streaming.macSurfaceRows.map(\.id) == [.macSurface(markdown.id)])
+            let legacyMac = value(snapshotRows: rows, supportsSimulatorStream: false)
+            #expect(legacyMac.macSurfaceRows.map(\.id) == [.macSurface(simulator.id), .macSurface(markdown.id)])
+        }
+    }
+
+    @Test func supportedStreamsKeepGenericSurfacesVisibleUntilTheirRowsArrive() {
+        let browser = MobileSurfacePreview(id: "surface-web", kind: .browser, title: "cmux.com")
+        let simulator = MobileSurfacePreview(
+            id: "surface-simulator",
+            kind: .other("simulator"),
+            title: "Simulator"
+        )
+        let markdown = MobileSurfacePreview(id: "surface-md", kind: .markdown, title: "README")
+        let value = TerminalPickerMenuValue(
+            liveTerminals: [],
+            liveSurfaces: [browser, simulator, markdown],
+            snapshotRows: [],
+            selectedID: nil,
+            canCreateWorkspace: true,
+            hasActiveBrowser: false,
+            isChatMode: false,
+            supportsBrowserStream: true,
+            supportsSimulatorStream: true
+        )
+
+        #expect(value.macSurfaceRows.map(\.id) == [
+            .macSurface(browser.id),
+            .macSurface(simulator.id),
+            .macSurface(markdown.id),
+        ])
+    }
+
+    private static func browserDescriptor(panelID: String) -> MobileBrowserPanelDescriptor {
+        MobileBrowserPanelDescriptor(
+            panelID: panelID,
+            workspaceID: "workspace-1",
+            url: "https://cmux.com",
+            title: "cmux.com",
+            pageWidth: 800,
+            pageHeight: 600,
+            canGoBack: false,
+            canGoForward: false,
+            isLoading: false
+        )
+    }
+
+    private static func simulatorDescriptor(panelID: String) -> MobileSimulatorPanelDescriptor {
+        MobileSimulatorPanelDescriptor(
+            panelID: panelID,
+            workspaceID: "workspace-1",
+            title: "Simulator",
+            selectedDeviceName: "iPhone 17",
+            selectedDeviceState: "Booted",
+            status: "streaming",
+            isReady: true,
+            supportsTouch: true,
+            supportsKeyboard: true,
+            supportsHardwareButtons: true,
+            supportsRotation: true
+        )
     }
 
     private func menuValue(


### PR DESCRIPTION
## Summary
- hide simulator Mac surfaces from the generic picker when simulator streaming is supported
- keep browser filtering and checkmark resolution consistent for specialized stream rows
- add a regression test covering live and snapshot menu rows

## Verification
- iOS Simulator-targeted SwiftPM product build passes
- direct SwiftPM execution is host-incompatible for the iOS test bundle; hosted iOS checks provide runtime coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790022732&installation_model_id=21920&pr_number=10575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10575&signature=05f70ac10d22e4f8f5360cd9e150f1caf9f668821c4a9f8fa45e6812e3063ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate iOS surface picker rows by hiding Mac surface entries for browsers and simulators when their stream rows exist. Previously a pane appeared in both the stream section and Mac Surfaces; now it appears once, and generic surfaces stay visible until their stream rows arrive.

- Filters macSurfaceRows to exclude surfaces whose IDs match current browserStreamRows or simulatorStreamRows when supported; preserves legacy behavior when streaming is unsupported or before stream rows load.
- Resolves checkedRowID as before and hides it when a browser or simulator stream overlay is active; selection and checkmarks stay consistent across live and snapshot menus.
- Extends tests to cover simulator cases and stream timing; updates browser test to require a stream row before filtering. iOS Simulator-targeted SwiftPM build and hosted tests pass.

<sup>Written for commit 22b04bbdcb191fb212493b00493461610feac40d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the terminal picker when displaying browser and simulator surfaces during live streaming and snapshot updates.
  - Ensured supported surfaces remain available until their corresponding stream data is received.

- **Tests**
  - Expanded coverage for browser and simulator entries, including live updates, snapshots, and stream timing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->