### PR TITLE
iOS: pin the workspace-detail navigation bar on scrollable surfaces

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePinnedNavigationBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePinnedNavigationBar.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+extension View {
+    /// Keeps the navigation bar fully expanded over scrollable content.
+    ///
+    /// iOS 26 minimizes the navigation bar into a floating overflow pill when
+    /// the content under it scrolls (Safari-style), which hides the back
+    /// button, the workspace title, and the trailing controls behind a "…"
+    /// menu on the browser and chat surfaces. The SwiftUI opt-out
+    /// (`toolbarMinimizeBehavior(.never)`) does not exist in the iOS 26 SDK,
+    /// and UIKit's 26 SDK only exposes a minimize behavior for the tab bar.
+    /// The bar's scroll linkage does have a public control: the view
+    /// controller's top-edge content scroll view (iOS 15+), which UIKit
+    /// otherwise discovers automatically (the browser pane's web view).
+    /// Re-pointing that association at a static, never-scrolling stand-in
+    /// decouples the bar from the content, so it stays expanded exactly like
+    /// the terminal surface, where no system scroll view exists to discover.
+    ///
+    /// On iOS 27 the native opt-out is applied as well once an Xcode 27
+    /// toolchain builds this target.
+    @ViewBuilder
+    func mobilePinnedNavigationBar() -> some View {
+        #if canImport(UIKit)
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, *) {
+            background(PinnedNavigationBarApplier())
+                .toolbarMinimizeBehavior(.never, for: .navigationBar)
+        } else {
+            background(PinnedNavigationBarApplier())
+        }
+        #else
+        background(PinnedNavigationBarApplier())
+        #endif
+        #else
+        self
+        #endif
+    }
+}
+
+#if canImport(UIKit)
+private struct PinnedNavigationBarApplier: UIViewRepresentable {
+    func makeUIView(context: Context) -> PinnedNavigationBarProbeView {
+        let view = PinnedNavigationBarProbeView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        return view
+    }
+
+    func updateUIView(_ view: PinnedNavigationBarProbeView, context: Context) {
+        view.applyIfNeeded()
+    }
+}
+
+final class PinnedNavigationBarProbeView: UIView {
+    /// The stand-in the bar tracks instead of the real content: zero content,
+    /// scrolling disabled, so the bar's scroll edge never moves.
+    private let anchorScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.isScrollEnabled = false
+        return scrollView
+    }()
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        applyIfNeeded()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Re-assert after layout passes: SwiftUI can re-derive the tracked
+        // scroll view for its own containers, and the association resets when
+        // the hosting controller re-parents during navigation transitions.
+        applyIfNeeded()
+    }
+
+    func applyIfNeeded() {
+        guard window != nil, let target = barOwningViewController() else { return }
+        if target.contentScrollView(for: .top) !== anchorScrollView {
+            target.setContentScrollView(anchorScrollView, for: .top)
+        }
+    }
+
+    /// The pushed screen's view controller: the ancestor whose parent is the
+    /// navigation controller (its navigation item drives the bar). Falls back
+    /// to the nearest ancestor view controller.
+    private func barOwningViewController() -> UIViewController? {
+        var responder: UIResponder? = next
+        var nearest: UIViewController?
+        while let current = responder {
+            if let viewController = current as? UIViewController {
+                nearest = nearest ?? viewController
+                if viewController.parent is UINavigationController {
+                    return viewController
+                }
+            }
+            responder = current.next
+        }
+        return nearest
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -455,12 +455,6 @@ struct WorkspaceDetailView: View {
                         subtitle: subtitle,
                         style: .toolbarCompact
                     )
-                case .browser(let title):
-                    Text(title)
-                        .font(.headline)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(value.terminalTheme.terminalChromeForegroundColor)
                 case .standard(let title, let subtitle):
                     WorkspaceToolbarTitleView(title: title, subtitle: subtitle)
                 }
@@ -481,11 +475,17 @@ struct WorkspaceDetailView: View {
                 subtitle: tabName(for: session)
             )
         } else if let browser = activeBrowser {
-            return .browser(title: browser.title ?? workspace.name)
+            // Browser-style surfaces keep the workspace as the pill's title,
+            // like the terminal; the surface's own title (the page or tab)
+            // rides the subtitle line.
+            return .standard(title: workspace.name, subtitle: browser.title)
         } else if let browser = activeBrowserStream {
-            return .browser(title: browser.title ?? workspace.name)
+            return .standard(title: workspace.name, subtitle: browser.title)
         } else if let simulator = activeSimulatorStream {
-            return .browser(title: simulator.selectedDeviceName ?? simulator.title)
+            return .standard(
+                title: workspace.name,
+                subtitle: simulator.selectedDeviceName ?? simulator.title
+            )
         } else {
             return .standard(title: workspace.name, subtitle: selectedToolbarSubtitle)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -191,6 +191,10 @@ struct WorkspaceDetailView: View {
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
             .navigationTitle(systemNavigationTitle)
             .mobileTerminalNavigationChrome(theme: store.activeTerminalTheme)
+            // The browser and chat surfaces scroll; without this the system
+            // minimizes the whole bar into a floating "…" pill, unlike the
+            // terminal surface, which has no system scroll view.
+            .mobilePinnedNavigationBar()
             .toolbar { workspaceDetailToolbar }
             .task(id: chatRefreshKey) { await refreshChatSessions() }
             .task(id: workspace.rpcWorkspaceID.rawValue) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuLabelToken.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuLabelToken.swift
@@ -8,6 +8,5 @@ enum WorkspaceTitleMenuLabelToken: Equatable {
         titleOverride: String?,
         subtitle: String?
     )
-    case browser(title: String)
     case standard(title: String, subtitle: String?)
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -9,7 +9,7 @@ import Testing
             labelToken: .standard(title: "Workspace", subtitle: "Terminal")
         )
         let browser = menuValue(
-            labelToken: .browser(title: "Workspace")
+            labelToken: .standard(title: "Workspace", subtitle: "GitHub - cmux")
         )
         let chat = menuValue(
             labelToken: .chat(


### PR DESCRIPTION
On iOS 26, scrolling the browser or chat surface minimizes the whole navigation bar into a floating "…" pill: back button, workspace title, and the trailing controls all end up inside it (screenshots in the internal dogfood thread). The terminal surface never shows this because it has no system scroll view for UIKit to discover, so the ask is to make every surface match the terminal.

There is no public opt-out in the 26 SDKs (`toolbarMinimizeBehavior(.never)` is iOS 27 SwiftUI; UIKit 26 only has `tabBarMinimizeBehavior`). The bar's scroll linkage is controllable though: `UIViewController.setContentScrollView(_:for:)` (iOS 15+) selects which scroll view drives bar scroll effects, overriding automatic discovery of the web view. A background probe view finds the pushed screen's view controller (the child of the navigation controller) via the responder chain and points its top-edge content scroll view at a retained, never-scrolling stand-in, re-asserting after layout passes and navigation re-parenting. The bar then stays expanded on 26.0+. On iOS 27 the native `.toolbarMinimizeBehavior(.never, for: .navigationBar)` is applied as well, gated behind `#if compiler(>=6.4)` like the existing `visibilityPriority` branch.

Applied to the workspace-detail screen (terminal, browser, chat, and stream modes share its toolbar). Other scrollable screens (notification feed, changes sheets) can adopt the same modifier if dogfood shows the pill there too.

No user-facing strings changed (localization audit: none needed). No practical unit test for UIKit runtime bar behavior; verified on an isolated simulator by scrolling the browser surface (evidence in thread).



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790043984&installation_model_id=21920&pr_number=10596&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10596&signature=67b0fefdb35bc2b7be8d5adfc00730cb3709c865285fd571897894739b91ff33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the workspace-detail navigation bar on iOS so it stays fully expanded over scrollable browser/chat surfaces, and aligns browser-style titles with the terminal. Previously on iOS 26 the bar collapsed into a floating "…" pill and browser/stream views showed only the page/device title; now the bar remains expanded and the workspace name is the title with the page/device as subtitle.

- Adds SwiftUI modifier `mobilePinnedNavigationBar()` that uses `UIViewController.setContentScrollView(_:for:)` to decouple the bar from content via a retained, non-scrolling stand‑in; re-applies after layout and navigation re-parenting.
- Applies the modifier to `WorkspaceDetailView` (terminal, browser, chat, and stream).
- On iOS 27+, also sets `.toolbarMinimizeBehavior(.never, for: .navigationBar)` behind `#if compiler(>=6.4)`.
- Standardizes browser, browser-stream, and simulator-stream titles to `.standard(title: workspace, subtitle: page/device)`; removes the unused `browser` label token and updates tests.
- No change to content scrolling or strings; verified manually on iOS 26.

<sup>Written for commit 4696dfbb860ce4a01cd75b9930a5b4788d0a8af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the navigation bar from minimizing while scrolling in workspace browser and chat views.
  * Improved navigation-bar behavior across supported iOS versions.

* **UI Improvements**
  * Updated browser, browser streaming, and simulator streaming navigation titles to show the workspace name with the active surface as a subtitle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also folded in per dogfood: the browser, browser-stream, and simulator-stream surfaces now use the same two-line title pill as the terminal, workspace name on top with the page/tab/device title as the subtitle, instead of showing the page title alone; the single-line browser label token is removed as dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)