### PR TITLE
docs(tui): define cross-language socket discovery contract

### DIFF
--- a/cmux-tui/bindings/SOCKET-DISCOVERY-CONTRACT.md
+++ b/cmux-tui/bindings/SOCKET-DISCOVERY-CONTRACT.md
@@ -1,0 +1,22 @@
+# Unix socket discovery contract
+
+SDKs resolve a socket in this order: explicit API or CLI path, non-blank
+`CMUX_TUI_SOCKET`, non-blank `CMUX_MUX_SOCKET`, then a derived path under
+`XDG_RUNTIME_DIR`, `TMPDIR` (or the platform temp directory), or `/tmp`.
+Derived paths use `cmux-tui-<uid>/<session>.sock`.
+
+Explicit empty paths are invalid. Session names are validated before deriving a
+path. If a derived path exceeds the platform `sockaddr_un.sun_path` byte
+capacity, the implementation uses the `/tmp` fallback. Explicit and inherited
+paths are returned unchanged. A failed connection is a connection error, not a
+second discovery attempt.
+
+Conformance vectors should contain `explicit`, an environment map, `session`,
+platform byte capacity, and one expected result: `path`, `invalid_argument`, or
+`connection_error`. Each language keeps a small native resolver while sharing
+these vectors, so public APIs and authority rules remain unchanged.
+
+The contract follows the platform APIs: Python `AF_UNIX`, Go `DialUnix`, Node
+IPC `path`, Java `UnixDomainSocketAddress`, C++ `AF_UNIX`, Rust Unix streams,
+and Zig POSIX sockets all connect to one named local endpoint and report path
+or connection failures directly.

--- a/cmux-tui/bindings/SOCKET-DISCOVERY-CONTRACT.md
+++ b/cmux-tui/bindings/SOCKET-DISCOVERY-CONTRACT.md
@@ -1,17 +1,24 @@
-# Unix socket discovery contract
+# Unix socket discovery contract (target)
 
-SDKs resolve a socket in this order: explicit API or CLI path, non-blank
+The intended shared behavior is: explicit API or CLI path, non-blank
 `CMUX_TUI_SOCKET`, non-blank `CMUX_MUX_SOCKET`, then a derived path under
 `XDG_RUNTIME_DIR`, `TMPDIR` (or the platform temp directory), or `/tmp`.
 Derived paths use `cmux-tui-<uid>/<session>.sock`.
 
-Explicit empty paths are invalid. Session names are validated before deriving a
-path. If a derived path exceeds the platform `sockaddr_un.sun_path` byte
-capacity, the implementation uses the `/tmp` fallback. Explicit and inherited
-paths are returned unchanged. A failed connection is a connection error, not a
-second discovery attempt.
+This file is a target contract, not a claim that every current SDK already
+implements each rule. In particular, Node currently uses the platform temp
+directory and Python/TypeScript do not perform the same session/path checks as
+the other SDKs. Empty explicit values and path-length handling also differ.
+Those gaps need focused implementation and vector-test changes before this
+document can become normative.
 
-Conformance vectors should contain `explicit`, an environment map, `session`,
+The target rules are: reject explicit empty paths; validate sessions before
+deriving a path; use the platform `sockaddr_un.sun_path` byte capacity (including
+the trailing NUL rule) before selecting the `/tmp` fallback; return explicit and
+inherited paths unchanged; and classify failed connections as connection errors
+without a second discovery attempt.
+
+Future conformance vectors should contain `explicit`, an environment map, `session`,
 platform byte capacity, and one expected result: `path`, `invalid_argument`, or
 `connection_error`. Each language keeps a small native resolver while sharing
 these vectors, so public APIs and authority rules remain unchanged.


### PR DESCRIPTION
Documents the shared socket discovery authority order, validation, path-length fallback, and error classification for all SDK languages. This is a contract-only change; no public APIs or runtime behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790091418&installation_model_id=21920&pr_number=10608&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10608&signature=3664932e3da6c3011954d3acd34fc15ab3d67035d224fb1c9dc84742619cc5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a target cross-language contract for Unix socket discovery in TUI SDKs and explicitly calls out current gaps; no public APIs or runtime behavior change.

- Authority order: explicit API/CLI path → `CMUX_TUI_SOCKET` → `CMUX_MUX_SOCKET` → derived under `XDG_RUNTIME_DIR`, `TMPDIR`/platform temp, or `/tmp` using `cmux-tui-<uid>/<session>.sock`.
- Validation and path rules: reject explicit empty paths; validate session before deriving; use platform `sockaddr_un.sun_path` byte capacity (including trailing NUL) before falling back to `/tmp`; return explicit/env paths unchanged.
- Errors: classify a failed connect as a connection error; do not continue discovery after a connect failure.
- Conformance vectors: include `explicit`, env map, `session`, platform byte capacity; result is `path`, `invalid_argument`, or `connection_error`. Each language keeps a small native resolver while sharing vectors.
- Non-normative note: documents known gaps (e.g., Node uses platform temp; Python/TypeScript differ on session/path checks and empty/path-length handling) that must be addressed before making this contract normative.

<sup>Written for commit f1a238540311cba0b1f37ba4a83f9f3aa59df3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Unix socket discovery contract covering path resolution, validation, fallback behavior, and connection errors.
  * Documented conformance requirements and native socket APIs for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->