### PR TITLE
ci: validate cmux-tui workflow changes

### DIFF
--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-build-package.yml"
+      - ".github/workflows/cmux-tui.yml"
       - ".github/workflows/cmux-tui-nightly.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"
@@ -28,6 +30,8 @@ on:
     paths:
       - "cmux-tui/**"
       - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-build-package.yml"
+      - ".github/workflows/cmux-tui.yml"
       - ".github/workflows/cmux-tui-nightly.yml"
       - ".github/workflows/cmux-tui-release-cut.yml"
       - ".github/workflows/cmux-tui-release.yml"

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -62,6 +62,21 @@ def workflow_dispatch_input(text: str, name: str) -> str:
     return match.group(1)
 
 
+def test_sdk_ci_tracks_tui_verification_and_packaging_workflows() -> None:
+    triggers = workflow_triggers(workflow("cmux-tui-sdks.yml"))
+    required_paths = {
+        ".github/workflows/cmux-tui-build-package.yml",
+        ".github/workflows/cmux-tui.yml",
+    }
+
+    for event in ("push", "pull_request"):
+        event_config = triggers[event]
+        assert isinstance(event_config, dict)
+        paths = event_config["paths"]
+        assert isinstance(paths, list)
+        assert required_paths <= set(paths)
+
+
 def test_sdk_registry_names_do_not_overlap_tui_cli_packages() -> None:
     bindings = ROOT / "cmux-tui" / "bindings"
     typescript = json.loads(


### PR DESCRIPTION
cmux-tui SDK and distribution contract checks now run when the hosted verification workflow or shared package workflow changes.

The regression test requires both paths for push and pull request events. The two-commit history records the failing test before the fix.

Verification: targeted Python workflow-trigger test, Python syntax check, and git diff check. No local Rust build ran.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790070674&installation_model_id=21920&pr_number=10601&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10601&signature=9f08f2dc704d2d4c443fb220fa555313d55db3723787c36a47e5d337dbb7da09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run cmux-tui SDK verification when core TUI workflows change to prevent missed checks. Previously, edits to cmux-tui-build-package.yml or cmux-tui.yml did not trigger the SDK CI; now both push and pull_request events do. This increases CI coverage when workflow logic changes.

- Review notes:
  - In .github/workflows/cmux-tui-sdks.yml, confirm the two workflows are added to the paths list for both push and pull_request.
  - tests/test_tui_publish_workflow_security.py adds a regression test that asserts these paths are tracked.
  - No build steps or runtime behavior changed; only CI trigger scope expanded.

<sup>Written for commit b8b89cbc19eb5b66390b132557bffd62a73a822f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Updated SDK workflow triggers to run when related TUI verification or packaging workflows change.
* **Tests**
  * Added coverage to verify that required workflow paths are included for push and pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->