### PR TITLE
Simulator stream v2: recover a fused simulator worker from the phone

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorStreamCapability.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSimulatorStreamCapability.swift
@@ -18,6 +18,9 @@ public struct MobileSimulatorStreamCapability: Sendable {
     /// `mobile.simulator.device.select`, so phones can switch which
     /// simulator a panel streams.
     public let devicesIdentifier: String
+    /// The host serves `mobile.simulator.recover`, so a phone can restart a
+    /// crash-fused simulator worker without touching the Mac.
+    public let recoverIdentifier: String
 
     public init(
         identifier: String = "simulator.stream.v1",
@@ -25,7 +28,8 @@ public struct MobileSimulatorStreamCapability: Sendable {
         ownershipIdentifier: String = "simulator.ownership.v1",
         keepaliveIdentifier: String = "simulator.keepalive.v1",
         streamV2Identifier: String = "simulator.stream.v2",
-        devicesIdentifier: String = "simulator.devices.v1"
+        devicesIdentifier: String = "simulator.devices.v1",
+        recoverIdentifier: String = "simulator.recover.v1"
     ) {
         self.identifier = identifier
         self.inputIdentifier = inputIdentifier
@@ -33,5 +37,6 @@ public struct MobileSimulatorStreamCapability: Sendable {
         self.keepaliveIdentifier = keepaliveIdentifier
         self.streamV2Identifier = streamV2Identifier
         self.devicesIdentifier = devicesIdentifier
+        self.recoverIdentifier = recoverIdentifier
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+SimulatorStream.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+SimulatorStream.swift
@@ -61,6 +61,16 @@ extension MobileCoreRPCClient {
         return try MobileSimulatorDevicesResponse.decode(data).devices
     }
 
+    public func recoverMobileSimulator(
+        panelID: String,
+        workspaceID: String
+    ) async throws -> MobileSimulatorCommandResponse {
+        try await sendSimulatorCommand(
+            method: "mobile.simulator.recover",
+            parameters: MobileSimulatorPanelParameters(panelID: panelID, workspaceID: workspaceID)
+        )
+    }
+
     public func selectMobileSimulatorDevice(
         panelID: String,
         workspaceID: String,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStreamV2.swift
@@ -32,6 +32,25 @@ extension MobileShellComposite {
             MobileSimulatorStreamCapability.current.devicesIdentifier)
     }
 
+    /// Whether the connected Mac can restart a crash-fused simulator worker.
+    public var supportsSimulatorRecover: Bool {
+        supportedHostCapabilities.contains(
+            MobileSimulatorStreamCapability.current.recoverIdentifier)
+    }
+
+    /// Asks the Mac to recover the panel's simulator session (the pane's
+    /// Reconnect). Fire-and-forget: the stream's status flow shows progress.
+    public func recoverSimulator(panelID: String, workspaceID: String) async -> Bool {
+        guard supportsSimulatorRecover, let client = remoteClient else { return false }
+        do {
+            _ = try await client.recoverMobileSimulator(
+                panelID: panelID, workspaceID: workspaceID)
+            return true
+        } catch {
+            return false
+        }
+    }
+
     /// Installed simulators the panel can stream; empty on any failure so
     /// the picker simply hides against older or unreachable hosts.
     public func listSimulatorDevices(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -21,6 +21,8 @@ struct SimulatorStreamV2Pane: View {
     let supportsDeviceSwitching: Bool
     let listDevices: @MainActor () async -> [MobileSimulatorDeviceDescriptor]
     let selectDevice: @MainActor (String) async -> Bool
+    let supportsRecover: Bool
+    let recover: @MainActor () async -> Bool
 
     @State private var store: SimulatorStreamV2Store?
     @State private var pendingText = ""
@@ -42,7 +44,11 @@ struct SimulatorStreamV2Pane: View {
                 if let store {
                     SimStreamDisplayRepresentable(store: store)
                         .accessibilityIdentifier("SimulatorStreamV2Video")
-                    overlay(for: store.phase)
+                    if store.hostStatus == .workerCrashed || store.hostStatus == .failed {
+                        recoveryOverlay
+                    } else {
+                        overlay(for: store.phase)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -124,6 +130,51 @@ struct SimulatorStreamV2Pane: View {
             .accessibilityIdentifier("SimulatorStreamV2UnavailableOverlay")
         case .streaming, .stopped:
             EmptyView()
+        }
+    }
+
+    /// The Mac's simulator worker crashed and fused (or failed): the frame
+    /// on screen is frozen and no lane retry can revive it. Mirror the Mac
+    /// pane's Reconnect affordance so the fix is one tap away on the phone.
+    private var recoveryOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.72)
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 36))
+                Text(
+                    L10n.string(
+                        "mobile.simulatorStream.needsRecovery",
+                        defaultValue: "Simulator Needs Recovery")
+                )
+                .font(.headline)
+                Text(
+                    L10n.string(
+                        "mobile.simulatorStream.needsRecoveryDetail",
+                        defaultValue:
+                            "The Simulator session on the Mac stopped and is showing its last frame.")
+                )
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                if supportsRecover {
+                    Button {
+                        Task { _ = await recover() }
+                    } label: {
+                        Text(
+                            L10n.string(
+                                "mobile.simulatorStream.recover", defaultValue: "Recover")
+                        )
+                        .font(.subheadline.weight(.semibold))
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.white)
+                    .accessibilityIdentifier("SimulatorStreamV2RecoverButton")
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(28)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
@@ -271,6 +271,11 @@ extension WorkspaceDetailView {
                 selectDevice: { [weak store] udid in
                     await store?.selectSimulatorDevice(
                         panelID: simulator.id, workspaceID: workspaceID, udid: udid) ?? false
+                },
+                supportsRecover: store.supportsSimulatorRecover,
+                recover: { [weak store] in
+                    await store?.recoverSimulator(
+                        panelID: simulator.id, workspaceID: workspaceID) ?? false
                 }
             )
             .task {

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
@@ -26,6 +26,11 @@ public enum SimStreamViewerPhase: Equatable, Sendable {
 public final class SimulatorStreamV2Store {
     public private(set) var phase: SimStreamViewerPhase = .idle
     public private(set) var hostDetail: String = ""
+    /// The host's last reported stream status. `workerCrashed`/`failed`
+    /// mean the Mac-side worker needs recovery: retrying the lane cannot
+    /// fix it, so the pane surfaces a Recover affordance instead of
+    /// pretending the frozen frame is live.
+    public private(set) var hostStatus: SimStreamHostStatus?
     public private(set) var lastPresentedFrameAt: Date?
     /// Bumps on every presented frame; cheap SwiftUI invalidation hook.
     public private(set) var presentedFrameCount: UInt64 = 0
@@ -277,9 +282,12 @@ public final class SimulatorStreamV2Store {
         case .framePresented:
             lastPresentedFrameAt = Date()
             presentedFrameCount &+= 1
+            // A presented frame is proof the worker is alive again.
+            hostStatus = .streaming
             apply(lifecycle.handle(.framePresented))
         case .hostState(let update):
             hostDetail = update.detail
+            hostStatus = update.status
             switch update.status {
             case .closed:
                 apply(lifecycle.handle(.hostEnded(status: .closed, detail: update.detail)))

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -47,6 +47,7 @@ extension MobileHostService {
         "mobile.rpc.methods",
         "mobile.simulator.device.select",
         "mobile.simulator.devices.list",
+        "mobile.simulator.recover",
         "mobile.simulator.input.button",
         "mobile.simulator.input.pointer",
         "mobile.simulator.input.text",
@@ -182,6 +183,7 @@ extension MobileHostService {
             MobileSimulatorStreamCapability.current.keepaliveIdentifier,
             MobileSimulatorStreamCapability.current.streamV2Identifier,
             MobileSimulatorStreamCapability.current.devicesIdentifier,
+            MobileSimulatorStreamCapability.current.recoverIdentifier,
             "events.v1",
             "notification.badge.v1",
             "notification.dismiss.v1",
@@ -247,6 +249,7 @@ extension MobileHostService {
                 MobileSimulatorStreamCapability.current.keepaliveIdentifier,
                 MobileSimulatorStreamCapability.current.streamV2Identifier,
                 MobileSimulatorStreamCapability.current.devicesIdentifier,
+                MobileSimulatorStreamCapability.current.recoverIdentifier,
             ]
             capabilities.removeAll { simulatorCapabilities.contains($0) }
         }

--- a/Sources/TerminalController+MobileSimulator.swift
+++ b/Sources/TerminalController+MobileSimulator.swift
@@ -102,6 +102,8 @@ extension TerminalController {
             return await v2MobileSimulatorDevicesList(params: params, connectionID: connectionID)
         case "mobile.simulator.device.select":
             return v2MobileSimulatorDeviceSelect(params: params, connectionID: connectionID)
+        case "mobile.simulator.recover":
+            return v2MobileSimulatorRecover(params: params, connectionID: connectionID)
         default:
             return .err(code: "method_not_found", message: "Unknown mobile method", data: ["method": method])
         }
@@ -143,6 +145,30 @@ extension TerminalController {
             ]
         }
         return .ok(["devices": devices])
+    }
+
+    /// Restarts a crash-fused simulator worker session, the same recovery
+    /// the pane's Reconnect button and `simulator.recover` debug RPC run.
+    /// Fire-and-forget: recovery completes only after the replacement worker
+    /// reports a live frame stream, which can outlive an RPC deadline; the
+    /// v2 stream's own status flow shows progress to the phone.
+    private func v2MobileSimulatorRecover(
+        params: [String: Any],
+        connectionID: UUID?
+    ) -> V2CallResult {
+        guard CmuxFeatureFlags.shared.isSimulatorEnabled else {
+            return .err(code: "capability_disabled", message: "Simulator panes are disabled", data: nil)
+        }
+        guard let panelIDString = v2RawString(params, "panel_id"),
+              let workspaceID = v2UUID(params, "workspace_id"),
+              let resolved = mobileSimulatorPanel(id: panelIDString, workspaceID: workspaceID) else {
+            return mobileSimulatorPanelResolutionError(params: params)
+        }
+        let coordinator = resolved.panel.coordinator
+        Task { @MainActor in
+            try? await coordinator.recoverAndWait()
+        }
+        return .ok(["ok": true, "panel_id": resolved.panel.id.uuidString])
     }
 
     /// Selects (and boots when needed) another simulator for the panel.

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1327,6 +1327,40 @@
         }
       }
     },
+    "mobile.simulatorStream.needsRecovery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulator Needs Recovery"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulatorの復旧が必要です"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.needsRecoveryDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Simulator session on the Mac stopped and is showing its last frame."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacのSimulatorセッションが停止し、最後のフレームを表示しています。"
+          }
+        }
+      }
+    },
     "mobile.simulatorStream.panelClosedDetail": {
       "extractionState": "manual",
       "localizations": {
@@ -1408,6 +1442,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "高画質"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.recover": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recover"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復旧"
           }
         }
       }


### PR DESCRIPTION
Fixes the dogfood report in https://github.com/manaflow-ai/cmux/pull/10563: a phone viewing a simulator pane whose Mac-side session shows "Simulator Connection Failed" sat on a frozen frame with no explanation and no interaction.

**Why it happens.** The pane's crash containment deliberately fuses after two consecutive worker crashes and waits for an explicit Reconnect (`docs/simulator-pane.md`); no lane retry can revive it. v1 phones show the stale frame silently. v2 phones already receive `state(workerCrashed/failed)` on the lane but treated them as informational.

**Fix.** The v2 viewer surfaces those states as a recovery overlay (the frozen frame is labeled, input expectations are honest) with a Recover button. The button calls new `mobile.simulator.recover`, which runs the same `recoverAndWait` path as the pane's own Reconnect, fire-and-forget because recovery completes only when the replacement worker reports live frames; the stream's existing status/config/keyframe flow shows progress, and the first presented frame clears the overlay. Capability `simulator.recover.v1` hides the button against older Macs. On stream attach the host reports current status immediately, so a phone opening an already-fused pane sees the overlay right away instead of a stale frame.

HIG note per `Packages/iOS/AGENTS.md`: I attempted to fetch the HIG "Feedback" page but web fetch is unavailable in this environment; the overlay mirrors the app's existing stalled/unavailable overlay pattern and the Mac pane's own Reconnect affordance.

en/ja strings included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790041802&installation_model_id=21920&pr_number=10595&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10595&signature=52cfcd10cdb9f220812f400050362eb077bbf89dc078e31548685ee364f9d4db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover crash‑fused Simulator sessions from the phone in stream v2. Previously the phone froze on the last frame after two worker crashes; now a recovery overlay appears with a Recover button that restarts the worker, and the first live frame clears the overlay.

- Capability and RPC: adds mobile.simulator.recover gated by simulator.recover.v1; `MobileHostService` advertises it and `TerminalController` implements it by calling recoverAndWait (fire‑and‑forget).
- Client surface: `MobileCoreRPCClient` adds recoverMobileSimulator; `MobileShellComposite` exposes supportsSimulatorRecover and recoverSimulator.
- Viewer UI/state: `SimulatorStreamV2Pane` shows the recovery overlay when hostStatus is workerCrashed or failed; the button shows only when recovery is supported. `SimulatorStreamV2Store` tracks hostStatus and sets it to streaming on framePresented; `WorkspaceDetailView+Surfaces` wires supportsRecover/recover through to the pane.
- Compatibility and strings: phones on older hosts without simulator.recover.v1 see the overlay without a button. Adds en/ja strings. No schema or migration changes.

<sup>Written for commit 11fb32630f9419be050725c9fac48a3994eb258a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulator recovery support for hosts that stop responding or crash.
  * Added capability detection so recovery controls appear only when supported.
  * Added a recovery action to the simulator interface, including localized English and Japanese messaging.
  * Exposed simulator host status updates to improve stream state reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->