### PR TITLE
docs: define relay cleanup cancellation contract

### DIFF
--- a/docs/relay-cleanup-cancellation.md
+++ b/docs/relay-cleanup-cancellation.md
@@ -1,0 +1,50 @@
+# Relay cleanup and child-task cancellation
+
+This note defines the shutdown contract for the Tokio relay service. It is a
+design boundary, not an implementation change.
+
+## Contract
+
+- A relay shutdown request stops new upgrades before cancelling existing work.
+- The cleanup task exits after cancellation. Dropping a `JoinHandle` is not
+  sufficient because Tokio detaches the task when the handle is dropped.
+- Each upgraded socket owns one child writer task and one admission permit.
+  Cancellation must release both, even if the writer is waiting on the
+  bounded outbound queue.
+- A socket close sends queued protocol frames before the final error and close
+  frame. This ordering is part of the wire contract.
+- State removal happens under the relay state lock. Network sends and task
+  joins happen after releasing that lock.
+
+## Proposed implementation boundary
+
+Give `spawn_cleanup` a cancellation token (or an abort handle) owned by the
+server lifecycle. On shutdown, stop admission, signal the token, and await the
+cleanup task. Keep per-socket shutdown on the existing watch channel. Do not
+replace the bounded mpsc queue with an unbounded channel.
+
+## Acceptance tests
+
+1. Shutdown causes the cleanup task to terminate within a bounded test timeout.
+2. A new upgrade is rejected after shutdown starts.
+3. An attached circuit receives its final error and close frame in queue order.
+4. Cancelling a socket releases the global connection permit exactly once.
+5. Cleanup never holds the state lock while awaiting a socket send or task join.
+6. Replacing a daemon registration does not remove a newer registration for
+   the same slot.
+
+## Non-goals
+
+- Do not merge native and Cloudflare admission limits. Their windows and
+  capacity semantics currently differ.
+- Do not change ticket validation, circuit lease durations, or queue limits.
+- Do not make socket sends awaitable. Backpressure remains an explicit
+  capacity error.
+
+Tokio documents that dropping a `JoinHandle` detaches its task, while `abort`
+only schedules cancellation and should be followed by awaiting the handle:
+[JoinHandle](https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html).
+Tokio also recommends keeping synchronous shared-state critical sections free
+of awaits and treating `select!` cancellation behavior explicitly:
+[shared state](https://tokio.rs/tokio/tutorial/shared-state),
+[select](https://tokio.rs/tokio/tutorial/select).


### PR DESCRIPTION
Documents relay shutdown, child-task cancellation, ordering guarantees, acceptance tests, and non-goals. No runtime behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790089521&installation_model_id=21920&pr_number=10604&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10604&signature=fa0dec142cd3f17c79db00ddc7467d5ddb0c1652e86a98df7bbba8f4dada0a35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the shutdown and child-task cancellation contract for the Tokio relay to clarify ordering guarantees and cleanup responsibilities. No runtime behavior changes.

**Review focus**
- Proposed boundary: give `spawn_cleanup` a lifecycle-owned cancellation token; on shutdown stop admission, signal the token, and await the cleanup task; keep per-socket shutdown via the existing watch; keep the bounded mpsc queue.
- Acceptance criteria: cleanup task terminates within a timeout; new upgrades reject after shutdown begins; final error/close frames preserve queue order; cancelling a socket releases the global connection permit exactly once; cleanup never awaits while holding the state lock.
- Non-goals: do not merge Cloudflare and native admission limits; do not change ticket validation, lease durations, or queue limits; do not make socket sends awaitable.

<sup>Written for commit e04d5e7e0161e490017ee1934368df4b39b23137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design guidance for relay shutdown and cancellation behavior.
  * Documented cleanup, resource release, queued-frame ordering, lifecycle handling, acceptance tests, and non-goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->