### PR TITLE
cmux-tui: extend SessionPort with agent reads

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -908,11 +908,6 @@ impl Session {
         }
     }
 
-    /// Read the current topology through the frontend session boundary.
-    pub(crate) fn snapshot(&self) -> TreeView {
-        <Self as SessionPort>::snapshot(self)
-    }
-
     pub fn agents(&self) -> Vec<AgentInfo> {
         <Self as SessionPort>::agents(self)
     }
@@ -3002,7 +2997,8 @@ mod tests {
 
     #[test]
     fn session_port_snapshot_matches_existing_tree_read() {
-        let session = Session::Local(Mux::new("session-port-snapshot-test", SurfaceOptions::default()));
+        let session =
+            Session::Local(Mux::new("session-port-snapshot-test", SurfaceOptions::default()));
         let direct = session.tree();
         let port: &dyn SessionPort = &session;
         let snapshot = port.snapshot();
@@ -3014,7 +3010,8 @@ mod tests {
 
     #[test]
     fn session_port_agents_matches_existing_agent_read() {
-        let session = Session::Local(Mux::new("session-port-agents-test", SurfaceOptions::default()));
+        let session =
+            Session::Local(Mux::new("session-port-agents-test", SurfaceOptions::default()));
         let direct = session.agents_impl();
         let port: &dyn SessionPort = &session;
         assert_eq!(port.agents(), direct);

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -55,6 +55,21 @@ pub enum Session {
     Remote(Arc<RemoteSession>),
 }
 
+/// Stable frontend boundary for session reads.
+///
+/// This is deliberately small: mutations and transport recovery remain on
+/// `Session` until their command and acknowledgement semantics are migrated.
+/// Both local and remote sessions therefore expose the same snapshot contract.
+pub(crate) trait SessionPort: Send + Sync {
+    fn snapshot(&self) -> TreeView;
+}
+
+impl SessionPort for Session {
+    fn snapshot(&self) -> TreeView {
+        self.tree()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct CreationReceipt {
     origin: String,
@@ -886,6 +901,11 @@ impl Session {
             }
             Session::Remote(remote) => remote.cached_tree(),
         }
+    }
+
+    /// Read the current topology through the frontend session boundary.
+    pub(crate) fn snapshot(&self) -> TreeView {
+        <Self as SessionPort>::snapshot(self)
     }
 
     pub fn agents(&self) -> Vec<AgentInfo> {
@@ -2969,6 +2989,18 @@ mod tests {
 
         let error = session.set_split_ratio(999_999, 0.5).unwrap_err();
         assert_eq!(error.to_string(), "unknown split 999999");
+    }
+
+    #[test]
+    fn session_port_snapshot_matches_existing_tree_read() {
+        let session = Session::Local(Mux::new("session-port-snapshot-test", SurfaceOptions::default()));
+        let direct = session.tree();
+        let port: &dyn SessionPort = &session;
+        let snapshot = port.snapshot();
+        assert_eq!(snapshot.workspace_revision, direct.workspace_revision);
+        assert_eq!(snapshot.pane_revision, direct.pane_revision);
+        assert_eq!(snapshot.active_workspace, direct.active_workspace);
+        assert_eq!(snapshot.workspaces.len(), direct.workspaces.len());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -62,11 +62,16 @@ pub enum Session {
 /// Both local and remote sessions therefore expose the same snapshot contract.
 pub(crate) trait SessionPort: Send + Sync {
     fn snapshot(&self) -> TreeView;
+    fn agents(&self) -> Vec<AgentInfo>;
 }
 
 impl SessionPort for Session {
     fn snapshot(&self) -> TreeView {
         self.tree()
+    }
+
+    fn agents(&self) -> Vec<AgentInfo> {
+        self.agents_impl()
     }
 }
 
@@ -909,6 +914,10 @@ impl Session {
     }
 
     pub fn agents(&self) -> Vec<AgentInfo> {
+        <Self as SessionPort>::agents(self)
+    }
+
+    fn agents_impl(&self) -> Vec<AgentInfo> {
         match self {
             Session::Local(mux) => mux
                 .list_agents(None, None)
@@ -3001,6 +3010,14 @@ mod tests {
         assert_eq!(snapshot.pane_revision, direct.pane_revision);
         assert_eq!(snapshot.active_workspace, direct.active_workspace);
         assert_eq!(snapshot.workspaces.len(), direct.workspaces.len());
+    }
+
+    #[test]
+    fn session_port_agents_matches_existing_agent_read() {
+        let session = Session::Local(Mux::new("session-port-agents-test", SurfaceOptions::default()));
+        let direct = session.agents_impl();
+        let port: &dyn SessionPort = &session;
+        assert_eq!(port.agents(), direct);
     }
 
     #[test]


### PR DESCRIPTION
Extends the SessionPort boundary with a typed agent-presence projection.

- Local and remote sessions expose the same agents() contract.
- Existing Session::agents API delegates through the port.
- Adds a behavior test proving the projection matches the existing local read.

This branch includes the prerequisite snapshot-port commit. Verification: git diff --check. Hosted Rust verification required; no local cargo/rustc/Zig run per task constraints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790070609&installation_model_id=21920&pr_number=10600&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10600&signature=bbdb1787f7a3a705c85f371b7ad2630b35d1a61edc4628126e1bd5d4bb98cfaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Projects session reads through a crate-private `SessionPort` so local and remote sessions share the same snapshot and agent read contract. Previously `Session::agents` read directly from the local mux; now it delegates through the port with no public API or behavior change.

- Introduces `SessionPort` with `snapshot()` and `agents()`, implemented for `Session` via `tree()` and a new private `agents_impl()`.
- `Session::agents()` now delegates to the port; no behavior change.
- Removes an unused snapshot wrapper; snapshot reads continue through the port.
- Adds tests verifying port reads match `tree()` and the previous agent read; no migrations.

<sup>Written for commit 05358273d720577d92ff2dc42b2292424d7990c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added a stable session interface for reading workspace state and agent information.
  * Existing session views continue to provide the same data through the updated interface.

* **Tests**
  * Added coverage confirming that interface-based session reads match existing direct reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->