### PR TITLE
docs(tui): remove redundant initial build step

### DIFF
--- a/cmux-tui/docs/getting-started.md
+++ b/cmux-tui/docs/getting-started.md
@@ -2,12 +2,7 @@
 
 ## Prerequisites
 
-Builds need Zig 0.16.0, a Rust toolchain, and the `ghostty` submodule. `ghostty-vt-sys` compiles `libghostty-vt.a` from that submodule, so an uninitialized submodule fails before the TUI starts.
-
-```bash
-cd cmux-tui
-cargo build -p cmux-tui
-```
+Builds need Zig 0.16.0, a Rust toolchain, and the `ghostty` submodule. `ghostty-vt-sys` compiles `libghostty-vt.a` from that submodule, so an uninitialized submodule fails before the TUI starts. The first `cargo run` below compiles the TUI and then starts it.
 
 ## Local session
 


### PR DESCRIPTION
## Summary
- remove the standalone `cargo build` from cmux-tui getting started
- explain that the first `cargo run` compiles and starts the TUI

## Verification
- `git diff --check`

Cargo’s official guide documents `cargo run` as compiling and running the package in one step: https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790089992&installation_model_id=21920&pr_number=10605&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10605&signature=5056e1feadfed21e5e2e99efeeaef4c8e38b4399422f94055e384ec3f56238cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant `cargo build` step from the `cmux-tui` getting-started guide and clarifies that the first `cargo run` compiles and launches the TUI. This reduces confusion and aligns the docs with Cargo’s behavior.

- Docs-only change; no runtime behavior changes.
- Prereqs unchanged: Zig 0.16.0, Rust toolchain, and initialized `ghostty` submodule. `ghostty-vt-sys` compiles `libghostty-vt.a` and will fail if the `ghostty` submodule is uninitialized.

<sup>Written for commit 6bbc5e13876292e8832de0ff07f63b6d5cf95319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the getting started instructions to clarify that the first `cargo run -p cmux-tui` command both compiles and launches the terminal interface.
  * Removed the separate build command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->