### PR TITLE
Add interactive macOS app mirror panes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8948,8 +8948,8 @@ struct CMUXCLI {
             method = "canvas.set_viewport"
         case "new-pane":
             if let type = optionValue(rest, name: "--type")?.lowercased() {
-                guard ["terminal", "browser", "simulator"].contains(type) else {
-                    throw CLIError(message: String(localized: "cli.canvas.error.newPaneTypeUsage", defaultValue: "Usage: cmux canvas new-pane [--type terminal|browser|simulator]"))
+                guard ["terminal", "browser", "simulator", "macapp"].contains(type) else {
+                    throw CLIError(message: String(localized: "cli.canvas.error.newPaneTypeUsage", defaultValue: "Usage: cmux canvas new-pane [--type terminal|browser|simulator|macapp]"))
                 }
                 params["type"] = type
             }
@@ -16156,7 +16156,7 @@ struct CMUXCLI {
               set-viewport --x <n> --y <n> [--zoom <n>]
                                             Center the viewport on a canvas point
                                             (optionally set magnification)
-              new-pane [--type terminal|browser|simulator]
+              new-pane [--type terminal|browser|simulator|macapp]
                                             Create a new free-floating canvas pane
               join <surface> <target>       Move a surface into the pane hosting target (tab)
               break <surface>               Tear a surface out of its multi-tab pane
@@ -17200,7 +17200,7 @@ struct CMUXCLI {
             Create a new pane in the workspace.
 
             Flags:
-              --type <terminal|browser|simulator> Pane type (default: terminal)
+              --type <terminal|browser|simulator|macapp> Pane type (default: terminal)
               --direction <left|right|up|down>    Split direction (default: right)
               --placement <workspace|dock>        Target container (default: workspace).
                                                   dock splits the right-sidebar Dock.
@@ -17223,7 +17223,7 @@ struct CMUXCLI {
             Create a new surface (tab) in a pane.
 
             Flags:
-              --type <terminal|browser|simulator|agent-session>   Surface type (default: terminal)
+              --type <terminal|browser|simulator|macapp|agent-session>   Surface type (default: terminal)
               --pane <id|ref|index>       Target pane
               --placement <workspace|dock>  Target container (default: workspace).
                                            dock adds the surface to the right-sidebar Dock
@@ -36964,8 +36964,8 @@ export default CMUXSessionRestore;
           top [--all] [--workspace <id|ref|index>] [--window <id|ref|index>] [--processes] [--sort <cpu|mem|proc>] [--flat] [--format <tree|tsv>]
           memory [--all] [--workspace <id|ref|index>] [--groups <count>]
           focus-pane --pane <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
-          new-pane [--type <terminal|browser|simulator>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>]
-          new-surface [--type <terminal|browser|simulator|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]
+          new-pane [--type <terminal|browser|simulator|macapp>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>]
+          new-surface [--type <terminal|browser|simulator|macapp|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]
           close-surface [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>]
           move-surface --surface <id|ref|index> [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--before <id|ref|index>] [--after <id|ref|index>] [--index <n>] [--focus <true|false>]
           split-off --surface <id|ref|index> <left|right|up|down> [--workspace <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>]

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Core/Values/SurfaceKind.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Core/Values/SurfaceKind.swift
@@ -29,6 +29,8 @@ public struct SurfaceKind: RawRepresentable, Hashable, Sendable {
     public static let customSidebar = SurfaceKind(rawValue: "customSidebar")
     /// A native Apple Simulator pane.
     public static let simulator = SurfaceKind(rawValue: "simulator")
+    /// A pane that mirrors an open macOS application window.
+    public static let macApp = SurfaceKind(rawValue: "macapp")
     /// An agent-session pane.
     public static let agentSession = SurfaceKind(rawValue: "agentSession")
     /// A project pane.

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -35472,13 +35472,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Usage: cmux canvas new-pane [--type terminal|browser|simulator]"
+            "value": "Usage: cmux canvas new-pane [--type terminal|browser|simulator|macapp]"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用方法: cmux canvas new-pane [--type terminal|browser|simulator]"
+            "value": "使用方法: cmux canvas new-pane [--type terminal|browser|simulator|macapp]"
           }
         }
       }
@@ -267550,6 +267550,146 @@
         "uk": { "stringUnit": { "state": "translated", "value": "Не знайдено потрібний CLI. Установіть команду та повторіть спробу." } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "未找到所需的 CLI。请安装该命令后重试。" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "找不到必要的 CLI。請安裝該命令後再試一次。" } }
+      }
+    },
+    "command.newMacAppPane.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mirror and interact with an open app" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "開いているアプリをミラーして操作" } }
+      }
+    },
+    "command.newMacAppPane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "New Mac App Pane" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "新規Macアプリペイン" } }
+      }
+    },
+    "commandPalette.kind.macApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mac App" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macアプリ" } }
+      }
+    },
+    "macApp.capture.permission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Allow Screen Recording for cmux, then choose this app again." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmuxの画面収録を許可してから、このアプリをもう一度選択してください。" } }
+      }
+    },
+    "macApp.capture.accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Allow Accessibility for cmux to interact with this app." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmuxがこのアプリを操作できるようにアクセシビリティを許可してください。" } }
+      }
+    },
+    "macApp.capture.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The app window could not be captured. Refresh and try again." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アプリウィンドウをキャプチャできませんでした。更新してもう一度お試しください。" } }
+      }
+    },
+    "macApp.capture.starting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Starting app mirror…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アプリミラーを開始中…" } }
+      }
+    },
+    "macApp.pane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mac App" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macアプリ" } }
+      }
+    },
+    "macApp.picker.empty.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Open an app window and refresh this pane." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アプリのウィンドウを開いて、このペインを更新してください。" } }
+      }
+    },
+    "macApp.picker.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No capturable app windows" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "キャプチャできるアプリウィンドウがありません" } }
+      }
+    },
+    "macApp.picker.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Finding open apps…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "開いているアプリを検索中…" } }
+      }
+    },
+    "macApp.picker.permission.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Allow Screen Recording for cmux in System Settings, then refresh." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "システム設定でcmuxの画面収録を許可してから、更新してください。" } }
+      }
+    },
+    "macApp.picker.openAccessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Open Accessibility Settings" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アクセシビリティ設定を開く" } }
+      }
+    },
+    "macApp.picker.openScreenRecording": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Open Screen Recording Settings" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画面収録設定を開く" } }
+      }
+    },
+    "macApp.picker.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Refresh" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "更新" } }
+      }
+    },
+    "macApp.picker.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Choose an open Mac app" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "開いているMacアプリを選択" } }
+      }
+    },
+    "macApp.toolbar.change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Change App" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アプリを変更" } }
+      }
+    },
+    "macApp.toolbar.refresh.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Refresh available apps" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "利用可能なアプリを更新" } }
+      }
+    },
+    "menu.file.newMacAppPane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "New Mac App Pane" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "新規Macアプリペイン" } }
+      }
+    },
+    "menu.history.recentlyClosed.panel.macApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mac App" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macアプリ" } }
       }
     }
   },

--- a/Sources/AppDelegate+SimulatorShortcutRouting.swift
+++ b/Sources/AppDelegate+SimulatorShortcutRouting.swift
@@ -45,6 +45,19 @@ extension AppDelegate {
         return true
     }
 
+    func performConfiguredNewMacAppAction(
+        context: MainWindowContext,
+        onExecuted: (() -> Void)?
+    ) -> Bool {
+        guard let workspace = context.tabManager.selectedWorkspace,
+              let pane = workspace.bonsplitController.focusedPaneId,
+              workspace.newMacAppSurface(inPane: pane, focus: true) != nil else {
+            return false
+        }
+        onExecuted?()
+        return true
+    }
+
     func isMenuBackedShortcutAction(_ action: KeyboardShortcutSettings.Action) -> Bool {
         action != .showHideAllWindows
             && action != .globalSearch

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -16562,6 +16562,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 if workspace != nil { onExecuted?() }
                 return workspace != nil
             case .newSimulator: return performConfiguredNewSimulatorAction(context: context, onExecuted: onExecuted)
+            case .newMacApp: return performConfiguredNewMacAppAction(context: context, onExecuted: onExecuted)
             case .newTerminal:
                 context.tabManager.newSurface()
                 onExecuted?()

--- a/Sources/Canvas/CanvasPaneContent.swift
+++ b/Sources/Canvas/CanvasPaneContent.swift
@@ -158,6 +158,7 @@ final class CanvasPaneContentMount: CanvasPaneContentMounting {
             panel.surface.setOcclusion(rendering)
         case .hosted(let panel, _, _):
             (panel as? SimulatorPanel)?.setCanvasRendering(rendering)
+            (panel as? MacAppPanel)?.setVisibleInUI(rendering)
             // Offscreen browsers may hidden-discard their webview; coming
             // back into the render region restores it.
             (panel as? BrowserPanel)?.noteWebViewVisibility(
@@ -183,6 +184,7 @@ final class CanvasPaneContentMount: CanvasPaneContentMounting {
                 simulatorPanel.setVisibleInUI(false)
                 simulatorPanel.setCanvasRendering(nil)
             }
+            (panel as? MacAppPanel)?.setVisibleInUI(false)
             if let browserPanel = panel as? BrowserPanel {
                 browserPanel.canvasInlineHostingActive = false
                 browserPanel.noteWebViewVisibility(false, reason: "canvas.unmount")

--- a/Sources/Canvas/Workspace+CanvasLayout.swift
+++ b/Sources/Canvas/Workspace+CanvasLayout.swift
@@ -221,6 +221,7 @@ enum CanvasNewPaneType {
     case terminal
     case browser
     case simulator
+    case macApp
 }
 
 extension Workspace {
@@ -255,6 +256,11 @@ extension Workspace {
             newPanelId = panel.id
         case .simulator:
             guard let panel = newSimulatorSurface(inPane: focusedPaneId, focus: focus) else {
+                return nil
+            }
+            newPanelId = panel.id
+        case .macApp:
+            guard let panel = newMacAppSurface(inPane: focusedPaneId, focus: focus) else {
                 return nil
             }
             newPanelId = panel.id

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -106,6 +106,7 @@ struct WorkspaceCanvasHostView: View {
         case .rightSidebarTool: return "sidebar.right"
         case .customSidebar: return "wand.and.stars"
         case .simulator: return "iphone.gen3"
+        case .macApp: return "macwindow"
         case .agentSession: return "sparkles"
         case .project: return "folder"
         case .extensionBrowser: return "puzzlepiece.extension"

--- a/Sources/ClosedItemHistory+PanelTitle.swift
+++ b/Sources/ClosedItemHistory+PanelTitle.swift
@@ -29,6 +29,8 @@ extension ClosedItemHistoryStore {
             return String(localized: "menu.history.recentlyClosed.panel.customSidebar", defaultValue: "Custom Sidebar")
         case .simulator:
             return String(localized: "menu.history.recentlyClosed.panel.simulator", defaultValue: "Simulator")
+        case .macApp:
+            return String(localized: "menu.history.recentlyClosed.panel.macApp", defaultValue: "Mac App")
         case .agentSession:
             return String(localized: "menu.history.recentlyClosed.panel.agentSession", defaultValue: "Agent")
         case .project:

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -936,6 +936,7 @@ struct CmuxSurfaceTabBarButton: Codable, Sendable, Hashable, Identifiable {
     static let newTerminal = actionReference(CmuxSurfaceTabBarBuiltInAction.newTerminal.configID)
     static let newBrowser = actionReference(CmuxSurfaceTabBarBuiltInAction.newBrowser.configID)
     static let newSimulator = actionReference(CmuxSurfaceTabBarBuiltInAction.newSimulator.configID)
+    static let newMacApp = actionReference(CmuxSurfaceTabBarBuiltInAction.newMacApp.configID)
     static let splitRight = actionReference(CmuxSurfaceTabBarBuiltInAction.splitRight.configID)
     static let splitDown = actionReference(CmuxSurfaceTabBarBuiltInAction.splitDown.configID)
 

--- a/Sources/CmuxLifecycleEventPublishing.swift
+++ b/Sources/CmuxLifecycleEventPublishing.swift
@@ -219,6 +219,8 @@ extension Workspace {
             return "custom_sidebar"
         case .simulator:
             return "simulator"
+        case .macApp:
+            return "macapp"
         case .agentSession:
             return "agent_session"
         case .project:

--- a/Sources/CmuxSurfaceTabBarBuiltInAction.swift
+++ b/Sources/CmuxSurfaceTabBarBuiltInAction.swift
@@ -9,6 +9,7 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
     case newTerminal = "cmux.newTerminal"
     case newBrowser = "cmux.newBrowser"
     case newSimulator = "cmux.newSimulator"
+    case newMacApp = "cmux.newMacApp"
     case splitRight = "cmux.splitRight"
     case splitDown = "cmux.splitDown"
 
@@ -31,6 +32,8 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
             self = .newBrowser
         case "cmux.newSimulator", "newSimulator", "new-simulator", "simulator":
             self = .newSimulator
+        case "cmux.newMacApp", "newMacApp", "new-mac-app", "macapp":
+            self = .newMacApp
         case "cmux.splitRight", "splitRight":
             self = .splitRight
         case "cmux.splitDown", "splitDown":
@@ -63,6 +66,8 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
             return (String(localized: "command.newBrowserTab.title", defaultValue: "New Browser Tab"), ["new", "browser", "tab", "surface"])
         case .newSimulator:
             return (String(localized: "command.newSimulatorPane.title", defaultValue: "New Simulator Pane"), ["new", "simulator", "iphone", "ipad", "ios", "surface"])
+        case .newMacApp:
+            return (String(localized: "command.newMacAppPane.title", defaultValue: "New Mac App Pane"), ["new", "mac", "app", "window", "mirror", "surface"])
         case .splitRight:
             return (String(localized: "command.terminalSplitRight.title", defaultValue: "Split Right"), ["terminal", "split", "right"])
         case .splitDown:
@@ -86,6 +91,8 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
             return "globe"
         case .newSimulator:
             return "iphone.gen3"
+        case .newMacApp:
+            return "macwindow"
         case .splitRight:
             return "square.split.2x1"
         case .splitDown:
@@ -95,7 +102,7 @@ enum CmuxSurfaceTabBarBuiltInAction: String, Codable, Sendable, CaseIterable, Ha
 
     var bonsplitAction: BonsplitConfiguration.SplitActionButton.Action? {
         switch self {
-        case .newWorkspace, .newAgentChat, .cloudVM, .mobileConnect, .newSimulator:
+        case .newWorkspace, .newAgentChat, .cloudVM, .mobileConnect, .newSimulator, .newMacApp:
             return nil
         case .newTerminal:
             return .newTerminal

--- a/Sources/ContentView+AgentChatCommandPalette.swift
+++ b/Sources/ContentView+AgentChatCommandPalette.swift
@@ -10,6 +10,8 @@ extension ContentView {
             return CmuxSurfaceTabBarBuiltInAction.newBrowser.configID
         case "palette.newSimulatorPane":
             return CmuxSurfaceTabBarBuiltInAction.newSimulator.configID
+        case "palette.newMacAppPane":
+            return CmuxSurfaceTabBarBuiltInAction.newMacApp.configID
         case "palette.newAgentChat":
             return CmuxSurfaceTabBarBuiltInAction.newAgentChat.configID
         case "palette.terminalSplitRight":

--- a/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
+++ b/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
@@ -16,6 +16,7 @@ extension ContentView {
         case .customSidebar:
             return String(localized: "commandPalette.kind.customSidebar", defaultValue: "Custom Sidebar")
         case .simulator: return String(localized: "commandPalette.kind.simulator", defaultValue: "Simulator")
+        case .macApp: return String(localized: "commandPalette.kind.macApp", defaultValue: "Mac App")
         case .agentSession:
             return String(localized: "commandPalette.kind.agentSession", defaultValue: "Agent")
         case .project:
@@ -49,6 +50,7 @@ extension ContentView {
         case .customSidebar:
             return ["custom", "sidebar", "pane"]
         case .simulator: return ["simulator", "iphone", "ipad", "ios"]
+        case .macApp: return ["mac", "app", "window", "mirror", "capture"]
         case .agentSession:
             return ["agent", "codex", "claude", "opencode", "react", "solid"]
         case .project:

--- a/Sources/ContentView+SidebarSurfaceKind.swift
+++ b/Sources/ContentView+SidebarSurfaceKind.swift
@@ -13,7 +13,7 @@ extension VerticalTabsSidebar {
             return .filePreview
         case .rightSidebarTool:
             return .rightSidebarTool
-        case .customSidebar, .simulator, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading,
+        case .customSidebar, .simulator, .macApp, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading,
              .mobilePairing, .accountSignIn:
             return .unknown
         case .agentSession:

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7161,6 +7161,7 @@ struct ContentView: View {
         if CmuxFeatureFlags.shared.isSimulatorEnabled {
             contributions.append(.newSimulatorPane)
         }
+        contributions.append(.newMacAppPane)
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.closeTab",
@@ -8417,6 +8418,7 @@ struct ContentView: View {
             }
         }
         registry.registerNewSimulatorPane(tabManager: tabManager, windowId: windowId)
+        registry.registerNewMacAppPane(tabManager: tabManager, windowId: windowId)
         registry.register(commandId: "palette.closeTab") {
             if let dockBrowserStore, let browserTarget {
                 guard dockBrowserStore.containsPanel(

--- a/Sources/MacAppCommandPaletteIntegration.swift
+++ b/Sources/MacAppCommandPaletteIntegration.swift
@@ -1,0 +1,35 @@
+import AppKit
+import CmuxCommandPalette
+import Foundation
+
+extension CommandPaletteCommandContribution {
+    static var newMacAppPane: Self {
+        Self(
+            commandId: "palette.newMacAppPane",
+            title: { _ in
+                String(localized: "command.newMacAppPane.title", defaultValue: "New Mac App Pane")
+            },
+            subtitle: { _ in
+                String(localized: "command.newMacAppPane.subtitle", defaultValue: "Mirror and interact with an open app")
+            },
+            keywords: ["new", "mac", "app", "window", "mirror", "capture", "pane"]
+        )
+    }
+}
+
+extension CommandPaletteHandlerRegistry {
+    @MainActor
+    mutating func registerNewMacAppPane(tabManager: TabManager, windowId: UUID) {
+        register(commandId: "palette.newMacAppPane") {
+            guard let appDelegate = AppDelegate.shared,
+                  appDelegate.executeConfiguredCmuxAction(
+                      id: CmuxSurfaceTabBarBuiltInAction.newMacApp.configID,
+                      tabManager: tabManager,
+                      preferredWindow: appDelegate.mainWindow(for: windowId)
+                  ) else {
+                NSSound.beep()
+                return
+            }
+        }
+    }
+}

--- a/Sources/PaneDropContainer.swift
+++ b/Sources/PaneDropContainer.swift
@@ -199,7 +199,7 @@ extension PaneDropContainer {
                 return nil
             }
             return .editor
-        case .browser, .markdown, .rightSidebarTool, .customSidebar, .simulator,
+        case .browser, .markdown, .rightSidebarTool, .customSidebar, .simulator, .macApp,
              .agentSession, .project, .extensionBrowser, .workspaceTodo,
              .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             return nil

--- a/Sources/Panels/MacAppCaptureSession.swift
+++ b/Sources/Panels/MacAppCaptureSession.swift
@@ -1,0 +1,110 @@
+import AppKit
+import CoreImage
+import CoreMedia
+import Foundation
+import ScreenCaptureKit
+
+/// Captures one application window and publishes decoded frames to the pane.
+@MainActor
+final class MacAppCaptureSession {
+    enum State: Equatable {
+        case idle
+        case starting
+        case streaming
+        case permissionRequired
+        case failed
+    }
+
+    private let catalog: MacAppWindowCatalog
+    private let frameQueue = DispatchQueue(label: "com.cmux.mac-app-pane.capture")
+    private let imageHandler: @MainActor (CGImage) -> Void
+    private let stateHandler: @MainActor (State) -> Void
+    private var stream: SCStream?
+    private var output: MacAppCaptureOutput?
+
+    init(
+        catalog: MacAppWindowCatalog,
+        imageHandler: @escaping @MainActor (CGImage) -> Void,
+        stateHandler: @escaping @MainActor (State) -> Void
+    ) {
+        self.catalog = catalog
+        self.imageHandler = imageHandler
+        self.stateHandler = stateHandler
+    }
+
+    func start(descriptor: MacAppWindowDescriptor) async {
+        await stop()
+        stateHandler(.starting)
+
+        do {
+            guard let window = try await catalog.findWindow(for: descriptor) else {
+                stateHandler(.failed)
+                return
+            }
+
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+            let configuration = SCStreamConfiguration()
+            configuration.width = max(1, Int(window.frame.width * 2))
+            configuration.height = max(1, Int(window.frame.height * 2))
+            configuration.minimumFrameInterval = CMTime(value: 1, timescale: 30)
+            configuration.queueDepth = 3
+            configuration.pixelFormat = kCVPixelFormatType_32BGRA
+            configuration.showsCursor = true
+
+            let stream = SCStream(filter: filter, configuration: configuration, delegate: nil)
+            let output = MacAppCaptureOutput { [weak self] image in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.imageHandler(image)
+                }
+            }
+            try stream.addStreamOutput(
+                output,
+                type: .screen,
+                sampleHandlerQueue: frameQueue
+            )
+            try await stream.startCapture()
+            self.stream = stream
+            self.output = output
+            stateHandler(.streaming)
+        } catch let error as SCStreamError where error.code == .userDeclined {
+            stateHandler(.permissionRequired)
+        } catch {
+            stateHandler(.failed)
+        }
+    }
+
+    func stop() async {
+        guard let stream else {
+            output = nil
+            return
+        }
+        self.stream = nil
+        output = nil
+        try? await stream.stopCapture()
+        stateHandler(.idle)
+    }
+}
+
+private final class MacAppCaptureOutput: NSObject, SCStreamOutput {
+    private let imageHandler: @Sendable (CGImage) -> Void
+    private nonisolated let context = CIContext()
+
+    init(imageHandler: @escaping @Sendable (CGImage) -> Void) {
+        self.imageHandler = imageHandler
+    }
+
+    nonisolated func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of outputType: SCStreamOutputType
+    ) {
+        guard outputType == .screen,
+              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            return
+        }
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        guard let image = context.createCGImage(ciImage, from: ciImage.extent) else { return }
+        imageHandler(image)
+    }
+}

--- a/Sources/Panels/MacAppPanel.swift
+++ b/Sources/Panels/MacAppPanel.swift
@@ -1,0 +1,183 @@
+import AppKit
+import Combine
+import Foundation
+
+/// Owns the selected application window and its ScreenCaptureKit lifecycle.
+@MainActor
+final class MacAppPanel: Panel, ObservableObject {
+    let id = UUID()
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    let panelType: PanelType = .macApp
+
+    @Published private(set) var availableWindows: [MacAppWindowDescriptor] = []
+    @Published private(set) var selectedWindow: MacAppWindowDescriptor?
+    @Published private(set) var latestImage: NSImage?
+    @Published private(set) var captureState: MacAppCaptureSession.State = .idle
+    @Published private(set) var isLoadingWindows = false
+    @Published private(set) var requiresAccessibilityPermission = false
+    @Published private(set) var requiresScreenRecordingPermission = false
+
+    private let catalog = MacAppWindowCatalog()
+    private lazy var capture = MacAppCaptureSession(
+        catalog: catalog,
+        imageHandler: { [weak self] image in
+            self?.latestImage = NSImage(
+                cgImage: image,
+                size: NSSize(width: image.width, height: image.height)
+            )
+        },
+        stateHandler: { [weak self] state in
+            self?.captureState = state
+        }
+    )
+    private var windowLoadTask: Task<Void, Never>?
+    private var captureTask: Task<Void, Never>?
+    private weak var surfaceView: NSView?
+    private var isClosed = false
+
+    var displayTitle: String {
+        selectedWindow?.applicationName ?? String(
+            localized: "macApp.pane.title",
+            defaultValue: "Mac App"
+        )
+    }
+
+    var displayIcon: String? { "macwindow" }
+
+    var isStreaming: Bool {
+        captureState == .streaming
+    }
+
+    func refreshWindows() {
+        windowLoadTask?.cancel()
+        isLoadingWindows = true
+        windowLoadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { isLoadingWindows = false }
+            do {
+                availableWindows = try await catalog.loadWindows()
+                requiresAccessibilityPermission = !AXIsProcessTrusted()
+                requiresScreenRecordingPermission = false
+            } catch {
+                availableWindows = []
+                requiresAccessibilityPermission = !AXIsProcessTrusted()
+                requiresScreenRecordingPermission = true
+                captureState = .permissionRequired
+            }
+        }
+    }
+
+    func openAccessibilitySettings() {
+        NSWorkspace.shared.open(
+            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+        )
+    }
+
+    func openScreenRecordingSettings() {
+        NSWorkspace.shared.open(
+            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+        )
+    }
+
+    func selectWindow(_ descriptor: MacAppWindowDescriptor) {
+        guard !isClosed else { return }
+        selectedWindow = descriptor
+        latestImage = nil
+        captureTask?.cancel()
+        captureTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await capture.start(descriptor: descriptor)
+        }
+    }
+
+    func clearSelection() {
+        selectedWindow = nil
+        latestImage = nil
+        captureTask?.cancel()
+        captureTask = Task { @MainActor [weak self] in
+            await self?.capture.stop()
+        }
+    }
+
+    func setSurfaceView(_ view: NSView?) {
+        surfaceView = view
+    }
+
+    func setVisibleInUI(_ visible: Bool) {
+        guard !isClosed else { return }
+        if visible {
+            guard let selectedWindow, !isStreaming else { return }
+            captureTask?.cancel()
+            captureTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await capture.start(descriptor: selectedWindow)
+            }
+        } else {
+            captureTask?.cancel()
+            captureTask = Task { @MainActor [weak self] in
+                await self?.capture.stop()
+            }
+        }
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        windowLoadTask?.cancel()
+        captureTask?.cancel()
+        captureTask = Task { @MainActor [weak self] in
+            await self?.capture.stop()
+        }
+    }
+
+    func focus() {
+        surfaceView?.window?.makeFirstResponder(surfaceView)
+    }
+
+    func unfocus() {}
+
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {
+        _ = reason
+    }
+
+    func ownedFocusIntent(for responder: NSResponder, in window: NSWindow) -> PanelFocusIntent? {
+        guard let surfaceView,
+              responder === surfaceView,
+              surfaceView.window === window else {
+            return nil
+        }
+        return .panel
+    }
+
+    func yieldFocusIntent(_ intent: PanelFocusIntent, in window: NSWindow) -> Bool {
+        guard intent == .panel,
+              let surfaceView,
+              surfaceView.window === window,
+              window.firstResponder === surfaceView else {
+            return false
+        }
+        return window.makeFirstResponder(nil)
+    }
+
+    func captureFocusIntent(in window: NSWindow?) -> PanelFocusIntent {
+        guard let window,
+              let surfaceView,
+              window.firstResponder === surfaceView else {
+            return .panel
+        }
+        return .panel
+    }
+
+    func preferredFocusIntentForActivation() -> PanelFocusIntent { .panel }
+
+    func prepareFocusIntentForActivation(_ intent: PanelFocusIntent) {
+        _ = intent
+    }
+
+    @discardableResult
+    func restoreFocusIntent(_ intent: PanelFocusIntent) -> Bool {
+        guard intent == .panel else { return false }
+        focus()
+        return true
+    }
+}

--- a/Sources/Panels/MacAppPanelView.swift
+++ b/Sources/Panels/MacAppPanelView.swift
@@ -1,0 +1,193 @@
+import AppKit
+import SwiftUI
+
+struct MacAppPanelView: View {
+    @ObservedObject var panel: MacAppPanel
+    let isFocused: Bool
+    let isVisibleInUI: Bool
+    let allowsPointerInput: Bool
+    let appearance: PanelAppearance
+    let onRequestPanelFocus: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            content
+        }
+        .background(Color(nsColor: appearance.contentBackgroundColor))
+        .onAppear {
+            panel.setVisibleInUI(true)
+            panel.refreshWindows()
+        }
+        .onChange(of: isVisibleInUI) { _, visible in
+            panel.setVisibleInUI(visible)
+            if visible { panel.refreshWindows() }
+        }
+        .onDisappear {
+            panel.close()
+        }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: panel.displayIcon ?? "macwindow")
+                .foregroundStyle(.secondary)
+            Text(panel.displayTitle)
+                .lineLimit(1)
+            Spacer()
+            if panel.selectedWindow != nil {
+                Button(String(localized: "macApp.toolbar.change", defaultValue: "Change App")) {
+                    panel.clearSelection()
+                    panel.refreshWindows()
+                }
+                .buttonStyle(.borderless)
+            }
+            Button {
+                panel.refreshWindows()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "macApp.toolbar.refresh.help", defaultValue: "Refresh available apps"))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let selectedWindow = panel.selectedWindow {
+            ZStack {
+                MacAppSurfaceRepresentable(
+                    panel: panel,
+                    isFocused: isFocused,
+                    allowsPointerInput: allowsPointerInput,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+                if panel.captureState != .streaming || panel.requiresAccessibilityPermission {
+                    statusOverlay
+                }
+            }
+            .id(selectedWindow.id)
+        } else if panel.isLoadingWindows {
+            ProgressView(String(localized: "macApp.picker.loading", defaultValue: "Finding open apps…"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if panel.availableWindows.isEmpty {
+            emptyState
+        } else {
+            windowPicker
+        }
+    }
+
+    private var windowPicker: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 6) {
+                Text(String(localized: "macApp.picker.title", defaultValue: "Choose an open Mac app"))
+                    .font(.headline)
+                    .padding(.bottom, 4)
+                ForEach(panel.availableWindows) { window in
+                    Button {
+                        panel.selectWindow(window)
+                        onRequestPanelFocus()
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "macwindow")
+                                .frame(width: 20)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(window.applicationName)
+                                    .font(.body.weight(.medium))
+                                if !window.title.isEmpty {
+                                    Text(window.title)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "arrow.right")
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 6))
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "macwindow.on.rectangle")
+                .font(.system(size: 30))
+                .foregroundStyle(.secondary)
+            Text(String(localized: "macApp.picker.empty.title", defaultValue: "No capturable app windows"))
+                .font(.headline)
+            Text(
+                panel.requiresScreenRecordingPermission
+                    ? String(localized: "macApp.picker.permission.message", defaultValue: "Allow Screen Recording for cmux in System Settings, then refresh.")
+                    : String(localized: "macApp.picker.empty.message", defaultValue: "Open an app window and refresh this pane.")
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            HStack(spacing: 8) {
+                if panel.requiresScreenRecordingPermission {
+                    Button(String(localized: "macApp.picker.openScreenRecording", defaultValue: "Open Screen Recording Settings")) {
+                        panel.openScreenRecordingSettings()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                Button(String(localized: "macApp.picker.refresh", defaultValue: "Refresh")) {
+                    panel.refreshWindows()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    private var statusOverlay: some View {
+        VStack(spacing: 8) {
+            Group {
+                if panel.captureState == .permissionRequired {
+                    Image(systemName: "record.circle")
+                        .font(.title2)
+                    Text(String(localized: "macApp.capture.permission", defaultValue: "Allow Screen Recording for cmux, then choose this app again."))
+                    Button(String(localized: "macApp.picker.openScreenRecording", defaultValue: "Open Screen Recording Settings")) {
+                        panel.openScreenRecordingSettings()
+                    }
+                    .buttonStyle(.borderedProminent)
+                } else if panel.requiresAccessibilityPermission {
+                    Image(systemName: "hand.raised")
+                        .font(.title2)
+                    Text(String(localized: "macApp.capture.accessibility", defaultValue: "Allow Accessibility for cmux to interact with this app."))
+                    Button(String(localized: "macApp.picker.openAccessibility", defaultValue: "Open Accessibility Settings")) {
+                        panel.openAccessibilitySettings()
+                    }
+                    .buttonStyle(.borderedProminent)
+                } else if panel.captureState == .failed {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.title2)
+                    Text(String(localized: "macApp.capture.failed", defaultValue: "The app window could not be captured. Refresh and try again."))
+                    Button(String(localized: "macApp.picker.refresh", defaultValue: "Refresh")) {
+                        panel.refreshWindows()
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    ProgressView()
+                    Text(String(localized: "macApp.capture.starting", defaultValue: "Starting app mirror…"))
+                }
+            }
+            .font(.callout)
+            .multilineTextAlignment(.center)
+        }
+        .padding(18)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Sources/Panels/MacAppSurfaceRepresentable.swift
+++ b/Sources/Panels/MacAppSurfaceRepresentable.swift
@@ -1,0 +1,35 @@
+import AppKit
+import SwiftUI
+
+struct MacAppSurfaceRepresentable: NSViewRepresentable {
+    let panel: MacAppPanel
+    let isFocused: Bool
+    let allowsPointerInput: Bool
+    let onRequestPanelFocus: () -> Void
+
+    func makeNSView(context: Context) -> MacAppSurfaceView {
+        let view = MacAppSurfaceView()
+        panel.setSurfaceView(view)
+        view.onFocus = onRequestPanelFocus
+        view.update(
+            image: panel.latestImage,
+            descriptor: panel.selectedWindow,
+            acceptsInput: isFocused && allowsPointerInput && !panel.requiresAccessibilityPermission
+        )
+        return view
+    }
+
+    func updateNSView(_ view: MacAppSurfaceView, context: Context) {
+        panel.setSurfaceView(view)
+        view.onFocus = onRequestPanelFocus
+        view.update(
+            image: panel.latestImage,
+            descriptor: panel.selectedWindow,
+            acceptsInput: isFocused && allowsPointerInput && !panel.requiresAccessibilityPermission
+        )
+    }
+
+    static func dismantleNSView(_ view: MacAppSurfaceView, coordinator: ()) {
+        view.onFocus = nil
+    }
+}

--- a/Sources/Panels/MacAppSurfaceView.swift
+++ b/Sources/Panels/MacAppSurfaceView.swift
@@ -1,0 +1,158 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Renders a captured window and forwards pane input to its owning process.
+final class MacAppSurfaceView: NSView {
+    private var image: NSImage?
+    private var descriptor: MacAppWindowDescriptor?
+    private var acceptsInput = false
+    private var isMouseDown = false
+
+    var onFocus: (() -> Void)?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    func update(
+        image: NSImage?,
+        descriptor: MacAppWindowDescriptor?,
+        acceptsInput: Bool
+    ) {
+        self.image = image
+        self.descriptor = descriptor
+        self.acceptsInput = acceptsInput
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.black.setFill()
+        dirtyRect.fill()
+        guard let image, let drawRect = imageRect(for: image) else { return }
+        image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard acceptsInput else { return }
+        onFocus?()
+        window?.makeFirstResponder(self)
+        isMouseDown = true
+        postMouseEvent(event, type: .leftMouseDown, button: .left)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard acceptsInput, isMouseDown else { return }
+        postMouseEvent(event, type: .leftMouseDragged, button: .left)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard acceptsInput, isMouseDown else { return }
+        isMouseDown = false
+        postMouseEvent(event, type: .leftMouseUp, button: .left)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        guard acceptsInput else { return }
+        onFocus?()
+        window?.makeFirstResponder(self)
+        postMouseEvent(event, type: .rightMouseDown, button: .right)
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        guard acceptsInput else { return }
+        postMouseEvent(event, type: .rightMouseUp, button: .right)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard acceptsInput, let descriptor else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let scroll = CGEvent(
+            scrollWheelEvent2Source: source,
+            units: .pixel,
+            wheelCount: 1,
+            wheel1: Int32(event.scrollingDeltaY.rounded()),
+            wheel2: Int32(event.scrollingDeltaX.rounded()),
+            wheel3: 0
+        )
+        scroll?.location = targetPoint(
+            for: convert(event.locationInWindow, from: nil),
+            descriptor: descriptor
+        )
+        scroll?.postToPid(descriptor.processID)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard acceptsInput else { return }
+        onFocus?()
+        event.cgEvent?.postToPid(descriptor?.processID ?? 0)
+    }
+
+    override func keyUp(with event: NSEvent) {
+        guard acceptsInput else { return }
+        event.cgEvent?.postToPid(descriptor?.processID ?? 0)
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        guard acceptsInput else { return }
+        event.cgEvent?.postToPid(descriptor?.processID ?? 0)
+    }
+
+    private func postMouseEvent(
+        _ event: NSEvent,
+        type: CGEventType,
+        button: CGMouseButton
+    ) {
+        guard let descriptor else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let mouse = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: targetPoint(
+                for: convert(event.locationInWindow, from: nil),
+                descriptor: descriptor
+            ),
+            mouseButton: button
+        )
+        mouse?.flags = event.cgEvent?.flags ?? []
+        mouse?.postToPid(descriptor.processID)
+    }
+
+    private func imageRect(for image: NSImage) -> NSRect? {
+        guard let descriptor,
+              let imageRepresentation = image.representations.first,
+              imageRepresentation.pixelsWide > 0,
+              imageRepresentation.pixelsHigh > 0 else {
+            return nil
+        }
+        let imageSize = NSSize(
+            width: CGFloat(imageRepresentation.pixelsWide),
+            height: CGFloat(imageRepresentation.pixelsHigh)
+        )
+        let scale = min(bounds.width / imageSize.width, bounds.height / imageSize.height)
+        guard scale.isFinite, scale > 0 else { return nil }
+        let size = NSSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        return NSRect(
+            x: bounds.midX - size.width / 2,
+            y: bounds.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    private func targetPoint(
+        for pointInWindow: NSPoint,
+        descriptor: MacAppWindowDescriptor
+    ) -> CGPoint {
+        guard let image,
+              let imageRect = imageRect(for: image),
+              imageRect.width > 0,
+              imageRect.height > 0 else {
+            return CGPoint(x: descriptor.frame.midX, y: descriptor.frame.midY)
+        }
+        let xFraction = min(1, max(0, (pointInWindow.x - imageRect.minX) / imageRect.width))
+        let yFraction = min(1, max(0, (pointInWindow.y - imageRect.minY) / imageRect.height))
+        return CGPoint(
+            x: descriptor.frame.minX + (xFraction * descriptor.frame.width),
+            y: descriptor.frame.maxY - (yFraction * descriptor.frame.height)
+        )
+    }
+}

--- a/Sources/Panels/MacAppWindowCatalog.swift
+++ b/Sources/Panels/MacAppWindowCatalog.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Foundation
+import ScreenCaptureKit
+
+/// Discovers the on-screen windows that ScreenCaptureKit can capture.
+@MainActor
+final class MacAppWindowCatalog {
+    func loadWindows() async throws -> [MacAppWindowDescriptor] {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: true
+        )
+        let currentProcessID = NSRunningApplication.current.processIdentifier
+        return content.windows.compactMap { window in
+            guard let application = window.owningApplication,
+                  application.processID != currentProcessID,
+                  window.windowID != 0,
+                  window.frame.width >= 80,
+                  window.frame.height >= 50 else {
+                return nil
+            }
+            let applicationName = application.applicationName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !applicationName.isEmpty else { return nil }
+            return MacAppWindowDescriptor(
+                windowID: window.windowID,
+                processID: application.processID,
+                applicationName: applicationName,
+                bundleIdentifier: application.bundleIdentifier,
+                title: window.title ?? "",
+                frame: window.frame
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.applicationName.localizedStandardCompare(rhs.applicationName) == .orderedSame {
+                return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
+            }
+            return lhs.applicationName.localizedStandardCompare(rhs.applicationName) == .orderedAscending
+        }
+    }
+
+    func findWindow(for descriptor: MacAppWindowDescriptor) async throws -> SCWindow? {
+        let windows = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: true
+        ).windows
+        return windows.first { window in
+            window.windowID == descriptor.windowID
+                && window.owningApplication?.processID == descriptor.processID
+        }
+    }
+}

--- a/Sources/Panels/MacAppWindowDescriptor.swift
+++ b/Sources/Panels/MacAppWindowDescriptor.swift
@@ -1,0 +1,21 @@
+import CoreGraphics
+import Foundation
+
+/// Identifies one on-screen macOS application window that can be mirrored.
+struct MacAppWindowDescriptor: Hashable, Identifiable, Sendable {
+    let windowID: CGWindowID
+    let processID: pid_t
+    let applicationName: String
+    let bundleIdentifier: String?
+    let title: String
+    let frame: CGRect
+
+    var id: String {
+        "\(processID):\(windowID)"
+    }
+
+    var displayTitle: String {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedTitle.isEmpty ? applicationName : "\(applicationName) · \(trimmedTitle)"
+    }
+}

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -11,6 +11,7 @@ public enum PanelType: String, Codable, CaseIterable, Sendable {
     case rightSidebarTool
     case customSidebar
     case simulator
+    case macApp = "macapp"
     case agentSession
     case project
     case extensionBrowser

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -157,6 +157,17 @@ struct PanelContentView: View {
                     )
                 }
             }
+        case .macApp:
+            if let macAppPanel = panel as? MacAppPanel {
+                MacAppPanelView(
+                    panel: macAppPanel,
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    allowsPointerInput: allowsPointerInput,
+                    appearance: appearance,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         case .agentSession:
             if let agentSessionPanel = panel as? AgentSessionPanel {
                 AgentSessionPanelView(
@@ -238,7 +249,7 @@ struct PanelContentView: View {
     private var shouldInstallPaneDropTarget: Bool {
         guard isVisibleInUI else { return false }
         switch panel.panelType {
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .macApp, .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             return true
         case .terminal, .browser:
             return false

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -35,7 +35,7 @@ enum GlobalSearchDocuments {
         case .markdown:
             kind = .markdown
         case .terminal, .filePreview, .rightSidebarTool, .customSidebar, .agentSession, .project,
-             .extensionBrowser, .simulator, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+             .extensionBrowser, .simulator, .macApp, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             kind = .title
         }
 

--- a/Sources/TerminalController+ControlCanvasContext.swift
+++ b/Sources/TerminalController+ControlCanvasContext.swift
@@ -235,6 +235,7 @@ extension TerminalController: ControlCanvasContext {
         switch type {
         case "browser": paneType = .browser
         case "simulator": paneType = .simulator
+        case "macapp", "mac-app": paneType = .macApp
         default: paneType = .terminal
         }
         guard let surfaceID = ws.openNewCanvasPane(type: paneType, focus: true) else {

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -339,6 +339,14 @@ extension TerminalController: ControlPaneContext {
                 focus: focus,
                 initialDividerPosition: initialDividerPosition.map { CGFloat($0) }
             )?.id
+        } else if panelType == .macApp {
+            newPanelId = ws.newMacAppSplit(
+                from: sourcePanelId,
+                orientation: orientation,
+                insertFirst: insertFirst,
+                focus: focus,
+                initialDividerPosition: initialDividerPosition.map { CGFloat($0) }
+            )?.id
         } else {
             switch ws.newTerminalSplitOutcome(
                 from: sourcePanelId,

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -162,6 +162,14 @@ extension TerminalController {
                 focus: focus,
                 initialDividerPosition: dividerPosition
             )?.id
+        } else if panelType == .macApp {
+            newId = ws.newMacAppSplit(
+                from: targetSurfaceId,
+                orientation: orientation,
+                insertFirst: insertFirst,
+                focus: focus,
+                initialDividerPosition: dividerPosition
+            )?.id
         } else {
             switch ws.newTerminalSplitOutcome(
                 from: targetSurfaceId,
@@ -386,6 +394,11 @@ extension TerminalController {
             )?.id
         } else if panelType == .simulator {
             newPanelId = ws.newSimulatorSurface(
+                inPane: paneId,
+                focus: focus
+            )?.id
+        } else if panelType == .macApp {
+            newPanelId = ws.newMacAppSurface(
                 inPane: paneId,
                 focus: focus
             )?.id

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -38,6 +38,8 @@ extension TerminalController {
             // Open wire vocabulary: phones without a native renderer show the
             // fallback card for this kind (design: unknown kinds stay cards).
             return MobileSurfaceKind(rawValue: "simulator")
+        case .macApp:
+            return MobileSurfaceKind(rawValue: "macapp")
         case .mobilePairing:
             return MobileSurfaceKind(rawValue: "mobilePairing")
         case .accountSignIn:

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -200,6 +200,8 @@ extension TerminalController {
             return .rightSidebarTool
         case "simulator", "iossimulator":
             return .simulator
+        case "macapp", "macapplication", "appwindow":
+            return .macApp
         case "agentsession":
             return .agentSession
         default:

--- a/Sources/Workspace+LayoutCapture.swift
+++ b/Sources/Workspace+LayoutCapture.swift
@@ -152,7 +152,7 @@ extension Workspace {
                     focus: nil
                 )
             }
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .macApp, .agentSession, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             unsupportedSurfaceCount += 1
             definition = CmuxSurfaceDefinition(type: .terminal)
         }

--- a/Sources/Workspace+MacAppPane.swift
+++ b/Sources/Workspace+MacAppPane.swift
@@ -1,0 +1,139 @@
+import Bonsplit
+import CmuxWorkspaces
+import Foundation
+
+extension Workspace {
+    /// Creates a Mac App mirror tab in an existing pane.
+    @discardableResult
+    func newMacAppSurface(
+        inPane paneId: PaneID,
+        focus: Bool? = nil,
+        targetIndex: Int? = nil
+    ) -> MacAppPanel? {
+        guard !isRemoteTmuxMirror else { return nil }
+        let shouldFocus = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalInputTarget()?.panel.hostedView
+        let panel = MacAppPanel()
+        panels[panel.id] = panel
+        panelTitles[panel.id] = panel.displayTitle
+
+        guard let tabId = bonsplitController.createTab(
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            kind: SurfaceKind.macApp.rawValue,
+            isDirty: false,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: panel.id)
+            panelTitles.removeValue(forKey: panel.id)
+            panel.close()
+            return nil
+        }
+
+        bindSurface(tabId, toPanelId: panel.id)
+        if let targetIndex {
+            _ = bonsplitController.reorderTab(tabId, toIndex: targetIndex)
+        }
+        publishCmuxSurfaceCreated(
+            panel.id,
+            paneId: paneId,
+            kind: SurfaceKind.macApp.rawValue,
+            origin: "mac_app_tab",
+            focused: shouldFocus
+        )
+
+        if shouldFocus {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(tabId)
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        } else if let previousFocusedPanelId {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: panel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+        return panel
+    }
+
+    /// Creates a Mac App mirror in a new split pane.
+    @discardableResult
+    func newMacAppSplit(
+        from panelId: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool = false,
+        focus: Bool = true,
+        initialDividerPosition: CGFloat? = nil
+    ) -> MacAppPanel? {
+        guard !isRemoteTmuxMirror,
+              let sourceTabId = surfaceIdFromPanelId(panelId),
+              let sourcePaneId = bonsplitController.allPaneIds.first(where: { paneId in
+                  bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == sourceTabId })
+              }) else {
+            return nil
+        }
+
+        let panel = MacAppPanel()
+        panels[panel.id] = panel
+        panelTitles[panel.id] = panel.displayTitle
+        let tab = Bonsplit.Tab(
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            kind: SurfaceKind.macApp.rawValue,
+            isDirty: false,
+            isLoading: false,
+            isPinned: false
+        )
+        bindSurface(tab.id, toPanelId: panel.id)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalInputTarget()?.panel.hostedView
+
+        isProgrammaticSplit = true
+        defer { isProgrammaticSplit = false }
+        guard let newPaneId = bonsplitController.splitPane(
+            sourcePaneId,
+            orientation: orientation,
+            withTab: tab,
+            insertFirst: insertFirst
+        ) else {
+            removeSurfaceMapping(forSurfaceId: tab.id)
+            panels.removeValue(forKey: panel.id)
+            panelTitles.removeValue(forKey: panel.id)
+            panel.close()
+            return nil
+        }
+
+        applyInitialSplitDividerPosition(
+            initialDividerPosition,
+            sourcePaneId: sourcePaneId,
+            newPaneId: newPaneId
+        )
+        publishCmuxSplitCreated(
+            newPaneId,
+            sourcePaneId: sourcePaneId,
+            orientation: orientation,
+            surfaceId: panel.id,
+            kind: SurfaceKind.macApp.rawValue,
+            origin: "mac_app_split",
+            focused: focus
+        )
+
+        if focus {
+            suppressReparentFocusUntilLayoutFollowUp(
+                previousHostedView,
+                reason: "workspace.macAppSplitReparent"
+            )
+            focusPanel(panel.id, previousHostedView: previousHostedView)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: panel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+        return panel
+    }
+}

--- a/Sources/Workspace+SurfaceNavigation.swift
+++ b/Sources/Workspace+SurfaceNavigation.swift
@@ -197,6 +197,8 @@ extension Workspace {
             return SurfaceKind.customSidebar.rawValue
         case .simulator:
             return SurfaceKind.simulator.rawValue
+        case .macApp:
+            return SurfaceKind.macApp.rawValue
         case .agentSession:
             return SurfaceKind.agentSession.rawValue
         case .project:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -720,6 +720,10 @@ extension Workspace {
             guard let snapshot = simulatorSessionSnapshot(for: panel) else { return nil }
             terminalSnapshot = nil; browserSnapshot = nil; markdownSnapshot = nil; filePreviewSnapshot = nil; rightSidebarToolSnapshot = nil
             simulatorSnapshot = snapshot; agentSessionSnapshot = nil; projectSnapshot = nil
+        case .macApp:
+            // App windows are process-owned and their identifiers are not stable
+            // across launches, so the pane intentionally reopens at the picker.
+            return nil
         case .agentSession:
             guard let agentPanel = panel as? AgentSessionPanel else { return nil }
             terminalSnapshot = nil
@@ -1853,6 +1857,7 @@ extension Workspace {
             return toolPanel.id
         case .customSidebar: return restoreCustomSidebarPanel(from: snapshot, inPane: paneId)
         case .simulator: return restoreSimulatorPanel(from: snapshot, inPane: paneId)
+        case .macApp: return nil
         case .agentSession:
             guard let agentSession = snapshot.agentSession,
                   let agentPanel = newAgentSessionSurface(
@@ -3787,6 +3792,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             if builtInAction == .mobileConnect { return CmuxFeatureFlags.shared.isMobileConnectButtonEnabled }
             if builtInAction == .newAgentChat { return CmuxFeatureFlags.shared.isAgentChatUIEnabled }
             if builtInAction == .newSimulator { return CmuxFeatureFlags.shared.isSimulatorEnabled }
+            if builtInAction == .newMacApp { return true }
             return true
         }
         let executableButtons = Dictionary(
@@ -13523,6 +13529,8 @@ extension Workspace: BonsplitDelegate {
                 }
             case .newSimulator:
                 _ = newSimulatorSurface(inPane: pane, focus: true)
+            case .newMacApp:
+                _ = newMacAppSurface(inPane: pane, focus: true)
             case .newTerminal, .newBrowser, .splitRight, .splitDown:
                 break
             }

--- a/Sources/cmuxApp+MacAppPane.swift
+++ b/Sources/cmuxApp+MacAppPane.swift
@@ -1,0 +1,15 @@
+import AppKit
+
+extension cmuxApp {
+    func performNewMacAppPaneFromMenu() {
+        guard let appDelegate = AppDelegate.shared,
+              appDelegate.executeConfiguredCmuxAction(
+                  id: CmuxSurfaceTabBarBuiltInAction.newMacApp.configID,
+                  tabManager: activeTabManager,
+                  preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
+              ) else {
+            NSSound.beep()
+            return
+        }
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -769,6 +769,10 @@ struct cmuxApp: App {
                     }
                 }
 
+                Button(String(localized: "menu.file.newMacAppPane", defaultValue: "New Mac App Pane")) {
+                    performNewMacAppPaneFromMenu()
+                }
+
                 splitCommandButton(title: String(localized: "menu.file.newWorkspaceGroup", defaultValue: "New Workspace Group"), shortcut: menuShortcut(for: .newWorkspaceGroup)) {
                     _ = AppDelegate.shared?.createEmptyWorkspaceGroup(
                         tabManager: activeTabManager,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -626,6 +626,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8295A0038295A0038295A003 /* CmuxAlertScrollableDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295A0048295A0048295A004 /* CmuxAlertScrollableDetailsView.swift */; };
 		E3309A07 /* cmuxApp+EqualizeSplitsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */; };
 		C4160A010000000000000001 /* cmuxApp+HistoryMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */; };
+		D0A700000000000000000013 /* cmuxApp+MacAppPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000014 /* cmuxApp+MacAppPane.swift */; };
 		875200000000000000000012 /* cmuxApp+SurfaceNavigationMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875200000000000000000002 /* cmuxApp+SurfaceNavigationMenu.swift */; };
 		80410000000000000000000D /* cmuxApp+WorkspaceCommandHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */; };
 		A5001001 /* cmuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001011 /* cmuxApp.swift */; };
@@ -1331,6 +1332,14 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		9492CAFE0000000000000002 /* LastTerminalChildExitRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9492CAFE0000000000000001 /* LastTerminalChildExitRecoveryTests.swift */; };
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
+		D0A700000000000000000001 /* MacAppCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000002 /* MacAppCaptureSession.swift */; };
+		D0A700000000000000000011 /* MacAppCommandPaletteIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000012 /* MacAppCommandPaletteIntegration.swift */; };
+		D0A700000000000000000003 /* MacAppPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000004 /* MacAppPanel.swift */; };
+		D0A700000000000000000005 /* MacAppPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000006 /* MacAppPanelView.swift */; };
+		D0A700000000000000000007 /* MacAppSurfaceRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000008 /* MacAppSurfaceRepresentable.swift */; };
+		D0A700000000000000000009 /* MacAppSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A70000000000000000000A /* MacAppSurfaceView.swift */; };
+		D0A70000000000000000000B /* MacAppWindowCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A70000000000000000000C /* MacAppWindowCatalog.swift */; };
+		D0A70000000000000000000D /* MacAppWindowDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A70000000000000000000E /* MacAppWindowDescriptor.swift */; };
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
 		D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */; };
 		D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */; };
@@ -2661,6 +2670,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */; };
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
 		C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */; };
+		D0A70000000000000000000F /* Workspace+MacAppPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A700000000000000000010 /* Workspace+MacAppPane.swift */; };
 		9504A0010000000000000001 /* Workspace+MovingTabSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9504A0010000000000000002 /* Workspace+MovingTabSplit.swift */; };
 		8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
@@ -3516,6 +3526,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		8295A0048295A0048295A004 /* CmuxAlertScrollableDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxAlertScrollableDetailsView.swift; sourceTree = "<group>"; };
 		E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+EqualizeSplitsMenu.swift"; sourceTree = "<group>"; };
 		C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+HistoryMenu.swift"; sourceTree = "<group>"; };
+		D0A700000000000000000014 /* cmuxApp+MacAppPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+MacAppPane.swift"; sourceTree = "<group>"; };
 		875200000000000000000002 /* cmuxApp+SurfaceNavigationMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+SurfaceNavigationMenu.swift"; sourceTree = "<group>"; };
 		80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+WorkspaceCommandHelpers.swift"; sourceTree = "<group>"; };
 		A5001011 /* cmuxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmuxApp.swift; sourceTree = "<group>"; };
@@ -4144,6 +4155,14 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9492CAFE0000000000000001 /* LastTerminalChildExitRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastTerminalChildExitRecoveryTests.swift; sourceTree = "<group>"; };
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		D0A700000000000000000002 /* MacAppCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppCaptureSession.swift; sourceTree = "<group>"; };
+		D0A700000000000000000012 /* MacAppCommandPaletteIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAppCommandPaletteIntegration.swift; sourceTree = "<group>"; };
+		D0A700000000000000000004 /* MacAppPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppPanel.swift; sourceTree = "<group>"; };
+		D0A700000000000000000006 /* MacAppPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppPanelView.swift; sourceTree = "<group>"; };
+		D0A700000000000000000008 /* MacAppSurfaceRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppSurfaceRepresentable.swift; sourceTree = "<group>"; };
+		D0A70000000000000000000A /* MacAppSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppSurfaceView.swift; sourceTree = "<group>"; };
+		D0A70000000000000000000C /* MacAppWindowCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppWindowCatalog.swift; sourceTree = "<group>"; };
+		D0A70000000000000000000E /* MacAppWindowDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MacAppWindowDescriptor.swift; sourceTree = "<group>"; };
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
 		D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupBody.swift; sourceTree = "<group>"; };
 		D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupOpWire.swift; sourceTree = "<group>"; };
@@ -5459,6 +5478,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
 		C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LayoutCapture.swift"; sourceTree = "<group>"; };
+		D0A700000000000000000010 /* Workspace+MacAppPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+MacAppPane.swift"; sourceTree = "<group>"; };
 		9504A0010000000000000002 /* Workspace+MovingTabSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+MovingTabSplit.swift"; sourceTree = "<group>"; };
 		688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+NotificationsPane.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
@@ -6071,6 +6091,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
 				C97160000000000000000002 /* AppHostProcessReceipt.swift */,
 				A5001011 /* cmuxApp.swift */,
+				D0A700000000000000000014 /* cmuxApp+MacAppPane.swift */,
 				875200000000000000000002 /* cmuxApp+SurfaceNavigationMenu.swift */,
 				C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */,
 				80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */,
@@ -7377,6 +7398,13 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C51A710000000000000000B2 /* SimulatorPanelView.swift */,
 				C51A71F10000000000000001 /* SimulatorFocusOwnershipBridge.swift */,
 				C51A71F10000000000000003 /* SimulatorFocusOwnershipView.swift */,
+				D0A700000000000000000002 /* MacAppCaptureSession.swift */,
+				D0A700000000000000000004 /* MacAppPanel.swift */,
+				D0A700000000000000000006 /* MacAppPanelView.swift */,
+				D0A700000000000000000008 /* MacAppSurfaceRepresentable.swift */,
+				D0A70000000000000000000A /* MacAppSurfaceView.swift */,
+				D0A70000000000000000000C /* MacAppWindowCatalog.swift */,
+				D0A70000000000000000000E /* MacAppWindowDescriptor.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001223 /* UpdateLogStore.swift */,
 				D7769000000000000000000C /* NotificationPopoverHoverTrackingRepresentable.swift */,
@@ -7538,10 +7566,12 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE43000000000000000004 /* CmuxSurfaceTabBarBuiltInAction+Codable.swift */,
 				C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */,
 				C51A720000000000000000A2 /* SimulatorCommandPaletteIntegration.swift */,
+				D0A700000000000000000012 /* MacAppCommandPaletteIntegration.swift */,
 				C51A720000000000000001A2 /* ContentView+CommandPaletteSurfaceMetadata.swift */,
 				A5FB120E /* Workspace+CustomLayout.swift */,
 				C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */,
 				C51A710000000000000000C2 /* Workspace+SimulatorPane.swift */,
+				D0A700000000000000000010 /* Workspace+MacAppPane.swift */,
 				C51A740000000000000000C2 /* Workspace+SimulatorSessionPersistence.swift */,
 				C0DEF0A10000000000000002 /* CmuxConfigUI.swift */,
 				E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */,
@@ -9462,6 +9492,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8295A0038295A0038295A003 /* CmuxAlertScrollableDetailsView.swift in Sources */,
 				E3309A07 /* cmuxApp+EqualizeSplitsMenu.swift in Sources */,
 				C4160A010000000000000001 /* cmuxApp+HistoryMenu.swift in Sources */,
+				D0A700000000000000000013 /* cmuxApp+MacAppPane.swift in Sources */,
 				875200000000000000000012 /* cmuxApp+SurfaceNavigationMenu.swift in Sources */,
 				80410000000000000000000D /* cmuxApp+WorkspaceCommandHelpers.swift in Sources */,
 				A5001001 /* cmuxApp.swift in Sources */,
@@ -9807,6 +9838,14 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5F10011A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift in Sources */,
 				C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
 				8561C0128561C0128561C012 /* KeyboardShortcutSettingsObserver.swift in Sources */,
+				D0A700000000000000000001 /* MacAppCaptureSession.swift in Sources */,
+				D0A700000000000000000011 /* MacAppCommandPaletteIntegration.swift in Sources */,
+				D0A700000000000000000003 /* MacAppPanel.swift in Sources */,
+				D0A700000000000000000005 /* MacAppPanelView.swift in Sources */,
+				D0A700000000000000000007 /* MacAppSurfaceRepresentable.swift in Sources */,
+				D0A700000000000000000009 /* MacAppSurfaceView.swift in Sources */,
+				D0A70000000000000000000B /* MacAppWindowCatalog.swift in Sources */,
+				D0A70000000000000000000D /* MacAppWindowDescriptor.swift in Sources */,
 				53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */,
 				D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */,
 				D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */,
@@ -10765,6 +10804,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */,
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
 				C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */,
+				D0A70000000000000000000F /* Workspace+MacAppPane.swift in Sources */,
 				9504A0010000000000000001 /* Workspace+MovingTabSplit.swift in Sources */,
 				8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,


### PR DESCRIPTION
## Summary
- add a Mac App pane that lists on-screen windows through ScreenCaptureKit
- stream the selected window into cmux and forward mouse, scroll, keyboard, and modifier events to the owning process
- expose File menu, command palette, canvas, pane/surface control API, and CLI entrypoints
- add Screen Recording and Accessibility guidance with localized English/Japanese strings

## Verification
- `python3 -m json.tool Resources/Localizable.xcstrings`
- `bash scripts/check-pbxproj.sh`
- `git diff --check`
- cloud tagged builds `mapp` passed: runs 32600142030, 32600609943, 32601221297, 32602254908
- real tagged socket created a `macapp` surface and captured screenshots of the picker

The pane mirrors a selected window rather than reparenting another process’s NSWindow, which is not a supported public AppKit operation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790030156&installation_model_id=21920&pr_number=10581&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10581&signature=c32a035366232d2d5d794b8e71addfecd02f383d5d5e2fa58078ca459036c2dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Mac App pane that mirrors and interacts with existing macOS app windows via `ScreenCaptureKit`. Previously cmux could not mirror native app windows; now it lists capturable windows, streams frames, and forwards mouse, scroll, keyboard, and modifier events to the owning process.

- Review notes:
  - Introduces Surface/Panel kind macapp (`SurfaceKind.macApp`, `PanelType.macapp`) with `MacAppPanel`, `MacAppPanelView`, and a `MacAppCaptureSession` using `ScreenCaptureKit`. Frames render in a custom `MacAppSurfaceView`; input events are forwarded via `CGEvent` to the target PID.
  - Adds UI entry points: File menu “New Mac App Pane”, command palette command, and a tab-bar action; localized strings (en/ja) include permission guidance and picker text.
  - CLI accepts `macapp` for canvas `new-pane` and `new-surface`; TerminalController parsing and control contexts handle splits and creation for this type.
  - Canvas/pane lifecycle starts/stops capture on mount/visibility and publishes lifecycle events as kind "macapp"; metrics strings updated; icons use SF Symbol “macwindow”.
  - Persistence behavior: macapp panes are not restored from snapshots by design (window IDs are ephemeral); panes reopen to the picker.

- Rollout/migration:
  - Grant Screen Recording and Accessibility to cmux for full interactivity; the pane provides links to System Settings when permissions are missing.
  - Update any scripts or tools that whitelist pane/surface types to include `macapp` for `cmux canvas new-pane/new-surface`.

<sup>Written for commit eb9580f10ea7915349d2202d05261cbe3dff7edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mac App panes that mirror open macOS application windows.
  * Create Mac App panes from the File menu, command palette, keyboard actions, or CLI.
  * Select, refresh, and switch between available application windows.
  * Interact with mirrored windows using mouse, keyboard, and scrolling.
  * Added Screen Recording and Accessibility permission guidance.
  * Added `macapp` support across pane creation commands and localized help text.

* **Bug Fixes**
  * Improved capture lifecycle, visibility handling, focus restoration, and cleanup for mirrored app panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->