### PR TITLE
iOS: keep the filtered search results when popping a search-opened workspace

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -194,7 +194,6 @@ public struct WorkspaceListLayoutPreviewView: View {
     @State private var fixtureRoute: FixtureWorkspaceRoute?
     // Mirrors the shell: search results push onto the search tab's own stack.
     @State private var searchFixturePath: [MobileWorkspacePreview.ID] = []
-    @State private var searchSelectionReturnsToWorkspaces = false
 
     private var scrollMetricsEnabled: Bool {
         ProcessInfo.processInfo.environment["CMUX_UITEST_SCROLL_METRICS"] == "1"
@@ -784,15 +783,7 @@ public struct WorkspaceListLayoutPreviewView: View {
         .onChange(of: selectedPrimaryTab) { oldValue, newValue in
             if oldValue == .search, newValue != .search {
                 searchFixturePath = []
-                searchSelectionReturnsToWorkspaces = false
             }
-        }
-        .onChange(of: searchFixturePath) { _, path in
-            guard path.isEmpty, searchSelectionReturnsToWorkspaces else { return }
-            searchSelectionReturnsToWorkspaces = false
-            guard selectedPrimaryTab == .search else { return }
-            primarySearchCoordinator.workspaces = ""
-            selectedPrimaryTab = .workspaces
         }
         .overlay(alignment: .topLeading) {
             ZStack(alignment: .topLeading) {
@@ -839,10 +830,9 @@ public struct WorkspaceListLayoutPreviewView: View {
         if showsTabScaffold,
            selectedPrimaryTab == .search || primarySearchCoordinator.isPresented {
             // Mirrors the shell: choosing a result ends the search session so
-            // the field re-collapses to the bottom control after popping back,
-            // and the pop finishes the round on the Workspaces tab.
+            // the field re-collapses to the bottom control after popping back
+            // onto the still-filtered results.
             primarySearchCoordinator.deactivateCurrentSearch()
-            searchSelectionReturnsToWorkspaces = true
             if searchFixturePath.last != id {
                 searchFixturePath = [id]
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -184,11 +184,6 @@ struct WorkspaceShellView: View {
     // the destination stack's own onAppear.
     @State private var workspacesStackIsOnScreen = false
     @State private var notificationsStackIsOnScreen = false
-    // Set when a workspace is opened from search results: popping back then
-    // finishes the search round on the Workspaces tab with the query cleared,
-    // instead of stranding the user on a deactivated search tab whose selected
-    // (tinted) search control suggests a search is still in progress.
-    @State private var searchSelectionReturnsToWorkspaces = false
     @State private var rootToolbarMachineSnapshots: WorkspaceMachineSnapshots?
     @State private var rootToolbarPendingSelection: WorkspaceMacSelection?
     @State private var rootToolbarSelectionTask: Task<Void, Never>?
@@ -325,20 +320,12 @@ struct WorkspaceShellView: View {
                 if oldValue == .search, newValue != .search {
                     notificationSearchNavigationPath = []
                     workspaceSearchNavigationPath = []
-                    searchSelectionReturnsToWorkspaces = false
                 }
             }
             .onChange(of: visibleSimulatorWorkspaceID) { previousWorkspaceID, workspaceID in
                 guard let previousWorkspaceID,
                       previousWorkspaceID != workspaceID else { return }
                 store.stopActiveMobileSimulatorStream(in: previousWorkspaceID)
-            }
-            .onChange(of: workspaceSearchNavigationPath) { _, path in
-                guard path.isEmpty, searchSelectionReturnsToWorkspaces else { return }
-                searchSelectionReturnsToWorkspaces = false
-                guard selectedPrimaryTab == .search else { return }
-                primarySearchCoordinator.workspaces = ""
-                selectedPrimaryTab = .workspaces
             }
             .onChange(of: store.deeplinkWorkspaceNavigationRequest) { _, request in
                 guard request != nil else { return }
@@ -987,7 +974,6 @@ struct WorkspaceShellView: View {
         )
         pendingCompactCreateNavigationWorkspaceIDs = nil
         primarySearchCoordinator.deactivateCurrentSearch()
-        searchSelectionReturnsToWorkspaces = true
         store.selectedWorkspaceID = id
         if workspaceSearchNavigationPath.last != id {
             workspaceSearchNavigationPath = [id]

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3171,30 +3171,33 @@ final class cmuxUITests: XCTestCase {
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
             return XCTFail("Workspaces list did not return after popping the detail")
         }
-        // Popping the detail finishes the search round on the Workspaces tab
-        // with the query cleared and the bottom search control collapsed.
+        // Popping the detail lands back on the still-filtered search results
+        // with the keyboard down and the bottom search control collapsed, so
+        // the user can open the next match without re-typing the query.
         guard waitForKeyboardDismissal(in: app) else {
             return XCTFail("Keyboard stayed up after popping back from the search detail")
         }
         guard workspacesTab.waitForExistence(timeout: 3) else {
             return XCTFail("Workspaces tab pill missing after popping the search detail")
         }
-        XCTAssertTrue(
+        XCTAssertFalse(
             workspacesTab.isSelected,
-            "Popping the search-opened workspace must land on the Workspaces tab"
+            "Popping the search-opened workspace must stay in the search round, not kick to the Workspaces tab"
         )
         guard minimizedSearch.waitForExistence(timeout: 3) else {
-            return XCTFail("Minimized search control missing after finishing the search round")
+            return XCTFail("Minimized search control missing after popping the search detail")
         }
         guard waitForHittable(docsRow, timeout: 3) else {
-            return XCTFail("Workspaces list missing rows after finishing the search round")
+            return XCTFail("Filtered search results missing after popping the search detail")
         }
-        guard waitForHittable(mainRow, timeout: 3) else {
-            return XCTFail("Query must be cleared after finishing the search round")
+        guard waitForNotHittable(mainRow, timeout: 3) else {
+            return XCTFail("The committed query must keep filtering the results after popping")
         }
 
         // An explicit submit still commits the query as the Workspaces filter;
-        // that committed filter must survive a list refresh.
+        // the reactivated field keeps the preserved query, so submitting it
+        // as-is must carry the committed filter to the Workspaces tab and
+        // survive a list refresh.
         tap(minimizedSearch, in: app)
         guard waitForHittable(searchField, timeout: 3) else {
             return XCTFail("Search field missing when reactivating search for submit")
@@ -3202,7 +3205,10 @@ final class cmuxUITests: XCTestCase {
         guard focusTextInput(searchField, in: app) else {
             return XCTFail("Could not focus the search field for submit")
         }
-        searchField.typeText("Docs\n")
+        guard waitForNotHittable(mainRow, timeout: 3) else {
+            return XCTFail("Preserved query filter not applied when search reactivates")
+        }
+        searchField.typeText("\n")
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
             return XCTFail("Workspaces root list missing after submitting the query")
         }
@@ -3677,6 +3683,12 @@ final class cmuxUITests: XCTestCase {
     /// The old flow deactivated search, transitioned to the Workspaces tab, and
     /// pushed onto that off-window stack mid search-dismissal, which could
     /// record the push without performing it.
+    ///
+    /// Also pins the search round-trip contract: popping the detail lands on
+    /// the still-filtered results with the query intact, so a user stepping
+    /// through matching workspaces one by one never re-types the query or
+    /// re-finds their place. Kicking back to the Workspaces tab (which wiped
+    /// the committed query) is the regression.
     @MainActor
     func testWorkspaceSearchSelectionOpensDetailInsideSearchTab() throws {
         guard #available(iOS 26.0, *) else {
@@ -3725,22 +3737,22 @@ final class cmuxUITests: XCTestCase {
         }
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
 
-        // Popping back finishes the search round on the Workspaces tab: the
-        // full unfiltered list, no query left silently applied, and no
-        // selected (tinted) search control suggesting a search is still live.
+        // Popping back lands on the still-filtered search results: same
+        // search round, query intact, so the user can open the next matching
+        // workspace without re-typing the query or re-finding their place.
         let workspacesTab = app.tabBars.buttons["Workspaces"]
         XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
-        XCTAssertTrue(
+        XCTAssertFalse(
             workspacesTab.isSelected,
-            "Popping the search-opened workspace must land on the Workspaces tab"
+            "Popping the search-opened workspace must stay in the search round, not kick to the Workspaces tab"
         )
         XCTAssertTrue(
             waitForHittable(docsRow, timeout: 3),
-            "Workspaces list missing rows after finishing the search round"
+            "Filtered search results missing after popping the search-opened workspace"
         )
         XCTAssertTrue(
-            waitForHittable(mainRow, timeout: 3),
-            "Query must be cleared after finishing the search round, not left filtering the list"
+            waitForNotHittable(mainRow, timeout: 3),
+            "The committed query must keep filtering the results after popping, not reset to the full list"
         )
 
         // Any visible search affordance belongs to the bottom edge (the


### PR DESCRIPTION
Searching workspaces, opening a result, and going back previously kicked the app to the Workspaces tab and wiped the committed query: the search round, the filtered results, and the scroll position were all lost, so stepping through matching agents one by one meant re-typing the query and re-scrolling after every visit.

The cause is the `searchSelectionReturnsToWorkspaces` transfer from https://github.com/manaflow-ai/cmux/pull/9820: when the search tab's stack popped to empty it cleared `primarySearchCoordinator.workspaces` and flipped `selectedPrimaryTab` to `.workspaces`, contradicting the documented contract of `selectWorkspaceFromSearch` ("Popping back lands on the still-filtered results with the bottom search control collapsed"). This PR removes the transfer (shell and layout-preview fixture), so the pop lands on the still-filtered results inside the search tab. The search stack's root list stays mounted across the push/pop, so the table's scroll offset survives natively, the same mechanism as the Workspaces-tab fix in https://github.com/manaflow-ai/cmux/pull/10488. Sibling of https://github.com/manaflow-ai/cmux/issues/10481.

Two commits so CI proves the tests catch the regression: commit 1 updates `testWorkspaceSearchSelectionOpensDetailInsideSearchTab` and `testWorkspaceSearchIsMinimizedAndPreservesQueryAcrossRefresh` to the preserved-results contract (red), commit 2 removes the transfer (green). Hosted `test-e2e.yml` evidence: red https://github.com/manaflow-ai/cmux/actions/runs/32601692593, green https://github.com/manaflow-ai/cmux/actions/runs/32601699358 and https://github.com/manaflow-ai/cmux/actions/runs/32601702110.

Localization audit: no user-facing strings added or changed; the diff only deletes state and transfer logic and updates test assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790028741&installation_model_id=21920&pr_number=10579&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10579&signature=d4411fd3fae488e25b58debfb52c60a18b0dd4c4e71786a62057fbddd191bab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep filtered search results when popping a workspace opened from Search. Previously the app switched to the Workspaces tab and cleared the committed query; now it returns to the Search tab with the query preserved, filtered list intact, keyboard dismissed, and scroll position retained.

**Review notes**
- Remove the search-to-workspaces transfer (`searchSelectionReturnsToWorkspaces`) and related `onChange` handlers in `WorkspaceShellView` and `WorkspaceListLayoutPreviewView`. The search stack’s root list stays mounted, preserving scroll offset.
- Deactivate the current search on selection so the bottom search control is collapsed after popping back.
- Update `cmuxUITests` to pin the preserved-results contract (`testWorkspaceSearchSelectionOpensDetailInsideSearchTab`, `testWorkspaceSearchIsMinimizedAndPreservesQueryAcrossRefresh`). No migrations or user-facing string changes.

<sup>Written for commit 107bee7fc02fa194678e79e18bd0e1a0a9d249b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace search selections now keep the Search tab active instead of returning to Workspaces.
  * Search queries and filtered results remain visible when returning from workspace details.
  * Refreshing or reactivating search preserves and reapplies the existing query.

* **Tests**
  * Expanded coverage for maintaining search-session continuity across navigation and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->