### PR TITLE
Fix degraded SF Symbol rasterization after #10549

### DIFF
--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -138,6 +138,25 @@ enum RenderableSystemSymbol {
         renderabilityCache.isRenderable(symbol)
     }
 
+    /// Resolves a bounded set of symbols before a view enters an AppKit
+    /// window's constraint/layout cycle.
+    @MainActor
+    static func prewarmAppKitImages(
+        systemNames: [String],
+        pointSizes: [CGFloat],
+        weight: Font.Weight? = nil
+    ) {
+        for systemName in systemNames {
+            for pointSize in pointSizes {
+                _ = configuredAppKitImage(
+                    systemName: systemName,
+                    pointSize: pointSize,
+                    weight: weight
+                )
+            }
+        }
+    }
+
     static func clampedRasterPointSize(_ pointSize: CGFloat) -> CGFloat {
         guard pointSize.isFinite else {
             return minimumRasterPointSize
@@ -186,9 +205,14 @@ enum RenderableSystemSymbol {
             weight: fontWeight
         )
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
-        let image = (configuredImage.copy() as? NSImage) ?? configuredImage
+        let imageSize = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
+        guard let image = materializedImage(configuredImage, size: imageSize) else {
+            return nil
+        }
+        // Keep the template contract used by the SwiftUI and AppKit callers,
+        // while replacing AppKit's lazy symbol representation with a bitmap
+        // that cannot be materialized again from an NSWindow layout pass.
         image.isTemplate = true
-        image.size = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
@@ -196,6 +220,77 @@ enum RenderableSystemSymbol {
             appKitImageCache.removeValue(forKey: evictedKey)
         }
         return image
+    }
+
+    /// Draws a symbol into an owned bitmap before handing it to AppKit views.
+    ///
+    /// `NSImage(systemSymbolName:)` stores a lazy symbol representation. If
+    /// that representation reaches an `NSImageView` while AppKit is solving
+    /// window constraints, the first provider lookup can block the main
+    /// thread for several seconds. A bitmap representation makes all later
+    /// intrinsic-size and layout queries constant-time.
+    @MainActor
+    private static func materializedImage(_ source: NSImage, size: NSSize) -> NSImage? {
+        let image = NSImage(size: size)
+        // Keep native reps for both common display scales. AppKit can then
+        // select a fully materialized bitmap instead of resampling a 2x rep
+        // on a 1x display (or vice versa).
+        for pixelScale in [CGFloat(2), CGFloat(1)] {
+            guard let bitmap = materializedBitmap(source, size: size, pixelScale: pixelScale) else {
+                return nil
+            }
+            image.addRepresentation(bitmap)
+        }
+        image.cacheMode = .never
+        return image
+    }
+
+    @MainActor
+    private static func materializedBitmap(
+        _ source: NSImage,
+        size: NSSize,
+        pixelScale: CGFloat
+    ) -> NSBitmapImageRep? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: max(1, Int(ceil(size.width * pixelScale))),
+            pixelsHigh: max(1, Int(ceil(size.height * pixelScale))),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+
+        // NSGraphicsContext derives its point-to-pixel CTM from the bitmap's
+        // point-space size. Set it before creating the context so the backing
+        // pixels are used for the symbol draw, rather than only when the
+        // representation is later displayed.
+        bitmap.size = size
+        guard let graphicsContext = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            return nil
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        graphicsContext.imageInterpolation = .high
+        source.draw(
+            in: NSRect(origin: .zero, size: size),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1,
+            respectFlipped: true,
+            hints: nil
+        )
+        return bitmap
     }
 
     static func symbolImageSize(_ naturalSize: NSSize, fallbackDimension: CGFloat) -> NSSize {

--- a/Sources/Update/TitlebarCloudVMButton.swift
+++ b/Sources/Update/TitlebarCloudVMButton.swift
@@ -163,8 +163,7 @@ struct TitlebarNewWorkspaceCloudSplitButton: View {
     var body: some View {
         HStack(spacing: 0) {
             Button(action: onNewTab) {
-                Image(systemName: "plus")
-                    .font(.system(size: config.iconSize, weight: .medium))
+                CmuxSystemSymbolImage(systemName: "plus", pointSize: config.iconSize, weight: .medium)
                     .padding(plusIconPadding)
                     .frame(width: primaryWidth, height: config.buttonSize)
             }
@@ -200,11 +199,11 @@ struct TitlebarNewWorkspaceCloudSplitButton: View {
                 ZStack {
                     Rectangle()
                         .fill(Color.clear)
-                    Image(systemName: "chevron.down")
-                        .font(.system(
-                            size: TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: config),
-                            weight: .bold
-                        ))
+                    CmuxSystemSymbolImage(
+                        systemName: "chevron.down",
+                        pointSize: TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: config),
+                        weight: .bold
+                    )
                         .padding(caretIconPadding)
                 }
                 .frame(width: dropdownWidth, height: config.buttonSize)
@@ -354,8 +353,7 @@ struct TitlebarCloudVMButton: View {
                 Self.showCloudVMMenu(anchorView: anchorView, event: event)
             }
         ) {
-            Image(systemName: "cloud")
-                .font(.system(size: config.iconSize, weight: .medium))
+            CmuxSystemSymbolImage(systemName: "cloud", pointSize: config.iconSize, weight: .medium)
                 .frame(width: config.buttonSize, height: config.buttonSize)
         }
         .safeHelp(String(localized: "titlebar.cloudVM.tooltip", defaultValue: "Open Base"))

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2732,10 +2732,58 @@ final class UpdateTitlebarAccessoryController {
 
     func start() {
         guard !didStart else { return }
+        prewarmTitlebarSymbols()
         didStart = true
         attachToExistingWindows()
         installObservers()
         scheduleStartupWindowScans()
+    }
+
+    private func prewarmTitlebarSymbols() {
+        let iconSizes = TitlebarControlsStyle.allCases.map { $0.config.iconSize }
+        let dropdownSizes = TitlebarControlsStyle.allCases.map {
+            TitlebarNewWorkspaceCloudSplitButtonMetrics.dropdownIconSize(config: $0.config)
+        }
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["bell", "arrow.left", "arrow.right"],
+            pointSizes: iconSizes,
+            weight: .regular
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["plus", "cloud"],
+            pointSizes: iconSizes,
+            weight: .medium
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["chevron.down"],
+            pointSizes: dropdownSizes,
+            weight: .bold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["arrow.down.to.line"],
+            pointSizes: [10],
+            weight: .semibold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["iphone"],
+            pointSizes: [12],
+            weight: .medium
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["chevron.right"],
+            pointSizes: [9],
+            weight: .semibold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["xmark"],
+            pointSizes: [9],
+            weight: .bold
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["bell.slash", "bell.badge"],
+            pointSizes: [30],
+            weight: .light
+        )
     }
 
     func attach(to window: NSWindow) {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -109,12 +109,16 @@ struct RenderableSystemSymbolTests {
         ))
 
         #expect(image.isTemplate)
-        #expect(image.representations.count == 1)
-        #expect(image.representations.first is NSBitmapImageRep)
+        #expect(image.representations.count == 2)
+        #expect(image.representations.allSatisfy { $0 is NSBitmapImageRep })
         #expect(image.tiffRepresentation != nil)
     }
 
-    @Test @MainActor func configuredAppKitImageMatchesDirectAppKitRasterGeometryAtTwoX() throws {
+    @MainActor
+    @Test(arguments: [CGFloat(1), CGFloat(2)])
+    func configuredAppKitImageMatchesDirectAppKitRasterGeometryAtBackingScale(
+        pixelScale: CGFloat
+    ) throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
 
         let systemName = "plus"
@@ -130,14 +134,22 @@ struct RenderableSystemSymbolTests {
         ))
         #expect(materializedImage.size == directImage.size)
 
-        let actualBitmap = try #require(Self.renderedBitmap(materializedImage, size: directImage.size))
-        let expectedBitmap = try #require(Self.renderedBitmap(directImage, size: directImage.size))
+        let actualBitmap = try #require(Self.renderedBitmap(
+            materializedImage,
+            size: directImage.size,
+            pixelScale: pixelScale
+        ))
+        let expectedBitmap = try #require(Self.renderedBitmap(
+            directImage,
+            size: directImage.size,
+            pixelScale: pixelScale
+        ))
         let actual = try #require(PixelFootprint(bitmap: actualBitmap))
         let expected = try #require(PixelFootprint(bitmap: expectedBitmap))
 
-        // The returned image is displayed at 2x, so its alpha footprint should match
-        // AppKit's own direct draw within a pixel. Creating the graphics context before
-        // assigning the bitmap's point size shifts and shrinks the glyph dramatically.
+        // The returned image should match AppKit's own direct draw within a pixel at
+        // each native backing scale. Creating the graphics context before assigning
+        // the bitmap's point size shifts and shrinks the glyph dramatically.
         let centroidTolerance = 1.0
         #expect(abs(actual.centroidX - expected.centroidX) <= centroidTolerance)
         #expect(abs(actual.centroidY - expected.centroidY) <= centroidTolerance)
@@ -221,8 +233,11 @@ struct RenderableSystemSymbolTests {
     }
 
     @MainActor
-    private static func renderedBitmap(_ image: NSImage, size: NSSize) -> NSBitmapImageRep? {
-        let pixelScale: CGFloat = 2
+    private static func renderedBitmap(
+        _ image: NSImage,
+        size: NSSize,
+        pixelScale: CGFloat
+    ) -> NSBitmapImageRep? {
         guard let bitmap = NSBitmapImageRep(
             bitmapDataPlanes: nil,
             pixelsWide: max(1, Int(ceil(size.width * pixelScale))),

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -10,6 +10,49 @@ import Testing
 
 @Suite("Renderable system symbols")
 struct RenderableSystemSymbolTests {
+    private struct PixelFootprint {
+        let alphaCoverage: Double
+        let centroidX: Double
+        let centroidY: Double
+        let minX: Int
+        let maxX: Int
+        let minY: Int
+        let maxY: Int
+
+        init?(bitmap: NSBitmapImageRep) {
+            var alphaCoverage = 0.0
+            var weightedX = 0.0
+            var weightedY = 0.0
+            var minX = bitmap.pixelsWide
+            var maxX = -1
+            var minY = bitmap.pixelsHigh
+            var maxY = -1
+
+            for y in 0..<bitmap.pixelsHigh {
+                for x in 0..<bitmap.pixelsWide {
+                    let alpha = Double(bitmap.colorAt(x: x, y: y)?.alphaComponent ?? 0)
+                    guard alpha > 0.001 else { continue }
+                    alphaCoverage += alpha
+                    weightedX += Double(x) * alpha
+                    weightedY += Double(y) * alpha
+                    minX = min(minX, x)
+                    maxX = max(maxX, x)
+                    minY = min(minY, y)
+                    maxY = max(maxY, y)
+                }
+            }
+
+            guard alphaCoverage > 0 else { return nil }
+            self.alphaCoverage = alphaCoverage
+            centroidX = weightedX / alphaCoverage
+            centroidY = weightedY / alphaCoverage
+            self.minX = minX
+            self.maxX = maxX
+            self.minY = minY
+            self.maxY = maxY
+        }
+    }
+
     @Test func rasterPointSizeClampsInvalidInputs() {
         #expect(RenderableSystemSymbol.clampedRasterPointSize(0) == 1)
         #expect(RenderableSystemSymbol.clampedRasterPointSize(-8) == 1)
@@ -54,6 +97,55 @@ struct RenderableSystemSymbolTests {
         let clampedImage = try #require(clampedBase.withSymbolConfiguration(clampedConfiguration))
         #expect(clampedImage.size.width > 0 && clampedImage.size.height > 0)
         #expect(image.size == clampedImage.size)
+    }
+
+    @Test @MainActor func configuredAppKitImageIsEagerlyMaterializedForLayout() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+
+        let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "folder.fill",
+            pointSize: 14,
+            weight: .regular
+        ))
+
+        #expect(image.isTemplate)
+        #expect(image.representations.count == 1)
+        #expect(image.representations.first is NSBitmapImageRep)
+        #expect(image.tiffRepresentation != nil)
+    }
+
+    @Test @MainActor func configuredAppKitImageMatchesDirectAppKitRasterGeometryAtTwoX() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+
+        let systemName = "plus"
+        let pointSize: CGFloat = 14
+        let weight = NSFont.Weight.regular
+        let baseImage = try #require(NSImage(systemSymbolName: systemName, accessibilityDescription: nil))
+        let configuration = NSImage.SymbolConfiguration(pointSize: pointSize, weight: weight)
+        let directImage = try #require(baseImage.withSymbolConfiguration(configuration))
+        let materializedImage = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: systemName,
+            pointSize: pointSize,
+            weight: .regular
+        ))
+        #expect(materializedImage.size == directImage.size)
+
+        let actualBitmap = try #require(Self.renderedBitmap(materializedImage, size: directImage.size))
+        let expectedBitmap = try #require(Self.renderedBitmap(directImage, size: directImage.size))
+        let actual = try #require(PixelFootprint(bitmap: actualBitmap))
+        let expected = try #require(PixelFootprint(bitmap: expectedBitmap))
+
+        // The returned image is displayed at 2x, so its alpha footprint should match
+        // AppKit's own direct draw within a pixel. Creating the graphics context before
+        // assigning the bitmap's point size shifts and shrinks the glyph dramatically.
+        let centroidTolerance = 1.0
+        #expect(abs(actual.centroidX - expected.centroidX) <= centroidTolerance)
+        #expect(abs(actual.centroidY - expected.centroidY) <= centroidTolerance)
+        #expect(abs(actual.minX - expected.minX) <= 1)
+        #expect(abs(actual.maxX - expected.maxX) <= 1)
+        #expect(abs(actual.minY - expected.minY) <= 1)
+        #expect(abs(actual.maxY - expected.maxY) <= 1)
+        #expect(abs(actual.alphaCoverage - expected.alphaCoverage) <= expected.alphaCoverage * 0.05)
     }
 
     @Test @MainActor func configuredAppKitImagePreservesConfiguredSizeForNonSquareSymbols() throws {
@@ -126,5 +218,47 @@ struct RenderableSystemSymbolTests {
         now = now.addingTimeInterval(61)
         #expect(cache.isRenderable("not.an.sf.symbol") == false)
         #expect(resolveCount == 2)
+    }
+
+    @MainActor
+    private static func renderedBitmap(_ image: NSImage, size: NSSize) -> NSBitmapImageRep? {
+        let pixelScale: CGFloat = 2
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: max(1, Int(ceil(size.width * pixelScale))),
+            pixelsHigh: max(1, Int(ceil(size.height * pixelScale))),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        // Set the point-space size before creating the context. This is the reference
+        // setup used to compare the materialized image with AppKit's direct rendering.
+        bitmap.size = size
+        guard let graphicsContext = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            return nil
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        graphicsContext.imageInterpolation = .high
+        image.draw(
+            in: NSRect(origin: .zero, size: size),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1,
+            respectFlipped: true,
+            hints: nil
+        )
+        return bitmap
     }
 }


### PR DESCRIPTION
## Summary

NSGraphicsContext(bitmapImageRep:) captures the bitmap representation's point-to-pixel transform when it is created. The materializer in https://github.com/manaflow-ai/cmux/pull/10549 created that context while the bitmap still reported its pixel dimensions, then assigned the logical point size afterward. The symbol was therefore rasterized at 1x into the upper-left portion of a 2x bitmap and displayed soft, thin, and displaced.

This change reapplies the eager materialization and titlebar prewarming from https://github.com/manaflow-ai/cmux/pull/10549 on top of the merged revert, but assigns each bitmap's point-space size before creating its context. The context CTM now maps the configured symbol rect across the full backing bitmap. Each returned image carries owned 1x and 2x bitmap representations, allowing AppKit to choose a native scale without resampling. The template flag remains true, preserving AppKit tinting and enabled/disabled appearance behavior.

## Regression coverage

- The first commit adds a pixel-level regression test that draws the returned image and a fresh configured AppKit symbol into independently initialized bitmaps.
- The test runs at both 1x and 2x and compares alpha-weighted centroid, bounding box, and coverage, so the pre-fix scale/placement regression fails.
- The eager-materialization test verifies both representations are bitmap-backed and that no lazy symbol provider is returned.
- The test-only regression commit precedes the fix commit intentionally.

This supersedes the stopgap revert https://github.com/manaflow-ai/cmux/pull/10584: it keeps https://github.com/manaflow-ai/cmux/issues/10547 fixed while restoring crisp titlebar icon rendering.

## Validation

- xcrun swiftc -parse passed for all changed Swift files.
- ./scripts/lint-pbxproj-test-wiring.sh passed.
- ./scripts/check-pbxproj.sh passed.
- python3 scripts/check-package-resolved-policy.py passed.
- No local Xcode build or test was run, per task instructions; hosted CI is the test environment.

Closes #10586