### PR TITLE
iOS: Task Composer drafts with save-on-leave confirmation and attachment persistence

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
@@ -2,7 +2,7 @@ public import CMUXMobileCore
 internal import CmuxMobilePairedMac
 public import CmuxMobileRPC
 public import CmuxMobileShellModel
-internal import Foundation
+public import Foundation
 
 /// A user-actionable failure returned by task-composer directory search.
 public enum MobileTaskDirectorySearchFailure: Error, Equatable, Sendable,
@@ -151,11 +151,21 @@ extension MobileShellComposite {
         }
     }
 
+    /// Every saved, unsent composer draft, newest first. Empty while signed
+    /// out or before the template store is configured.
+    public func taskComposerSavedDrafts() -> [MobileTaskComposerSavedDraft] {
+        guard isSignedIn, let taskTemplateStore else { return [] }
+        return taskTemplateStore.composerDrafts()
+    }
+
     /// Persists an unsent composer draft only for the signed-in session that
     /// created the sheet. A stale disappearing sheet must not restore the
-    /// previous account's draft after sign-out has cleared it.
+    /// previous account's draft after sign-out has cleared it. A draft that
+    /// keeps nothing the user prepared deletes its saved entry instead, so
+    /// emptied sessions cannot pile up in the drafts list.
     /// - Parameters:
     ///   - draft: Draft snapshot to persist.
+    ///   - draftID: Stable identity of the composer session's draft entry.
     ///   - capturedGeneration: ``currentSessionGeneration`` captured when the
     ///     composer sheet was created.
     /// - Returns: `true` when the draft belongs to the active session and was
@@ -163,6 +173,7 @@ extension MobileShellComposite {
     @discardableResult
     public func persistTaskComposerDraft(
         _ draft: MobileTaskComposerDraft,
+        draftID: UUID,
         ifSessionGeneration capturedGeneration: Int
     ) -> Bool {
         guard isSignedIn, capturedGeneration == currentSessionGeneration else {
@@ -173,19 +184,31 @@ extension MobileShellComposite {
             recordAppEvent(.draftPersistenceFailed, failure: .localStateUnavailable)
             return false
         }
-        taskTemplateStore.setComposerDraft(draft)
-        recordAppEvent(.draftSaved)
+        if draft.isEffectivelyEmpty {
+            taskTemplateStore.deleteComposerDrafts(ids: [draftID])
+            recordAppEvent(.draftDeleted)
+        } else {
+            taskTemplateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+                id: draftID,
+                updatedAt: Date(),
+                content: draft
+            ))
+            recordAppEvent(.draftSaved)
+        }
         return true
     }
 
-    /// Clears the composer draft only for the signed-in session that created
+    /// Deletes composer drafts only for the signed-in session that created
     /// the sheet. A stale cancel or async success must not erase a newer
-    /// account's draft.
-    /// - Parameter capturedGeneration: ``currentSessionGeneration`` captured
-    ///   when the composer sheet was created.
-    /// - Returns: `true` when the active session's draft store was cleared.
+    /// account's drafts.
+    /// - Parameters:
+    ///   - ids: Identities of the drafts to delete.
+    ///   - capturedGeneration: ``currentSessionGeneration`` captured when the
+    ///     composer sheet was created.
+    /// - Returns: `true` when the active session's drafts were deleted.
     @discardableResult
-    public func clearTaskComposerDraft(
+    public func deleteTaskComposerDrafts(
+        ids: Set<UUID>,
         ifSessionGeneration capturedGeneration: Int
     ) -> Bool {
         guard isSignedIn, capturedGeneration == currentSessionGeneration else {
@@ -196,16 +219,17 @@ extension MobileShellComposite {
             recordAppEvent(.draftPersistenceFailed, failure: .localStateUnavailable)
             return false
         }
-        taskTemplateStore.setComposerDraft(nil)
+        taskTemplateStore.deleteComposerDrafts(ids: ids)
         recordAppEvent(.draftDeleted)
         return true
     }
 
-    /// Persists successful task-composer defaults and clears the submitted
+    /// Persists successful task-composer defaults and deletes the submitted
     /// draft as one generation-checked main-actor transaction. A completion
     /// from a signed-out session must not repopulate the next account's store.
     /// - Parameters:
     ///   - snapshot: Immutable values used by the successful submission.
+    ///   - draftID: Identity of the submitted composer session's draft entry.
     ///   - capturedGeneration: ``currentSessionGeneration`` captured when the
     ///     composer sheet was created.
     /// - Returns: `true` when the success belonged to the active session and
@@ -213,6 +237,7 @@ extension MobileShellComposite {
     @discardableResult
     public func completeTaskComposerSubmission(
         _ snapshot: MobileTaskSubmissionSnapshot,
+        draftID: UUID,
         ifSessionGeneration capturedGeneration: Int
     ) -> Bool {
         guard isSignedIn, capturedGeneration == currentSessionGeneration else {
@@ -240,7 +265,7 @@ extension MobileShellComposite {
                 at: Date()
             )
         }
-        taskTemplateStore.setComposerDraft(nil)
+        taskTemplateStore.deleteComposerDrafts(ids: [draftID])
         recordAppEvent(.draftDeleted)
         return true
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
@@ -36,11 +36,35 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
     private static let recentDirectoryLimit = 20
     private static let composerDraftLimit = 20
 
+    /// Draft-owned attachment bytes live under this directory, one
+    /// subdirectory per draft id, so deleting a draft is one folder removal.
+    private let attachmentFilesRootDirectory: URL
+
     /// Creates a task template store backed by `defaults`.
-    /// - Parameter defaults: The `UserDefaults` instance to persist into.
-    public init(defaults: UserDefaults, diagnosticLog: DiagnosticLog? = nil) {
+    /// - Parameters:
+    ///   - defaults: The `UserDefaults` instance to persist into.
+    ///   - attachmentFilesRootDirectory: Root for preserved draft attachment
+    ///     files; defaults to Application Support.
+    public init(
+        defaults: UserDefaults,
+        diagnosticLog: DiagnosticLog? = nil,
+        attachmentFilesRootDirectory: URL =
+            UserDefaultsMobileTaskTemplateStore.defaultComposerAttachmentsRootDirectory()
+    ) {
         self.defaults = defaults
         self.diagnosticLog = diagnosticLog
+        self.attachmentFilesRootDirectory = attachmentFilesRootDirectory
+    }
+
+    /// The production location for preserved draft attachment files.
+    public static func defaultComposerAttachmentsRootDirectory() -> URL {
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        return base
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("composer-draft-attachments", isDirectory: true)
     }
 
     /// Returns all stored templates, seeding defaults on the first read.
@@ -166,25 +190,82 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
     }
 
     /// Inserts or replaces one draft by id at the front of the collection,
-    /// dropping the oldest entries beyond the bounded storage limit.
+    /// dropping the oldest entries (and their attachment files) beyond the
+    /// bounded storage limit.
     public func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft) {
         var drafts = composerDrafts()
         drafts.removeAll { $0.id == draft.id }
         drafts.insert(draft, at: 0)
         if drafts.count > Self.composerDraftLimit {
+            let evicted = drafts.suffix(from: Self.composerDraftLimit)
             drafts.removeLast(drafts.count - Self.composerDraftLimit)
+            removeAttachmentDirectories(draftIDs: Set(evicted.map(\.id)))
         }
         saveComposerDrafts(drafts)
     }
 
-    /// Deletes the drafts with the provided ids in one persistence update.
+    /// Deletes the drafts with the provided ids in one persistence update,
+    /// including any preserved attachment files they own.
     public func deleteComposerDrafts(ids: Set<UUID>) {
         guard !ids.isEmpty else { return }
+        removeAttachmentDirectories(draftIDs: ids)
         var drafts = composerDrafts()
         let countBefore = drafts.count
         drafts.removeAll { ids.contains($0.id) }
         guard drafts.count != countBefore else { return }
         saveComposerDrafts(drafts)
+    }
+
+    /// Copies staged attachment bytes into draft-owned storage. An existing
+    /// copy of the same attachment is reused so per-leave persists stay cheap.
+    public func persistComposerAttachmentFile(
+        draftID: UUID,
+        attachmentID: UUID,
+        preferredExtension: String,
+        from sourceURL: URL
+    ) throws -> String {
+        let sanitizedExtension = preferredExtension
+            .filter { $0.isLetter || $0.isNumber }
+            .lowercased()
+        let fileName = attachmentID.uuidString
+            + "." + (sanitizedExtension.isEmpty ? "bin" : sanitizedExtension)
+        let relativePath = draftID.uuidString + "/" + fileName
+        let draftDirectory = attachmentFilesRootDirectory
+            .appendingPathComponent(draftID.uuidString, isDirectory: true)
+        let destination = draftDirectory.appendingPathComponent(fileName)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            return relativePath
+        }
+        try FileManager.default.createDirectory(
+            at: draftDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+        return relativePath
+    }
+
+    /// Returns the location of preserved attachment bytes, or `nil` when the
+    /// path is invalid or the file no longer exists.
+    public func composerAttachmentFileURL(relativePath: String) -> URL? {
+        let components = relativePath.split(separator: "/")
+        guard components.count == 2,
+              !relativePath.contains(".."),
+              !relativePath.hasPrefix("/") else {
+            return nil
+        }
+        let url = attachmentFilesRootDirectory
+            .appendingPathComponent(String(components[0]), isDirectory: true)
+            .appendingPathComponent(String(components[1]))
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    private func removeAttachmentDirectories(draftIDs: Set<UUID>) {
+        for draftID in draftIDs {
+            let directory = attachmentFilesRootDirectory
+                .appendingPathComponent(draftID.uuidString, isDirectory: true)
+            try? FileManager.default.removeItem(at: directory)
+        }
     }
 
     /// Adopts the pre-collection single draft as the newest saved draft so an
@@ -241,6 +322,7 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(Self.recentDirectoriesPrefix) {
             defaults.removeObject(forKey: key)
         }
+        try? FileManager.default.removeItem(at: attachmentFilesRootDirectory)
     }
 
     private func seedIfNeeded() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
@@ -31,8 +31,10 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
     private static let lastMacDeviceIDKey = "cmux.mobile.taskComposer.lastMacDeviceID"
     private static let lastDirectoryPrefix = "cmux.mobile.taskComposer.lastDirectory."
     private static let recentDirectoriesPrefix = "cmux.mobile.taskComposer.recentDirectories.v1."
-    private static let composerDraftKey = "cmux.mobile.taskComposer.draft.v1"
+    private static let legacyComposerDraftKey = "cmux.mobile.taskComposer.draft.v1"
+    private static let composerDraftsKey = "cmux.mobile.taskComposer.drafts.v1"
     private static let recentDirectoryLimit = 20
+    private static let composerDraftLimit = 20
 
     /// Creates a task template store backed by `defaults`.
     /// - Parameter defaults: The `UserDefaults` instance to persist into.
@@ -147,34 +149,76 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
         defaults.set(data, forKey: Self.recentDirectoriesPrefix + macDeviceID)
     }
 
-    /// Returns the unsent task-composer draft, if one was saved.
-    public func composerDraft() -> MobileTaskComposerDraft? {
-        guard let data = defaults.data(forKey: Self.composerDraftKey) else { return nil }
+    /// Returns every unsent task-composer draft, newest first, adopting a
+    /// legacy single-slot draft into the collection on first read.
+    public func composerDrafts() -> [MobileTaskComposerSavedDraft] {
+        migrateLegacyComposerDraftIfNeeded()
+        guard let data = defaults.data(forKey: Self.composerDraftsKey) else { return [] }
         do {
-            return try decoder.decode(MobileTaskComposerDraft.self, from: data)
+            return try decoder.decode([MobileTaskComposerSavedDraft].self, from: data)
         } catch {
             diagnosticLog?.recordAppEvent(
                 .draftPersistenceFailed,
                 failure: .protocolViolation
             )
-            return nil
+            return []
         }
     }
 
-    /// Stores or clears the unsent task-composer draft.
-    public func setComposerDraft(_ draft: MobileTaskComposerDraft?) {
-        guard let draft else {
-            defaults.removeObject(forKey: Self.composerDraftKey)
+    /// Inserts or replaces one draft by id at the front of the collection,
+    /// dropping the oldest entries beyond the bounded storage limit.
+    public func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft) {
+        var drafts = composerDrafts()
+        drafts.removeAll { $0.id == draft.id }
+        drafts.insert(draft, at: 0)
+        if drafts.count > Self.composerDraftLimit {
+            drafts.removeLast(drafts.count - Self.composerDraftLimit)
+        }
+        saveComposerDrafts(drafts)
+    }
+
+    /// Deletes the drafts with the provided ids in one persistence update.
+    public func deleteComposerDrafts(ids: Set<UUID>) {
+        guard !ids.isEmpty else { return }
+        var drafts = composerDrafts()
+        let countBefore = drafts.count
+        drafts.removeAll { ids.contains($0.id) }
+        guard drafts.count != countBefore else { return }
+        saveComposerDrafts(drafts)
+    }
+
+    /// Adopts the pre-collection single draft as the newest saved draft so an
+    /// update never discards what the user prepared on an older build.
+    private func migrateLegacyComposerDraftIfNeeded() {
+        guard let data = defaults.data(forKey: Self.legacyComposerDraftKey) else { return }
+        defaults.removeObject(forKey: Self.legacyComposerDraftKey)
+        guard let legacy = try? decoder.decode(MobileTaskComposerDraft.self, from: data),
+              !legacy.isEffectivelyEmpty else { return }
+        var drafts: [MobileTaskComposerSavedDraft] = []
+        if let existing = defaults.data(forKey: Self.composerDraftsKey),
+           let decoded = try? decoder.decode([MobileTaskComposerSavedDraft].self, from: existing) {
+            drafts = decoded
+        }
+        drafts.insert(
+            MobileTaskComposerSavedDraft(updatedAt: Date(), content: legacy),
+            at: 0
+        )
+        saveComposerDrafts(drafts)
+    }
+
+    private func saveComposerDrafts(_ drafts: [MobileTaskComposerSavedDraft]) {
+        guard !drafts.isEmpty else {
+            defaults.removeObject(forKey: Self.composerDraftsKey)
             return
         }
-        guard let data = try? encoder.encode(draft) else {
+        guard let data = try? encoder.encode(drafts) else {
             diagnosticLog?.recordAppEvent(
                 .draftPersistenceFailed,
                 failure: .protocolViolation
             )
             return
         }
-        defaults.set(data, forKey: Self.composerDraftKey)
+        defaults.set(data, forKey: Self.composerDraftsKey)
     }
 
     /// Removes every account-derived template, selection, directory, and draft.
@@ -185,7 +229,8 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
             Self.builtInProtectionMigrationKey,
             Self.lastTemplateIDKey,
             Self.lastMacDeviceIDKey,
-            Self.composerDraftKey,
+            Self.legacyComposerDraftKey,
+            Self.composerDraftsKey,
         ] + Self.legacyKeys
         for key in keys {
             defaults.removeObject(forKey: key)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStore.swift
@@ -191,9 +191,20 @@ public final class UserDefaultsMobileTaskTemplateStore: MobileTaskTemplateStorin
 
     /// Inserts or replaces one draft by id at the front of the collection,
     /// dropping the oldest entries (and their attachment files) beyond the
-    /// bounded storage limit.
+    /// bounded storage limit. Files owned by attachments the replacement no
+    /// longer references are deleted so removed attachments leave no bytes.
     public func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft) {
         var drafts = composerDrafts()
+        if let previous = drafts.first(where: { $0.id == draft.id }) {
+            let keptPaths = Set(draft.content.attachments.map(\.relativePath))
+            for dropped in previous.content.attachments
+            where !keptPaths.contains(dropped.relativePath) {
+                guard let url = composerAttachmentFileURL(
+                    relativePath: dropped.relativePath
+                ) else { continue }
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
         drafts.removeAll { $0.id == draft.id }
         drafts.insert(draft, at: 0)
         if drafts.count > Self.composerDraftLimit {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStoring.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStoring.swift
@@ -33,8 +33,21 @@ public protocol MobileTaskTemplateStoring: AnyObject {
     /// Inserts or replaces one draft by its stable id and promotes it to the
     /// front of the collection.
     func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft)
-    /// Deletes the drafts with the provided ids in one persistence update.
+    /// Deletes the drafts with the provided ids in one persistence update,
+    /// including any preserved attachment files they own.
     func deleteComposerDrafts(ids: Set<UUID>)
+    /// Copies staged attachment bytes into draft-owned storage and returns
+    /// the stable relative path, reusing an existing copy of the same
+    /// attachment instead of copying again.
+    func persistComposerAttachmentFile(
+        draftID: UUID,
+        attachmentID: UUID,
+        preferredExtension: String,
+        from sourceURL: URL
+    ) throws -> String
+    /// Returns the location of preserved attachment bytes, or `nil` when the
+    /// path is invalid or the file no longer exists.
+    func composerAttachmentFileURL(relativePath: String) -> URL?
     /// Removes all templates and composer state owned by the signed-out user.
     func clearAllUserData()
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStoring.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTaskTemplateStoring.swift
@@ -28,10 +28,13 @@ public protocol MobileTaskTemplateStoring: AnyObject {
     func recentDirectories(macDeviceID: String) -> [MobileTaskRecentDirectory]
     /// Promotes one successful directory in the per-Mac history.
     func recordRecentDirectory(_ directory: String, macDeviceID: String, at date: Date)
-    /// Returns the unsent task-composer draft, if one was saved.
-    func composerDraft() -> MobileTaskComposerDraft?
-    /// Stores or clears the unsent task-composer draft.
-    func setComposerDraft(_ draft: MobileTaskComposerDraft?)
+    /// Returns every unsent task-composer draft, newest first.
+    func composerDrafts() -> [MobileTaskComposerSavedDraft]
+    /// Inserts or replaces one draft by its stable id and promotes it to the
+    /// front of the collection.
+    func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft)
+    /// Deletes the drafts with the provided ids in one persistence update.
+    func deleteComposerDrafts(ids: Set<UUID>)
     /// Removes all templates and composer state owned by the signed-out user.
     func clearAllUserData()
 }
@@ -40,5 +43,10 @@ public extension MobileTaskTemplateStoring {
     /// Deletes one template.
     func deleteTemplate(id: MobileTaskTemplate.ID) {
         deleteTemplates(ids: [id])
+    }
+
+    /// Returns the saved draft with this id, if it still exists.
+    func composerDraft(id: UUID) -> MobileTaskComposerSavedDraft? {
+        composerDrafts().first { $0.id == id }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
@@ -249,44 +249,154 @@ import CmuxMobileShellModel
         #expect(reloaded.recentDirectories(macDeviceID: "mac-b").map(\.path) == ["~/other"])
     }
 
-    @Test func composerDraftRoundTripsAcrossStoreInstancesAndClears() {
+    @Test func composerDraftsRoundTripNewestFirstAcrossStoreInstances() {
         let defaults = Self.defaults()
         let store = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
         let operationID = UUID()
-        let draft = MobileTaskComposerDraft(
-            prompt: "Fix the reconnect flow\nthen test it",
+        let older = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 100),
+            content: MobileTaskComposerDraft(
+                prompt: "Fix the reconnect flow\nthen test it",
+                templateID: UUID(),
+                macDeviceID: "mac-a",
+                directory: "~/Dev/cmux",
+                didEditDirectory: true,
+                operationID: operationID
+            )
+        )
+        let newer = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 200),
+            content: MobileTaskComposerDraft(
+                prompt: "Ship drafts",
+                templateID: nil,
+                macDeviceID: "mac-b",
+                directory: "~/Dev/other",
+                didEditDirectory: false
+            )
+        )
+
+        store.saveComposerDraft(older)
+        store.saveComposerDraft(newer)
+
+        let reloaded = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        #expect(reloaded.composerDrafts() == [newer, older])
+        #expect(reloaded.composerDraft(id: older.id)?.content.operationID == operationID)
+
+        reloaded.deleteComposerDrafts(ids: [newer.id])
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts() == [older])
+
+        reloaded.deleteComposerDrafts(ids: [older.id])
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts().isEmpty)
+    }
+
+    @Test func savingAnExistingDraftIDReplacesItsEntryAndPromotesIt() {
+        let defaults = Self.defaults()
+        let store = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        let sessionID = UUID()
+        let first = MobileTaskComposerSavedDraft(
+            id: sessionID,
+            updatedAt: Date(timeIntervalSince1970: 100),
+            content: Self.draftContent(prompt: "First pass")
+        )
+        let other = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 150),
+            content: Self.draftContent(prompt: "Other task")
+        )
+        let revised = MobileTaskComposerSavedDraft(
+            id: sessionID,
+            updatedAt: Date(timeIntervalSince1970: 200),
+            content: Self.draftContent(prompt: "Revised pass")
+        )
+
+        store.saveComposerDraft(first)
+        store.saveComposerDraft(other)
+        store.saveComposerDraft(revised)
+
+        let drafts = store.composerDrafts()
+        #expect(drafts == [revised, other])
+        #expect(drafts.first?.content.prompt == "Revised pass")
+    }
+
+    @Test func composerDraftStorageIsBounded() {
+        let defaults = Self.defaults()
+        let store = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+
+        for index in 0..<25 {
+            store.saveComposerDraft(MobileTaskComposerSavedDraft(
+                updatedAt: Date(timeIntervalSince1970: Double(index)),
+                content: Self.draftContent(prompt: "Task \(index)")
+            ))
+        }
+
+        let drafts = UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts()
+        #expect(drafts.count == 20)
+        #expect(drafts.first?.content.prompt == "Task 24")
+        #expect(drafts.last?.content.prompt == "Task 5")
+    }
+
+    @Test func legacySingleSlotDraftMigratesIntoCollectionOnce() throws {
+        let defaults = Self.defaults()
+        let legacy = MobileTaskComposerDraft(
+            prompt: "Prepared on an older build",
             templateID: UUID(),
             macDeviceID: "mac-a",
             directory: "~/Dev/cmux",
             didEditDirectory: true,
-            operationID: operationID
+            operationID: UUID()
+        )
+        defaults.set(
+            try JSONEncoder().encode(legacy),
+            forKey: "cmux.mobile.taskComposer.draft.v1"
         )
 
-        store.setComposerDraft(draft)
+        let store = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        let migrated = store.composerDrafts()
+        #expect(migrated.map(\.content) == [legacy])
+        #expect(defaults.data(forKey: "cmux.mobile.taskComposer.draft.v1") == nil)
 
-        let reloaded = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
-        #expect(reloaded.composerDraft() == draft)
-        #expect(reloaded.composerDraft()?.operationID == operationID)
-
-        reloaded.setComposerDraft(nil)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == nil)
+        // A second read must not duplicate the adopted draft.
+        #expect(store.composerDrafts() == migrated)
+        store.deleteComposerDrafts(ids: [try #require(migrated.first).id])
+        #expect(store.composerDrafts().isEmpty)
     }
 
-    @Test func signOutClearsPersistedComposerDraftBeforeAnotherAccountCanRestoreIt() {
+    @Test func legacyEmptyDraftIsDroppedInsteadOfMigrated() throws {
+        let defaults = Self.defaults()
+        let legacy = MobileTaskComposerDraft(
+            prompt: "   ",
+            templateID: UUID(),
+            macDeviceID: "mac-a",
+            directory: "~/Dev/cmux",
+            didEditDirectory: true
+        )
+        defaults.set(
+            try JSONEncoder().encode(legacy),
+            forKey: "cmux.mobile.taskComposer.draft.v1"
+        )
+
+        let store = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        #expect(store.composerDrafts().isEmpty)
+        #expect(defaults.data(forKey: "cmux.mobile.taskComposer.draft.v1") == nil)
+    }
+
+    @Test func signOutClearsPersistedComposerDraftsBeforeAnotherAccountCanRestoreThem() {
         let defaults = Self.defaults()
         let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
-        templateStore.setComposerDraft(MobileTaskComposerDraft(
-            prompt: "Account A secret",
-            templateID: nil,
-            macDeviceID: "mac-a",
-            directory: "~/Account-A",
-            didEditDirectory: true
+        templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account A secret",
+                templateID: nil,
+                macDeviceID: "mac-a",
+                directory: "~/Account-A",
+                didEditDirectory: true
+            )
         ))
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
 
         shell.signOut()
 
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == nil)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts().isEmpty)
     }
 
     @Test func signOutClearsAllTemplateDataAndNextListReseedsSafeDefaults() throws {
@@ -303,12 +413,15 @@ import CmuxMobileShellModel
         templateStore.setLastMacDeviceID("account-a-mac")
         templateStore.setLastDirectory("/Users/account-a/project", macDeviceID: "account-a-mac")
         templateStore.setLastDirectory("/tmp/account-a", macDeviceID: "other-mac")
-        templateStore.setComposerDraft(MobileTaskComposerDraft(
-            prompt: "Account A secret",
-            templateID: custom.id,
-            macDeviceID: "account-a-mac",
-            directory: "/Users/account-a/project",
-            didEditDirectory: true
+        templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account A secret",
+                templateID: custom.id,
+                macDeviceID: "account-a-mac",
+                directory: "/Users/account-a/project",
+                didEditDirectory: true
+            )
         ))
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
 
@@ -319,7 +432,7 @@ import CmuxMobileShellModel
         #expect(reloaded.lastMacDeviceID() == nil)
         #expect(reloaded.lastDirectory(macDeviceID: "account-a-mac") == nil)
         #expect(reloaded.lastDirectory(macDeviceID: "other-mac") == nil)
-        #expect(reloaded.composerDraft() == nil)
+        #expect(reloaded.composerDrafts().isEmpty)
         let seeds = reloaded.listTemplates()
         #expect(seeds.map(\.command) == [
             "claude -- \"$CMUX_TASK_PROMPT\"",
@@ -349,11 +462,12 @@ import CmuxMobileShellModel
         shell.signOut()
         let didPersist = shell.persistTaskComposerDraft(
             staleDraft,
+            draftID: UUID(),
             ifSessionGeneration: capturedGeneration
         )
 
         #expect(!didPersist)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == nil)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts().isEmpty)
     }
 
     @Test func staleComposerSheetCannotClearNewSessionDraft() {
@@ -369,78 +483,94 @@ import CmuxMobileShellModel
             didEditDirectory: true,
             operationID: UUID()
         )
-        let currentDraft = MobileTaskComposerDraft(
-            prompt: "Account B task",
-            templateID: nil,
-            macDeviceID: "mac-b",
-            directory: "~/Account-B",
-            didEditDirectory: true,
-            operationID: UUID()
+        let currentDraft = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account B task",
+                templateID: nil,
+                macDeviceID: "mac-b",
+                directory: "~/Account-B",
+                didEditDirectory: true,
+                operationID: UUID()
+            )
         )
 
         shell.signOut()
         shell.signIn()
-        templateStore.setComposerDraft(currentDraft)
+        templateStore.saveComposerDraft(currentDraft)
         let didPersist = shell.persistTaskComposerDraft(
             staleDraft,
+            draftID: UUID(),
             ifSessionGeneration: staleGeneration
         )
 
         #expect(!didPersist)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == currentDraft)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts() == [currentDraft])
     }
 
-    @Test func staleCancelClearCannotEraseNewSessionDraft() {
+    @Test func staleCancelDeleteCannotEraseNewSessionDraft() {
         let defaults = Self.defaults()
         let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
         let staleGeneration = shell.currentSessionGeneration
-        let currentDraft = MobileTaskComposerDraft(
-            prompt: "Account B task",
-            templateID: nil,
-            macDeviceID: "mac-b",
-            directory: "~/Account-B",
-            didEditDirectory: true,
-            operationID: UUID()
+        let currentDraft = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account B task",
+                templateID: nil,
+                macDeviceID: "mac-b",
+                directory: "~/Account-B",
+                didEditDirectory: true,
+                operationID: UUID()
+            )
         )
 
         shell.signOut()
         shell.signIn()
-        templateStore.setComposerDraft(currentDraft)
-        let didClear = shell.clearTaskComposerDraft(ifSessionGeneration: staleGeneration)
+        templateStore.saveComposerDraft(currentDraft)
+        let didDelete = shell.deleteTaskComposerDrafts(
+            ids: [currentDraft.id],
+            ifSessionGeneration: staleGeneration
+        )
 
-        #expect(!didClear)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == currentDraft)
+        #expect(!didDelete)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts() == [currentDraft])
     }
 
-    @Test func staleAsyncSuccessClearCannotEraseNewSessionDraft() async {
+    @Test func staleAsyncSuccessDeleteCannotEraseNewSessionDraft() async {
         let defaults = Self.defaults()
         let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
         let staleGeneration = shell.currentSessionGeneration
-        let currentDraft = MobileTaskComposerDraft(
-            prompt: "Account B task",
-            templateID: nil,
-            macDeviceID: "mac-b",
-            directory: "~/Account-B",
-            didEditDirectory: true,
-            operationID: UUID()
+        let currentDraft = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account B task",
+                templateID: nil,
+                macDeviceID: "mac-b",
+                directory: "~/Account-B",
+                didEditDirectory: true,
+                operationID: UUID()
+            )
         )
         let completion = AsyncStream<Void>.makeStream()
-        let clearAfterSuccess = Task { @MainActor in
+        let deleteAfterSuccess = Task { @MainActor in
             for await _ in completion.stream { break }
-            return shell.clearTaskComposerDraft(ifSessionGeneration: staleGeneration)
+            return shell.deleteTaskComposerDrafts(
+                ids: [currentDraft.id],
+                ifSessionGeneration: staleGeneration
+            )
         }
 
         shell.signOut()
         shell.signIn()
-        templateStore.setComposerDraft(currentDraft)
+        templateStore.saveComposerDraft(currentDraft)
         completion.continuation.yield()
         completion.continuation.finish()
-        let didClear = await clearAfterSuccess.value
+        let didDelete = await deleteAfterSuccess.value
 
-        #expect(!didClear)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == currentDraft)
+        #expect(!didDelete)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts() == [currentDraft])
     }
 
     @Test func staleComposerSuccessCannotOverwriteNextSessionDefaults() {
@@ -469,22 +599,26 @@ import CmuxMobileShellModel
             icon: "terminal",
             command: "agent-b"
         )
-        let accountBDraft = MobileTaskComposerDraft(
-            prompt: "Account B task",
-            templateID: accountBTemplate.id,
-            macDeviceID: "mac-b",
-            directory: "/Users/account-b/current",
-            didEditDirectory: true,
-            operationID: UUID()
+        let accountBDraft = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: MobileTaskComposerDraft(
+                prompt: "Account B task",
+                templateID: accountBTemplate.id,
+                macDeviceID: "mac-b",
+                directory: "/Users/account-b/current",
+                didEditDirectory: true,
+                operationID: UUID()
+            )
         )
         templateStore.addTemplate(accountBTemplate)
         templateStore.setLastTemplateID(accountBTemplate.id)
         templateStore.setLastMacDeviceID("mac-b")
         templateStore.setLastDirectory("/Users/account-b/current", macDeviceID: "mac-b")
-        templateStore.setComposerDraft(accountBDraft)
+        templateStore.saveComposerDraft(accountBDraft)
 
         let didComplete = shell.completeTaskComposerSubmission(
             staleSnapshot,
+            draftID: accountBDraft.id,
             ifSessionGeneration: staleGeneration
         )
 
@@ -494,10 +628,10 @@ import CmuxMobileShellModel
         #expect(reloaded.lastMacDeviceID() == "mac-b")
         #expect(reloaded.lastDirectory(macDeviceID: "mac-a") == nil)
         #expect(reloaded.lastDirectory(macDeviceID: "mac-b") == "/Users/account-b/current")
-        #expect(reloaded.composerDraft() == accountBDraft)
+        #expect(reloaded.composerDrafts() == [accountBDraft])
     }
 
-    @Test func currentComposerSuccessPersistsDefaultsAndClearsDraftTogether() {
+    @Test func currentComposerSuccessPersistsDefaultsAndDeletesOnlyItsDraft() {
         let defaults = Self.defaults()
         let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
@@ -510,10 +644,20 @@ import CmuxMobileShellModel
             didEditDirectory: true,
             operationID: UUID()
         )
-        templateStore.setComposerDraft(snapshot.draft)
+        let submitted = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: snapshot.draft
+        )
+        let parked = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 100),
+            content: Self.draftContent(prompt: "Task prepared earlier")
+        )
+        templateStore.saveComposerDraft(parked)
+        templateStore.saveComposerDraft(submitted)
 
         let didComplete = shell.completeTaskComposerSubmission(
             snapshot,
+            draftID: submitted.id,
             ifSessionGeneration: shell.currentSessionGeneration
         )
 
@@ -522,28 +666,81 @@ import CmuxMobileShellModel
         #expect(reloaded.lastTemplateID() == template.id)
         #expect(reloaded.lastMacDeviceID() == "mac-current")
         #expect(reloaded.lastDirectory(macDeviceID: "mac-current") == "~/current")
-        #expect(reloaded.composerDraft() == nil)
+        #expect(reloaded.composerDrafts() == [parked])
     }
 
-    @Test func currentSessionClearRemovesComposerDraft() {
+    @Test func currentSessionDeleteRemovesOnlyRequestedDrafts() {
         let defaults = Self.defaults()
         let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
         let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
-        templateStore.setComposerDraft(MobileTaskComposerDraft(
-            prompt: "Current task",
-            templateID: nil,
-            macDeviceID: "mac-a",
-            directory: "~/Current",
-            didEditDirectory: true,
-            operationID: UUID()
-        ))
+        let cancelled = MobileTaskComposerSavedDraft(
+            updatedAt: Date(),
+            content: Self.draftContent(prompt: "Cancelled task")
+        )
+        let kept = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 100),
+            content: Self.draftContent(prompt: "Kept task")
+        )
+        templateStore.saveComposerDraft(kept)
+        templateStore.saveComposerDraft(cancelled)
 
-        let didClear = shell.clearTaskComposerDraft(
+        let didDelete = shell.deleteTaskComposerDrafts(
+            ids: [cancelled.id],
             ifSessionGeneration: shell.currentSessionGeneration
         )
 
-        #expect(didClear)
-        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDraft() == nil)
+        #expect(didDelete)
+        #expect(UserDefaultsMobileTaskTemplateStore(defaults: defaults).composerDrafts() == [kept])
+    }
+
+    @Test func persistingAnEffectivelyEmptyDraftDeletesItsSavedEntry() {
+        let defaults = Self.defaults()
+        let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
+        let draftID = UUID()
+
+        let didPersist = shell.persistTaskComposerDraft(
+            Self.draftContent(prompt: "Prepared task"),
+            draftID: draftID,
+            ifSessionGeneration: shell.currentSessionGeneration
+        )
+        #expect(didPersist)
+        #expect(templateStore.composerDrafts().count == 1)
+
+        let didPersistEmptied = shell.persistTaskComposerDraft(
+            Self.draftContent(prompt: "  \n "),
+            draftID: draftID,
+            ifSessionGeneration: shell.currentSessionGeneration
+        )
+        #expect(didPersistEmptied)
+        #expect(templateStore.composerDrafts().isEmpty)
+    }
+
+    @Test func emptyDraftWithCompletedOperationAnchorIsStillPersisted() {
+        let defaults = Self.defaults()
+        let templateStore = UserDefaultsMobileTaskTemplateStore(defaults: defaults)
+        let shell = MobileShellComposite(isSignedIn: true, taskTemplateStore: templateStore)
+        var content = Self.draftContent(prompt: "")
+        content.completedOperationID = UUID()
+
+        let didPersist = shell.persistTaskComposerDraft(
+            content,
+            draftID: UUID(),
+            ifSessionGeneration: shell.currentSessionGeneration
+        )
+
+        #expect(didPersist)
+        #expect(templateStore.composerDrafts().map(\.content) == [content])
+    }
+
+    private static func draftContent(prompt: String) -> MobileTaskComposerDraft {
+        MobileTaskComposerDraft(
+            prompt: prompt,
+            templateID: nil,
+            macDeviceID: "mac-a",
+            directory: "~/Dev/cmux",
+            didEditDirectory: false
+        )
     }
 
     private static func defaults() -> UserDefaults {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
@@ -733,6 +733,91 @@ import CmuxMobileShellModel
         #expect(templateStore.composerDrafts().map(\.content) == [content])
     }
 
+    @Test func draftAttachmentFilesPersistRestoreAndDeleteWithTheirDraft() throws {
+        let root = Self.attachmentsRoot()
+        let store = UserDefaultsMobileTaskTemplateStore(
+            defaults: Self.defaults(),
+            attachmentFilesRootDirectory: root
+        )
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("draft-attachment-source-\(UUID().uuidString).txt")
+        try Data("attached bytes".utf8).write(to: source)
+        defer { try? FileManager.default.removeItem(at: source) }
+        let draftID = UUID()
+        let attachmentID = UUID()
+
+        let relativePath = try store.persistComposerAttachmentFile(
+            draftID: draftID,
+            attachmentID: attachmentID,
+            preferredExtension: "TXT",
+            from: source
+        )
+
+        let preserved = try #require(store.composerAttachmentFileURL(relativePath: relativePath))
+        #expect(try Data(contentsOf: preserved) == Data("attached bytes".utf8))
+        // Persisting the same attachment again reuses the existing copy.
+        #expect(try store.persistComposerAttachmentFile(
+            draftID: draftID,
+            attachmentID: attachmentID,
+            preferredExtension: "TXT",
+            from: source
+        ) == relativePath)
+        // Paths cannot escape the attachment root.
+        #expect(store.composerAttachmentFileURL(relativePath: "../\(relativePath)") == nil)
+
+        var content = Self.draftContent(prompt: "With attachment")
+        content.attachments = [MobileTaskComposerDraftAttachment(
+            id: attachmentID,
+            kind: "file",
+            displayName: "notes.txt",
+            relativePath: relativePath,
+            byteCount: 14
+        )]
+        store.saveComposerDraft(MobileTaskComposerSavedDraft(
+            id: draftID,
+            updatedAt: Date(),
+            content: content
+        ))
+
+        store.deleteComposerDrafts(ids: [draftID])
+        #expect(store.composerDrafts().isEmpty)
+        #expect(store.composerAttachmentFileURL(relativePath: relativePath) == nil)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    @Test func clearAllUserDataRemovesPreservedAttachmentFiles() throws {
+        let root = Self.attachmentsRoot()
+        let defaults = Self.defaults()
+        let store = UserDefaultsMobileTaskTemplateStore(
+            defaults: defaults,
+            attachmentFilesRootDirectory: root
+        )
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("draft-attachment-source-\(UUID().uuidString).png")
+        try Data([9, 9, 9]).write(to: source)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let relativePath = try store.persistComposerAttachmentFile(
+            draftID: UUID(),
+            attachmentID: UUID(),
+            preferredExtension: "png",
+            from: source
+        )
+        #expect(store.composerAttachmentFileURL(relativePath: relativePath) != nil)
+
+        store.clearAllUserData()
+
+        #expect(store.composerAttachmentFileURL(relativePath: relativePath) == nil)
+        #expect(!FileManager.default.fileExists(atPath: root.path))
+    }
+
+    private static func attachmentsRoot() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(
+            "MobileTaskTemplateStoreTests-attachments-\(UUID().uuidString)",
+            isDirectory: true
+        )
+    }
+
     private static func draftContent(prompt: String) -> MobileTaskComposerDraft {
         MobileTaskComposerDraft(
             prompt: prompt,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskTemplateStoreTests.swift
@@ -785,6 +785,50 @@ import CmuxMobileShellModel
         try? FileManager.default.removeItem(at: root)
     }
 
+    @Test func resavingADraftWithoutAnAttachmentDeletesItsPreservedFile() throws {
+        let root = Self.attachmentsRoot()
+        let store = UserDefaultsMobileTaskTemplateStore(
+            defaults: Self.defaults(),
+            attachmentFilesRootDirectory: root
+        )
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("draft-attachment-source-\(UUID().uuidString).txt")
+        try Data("removable".utf8).write(to: source)
+        defer { try? FileManager.default.removeItem(at: source) }
+        let draftID = UUID()
+        let relativePath = try store.persistComposerAttachmentFile(
+            draftID: draftID,
+            attachmentID: UUID(),
+            preferredExtension: "txt",
+            from: source
+        )
+        var content = Self.draftContent(prompt: "With attachment")
+        content.attachments = [MobileTaskComposerDraftAttachment(
+            id: UUID(),
+            kind: "file",
+            displayName: "notes.txt",
+            relativePath: relativePath,
+            byteCount: 9
+        )]
+        store.saveComposerDraft(MobileTaskComposerSavedDraft(
+            id: draftID,
+            updatedAt: Date(),
+            content: content
+        ))
+        #expect(store.composerAttachmentFileURL(relativePath: relativePath) != nil)
+
+        content.attachments = []
+        store.saveComposerDraft(MobileTaskComposerSavedDraft(
+            id: draftID,
+            updatedAt: Date(),
+            content: content
+        ))
+
+        #expect(store.composerAttachmentFileURL(relativePath: relativePath) == nil)
+        #expect(store.composerDrafts().count == 1)
+        try? FileManager.default.removeItem(at: root)
+    }
+
     @Test func clearAllUserDataRemovesPreservedAttachmentFiles() throws {
         let root = Self.attachmentsRoot()
         let defaults = Self.defaults()

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraft.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraft.swift
@@ -30,6 +30,9 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
     /// Accepted identity awaiting an explicit refresh before this draft may be
     /// started with a fresh operation ID.
     public var completedOperationID: UUID?
+    /// Attachments preserved with this draft. Missing keys decode as empty so
+    /// drafts written by older builds remain valid.
+    public var attachments: [MobileTaskComposerDraftAttachment]
 
     /// Creates a restorable composer draft.
     public init(
@@ -44,7 +47,8 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
         workspaceName: String? = nil,
         workspaceGroupID: MobileWorkspaceGroupPreview.ID? = nil,
         operationID: UUID? = nil,
-        completedOperationID: UUID? = nil
+        completedOperationID: UUID? = nil,
+        attachments: [MobileTaskComposerDraftAttachment] = []
     ) {
         let identity: CmxMacAppInstanceIdentity?
         if let macDeviceID {
@@ -67,6 +71,30 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
         self.workspaceGroupID = workspaceGroupID
         self.operationID = operationID
         self.completedOperationID = completedOperationID
+        self.attachments = attachments
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        prompt = try container.decode(String.self, forKey: .prompt)
+        modelID = try container.decodeIfPresent(String.self, forKey: .modelID)
+        effortID = try container.decodeIfPresent(String.self, forKey: .effortID)
+        templateID = try container.decodeIfPresent(MobileTaskTemplate.ID.self, forKey: .templateID)
+        macDeviceID = try container.decodeIfPresent(String.self, forKey: .macDeviceID)
+        macInstanceTag = try container.decodeIfPresent(String.self, forKey: .macInstanceTag)
+        directory = try container.decode(String.self, forKey: .directory)
+        didEditDirectory = try container.decode(Bool.self, forKey: .didEditDirectory)
+        workspaceName = try container.decodeIfPresent(String.self, forKey: .workspaceName)
+        workspaceGroupID = try container.decodeIfPresent(
+            MobileWorkspaceGroupPreview.ID.self,
+            forKey: .workspaceGroupID
+        )
+        operationID = try container.decodeIfPresent(UUID.self, forKey: .operationID)
+        completedOperationID = try container.decodeIfPresent(UUID.self, forKey: .completedOperationID)
+        attachments = try container.decodeIfPresent(
+            [MobileTaskComposerDraftAttachment].self,
+            forKey: .attachments
+        ) ?? []
     }
 
     /// Selects a template and adopts its suggested directory until the user

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraftAttachment.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraftAttachment.swift
@@ -1,0 +1,68 @@
+public import Foundation
+
+/// One attachment preserved with a saved composer draft. The raw bytes live
+/// in a draft-owned file referenced by `relativePath`; resuming the draft
+/// stages a fresh session copy so session teardown never touches the
+/// draft-owned bytes.
+public struct MobileTaskComposerDraftAttachment: Codable, Equatable, Sendable, Identifiable {
+    /// Stable upload identity, shared with the live composer attachment.
+    public let id: UUID
+    /// Raw attachment kind; mirrors ``TaskComposerAttachment/Kind``.
+    public let kind: String
+    /// User-visible file name.
+    public let displayName: String
+    /// Path of the preserved bytes relative to the drafts attachment root.
+    public let relativePath: String
+    /// Exact raw byte count of the preserved file.
+    public let byteCount: Int
+    /// Small encoded image preview, or `nil` for files.
+    public let thumbnailData: Data?
+
+    /// Creates one preserved draft attachment.
+    public init(
+        id: UUID,
+        kind: String,
+        displayName: String,
+        relativePath: String,
+        byteCount: Int,
+        thumbnailData: Data? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.displayName = displayName
+        self.relativePath = relativePath
+        self.byteCount = byteCount
+        self.thumbnailData = thumbnailData
+    }
+}
+
+extension TaskComposerAttachment.Kind {
+    /// Stable persisted spelling of this kind.
+    public var persistedValue: String {
+        switch self {
+        case .image: "image"
+        case .file: "file"
+        }
+    }
+
+    /// Restores a kind from its persisted spelling; unknown values decode as
+    /// `.file` so a newer build's draft still restores as a plain document.
+    public init(persistedValue: String) {
+        self = persistedValue == "image" ? .image : .file
+    }
+}
+
+extension TaskComposerAttachment {
+    /// The preserved representation of this staged attachment.
+    /// - Parameter relativePath: Draft-owned file path for the copied bytes.
+    public func draftAttachment(relativePath: String) -> MobileTaskComposerDraftAttachment {
+        MobileTaskComposerDraftAttachment(
+            id: id,
+            kind: kind.persistedValue,
+            displayName: displayName,
+            relativePath: relativePath,
+            byteCount: byteCount,
+            thumbnailData: thumbnailData
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerSavedDraft.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerSavedDraft.swift
@@ -23,11 +23,13 @@ public struct MobileTaskComposerSavedDraft: Codable, Equatable, Sendable, Identi
 extension MobileTaskComposerDraft {
     /// Whether persisting this draft would keep nothing the user prepared.
     /// Selections alone (template, Mac, directory) are re-derived from
-    /// last-used defaults, but a completed-operation anchor must survive so
-    /// recovery can still prevent a duplicate task.
+    /// last-used defaults, but attachments are prepared work and a
+    /// completed-operation anchor must survive so recovery can still prevent
+    /// a duplicate task.
     public var isEffectivelyEmpty: Bool {
         prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && (workspaceName ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && attachments.isEmpty
             && completedOperationID == nil
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerSavedDraft.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerSavedDraft.swift
@@ -1,0 +1,33 @@
+public import Foundation
+
+/// One durable entry in the task-composer drafts collection. The identity is
+/// owned by the composer session that created the draft, so every leave,
+/// retry, and submit of that session updates or removes the same entry
+/// without touching other saved drafts.
+public struct MobileTaskComposerSavedDraft: Codable, Equatable, Sendable, Identifiable {
+    /// Stable identity of this draft across saves, restores, and deletion.
+    public let id: UUID
+    /// Moment the draft content was last persisted.
+    public var updatedAt: Date
+    /// The restorable composer state exactly as last saved.
+    public var content: MobileTaskComposerDraft
+
+    /// Creates a saved draft entry.
+    public init(id: UUID = UUID(), updatedAt: Date, content: MobileTaskComposerDraft) {
+        self.id = id
+        self.updatedAt = updatedAt
+        self.content = content
+    }
+}
+
+extension MobileTaskComposerDraft {
+    /// Whether persisting this draft would keep nothing the user prepared.
+    /// Selections alone (template, Mac, directory) are re-derived from
+    /// last-used defaults, but a completed-operation anchor must survive so
+    /// recovery can still prevent a duplicate task.
+    public var isEffectivelyEmpty: Bool {
+        prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (workspaceName ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && completedOperationID == nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskComposerSavedDraftTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskComposerSavedDraftTests.swift
@@ -1,0 +1,70 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+
+struct MobileTaskComposerSavedDraftTests {
+    @Test func savedDraftRoundTripsThroughCodable() throws {
+        let draft = MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: 1_755_000_000),
+            content: MobileTaskComposerDraft(
+                prompt: "Build the drafts feature\nwith tests",
+                modelID: "model-1",
+                effortID: "high",
+                templateID: UUID(),
+                macDeviceID: "mac-a",
+                macInstanceTag: "drft",
+                directory: "~/Dev/cmux",
+                didEditDirectory: true,
+                workspaceName: "Drafts",
+                operationID: UUID(),
+                completedOperationID: UUID()
+            )
+        )
+
+        let data = try JSONEncoder().encode(draft)
+        let decoded = try JSONDecoder().decode(MobileTaskComposerSavedDraft.self, from: data)
+
+        #expect(decoded == draft)
+        #expect(decoded.id == draft.id)
+        #expect(decoded.content.completedOperationID == draft.content.completedOperationID)
+    }
+
+    @Test func whitespaceOnlyPromptAndNameIsEffectivelyEmpty() {
+        var draft = MobileTaskComposerDraft(
+            prompt: " \n\t ",
+            templateID: UUID(),
+            macDeviceID: "mac-a",
+            directory: "~/Dev/cmux",
+            didEditDirectory: true,
+            workspaceName: "  "
+        )
+        #expect(draft.isEffectivelyEmpty)
+
+        draft.prompt = "Fix the bug"
+        #expect(!draft.isEffectivelyEmpty)
+    }
+
+    @Test func workspaceNameAloneKeepsADraft() {
+        let draft = MobileTaskComposerDraft(
+            prompt: "",
+            templateID: nil,
+            macDeviceID: nil,
+            directory: "~",
+            didEditDirectory: false,
+            workspaceName: "Prepared workspace"
+        )
+        #expect(!draft.isEffectivelyEmpty)
+    }
+
+    @Test func completedOperationAnchorKeepsAnOtherwiseEmptyDraft() {
+        let draft = MobileTaskComposerDraft(
+            prompt: "",
+            templateID: nil,
+            macDeviceID: nil,
+            directory: "~",
+            didEditDirectory: false,
+            completedOperationID: UUID()
+        )
+        #expect(!draft.isEffectivelyEmpty)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskComposerSavedDraftTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskComposerSavedDraftTests.swift
@@ -67,4 +67,65 @@ struct MobileTaskComposerSavedDraftTests {
         )
         #expect(!draft.isEffectivelyEmpty)
     }
+
+    @Test func attachmentsAloneKeepADraft() {
+        let draft = MobileTaskComposerDraft(
+            prompt: "",
+            templateID: nil,
+            macDeviceID: nil,
+            directory: "~",
+            didEditDirectory: false,
+            attachments: [MobileTaskComposerDraftAttachment(
+                id: UUID(),
+                kind: "image",
+                displayName: "screenshot.png",
+                relativePath: "d/a.png",
+                byteCount: 42
+            )]
+        )
+        #expect(!draft.isEffectivelyEmpty)
+    }
+
+    @Test func legacyDraftJSONWithoutAttachmentsDecodesAsEmpty() throws {
+        let legacyJSON = """
+        {"prompt":"Old build draft","directory":"~","didEditDirectory":true}
+        """
+        let decoded = try JSONDecoder().decode(
+            MobileTaskComposerDraft.self,
+            from: Data(legacyJSON.utf8)
+        )
+        #expect(decoded.attachments.isEmpty)
+        #expect(decoded.prompt == "Old build draft")
+        #expect(decoded.didEditDirectory)
+    }
+
+    @Test func draftAttachmentsRoundTripThroughCodable() throws {
+        let attachment = MobileTaskComposerDraftAttachment(
+            id: UUID(),
+            kind: TaskComposerAttachment.Kind.image.persistedValue,
+            displayName: "IMG_0001.heic",
+            relativePath: "draft-id/attachment-id.heic",
+            byteCount: 1_234,
+            thumbnailData: Data([1, 2, 3])
+        )
+        let draft = MobileTaskComposerDraft(
+            prompt: "With attachment",
+            templateID: nil,
+            macDeviceID: nil,
+            directory: "~",
+            didEditDirectory: false,
+            attachments: [attachment]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            MobileTaskComposerDraft.self,
+            from: JSONEncoder().encode(draft)
+        )
+
+        #expect(decoded == draft)
+        #expect(decoded.attachments == [attachment])
+        #expect(TaskComposerAttachment.Kind(persistedValue: decoded.attachments[0].kind) == .image)
+        #expect(TaskComposerAttachment.Kind(persistedValue: "file") == .file)
+        #expect(TaskComposerAttachment.Kind(persistedValue: "unknown-future-kind") == .file)
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
@@ -28,6 +28,8 @@ public struct TaskComposerAccessibilityPreviewView: View {
     private let holdsSubmissionInPreparation: Bool
     private let advertisesTaskAttachments: Bool
     private let startsWithStagedAttachments: Bool
+    /// Drafts never auto-load, so seeded-draft previews resume explicitly.
+    private let seededDraftID: UUID?
     @State private var directoryPaginationRecoveryPreview: TaskComposerDirectoryPaginationRecoveryPreview?
 
     /// Creates the preview with isolated, in-memory task state so repeated UI
@@ -59,8 +61,11 @@ public struct TaskComposerAccessibilityPreviewView: View {
             "CMUX_UITEST_TASK_COMPOSER_OPEN_DIRECTORY_PREVIEW"
         ] == "1"
         let templateStore = TaskComposerAccessibilityTemplateStore()
+        // Drafts load only when explicitly resumed, so seeded-draft previews
+        // remember the seeded id and launch the composer with .resume(id).
+        var seededDraftID: UUID?
         if environment["CMUX_UITEST_TASK_COMPOSER_LONG_PROMPT"] == "1" {
-            templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+            let seeded = MobileTaskComposerSavedDraft(
                 updatedAt: Date(),
                 content: MobileTaskComposerDraft(
                     prompt: Self.longPrompt,
@@ -70,10 +75,12 @@ public struct TaskComposerAccessibilityPreviewView: View {
                     directory: "~",
                     didEditDirectory: false
                 )
-            ))
+            )
+            templateStore.saveComposerDraft(seeded)
+            seededDraftID = seeded.id
         }
         if environment["CMUX_UITEST_TASK_COMPOSER_RESTORED_MODEL_DRAFT"] == "1" {
-            templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+            let seeded = MobileTaskComposerSavedDraft(
                 updatedAt: Date(),
                 content: MobileTaskComposerDraft(
                     prompt: "Retry the persisted model",
@@ -85,8 +92,11 @@ public struct TaskComposerAccessibilityPreviewView: View {
                     didEditDirectory: false,
                     operationID: UUID(uuidString: "0D9A7F2E-0B69-49C7-A725-F6F72517C584")
                 )
-            ))
+            )
+            templateStore.saveComposerDraft(seeded)
+            seededDraftID = seeded.id
         }
+        self.seededDraftID = seededDraftID
         if presentsOpenDirectory {
             templateStore.setLastDirectory(
                 "/Users/ui/previous-task",
@@ -179,7 +189,8 @@ public struct TaskComposerAccessibilityPreviewView: View {
                 } else {
                     TaskComposerSheet(
                         store: store,
-                        launchIntent: launch.intent,
+                        launchIntent: seededDraftID.map(TaskComposerLaunchIntent.resume)
+                            ?? launch.intent,
                         onSwitchDraft: switchDraft,
                         availableMachines: [
                             Self.previewMac,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
@@ -60,25 +60,31 @@ public struct TaskComposerAccessibilityPreviewView: View {
         ] == "1"
         let templateStore = TaskComposerAccessibilityTemplateStore()
         if environment["CMUX_UITEST_TASK_COMPOSER_LONG_PROMPT"] == "1" {
-            templateStore.setComposerDraft(MobileTaskComposerDraft(
-                prompt: Self.longPrompt,
-                templateID: templateStore.listTemplates().first?.id,
-                macDeviceID: Self.previewMac.macDeviceID,
-                macInstanceTag: Self.previewMac.instanceTag,
-                directory: "~",
-                didEditDirectory: false
+            templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+                updatedAt: Date(),
+                content: MobileTaskComposerDraft(
+                    prompt: Self.longPrompt,
+                    templateID: templateStore.listTemplates().first?.id,
+                    macDeviceID: Self.previewMac.macDeviceID,
+                    macInstanceTag: Self.previewMac.instanceTag,
+                    directory: "~",
+                    didEditDirectory: false
+                )
             ))
         }
         if environment["CMUX_UITEST_TASK_COMPOSER_RESTORED_MODEL_DRAFT"] == "1" {
-            templateStore.setComposerDraft(MobileTaskComposerDraft(
-                prompt: "Retry the persisted model",
-                modelID: "persisted-agent-model",
-                templateID: templateStore.listTemplates().first?.id,
-                macDeviceID: Self.previewMac.macDeviceID,
-                macInstanceTag: Self.previewMac.instanceTag,
-                directory: "~",
-                didEditDirectory: false,
-                operationID: UUID(uuidString: "0D9A7F2E-0B69-49C7-A725-F6F72517C584")
+            templateStore.saveComposerDraft(MobileTaskComposerSavedDraft(
+                updatedAt: Date(),
+                content: MobileTaskComposerDraft(
+                    prompt: "Retry the persisted model",
+                    modelID: "persisted-agent-model",
+                    templateID: templateStore.listTemplates().first?.id,
+                    macDeviceID: Self.previewMac.macDeviceID,
+                    macInstanceTag: Self.previewMac.instanceTag,
+                    directory: "~",
+                    didEditDirectory: false,
+                    operationID: UUID(uuidString: "0D9A7F2E-0B69-49C7-A725-F6F72517C584")
+                )
             ))
         }
         if presentsOpenDirectory {
@@ -159,7 +165,7 @@ public struct TaskComposerAccessibilityPreviewView: View {
                     TaskComposerSubmissionHistoryProbe(attempts: submissionAttempts)
                 }
             }
-            .taskComposerPresentation(isPresented: $isPresented) {
+            .taskComposerPresentation(isPresented: $isPresented) { launch, switchDraft in
                 if presentsTemplateForm {
                     TaskTemplateFormView(template: nil, onSave: { _ in })
                 } else if presentsDirectoryPicker {
@@ -173,6 +179,8 @@ public struct TaskComposerAccessibilityPreviewView: View {
                 } else {
                     TaskComposerSheet(
                         store: store,
+                        launchIntent: launch.intent,
+                        onSwitchDraft: switchDraft,
                         availableMachines: [
                             Self.previewMac,
                             Self.stablePreviewMac,
@@ -190,7 +198,8 @@ public struct TaskComposerAccessibilityPreviewView: View {
                                 operationID: spec.operationID?.uuidString ?? "<nil>",
                                 prompt: spec.initialEnv?["CMUX_TASK_PROMPT"] ?? "<nil>"
                             ))
-                            draftWasPersistedAtSubmit = store.taskTemplateStore?.composerDraft() != nil
+                            draftWasPersistedAtSubmit =
+                                store.taskTemplateStore?.composerDrafts().isEmpty == false
                             if holdsSubmissionInPreparation {
                                 do {
                                     try await Task.sleep(for: .seconds(30))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAccessibilityTemplateStore.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAccessibilityTemplateStore.swift
@@ -96,6 +96,47 @@ final class TaskComposerAccessibilityTemplateStore: MobileTaskTemplateStoring {
 
     func deleteComposerDrafts(ids: Set<UUID>) {
         drafts.removeAll { ids.contains($0.id) }
+        for id in ids {
+            try? FileManager.default.removeItem(at: attachmentDirectory(draftID: id))
+        }
+    }
+
+    func persistComposerAttachmentFile(
+        draftID: UUID,
+        attachmentID: UUID,
+        preferredExtension: String,
+        from sourceURL: URL
+    ) throws -> String {
+        let sanitizedExtension = preferredExtension
+            .filter { $0.isLetter || $0.isNumber }
+            .lowercased()
+        let fileName = attachmentID.uuidString
+            + "." + (sanitizedExtension.isEmpty ? "bin" : sanitizedExtension)
+        let directory = attachmentDirectory(draftID: draftID)
+        let destination = directory.appendingPathComponent(fileName)
+        if !FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(at: sourceURL, to: destination)
+        }
+        return draftID.uuidString + "/" + fileName
+    }
+
+    func composerAttachmentFileURL(relativePath: String) -> URL? {
+        let url = attachmentsRoot.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    private var attachmentsRoot: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-accessibility-draft-attachments", isDirectory: true)
+    }
+
+    private func attachmentDirectory(draftID: UUID) -> URL {
+        attachmentsRoot.appendingPathComponent(draftID.uuidString, isDirectory: true)
     }
 
     func clearAllUserData() {
@@ -105,6 +146,7 @@ final class TaskComposerAccessibilityTemplateStore: MobileTaskTemplateStoring {
         directoriesByMacDeviceID.removeAll()
         recentsByMacDeviceID.removeAll()
         drafts.removeAll()
+        try? FileManager.default.removeItem(at: attachmentsRoot)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAccessibilityTemplateStore.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAccessibilityTemplateStore.swift
@@ -16,7 +16,7 @@ final class TaskComposerAccessibilityTemplateStore: MobileTaskTemplateStoring {
     private var selectedMacDeviceID: String?
     private var directoriesByMacDeviceID: [String: String] = [:]
     private var recentsByMacDeviceID: [String: [MobileTaskRecentDirectory]] = [:]
-    private var draft: MobileTaskComposerDraft?
+    private var drafts: [MobileTaskComposerSavedDraft] = []
 
     func listTemplates() -> [MobileTaskTemplate] {
         templates
@@ -85,12 +85,17 @@ final class TaskComposerAccessibilityTemplateStore: MobileTaskTemplateStoring {
         recentsByMacDeviceID[macDeviceID] = Array(recents.prefix(20))
     }
 
-    func composerDraft() -> MobileTaskComposerDraft? {
-        draft
+    func composerDrafts() -> [MobileTaskComposerSavedDraft] {
+        drafts
     }
 
-    func setComposerDraft(_ draft: MobileTaskComposerDraft?) {
-        self.draft = draft
+    func saveComposerDraft(_ draft: MobileTaskComposerSavedDraft) {
+        drafts.removeAll { $0.id == draft.id }
+        drafts.insert(draft, at: 0)
+    }
+
+    func deleteComposerDrafts(ids: Set<UUID>) {
+        drafts.removeAll { ids.contains($0.id) }
     }
 
     func clearAllUserData() {
@@ -99,7 +104,7 @@ final class TaskComposerAccessibilityTemplateStore: MobileTaskTemplateStoring {
         selectedMacDeviceID = nil
         directoriesByMacDeviceID.removeAll()
         recentsByMacDeviceID.removeAll()
-        draft = nil
+        drafts.removeAll()
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
@@ -1,0 +1,150 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// The saved, unsent drafts a user can return to. The active composer
+/// session is not listed; resuming a row replaces that session after its
+/// content is saved as a draft of its own.
+struct TaskComposerDraftsSheet: View {
+    let drafts: [MobileTaskComposerSavedDraft]
+    let templates: [MobileTaskTemplate]
+    let resume: (UUID) -> Void
+    let startNew: () -> Void
+    let delete: (Set<UUID>) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if drafts.isEmpty {
+                    ContentUnavailableView {
+                        Label(
+                            L10n.string(
+                                "mobile.taskComposer.drafts.empty.title",
+                                defaultValue: "No Other Drafts"
+                            ),
+                            systemImage: "tray"
+                        )
+                    } description: {
+                        Text(L10n.string(
+                            "mobile.taskComposer.drafts.empty.description",
+                            defaultValue: "Leave the composer with an unsent task and it is saved here."
+                        ))
+                    }
+                } else {
+                    List {
+                        ForEach(drafts) { draft in
+                            Button {
+                                resume(draft.id)
+                            } label: {
+                                TaskComposerDraftRow(
+                                    draft: draft,
+                                    templateName: templateName(for: draft)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("MobileTaskComposerDraftRow")
+                        }
+                        .onDelete { offsets in
+                            delete(Set(offsets.map { drafts[$0].id }))
+                        }
+                    }
+                    .accessibilityIdentifier("MobileTaskComposerDraftsList")
+                }
+            }
+            .navigationTitle(L10n.string(
+                "mobile.taskComposer.drafts.title",
+                defaultValue: "Drafts"
+            ))
+            .mobileInlineNavigationTitle()
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: startNew) {
+                        Label(
+                            L10n.string(
+                                "mobile.taskComposer.drafts.new",
+                                defaultValue: "New Draft"
+                            ),
+                            systemImage: "square.and.pencil"
+                        )
+                    }
+                    .accessibilityIdentifier("MobileTaskComposerNewDraftButton")
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func templateName(for draft: MobileTaskComposerSavedDraft) -> String? {
+        draft.content.templateID.flatMap { id in
+            templates.first { $0.id == id }?.name
+        }
+    }
+}
+
+private struct TaskComposerDraftRow: View {
+    let draft: MobileTaskComposerSavedDraft
+    let templateName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                    .lineLimit(2)
+                    .foregroundStyle(hasPrompt ? Color.primary : Color.secondary)
+                Spacer(minLength: 8)
+                Text(draft.updatedAt, format: .relative(presentation: .named))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .layoutPriority(1)
+            }
+            if !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+
+    private var hasPrompt: Bool {
+        !draft.content.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var title: String {
+        let workspaceName = (draft.content.workspaceName ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let promptLine = draft.content.prompt
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .newlines)
+            .first ?? ""
+        if !promptLine.isEmpty {
+            return promptLine
+        }
+        if !workspaceName.isEmpty {
+            return workspaceName
+        }
+        return L10n.string(
+            "mobile.taskComposer.drafts.untitled",
+            defaultValue: "No prompt yet"
+        )
+    }
+
+    private var subtitle: String {
+        var parts: [String] = []
+        if let templateName, !templateName.isEmpty {
+            parts.append(templateName)
+        }
+        let directory = draft.content.directory
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !directory.isEmpty {
+            parts.append(TaskComposerDirectoryDisplayPath(path: directory).name)
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
@@ -8,11 +8,16 @@ import SwiftUI
 /// content is saved as a draft of its own.
 struct TaskComposerDraftsSheet: View {
     @Environment(\.dismiss) private var dismiss
-    let drafts: [MobileTaskComposerSavedDraft]
+    /// Live source of the listed drafts. The sheet loads on its own appear
+    /// instead of receiving a snapshot: a snapshot captured across the
+    /// composer's draft-switch identity swap can be stale or empty.
+    let loadDrafts: () -> [MobileTaskComposerSavedDraft]
     let templates: [MobileTaskTemplate]
     let resume: (UUID) -> Void
     let startNew: () -> Void
     let delete: (Set<UUID>) -> Void
+
+    @State private var drafts: [MobileTaskComposerSavedDraft] = []
 
     var body: some View {
         NavigationStack {
@@ -47,12 +52,15 @@ struct TaskComposerDraftsSheet: View {
                             .accessibilityIdentifier("MobileTaskComposerDraftRow")
                         }
                         .onDelete { offsets in
-                            delete(Set(offsets.map { drafts[$0].id }))
+                            let ids = Set(offsets.map { drafts[$0].id })
+                            delete(ids)
+                            drafts.removeAll { ids.contains($0.id) }
                         }
                     }
                     .accessibilityIdentifier("MobileTaskComposerDraftsList")
                 }
             }
+            .onAppear { drafts = loadDrafts() }
             .navigationTitle(L10n.string(
                 "mobile.taskComposer.drafts.title",
                 defaultValue: "Drafts"

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDraftsSheet.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// session is not listed; resuming a row replaces that session after its
 /// content is saved as a draft of its own.
 struct TaskComposerDraftsSheet: View {
+    @Environment(\.dismiss) private var dismiss
     let drafts: [MobileTaskComposerSavedDraft]
     let templates: [MobileTaskTemplate]
     let resume: (UUID) -> Void
@@ -58,17 +59,23 @@ struct TaskComposerDraftsSheet: View {
             ))
             .mobileInlineNavigationTitle()
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button(action: startNew) {
                         Label(
                             L10n.string(
                                 "mobile.taskComposer.drafts.new",
                                 defaultValue: "New Draft"
                             ),
-                            systemImage: "square.and.pencil"
+                            systemImage: "plus"
                         )
                     }
                     .accessibilityIdentifier("MobileTaskComposerNewDraftButton")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.string("mobile.common.done", defaultValue: "Done")) {
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("MobileTaskComposerDraftsDoneButton")
                 }
             }
         }
@@ -100,11 +107,23 @@ private struct TaskComposerDraftRow: View {
                     .foregroundStyle(.secondary)
                     .layoutPriority(1)
             }
-            if !subtitle.isEmpty {
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+            if !subtitle.isEmpty || !draft.content.attachments.isEmpty {
+                HStack(spacing: 6) {
+                    if !subtitle.isEmpty {
+                        Text(subtitle)
+                            .lineLimit(1)
+                    }
+                    if !draft.content.attachments.isEmpty {
+                        Label(
+                            "\(draft.content.attachments.count)",
+                            systemImage: "paperclip"
+                        )
+                        .labelStyle(.titleAndIcon)
+                        .layoutPriority(1)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
         .contentShape(Rectangle())

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLaunchIntent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLaunchIntent.swift
@@ -1,0 +1,43 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import Foundation
+
+/// Which draft a task-composer session starts from.
+enum TaskComposerLaunchIntent: Equatable, Sendable {
+    /// Resume the newest saved draft, or start fresh when none exists. This
+    /// is the long-standing behavior of opening the composer.
+    case automatic
+    /// Resume one saved draft; starts fresh if it was deleted meanwhile.
+    case resume(UUID)
+    /// Start a fresh draft even when saved drafts exist.
+    case new
+
+    /// Resolves the saved draft this intent restores from `drafts`
+    /// (newest first), or `nil` for a fresh composer session.
+    func resolveDraft(
+        in drafts: [MobileTaskComposerSavedDraft]
+    ) -> MobileTaskComposerSavedDraft? {
+        switch self {
+        case .automatic:
+            drafts.first
+        case .resume(let id):
+            drafts.first { $0.id == id }
+        case .new:
+            nil
+        }
+    }
+}
+
+/// One composer editing session. The token feeds the presented view's
+/// identity, so switching drafts rebuilds the sheet and re-runs its
+/// restore-validation init instead of mutating live state in place.
+struct TaskComposerLaunch: Equatable, Sendable {
+    var token = 0
+    var intent: TaskComposerLaunchIntent = .automatic
+
+    /// The next session for `intent`, always with a fresh view identity.
+    func switching(to intent: TaskComposerLaunchIntent) -> TaskComposerLaunch {
+        TaskComposerLaunch(token: token + 1, intent: intent)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLaunchIntent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLaunchIntent.swift
@@ -2,14 +2,13 @@
 import CmuxMobileShellModel
 import Foundation
 
-/// Which draft a task-composer session starts from.
+/// Which draft a task-composer session starts from. Drafts are explicit,
+/// like X/Twitter: opening the composer always starts fresh, and a saved
+/// draft is only loaded by picking it from the drafts list.
 enum TaskComposerLaunchIntent: Equatable, Sendable {
-    /// Resume the newest saved draft, or start fresh when none exists. This
-    /// is the long-standing behavior of opening the composer.
-    case automatic
     /// Resume one saved draft; starts fresh if it was deleted meanwhile.
     case resume(UUID)
-    /// Start a fresh draft even when saved drafts exist.
+    /// Start a fresh draft.
     case new
 
     /// Resolves the saved draft this intent restores from `drafts`
@@ -18,8 +17,6 @@ enum TaskComposerLaunchIntent: Equatable, Sendable {
         in drafts: [MobileTaskComposerSavedDraft]
     ) -> MobileTaskComposerSavedDraft? {
         switch self {
-        case .automatic:
-            drafts.first
         case .resume(let id):
             drafts.first { $0.id == id }
         case .new:
@@ -33,7 +30,7 @@ enum TaskComposerLaunchIntent: Equatable, Sendable {
 /// restore-validation init instead of mutating live state in place.
 struct TaskComposerLaunch: Equatable, Sendable {
     var token = 0
-    var intent: TaskComposerLaunchIntent = .automatic
+    var intent: TaskComposerLaunchIntent = .new
 
     /// The next session for `intent`, always with a fresh view identity.
     func switching(to intent: TaskComposerLaunchIntent) -> TaskComposerLaunch {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerLayout.swift
@@ -37,6 +37,8 @@ struct TaskComposerLayout: View {
     /// directory candidates, so it must not run on every keystroke's body
     /// rebuild, only when Task Options is actually presented.
     let optionsSheet: () -> TaskComposerOptionsSheet
+    /// Presents the saved-drafts list; `nil` hides the drafts button.
+    let openDrafts: (() -> Void)?
     let endEditing: () -> Void
     let selectTemplate: (MobileTaskTemplate.ID) -> Void
     let selectModel: (MobileTaskAgentModel?) -> Void
@@ -76,6 +78,19 @@ struct TaskComposerLayout: View {
                     defaultValue: "Cancel"
                 ))
                 .accessibilityIdentifier("MobileTaskComposerCancelButton")
+            }
+            if let openDrafts {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: openDrafts) {
+                        Image(systemName: "tray.full")
+                    }
+                    .disabled(locksDismissal)
+                    .accessibilityLabel(L10n.string(
+                        "mobile.taskComposer.drafts.title",
+                        defaultValue: "Drafts"
+                    ))
+                    .accessibilityIdentifier("MobileTaskComposerDraftsButton")
+                }
             }
         }
         .sheet(isPresented: $isOptionsPresented) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
@@ -35,8 +35,12 @@ private struct TaskComposerPresentationModifier<PresentedContent: View>: ViewMod
             isPresented: $isPresented,
             onDismiss: {
                 // The next presentation starts a new session that resumes the
-                // newest draft, exactly as before drafts had a switcher.
-                launch = TaskComposerLaunch()
+                // newest draft, and it must get a brand-new view identity:
+                // reusing the token would let @State (draft identity, persist
+                // flags, dirty baseline) leak from the closed session, and
+                // the fresh view must be built after this session's final
+                // save landed.
+                launch = TaskComposerLaunch(token: launch.token + 1)
                 onDismiss()
             },
             content: {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
@@ -4,12 +4,23 @@ import SwiftUI
 private struct TaskComposerPresentationModifier<PresentedContent: View>: ViewModifier {
     @Binding private var isPresented: Bool
     private let onDismiss: () -> Void
-    private let presentedContent: () -> PresentedContent
+    private let presentedContent: (
+        TaskComposerLaunch,
+        _ switchDraft: @escaping (TaskComposerLaunchIntent) -> Void
+    ) -> PresentedContent
+
+    /// The current editing session inside one presentation. Draft switches
+    /// replace it, which recreates the sheet through `.id(launch.token)` so
+    /// the selected draft passes the init's full restore validation.
+    @State private var launch = TaskComposerLaunch()
 
     init(
         isPresented: Binding<Bool>,
         onDismiss: @escaping () -> Void,
-        @ViewBuilder presentedContent: @escaping () -> PresentedContent
+        @ViewBuilder presentedContent: @escaping (
+            TaskComposerLaunch,
+            _ switchDraft: @escaping (TaskComposerLaunchIntent) -> Void
+        ) -> PresentedContent
     ) {
         _isPresented = isPresented
         self.onDismiss = onDismiss
@@ -22,8 +33,18 @@ private struct TaskComposerPresentationModifier<PresentedContent: View>: ViewMod
         // the draft, focus, and staged attachments.
         content.fullScreenCover(
             isPresented: $isPresented,
-            onDismiss: onDismiss,
-            content: presentedContent
+            onDismiss: {
+                // The next presentation starts a new session that resumes the
+                // newest draft, exactly as before drafts had a switcher.
+                launch = TaskComposerLaunch()
+                onDismiss()
+            },
+            content: {
+                presentedContent(launch) { intent in
+                    launch = launch.switching(to: intent)
+                }
+                .id(launch.token)
+            }
         )
     }
 }
@@ -32,7 +53,10 @@ extension View {
     func taskComposerPresentation<PresentedContent: View>(
         isPresented: Binding<Bool>,
         onDismiss: @escaping () -> Void = {},
-        @ViewBuilder content: @escaping () -> PresentedContent
+        @ViewBuilder content: @escaping (
+            TaskComposerLaunch,
+            _ switchDraft: @escaping (TaskComposerLaunchIntent) -> Void
+        ) -> PresentedContent
     ) -> some View {
         modifier(TaskComposerPresentationModifier(
             isPresented: isPresented,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPresentationModifier.swift
@@ -34,12 +34,11 @@ private struct TaskComposerPresentationModifier<PresentedContent: View>: ViewMod
         content.fullScreenCover(
             isPresented: $isPresented,
             onDismiss: {
-                // The next presentation starts a new session that resumes the
-                // newest draft, and it must get a brand-new view identity:
-                // reusing the token would let @State (draft identity, persist
-                // flags, dirty baseline) leak from the closed session, and
-                // the fresh view must be built after this session's final
-                // save landed.
+                // The next presentation starts a fresh session (drafts load
+                // only from the drafts list), and it must get a brand-new
+                // view identity: reusing the token would let @State (draft
+                // identity, persist flags, dirty baseline) leak from the
+                // closed session.
                 launch = TaskComposerLaunch(token: launch.token + 1)
                 onDismiss()
             },

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSessionFingerprint.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSessionFingerprint.swift
@@ -3,8 +3,9 @@ import CmuxMobileShellModel
 import Foundation
 
 /// The leave-relevant composer state, captured when a session opens and
-/// compared when it closes. Model and effort picker choices are deliberately
-/// excluded: changing only those never prompts to save a draft.
+/// compared when it closes. Model and effort picker VALUES are excluded
+/// because catalog refreshes auto-reconcile them; deliberate picker taps are
+/// tracked separately as an action flag so they still prompt on leave.
 struct TaskComposerSessionFingerprint: Equatable {
     var prompt: String
     var workspaceName: String

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSessionFingerprint.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSessionFingerprint.swift
@@ -1,0 +1,18 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import Foundation
+
+/// The leave-relevant composer state, captured when a session opens and
+/// compared when it closes. Model and effort picker choices are deliberately
+/// excluded: changing only those never prompts to save a draft.
+struct TaskComposerSessionFingerprint: Equatable {
+    var prompt: String
+    var workspaceName: String
+    var templateID: MobileTaskTemplate.ID?
+    var macPairingID: String
+    var directory: String
+    var didEditDirectory: Bool
+    var workspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    var attachmentIDs: Set<UUID>
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+CompletedOperationRecovery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+CompletedOperationRecovery.swift
@@ -86,6 +86,7 @@ extension TaskComposerSheet {
     func completeSubmission(_ snapshot: MobileTaskSubmissionSnapshot) {
         _ = store.completeTaskComposerSubmission(
             snapshot,
+            draftID: draftID,
             ifSessionGeneration: sessionGeneration
         )
         // Remote success is authoritative. A stale signed-in session may stop

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+ModelSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+ModelSelection.swift
@@ -150,6 +150,7 @@ extension TaskComposerSheet {
             explicitlySelectedModel = model
             selectedEffortID = (model ?? modelAvailability.defaultModel)?.defaultEffortID
         }
+        hasUserPickedModelOrEffort = true
         store.recordAppEvent(
             .taskModelSelected,
             correlationID: selectedID
@@ -164,6 +165,7 @@ extension TaskComposerSheet {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedEffortID = selectedID
         }
+        hasUserPickedModelOrEffort = true
     }
 
     func reconcileSelectedEffort() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -457,13 +457,12 @@ struct TaskComposerSheet: View {
                 isPresented: $isStartAgainConfirmationPresented,
                 confirm: confirmStartAgain
             ))
-            .confirmationDialog(
+            .alert(
                 L10n.string(
                     "mobile.taskComposer.drafts.leaveDialog.title",
                     defaultValue: "Save this task as a draft?"
                 ),
-                isPresented: $isLeaveConfirmationPresented,
-                titleVisibility: .visible
+                isPresented: $isLeaveConfirmationPresented
             ) {
                 Button(L10n.string(
                     "mobile.taskComposer.drafts.leaveDialog.save",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -56,8 +56,18 @@ struct TaskComposerSheet: View {
     /// Draft typing is sampled once per composer presentation so this bounded
     /// log records that editing occurred without one event per keystroke.
     @State var hasRecordedDraftChange = false
+    /// Saved drafts other than this session's, loaded when the list presents.
+    @State private var otherDrafts: [MobileTaskComposerSavedDraft] = []
+    @State private var isDraftsListPresented = false
 
     let sessionGeneration: Int
+    /// Stable identity of this session's saved-draft entry. Every leave,
+    /// retry, and submit updates or removes exactly this entry.
+    let draftID: UUID
+    /// Replaces this editing session with another draft's. `nil` hides the
+    /// drafts affordance for hosts without a session presenter (previews and
+    /// accessibility harnesses).
+    private let onSwitchDraft: ((TaskComposerLaunchIntent) -> Void)?
     private let restoredDraftAtInitialization: Bool
     private let availableMachines: [MobilePairedMac]?
     private let availableWorkspaceGroups: [MobileWorkspaceGroupPreview]?
@@ -83,6 +93,8 @@ struct TaskComposerSheet: View {
 
     init(
         store: CMUXMobileShellStore,
+        launchIntent: TaskComposerLaunchIntent = .automatic,
+        onSwitchDraft: ((TaskComposerLaunchIntent) -> Void)? = nil,
         availableMachines: [MobilePairedMac]? = nil,
         availableWorkspaceGroups: [MobileWorkspaceGroupPreview]? = nil,
         taskAttachmentsCapabilityOverride: Bool? = nil,
@@ -126,9 +138,13 @@ struct TaskComposerSheet: View {
                 willStartCreate: willStartCreate
             )
         }
+        self.onSwitchDraft = onSwitchDraft
         let loadedTemplates = store.taskTemplateStore?.listTemplates() ?? []
         let templates = loadedTemplates
-        let draft = store.taskTemplateStore?.composerDraft()
+        let savedDrafts = store.taskTemplateStore?.composerDrafts() ?? []
+        let resumedDraft = launchIntent.resolveDraft(in: savedDrafts)
+        let draft = resumedDraft?.content
+        self.draftID = resumedDraft?.id ?? UUID()
         self.restoredDraftAtInitialization = draft != nil
         let foregroundMacID = store.connectedMacDeviceID
         let foregroundMacInstanceTag = store.connectedMacInstanceTag
@@ -342,6 +358,15 @@ struct TaskComposerSheet: View {
                     refresh: refreshTemplates
                 )
             }
+            .sheet(isPresented: $isDraftsListPresented) {
+                TaskComposerDraftsSheet(
+                    drafts: otherDrafts,
+                    templates: templates,
+                    resume: resumeDraft,
+                    startNew: startNewDraft,
+                    delete: deleteDrafts
+                )
+            }
             .onDisappear {
                 store.recordAppEvent(
                     .taskComposerClosed,
@@ -481,6 +506,7 @@ struct TaskComposerSheet: View {
             attachments: attachments,
             showsAttachmentButton: showsAttachmentButton,
             optionsSheet: { optionsSheet },
+            openDrafts: openDraftsAction,
             endEditing: resolveCompletedOperationRecoveryAfterEditing,
             selectTemplate: selectTemplateFromPicker,
             selectModel: selectModel,
@@ -835,8 +861,46 @@ struct TaskComposerSheet: View {
         )
         submitTask?.cancel()
         shouldPersistDraftOnDisappear = false
-        store.clearTaskComposerDraft(ifSessionGeneration: sessionGeneration)
+        store.deleteTaskComposerDrafts(
+            ids: [draftID],
+            ifSessionGeneration: sessionGeneration
+        )
         dismiss()
+    }
+
+    /// The drafts toolbar affordance; hidden for hosts without a presenter.
+    private var openDraftsAction: (() -> Void)? {
+        guard onSwitchDraft != nil else { return nil }
+        return { presentDraftsList() }
+    }
+
+    /// Opens the saved-drafts list for every session except this one.
+    private func presentDraftsList() {
+        otherDrafts = store.taskComposerSavedDrafts().filter { $0.id != draftID }
+        isDraftsListPresented = true
+    }
+
+    /// Saves the current content under this session's identity, then hands
+    /// the presenter another draft to rebuild the composer from.
+    private func resumeDraft(_ id: UUID) {
+        guard let onSwitchDraft else { return }
+        persistDraft()
+        onSwitchDraft(.resume(id))
+    }
+
+    /// Saves the current content as its own draft and starts a fresh one.
+    private func startNewDraft() {
+        guard let onSwitchDraft else { return }
+        persistDraft()
+        onSwitchDraft(.new)
+    }
+
+    private func deleteDrafts(_ ids: Set<UUID>) {
+        guard store.deleteTaskComposerDrafts(
+            ids: ids,
+            ifSessionGeneration: sessionGeneration
+        ) else { return }
+        otherDrafts.removeAll { ids.contains($0.id) }
     }
 
     private func selectMachine(_ macDeviceID: String, _ instanceTag: String?) {
@@ -911,6 +975,7 @@ struct TaskComposerSheet: View {
               let snapshot = submissionSnapshot() else { return }
         guard store.persistTaskComposerDraft(
             snapshot.draft,
+            draftID: draftID,
             ifSessionGeneration: sessionGeneration
         ) else {
             failureTitleStyle = .launchFailed
@@ -933,6 +998,7 @@ struct TaskComposerSheet: View {
             restoreSubmittedDraft(snapshot)
             _ = store.persistTaskComposerDraft(
                 snapshot.draft,
+                draftID: draftID,
                 ifSessionGeneration: sessionGeneration
             )
             submissionPhase = .retryReady
@@ -978,11 +1044,13 @@ struct TaskComposerSheet: View {
                 submissionIdentity.rotate()
                 _ = store.persistTaskComposerDraft(
                     draftSnapshot(),
+                    draftID: draftID,
                     ifSessionGeneration: sessionGeneration
                 )
             } else {
                 _ = store.persistTaskComposerDraft(
                     snapshot.draft,
+                    draftID: draftID,
                     ifSessionGeneration: sessionGeneration
                 )
                 submissionPhase = .retryReady
@@ -1104,11 +1172,16 @@ struct TaskComposerSheet: View {
         if let activeSubmissionSnapshot {
             store.persistTaskComposerDraft(
                 activeSubmissionSnapshot.draft,
+                draftID: draftID,
                 ifSessionGeneration: sessionGeneration
             )
             return
         }
-        store.persistTaskComposerDraft(draftSnapshot(), ifSessionGeneration: sessionGeneration)
+        store.persistTaskComposerDraft(
+            draftSnapshot(),
+            draftID: draftID,
+            ifSessionGeneration: sessionGeneration
+        )
     }
 
     private func validWorkspaceGroupID(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -59,6 +59,11 @@ struct TaskComposerSheet: View {
     /// Saved drafts other than this session's, loaded when the list presents.
     @State private var otherDrafts: [MobileTaskComposerSavedDraft] = []
     @State private var isDraftsListPresented = false
+    @State var isLeaveConfirmationPresented = false
+    /// True until this session's preserved attachments finish re-staging, so
+    /// an early leave still persists their references instead of dropping
+    /// them with the not-yet-populated live list.
+    @State var isDraftAttachmentRestorePending: Bool
 
     let sessionGeneration: Int
     /// Stable identity of this session's saved-draft entry. Every leave,
@@ -68,6 +73,12 @@ struct TaskComposerSheet: View {
     /// drafts affordance for hosts without a session presenter (previews and
     /// accessibility harnesses).
     private let onSwitchDraft: ((TaskComposerLaunchIntent) -> Void)?
+    /// Attachment references preserved with the resumed draft; re-staged
+    /// into session-owned temporary copies on appear.
+    let restoredDraftAttachments: [MobileTaskComposerDraftAttachment]
+    /// Leave-relevant state as this session opened; leaving with anything
+    /// different (except model/effort picks) asks before discarding.
+    let initialSessionFingerprint: TaskComposerSessionFingerprint
     private let restoredDraftAtInitialization: Bool
     private let availableMachines: [MobilePairedMac]?
     private let availableWorkspaceGroups: [MobileWorkspaceGroupPreview]?
@@ -281,6 +292,10 @@ struct TaskComposerSheet: View {
         let initialPrompt = draft?.prompt ?? ""
         let initialWorkspaceName = draft?.workspaceName ?? ""
         let initialOperationID = restoredOperationID ?? UUID()
+        let restoredAttachments = draft?.attachments ?? []
+        // The restored attachment identities are part of the request the
+        // operation ID belongs to; without them the async attachment restore
+        // would look like an edit and rotate a still-valid retry identity.
         let initialRequest = selectedTemplate.map {
             MobileTaskSubmissionSnapshot(
                 template: $0,
@@ -293,9 +308,28 @@ struct TaskComposerSheet: View {
                 workspaceName: initialWorkspaceName,
                 workspaceGroupID: initialWorkspaceGroupID,
                 didEditDirectory: canRestoreDraftDirectory && draft?.didEditDirectory == true,
+                attachments: restoredAttachments.map {
+                    MobileTaskSubmissionAttachment(uploadID: $0.id, byteCount: $0.byteCount)
+                },
                 operationID: initialOperationID
             )
         }
+        self.restoredDraftAttachments = restoredAttachments
+        _isDraftAttachmentRestorePending = State(initialValue: !restoredAttachments.isEmpty)
+        self.initialSessionFingerprint = TaskComposerSessionFingerprint(
+            prompt: initialPrompt,
+            workspaceName: initialWorkspaceName,
+            templateID: selectedTemplateID,
+            macPairingID: MobilePairedMac.pairingID(
+                macDeviceID: selectedMacID,
+                instanceTag: selectedMacInstanceTag
+            ),
+            directory: initialDirectory,
+            didEditDirectory: canRestoreDraftDirectory && draft?.didEditDirectory == true,
+            workspaceGroupID: initialWorkspaceGroupID,
+            attachmentIDs: Set(initialAttachments.map(\.id))
+                .union(restoredAttachments.map(\.id))
+        )
         let canRestoreCompletedOperation = draft?.templateID == selectedTemplateID
             && draftMatchesSelectedMac
             && draft?.workspaceGroupID == initialWorkspaceGroupID
@@ -395,6 +429,7 @@ struct TaskComposerSheet: View {
                 if restoredDraftAtInitialization {
                     store.recordAppEvent(.draftRestored)
                 }
+                restoreDraftAttachments()
             }
             .onChange(of: scenePhase) { _, newPhase in
                 guard newPhase != .active else { return }
@@ -422,6 +457,34 @@ struct TaskComposerSheet: View {
                 isPresented: $isStartAgainConfirmationPresented,
                 confirm: confirmStartAgain
             ))
+            .confirmationDialog(
+                L10n.string(
+                    "mobile.taskComposer.drafts.leaveDialog.title",
+                    defaultValue: "Save this task as a draft?"
+                ),
+                isPresented: $isLeaveConfirmationPresented,
+                titleVisibility: .visible
+            ) {
+                Button(L10n.string(
+                    "mobile.taskComposer.drafts.leaveDialog.save",
+                    defaultValue: "Save Draft"
+                )) {
+                    saveDraftAndDismiss()
+                }
+                Button(
+                    L10n.string(
+                        "mobile.taskComposer.drafts.leaveDialog.delete",
+                        defaultValue: "Delete Draft"
+                    ),
+                    role: .destructive
+                ) {
+                    deleteDraftAndDismiss()
+                }
+                Button(
+                    L10n.string("mobile.common.cancel", defaultValue: "Cancel"),
+                    role: .cancel
+                ) {}
+            }
             .modifier(TaskComposerAttachmentPickerModifier(
                 isPhotoPickerPresented: $isAttachmentPhotoPickerPresented,
                 photoSelection: $attachmentPhotoSelection,
@@ -853,7 +916,51 @@ struct TaskComposerSheet: View {
         isEditorPresented = true
     }
 
+    /// Leave-relevant state right now, compared against the session baseline.
+    var currentSessionFingerprint: TaskComposerSessionFingerprint {
+        TaskComposerSessionFingerprint(
+            prompt: prompt,
+            workspaceName: workspaceName,
+            templateID: selectedTemplateID,
+            macPairingID: MobilePairedMac.pairingID(
+                macDeviceID: selectedMacDeviceID,
+                instanceTag: selectedMacInstanceTag
+            ),
+            directory: directory,
+            didEditDirectory: didEditDirectory,
+            workspaceGroupID: selectedWorkspaceGroupID,
+            attachmentIDs: isDraftAttachmentRestorePending
+                ? Set(restoredDraftAttachments.map(\.id))
+                : Set(attachments.map(\.id))
+        )
+    }
+
+    /// Whether leaving now would abandon anything the user changed this
+    /// session (model and effort picks excluded by design).
+    var hasUnsavedComposerChanges: Bool {
+        currentSessionFingerprint != initialSessionFingerprint
+    }
+
     private func cancelComposer() {
+        guard hasUnsavedComposerChanges else {
+            // Nothing changed this session: a resumed draft stays exactly as
+            // saved, and a fresh empty session leaves nothing behind.
+            shouldPersistDraftOnDisappear = false
+            dismiss()
+            return
+        }
+        isLeaveConfirmationPresented = true
+    }
+
+    /// Confirmed "Save Draft" while leaving.
+    func saveDraftAndDismiss() {
+        persistDraft()
+        shouldPersistDraftOnDisappear = false
+        dismiss()
+    }
+
+    /// Confirmed "Delete Draft" while leaving: the previous cancel semantics.
+    func deleteDraftAndDismiss() {
         store.recordAppEvent(
             .taskSubmitCancelled,
             correlationID: submissionIdentity.id.uuidString,
@@ -973,11 +1080,7 @@ struct TaskComposerSheet: View {
     private func submit() async {
         guard submissionPhase.allowsSubmission,
               let snapshot = submissionSnapshot() else { return }
-        guard store.persistTaskComposerDraft(
-            snapshot.draft,
-            draftID: draftID,
-            ifSessionGeneration: sessionGeneration
-        ) else {
+        guard persistDraftContent(base: snapshot.draft) else {
             failureTitleStyle = .launchFailed
             let message = Self.draftPersistenceFailureMessage
             failureText = message
@@ -996,11 +1099,7 @@ struct TaskComposerSheet: View {
             activeSubmissionSnapshot = nil
             guard !Task.isCancelled else { return }
             restoreSubmittedDraft(snapshot)
-            _ = store.persistTaskComposerDraft(
-                snapshot.draft,
-                draftID: draftID,
-                ifSessionGeneration: sessionGeneration
-            )
+            persistDraftContent(base: snapshot.draft)
             submissionPhase = .retryReady
             failureTitleStyle = .launchFailed
             let message = Self.attachmentUploadFailureMessage(failure)
@@ -1042,17 +1141,9 @@ struct TaskComposerSheet: View {
                 // this same draft with a fresh ID, but UI recovery still gates
                 // sending it until refresh and explicit confirmation.
                 submissionIdentity.rotate()
-                _ = store.persistTaskComposerDraft(
-                    draftSnapshot(),
-                    draftID: draftID,
-                    ifSessionGeneration: sessionGeneration
-                )
+                persistDraftContent(base: draftSnapshot())
             } else {
-                _ = store.persistTaskComposerDraft(
-                    snapshot.draft,
-                    draftID: draftID,
-                    ifSessionGeneration: sessionGeneration
-                )
+                persistDraftContent(base: snapshot.draft)
                 submissionPhase = .retryReady
             }
             failureTitleStyle = TaskComposerFailureTitleStyle(failure: failure)
@@ -1170,18 +1261,114 @@ struct TaskComposerSheet: View {
     private func persistDraft() {
         guard shouldPersistDraftOnDisappear else { return }
         if let activeSubmissionSnapshot {
-            store.persistTaskComposerDraft(
-                activeSubmissionSnapshot.draft,
-                draftID: draftID,
-                ifSessionGeneration: sessionGeneration
-            )
+            persistDraftContent(base: activeSubmissionSnapshot.draft)
             return
         }
-        store.persistTaskComposerDraft(
-            draftSnapshot(),
+        persistDraftContent(base: draftSnapshot())
+    }
+
+    /// Persists `base` under this session's identity with the session's
+    /// attachments preserved into draft-owned files.
+    @discardableResult
+    func persistDraftContent(base: MobileTaskComposerDraft) -> Bool {
+        var content = base
+        content.attachments = persistedDraftAttachments()
+        return store.persistTaskComposerDraft(
+            content,
             draftID: draftID,
             ifSessionGeneration: sessionGeneration
         )
+    }
+
+    /// Copies every staged attachment into draft-owned storage and returns
+    /// their preserved references. While the resume re-stage is still
+    /// pending, the resumed references are reused verbatim so an early leave
+    /// cannot drop them.
+    private func persistedDraftAttachments() -> [MobileTaskComposerDraftAttachment] {
+        if isDraftAttachmentRestorePending, attachments.isEmpty {
+            return restoredDraftAttachments
+        }
+        guard let templateStore = store.taskTemplateStore else { return [] }
+        var entries: [MobileTaskComposerDraftAttachment] = []
+        for attachment in attachments {
+            let displayNameExtension = (attachment.displayName as NSString).pathExtension
+            let preferredExtension = displayNameExtension.isEmpty
+                ? attachment.localStagedFileURL.pathExtension
+                : displayNameExtension
+            do {
+                let relativePath = try templateStore.persistComposerAttachmentFile(
+                    draftID: draftID,
+                    attachmentID: attachment.id,
+                    preferredExtension: preferredExtension,
+                    from: attachment.localStagedFileURL
+                )
+                entries.append(attachment.draftAttachment(relativePath: relativePath))
+            } catch {
+                store.recordAppEvent(
+                    .draftPersistenceFailed,
+                    failure: DiagnosticFailureKind.classify(error)
+                )
+            }
+        }
+        return entries
+    }
+
+    /// Re-stages preserved draft attachments into fresh session-owned
+    /// temporary copies, so session teardown never deletes draft-owned bytes.
+    func restoreDraftAttachments() {
+        guard !restoredDraftAttachments.isEmpty, attachments.isEmpty else {
+            isDraftAttachmentRestorePending = false
+            return
+        }
+        attachmentStagingTask?.cancel()
+        attachmentStagingTask = Task { @MainActor in
+            defer { attachmentStagingTask = nil }
+            var restored: [TaskComposerAttachment] = []
+            for entry in restoredDraftAttachments {
+                guard !Task.isCancelled else { break }
+                guard let sourceURL = store.taskTemplateStore?
+                    .composerAttachmentFileURL(relativePath: entry.relativePath) else {
+                    store.recordAppEvent(
+                        .draftPersistenceFailed,
+                        failure: .localStateUnavailable
+                    )
+                    continue
+                }
+                let fileExtension = (entry.relativePath as NSString).pathExtension
+                let stagedURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(
+                        "cmux-task-attachment-\(UUID().uuidString)"
+                            + (fileExtension.isEmpty ? "" : ".\(fileExtension)")
+                    )
+                do {
+                    try FileManager.default.copyItem(at: sourceURL, to: stagedURL)
+                } catch {
+                    store.recordAppEvent(
+                        .draftPersistenceFailed,
+                        failure: DiagnosticFailureKind.classify(error)
+                    )
+                    continue
+                }
+                restored.append(TaskComposerAttachment(
+                    id: entry.id,
+                    kind: TaskComposerAttachment.Kind(persistedValue: entry.kind),
+                    displayName: entry.displayName,
+                    localStagedFileURL: stagedURL,
+                    byteCount: entry.byteCount,
+                    thumbnailData: entry.thumbnailData
+                ))
+            }
+            guard !Task.isCancelled else {
+                for attachment in restored {
+                    try? FileManager.default.removeItem(at: attachment.localStagedFileURL)
+                }
+                return
+            }
+            // Direct assignment: restoring saved state is not a user edit and
+            // must not rotate a still-valid retry identity.
+            attachments = restored
+            isDraftAttachmentRestorePending = false
+        }
     }
 
     private func validWorkspaceGroupID(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -108,7 +108,7 @@ struct TaskComposerSheet: View {
 
     init(
         store: CMUXMobileShellStore,
-        launchIntent: TaskComposerLaunchIntent = .automatic,
+        launchIntent: TaskComposerLaunchIntent = .new,
         onSwitchDraft: ((TaskComposerLaunchIntent) -> Void)? = nil,
         availableMachines: [MobilePairedMac]? = nil,
         availableWorkspaceGroups: [MobileWorkspaceGroupPreview]? = nil,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -422,10 +422,13 @@ struct TaskComposerSheet: View {
                 modelRefreshTask?.cancel()
                 modelRefreshOperationID = nil
                 attachmentStagingTask?.cancel()
-                removeStagedAttachmentFiles()
+                // Persist before deleting the staged files: preserving an
+                // attachment copies from its staged URL, so the reverse order
+                // silently drops attachments from the saved draft.
                 if shouldPersistDraftOnDisappear {
                     persistDraft()
                 }
+                removeStagedAttachmentFiles()
             }
             .onAppear {
                 store.recordAppEvent(
@@ -999,10 +1002,11 @@ struct TaskComposerSheet: View {
     }
 
     /// Saves the current content under this session's identity, then hands
-    /// the presenter another draft to rebuild the composer from.
+    /// the presenter another draft to rebuild the composer from. A failed
+    /// save keeps the session in place instead of silently discarding it.
     private func resumeDraft(_ id: UUID) {
         guard let onSwitchDraft else { return }
-        persistDraft()
+        guard persistDraftContent(base: draftSnapshot()) else { return }
         // The replaced view's onDisappear must not persist again: state
         // storage is already torn down by the identity switch, so that late
         // persist reads initial values and its empty snapshot would delete
@@ -1012,9 +1016,10 @@ struct TaskComposerSheet: View {
     }
 
     /// Saves the current content as its own draft and starts a fresh one.
+    /// A failed save keeps the session in place instead of discarding it.
     private func startNewDraft() {
         guard let onSwitchDraft else { return }
-        persistDraft()
+        guard persistDraftContent(base: draftSnapshot()) else { return }
         // See resumeDraft: block the torn-down view's late empty persist.
         shouldPersistDraftOnDisappear = false
         onSwitchDraft(.new)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -65,18 +65,24 @@ struct TaskComposerSheet: View {
 
     let sessionGeneration: Int
     /// Stable identity of this session's saved-draft entry. Every leave,
-    /// retry, and submit updates or removes exactly this entry.
-    let draftID: UUID
+    /// retry, and submit updates or removes exactly this entry. State, not a
+    /// stored `let`: the host re-evaluates this view's init on unrelated
+    /// re-renders (connection churn), and a fresh session must not mint a
+    /// new identity per evaluation or consecutive saves split into
+    /// duplicate draft entries.
+    @State var draftID: UUID
     /// Replaces this editing session with another draft's. `nil` hides the
     /// drafts affordance for hosts without a session presenter (previews and
     /// accessibility harnesses).
     private let onSwitchDraft: ((TaskComposerLaunchIntent) -> Void)?
     /// Attachment references preserved with the resumed draft; re-staged
-    /// into session-owned temporary copies on appear.
-    let restoredDraftAttachments: [MobileTaskComposerDraftAttachment]
+    /// into session-owned temporary copies on appear. State for the same
+    /// re-evaluation stability as `draftID`.
+    @State var restoredDraftAttachments: [MobileTaskComposerDraftAttachment]
     /// Leave-relevant state as this session opened; leaving with anything
-    /// different (except model/effort picks) asks before discarding.
-    let initialSessionFingerprint: TaskComposerSessionFingerprint
+    /// different (except model/effort picks) asks before discarding. State
+    /// so a mid-session save cannot move the baseline on re-evaluation.
+    @State var initialSessionFingerprint: TaskComposerSessionFingerprint
     private let restoredDraftAtInitialization: Bool
     private let availableMachines: [MobilePairedMac]?
     private let availableWorkspaceGroups: [MobileWorkspaceGroupPreview]?
@@ -153,7 +159,7 @@ struct TaskComposerSheet: View {
         let savedDrafts = store.taskTemplateStore?.composerDrafts() ?? []
         let resumedDraft = launchIntent.resolveDraft(in: savedDrafts)
         let draft = resumedDraft?.content
-        self.draftID = resumedDraft?.id ?? UUID()
+        _draftID = State(initialValue: resumedDraft?.id ?? UUID())
         self.restoredDraftAtInitialization = draft != nil
         let foregroundMacID = store.connectedMacDeviceID
         let foregroundMacInstanceTag = store.connectedMacInstanceTag
@@ -312,9 +318,9 @@ struct TaskComposerSheet: View {
                 operationID: initialOperationID
             )
         }
-        self.restoredDraftAttachments = restoredAttachments
+        _restoredDraftAttachments = State(initialValue: restoredAttachments)
         _isDraftAttachmentRestorePending = State(initialValue: !restoredAttachments.isEmpty)
-        self.initialSessionFingerprint = TaskComposerSessionFingerprint(
+        _initialSessionFingerprint = State(initialValue: TaskComposerSessionFingerprint(
             prompt: initialPrompt,
             workspaceName: initialWorkspaceName,
             templateID: selectedTemplateID,
@@ -327,7 +333,7 @@ struct TaskComposerSheet: View {
             workspaceGroupID: initialWorkspaceGroupID,
             attachmentIDs: Set(initialAttachments.map(\.id))
                 .union(restoredAttachments.map(\.id))
-        )
+        ))
         let canRestoreCompletedOperation = draft?.templateID == selectedTemplateID
             && draftMatchesSelectedMac
             && draft?.workspaceGroupID == initialWorkspaceGroupID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -992,6 +992,11 @@ struct TaskComposerSheet: View {
     private func resumeDraft(_ id: UUID) {
         guard let onSwitchDraft else { return }
         persistDraft()
+        // The replaced view's onDisappear must not persist again: state
+        // storage is already torn down by the identity switch, so that late
+        // persist reads initial values and its empty snapshot would delete
+        // the draft that was just saved.
+        shouldPersistDraftOnDisappear = false
         onSwitchDraft(.resume(id))
     }
 
@@ -999,6 +1004,8 @@ struct TaskComposerSheet: View {
     private func startNewDraft() {
         guard let onSwitchDraft else { return }
         persistDraft()
+        // See resumeDraft: block the torn-down view's late empty persist.
+        shouldPersistDraftOnDisappear = false
         onSwitchDraft(.new)
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -58,6 +58,11 @@ struct TaskComposerSheet: View {
     @State var hasRecordedDraftChange = false
     @State private var isDraftsListPresented = false
     @State var isLeaveConfirmationPresented = false
+    /// Whether the user explicitly picked a model or effort this session.
+    /// Tracked as an action, not by comparing values: catalog refreshes
+    /// auto-reconcile those pickers, and an automatic adjustment must not
+    /// prompt to save on leave, while a deliberate pick must.
+    @State var hasUserPickedModelOrEffort = false
     /// True until this session's preserved attachments finish re-staging, so
     /// an early leave still persists their references instead of dropping
     /// them with the not-yet-populated live list.
@@ -80,8 +85,8 @@ struct TaskComposerSheet: View {
     /// re-evaluation stability as `draftID`.
     @State var restoredDraftAttachments: [MobileTaskComposerDraftAttachment]
     /// Leave-relevant state as this session opened; leaving with anything
-    /// different (except model/effort picks) asks before discarding. State
-    /// so a mid-session save cannot move the baseline on re-evaluation.
+    /// different asks before discarding. State so a mid-session save cannot
+    /// move the baseline on re-evaluation.
     @State var initialSessionFingerprint: TaskComposerSessionFingerprint
     private let restoredDraftAtInitialization: Bool
     private let availableMachines: [MobilePairedMac]?
@@ -941,9 +946,11 @@ struct TaskComposerSheet: View {
     }
 
     /// Whether leaving now would abandon anything the user changed this
-    /// session (model and effort picks excluded by design).
+    /// session, including deliberate model and effort picks (automatic
+    /// catalog reconciliation does not count).
     var hasUnsavedComposerChanges: Bool {
         currentSessionFingerprint != initialSessionFingerprint
+            || hasUserPickedModelOrEffort
     }
 
     private func cancelComposer() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -56,8 +56,6 @@ struct TaskComposerSheet: View {
     /// Draft typing is sampled once per composer presentation so this bounded
     /// log records that editing occurred without one event per keystroke.
     @State var hasRecordedDraftChange = false
-    /// Saved drafts other than this session's, loaded when the list presents.
-    @State private var otherDrafts: [MobileTaskComposerSavedDraft] = []
     @State private var isDraftsListPresented = false
     @State var isLeaveConfirmationPresented = false
     /// True until this session's preserved attachments finish re-staging, so
@@ -394,7 +392,9 @@ struct TaskComposerSheet: View {
             }
             .sheet(isPresented: $isDraftsListPresented) {
                 TaskComposerDraftsSheet(
-                    drafts: otherDrafts,
+                    loadDrafts: { [store, draftID] in
+                        store.taskComposerSavedDrafts().filter { $0.id != draftID }
+                    },
                     templates: templates,
                     resume: resumeDraft,
                     startNew: startNewDraft,
@@ -981,9 +981,8 @@ struct TaskComposerSheet: View {
         return { presentDraftsList() }
     }
 
-    /// Opens the saved-drafts list for every session except this one.
+    /// Opens the saved-drafts list; the sheet loads its rows on appear.
     private func presentDraftsList() {
-        otherDrafts = store.taskComposerSavedDrafts().filter { $0.id != draftID }
         isDraftsListPresented = true
     }
 
@@ -1010,11 +1009,10 @@ struct TaskComposerSheet: View {
     }
 
     private func deleteDrafts(_ ids: Set<UUID>) {
-        guard store.deleteTaskComposerDrafts(
+        store.deleteTaskComposerDrafts(
             ids: ids,
             ifSessionGeneration: sessionGeneration
-        ) else { return }
-        otherDrafts.removeAll { ids.contains($0.id) }
+        )
     }
 
     private func selectMachine(_ macDeviceID: String, _ instanceTag: String?) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -480,9 +480,11 @@ struct WorkspaceShellView: View {
         .taskComposerPresentation(
             isPresented: taskComposerPresentation.isPresented,
             onDismiss: taskComposerPresentation.didDismiss
-        ) {
+        ) { launch, switchDraft in
             TaskComposerSheet(
                 store: store,
+                launchIntent: launch.intent,
+                onSwitchDraft: switchDraft,
                 submitTaskComposer: submitTaskComposerFromShell
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TaskComposerLaunchIntentTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TaskComposerLaunchIntentTests.swift
@@ -1,0 +1,59 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct TaskComposerLaunchIntentTests {
+    private static func savedDraft(prompt: String, at seconds: Double) -> MobileTaskComposerSavedDraft {
+        MobileTaskComposerSavedDraft(
+            updatedAt: Date(timeIntervalSince1970: seconds),
+            content: MobileTaskComposerDraft(
+                prompt: prompt,
+                templateID: nil,
+                macDeviceID: "mac-a",
+                directory: "~",
+                didEditDirectory: false
+            )
+        )
+    }
+
+    @Test func automaticResumesTheNewestDraftAndFallsBackToFresh() {
+        let newest = Self.savedDraft(prompt: "Newest", at: 200)
+        let older = Self.savedDraft(prompt: "Older", at: 100)
+
+        #expect(TaskComposerLaunchIntent.automatic.resolveDraft(in: [newest, older]) == newest)
+        #expect(TaskComposerLaunchIntent.automatic.resolveDraft(in: []) == nil)
+    }
+
+    @Test func resumeSelectsExactlyTheRequestedDraft() {
+        let newest = Self.savedDraft(prompt: "Newest", at: 200)
+        let older = Self.savedDraft(prompt: "Older", at: 100)
+
+        #expect(TaskComposerLaunchIntent.resume(older.id).resolveDraft(in: [newest, older]) == older)
+    }
+
+    @Test func resumeOfADeletedDraftStartsFreshInsteadOfStealingAnother() {
+        let newest = Self.savedDraft(prompt: "Newest", at: 200)
+
+        #expect(TaskComposerLaunchIntent.resume(UUID()).resolveDraft(in: [newest]) == nil)
+    }
+
+    @Test func newIgnoresSavedDrafts() {
+        let newest = Self.savedDraft(prompt: "Newest", at: 200)
+
+        #expect(TaskComposerLaunchIntent.new.resolveDraft(in: [newest]) == nil)
+    }
+
+    @Test func switchingAlwaysChangesSessionIdentity() {
+        let first = TaskComposerLaunch()
+        let second = first.switching(to: .new)
+        let third = second.switching(to: .automatic)
+
+        #expect(second.token != first.token)
+        #expect(third.token != second.token)
+        #expect(third.intent == .automatic)
+        #expect(third != first)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TaskComposerLaunchIntentTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TaskComposerLaunchIntentTests.swift
@@ -18,14 +18,6 @@ import Testing
         )
     }
 
-    @Test func automaticResumesTheNewestDraftAndFallsBackToFresh() {
-        let newest = Self.savedDraft(prompt: "Newest", at: 200)
-        let older = Self.savedDraft(prompt: "Older", at: 100)
-
-        #expect(TaskComposerLaunchIntent.automatic.resolveDraft(in: [newest, older]) == newest)
-        #expect(TaskComposerLaunchIntent.automatic.resolveDraft(in: []) == nil)
-    }
-
     @Test func resumeSelectsExactlyTheRequestedDraft() {
         let newest = Self.savedDraft(prompt: "Newest", at: 200)
         let older = Self.savedDraft(prompt: "Older", at: 100)
@@ -43,16 +35,16 @@ import Testing
         let newest = Self.savedDraft(prompt: "Newest", at: 200)
 
         #expect(TaskComposerLaunchIntent.new.resolveDraft(in: [newest]) == nil)
+        #expect(TaskComposerLaunch().intent == .new)
     }
 
     @Test func switchingAlwaysChangesSessionIdentity() {
         let first = TaskComposerLaunch()
         let second = first.switching(to: .new)
-        let third = second.switching(to: .automatic)
+        let third = second.switching(to: .resume(UUID()))
 
         #expect(second.token != first.token)
         #expect(third.token != second.token)
-        #expect(third.intent == .automatic)
         #expect(third != first)
     }
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -12484,6 +12484,91 @@
         }
       }
     },
+    "mobile.taskComposer.drafts.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drafts"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下書き"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.new": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Draft"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい下書き"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Other Drafts"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "他の下書きはありません"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.empty.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave the composer with an unsent task and it is saved here."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未送信のタスクを残したまま閉じると、ここに保存されます。"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.untitled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No prompt yet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロンプト未入力"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.effort": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -12552,6 +12552,57 @@
         }
       }
     },
+    "mobile.taskComposer.drafts.leaveDialog.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save this task as a draft?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このタスクを下書きとして保存しますか？"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.leaveDialog.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Draft"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下書きを保存"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.drafts.leaveDialog.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Draft"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下書きを削除"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.drafts.untitled": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
- Replaces the Task Composer's single-slot draft with a bounded multi-draft collection (`cmux.mobile.taskComposer.drafts.v1`, cap 20, newest first). The legacy `draft.v1` slot migrates into the collection on first read, so nothing prepared on an older build is lost.
- Drafts are explicit, matching X/Twitter: the composer always opens fresh, and the Drafts toolbar button lists every saved draft — tap to resume (an in-progress session saves as its own draft first), swipe to delete, plus (top left) parks the current session and starts fresh, Done (top right) closes the list. Draft switching recreates the sheet through a launch-intent token so the existing init restore-validation runs unchanged for every draft.
- Leaving the composer with any change relative to the session's opening state shows a centered alert, "Save this task as a draft?" (Save Draft / Delete Draft / Cancel). Deliberate model and effort picks count as changes; automatic catalog reconciliation does not. An unchanged session leaves its saved draft untouched; submit deletes only its own draft.
- Drafts preserve attachments. Staged bytes copy into `Application Support/cmux/composer-draft-attachments/<draftID>/` when a draft saves, re-stage into fresh session temp copies on resume, and are garbage-collected with draft deletion, cap eviction, and sign-out. Restored attachment identities join the initial request so resuming a draft cannot rotate a still-valid retry operation ID.
- Draft writes stay behind the existing session-generation guards; persisting an effectively empty draft (no prompt, name, or attachments, and no completed-operation recovery anchor) deletes its entry instead of accumulating blanks.

## Testing
- `swift test --package-path Packages/iOS/CmuxMobileShellModel` — 323 tests green (saved-draft codable, legacy decode without attachments, emptiness rules, kind mapping).
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileTaskTemplateStoreTests` — 29 tests green (multi-draft CRUD, upsert promotion, cap eviction, legacy migration, attachment file persist/reuse/traversal-guard/GC, session-generation guards).
- `swift build` of CmuxMobileShellUI for arm64 iOS simulator — clean.
- Pre-existing local failures in `MobileTaskComposerSubmitTests` (Mac promotion/routing) reproduce identically at `origin/main` and are unrelated.

## Notes
- The attachment copy on save is synchronous on the main actor; bytes are bounded at 64 MB per task, so worst-case saves are still fast. Removing one attachment from a live session leaves its preserved file until the draft next saves or is deleted; the per-draft folder removal covers it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790033646&installation_model_id=21920&pr_number=10588&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10588&signature=eea8c7c67cd52182d2c47bcba26c20c2e2915c1b9abd217f15bfe6c42835e15d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Task Composer drafts explicit and durable, with save-on-leave confirmation and attachment persistence. The composer now always opens fresh; users resume drafts from a Drafts list. Previously the newest draft auto-resumed and attachments could be lost on dismissal.

- Storage and migration:
  - Replace the single draft with a capped drafts collection (newest first, limit 20); migrate legacy draft.v1 to drafts.v1 on first read.
  - Persist attachments under Application Support/cmux/composer-draft-attachments/<draftID>/; garbage-collect on draft deletion, cap eviction, sign-out, and when re-saving removes files no longer referenced.
  - Add composerDrafts/saveComposerDraft/deleteComposerDrafts; MobileShellComposite exposes taskComposerSavedDrafts(); submission and completion include draftID.
  - Stable per-session draft IDs prevent duplicates; persisting an empty draft deletes it instead of saving junk.
  - Persist onDisappear before staged-file cleanup so attachments aren’t dropped on parent-driven dismissal.

- UI and behavior:
  - Drafts list button: resume, New Draft, swipe-delete; the list loads from storage on appear to avoid stale snapshots.
  - Switching drafts first saves the current session, then recreates the sheet via a launch token; onDisappear persist is disabled after the explicit switch save; if that save fails, remain on the current draft.
  - Leaving with changes prompts Save Draft / Delete Draft / Cancel; deliberate model/effort picks also prompt; automatic reconciliation does not; unchanged sessions leave drafts untouched.
  - Attachments restore into fresh temp files and keep their IDs to avoid rotating a valid retry operation ID.
  - Strings localized (en/ja).

<sup>Written for commit 3304e7998222cd381625c1d026713e69fadd77bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and manage up to 20 task-composer drafts.
  * Browse, resume, create, switch between, or delete drafts.
  * Drafts preserve attachments and related metadata.
  * Automatically resume the latest draft or start a new one.
  * Added leave confirmation and draft-specific submission handling.
  * Added English and Japanese localization for draft features.

* **Bug Fixes**
  * Existing drafts remain compatible after upgrading.
  * Deleted drafts and cleared data now remove associated attachments safely.
  * Completed submissions no longer clear unrelated saved drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
