### PR TITLE
fix(ssh): self-heal daemon bootstrap uploads on remote hosts

### DIFF
--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -96,7 +96,12 @@ extension RemoteSessionCoordinator {
         pid_path=\(quotedRemoteTempPIDPath)
         printf '%s\\n' "$$" > "$pid_path"
         trap 'if [ -n "$cat_pid" ]; then kill "$cat_pid" 2>/dev/null || true; fi; if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; fi; rm -f -- "$temp_path" "$pid_path"; exit 1' HUP INT TERM
-        cat > "$temp_path" &
+        # POSIX shells give an asynchronous command /dev/null for stdin unless
+        # the parent explicitly preserves the descriptor first. Without this
+        # dup, cat exits 0 after writing an empty payload even though ssh had
+        # a file-backed stdin stream to forward.
+        exec 3<&0
+        cat <&3 > "$temp_path" &
         cat_pid=$!
         printf '%s\\n' "$cat_pid" > "$pid_path"
         (
@@ -126,6 +131,7 @@ extension RemoteSessionCoordinator {
         wait "$cat_pid"
         cat_status=$?
         cat_pid=
+        exec 3<&-
         if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; fi
         watchdog_pid=
         rm -f -- "$pid_path"

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -5,6 +5,78 @@ import Testing
 @testable import CmuxRemoteSession
 
 extension RemoteDaemonUploadTests {
+    @Test("Background upload reader consumes the SSH stdin stream")
+    func backgroundUploadReaderConsumesSSHStdin() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-stdin-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let remoteDirectory = root.appendingPathComponent("remote", isDirectory: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let localBinary = root.appendingPathComponent("cmuxd-remote", isDirectory: false)
+        let payload = Data(repeating: 0x5A, count: 128 * 1024)
+        try payload.write(to: localBinary)
+
+        let runner = RecordingProcessRunner { request in
+            // The upload request is the only request with file-backed stdin.
+            // Keep the fake endpoint focused on capturing the generated remote
+            // command; the command itself is executed below with real stdin.
+            if request.stdinFile != nil {
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            }
+            switch Self.uploadStep(for: request) {
+            case .createDirectory, .finalize:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .cleanup, .upload, .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(runner: runner)
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: "remote/cmuxd-remote",
+            absolutePath: remoteDirectory.appendingPathComponent("cmuxd-remote").path
+        )
+
+        try coordinator.queue.sync {
+            try coordinator.uploadRemoteDaemonBinaryLocked(
+                localBinary: localBinary,
+                location: location
+            )
+        }
+
+        let uploadRequest = try #require(
+            runner.requests.first { $0.stdinFile == localBinary }
+        )
+        let uploadCommand = try #require(uploadRequest.arguments.last)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", uploadCommand]
+        let inputHandle = try FileHandle(forReadingFrom: localBinary)
+        process.standardInput = inputHandle
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        try? inputHandle.close()
+
+        #expect(process.terminationStatus == 0)
+        let temporaryFiles = try fileManager.contentsOfDirectory(
+            at: remoteDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.contains(".tmp-") }
+        let temporaryFile = try #require(temporaryFiles.first)
+        #expect(temporaryFiles.count == 1)
+        #expect(try Data(contentsOf: temporaryFile) == payload)
+        #expect(
+            !fileManager.fileExists(atPath: "\(temporaryFile.path).pid"),
+            "The upload writer marker must be removed after the stream closes"
+        )
+    }
+
     @Test("Finalize script promotes only a byte-and-hash-matching payload")
     func finalizeScriptIsFailClosed() throws {
         let fileManager = FileManager.default

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -315,7 +315,7 @@ extension RemoteDaemonUploadTests {
         if command.contains("mkdir -p ") {
             return .createDirectory
         }
-        if command.contains("cat > ") {
+        if command.contains("cat > ") || command.contains("cat <&3 > ") {
             return .upload
         }
         if command.contains("chmod 755 "), command.contains("mv ") {

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -479,7 +479,7 @@ struct RemoteDaemonUploadTests {
         if command.contains("mkdir -p ") {
             return .createDirectory
         }
-        if command.contains("cat > ") {
+        if command.contains("cat > ") || command.contains("cat <&3 > ") {
             return .upload
         }
         if command.contains("chmod 755 "), command.contains("mv ") {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2067,10 +2067,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
-                // The daemon upload streams the binary through an ssh exec channel into `cat >`
+                // The daemon upload streams the binary through an ssh exec channel into a backgrounded `cat`
                 // rather than shelling out to scp, so the remote path this test is about arrives
                 // inside the command and the destination host is its own argument.
-                if command.contains("cat > ") {
+                if command.contains("cat > ") || command.contains("cat <&3 > ") {
                     lock.withLock {
                         uploadCommand = command
                         uploadDestination = arguments.dropLast().last
@@ -2208,11 +2208,11 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
-                // The upload streams over the ssh exec channel into `cat >`, not scp. Recording how
+                // The upload streams over the ssh exec channel into a backgrounded `cat`, not scp. Recording how
                 // many hellos preceded it is what keeps this test about a *reinstall*: an upload
                 // before any hello would be a first install and would not exercise the
                 // missing-capability path this test is named for.
-                if command.contains("cat > ") {
+                if command.contains("cat > ") || command.contains("cat <&3 > ") {
                     lock.withLock {
                         uploadCommand = command
                         uploadPayload = stdin


### PR DESCRIPTION
## Summary

Closes #10587.

This is a transfer bug, not expected fail-closed behavior. PR https://github.com/manaflow-ai/cmux/pull/10555 correctly computes the local byte count and SHA-256 and refuses to promote an unverified payload, but its backgrounded remote `cat` loses SSH stdin under a non-interactive POSIX shell and deterministically writes 0 bytes.

Read-only evidence from tinybox and the local nightly snapshot:

- `/home/tiny/.cmux/bin/cmuxd-remote/0.64.22-nightly.3254304245301/linux-amd64/cmuxd-remote` was mode 755 and **0 bytes** at `2026-08-22T23:19:16Z`.
- The matching local Linux artifact was **6,295,704 bytes**; the older `0.64.22-nightly.3252776701701` remote binary was 6,295,704 bytes and hash-matched its cache. The current `0.64.22-nightly.3260048785601` final path was absent after the rejected attempt.
- The persisted session at park time showed the integrity-class suspension after repeated hello failures. Upload verification occurs before the existing diagnostic probe, so the parked user-facing record did not include path/size; this PR does not weaken the sanitized logging or fail-closed behavior.
- The exact old and new stdin forms were exercised over SSH to tinybox without writing remote state: the old form returned 0 bytes, and the fd-preserving form returned all 22 bytes.

## Fix and coverage

The upload script now uses the portable `exec 3<&0` / `cat <&3` pattern and closes fd 3 after the reader exits. Byte-count/SHA-256 verification, temporary cleanup, atomic promotion, and bounded retry/fingerprint accounting are unchanged. Commit `2cc7fcb5ff` adds a behavioral regression test first; commit `bea3179c4a` fixes it. The test executes the generated command with real file-backed stdin and verifies the complete temporary payload and writer-marker cleanup.

No remote state was modified. No user-facing strings changed, so localization catalogs were unaffected.