### PR TITLE
ios: hold scroll position through replays mid-gesture + frame-rate audit probes

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+ScrollScriptDebug.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+ScrollScriptDebug.swift
@@ -50,6 +50,55 @@ extension GhosttySurfaceView {
         enqueueScrollToBottom()
         debugScrollScriptDone = true
     }
+
+    /// Scroll-smoothness audit: logs the display's max rate once, then one
+    /// per-second summary of achieved display-link cadence while a scroll
+    /// gesture or its deceleration is active. `scroll_fps` is what the app
+    /// achieved, `link_fps` is the rate Core Animation currently grants, and
+    /// `missed` counts ticks that arrived over 1.6x the granted frame time.
+    func debugRecordScrollFrameRateTick(now: CFTimeInterval) {
+        if !debugScrollFrameRateStats.loggedDisplayInfo,
+           let screen = window?.windowScene?.screen {
+            debugScrollFrameRateStats.loggedDisplayInfo = true
+            MobileDebugLog.anchormux(
+                "perf.display max_fps=\(screen.maximumFramesPerSecond)"
+            )
+        }
+        guard scrollInteractionActive else {
+            debugScrollFrameRateStats.windowStart = 0
+            debugScrollFrameRateStats.ticks = 0
+            debugScrollFrameRateStats.missed = 0
+            debugScrollFrameRateStats.maxGapMs = 0
+            return
+        }
+        if debugScrollFrameRateStats.windowStart == 0 {
+            debugScrollFrameRateStats.windowStart = now
+            debugScrollFrameRateStats.lastTick = now
+            return
+        }
+        let gap = now - debugScrollFrameRateStats.lastTick
+        debugScrollFrameRateStats.lastTick = now
+        debugScrollFrameRateStats.ticks += 1
+        debugScrollFrameRateStats.maxGapMs = max(
+            debugScrollFrameRateStats.maxGapMs,
+            gap * 1000
+        )
+        let grantedDuration = displayLink?.duration ?? 0
+        if grantedDuration > 0, gap > grantedDuration * 1.6 {
+            debugScrollFrameRateStats.missed += 1
+        }
+        let windowElapsed = now - debugScrollFrameRateStats.windowStart
+        guard windowElapsed >= 1.0 else { return }
+        let fps = Double(debugScrollFrameRateStats.ticks) / windowElapsed
+        let linkFps = grantedDuration > 0 ? Int((1.0 / grantedDuration).rounded()) : 0
+        MobileDebugLog.anchormux(
+            "perf.refresh scroll_fps=\(Int(fps.rounded())) link_fps=\(linkFps) missed=\(debugScrollFrameRateStats.missed) max_gap_ms=\(Int(debugScrollFrameRateStats.maxGapMs))"
+        )
+        debugScrollFrameRateStats.windowStart = now
+        debugScrollFrameRateStats.ticks = 0
+        debugScrollFrameRateStats.missed = 0
+        debugScrollFrameRateStats.maxGapMs = 0
+    }
 }
 #endif
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -40,6 +40,7 @@ extension GhosttySurfaceView {
               delegate?.ghosttySurfaceViewOwnsLocalPrimaryScreenScroll(self) == true,
               localPixelScrollState.withLock({ $0.lastApplied }) != nil else {
             localPixelScrollState.withLock {
+                $0.epoch &+= 1
                 $0.remainderPx = 0
                 $0.lastApplied = nil
             }
@@ -75,7 +76,8 @@ extension GhosttySurfaceView {
         let operation = LocalPixelScrollSurfaceOperation(
             surface: surface,
             generation: surfaceGeneration,
-            token: token
+            token: token,
+            pixelStateEpoch: localPixelScrollState.withLock { $0.epoch }
         )
         let workQueue = outputQueue
         let gate = viewportRestoreGate
@@ -167,7 +169,10 @@ extension GhosttySurfaceView {
         let size = ghostty_surface_size(operation.surface)
         let cellHeightPx = Double(size.cell_height_px)
         guard cellHeightPx >= 1 else {
-            pixelState.withLock { $0.remainderPx = 0 }
+            pixelState.withLock {
+                guard $0.epoch == operation.pixelStateEpoch else { return }
+                $0.remainderPx = 0
+            }
             return
         }
         var (remainder, held) = pixelState.withLock { ($0.remainderPx, $0.lastApplied) }
@@ -217,6 +222,10 @@ extension GhosttySurfaceView {
                 let appliedRevision = applied.row_space_revision
                 let appliedTotal = applied.total
                 pixelState.withLock {
+                    // A snap or surface replacement bumped the epoch while
+                    // this batch was in flight; its result must not
+                    // resurrect the cleared scroll authority.
+                    guard $0.epoch == operation.pixelStateEpoch else { return }
                     $0.remainderPx = appliedOffset
                     $0.lastApplied = (
                         row: appliedRow,
@@ -237,8 +246,10 @@ extension GhosttySurfaceView {
         // from `enqueueScrollMechanicsDelta` (points = px/scale, divisor 3x
         // cell height), so the fallback scrolls the same distance in rows.
         let shouldLog = pixelState.withLock { state -> Bool in
-            state.remainderPx = 0
-            state.lastApplied = nil
+            if state.epoch == operation.pixelStateEpoch {
+                state.remainderPx = 0
+                state.lastApplied = nil
+            }
             let now = CACurrentMediaTime()
             guard now - state.lastFallbackLogTime >= 1 else { return false }
             state.lastFallbackLogTime = now
@@ -265,5 +276,8 @@ private nonisolated struct LocalPixelScrollSurfaceOperation: @unchecked Sendable
     let surface: ghostty_surface_t
     let generation: UInt64
     let token: UInt64
+    /// Pixel-state epoch captured at pump time; the batch only commits its
+    /// results while the state still carries this epoch.
+    let pixelStateEpoch: UInt64
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -185,19 +185,23 @@ extension GhosttySurfaceView {
             // Mid-gesture the held position is the authority: a verified
             // replay may have reset the live viewport to the bottom between
             // batches, and deriving from it would make the reset hijack the
-            // gesture. Clamping to maxPosition keeps the held value valid
-            // across content growth and eviction.
+            // gesture. The exact (unrounded) position carries sub-pixel
+            // deltas across batches, and the anchor is only trusted while
+            // its row space is unchanged: replays repaint in place and keep
+            // the revision, while eviction or reflow renumber rows, so a
+            // revision change falls back to the live viewport.
             let current: Double
-            if rebaseFromHeldPosition, let held {
-                current = min(Double(held.row) * cellHeightPx + held.remainderPx, maxPosition)
+            if rebaseFromHeldPosition, let held,
+               held.revision == scrollbar.row_space_revision {
+                current = min(held.positionPx, maxPosition)
             } else {
                 current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
             }
             let next = min(max(current + deltaPixels, 0), maxPosition)
             var row = UInt64((next / cellHeightPx).rounded(.down))
-            // Round to whole device pixels: a fractional-pixel offset makes
-            // glyph antialiasing resample every frame (shimmer); native
-            // scrollers always move content by integral pixels.
+            // Ghostty gets whole device pixels: a fractional-pixel offset
+            // makes glyph antialiasing resample every frame (shimmer);
+            // native scrollers always move content by integral pixels.
             var pixelOffset = (next - Double(row) * cellHeightPx).rounded()
             if pixelOffset >= cellHeightPx {
                 row += 1
@@ -219,6 +223,7 @@ extension GhosttySurfaceView {
             ) {
                 let appliedRow = row
                 let appliedOffset = pixelOffset
+                let appliedPosition = next
                 let appliedRevision = applied.row_space_revision
                 let appliedTotal = applied.total
                 pixelState.withLock {
@@ -230,6 +235,7 @@ extension GhosttySurfaceView {
                     $0.lastApplied = (
                         row: appliedRow,
                         remainderPx: appliedOffset,
+                        positionPx: appliedPosition,
                         revision: appliedRevision,
                         total: appliedTotal
                     )

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -149,7 +149,14 @@ extension GhosttySurfaceView {
             let current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
             let next = min(max(current + deltaPixels, 0), maxPosition)
             var row = UInt64((next / cellHeightPx).rounded(.down))
-            var pixelOffset = next - Double(row) * cellHeightPx
+            // Round to whole device pixels: a fractional-pixel offset makes
+            // glyph antialiasing resample every frame (shimmer); native
+            // scrollers always move content by integral pixels.
+            var pixelOffset = (next - Double(row) * cellHeightPx).rounded()
+            if pixelOffset >= cellHeightPx {
+                row += 1
+                pixelOffset = 0
+            }
             if next >= maxPosition - 0.5 {
                 // Docked at the tail: target the absolute bottom and let
                 // Ghostty clamp the row into the active area.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -26,9 +26,26 @@ extension GhosttySurfaceView {
         pumpLocalPixelScroll()
     }
 
+    /// Re-asserts the held scroll position after a verified replay completed
+    /// mid-gesture. The replay reset the mirror to the bottom and the anchor
+    /// restore stands down for user interaction, so without this a stationary
+    /// finger would see the reset until the next real delta.
+    func reassertLocalPixelScrollPositionAfterReplay() {
+        guard scrollInteractionActive,
+              localPixelScrollState.withLock({ $0.lastApplied }) != nil else {
+            localPixelScrollState.withLock {
+                $0.remainderPx = 0
+                $0.lastApplied = nil
+            }
+            return
+        }
+        pendingLocalPixelScrollReassert = true
+        pumpLocalPixelScroll()
+    }
+
     func pumpLocalPixelScroll() {
         guard !localPixelScrollApplyInFlight,
-              pendingLocalScrollPixels != 0,
+              pendingLocalScrollPixels != 0 || pendingLocalPixelScrollReassert,
               let surface else {
             return
         }
@@ -37,6 +54,12 @@ extension GhosttySurfaceView {
             ?? viewportRestoreGate.withLock { $0.interactionGeneration }
         pendingLocalScrollPixels = 0
         pendingLocalPixelScrollInteractionGeneration = nil
+        pendingLocalPixelScrollReassert = false
+        // While the finger (or deceleration) owns the gesture, the pump is
+        // the position authority: rebase from the last applied position so a
+        // verified-replay bottom reset between batches cannot hijack the
+        // gesture. Idle batches keep trusting the live viewport.
+        let rebaseFromHeldPosition = scrollInteractionActive
         localPixelScrollApplyInFlight = true
         localPixelScrollApplyInFlightGeneration = interactionGeneration
         let token = makeSurfaceOperationID()
@@ -61,6 +84,7 @@ extension GhosttySurfaceView {
             Self.applyPixelScrollBatch(
                 operation: operation,
                 deltaPixels: deltaPixels,
+                rebaseFromHeldPosition: rebaseFromHeldPosition,
                 pixelState: pixelState
             )
             gate.withLock {
@@ -131,6 +155,7 @@ extension GhosttySurfaceView {
     private nonisolated static func applyPixelScrollBatch(
         operation: LocalPixelScrollSurfaceOperation,
         deltaPixels: Double,
+        rebaseFromHeldPosition: Bool,
         pixelState: OSAllocatedUnfairLock<LocalPixelScrollState>
     ) {
         let size = ghostty_surface_size(operation.surface)
@@ -139,14 +164,24 @@ extension GhosttySurfaceView {
             pixelState.withLock { $0.remainderPx = 0 }
             return
         }
-        var remainder = pixelState.withLock { $0.remainderPx }
+        var (remainder, held) = pixelState.withLock { ($0.remainderPx, $0.lastApplied) }
         for _ in 0..<2 {
             var scrollbar = ghostty_surface_scrollbar_s()
             guard ghostty_surface_scrollbar(operation.surface, &scrollbar) else { break }
             let total = scrollbar.total
             let len = min(scrollbar.len, total)
             let maxPosition = Double(total - len) * cellHeightPx
-            let current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
+            // Mid-gesture the held position is the authority: a verified
+            // replay may have reset the live viewport to the bottom between
+            // batches, and deriving from it would make the reset hijack the
+            // gesture. Clamping to maxPosition keeps the held value valid
+            // across content growth and eviction.
+            let current: Double
+            if rebaseFromHeldPosition, let held {
+                current = min(Double(held.row) * cellHeightPx + held.remainderPx, maxPosition)
+            } else {
+                current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
+            }
             let next = min(max(current + deltaPixels, 0), maxPosition)
             var row = UInt64((next / cellHeightPx).rounded(.down))
             // Round to whole device pixels: a fractional-pixel offset makes
@@ -177,25 +212,27 @@ extension GhosttySurfaceView {
                 let appliedTotal = applied.total
                 pixelState.withLock {
                     $0.remainderPx = appliedOffset
-                    #if DEBUG
                     $0.lastApplied = (
                         row: appliedRow,
                         remainderPx: appliedOffset,
                         revision: appliedRevision,
                         total: appliedTotal
                     )
-                    #endif
                 }
                 return
             }
-            // Content changed shape mid-batch; rebase once from bottom-of-row.
+            // Content changed shape mid-batch; rebase once from the live
+            // viewport with a zeroed remainder (held row numbers are no
+            // longer trustworthy in the new row space).
             remainder = 0
+            held = nil
         }
         // Two mismatches in one batch: same units the legacy line path derives
         // from `enqueueScrollMechanicsDelta` (points = px/scale, divisor 3x
         // cell height), so the fallback scrolls the same distance in rows.
         let shouldLog = pixelState.withLock { state -> Bool in
             state.remainderPx = 0
+            state.lastApplied = nil
             let now = CACurrentMediaTime()
             guard now - state.lastFallbackLogTime >= 1 else { return false }
             state.lastFallbackLogTime = now

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -31,7 +31,13 @@ extension GhosttySurfaceView {
     /// restore stands down for user interaction, so without this a stationary
     /// finger would see the reset until the next real delta.
     func reassertLocalPixelScrollPositionAfterReplay() {
+        // Pixel scrolling exists only on the confirmed-primary screen. Alt
+        // screens replay constantly (every frame is verified), and a stale
+        // held anchor from earlier primary scrolling must never drive alt
+        // renders, so anything but an active primary-screen gesture clears
+        // the pixel state outright.
         guard scrollInteractionActive,
+              delegate?.ghosttySurfaceViewOwnsLocalPrimaryScreenScroll(self) == true,
               localPixelScrollState.withLock({ $0.lastApplied }) != nil else {
             localPixelScrollState.withLock {
                 $0.remainderPx = 0

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -169,10 +169,12 @@ extension GhosttySurfaceView {
                         )
                         return
                     }
-                    // The replay rebuilt the row space and the row-only restore
-                    // zeroed Ghostty's fractional pixel offset; drop the stale
-                    // Swift-side remainder so the next pixel batch rebases.
-                    self.localPixelScrollState.withLock { $0.remainderPx = 0 }
+                    // The replay reset the mirror; mid-gesture the pixel pump
+                    // re-asserts the held position (the anchor restore stands
+                    // down for user interaction), otherwise drop the stale
+                    // remainder so the next batch rebases from the live
+                    // viewport.
+                    self.reassertLocalPixelScrollPositionAfterReplay()
                     if restored {
                         self.needsDraw = true
                         self.scheduleVisibleArtifactCountUpdate()

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2158,11 +2158,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// keep scrolling a full-screen app for seconds.
     private var linePathDecelerationStartedAt: CFTimeInterval?
     private static let linePathDecelerationBudget: CFTimeInterval = 0.45
+    /// Sub-line remainder from whole-line dispatch on the line path. Kept
+    /// out of `pendingScrollLines` so a leftover fraction cannot re-trigger
+    /// the flush (and record interactions) with no real gesture delta.
+    private var linePathFractionCarry: Double = 0
     var pendingLocalScrollDrains: [(generation: UInt64, continuation: CheckedContinuation<Bool, Never>)] = []
 
     /// Drops scroll work tied to a surface generation that will no longer run.
     func resetScrollStateForSurfaceReplacement() {
         pendingScrollLines = 0
+        linePathFractionCarry = 0
         pendingScrollPixels = 0
         pendingScrollInteractionGeneration = nil
         pendingLocalScrollLines = 0
@@ -2233,11 +2238,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     $0.lastApplied = nil
                 }
                 // TUI scroll feel: dispatch whole lines only, carrying the
-                // fraction, so the app sees clean steps instead of a 120Hz
-                // fragment stream; and cap the momentum tail so a flick
-                // cannot keep scrolling a full-screen app for seconds.
-                let wholeLines = lines < 0 ? lines.rounded(.up) : lines.rounded(.down)
-                pendingScrollLines += lines - wholeLines
+                // fraction in its own accumulator, so the app sees clean
+                // steps instead of a 120Hz fragment stream; and cap the
+                // momentum tail so a flick cannot keep scrolling a
+                // full-screen app for seconds. The carry lives OUTSIDE
+                // pendingScrollLines so a sub-line leftover cannot re-trigger
+                // the flush every frame and churn interaction generations.
+                let totalLines = linePathFractionCarry + lines
+                let wholeLines = totalLines < 0
+                    ? totalLines.rounded(.up)
+                    : totalLines.rounded(.down)
+                linePathFractionCarry = totalLines - wholeLines
                 dispatchLines = wholeLines
                 if scrollMechanicsView.isDecelerating {
                     let now = CACurrentMediaTime()
@@ -2248,6 +2259,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                                 animated: false
                             )
                             pendingScrollLines = 0
+                            linePathFractionCarry = 0
                             dispatchLines = 0
                         }
                     } else {
@@ -3593,6 +3605,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // pending deltas and freeze the scroll mechanics at the current offset
         // (kill-deceleration idiom) so typed input lands at the bottom.
         pendingScrollLines = 0
+        linePathFractionCarry = 0
         pendingScrollPixels = 0
         pendingScrollInteractionGeneration = nil
         pendingLocalScrollLines = 0

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2223,6 +2223,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // transports keep the row-quantized line path.
             if pixels != 0,
                delegate?.ghosttySurfaceViewOwnsLocalPrimaryScreenScroll(self) == true {
+                // Entering the pixel path: drop any line-path residue so a
+                // sub-line fraction from an earlier alt gesture cannot leak
+                // into a later line-path dispatch.
+                linePathFractionCarry = 0
+                linePathDecelerationStartedAt = nil
                 applyLocalPixelScroll(
                     pixels: pixels,
                     interactionGeneration: generation

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -429,6 +429,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Frame counter + one-shot latch for the scripted headless scroll
     /// (`Debug/GhosttySurfaceView+ScrollScriptDebug.swift`).
     var debugScrollScriptFrame = 0
+    /// Scroll-smoothness audit: aggregates display-link cadence while a scroll
+    /// gesture or its deceleration is active, logging one summary per second.
+    struct DebugScrollFrameRateStats {
+        var windowStart: CFTimeInterval = 0
+        var lastTick: CFTimeInterval = 0
+        var ticks = 0
+        var missed = 0
+        var maxGapMs: Double = 0
+        var loggedDisplayInfo = false
+    }
+    var debugScrollFrameRateStats = DebugScrollFrameRateStats()
+    /// Whether a scroll gesture or its deceleration currently owns the
+    /// scroll mechanics view (narrow seam for the frame-rate audit).
+    var scrollInteractionActive: Bool {
+        scrollMechanicsView.isTracking
+            || scrollMechanicsView.isDragging
+            || scrollMechanicsView.isDecelerating
+    }
     var debugScrollScriptDone = false
 
     /// The live `key=value;…` description of the bottom dock, read by
@@ -3552,6 +3570,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         #if DEBUG
         debugStepScrollScriptIfNeeded()
+        debugRecordScrollFrameRateTick(now: now)
         #endif
         #if DEBUG
         // Main-thread liveness heartbeat + presented-surface state. Time-gated,
@@ -3832,12 +3851,31 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         renderInFlight = true
         renderInFlightSince = CACurrentMediaTime()
         let enqueuedAt = CACurrentMediaTime()
-        outputQueue.async { [weak self] in
+        let workQueue = outputQueue
+        workQueue.async { [weak self] in
             let lagMs = (CACurrentMediaTime() - enqueuedAt) * 1000
             if lagMs > 150 { MobileDebugLog.anchormux("oq.render.LAG \(Int(lagMs))ms") }
             switch submission.kind {
             case .ordinary, .localScroll:
+                #if DEBUG
+                let renderStartedAt = CACurrentMediaTime()
+                #endif
                 ghostty_surface_render_now_with_token(submission.surface, submission.token)
+                #if DEBUG
+                // Scroll-smoothness audit: the draw shares this serial queue
+                // with VT applies and scroll batches, so a slow frame
+                // stretches everything behind it.
+                let renderMs = (CACurrentMediaTime() - renderStartedAt) * 1000
+                if renderMs > 8 {
+                    let perfNow = CACurrentMediaTime()
+                    if perfNow - workQueue.lastRenderPerfLogTime >= 0.25 {
+                        workQueue.lastRenderPerfLogTime = perfNow
+                        MobileDebugLog.anchormux(
+                            "perf.render_now ms=\(Int(renderMs)) kind=\(String(describing: submission.kind))"
+                        )
+                    }
+                }
+                #endif
             case .verifiedReplay:
                 guard let read = submission.verifiedReplayRead else {
                     ghostty_surface_render_now_with_token(

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -315,7 +315,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// between batches is overwritten on the next frame instead of
         /// hijacking the gesture. Cleared on dock/typing snaps and surface
         /// replacement, where the live viewport becomes the truth again.
-        var lastApplied: (row: UInt64, remainderPx: Double, revision: UInt64, total: UInt64)?
+        /// `positionPx` is the exact (unrounded) content-space position so
+        /// sub-pixel deltas accumulate across batches; `remainderPx` is the
+        /// whole-pixel offset actually applied to Ghostty. `revision` guards
+        /// the row space: the held anchor is only valid while it matches.
+        var lastApplied: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64)?
         #if DEBUG
         /// Rate-limits slow-batch perf log lines (scroll-hitch investigation).
         var lastPerfLogTime: CFTimeInterval = 0
@@ -325,7 +329,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         OSAllocatedUnfairLock<LocalPixelScrollState>(initialState: .init())
     #if DEBUG
     /// Last pixel-precise viewport position the pixel pump applied.
-    var debugLastPixelScroll: (row: UInt64, remainderPx: Double, revision: UInt64, total: UInt64)? {
+    var debugLastPixelScroll: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64)? {
         localPixelScrollState.withLock { $0.lastApplied }
     }
     #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -304,8 +304,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     nonisolated struct LocalPixelScrollState {
         var remainderPx: Double = 0
         var lastFallbackLogTime: CFTimeInterval = 0
-        #if DEBUG
+        /// The last (row, remainder) the pixel pump applied. While a gesture
+        /// is active this is the position AUTHORITY: batches rebase from it
+        /// instead of the live viewport, so a verified-replay bottom-reset
+        /// between batches is overwritten on the next frame instead of
+        /// hijacking the gesture. Cleared on dock/typing snaps and surface
+        /// replacement, where the live viewport becomes the truth again.
         var lastApplied: (row: UInt64, remainderPx: Double, revision: UInt64, total: UInt64)?
+        #if DEBUG
         /// Rate-limits slow-batch perf log lines (scroll-hitch investigation).
         var lastPerfLogTime: CFTimeInterval = 0
         #endif
@@ -2144,6 +2150,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var pendingLocalPixelScrollInteractionGeneration: UInt64?
     var localPixelScrollApplyInFlight = false
     var localPixelScrollApplyInFlightGeneration: UInt64?
+    /// A verified replay completed mid-gesture: run one zero-delta pixel
+    /// batch to re-assert the held position over the replay's bottom reset.
+    var pendingLocalPixelScrollReassert = false
     var pendingLocalScrollDrains: [(generation: UInt64, continuation: CheckedContinuation<Bool, Never>)] = []
 
     /// Drops scroll work tied to a surface generation that will no longer run.
@@ -2163,6 +2172,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         localPixelScrollApplyInFlightGeneration = nil
         localPixelScrollApplyStartedAt = nil
         localPixelScrollApplyToken = nil
+        pendingLocalPixelScrollReassert = false
         localPixelScrollState.withLock { $0 = .init() }
         scrollToBottomInFlight = false
         scrollToBottomRequested = false
@@ -2949,11 +2959,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// stall never fans out into one lock-taking queue item per event.
     func enqueueScrollToBottom() {
         // The bottom snap resets Ghostty's fractional pixel offset; drop the
-        // pixel batch and remainder so the next gesture rebases from bottom.
+        // pixel batch, remainder, and held position so the next gesture
+        // rebases from the bottom.
         pendingScrollPixels = 0
         pendingLocalScrollPixels = 0
         pendingLocalPixelScrollInteractionGeneration = nil
-        localPixelScrollState.withLock { $0.remainderPx = 0 }
+        pendingLocalPixelScrollReassert = false
+        localPixelScrollState.withLock {
+            $0.remainderPx = 0
+            $0.lastApplied = nil
+        }
         let interactionGeneration = recordFollowBottomInteraction()
         scrollToBottomInteractionGeneration = interactionGeneration
         if !scrollToBottomRequested && !scrollToBottomInFlight {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2153,6 +2153,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// A verified replay completed mid-gesture: run one zero-delta pixel
     /// batch to re-assert the held position over the replay's bottom reset.
     var pendingLocalPixelScrollReassert = false
+    /// When line-path (alt/TUI) deceleration began; the flush kills the
+    /// momentum tail after ``linePathDecelerationBudget`` so a flick cannot
+    /// keep scrolling a full-screen app for seconds.
+    private var linePathDecelerationStartedAt: CFTimeInterval?
+    private static let linePathDecelerationBudget: CFTimeInterval = 0.45
     var pendingLocalScrollDrains: [(generation: UInt64, continuation: CheckedContinuation<Bool, Never>)] = []
 
     /// Drops scroll work tied to a surface generation that will no longer run.
@@ -2205,6 +2210,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         pendingScrollPixels = 0
         pendingScrollInteractionGeneration = nil
         let appliedLocally = scrollPresentationAuthority.appliesLocally
+        var dispatchLines = lines
         if appliedLocally {
             // Pixel-precise local scroll only where the phone owns
             // primary-screen scrolling (the confirmed-primary condition that
@@ -2226,15 +2232,43 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     $0.remainderPx = 0
                     $0.lastApplied = nil
                 }
-                applyLocalScrollbackScroll(
-                    lines: lines,
-                    col: cell.col,
-                    row: cell.row,
-                    interactionGeneration: generation
-                )
+                // TUI scroll feel: dispatch whole lines only, carrying the
+                // fraction, so the app sees clean steps instead of a 120Hz
+                // fragment stream; and cap the momentum tail so a flick
+                // cannot keep scrolling a full-screen app for seconds.
+                let wholeLines = lines < 0 ? lines.rounded(.up) : lines.rounded(.down)
+                pendingScrollLines += lines - wholeLines
+                dispatchLines = wholeLines
+                if scrollMechanicsView.isDecelerating {
+                    let now = CACurrentMediaTime()
+                    if let startedAt = linePathDecelerationStartedAt {
+                        if now - startedAt > Self.linePathDecelerationBudget {
+                            scrollMechanicsView.setContentOffset(
+                                scrollMechanicsView.contentOffset,
+                                animated: false
+                            )
+                            pendingScrollLines = 0
+                            dispatchLines = 0
+                        }
+                    } else {
+                        linePathDecelerationStartedAt = now
+                    }
+                } else {
+                    linePathDecelerationStartedAt = nil
+                }
+                if dispatchLines != 0 {
+                    applyLocalScrollbackScroll(
+                        lines: dispatchLines,
+                        col: cell.col,
+                        row: cell.row,
+                        interactionGeneration: generation
+                    )
+                }
             }
         }
-        delegate?.ghosttySurfaceView(self, didScrollLines: lines, atCol: cell.col, row: cell.row)
+        if dispatchLines != 0 {
+            delegate?.ghosttySurfaceView(self, didScrollLines: dispatchLines, atCol: cell.col, row: cell.row)
+        }
         return (generation, appliedLocally)
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -302,6 +302,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the main actor. Same lock discipline as `viewportRestoreGate`: held
     /// only for field reads and writes, never across a Ghostty C call.
     nonisolated struct LocalPixelScrollState {
+        /// Bumped by every clear (dock/typing snap, surface replacement,
+        /// alt routing). Batches capture the epoch at pump time and only
+        /// commit results while it still matches, so an in-flight batch
+        /// cannot resurrect a held position that a snap just cleared.
+        var epoch: UInt64 = 0
         var remainderPx: Double = 0
         var lastFallbackLogTime: CFTimeInterval = 0
         /// The last (row, remainder) the pixel pump applied. While a gesture
@@ -2183,7 +2188,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         localPixelScrollApplyStartedAt = nil
         localPixelScrollApplyToken = nil
         pendingLocalPixelScrollReassert = false
-        localPixelScrollState.withLock { $0 = .init() }
+        localPixelScrollState.withLock {
+            let epoch = $0.epoch
+            $0 = .init()
+            $0.epoch = epoch &+ 1
+        }
         scrollToBottomInFlight = false
         scrollToBottomRequested = false
         scrollToBottomRetryCount = 0
@@ -2239,6 +2248,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 pendingLocalScrollPixels = 0
                 pendingLocalPixelScrollReassert = false
                 localPixelScrollState.withLock {
+                    $0.epoch &+= 1
                     $0.remainderPx = 0
                     $0.lastApplied = nil
                 }
@@ -3026,6 +3036,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         pendingLocalPixelScrollInteractionGeneration = nil
         pendingLocalPixelScrollReassert = false
         localPixelScrollState.withLock {
+            $0.epoch &+= 1
             $0.remainderPx = 0
             $0.lastApplied = nil
         }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2217,6 +2217,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     interactionGeneration: generation
                 )
             } else {
+                // Routing to the line path (alt screen or legacy transport):
+                // drop any pixel-path residue so a primary->alt flip cannot
+                // carry a held anchor or re-assert into the TUI's screen.
+                pendingLocalScrollPixels = 0
+                pendingLocalPixelScrollReassert = false
+                localPixelScrollState.withLock {
+                    $0.remainderPx = 0
+                    $0.lastApplied = nil
+                }
                 applyLocalScrollbackScroll(
                     lines: lines,
                     col: cell.col,

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceWorkQueue.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceWorkQueue.swift
@@ -9,6 +9,8 @@ final class GhosttySurfaceWorkQueue: @unchecked Sendable {
     var lastAccessibilityTextTime: CFTimeInterval = 0
     /// Accessed only from ``queue``; rate-limits slow-output perf log lines.
     var lastOutputPerfLogTime: CFTimeInterval = 0
+    /// Accessed only from ``queue``; rate-limits slow-render perf log lines.
+    var lastRenderPerfLogTime: CFTimeInterval = 0
     #endif
 
     init(generation: UInt64) {

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a44cf039348606fc14d5a8b392911aa9d2903db44b1aee29f12ff0a736caf38d",
+  "originHash" : "2565647770c7d8bd4febd1c24cc66a7e250072c2334100f7169e8555d5b1ee5e",
   "pins" : [
     {
       "identity" : "aexml",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "3259a01e7193d55174c2f370d72e3ff4c277d8fd",
-        "version" : "9.15.0"
+        "revision" : "cfc3234fa2a60babbd26712ac0dec0d44734c019",
+        "version" : "9.16.0"
       }
     }
   ],

--- a/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0831ab4190d7f43031cf5a15bf4e390348abcb33d575b0dbe3e3cf0cf51a3f2c",
+  "originHash" : "f54f15ee24a7e4c103df21de60f84415c8f2f094b2aeba559786a12987421823",
   "pins" : [
     {
       "identity" : "highlightr",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "d82bb1c5eb353a593573a5624bb370f5a1f500ce",
-        "version" : "9.24.0"
+        "revision" : "cd213f98af160e6497eeff0707bc3f6a205b159c",
+        "version" : "9.26.0"
       }
     },
     {


### PR DESCRIPTION
Two changes driven by on-device probe data from the pixel-scroll dogfood (follow-up to https://github.com/manaflow-ai/cmux/pull/10523):

**Fix: replays no longer fight an active scroll.** The device log showed 117 verified replays in one session under agent output; each reset the mirror to the bottom, the anchor restore stood down for user interaction (`viewport_restore.skipped reason=user_interaction` every few hundred ms), and the next scroll frame rebased from the reset viewport, so the app visibly fought the gesture. While a gesture or its deceleration is active, the pixel pump is now the position authority: batches rebase from the last position the pump itself applied rather than the live viewport, and a replay completing mid-gesture triggers one zero-delta batch so a stationary finger is restored too. Idle behavior is unchanged (live viewport stays authoritative; dock/typing snaps and row-space changes clear the held position). Also rounds the scroll offset to whole device pixels so glyph antialiasing doesn't resample every frame.

**DEBUG audit probes:** per-second `perf.refresh scroll_fps/link_fps/missed/max_gap_ms` while scrolling, one-shot `perf.display max_fps`, rate-limited `perf.render_now`. Together with the merged `perf.pixel_scroll`/`perf.process_output` probes they cover the whole scroll path. First device data: 120Hz granted and 113fps achieved when quiet; replay-storm windows downshift Core Animation to 80Hz with 23-53ms gaps, and all pipeline stages measure fast, which makes storm reduction (separate follow-up) the remaining smoothness work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling smoothness by aligning pixel movement to device pixels.
  * Preserved active scroll positions during viewport restoration, reducing unexpected jumps during gestures.
  * Reduced visual inconsistencies caused by fractional offsets, replay resets, and switching between scrolling modes.
  * Improved momentum handling for line-based scrolling.

* **Diagnostics**
  * Added debug metrics for scroll frame rates, delayed frames, display timing, and rendering duration.
  * Added rate-limited reporting for slow rendering operations to support performance troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->