### PR TITLE
iOS: Terminal Lab debug screen for the termd snapshot/tail protocol

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -7,6 +7,9 @@ import CmuxMobileSupport
 import CmuxMobileToast
 import CmuxMobileWorkspace
 import SwiftUI
+#if DEBUG
+import CmuxMobileTerminal
+#endif
 
 /// The mobile app's settings page. Surfaces the signed-in account (so the user
 /// can confirm which cmux account this device uses — the account must match the
@@ -325,6 +328,19 @@ struct MobileSettingsView: View {
                         )
                     }
                     .accessibilityIdentifier("MobileSettingsShellIconLab")
+
+                    NavigationLink {
+                        TerminalLabView()
+                    } label: {
+                        Label(
+                            L10n.string(
+                                "mobile.settings.terminalLab",
+                                defaultValue: "Terminal Lab"
+                            ),
+                            systemImage: "cable.connector.horizontal"
+                        )
+                    }
+                    .accessibilityIdentifier("MobileSettingsTerminalLab")
                 }
                 #endif
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/TerminalLabClient.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/TerminalLabClient.swift
@@ -1,0 +1,481 @@
+#if canImport(UIKit) && DEBUG
+import Foundation
+import Network
+import Security
+
+// Terminal Lab: DEBUG-only client for the terminal-lab wire protocol v1
+// (cmuxterm-hq terminal-lab/PROTOCOL.md, served by termd). Ported from the
+// TermLab spike app so the same snapshot/tail attach semantics can be
+// dogfooded inside the real cmux iOS app against a termd on the paired Mac.
+// Never compiled into release.
+
+/// Frame types from PROTOCOL.md v1.
+enum TerminalLabFrameType: UInt8 {
+    case hello = 0x01
+    case welcome = 0x02
+    case attach = 0x03
+    case snapshot = 0x04
+    case output = 0x05
+    case input = 0x06
+    case resize = 0x07
+    case resized = 0x08
+    case exit = 0x09
+    case ping = 0x0A
+    case pong = 0x0B
+    case error = 0x0C
+}
+
+enum TerminalLabWire {
+    static let maxPayload = 16 * 1024 * 1024 // 16 MiB
+
+    /// Encode one frame: u32 LE payload_len, u8 type, payload.
+    static func encode(_ type: TerminalLabFrameType, payload: Data) -> Data {
+        var out = Data(capacity: 5 + payload.count)
+        var len = UInt32(payload.count).littleEndian
+        withUnsafeBytes(of: &len) { out.append(contentsOf: $0) }
+        out.append(type.rawValue)
+        out.append(payload)
+        return out
+    }
+}
+
+/// Incremental frame parser. Feed arbitrary chunks; emits complete frames.
+struct TerminalLabFrameDecoder {
+    private var buffer = Data()
+
+    enum DecodeError: Error {
+        case oversizedPayload(UInt32)
+    }
+
+    /// Appends bytes and returns all complete frames now available.
+    /// Unknown frame types are returned with rawType set and type nil.
+    mutating func feed(_ data: Data) throws -> [(type: TerminalLabFrameType?, rawType: UInt8, payload: Data)] {
+        buffer.append(data)
+        var frames: [(TerminalLabFrameType?, UInt8, Data)] = []
+        while buffer.count >= 5 {
+            let len = UInt32(littleEndian: buffer.withUnsafeBytes {
+                $0.loadUnaligned(fromByteOffset: 0, as: UInt32.self)
+            })
+            guard len <= TerminalLabWire.maxPayload else { throw DecodeError.oversizedPayload(len) }
+            let total = 5 + Int(len)
+            guard buffer.count >= total else { break }
+            let rawType = buffer[buffer.startIndex + 4]
+            let payload = Data(buffer[(buffer.startIndex + 5)..<(buffer.startIndex + total)])
+            buffer.removeFirst(total)
+            frames.append((TerminalLabFrameType(rawValue: rawType), rawType, payload))
+        }
+        return frames
+    }
+
+    mutating func reset() { buffer.removeAll(keepingCapacity: false) }
+}
+
+private extension Data {
+    func labLEUInt64(at offset: Int) -> UInt64? {
+        guard count >= offset + 8 else { return nil }
+        let v = withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt64.self) }
+        return UInt64(littleEndian: v)
+    }
+
+    func labLEUInt16(at offset: Int) -> UInt16? {
+        guard count >= offset + 2 else { return nil }
+        let v = withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt16.self) }
+        return UInt16(littleEndian: v)
+    }
+
+    func labLEInt32(at offset: Int) -> Int32? {
+        guard count >= offset + 4 else { return nil }
+        let v = withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) }
+        return Int32(bitPattern: UInt32(littleEndian: v))
+    }
+
+    mutating func labAppendLE(_ v: UInt16) {
+        var le = v.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+}
+
+/// TCP client for the terminal-lab wire protocol v1.
+///
+/// State machine: idle -> connecting -> helloSent -> attaching -> streaming.
+/// On any transport error, protocol error, or OUTPUT gen discontinuity the
+/// connection is torn down and rebuilt (reconnect is just re-attach; the
+/// protocol is idempotent). SNAPSHOT is also accepted while streaming and
+/// resets client state.
+final class TerminalLabClient: ObservableObject, @unchecked Sendable {
+    enum ConnState: String {
+        case idle, connecting, helloSent, attaching, streaming, exited
+    }
+
+    // Published UI state (main thread). Mirrors the queue-side authoritative
+    // `connState`.
+    @Published private(set) var state: ConnState = .idle
+    @Published private(set) var sessionId: String = "-"
+    @Published private(set) var gen: UInt64 = 0
+    @Published private(set) var cols: UInt16 = 0
+    @Published private(set) var rows: UInt16 = 0
+    @Published private(set) var attachCount: Int = 0
+    @Published private(set) var lastError: String?
+
+    /// SNAPSHOT payload bytes (screen must reset, then apply). Called on main.
+    var onSnapshot: ((Data) -> Void)?
+    /// Contiguous OUTPUT bytes. Called on main.
+    var onOutput: ((Data) -> Void)?
+    /// Server confirmed a PTY size (reply to RESIZE, or another client's). Main.
+    var onResized: ((UInt16, UInt16) -> Void)?
+
+    let host: String
+    let port: UInt16
+    /// Shared-secret HELLO token, required by termd --token (non-loopback binds).
+    let token: String?
+
+    private let queue = DispatchQueue(label: "dev.cmux.terminal-lab.client")
+    private var connState: ConnState = .idle // authoritative, queue-only
+    private var conn: NWConnection?
+    private var decoder = TerminalLabFrameDecoder()
+    private var expectedGen: UInt64 = 0
+    private var started = false
+    private var reconnectDelay: TimeInterval = 0.5
+    private var reconnectTimer: DispatchSourceTimer?
+    private var pingTimer: DispatchSourceTimer?
+    private var lastPingPayload = Data()
+    private var generation = 0 // connection incarnation, guards stale callbacks
+
+    /// Desired size; replayed right after every attach so a RESIZE composed
+    /// while disconnected is not lost.
+    private var desiredCols: UInt16 = 0
+    private var desiredRows: UInt16 = 0
+
+    init(host: String, port: UInt16, token: String?) {
+        self.host = host
+        self.port = port
+        self.token = (token?.isEmpty == true) ? nil : token
+    }
+
+    func start() {
+        queue.async { [self] in
+            guard !started else { return }
+            started = true
+            openConnection()
+        }
+    }
+
+    func stop() {
+        queue.async { [self] in
+            started = false
+            teardown(reason: nil, reconnect: false)
+        }
+    }
+
+    // MARK: - Connection lifecycle (all on `queue`)
+
+    private func openConnection() {
+        generation += 1
+        let myGen = generation
+        decoder.reset()
+        expectedGen = 0
+        setState(.connecting)
+
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            fail("invalid port \(port)", reconnect: false)
+            return
+        }
+        let tcp = NWProtocolTCP.Options()
+        tcp.noDelay = true
+        let params = NWParameters(tls: nil, tcp: tcp)
+        let c = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: params)
+        conn = c
+        c.stateUpdateHandler = { [weak self] st in
+            self?.queue.async {
+                guard let self, self.generation == myGen else { return }
+                switch st {
+                case .ready:
+                    self.sendHello()
+                    self.receiveLoop(c, myGen)
+                case .failed(let err):
+                    self.fail("connect failed: \(err)", reconnect: true)
+                case .waiting(let err):
+                    // Connection refused / no listener. NWConnection would sit
+                    // in .waiting until a path change, which never fires for a
+                    // new listener, so cancel and re-dial on our own timer.
+                    self.fail("waiting: \(err); retrying", reconnect: true)
+                default:
+                    break
+                }
+            }
+        }
+        c.start(queue: queue)
+    }
+
+    private func teardown(reason: String?, reconnect: Bool) {
+        generation += 1
+        pingTimer?.cancel(); pingTimer = nil
+        reconnectTimer?.cancel(); reconnectTimer = nil
+        conn?.cancel(); conn = nil
+        decoder.reset()
+        if let reason { publish { self.lastError = reason } }
+        setState(.idle)
+        if reconnect && started {
+            scheduleReconnect()
+        }
+    }
+
+    private func fail(_ reason: String, reconnect: Bool) {
+        teardown(reason: reason, reconnect: reconnect)
+    }
+
+    private func scheduleReconnect() {
+        let t = DispatchSource.makeTimerSource(queue: queue)
+        t.schedule(deadline: .now() + reconnectDelay)
+        reconnectDelay = min(reconnectDelay * 2, 5.0)
+        t.setEventHandler { [weak self] in
+            guard let self, self.started else { return }
+            self.openConnection()
+        }
+        t.resume()
+        reconnectTimer = t
+    }
+
+    // MARK: - Receive
+
+    private func receiveLoop(_ c: NWConnection, _ myGen: Int) {
+        c.receive(minimumIncompleteLength: 1, maximumLength: 128 * 1024) { [weak self] data, _, isComplete, error in
+            self?.queue.async {
+                guard let self, self.generation == myGen else { return }
+                if let data, !data.isEmpty {
+                    do {
+                        for frame in try self.decoder.feed(data) {
+                            self.handleFrame(frame.type, frame.rawType, frame.payload)
+                            guard self.generation == myGen else { return } // torn down mid-batch
+                        }
+                    } catch {
+                        self.fail("framing error: \(error)", reconnect: true)
+                        return
+                    }
+                }
+                if let error {
+                    self.fail("recv failed: \(error)", reconnect: true)
+                    return
+                }
+                if isComplete {
+                    self.fail("server closed connection", reconnect: true)
+                    return
+                }
+                self.receiveLoop(c, myGen)
+            }
+        }
+    }
+
+    // MARK: - Frame handling (on `queue`)
+
+    private func handleFrame(_ type: TerminalLabFrameType?, _ rawType: UInt8, _ payload: Data) {
+        guard let type else {
+            // Unknown type: tolerate and skip (forward compatibility).
+            publish { self.lastError = String(format: "unknown frame 0x%02X", rawType) }
+            return
+        }
+        switch type {
+        case .welcome: handleWelcome(payload)
+        case .snapshot: handleSnapshot(payload)
+        case .output: handleOutput(payload)
+        case .resized: handleResized(payload)
+        case .exit: handleExit(payload)
+        case .pong: handlePong(payload)
+        case .error: handleServerError(payload)
+        default:
+            // Client->server frame types arriving at the client are a protocol error.
+            fail(String(format: "unexpected frame 0x%02X from server", rawType), reconnect: true)
+        }
+    }
+
+    private func sendHello() {
+        setState(.helloSent)
+        var hello: [String: Any] = ["proto": 1, "client": "ios", "name": "cmux-ios-lab"]
+        if let token { hello["token"] = token }
+        sendJSON(.hello, hello)
+    }
+
+    private func handleWelcome(_ payload: Data) {
+        guard connState == .helloSent,
+              let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              let proto = obj["proto"] as? Int, proto == 1,
+              let sessions = obj["sessions"] as? [[String: Any]] else {
+            fail("bad WELCOME payload", reconnect: true)
+            return
+        }
+        let target = sessions.first(where: { ($0["id"] as? String) == "main" }) ?? sessions.first
+        guard let target, let id = target["id"] as? String else {
+            fail("WELCOME listed no sessions", reconnect: true)
+            return
+        }
+        publish {
+            self.sessionId = id
+            if let c = target["cols"] as? Int { self.cols = UInt16(clamping: c) }
+            if let r = target["rows"] as? Int { self.rows = UInt16(clamping: r) }
+            if let g = target["gen"] as? Int { self.gen = UInt64(max(0, g)) }
+        }
+        setState(.attaching)
+        sendJSON(.attach, ["session": id])
+    }
+
+    private func handleSnapshot(_ payload: Data) {
+        // Accepted in .attaching (the one guaranteed reply) and in .streaming
+        // (v2 spam coalescing sends a fresh SNAPSHOT instead of a gap).
+        guard connState == .attaching || connState == .streaming else {
+            fail("SNAPSHOT in state \(connState.rawValue)", reconnect: true)
+            return
+        }
+        guard payload.count >= 13,
+              let g = payload.labLEUInt64(at: 0),
+              let c = payload.labLEUInt16(at: 8),
+              let r = payload.labLEUInt16(at: 10) else {
+            fail("short SNAPSHOT header", reconnect: true)
+            return
+        }
+        let bytes = payload.count > 13 ? payload.subdata(in: (payload.startIndex + 13)..<payload.endIndex) : Data()
+        expectedGen = g
+        reconnectDelay = 0.5 // healthy attach resets backoff
+        setState(.streaming)
+        publish {
+            self.gen = g
+            self.cols = c
+            self.rows = r
+            self.attachCount += 1
+            self.lastError = nil
+            self.onSnapshot?(bytes)
+        }
+        // Replay desired size so a RESIZE composed while disconnected lands.
+        if desiredCols > 0 && desiredRows > 0 {
+            sendResizeRaw(desiredCols, desiredRows)
+        }
+        startPing()
+    }
+
+    private func handleOutput(_ payload: Data) {
+        guard connState == .streaming else { return } // OUTPUT before SNAPSHOT: ignore
+        guard let genStart = payload.labLEUInt64(at: 0) else {
+            fail("short OUTPUT header", reconnect: true)
+            return
+        }
+        let bytes = payload.count > 8 ? payload.subdata(in: (payload.startIndex + 8)..<payload.endIndex) : Data()
+        guard genStart == expectedGen else {
+            // Gen discontinuity: tear down and re-attach automatically.
+            fail("gen gap: expected \(expectedGen), got \(genStart); re-attaching", reconnect: true)
+            return
+        }
+        expectedGen += UInt64(bytes.count)
+        let newGen = expectedGen
+        publish {
+            self.gen = newGen
+            self.onOutput?(bytes)
+        }
+    }
+
+    private func handleResized(_ payload: Data) {
+        guard let c = payload.labLEUInt16(at: 0),
+              let r = payload.labLEUInt16(at: 2),
+              payload.labLEUInt64(at: 4) != nil else {
+            fail("short RESIZED payload", reconnect: true)
+            return
+        }
+        publish {
+            self.cols = c
+            self.rows = r
+            self.onResized?(c, r)
+        }
+    }
+
+    private func handleExit(_ payload: Data) {
+        let status = payload.labLEInt32(at: 0) ?? -1
+        // Session is over; log stays readable server-side. Stop reconnecting.
+        pingTimer?.cancel(); pingTimer = nil
+        setState(.exited)
+        publish { self.lastError = "session exited (status \(status))" }
+    }
+
+    private func handlePong(_ payload: Data) {
+        if payload != lastPingPayload {
+            publish { self.lastError = "PONG payload mismatch" }
+        }
+    }
+
+    private func handleServerError(_ payload: Data) {
+        let msg: String
+        if let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] {
+            msg = "server error \(obj["code"] as? String ?? "?"): \(obj["msg"] as? String ?? "")"
+        } else {
+            msg = "server error (unparseable payload)"
+        }
+        fail(msg, reconnect: true)
+    }
+
+    // MARK: - Sends (public API hops to `queue`)
+
+    /// Send raw bytes as INPUT.
+    func sendInput(_ data: Data) {
+        queue.async { [self] in
+            guard connState == .streaming else { return }
+            send(.input, data)
+        }
+    }
+
+    /// Record desired size and send RESIZE if attached.
+    func requestResize(cols: UInt16, rows: UInt16) {
+        queue.async { [self] in
+            guard cols > 0, rows > 0 else { return }
+            desiredCols = cols
+            desiredRows = rows
+            if connState == .streaming {
+                sendResizeRaw(cols, rows)
+            }
+        }
+    }
+
+    private func sendResizeRaw(_ cols: UInt16, _ rows: UInt16) {
+        var p = Data(capacity: 4)
+        p.labAppendLE(cols)
+        p.labAppendLE(rows)
+        send(.resize, p)
+    }
+
+    private func startPing() {
+        pingTimer?.cancel()
+        let t = DispatchSource.makeTimerSource(queue: queue)
+        t.schedule(deadline: .now() + 5, repeating: 5)
+        t.setEventHandler { [weak self] in
+            guard let self, self.connState == .streaming else { return }
+            var p = Data(count: 8)
+            _ = p.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, 8, $0.baseAddress!) }
+            self.lastPingPayload = p
+            self.send(.ping, p)
+        }
+        t.resume()
+        pingTimer = t
+    }
+
+    private func sendJSON(_ type: TerminalLabFrameType, _ obj: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj) else { return }
+        send(type, data)
+    }
+
+    private func send(_ type: TerminalLabFrameType, _ payload: Data) {
+        guard let conn else { return }
+        conn.send(content: TerminalLabWire.encode(type, payload: payload), completion: .contentProcessed { [weak self] err in
+            if let err {
+                self?.queue.async { self?.fail("send failed: \(err)", reconnect: true) }
+            }
+        })
+    }
+
+    // MARK: - Helpers
+
+    private func setState(_ s: ConnState) {
+        connState = s
+        publish { self.state = s }
+    }
+
+    private func publish(_ block: @escaping () -> Void) {
+        DispatchQueue.main.async(execute: block)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/TerminalLabView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/TerminalLabView.swift
@@ -1,0 +1,211 @@
+#if canImport(UIKit) && DEBUG
+import CMUXMobileCore
+import SwiftUI
+import UIKit
+
+/// Terminal Lab: DEBUG-only dogfood screen for the terminal-lab snapshot/tail
+/// protocol (termd). Connects over raw TCP to a termd on the paired Mac and
+/// renders the session through the REAL production `GhosttySurfaceView`, so
+/// typing, the accessory bar, zoom, and scrollback behave exactly like the
+/// production terminal while the transport is the lab's generation-indexed
+/// attach protocol.
+///
+/// Mac side (from a cmuxterm-hq checkout, PR 318):
+///   terminal-lab/daemon/.build/release/termd \
+///     --host <tailscale-ip> --port 7681 --token <secret>
+///
+/// Reachable from Settings > Developer > Terminal Lab, or at the root with
+/// CMUX_TERMINAL_LAB=1. Scripted preflight can pre-fill and auto-connect with
+/// CMUX_TERMINAL_LAB_HOST / _PORT / _TOKEN / _AUTOCONNECT=1.
+public struct TerminalLabView: View {
+    @AppStorage("cmux.debug.terminalLab.host") private var host = ""
+    @AppStorage("cmux.debug.terminalLab.port") private var portText = "7681"
+    @AppStorage("cmux.debug.terminalLab.token") private var token = ""
+    @State private var client: TerminalLabClient?
+    @Environment(\.dismiss) private var dismiss
+
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            controlBar
+            Divider()
+            if let client {
+                TerminalLabStatusBar(client: client)
+                Divider()
+                TerminalLabSurface(client: client)
+            } else {
+                ContentUnavailableView(
+                    "Not connected",
+                    systemImage: "terminal",
+                    description: Text("Start termd on the Mac, enter its host, port, and token, then Connect.")
+                )
+                .frame(maxHeight: .infinity)
+            }
+        }
+        .background(Color.black)
+        .preferredColorScheme(.dark)
+        .onAppear(perform: applyEnvironmentOverrides)
+    }
+
+    private var controlBar: some View {
+        HStack(spacing: 8) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill").font(.system(size: 20))
+            }
+            .buttonStyle(.plain)
+            TextField("host", text: $host)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .keyboardType(.URL)
+            TextField("port", text: $portText)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.numberPad)
+                .frame(width: 64)
+            SecureField("token", text: $token)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 90)
+            Button(client == nil ? "Connect" : "Disconnect") {
+                if client == nil { connect() } else { disconnect() }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(client == nil && (host.isEmpty || UInt16(portText) == nil))
+        }
+        .font(.system(size: 13))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    private func connect() {
+        guard let port = UInt16(portText), !host.isEmpty else { return }
+        client = TerminalLabClient(host: host, port: port, token: token)
+    }
+
+    private func disconnect() {
+        client?.stop()
+        client = nil
+    }
+
+    /// Scripted-launch overrides for tagged sim preflights: environment wins
+    /// over the persisted fields, and autoconnect skips the manual tap.
+    private func applyEnvironmentOverrides() {
+        let env = ProcessInfo.processInfo.environment
+        if let h = env["CMUX_TERMINAL_LAB_HOST"], !h.isEmpty { host = h }
+        if let p = env["CMUX_TERMINAL_LAB_PORT"], UInt16(p) != nil { portText = p }
+        if let t = env["CMUX_TERMINAL_LAB_TOKEN"] { token = t }
+        if env["CMUX_TERMINAL_LAB_AUTOCONNECT"] == "1", client == nil {
+            connect()
+        }
+    }
+}
+
+/// Status line mirroring the lab spike: state, session, gen, grid, attaches.
+private struct TerminalLabStatusBar: View {
+    @ObservedObject var client: TerminalLabClient
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle().fill(stateColor).frame(width: 8, height: 8)
+            Text(client.state.rawValue).foregroundStyle(stateColor)
+            Text(client.sessionId)
+            Text("gen \(client.gen)")
+            Text("\(client.cols)x\(client.rows)")
+            Text("attach #\(client.attachCount)")
+            Spacer()
+            if let err = client.lastError {
+                Text(err).foregroundStyle(.orange).lineLimit(1)
+            }
+        }
+        .font(.system(size: 11, design: .monospaced))
+        .foregroundStyle(Color(white: 0.85))
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Color(white: 0.08))
+    }
+
+    private var stateColor: Color {
+        switch client.state {
+        case .streaming: return .green
+        case .exited: return .red
+        case .idle: return .orange
+        default: return .yellow
+        }
+    }
+}
+
+/// Mounts the production surface and bridges it to the lab client:
+/// daemon bytes -> processOutput (SNAPSHOT prefixed with RIS so every attach
+/// converges from a clean grid), typed bytes -> INPUT frames, natural-grid
+/// changes -> RESIZE, server RESIZED -> applyViewSize.
+private struct TerminalLabSurface: UIViewRepresentable {
+    let client: TerminalLabClient
+
+    func makeCoordinator() -> Coordinator { Coordinator(client: client) }
+
+    func makeUIView(context: Context) -> UIView {
+        guard let runtime = try? GhosttyRuntime.shared() else {
+            let label = UILabel()
+            label.text = "Terminal Lab: Ghostty runtime init failed"
+            label.textColor = .white
+            return label
+        }
+        let view = GhosttySurfaceView(runtime: runtime, delegate: context.coordinator, fontSize: 12)
+        context.coordinator.surfaceView = view
+        context.coordinator.start()
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.stop()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, GhosttySurfaceViewDelegate {
+        weak var surfaceView: GhosttySurfaceView?
+        private let client: TerminalLabClient
+
+        init(client: TerminalLabClient) {
+            self.client = client
+        }
+
+        func start() {
+            client.onSnapshot = { [weak self] bytes in
+                // RIS before every snapshot: first attach and every re-attach
+                // converge from a clean grid regardless of leftover modes or
+                // alt-screen state from the previous attach epoch.
+                var reset = Data([0x1B, UInt8(ascii: "c")])
+                reset.append(bytes)
+                self?.surfaceView?.processOutput(reset)
+            }
+            client.onOutput = { [weak self] bytes in
+                self?.surfaceView?.processOutput(bytes)
+            }
+            client.onResized = { [weak self] cols, rows in
+                self?.surfaceView?.applyViewSize(cols: Int(cols), rows: Int(rows))
+            }
+            client.start()
+        }
+
+        func stop() {
+            client.stop()
+        }
+
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {
+            client.sendInput(data)
+        }
+
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize, reportID: UInt64) {
+            guard size.columns > 0, size.rows > 0 else { return }
+            client.requestResize(cols: UInt16(clamping: size.columns),
+                                 rows: UInt16(clamping: size.rows))
+        }
+    }
+}
+#endif

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -8492,6 +8492,23 @@
         }
       }
     },
+    "mobile.settings.terminalLab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal Lab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルラボ"
+          }
+        }
+      }
+    },
     "mobile.settings.shellIconLab.footer": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -397,6 +397,8 @@ public struct CMUXMobileRootScene: View {
             MobileBottomScrollStressView()
         } else if ProcessInfo.processInfo.environment["CMUX_TOAST_GALLERY"] == "1" {
             ToastGalleryView()
+        } else if ProcessInfo.processInfo.environment["CMUX_TERMINAL_LAB"] == "1" {
+            TerminalLabView()
         } else {
             makeMobileAppView()
         }


### PR DESCRIPTION
DEBUG-only dogfood surface for the terminal-lab transport being developed in [cmuxterm-hq#318](https://github.com/manaflow-ai/cmuxterm-hq/pull/318): the from-scratch Mac session daemon (`termd`) with a generation-indexed ring log and snapshot-plus-tail attach protocol, built for terminal streaming reliability.

`TerminalLabClient` ports the lab wire protocol v1 (HELLO/ATTACH/SNAPSHOT/OUTPUT/INPUT/RESIZE, generation-continuity checking, automatic re-attach with backoff, shared-token auth for non-loopback binds). The screen renders through the production `GhosttySurfaceView`, so typing, the accessory bar, zoom, and scrollback are the real production input stack while only the transport differs. Everything is `#if DEBUG` and never compiles into release.

Entry points: Settings > CMUX Labs > Terminal Lab (host/port/token fields persist in UserDefaults), or `CMUX_TERMINAL_LAB=1` at launch with `CMUX_TERMINAL_LAB_HOST/_PORT/_TOKEN/_AUTOCONNECT` for scripted sim preflights.

Mac side, from a cmuxterm-hq checkout on the PR 318 branch:

```
terminal-lab/daemon/.build/release/termd --host <tailscale-ip> --port 7681 --token <secret>
```

termd refuses non-loopback binds without `--token`; wrong or missing token gets an ERROR frame and a close before any session state is disclosed.

Localization audit: one new user-facing string, `mobile.settings.terminalLab` (en + ja), in the DEBUG-only CMUX Labs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790033964&installation_model_id=21920&pr_number=10589&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10589&signature=e2a8b6467364ebf80fb3c6cf37f078c27645cdf691c5a2d1d6be20cb2188f3f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DEBUG-only Terminal Lab screen that connects to a Mac `termd` using the snapshot+tail protocol and renders via the production `GhosttySurfaceView`. This lets us dogfood the new transport (HELLO/ATTACH/SNAPSHOT/OUTPUT/INPUT/RESIZE) with generation continuity and auto re-attach, without changing release builds.

- Review notes:
  - Entry points: Settings > CMUX Labs > Terminal Lab, or set `CMUX_TERMINAL_LAB=1` (optional: `CMUX_TERMINAL_LAB_HOST/_PORT/_TOKEN/_AUTOCONNECT`). Host/port/token persist between runs.
  - Client behavior: validates generation continuity, auto re-attaches with backoff on gaps/errors, sends periodic PINGs, and replays pending RESIZE on attach; SNAPSHOT resets the grid before applying bytes.
  - Surface integration: uses `GhosttySurfaceView` for real input/scrollback/zoom; INPUT and RESIZE are bridged directly.
  - Security: sends shared-token in HELLO; `termd` refuses non-loopback binds without `--token` and closes on wrong/missing tokens before exposing state.
  - Scope of changes: new `TerminalLabClient.swift` and `TerminalLabView.swift`; DEBUG-only link in `MobileSettingsView`; env-gated entry in `CMUXMobileRootScene`; one new localized string `mobile.settings.terminalLab` (en/ja). No release build impact.

<sup>Written for commit f444c54efffe49138a9095fe61bdb6d8bd329a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a DEBUG-only Terminal Lab for testing mobile terminal connections.
  * Added connection controls, session status, terminal input, resizing, snapshots, and live output.
  * Added optional environment-based launch support for the Terminal Lab.
  * Added English and Japanese localization for the new Terminal Lab setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->