### PR TITLE
iOS: trim toolbar title reserves 12pt with a collapse-recovery ratchet

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -108,7 +108,7 @@ struct AgentChatDemoScreen: View {
                 measuredTrailingItemsWidth: 0,
                 measuredTrailingItemCount: 0,
                 trailingItemCount: 0,
-                measuredTitleToTrailingSpan: nil,
+                hadTrailingCollapse: false,
                 isEnabled: true,
                 workspaceName: inlineWorkspaceTitle ?? "",
                 hasUnread: false,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -108,6 +108,7 @@ struct AgentChatDemoScreen: View {
                 measuredTrailingItemsWidth: 0,
                 measuredTrailingItemCount: 0,
                 trailingItemCount: 0,
+                measuredTitleToTrailingSpan: nil,
                 isEnabled: true,
                 workspaceName: inlineWorkspaceTitle ?? "",
                 hasUnread: false,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -33,9 +33,16 @@ struct MobileLeadingToolbarTitleWidth {
     static let backButtonReserve: CGFloat = 44
     static let trailingReserveBase: CGFloat = 64
     static let chatToggleReserve: CGFloat = 60
-    static let barMarginsAndSpacing: CGFloat = 84
+    /// Bar side margins, the back-to-title spacer, the title pill's own glass
+    /// padding, and the minimum title-to-trailing gap. Calibrated against a
+    /// 402pt iPhone 17 bar (16 + 17 side margins, 13 back gap, ~18 pill
+    /// padding, 13 minimum trailing gap ≈ the back-to-title gap) so the title
+    /// stops just short of the trailing cluster instead of leaving a dead gap.
+    static let barMarginsAndSpacing: CGFloat = 78
     /// Horizontal glass-capsule chrome around one trailing item's content.
-    static let trailingItemChrome: CGFloat = 24
+    /// Measured: a 2-item trailing group renders ~33pt wider than the sum of
+    /// its content widths, so ~16pt per item, not the 24pt first estimated.
+    static let trailingItemChrome: CGFloat = 16
     /// Safe content-width reserve for a structural item that has not reported
     /// geometry yet.
     static let unmeasuredTrailingItemReserve: CGFloat = 64

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -29,6 +29,14 @@ struct MobileLeadingToolbarTitleWidth {
     /// How many trailing toolbar items are structurally visible right now;
     /// each carries its own glass capsule chrome around the measured content.
     let trailingItemCount: Int
+    /// Rendered distance from the title content's leading edge to the
+    /// leading-most trailing item content's leading edge, when every
+    /// structural trailing item and the title label have reported geometry at
+    /// the current pane width (LTR only). This is the system's realized
+    /// layout, so a cap derived from it can only consume space that is
+    /// actually empty on screen: unlike the estimate constants it can never
+    /// over-commit the bar and bounce trailing items into the More menu.
+    let measuredTitleToTrailingSpan: CGFloat?
 
     static let backButtonReserve: CGFloat = 44
     static let trailingReserveBase: CGFloat = 64
@@ -41,6 +49,11 @@ struct MobileLeadingToolbarTitleWidth {
     static let unmeasuredTrailingItemReserve: CGFloat = 64
     static let unmeasuredFallback: CGFloat = 140
     static let floor: CGFloat = 96
+    /// Subtracted from the measured span before the title may use it: the
+    /// title pill's trailing glass chrome plus the trailing capsule's leading
+    /// chrome (~13pt each) plus a minimum visual gap matching the
+    /// back-to-title spacing (~13pt).
+    static let spanGapReserve: CGFloat = 40
 
     init(
         contentWidth: CGFloat,
@@ -49,7 +62,8 @@ struct MobileLeadingToolbarTitleWidth {
         hasChatToggle: Bool,
         measuredTrailingItemsWidth: CGFloat = 0,
         measuredTrailingItemCount: Int = 0,
-        trailingItemCount: Int = 0
+        trailingItemCount: Int = 0,
+        measuredTitleToTrailingSpan: CGFloat? = nil
     ) {
         self.contentWidth = contentWidth
         self.hasBackButton = hasBackButton
@@ -58,10 +72,18 @@ struct MobileLeadingToolbarTitleWidth {
         self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
         self.measuredTrailingItemCount = measuredTrailingItemCount
         self.trailingItemCount = trailingItemCount
+        self.measuredTitleToTrailingSpan = measuredTitleToTrailingSpan
     }
 
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
+        // Realized-layout path: both edges of the gap were measured at this
+        // width, so size the title from actual positions. The title's leading
+        // edge and the trailing items' positions do not depend on the title's
+        // width, so this does not feed back into itself.
+        if let span = measuredTitleToTrailingSpan, span > 0 {
+            return max(0, span - Self.spanGapReserve)
+        }
         let leading = hasBackButton ? Self.backButtonReserve : 0
         return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -33,16 +33,9 @@ struct MobileLeadingToolbarTitleWidth {
     static let backButtonReserve: CGFloat = 44
     static let trailingReserveBase: CGFloat = 64
     static let chatToggleReserve: CGFloat = 60
-    /// Bar side margins, the back-to-title spacer, the title pill's own glass
-    /// padding, and the minimum title-to-trailing gap. Calibrated against a
-    /// 402pt iPhone 17 bar (16 + 17 side margins, 13 back gap, ~18 pill
-    /// padding, 13 minimum trailing gap ≈ the back-to-title gap) so the title
-    /// stops just short of the trailing cluster instead of leaving a dead gap.
-    static let barMarginsAndSpacing: CGFloat = 78
+    static let barMarginsAndSpacing: CGFloat = 84
     /// Horizontal glass-capsule chrome around one trailing item's content.
-    /// Measured: a 2-item trailing group renders ~33pt wider than the sum of
-    /// its content widths, so ~16pt per item, not the 24pt first estimated.
-    static let trailingItemChrome: CGFloat = 16
+    static let trailingItemChrome: CGFloat = 24
     /// Safe content-width reserve for a structural item that has not reported
     /// geometry yet.
     static let unmeasuredTrailingItemReserve: CGFloat = 64

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -12,7 +12,10 @@ import CoreGraphics
 /// specific items in the bar. The title therefore must never claim space the
 /// trailing items actually render with. Callers report the measured content
 /// widths of the trailing toolbar items; the estimate constants only cover the
-/// frames before the first measurement arrives.
+/// frames before the first measurement arrives. As a backstop, callers also
+/// report when a trailing item's content left the bar (the system folded it
+/// into More); that ratchets `collapseRecoveryReserve` on for the rest of the
+/// view's lifetime so a collapse can never persist.
 struct MobileLeadingToolbarTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
@@ -29,31 +32,33 @@ struct MobileLeadingToolbarTitleWidth {
     /// How many trailing toolbar items are structurally visible right now;
     /// each carries its own glass capsule chrome around the measured content.
     let trailingItemCount: Int
-    /// Rendered distance from the title content's leading edge to the
-    /// leading-most trailing item content's leading edge, when every
-    /// structural trailing item and the title label have reported geometry at
-    /// the current pane width (LTR only). This is the system's realized
-    /// layout, so a cap derived from it can only consume space that is
-    /// actually empty on screen: unlike the estimate constants it can never
-    /// over-commit the bar and bounce trailing items into the More menu.
-    let measuredTitleToTrailingSpan: CGFloat?
+    /// True once a trailing item's content left the bar while structurally
+    /// present (the system collapsed it into the More menu): the reserves
+    /// undershot this device's real chrome, so give the space back.
+    let hadTrailingCollapse: Bool
 
     static let backButtonReserve: CGFloat = 44
     static let trailingReserveBase: CGFloat = 64
     static let chatToggleReserve: CGFloat = 60
-    static let barMarginsAndSpacing: CGFloat = 84
+    /// Dogfood on a 402pt iPhone 17 measured ~22pt of dead gap between the
+    /// title pill and the trailing capsule under the original 84pt margin +
+    /// 24pt/item chrome reserves. Only part of that slack is returned to the
+    /// title (4pt here, 4pt per item below): larger-chrome devices proved
+    /// able to eat the full amount (a 30pt trim collapsed the trailing items
+    /// into More on an iPhone 17 Pro Max), and `collapseRecoveryReserve`
+    /// backstops the remainder.
+    static let barMarginsAndSpacing: CGFloat = 80
     /// Horizontal glass-capsule chrome around one trailing item's content.
-    static let trailingItemChrome: CGFloat = 24
+    static let trailingItemChrome: CGFloat = 20
     /// Safe content-width reserve for a structural item that has not reported
     /// geometry yet.
     static let unmeasuredTrailingItemReserve: CGFloat = 64
+    /// Added once a collapse was observed: more than the 12pt trimmed from
+    /// the estimate reserves, so the recovered layout is strictly roomier
+    /// than the original constants and the bar un-collapses.
+    static let collapseRecoveryReserve: CGFloat = 28
     static let unmeasuredFallback: CGFloat = 140
     static let floor: CGFloat = 96
-    /// Subtracted from the measured span before the title may use it: the
-    /// title pill's trailing glass chrome plus the trailing capsule's leading
-    /// chrome (~13pt each) plus a minimum visual gap matching the
-    /// back-to-title spacing (~13pt).
-    static let spanGapReserve: CGFloat = 40
 
     init(
         contentWidth: CGFloat,
@@ -63,7 +68,7 @@ struct MobileLeadingToolbarTitleWidth {
         measuredTrailingItemsWidth: CGFloat = 0,
         measuredTrailingItemCount: Int = 0,
         trailingItemCount: Int = 0,
-        measuredTitleToTrailingSpan: CGFloat? = nil
+        hadTrailingCollapse: Bool = false
     ) {
         self.contentWidth = contentWidth
         self.hasBackButton = hasBackButton
@@ -72,20 +77,14 @@ struct MobileLeadingToolbarTitleWidth {
         self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
         self.measuredTrailingItemCount = measuredTrailingItemCount
         self.trailingItemCount = trailingItemCount
-        self.measuredTitleToTrailingSpan = measuredTitleToTrailingSpan
+        self.hadTrailingCollapse = hadTrailingCollapse
     }
 
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
-        // Realized-layout path: both edges of the gap were measured at this
-        // width, so size the title from actual positions. The title's leading
-        // edge and the trailing items' positions do not depend on the title's
-        // width, so this does not feed back into itself.
-        if let span = measuredTitleToTrailingSpan, span > 0 {
-            return max(0, span - Self.spanGapReserve)
-        }
         let leading = hasBackButton ? Self.backButtonReserve : 0
-        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing)
+        let recovery = hadTrailingCollapse ? Self.collapseRecoveryReserve : 0
+        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing - recovery)
     }
 
     private var trailingReserve: CGFloat {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -3,146 +3,87 @@ import SwiftUI
 import UIKit
 #endif
 
-/// One trailing toolbar item's rendered content geometry.
-///
-/// Width comes from `onGeometryChange` (island-local sizes are correct) and
-/// feeds the estimate-based reserve exactly as before. The leading edge is
-/// measured separately in the shared UIKit window space, because each
-/// `ToolbarItem` is bridged into the navigation bar as its own SwiftUI
-/// hosting island and `.global` frames are not comparable across islands.
-/// The edge is optional: the realized-span path only engages when every
-/// structural item has one, and an item whose probe leaves the window (for
-/// example, collapsed into the overflow More menu) clears its edge so the
-/// span invalidates and the title falls back to the safe estimate reserve,
-/// un-collapsing the bar.
-struct TrailingToolbarItemGeometry: Equatable {
-    /// Rendered content width (inside the glass capsule chrome).
-    var width: CGFloat = 0
-    /// Leading edge of the content in the window space, when known.
-    var globalMinX: CGFloat?
-}
-
 extension View {
-    /// Reports this trailing toolbar item's rendered content geometry into the
-    /// shared measurement dictionary.
+    /// Reports this trailing toolbar item's rendered content width into the
+    /// shared measurement dictionary, and optionally reports when the item's
+    /// content leaves the window while still structurally present, which on
+    /// iOS means the system folded the item into the overflow More menu.
     ///
     /// The leading title menu caps its width to the bar's remaining space so
-    /// the trailing items are never squeezed into the overflow More menu.
-    /// Width entries are deliberately never removed on disappear: overflowing
-    /// into More also removes the bar content, so clearing the width there
-    /// would release the reservation and make the collapse sticky. Callers
-    /// that structurally remove an item clear its key from the condition that
+    /// the trailing items are never squeezed into the More menu. Width
+    /// entries are deliberately never removed on disappear: overflowing into
+    /// More also removes the bar content, so clearing the width there would
+    /// release the reservation and make the collapse sticky. Callers that
+    /// structurally remove an item clear its key from the condition that
     /// removed it.
+    ///
+    /// `onLeaveBar` is only wired for items that are always structurally
+    /// present: a conditional item's structural removal also detaches its
+    /// probe and would be indistinguishable from a collapse.
+    @ViewBuilder
     func measureTrailingToolbarItem(
         _ key: String,
-        into geometry: Binding<[String: TrailingToolbarItemGeometry]>
+        into widths: Binding<[String: CGFloat]>,
+        onLeaveBar: (@MainActor () -> Void)? = nil
     ) -> some View {
-        onGeometryChange(for: CGFloat.self) { proxy in
+        let measured = onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.width
         } action: { width in
-            guard geometry.wrappedValue[key]?.width != width else { return }
-            geometry.wrappedValue[key, default: TrailingToolbarItemGeometry()].width = width
+            widths.wrappedValue[key] = width
         }
-        .measureWindowFrame(probeKey: key) { frame in
-            guard geometry.wrappedValue[key]?.globalMinX != frame?.minX else { return }
-            geometry.wrappedValue[key, default: TrailingToolbarItemGeometry()].globalMinX = frame?.minX
-        }
-    }
-
-    /// Reports the fitted title label's frame in window space; the leading
-    /// edge is stable under cap changes (the frame is leading-aligned).
-    func measureToolbarTitleFrame(_ onChange: @escaping (CGRect?) -> Void) -> some View {
-        measureWindowFrame(probeKey: "title", onChange)
-    }
-
-    /// `onChange` receives nil when the probe leaves the window (the content
-    /// was removed from the bar, for example into the overflow More menu).
-    @ViewBuilder
-    private func measureWindowFrame(
-        probeKey: String,
-        _ onChange: @escaping (CGRect?) -> Void
-    ) -> some View {
         #if canImport(UIKit)
-        background(WindowFrameReader(probeKey: probeKey, onChange: onChange))
+        measured.background(BarPresenceReader(probeKey: key, onLeaveBar: onLeaveBar))
         #else
-        onGeometryChange(for: CGRect.self) { proxy in
-            proxy.frame(in: .global)
-        } action: { frame in
-            onChange(frame)
-        }
+        measured
         #endif
     }
 }
 
 #if canImport(UIKit)
-/// Bridges out of the SwiftUI hosting island to read the probe's frame in the
-/// shared UIKit window. Reports on layout, window attachment, and SwiftUI
-/// updates, deduplicated; reports nil on window detachment.
-private struct WindowFrameReader: UIViewRepresentable {
+/// Bridges out of the SwiftUI hosting island to observe whether the item's
+/// content is attached to a UIKit window. Detaching after having been
+/// attached, while the SwiftUI view is still alive, is the observable
+/// signature of the system moving the item into the overflow More menu.
+private struct BarPresenceReader: UIViewRepresentable {
     let probeKey: String
-    let onChange: (CGRect?) -> Void
+    let onLeaveBar: (@MainActor () -> Void)?
 
-    func makeUIView(context: Context) -> WindowFrameProbeView {
-        let view = WindowFrameProbeView()
+    func makeUIView(context: Context) -> BarPresenceProbeView {
+        let view = BarPresenceProbeView()
         view.isUserInteractionEnabled = false
         view.backgroundColor = .clear
         view.probeKey = probeKey
-        view.onChange = onChange
-        #if DEBUG
-        NSLog("cmux.toolbar.span probe-made key=%@", probeKey)
-        #endif
+        view.onLeaveBar = onLeaveBar
         return view
     }
 
-    func updateUIView(_ view: WindowFrameProbeView, context: Context) {
-        view.onChange = onChange
-        // SwiftUI updates land after the layout that moved this view; frames
-        // are current here even when only an ancestor's position changed
-        // (position-only moves do not call layoutSubviews on this leaf).
-        view.reportIfChanged()
+    func updateUIView(_ view: BarPresenceProbeView, context: Context) {
+        view.onLeaveBar = onLeaveBar
     }
 }
 
-final class WindowFrameProbeView: UIView {
+final class BarPresenceProbeView: UIView {
     var probeKey = ""
-    var onChange: ((CGRect?) -> Void)?
-    private var lastReported: CGRect?
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        reportIfChanged()
-    }
+    var onLeaveBar: (@MainActor () -> Void)?
+    private var wasAttached = false
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
         #if DEBUG
         NSLog(
-            "cmux.toolbar.span probe-window key=%@ attached=%d",
+            "cmux.toolbar.collapse probe key=%@ attached=%d",
             probeKey, window == nil ? 0 : 1
         )
         #endif
-        if window == nil {
-            // Removed from the bar (e.g. the system collapsed the item into
-            // the More menu). Invalidate so the span consumer falls back.
-            lastReported = nil
-            onChange?(nil)
+        if window != nil {
+            wasAttached = true
             return
         }
-        reportIfChanged()
-    }
-
-    func reportIfChanged() {
-        guard let window else { return }
-        let frame = convert(bounds, to: window)
-        guard frame != lastReported else { return }
-        lastReported = frame
-        #if DEBUG
-        NSLog(
-            "cmux.toolbar.span probe key=%@ minX=%.1f width=%.1f",
-            probeKey, frame.minX, frame.width
-        )
-        #endif
-        onChange?(frame)
+        guard wasAttached else { return }
+        wasAttached = false
+        MainActor.assumeIsolated {
+            onLeaveBar?()
+        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -5,18 +5,21 @@ import UIKit
 
 /// One trailing toolbar item's rendered content geometry.
 ///
-/// Positions are measured in the UIKit window space: each `ToolbarItem` is
-/// bridged into the navigation bar as its own SwiftUI hosting island, so
-/// SwiftUI's `.global` space resolves per-island and cross-item math needs
-/// the shared window. Values carry no width epoch: the span consumer rejects
-/// measurements implausible for the current pane width (a stale wider-layout
-/// edge lands past the pane's end), and stale narrower-layout values only
-/// under-size the title, which is safe.
+/// Width comes from `onGeometryChange` (island-local sizes are correct) and
+/// feeds the estimate-based reserve exactly as before. The leading edge is
+/// measured separately in the shared UIKit window space, because each
+/// `ToolbarItem` is bridged into the navigation bar as its own SwiftUI
+/// hosting island and `.global` frames are not comparable across islands.
+/// The edge is optional: the realized-span path only engages when every
+/// structural item has one, and an item whose probe leaves the window (for
+/// example, collapsed into the overflow More menu) clears its edge so the
+/// span invalidates and the title falls back to the safe estimate reserve,
+/// un-collapsing the bar.
 struct TrailingToolbarItemGeometry: Equatable {
     /// Rendered content width (inside the glass capsule chrome).
-    var width: CGFloat
-    /// Leading edge of the content in the window space.
-    var globalMinX: CGFloat
+    var width: CGFloat = 0
+    /// Leading edge of the content in the window space, when known.
+    var globalMinX: CGFloat?
 }
 
 extension View {
@@ -25,40 +28,42 @@ extension View {
     ///
     /// The leading title menu caps its width to the bar's remaining space so
     /// the trailing items are never squeezed into the overflow More menu.
-    /// Deliberately no removal on disappear: overflowing into More also
-    /// removes the bar content, so clearing on disappear would release the
-    /// reservation and make the collapse sticky. Callers that structurally
-    /// remove an item clear its key from the condition that removed it.
+    /// Width entries are deliberately never removed on disappear: overflowing
+    /// into More also removes the bar content, so clearing the width there
+    /// would release the reservation and make the collapse sticky. Callers
+    /// that structurally remove an item clear its key from the condition that
+    /// removed it.
     func measureTrailingToolbarItem(
         _ key: String,
         into geometry: Binding<[String: TrailingToolbarItemGeometry]>
     ) -> some View {
-        measureWindowFrame { frame in
-            let next = TrailingToolbarItemGeometry(
-                width: frame.width,
-                globalMinX: frame.minX
-            )
-            guard geometry.wrappedValue[key] != next else { return }
-            geometry.wrappedValue[key] = next
-            #if DEBUG
-            NSLog(
-                "cmux.toolbar.span probe key=%@ minX=%.1f width=%.1f",
-                key, frame.minX, frame.width
-            )
-            #endif
+        onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard geometry.wrappedValue[key]?.width != width else { return }
+            geometry.wrappedValue[key, default: TrailingToolbarItemGeometry()].width = width
+        }
+        .measureWindowFrame(probeKey: key) { frame in
+            guard geometry.wrappedValue[key]?.globalMinX != frame?.minX else { return }
+            geometry.wrappedValue[key, default: TrailingToolbarItemGeometry()].globalMinX = frame?.minX
         }
     }
 
     /// Reports the fitted title label's frame in window space; the leading
     /// edge is stable under cap changes (the frame is leading-aligned).
-    func measureToolbarTitleFrame(_ onChange: @escaping (CGRect) -> Void) -> some View {
-        measureWindowFrame(onChange)
+    func measureToolbarTitleFrame(_ onChange: @escaping (CGRect?) -> Void) -> some View {
+        measureWindowFrame(probeKey: "title", onChange)
     }
 
+    /// `onChange` receives nil when the probe leaves the window (the content
+    /// was removed from the bar, for example into the overflow More menu).
     @ViewBuilder
-    private func measureWindowFrame(_ onChange: @escaping (CGRect) -> Void) -> some View {
+    private func measureWindowFrame(
+        probeKey: String,
+        _ onChange: @escaping (CGRect?) -> Void
+    ) -> some View {
         #if canImport(UIKit)
-        background(WindowFrameReader(onChange: onChange))
+        background(WindowFrameReader(probeKey: probeKey, onChange: onChange))
         #else
         onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .global)
@@ -71,15 +76,21 @@ extension View {
 
 #if canImport(UIKit)
 /// Bridges out of the SwiftUI hosting island to read the probe's frame in the
-/// shared UIKit window. Reports on layout and window attachment, deduplicated.
+/// shared UIKit window. Reports on layout, window attachment, and SwiftUI
+/// updates, deduplicated; reports nil on window detachment.
 private struct WindowFrameReader: UIViewRepresentable {
-    let onChange: (CGRect) -> Void
+    let probeKey: String
+    let onChange: (CGRect?) -> Void
 
     func makeUIView(context: Context) -> WindowFrameProbeView {
         let view = WindowFrameProbeView()
         view.isUserInteractionEnabled = false
         view.backgroundColor = .clear
+        view.probeKey = probeKey
         view.onChange = onChange
+        #if DEBUG
+        NSLog("cmux.toolbar.span probe-made key=%@", probeKey)
+        #endif
         return view
     }
 
@@ -93,7 +104,8 @@ private struct WindowFrameReader: UIViewRepresentable {
 }
 
 final class WindowFrameProbeView: UIView {
-    var onChange: ((CGRect) -> Void)?
+    var probeKey = ""
+    var onChange: ((CGRect?) -> Void)?
     private var lastReported: CGRect?
 
     override func layoutSubviews() {
@@ -103,6 +115,19 @@ final class WindowFrameProbeView: UIView {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
+        #if DEBUG
+        NSLog(
+            "cmux.toolbar.span probe-window key=%@ attached=%d",
+            probeKey, window == nil ? 0 : 1
+        )
+        #endif
+        if window == nil {
+            // Removed from the bar (e.g. the system collapsed the item into
+            // the More menu). Invalidate so the span consumer falls back.
+            lastReported = nil
+            onChange?(nil)
+            return
+        }
         reportIfChanged()
     }
 
@@ -111,6 +136,12 @@ final class WindowFrameProbeView: UIView {
         let frame = convert(bounds, to: window)
         guard frame != lastReported else { return }
         lastReported = frame
+        #if DEBUG
+        NSLog(
+            "cmux.toolbar.span probe key=%@ minX=%.1f width=%.1f",
+            probeKey, frame.minX, frame.width
+        )
+        #endif
         onChange?(frame)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -1,17 +1,21 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// One trailing toolbar item's rendered content geometry.
 ///
-/// Values are plain positions with no width epoch: the span consumer rejects
-/// measurements that are implausible for the current pane width (a stale
-/// wider-layout edge lands past the pane's end), and stale narrower-layout
-/// values only under-size the title, which is safe. Fresh geometry re-fires
-/// the probes because real positions change whenever the bar re-lays out.
+/// Positions are measured in the UIKit window space: each `ToolbarItem` is
+/// bridged into the navigation bar as its own SwiftUI hosting island, so
+/// SwiftUI's `.global` space resolves per-island and cross-item math needs
+/// the shared window. Values carry no width epoch: the span consumer rejects
+/// measurements implausible for the current pane width (a stale wider-layout
+/// edge lands past the pane's end), and stale narrower-layout values only
+/// under-size the title, which is safe.
 struct TrailingToolbarItemGeometry: Equatable {
     /// Rendered content width (inside the glass capsule chrome).
     var width: CGFloat
-    /// Leading edge of the content in the global space, used to derive the
-    /// real title-to-trailing span.
+    /// Leading edge of the content in the window space.
     var globalMinX: CGFloat
 }
 
@@ -21,7 +25,7 @@ extension View {
     ///
     /// The leading title menu caps its width to the bar's remaining space so
     /// the trailing items are never squeezed into the overflow More menu.
-    /// Deliberately no `onDisappear` cleanup: overflowing into More also
+    /// Deliberately no removal on disappear: overflowing into More also
     /// removes the bar content, so clearing on disappear would release the
     /// reservation and make the collapse sticky. Callers that structurally
     /// remove an item clear its key from the condition that removed it.
@@ -29,14 +33,85 @@ extension View {
         _ key: String,
         into geometry: Binding<[String: TrailingToolbarItemGeometry]>
     ) -> some View {
-        onGeometryChange(for: TrailingToolbarItemGeometry.self) { proxy in
-            TrailingToolbarItemGeometry(
-                width: proxy.size.width,
-                globalMinX: proxy.frame(in: .global).minX
+        measureWindowFrame { frame in
+            let next = TrailingToolbarItemGeometry(
+                width: frame.width,
+                globalMinX: frame.minX
             )
-        } action: { probe in
-            geometry.wrappedValue[key] = probe
+            guard geometry.wrappedValue[key] != next else { return }
+            geometry.wrappedValue[key] = next
+            #if DEBUG
+            NSLog(
+                "cmux.toolbar.span probe key=%@ minX=%.1f width=%.1f",
+                key, frame.minX, frame.width
+            )
+            #endif
         }
+    }
+
+    /// Reports the fitted title label's frame in window space; the leading
+    /// edge is stable under cap changes (the frame is leading-aligned).
+    func measureToolbarTitleFrame(_ onChange: @escaping (CGRect) -> Void) -> some View {
+        measureWindowFrame(onChange)
+    }
+
+    @ViewBuilder
+    private func measureWindowFrame(_ onChange: @escaping (CGRect) -> Void) -> some View {
+        #if canImport(UIKit)
+        background(WindowFrameReader(onChange: onChange))
+        #else
+        onGeometryChange(for: CGRect.self) { proxy in
+            proxy.frame(in: .global)
+        } action: { frame in
+            onChange(frame)
+        }
+        #endif
     }
 }
 
+#if canImport(UIKit)
+/// Bridges out of the SwiftUI hosting island to read the probe's frame in the
+/// shared UIKit window. Reports on layout and window attachment, deduplicated.
+private struct WindowFrameReader: UIViewRepresentable {
+    let onChange: (CGRect) -> Void
+
+    func makeUIView(context: Context) -> WindowFrameProbeView {
+        let view = WindowFrameProbeView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        view.onChange = onChange
+        return view
+    }
+
+    func updateUIView(_ view: WindowFrameProbeView, context: Context) {
+        view.onChange = onChange
+        // SwiftUI updates land after the layout that moved this view; frames
+        // are current here even when only an ancestor's position changed
+        // (position-only moves do not call layoutSubviews on this leaf).
+        view.reportIfChanged()
+    }
+}
+
+final class WindowFrameProbeView: UIView {
+    var onChange: ((CGRect) -> Void)?
+    private var lastReported: CGRect?
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        reportIfChanged()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        reportIfChanged()
+    }
+
+    func reportIfChanged() {
+        guard let window else { return }
+        let frame = convert(bounds, to: window)
+        guard frame != lastReported else { return }
+        lastReported = frame
+        onChange?(frame)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -1,7 +1,20 @@
 import SwiftUI
 
+/// One trailing toolbar item's rendered content geometry, captured together
+/// with the pane width it was measured at so a stale value from before a
+/// rotation or split-width change is never mixed into current-width math.
+struct TrailingToolbarItemGeometry: Equatable {
+    /// Rendered content width (inside the glass capsule chrome).
+    var width: CGFloat
+    /// Leading edge of the content in the global space, used to derive the
+    /// real title-to-trailing span.
+    var globalMinX: CGFloat
+    /// The pane width current when this measurement fired.
+    var contentWidth: CGFloat
+}
+
 extension View {
-    /// Reports this trailing toolbar item's rendered content width into the
+    /// Reports this trailing toolbar item's rendered content geometry into the
     /// shared measurement dictionary.
     ///
     /// The leading title menu caps its width to the bar's remaining space so
@@ -12,12 +25,34 @@ extension View {
     /// remove an item clear its key from the condition that removed it.
     func measureTrailingToolbarItem(
         _ key: String,
-        into widths: Binding<[String: CGFloat]>
+        into geometry: Binding<[String: TrailingToolbarItemGeometry]>,
+        contentWidth: @escaping @autoclosure () -> CGFloat
     ) -> some View {
-        onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.width
-        } action: { width in
-            widths.wrappedValue[key] = width
+        onGeometryChange(for: TrailingToolbarItemProbe.self) { proxy in
+            TrailingToolbarItemProbe(
+                width: proxy.size.width,
+                globalMinX: proxy.frame(in: .global).minX
+            )
+        } action: { probe in
+            geometry.wrappedValue[key] = TrailingToolbarItemGeometry(
+                width: probe.width,
+                globalMinX: probe.globalMinX,
+                contentWidth: contentWidth()
+            )
         }
     }
+}
+
+/// Equatable payload for `onGeometryChange`, which only re-fires when the
+/// reduced value changes.
+private struct TrailingToolbarItemProbe: Equatable {
+    var width: CGFloat
+    var globalMinX: CGFloat
+}
+
+/// The fitted title label's leading edge, captured with the pane width it was
+/// measured at (same staleness contract as `TrailingToolbarItemGeometry`).
+struct WorkspaceTitleLabelEdge: Equatable {
+    var globalMinX: CGFloat
+    var contentWidth: CGFloat
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TrailingToolbarItemMeasurement.swift
@@ -1,16 +1,18 @@
 import SwiftUI
 
-/// One trailing toolbar item's rendered content geometry, captured together
-/// with the pane width it was measured at so a stale value from before a
-/// rotation or split-width change is never mixed into current-width math.
+/// One trailing toolbar item's rendered content geometry.
+///
+/// Values are plain positions with no width epoch: the span consumer rejects
+/// measurements that are implausible for the current pane width (a stale
+/// wider-layout edge lands past the pane's end), and stale narrower-layout
+/// values only under-size the title, which is safe. Fresh geometry re-fires
+/// the probes because real positions change whenever the bar re-lays out.
 struct TrailingToolbarItemGeometry: Equatable {
     /// Rendered content width (inside the glass capsule chrome).
     var width: CGFloat
     /// Leading edge of the content in the global space, used to derive the
     /// real title-to-trailing span.
     var globalMinX: CGFloat
-    /// The pane width current when this measurement fired.
-    var contentWidth: CGFloat
 }
 
 extension View {
@@ -25,34 +27,16 @@ extension View {
     /// remove an item clear its key from the condition that removed it.
     func measureTrailingToolbarItem(
         _ key: String,
-        into geometry: Binding<[String: TrailingToolbarItemGeometry]>,
-        contentWidth: @escaping @autoclosure () -> CGFloat
+        into geometry: Binding<[String: TrailingToolbarItemGeometry]>
     ) -> some View {
-        onGeometryChange(for: TrailingToolbarItemProbe.self) { proxy in
-            TrailingToolbarItemProbe(
+        onGeometryChange(for: TrailingToolbarItemGeometry.self) { proxy in
+            TrailingToolbarItemGeometry(
                 width: proxy.size.width,
                 globalMinX: proxy.frame(in: .global).minX
             )
         } action: { probe in
-            geometry.wrappedValue[key] = TrailingToolbarItemGeometry(
-                width: probe.width,
-                globalMinX: probe.globalMinX,
-                contentWidth: contentWidth()
-            )
+            geometry.wrappedValue[key] = probe
         }
     }
 }
 
-/// Equatable payload for `onGeometryChange`, which only re-fires when the
-/// reduced value changes.
-private struct TrailingToolbarItemProbe: Equatable {
-    var width: CGFloat
-    var globalMinX: CGFloat
-}
-
-/// The fitted title label's leading edge, captured with the pane width it was
-/// measured at (same staleness contract as `TrailingToolbarItemGeometry`).
-struct WorkspaceTitleLabelEdge: Equatable {
-    var globalMinX: CGFloat
-    var contentWidth: CGFloat
-}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -81,12 +81,12 @@ struct WorkspaceDetailView: View {
     // deletes an entry (see the onChange handlers); a layout-driven
     // disappearance (overflow into More) cannot release a reservation and
     // make the collapse sticky.
-    @State private var trailingToolbarItemGeometry: [String: TrailingToolbarItemGeometry] = [:]
-    /// The fitted title label's leading edge in global space; pairs with the
-    /// trailing item geometry to derive the realized title-to-trailing span.
-    /// Leading-aligned, so it does not move as the title's cap changes.
-    @State private var titleLabelLeadingEdge: CGFloat?
-    @Environment(\.layoutDirection) private var layoutDirection
+    @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
+    /// Ratchets on when the trailing cluster's content leaves the bar while
+    /// structurally present: the system folded it into the More menu, so the
+    /// estimate reserves undershot this device's chrome. Never cleared for
+    /// this view's lifetime; the extra recovery reserve un-collapses the bar.
+    @State private var trailingToolbarCollapseDetected = false
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
     /// Identity of the in-flight New Browser creation. A late RPC result must
@@ -217,10 +217,10 @@ struct WorkspaceDetailView: View {
             // disappearance (overflow into More) never flips these conditions,
             // so it cannot release a reservation and make the collapse sticky.
             .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
-                if !isAvailable { trailingToolbarItemGeometry["changes"] = nil }
+                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
             }
             .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
-                if !isVisible { trailingToolbarItemGeometry["altscreen-notice"] = nil }
+                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
             }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
@@ -374,7 +374,7 @@ struct WorkspaceDetailView: View {
         AltScreenNoticeButton {
             displaySettings.showAltScreenNotice = false
         }
-        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemGeometry)
+        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
     }
 
     private var workspaceChangesToolbarContent: some View {
@@ -386,12 +386,19 @@ struct WorkspaceDetailView: View {
         // The chrome sits on the terminal theme's background, not the
         // system scheme; resolve the counts' green/red for that.
         .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
-        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemGeometry)
+        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
     }
 
     private var trailingClusterToolbarContent: some View {
         toolbarTrailingCluster
-            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemGeometry)
+            // Only the always-structural cluster wires collapse detection: a
+            // conditional item's structural removal also detaches its probe
+            // and would be indistinguishable from a More-menu collapse.
+            .measureTrailingToolbarItem(
+                "trailing-cluster",
+                into: $trailingToolbarItemWidths,
+                onLeaveBar: { trailingToolbarCollapseDetected = true }
+            )
     }
 
     // Which trailing toolbar items are structurally in the bar right now.
@@ -403,37 +410,8 @@ struct WorkspaceDetailView: View {
         return keys
     }
 
-    /// The realized distance from the title label's leading edge to the
-    /// leading-most trailing item's content, only when the title and every
-    /// structural trailing item have reported geometry that is plausible for
-    /// the current pane width. A stale measurement from a wider layout puts
-    /// the trailing content past the pane's end and is rejected; a stale
-    /// narrower-layout value only under-sizes the title, which cannot
-    /// over-commit the bar. RTL returns nil (the global-x projection would
-    /// need mirroring), falling back to the estimate-based reserve.
-    private var measuredTitleToTrailingSpan: CGFloat? {
-        guard layoutDirection == .leftToRight,
-              contentWidth > 0,
-              let titleMinX = titleLabelLeadingEdge else { return nil }
-        let geometries = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0] }
-        guard geometries.count == structuralTrailingItemKeys.count else { return nil }
-        let edges = geometries.compactMap(\.globalMinX)
-        guard edges.count == geometries.count,
-              let trailingLeadingEdge = edges.min()
-        else { return nil }
-        let trailingContentTotal = geometries.map(\.width).reduce(0, +)
-        guard trailingLeadingEdge > titleMinX,
-              trailingLeadingEdge + trailingContentTotal <= contentWidth
-        else { return nil }
-        return trailingLeadingEdge - titleMinX
-    }
-
     private var workspaceTitleToolbarMenu: some View {
-        // An entry can exist with only its window edge reported; only a real
-        // rendered width counts toward the estimate reserve.
-        let measuredWidths = structuralTrailingItemKeys
-            .compactMap { trailingToolbarItemGeometry[$0]?.width }
-            .filter { $0 > 0 }
+        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
@@ -442,7 +420,7 @@ struct WorkspaceDetailView: View {
             measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
             measuredTrailingItemCount: measuredWidths.count,
             trailingItemCount: structuralTrailingItemKeys.count,
-            measuredTitleToTrailingSpan: measuredTitleToTrailingSpan,
+            hadTrailingCollapse: trailingToolbarCollapseDetected,
             isEnabled: hasTitleMenuActions,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,
@@ -455,10 +433,6 @@ struct WorkspaceDetailView: View {
         )
         return WorkspaceTitleMenu(
             value: value,
-            onLabelLeadingEdgeChange: { minX in
-                guard titleLabelLeadingEdge != minX else { return }
-                titleLabelLeadingEdge = minX
-            },
             menuContent: {
                 WorkspaceTitleMenuContent(
                     workspaceName: value.workspaceName,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -450,7 +450,11 @@ struct WorkspaceDetailView: View {
         return WorkspaceTitleMenu(
             value: value,
             onLabelLeadingEdgeChange: { minX in
+                guard titleLabelLeadingEdge != minX else { return }
                 titleLabelLeadingEdge = minX
+                #if DEBUG
+                NSLog("cmux.toolbar.span probe key=title minX=%.1f", minX)
+                #endif
             },
             menuContent: {
                 WorkspaceTitleMenuContent(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -416,8 +416,10 @@ struct WorkspaceDetailView: View {
               contentWidth > 0,
               let titleMinX = titleLabelLeadingEdge else { return nil }
         let geometries = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0] }
-        guard geometries.count == structuralTrailingItemKeys.count,
-              let trailingLeadingEdge = geometries.map(\.globalMinX).min()
+        guard geometries.count == structuralTrailingItemKeys.count else { return nil }
+        let edges = geometries.compactMap(\.globalMinX)
+        guard edges.count == geometries.count,
+              let trailingLeadingEdge = edges.min()
         else { return nil }
         let trailingContentTotal = geometries.map(\.width).reduce(0, +)
         guard trailingLeadingEdge > titleMinX,
@@ -427,7 +429,11 @@ struct WorkspaceDetailView: View {
     }
 
     private var workspaceTitleToolbarMenu: some View {
-        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0]?.width }
+        // An entry can exist with only its window edge reported; only a real
+        // rendered width counts toward the estimate reserve.
+        let measuredWidths = structuralTrailingItemKeys
+            .compactMap { trailingToolbarItemGeometry[$0]?.width }
+            .filter { $0 > 0 }
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
@@ -452,9 +458,6 @@ struct WorkspaceDetailView: View {
             onLabelLeadingEdgeChange: { minX in
                 guard titleLabelLeadingEdge != minX else { return }
                 titleLabelLeadingEdge = minX
-                #if DEBUG
-                NSLog("cmux.toolbar.span probe key=title minX=%.1f", minX)
-                #endif
             },
             menuContent: {
                 WorkspaceTitleMenuContent(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -82,10 +82,10 @@ struct WorkspaceDetailView: View {
     // disappearance (overflow into More) cannot release a reservation and
     // make the collapse sticky.
     @State private var trailingToolbarItemGeometry: [String: TrailingToolbarItemGeometry] = [:]
-    /// The fitted title label's leading edge, with the pane width it was
-    /// measured at; pairs with the trailing item geometry to derive the
-    /// realized title-to-trailing span.
-    @State private var titleLabelLeadingEdge: WorkspaceTitleLabelEdge?
+    /// The fitted title label's leading edge in global space; pairs with the
+    /// trailing item geometry to derive the realized title-to-trailing span.
+    /// Leading-aligned, so it does not move as the title's cap changes.
+    @State private var titleLabelLeadingEdge: CGFloat?
     @Environment(\.layoutDirection) private var layoutDirection
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
@@ -374,7 +374,7 @@ struct WorkspaceDetailView: View {
         AltScreenNoticeButton {
             displaySettings.showAltScreenNotice = false
         }
-        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
+        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemGeometry)
     }
 
     private var workspaceChangesToolbarContent: some View {
@@ -386,12 +386,12 @@ struct WorkspaceDetailView: View {
         // The chrome sits on the terminal theme's background, not the
         // system scheme; resolve the counts' green/red for that.
         .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
-        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
+        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemGeometry)
     }
 
     private var trailingClusterToolbarContent: some View {
         toolbarTrailingCluster
-            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
+            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemGeometry)
     }
 
     // Which trailing toolbar items are structurally in the bar right now.
@@ -405,21 +405,25 @@ struct WorkspaceDetailView: View {
 
     /// The realized distance from the title label's leading edge to the
     /// leading-most trailing item's content, only when the title and every
-    /// structural trailing item have reported geometry at the current pane
-    /// width. Stale-width measurements (mid-rotation) and RTL (where the
-    /// global-x projection would need mirroring) return nil, falling back to
-    /// the estimate-based reserve.
+    /// structural trailing item have reported geometry that is plausible for
+    /// the current pane width. A stale measurement from a wider layout puts
+    /// the trailing content past the pane's end and is rejected; a stale
+    /// narrower-layout value only under-sizes the title, which cannot
+    /// over-commit the bar. RTL returns nil (the global-x projection would
+    /// need mirroring), falling back to the estimate-based reserve.
     private var measuredTitleToTrailingSpan: CGFloat? {
         guard layoutDirection == .leftToRight,
-              let titleEdge = titleLabelLeadingEdge,
-              titleEdge.contentWidth == contentWidth else { return nil }
+              contentWidth > 0,
+              let titleMinX = titleLabelLeadingEdge else { return nil }
         let geometries = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0] }
         guard geometries.count == structuralTrailingItemKeys.count,
-              geometries.allSatisfy({ $0.contentWidth == contentWidth }),
               let trailingLeadingEdge = geometries.map(\.globalMinX).min()
         else { return nil }
-        let span = trailingLeadingEdge - titleEdge.globalMinX
-        return span > 0 ? span : nil
+        let trailingContentTotal = geometries.map(\.width).reduce(0, +)
+        guard trailingLeadingEdge > titleMinX,
+              trailingLeadingEdge + trailingContentTotal <= contentWidth
+        else { return nil }
+        return trailingLeadingEdge - titleMinX
     }
 
     private var workspaceTitleToolbarMenu: some View {
@@ -446,10 +450,7 @@ struct WorkspaceDetailView: View {
         return WorkspaceTitleMenu(
             value: value,
             onLabelLeadingEdgeChange: { minX in
-                titleLabelLeadingEdge = WorkspaceTitleLabelEdge(
-                    globalMinX: minX,
-                    contentWidth: contentWidth
-                )
+                titleLabelLeadingEdge = minX
             },
             menuContent: {
                 WorkspaceTitleMenuContent(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -81,7 +81,12 @@ struct WorkspaceDetailView: View {
     // deletes an entry (see the onChange handlers); a layout-driven
     // disappearance (overflow into More) cannot release a reservation and
     // make the collapse sticky.
-    @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
+    @State private var trailingToolbarItemGeometry: [String: TrailingToolbarItemGeometry] = [:]
+    /// The fitted title label's leading edge, with the pane width it was
+    /// measured at; pairs with the trailing item geometry to derive the
+    /// realized title-to-trailing span.
+    @State private var titleLabelLeadingEdge: WorkspaceTitleLabelEdge?
+    @Environment(\.layoutDirection) private var layoutDirection
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
     /// Identity of the in-flight New Browser creation. A late RPC result must
@@ -212,10 +217,10 @@ struct WorkspaceDetailView: View {
             // disappearance (overflow into More) never flips these conditions,
             // so it cannot release a reservation and make the collapse sticky.
             .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
-                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
+                if !isAvailable { trailingToolbarItemGeometry["changes"] = nil }
             }
             .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
-                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
+                if !isVisible { trailingToolbarItemGeometry["altscreen-notice"] = nil }
             }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
@@ -369,7 +374,7 @@ struct WorkspaceDetailView: View {
         AltScreenNoticeButton {
             displaySettings.showAltScreenNotice = false
         }
-        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
+        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
     }
 
     private var workspaceChangesToolbarContent: some View {
@@ -381,12 +386,12 @@ struct WorkspaceDetailView: View {
         // The chrome sits on the terminal theme's background, not the
         // system scheme; resolve the counts' green/red for that.
         .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
-        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
+        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
     }
 
     private var trailingClusterToolbarContent: some View {
         toolbarTrailingCluster
-            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemWidths)
+            .measureTrailingToolbarItem("trailing-cluster", into: $trailingToolbarItemGeometry, contentWidth: contentWidth)
     }
 
     // Which trailing toolbar items are structurally in the bar right now.
@@ -398,8 +403,27 @@ struct WorkspaceDetailView: View {
         return keys
     }
 
+    /// The realized distance from the title label's leading edge to the
+    /// leading-most trailing item's content, only when the title and every
+    /// structural trailing item have reported geometry at the current pane
+    /// width. Stale-width measurements (mid-rotation) and RTL (where the
+    /// global-x projection would need mirroring) return nil, falling back to
+    /// the estimate-based reserve.
+    private var measuredTitleToTrailingSpan: CGFloat? {
+        guard layoutDirection == .leftToRight,
+              let titleEdge = titleLabelLeadingEdge,
+              titleEdge.contentWidth == contentWidth else { return nil }
+        let geometries = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0] }
+        guard geometries.count == structuralTrailingItemKeys.count,
+              geometries.allSatisfy({ $0.contentWidth == contentWidth }),
+              let trailingLeadingEdge = geometries.map(\.globalMinX).min()
+        else { return nil }
+        let span = trailingLeadingEdge - titleEdge.globalMinX
+        return span > 0 ? span : nil
+    }
+
     private var workspaceTitleToolbarMenu: some View {
-        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
+        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemGeometry[$0]?.width }
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
@@ -408,6 +432,7 @@ struct WorkspaceDetailView: View {
             measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
             measuredTrailingItemCount: measuredWidths.count,
             trailingItemCount: structuralTrailingItemKeys.count,
+            measuredTitleToTrailingSpan: measuredTitleToTrailingSpan,
             isEnabled: hasTitleMenuActions,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,
@@ -420,6 +445,12 @@ struct WorkspaceDetailView: View {
         )
         return WorkspaceTitleMenu(
             value: value,
+            onLabelLeadingEdgeChange: { minX in
+                titleLabelLeadingEdge = WorkspaceTitleLabelEdge(
+                    globalMinX: minX,
+                    contentWidth: contentWidth
+                )
+            },
             menuContent: {
                 WorkspaceTitleMenuContent(
                     workspaceName: value.workspaceName,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -2,11 +2,6 @@ import SwiftUI
 
 struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
     let value: WorkspaceTitleMenuValue
-    /// Reports the fitted label's leading edge in window space (nil when the
-    /// label leaves the bar) so the host can derive the realized
-    /// title-to-trailing span. Not part of equality: geometry callbacks
-    /// re-fire on layout changes regardless.
-    var onLabelLeadingEdgeChange: ((CGFloat?) -> Void)? = nil
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
@@ -42,7 +37,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
             measuredTrailingItemCount: value.measuredTrailingItemCount,
             trailingItemCount: value.trailingItemCount,
-            measuredTitleToTrailingSpan: value.measuredTitleToTrailingSpan
+            hadTrailingCollapse: value.hadTrailingCollapse
         ).cap
 
         return label()
@@ -51,10 +46,5 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
                 maxWidth: cap,
                 alignment: .leading
             )
-            // The frame is leading-aligned, so its leading edge does not move
-            // as the cap grows; reporting it cannot feed back into the cap.
-            .measureToolbarTitleFrame { frame in
-                onLabelLeadingEdgeChange?(frame?.minX)
-            }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
     let value: WorkspaceTitleMenuValue
-    /// Reports the fitted label's leading edge in global space so the host
-    /// can derive the realized title-to-trailing span. Not part of equality:
-    /// geometry callbacks re-fire on layout changes regardless.
-    var onLabelLeadingEdgeChange: ((CGFloat) -> Void)? = nil
+    /// Reports the fitted label's leading edge in window space (nil when the
+    /// label leaves the bar) so the host can derive the realized
+    /// title-to-trailing span. Not part of equality: geometry callbacks
+    /// re-fire on layout changes regardless.
+    var onLabelLeadingEdgeChange: ((CGFloat?) -> Void)? = nil
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
@@ -53,7 +54,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             // The frame is leading-aligned, so its leading edge does not move
             // as the cap grows; reporting it cannot feed back into the cap.
             .measureToolbarTitleFrame { frame in
-                onLabelLeadingEdgeChange?(frame.minX)
+                onLabelLeadingEdgeChange?(frame?.minX)
             }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
     let value: WorkspaceTitleMenuValue
+    /// Reports the fitted label's leading edge in global space so the host
+    /// can derive the realized title-to-trailing span. Not part of equality:
+    /// geometry callbacks re-fire on layout changes regardless.
+    var onLabelLeadingEdgeChange: ((CGFloat) -> Void)? = nil
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
@@ -36,7 +40,8 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             hasChatToggle: value.hasChatToggle,
             measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
             measuredTrailingItemCount: value.measuredTrailingItemCount,
-            trailingItemCount: value.trailingItemCount
+            trailingItemCount: value.trailingItemCount,
+            measuredTitleToTrailingSpan: value.measuredTitleToTrailingSpan
         ).cap
 
         return label()
@@ -45,5 +50,12 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
                 maxWidth: cap,
                 alignment: .leading
             )
+            // The frame is leading-aligned, so its leading edge does not move
+            // as the cap grows; reporting it cannot feed back into the cap.
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.frame(in: .global).minX
+            } action: { minX in
+                onLabelLeadingEdgeChange?(minX)
+            }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -52,10 +52,8 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
             )
             // The frame is leading-aligned, so its leading edge does not move
             // as the cap grows; reporting it cannot feed back into the cap.
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.frame(in: .global).minX
-            } action: { minX in
-                onLabelLeadingEdgeChange?(minX)
+            .measureToolbarTitleFrame { frame in
+                onLabelLeadingEdgeChange?(frame.minX)
             }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -9,8 +9,8 @@ struct WorkspaceTitleMenuValue: Equatable {
     let measuredTrailingItemsWidth: CGFloat
     let measuredTrailingItemCount: Int
     let trailingItemCount: Int
-    /// Realized title-to-trailing span; see `MobileLeadingToolbarTitleWidth`.
-    let measuredTitleToTrailingSpan: CGFloat?
+    /// Collapse-recovery ratchet; see `MobileLeadingToolbarTitleWidth`.
+    let hadTrailingCollapse: Bool
     let isEnabled: Bool
     let workspaceName: String
     let hasUnread: Bool

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -9,6 +9,8 @@ struct WorkspaceTitleMenuValue: Equatable {
     let measuredTrailingItemsWidth: CGFloat
     let measuredTrailingItemCount: Int
     let trailingItemCount: Int
+    /// Realized title-to-trailing span; see `MobileLeadingToolbarTitleWidth`.
+    let measuredTitleToTrailingSpan: CGFloat?
     let isEnabled: Bool
     let workspaceName: String
     let hasUnread: Bool

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -107,31 +107,6 @@ import Testing
         #expect(unmeasured.cap == cap(393))
     }
 
-    @Test func measuredBranchLeavesOnlyAMinimalTrailingGap() {
-        // Dogfood calibration on a 402pt iPhone 17 bar (changes chip ~30 +
-        // trailing cluster 96 measured): the earlier 24pt/item chrome plus
-        // 84pt margin reserve left a ~35pt dead gap before the trailing
-        // cluster while the title truncated. The recalibrated reserves must
-        // hand that slack to the title, leaving only a back-gap-sized space.
-        let value = MobileLeadingToolbarTitleWidth(
-            contentWidth: 402,
-            hasBackButton: true,
-            hasTrailingCluster: true,
-            hasChatToggle: true,
-            measuredTrailingItemsWidth: 126,
-            measuredTrailingItemCount: 2,
-            trailingItemCount: 2
-        )
-        let expected: CGFloat = 402
-            - MobileLeadingToolbarTitleWidth.backButtonReserve
-            - (126 + 2 * MobileLeadingToolbarTitleWidth.trailingItemChrome)
-            - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
-
-        #expect(value.cap == expected)
-        // 100pt under the old reserves; the freed ~22pt goes to the title.
-        #expect(value.cap >= 120)
-    }
-
     @Test func structuralItemWithoutMeasurementStillReservesSpace() {
         // The changes chip just appeared: the cluster has measured, the chip
         // has not. The cap must not expand into the chip's space, or the

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -107,6 +107,62 @@ import Testing
         #expect(unmeasured.cap == cap(393))
     }
 
+    @Test func realizedSpanSizesTheTitleFromActualPositions() {
+        // Dogfood on a 402pt iPhone 17: the estimate-based reserve left a
+        // ~35pt dead gap before the trailing cluster while the title
+        // truncated. With both edges of that gap measured, the cap is the
+        // span minus only the pill/capsule chrome and a back-gap-sized
+        // minimum gap, so the freed space goes to the title.
+        let measured = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2,
+            measuredTitleToTrailingSpan: 160
+        )
+
+        #expect(measured.cap == 160 - MobileLeadingToolbarTitleWidth.spanGapReserve)
+    }
+
+    @Test func realizedSpanNeverProducesANegativeCap() {
+        let cramped = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTitleToTrailingSpan: 20
+        )
+
+        #expect(cramped.cap == 0)
+    }
+
+    @Test func missingSpanFallsBackToTheEstimateReserve() {
+        let withNilSpan = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 150,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2,
+            measuredTitleToTrailingSpan: nil
+        )
+        let estimate = MobileLeadingToolbarTitleWidth(
+            contentWidth: 393,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 150,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+
+        #expect(withNilSpan.cap == estimate.cap)
+    }
+
     @Test func structuralItemWithoutMeasurementStillReservesSpace() {
         // The changes chip just appeared: the cluster has measured, the chip
         // has not. The cap must not expand into the chip's space, or the

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -107,13 +107,22 @@ import Testing
         #expect(unmeasured.cap == cap(393))
     }
 
-    @Test func realizedSpanSizesTheTitleFromActualPositions() {
-        // Dogfood on a 402pt iPhone 17: the estimate-based reserve left a
-        // ~35pt dead gap before the trailing cluster while the title
-        // truncated. With both edges of that gap measured, the cap is the
-        // span minus only the pill/capsule chrome and a back-gap-sized
-        // minimum gap, so the freed space goes to the title.
-        let measured = MobileLeadingToolbarTitleWidth(
+    @Test func observedCollapseRatchetsTheTitleSmaller() {
+        // A trailing item's content left the bar while structurally present:
+        // the system folded it into the More menu, so the reserves undershot
+        // this device's chrome. The recovery reserve exceeds the 12pt trimmed
+        // from the estimates, so the recovered layout is strictly roomier
+        // than the original constants and the bar un-collapses.
+        let base = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let recovered = MobileLeadingToolbarTitleWidth(
             contentWidth: 402,
             hasBackButton: true,
             hasTrailingCluster: true,
@@ -121,46 +130,12 @@ import Testing
             measuredTrailingItemsWidth: 126,
             measuredTrailingItemCount: 2,
             trailingItemCount: 2,
-            measuredTitleToTrailingSpan: 160
+            hadTrailingCollapse: true
         )
 
-        #expect(measured.cap == 160 - MobileLeadingToolbarTitleWidth.spanGapReserve)
-    }
-
-    @Test func realizedSpanNeverProducesANegativeCap() {
-        let cramped = MobileLeadingToolbarTitleWidth(
-            contentWidth: 402,
-            hasBackButton: true,
-            hasTrailingCluster: true,
-            hasChatToggle: true,
-            measuredTitleToTrailingSpan: 20
-        )
-
-        #expect(cramped.cap == 0)
-    }
-
-    @Test func missingSpanFallsBackToTheEstimateReserve() {
-        let withNilSpan = MobileLeadingToolbarTitleWidth(
-            contentWidth: 393,
-            hasBackButton: true,
-            hasTrailingCluster: true,
-            hasChatToggle: true,
-            measuredTrailingItemsWidth: 150,
-            measuredTrailingItemCount: 2,
-            trailingItemCount: 2,
-            measuredTitleToTrailingSpan: nil
-        )
-        let estimate = MobileLeadingToolbarTitleWidth(
-            contentWidth: 393,
-            hasBackButton: true,
-            hasTrailingCluster: true,
-            hasChatToggle: true,
-            measuredTrailingItemsWidth: 150,
-            measuredTrailingItemCount: 2,
-            trailingItemCount: 2
-        )
-
-        #expect(withNilSpan.cap == estimate.cap)
+        #expect(recovered.cap
+            == base.cap - MobileLeadingToolbarTitleWidth.collapseRecoveryReserve)
+        #expect(MobileLeadingToolbarTitleWidth.collapseRecoveryReserve > 12)
     }
 
     @Test func structuralItemWithoutMeasurementStillReservesSpace() {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -107,6 +107,31 @@ import Testing
         #expect(unmeasured.cap == cap(393))
     }
 
+    @Test func measuredBranchLeavesOnlyAMinimalTrailingGap() {
+        // Dogfood calibration on a 402pt iPhone 17 bar (changes chip ~30 +
+        // trailing cluster 96 measured): the earlier 24pt/item chrome plus
+        // 84pt margin reserve left a ~35pt dead gap before the trailing
+        // cluster while the title truncated. The recalibrated reserves must
+        // hand that slack to the title, leaving only a back-gap-sized space.
+        let value = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let expected: CGFloat = 402
+            - MobileLeadingToolbarTitleWidth.backButtonReserve
+            - (126 + 2 * MobileLeadingToolbarTitleWidth.trailingItemChrome)
+            - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+
+        #expect(value.cap == expected)
+        // 100pt under the old reserves; the freed ~22pt goes to the title.
+        #expect(value.cap >= 120)
+    }
+
     @Test func structuralItemWithoutMeasurementStillReservesSpace() {
         // The changes chip just appeared: the cluster has measured, the chip
         // has not. The cap must not expand into the chip's space, or the

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -57,6 +57,7 @@ import Testing
             measuredTrailingItemsWidth: 0,
             measuredTrailingItemCount: 0,
             trailingItemCount: 0,
+            measuredTitleToTrailingSpan: nil,
             isEnabled: true,
             workspaceName: "Workspace",
             hasUnread: false,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -57,7 +57,7 @@ import Testing
             measuredTrailingItemsWidth: 0,
             measuredTrailingItemCount: 0,
             trailingItemCount: 0,
-            measuredTitleToTrailingSpan: nil,
+            hadTrailingCollapse: false,
             isEnabled: true,
             workspaceName: "Workspace",
             hasUnread: false,


### PR DESCRIPTION
The workspace-detail title pill truncated beside a ~35pt dead gap before the trailing button cluster, because the estimate reserve from https://github.com/manaflow-ai/cmux/pull/10376 must over-count chrome to stay safe. Two approaches died on the way here, both in-branch: shrinking the constants by 30pt collapsed the trailing items into the system More menu on an iPhone 17 Pro Max, and sizing the title from measured window-space positions proved unreliable on iOS 26 (a grouped ToolbarItem's content can render composited without its own window attachment, so cross-item positions are unobtainable; DEBUG probe logs in the history document this).

What lands: the reserves give back 12pt of the ~22pt of slack measured on a 402pt iPhone 17 (per-item chrome 24→20, margins 84→80), well under the trim that broke the Pro Max, and a collapse-recovery ratchet backstops the rest. The always-structural trailing cluster carries a UIKit probe view; its content leaving the window while the SwiftUI view is alive is the observable signature of the system folding the item into More. When that fires, a 28pt recovery reserve ratchets on for the view's lifetime, which is strictly roomier than the original constants, so the bar un-collapses within a frame. Worst case on a device with unusually wide chrome is a one-frame flicker, never a persistent More menu.

Conditional items (Changes chip, alt-screen notice) do not wire the detector because their structural removal also detaches the probe and is indistinguishable from a collapse; the cluster is the widest item and collapses first in practice.

No user-facing strings changed (localization audit: none needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)