### PR TITLE
Fix sidebar unread preview row-height desync

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -37,11 +37,15 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var workspaceIds: [UUID] = []
     private var selectedScrollTargetWorkspaceId: UUID?
     private var isPresentationActive = true
+    private var isApplyingTableGeometryUpdate = false
+    private var deferredPumpHeightRowIds: Set<SidebarWorkspaceRenderItemID> = []
     private var appKitDropIndicator: SidebarDropIndicator?
     private var appKitDropIndicatorScope: SidebarWorkspaceReorderDropIndicatorScope = .raw
     private var appKitDropIndicatorIncludesRowTargets = false
     private weak var unreadSource: SidebarUnreadModel?
     private var unreadSnapshot = SidebarUnreadSnapshot()
+    private var appliedUnreadSnapshot = SidebarUnreadSnapshot()
+    private var hasPendingContentRefresh = false
     private var unreadObservation: SidebarUnreadObservation?
     private var clipBoundsObserver: NSObjectProtocol?
     private var resizeDidEndObserver: NSObjectProtocol?
@@ -51,7 +55,8 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private lazy var mutationScheduler = SidebarWorkspaceTableMutationScheduler(
         applyFlush: { [weak self] in self?.flushApply($0) },
         viewportChangeFlush: { [weak self] in self?.flushViewportChange() },
-        reloadFlush: { [weak self] in self?.containerView?.tableView.reloadData() }
+        reloadFlush: { [weak self] in self?.containerView?.tableView.reloadData() },
+        contentRefreshFlush: { [weak self] in self?.flushContentRefresh() }
     )
     private let rowHeightCache = SidebarWorkspaceTableRowHeightCache()
     private let dropTargetGeometry = SidebarWorkspaceTableDropTargetGeometryGate()
@@ -162,6 +167,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         guard containerView === container else { return }
         mutationScheduler.cancelPendingApplyAndViewport()
         deferredInteractiveResizeApply = nil
+        deferredPumpHeightRowIds.removeAll(keepingCapacity: false)
         previewBailoutTask?.cancel()
         previewBailoutTask = nil
         widthRemeasureTask?.cancel()
@@ -173,6 +179,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         unreadObservation = nil
         unreadSource = nil
         unreadSnapshot = SidebarUnreadSnapshot()
+        appliedUnreadSnapshot = SidebarUnreadSnapshot()
+        hasPendingContentRefresh = false
+        pumpHeightOverrides.removeAll(keepingCapacity: false)
         rows.removeAll(keepingCapacity: false)
         workspaceIds.removeAll(keepingCapacity: false)
         selectedScrollTargetWorkspaceId = nil
@@ -203,9 +212,34 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     private func applyUnreadSnapshot(_ nextSnapshot: SidebarUnreadSnapshot) {
-        let previousSnapshot = unreadSnapshot
         unreadSnapshot = nextSnapshot
-        guard isPresentationActive, let table = containerView?.tableView else { return }
+        guard isPresentationActive else { return }
+        hasPendingContentRefresh = true
+        mutationScheduler.stageContentRefresh()
+    }
+
+    /// Applies unread content only after any staged table snapshot has committed.
+    private func flushContentRefresh() {
+        guard hasPendingContentRefresh,
+              isPresentationActive,
+              let containerView,
+              !TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: containerView.window)
+        else { return }
+
+        let width = currentColumnWidth()
+        guard width > 0 else {
+            mutationScheduler.stageViewportChange()
+            return
+        }
+        if lastMeasuredWidth > 0, width != lastMeasuredWidth {
+            mutationScheduler.stageViewportChange()
+            return
+        }
+
+        hasPendingContentRefresh = false
+        let previousSnapshot = appliedUnreadSnapshot
+        let nextSnapshot = unreadSnapshot
+        appliedUnreadSnapshot = nextSnapshot
 
         let candidateIds = Set(previousSnapshot.summaryByWorkspaceId.keys)
             .union(nextSnapshot.summaryByWorkspaceId.keys)
@@ -230,15 +264,29 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
         guard !changedRows.isEmpty else { return }
 
+        // A pump can have installed a height override for the old model. It
+        // must not win over the fresh cache entry while this content change is
+        // committed.
+        for index in changedRows where rows.indices.contains(index) {
+            pumpHeightOverrides.removeValue(forKey: rows[index].id)
+        }
         let heightChanges = rowHeightCache.prepareRows(
             at: changedRows,
             in: rows,
-            columnWidth: currentColumnWidth()
+            columnWidth: width
         )
-        reconfigureVisibleRows(changedRows)
-        if !heightChanges.isEmpty {
-            noteHeightOfRowsWithoutAnimation(table, heightChanges)
+        if lastMeasuredWidth == 0 {
+            lastMeasuredWidth = width
         }
+        // Re-note every changed row, not only rows whose cache height differs:
+        // AppKit may have queried the old delegate answer before this pass.
+        var rowsToNote = changedRows
+        rowsToNote.formUnion(heightChanges)
+        reconfigureAndNoteRowsWithoutAnimation(
+            changedRows,
+            rowsToNote,
+            in: containerView.tableView
+        )
     }
 
     func setPresentationActive(_ isActive: Bool, workspaceIds liveWorkspaceIds: [UUID]) {
@@ -250,11 +298,16 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
         isPresentationActive = isActive
         if isActive {
+            if unreadSnapshot != appliedUnreadSnapshot {
+                hasPendingContentRefresh = true
+                mutationScheduler.stageContentRefresh()
+            }
             mutationScheduler.stageViewportChange()
             return
         }
         mutationScheduler.cancelPendingApplyAndViewport()
         deferredInteractiveResizeApply = nil
+        deferredPumpHeightRowIds.removeAll(keepingCapacity: true)
         previewBailoutTask?.cancel()
         previewBailoutTask = nil
         widthRemeasureTask?.cancel()
@@ -365,6 +418,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
         deferredInteractiveResizeApply = nil
         let nextRows = input.rows.map { $0.applyingUnreadSnapshot(unreadSnapshot) }
+        appliedUnreadSnapshot = unreadSnapshot
         let actions = input.actions
         let nextWorkspaceIds = input.workspaceIds
         let selectedWorkspaceId = input.selectedWorkspaceId
@@ -475,22 +529,24 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                 // before the separate height notification takes effect,
                 // clipping checklist or notification content.
                 let table = containerView.tableView
-                table.beginUpdates()
-                var current = previousIds
-                for targetIndex in nextIds.indices where current[targetIndex] != nextIds[targetIndex] {
-                    guard let fromIndex = current.firstIndex(of: nextIds[targetIndex]) else { continue }
-                    table.moveRow(at: fromIndex, to: targetIndex)
-                    current.remove(at: fromIndex)
-                    current.insert(nextIds[targetIndex], at: targetIndex)
-                }
-                table.endUpdates()
-                // Per-index state (first-row flag, drop-indicator geometry)
-                // shifts with the order even when per-id content didn't.
-                let visible = table.rows(in: table.visibleRect)
-                if visible.length > 0 {
-                    reconfigureVisibleRows(
-                        IndexSet(integersIn: visible.lowerBound..<(visible.lowerBound + visible.length))
-                    )
+                performTableGeometryUpdateWithoutAnimation(in: table) {
+                    table.beginUpdates()
+                    var current = previousIds
+                    for targetIndex in nextIds.indices where current[targetIndex] != nextIds[targetIndex] {
+                        guard let fromIndex = current.firstIndex(of: nextIds[targetIndex]) else { continue }
+                        table.moveRow(at: fromIndex, to: targetIndex)
+                        current.remove(at: fromIndex)
+                        current.insert(nextIds[targetIndex], at: targetIndex)
+                    }
+                    table.endUpdates()
+                    // Per-index state (first-row flag, drop-indicator geometry)
+                    // shifts with the order even when per-id content didn't.
+                    let visible = table.rows(in: table.visibleRect)
+                    if visible.length > 0 {
+                        reconfigureVisibleRows(
+                            IndexSet(integersIn: visible.lowerBound..<(visible.lowerBound + visible.length))
+                        )
+                    }
                 }
             } else {
                 let table = containerView.tableView
@@ -501,17 +557,24 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                 let postUpdateActions = requiresAtomicReorderReload
                     ? detachLoadedCells()
                     : []
-                table.reloadData()
-                // A height-changing reorder needs the atomic reload above to
-                // avoid stale moved-row frames. Preserve a stable visible row's
-                // pixel offset so that correctness does not jump the viewport.
-                viewportAnchor?.restore(table: table, rows: nextRows)
+                performTableGeometryUpdateWithoutAnimation(heightChanges, in: table) {
+                    table.reloadData()
+                    // A height-changing reorder needs the atomic reload above to
+                    // avoid stale moved-row frames. Preserve a stable visible
+                    // row's pixel offset so that correctness does not jump the viewport.
+                    viewportAnchor?.restore(table: table, rows: nextRows)
+                }
                 mutationScheduler.stagePostUpdateActions(postUpdateActions)
             }
         } else {
-            reconfigureVisibleRows(contentChanges)
-            if !heightChanges.isEmpty {
-                noteHeightOfRowsWithoutAnimation(containerView.tableView, heightChanges)
+            if !contentChanges.isEmpty || !heightChanges.isEmpty {
+                var rowsToNote = heightChanges
+                rowsToNote.formUnion(contentChanges)
+                reconfigureAndNoteRowsWithoutAnimation(
+                    contentChanges,
+                    rowsToNote,
+                    in: containerView.tableView
+                )
             }
         }
 
@@ -564,6 +627,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         enforceHoverOnVisibleCells()
         updateDropTargets()
         replanReorderDragIfActive()
+        if hasPendingContentRefresh, width > 0, width == lastMeasuredWidth {
+            mutationScheduler.stageContentRefresh()
+        }
         replayDeferredRowClickIfPossible()
     }
 
@@ -1402,6 +1468,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         if !changed.isEmpty {
             if let table = containerView?.tableView { noteHeightOfRowsWithoutAnimation(table, changed) }
         }
+        if hasPendingContentRefresh {
+            mutationScheduler.stageContentRefresh()
+        }
     }
 
     private func currentColumnWidth() -> CGFloat {
@@ -1436,6 +1505,52 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         NSAnimationContext.current.allowsImplicitAnimation = false
         table.noteHeightOfRows(withIndexesChanged: indexes)
         NSAnimationContext.endGrouping()
+    }
+
+    /// Reconfigures content and commits its row heights in one AppKit
+    /// transaction. The table's delegate sees the freshly prepared cache while
+    /// the cell's layout is invalidated, so no intermediate frame can paint.
+    private func reconfigureAndNoteRowsWithoutAnimation(
+        _ contentRows: IndexSet,
+        _ heightRows: IndexSet,
+        in table: NSTableView
+    ) {
+        performTableGeometryUpdateWithoutAnimation(heightRows, in: table) {
+            reconfigureVisibleRows(contentRows)
+        }
+    }
+
+    /// Serializes any table geometry mutation with pump-driven height updates.
+    private func performTableGeometryUpdateWithoutAnimation(
+        _ heightRows: IndexSet = [],
+        in table: NSTableView,
+        update: () -> Void
+    ) {
+        isApplyingTableGeometryUpdate = true
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.current.duration = 0
+        NSAnimationContext.current.allowsImplicitAnimation = false
+        update()
+        var rowsToNote = heightRows
+        for rowId in deferredPumpHeightRowIds {
+            if let index = rows.firstIndex(where: { $0.id == rowId }) {
+                rowsToNote.insert(index)
+            }
+        }
+        if !rowsToNote.isEmpty {
+            table.noteHeightOfRows(withIndexesChanged: rowsToNote)
+        }
+        NSAnimationContext.endGrouping()
+        isApplyingTableGeometryUpdate = false
+        let latePumpRows = deferredPumpHeightRowIds
+        deferredPumpHeightRowIds.removeAll(keepingCapacity: true)
+        guard !latePumpRows.isEmpty else { return }
+        let lateIndexes = IndexSet(rows.indices.compactMap { index in
+            latePumpRows.contains(rows[index].id) ? index : nil
+        })
+        if !lateIndexes.isEmpty {
+            noteHeightOfRowsWithoutAnimation(table, lateIndexes)
+        }
     }
 
     private func reconfigureRows(withIds ids: [SidebarWorkspaceRenderItemID]) {
@@ -1507,9 +1622,17 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
            let rebuild = configuration.appKitWorkspaceRowRebuild {
             cell.installPump(workspace: workspace) { [weak self, weak cell] in
                 guard let self, let cell else { return }
-                let fresh = rebuild()
+                guard let rowIndex = self.rows.firstIndex(where: { $0.id == rowId }) else { return }
+                var fresh = rebuild()
+                // The workspace pump owns metadata/branch/PR churn, while the
+                // unread snapshot owns these two fields. A replaying pump must
+                // not put an older unread preview back over a committed row.
+                if let currentModel = self.rows[rowIndex].appKitWorkspaceRowModel {
+                    fresh.unreadCount = currentModel.unreadCount
+                    fresh.latestNotificationText = currentModel.latestNotificationText
+                }
                 cell.applyRebuiltModel(fresh)
-                self.noteRowHeightOverride(rowId: rowId, cell: cell, model: fresh)
+                self.noteRowHeightOverride(rowId: rowId, index: rowIndex, cell: cell, model: fresh)
             }
         }
         // configure() resets the drop lines from the model (always false
@@ -1528,16 +1651,26 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     private func noteRowHeightOverride(
         rowId: SidebarWorkspaceRenderItemID,
+        index: Int,
         cell: SidebarWorkspaceRowTableCellView,
         model: SidebarWorkspaceRowModel
     ) {
         guard let table = containerView?.tableView,
-              let index = rows.firstIndex(where: { $0.id == rowId }) else { return }
-        let height = ceil(cell.layoutContent(model: model, width: currentColumnWidth(), apply: false))
-        let current = table.rect(ofRow: index).height
+              rows.indices.contains(index), rows[index].id == rowId else { return }
+        let row = rows[index]
+        let width = currentColumnWidth()
+        guard width > 0 else { return }
+        let height = ceil(cell.layoutContent(model: model, width: width, apply: false))
+        let current = pumpHeightOverrides[rowId]
+            ?? rowHeightCache.height(for: row, columnWidth: width)
+            ?? row.estimatedHeight
         guard abs(height - current) >= 0.5 else { return }
         pumpHeightOverrides[rowId] = height
-        noteHeightOfRowsWithoutAnimation(table, IndexSet(integer: index))
+        if isApplyingTableGeometryUpdate {
+            deferredPumpHeightRowIds.insert(rowId)
+        } else {
+            noteHeightOfRowsWithoutAnimation(table, IndexSet(integer: index))
+        }
     }
 
     private func configure(headerCell cell: SidebarGroupHeaderTableCellView, at row: Int) {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
@@ -13,20 +13,25 @@ final class SidebarWorkspaceTableMutationScheduler {
     private var pendingApply: SidebarWorkspaceTableApplyInput?
     private var shouldFlushViewportChange = false
     private var shouldFlushTableReload = false
+    private var shouldFlushContentRefresh = false
     private var pendingPostUpdateActions: [@MainActor () -> Void] = []
     private var isFlushScheduled = false
+    private var isFlushing = false
     private let applyFlush: @MainActor (SidebarWorkspaceTableApplyInput) -> Void
     private let viewportChangeFlush: @MainActor () -> Void
     private let reloadFlush: @MainActor () -> Void
+    private let contentRefreshFlush: @MainActor () -> Void
 
     init(
         applyFlush: @escaping @MainActor (SidebarWorkspaceTableApplyInput) -> Void,
         viewportChangeFlush: @escaping @MainActor () -> Void,
-        reloadFlush: @escaping @MainActor () -> Void
+        reloadFlush: @escaping @MainActor () -> Void,
+        contentRefreshFlush: @escaping @MainActor () -> Void = {}
     ) {
         self.applyFlush = applyFlush
         self.viewportChangeFlush = viewportChangeFlush
         self.reloadFlush = reloadFlush
+        self.contentRefreshFlush = contentRefreshFlush
     }
 
     func stageApply(_ input: SidebarWorkspaceTableApplyInput) {
@@ -42,10 +47,19 @@ final class SidebarWorkspaceTableMutationScheduler {
     func cancelPendingApplyAndViewport() {
         pendingApply = nil
         shouldFlushViewportChange = false
+        shouldFlushContentRefresh = false
     }
 
     func stageTableReload() {
         shouldFlushTableReload = true
+        scheduleFlushIfNeeded()
+    }
+
+    /// Coalesces unread-driven row content behind the authoritative table apply.
+    /// AppKit cells must not be reconfigured while a staged row graph is being
+    /// reloaded or reordered.
+    func stageContentRefresh() {
+        shouldFlushContentRefresh = true
         scheduleFlushIfNeeded()
     }
 
@@ -56,7 +70,7 @@ final class SidebarWorkspaceTableMutationScheduler {
     }
 
     private func scheduleFlushIfNeeded() {
-        guard !isFlushScheduled else { return }
+        guard !isFlushScheduled, !isFlushing else { return }
         isFlushScheduled = true
         // Deliberately retain the scheduler through this turn. Post-update
         // actions can commit user edits while their controller is tearing down.
@@ -73,18 +87,30 @@ final class SidebarWorkspaceTableMutationScheduler {
         let apply = pendingApply
         let flushViewportChange = shouldFlushViewportChange
         let flushTableReload = shouldFlushTableReload
+        let flushContentRefresh = shouldFlushContentRefresh
         let postUpdateActions = pendingPostUpdateActions
         pendingApply = nil
         shouldFlushViewportChange = false
         shouldFlushTableReload = false
+        shouldFlushContentRefresh = false
         pendingPostUpdateActions.removeAll(keepingCapacity: true)
         isFlushScheduled = false
+        isFlushing = true
+        defer {
+            isFlushing = false
+            if pendingMutationsExist {
+                scheduleFlushIfNeeded()
+            }
+        }
 
-        if flushTableReload {
+        if flushTableReload, apply == nil {
             reloadFlush()
         }
         if let apply {
             applyFlush(apply)
+        }
+        if flushContentRefresh {
+            contentRefreshFlush()
         }
         if flushViewportChange {
             viewportChangeFlush()
@@ -92,5 +118,13 @@ final class SidebarWorkspaceTableMutationScheduler {
         for action in postUpdateActions {
             action()
         }
+    }
+
+    private var pendingMutationsExist: Bool {
+        pendingApply != nil
+            || shouldFlushViewportChange
+            || shouldFlushTableReload
+            || shouldFlushContentRefresh
+            || !pendingPostUpdateActions.isEmpty
     }
 }

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -558,7 +558,10 @@ struct SidebarWorkspaceTableSuspensionTests {
         #expect(appliedInputs == 1)
         #expect(viewportFlushes == 1)
         #expect(postUpdateActions == 1)
-        #expect(reloads == 2)
+        #expect(
+            reloads == 1,
+            "An authoritative apply owns the current row graph, so a stale staged reload is superseded."
+        )
     }
 
     @Test

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -532,15 +532,14 @@ struct SidebarWorkspaceTableTests {
             ),
             totalUnreadCount: 1
         )
-        await flushStagedTableMutations()
+        await flushUntil { cell.currentModelForMeasurement?.latestNotificationText == latestText }
+        #expect(cell.currentModelForMeasurement?.latestNotificationText == latestText)
         container.layoutSubtreeIfNeeded()
         container.tableView.layoutSubtreeIfNeeded()
 
-        var expectedModel = baseModel
-        expectedModel.unreadCount = 1
-        expectedModel.latestNotificationText = latestText
+        let installedModel = try #require(cell.currentModelForMeasurement)
         let expectedHeight = ceil(
-            cell.layoutContent(model: expectedModel, width: cell.bounds.width, apply: false)
+            cell.layoutContent(model: installedModel, width: cell.bounds.width, apply: false)
         )
         let servedHeight = controller.tableView(container.tableView, heightOfRow: 0)
         let tableHeight = container.tableView.rect(ofRow: 0).height
@@ -654,6 +653,15 @@ struct SidebarWorkspaceTableTests {
             RunLoop.main.perform(inModes: [.common]) {
                 continuation.resume()
             }
+        }
+    }
+
+    @MainActor
+    private func flushUntil(_ predicate: @escaping () -> Bool) async {
+        for _ in 0..<32 {
+            if predicate() { return }
+            await flushStagedTableMutations()
+            await Task.yield()
         }
     }
 

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxFoundation
+import CmuxNotifications
 import SwiftUI
 import Testing
 
@@ -437,6 +438,115 @@ struct SidebarWorkspaceTableTests {
         let nextAnchorIndex = try #require(nextRows.firstIndex { $0.id == anchorId })
         let offsetAfter = table.rect(ofRow: nextAnchorIndex).minY - table.visibleRect.minY
         #expect(abs(offsetAfter - offsetBefore) < 0.5)
+    }
+
+    @Test
+    @MainActor
+    func unreadRefreshKeepsTableHeightInLockstepWithTheReconfiguredCell() async throws {
+        let workspace = Workspace()
+        let baseModel = SidebarWorkspaceRowSuspensionTests.makeModel(workspaceId: workspace.id)
+        var pumpModel = baseModel
+        pumpModel.latestNotificationText = "metadata refresh"
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: .dark,
+            globalFontMagnificationPercent: 100,
+            lazyContractProbe: SidebarLazyContractProbe()
+        )
+        let row = SidebarWorkspaceTableRowConfiguration(
+            workspaceRowModel: baseModel,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(
+                model: baseModel,
+                workspace: workspace
+            ),
+            groupId: nil,
+            isPinned: false,
+            environment: environment,
+            workspace: workspace,
+            rebuild: { pumpModel },
+            unreadRebuild: { snapshot in
+                var fresh = baseModel
+                let summary = snapshot.summary(forWorkspaceId: workspace.id)
+                fresh.unreadCount = summary.unreadCount
+                fresh.latestNotificationText = summary.latestNotificationText
+                return fresh
+            }
+        )
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        _ = cache.prepareRows(at: [0], in: [row], columnWidth: 320)
+        let cacheSnapshot = SidebarUnreadSnapshot(
+            summaryByWorkspaceId: [workspace.id: SidebarWorkspaceUnreadSummary(
+                unreadCount: 1,
+                latestNotificationText: "cache fingerprint notification"
+            )]
+        )
+        let cacheUpdatedRow = row.applyingUnreadSnapshot(cacheSnapshot)
+        let cacheChanges = cache.prepareRows(
+            at: [0],
+            in: [cacheUpdatedRow],
+            columnWidth: 320
+        )
+        #expect(cacheChanges == IndexSet(integer: 0))
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        defer { window.close() }
+
+        let unread = SidebarUnreadModel()
+        controller.setUnreadSource(unread)
+        controller.apply(
+            rows: [row],
+            actions: makeTableActions(),
+            workspaceIds: [workspace.id],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+        let cell = try #require(
+            container.tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
+                as? SidebarWorkspaceRowTableCellView
+        )
+
+        // The initial pump replay installs a height override for the shorter
+        // live model. The unread update below must retire that override before
+        // the cell is painted with its taller notification preview.
+        let pumpHeight = controller.tableView(container.tableView, heightOfRow: 0)
+        let baseHeight = ceil(
+            cell.layoutContent(model: baseModel, width: cell.bounds.width, apply: false)
+        )
+        #expect(pumpHeight > baseHeight)
+
+        let latestText = String(repeating: "latest agent message ", count: 30)
+        unread.applyWorkspaceSummaryProjection(
+            forWorkspaceId: workspace.id,
+            summary: SidebarWorkspaceUnreadSummary(
+                unreadCount: 1,
+                latestNotificationText: latestText
+            ),
+            totalUnreadCount: 1
+        )
+        await flushStagedTableMutations()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        var expectedModel = baseModel
+        expectedModel.unreadCount = 1
+        expectedModel.latestNotificationText = latestText
+        let expectedHeight = ceil(
+            cell.layoutContent(model: expectedModel, width: cell.bounds.width, apply: false)
+        )
+        let servedHeight = controller.tableView(container.tableView, heightOfRow: 0)
+        let tableHeight = container.tableView.rect(ofRow: 0).height
+            - container.tableView.intercellSpacing.height
+        #expect(abs(servedHeight - expectedHeight) < 0.5)
+        #expect(abs(tableHeight - expectedHeight) < 0.5)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes the transient sidebar row-height/content desync reported in https://github.com/manaflow-ai/cmux/issues/10582.

The unread fast path previously reconfigured visible cells directly while a pump height override could still win in `heightOfRow`. It also bypassed the table mutation scheduler, allowing the refresh to land while an authoritative row apply/reload was changing geometry. That left the cell's expanded notification/metadata stack taller than the committed NSTableView row and its selection background.

The fix:

- serializes unread projection through the table mutation scheduler after authoritative applies and prevents re-entrant staged mutations;
- measures changed native rows at the committed column width and retires stale pump overrides;
- treats the row's unread fields as authoritative when a metadata pump replays;
- reconfigures visible cells and re-notes their heights in one no-animation AppKit transaction, including rows whose cache value was already equal;
- gates structural moves/reloads through the same geometry transaction and supersedes a stale reload when an authoritative row apply is already queued.

The row-height cache already keys native measurements by the complete `SidebarWorkspaceRowModel`/environment equivalence value; the regression asserts that adding `latestNotificationText` invalidates the measurement and that the installed cell model, controller height delegate, and table row rect agree. The same ordered geometry lane also removes the content-vs-row race involved in https://github.com/manaflow-ai/cmux/issues/10373, without adding that issue's mutation-burst repro scope.

## Testing

- Regression test committed first as `893b41b96e`; fix committed as `ab75fb75ca`.
- `git diff --check`, Swift syntax parse, `./scripts/lint-pbxproj-test-wiring.sh`, `python3 scripts/check-sidebar-lazy-layout.py`, and `python3 scripts/check-package-resolved-policy.py` passed.
- No local Xcode build/tests or reload scripts were run, per task instructions.
- Remote CI run https://github.com/manaflow-ai/cmux/actions/runs/32606319508 and its clean retry https://github.com/manaflow-ai/cmux/actions/runs/32607545136 reached the macOS test lanes, but the app-host test bundle failed before test execution with repeated pre-existing `CMUXAuthCore`/`CmuxAuthRuntime` undefined-symbol linker errors. The Swift package lane independently timed out in unrelated `CmxConnectivityPeerSessionTests`.
- Focused remote run https://github.com/manaflow-ai/cmux/actions/runs/32606834591 reproduced the same auth-runtime linker failure before the requested test could start. No changed-file compiler diagnostic or test assertion failure was reported.
- The requested `scripts/swift_file_length_budget.py` is not present in this origin/main checkout; no budget TSV was modified.

## Demo Video

Not recorded: this task explicitly requires CI-only validation and forbids local app dogfood/builds.

## Checklist

- [x] Added behavior regression coverage.
- [x] Kept the failing-test and fix commits separate.
- [x] Pushed only to the upstream `manaflow-ai/cmux` repository.
- [ ] Demo video (not applicable under the CI-only task constraint).

Closes #10582