### PR TITLE
docs(ios): require Apple HIG consultation for iOS UI work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ CMUX_TAG=<tag> scripts/cmux-debug-cli.sh send --workspace workspace:1 --surface 
 
 The helper refuses to run without `CMUX_TAG`, targets `/tmp/cmux-debug-<tag>.sock`, and uses the matching tagged CLI from DerivedData. It scrubs ambient cmux terminal context (`CMUX_SOCKET`, `CMUX_SOCKET_PASSWORD`, workspace/surface/tab/panel IDs, cmuxd socket, debug log), then sets `CMUX_SOCKET_PATH`, `CMUX_BUNDLE_ID`, and `CMUX_BUNDLED_CLI_PATH` for the tag.
 
+## iOS UI follows the Apple HIG
+
+`Packages/iOS/AGENTS.md` requires consulting the Apple Human Interface
+Guidelines for any iOS UI change and citing the page in the PR. It applies to
+`Packages/iOS/` and `ios/`.
+
 ## iOS builds open on the iPhone by default
 
 Any work verified by opening the iOS app installs BOTH an isolated-simulator build AND the same build on the user's iPhone. Never stop at simulator-only. Use `ios/scripts/reload-cloud.sh --tag <tag>` (or `ios/scripts/reload.sh --tag <tag>`); with a default iPhone configured (`CMUX_IPHONE_DEVICE_ID` or `~/.config/cmux/iphone-device-id`) the device leg is automatic, and `--device-id <id>` still overrides (`xcrun devicectl list devices`). Physical iPhone builds always select the `personal` auth profile. Agent-driven Simulator verification always selects `agent`. Both named profiles live in `~/.secrets/cmuxterm-dev.env`; neither may fall back to the other. The simulator leg uses the tag's own isolated device `cmux-dev-<slug>`, created on demand; do not target a shared or user-visible simulator.

--- a/Packages/iOS/AGENTS.md
+++ b/Packages/iOS/AGENTS.md
@@ -1,0 +1,12 @@
+# iOS agent instructions
+
+## Follow the Apple Human Interface Guidelines
+
+Before you add or change iOS UI, fetch and read the Apple Human Interface
+Guidelines page for the component or pattern you are touching
+(https://developer.apple.com/design/human-interface-guidelines), and follow it
+by default. This covers layout, navigation, gestures, keyboard behavior,
+haptics, color, typography, and system component usage. When cmux deviates
+from the HIG deliberately, say so in the PR description and name the HIG page
+you checked. If you cannot fetch the page (offline sandbox), state that in the
+PR instead of guessing.

--- a/Packages/iOS/CLAUDE.md
+++ b/Packages/iOS/CLAUDE.md
@@ -1,0 +1,3 @@
+# Packages/iOS
+
+Read and follow `AGENTS.md` in this directory before you change iOS code.

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -1,0 +1,5 @@
+# ios/ agent instructions
+
+iOS app-target work in this directory follows `Packages/iOS/AGENTS.md`,
+including its Apple Human Interface Guidelines rule. Read it before changing
+UI.

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -1,0 +1,3 @@
+# ios/
+
+Read and follow `AGENTS.md` in this directory before you change iOS code.


### PR DESCRIPTION
Agents working on the iOS app had no design guidance: the root agents file covers builds and auth only, and no nested agents file existed for `Packages/iOS/` or `ios/`.

This adds `Packages/iOS/AGENTS.md` requiring agents to fetch and follow the relevant [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines) page before adding or changing iOS UI, cite the page in the PR description, and state deliberate deviations (or an inability to fetch) instead of guessing. `ios/AGENTS.md` points at it, `CLAUDE.md` pointer files mirror the existing `cmux-tui/` convention, and the root `CLAUDE.md` gains a two-line section for discoverability.

Meta-only change: no runtime code, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790032959&installation_model_id=21920&pr_number=10585&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10585&signature=391cae0165582d64b9cf825e38a2c5f9e5dee84c0f210341bee6175ed87d04df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires all iOS UI changes to consult and follow the Apple Human Interface Guidelines. Previously there was no iOS UI guidance; now PRs must cite the relevant HIG page and explicitly note deliberate deviations or an inability to fetch the page.

- New `Packages/iOS/AGENTS.md` defines the rule and applies to `Packages/iOS/` and `ios/`. `ios/AGENTS.md` and `CLAUDE.md` files point to it, and the root `CLAUDE.md` adds a brief discoverability note.
- Docs-only change; no runtime or build impact.
- For PRs touching `Packages/iOS/` or `ios/`, verify the HIG citation and any stated deviations.

<sup>Written for commit 2104328765403308991ebe0d0e7a5924c8c17979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added iOS development guidance requiring alignment with Apple’s Human Interface Guidelines for UI changes.
  * Added instructions to review applicable project guidance before modifying iOS code.
  * Documented the need to cite relevant Apple HIG references or explain deliberate deviations in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->