### PR TITLE
Accept handoff-bound cmux-dev-jmux Login callbacks on cmux.com

### DIFF
--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -145,6 +145,20 @@ function verifiedNativeHandoff(
   return cookieStore.get(NATIVE_HANDOFF_COOKIE_NAME)?.value === handoffNonce;
 }
 
+/** Production-only jmux Login return: scheme/host/path exact; never HTML-token fallback. */
+function isJmuxNativeAuthCallback(href: string): boolean {
+  try {
+    const url = new URL(href);
+    return (
+      url.protocol === "cmux-dev-jmux:" &&
+      url.hostname === "auth-callback" &&
+      (url.pathname === "" || url.pathname === "/")
+    );
+  } catch {
+    return false;
+  }
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -359,6 +373,14 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
           }
           return nativeReturnResponse(href, localizedMessages, switchAccountHref(request));
         }
+      }
+      // Deployed-host jmux Login: accept only verified handoff; never emit token HTML.
+      if (
+        isJmuxNativeAuthCallback(nativeReturnTo) &&
+        verifiedNativeHandoff(request, stackCookies, nativeReturnTo)
+      ) {
+        const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
+        if (href) return nativeRedirectResponse(request, href);
       }
       return NextResponse.redirect(new URL("/", request.url));
     }

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -302,6 +302,53 @@ describe("after sign-in native handoff", () => {
       }
     }
   });
+
+  test("redirects verified cmux-dev-jmux handoffs on the deployed host", async () => {
+    handoffCookie = "handoff-nonce";
+    const nativeReturnTo = "cmux-dev-jmux://auth-callback?cmux_auth_state=state-jmux";
+
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const callbackURL = new URL(location!);
+    expect(callbackURL.protocol).toBe("cmux-dev-jmux:");
+    expect(callbackURL.hostname).toBe("auth-callback");
+    expect(callbackURL.searchParams.get("cmux_auth_state")).toBe("state-jmux");
+    expect(callbackURL.searchParams.get("stack_refresh")).toBe("refresh-token");
+    expect(callbackURL.searchParams.get("stack_access")).toBe(
+      JSON.stringify(["refresh-token", "access-token"]),
+    );
+  });
+
+  test("rejects unverified cmux-dev-jmux handoffs without leaking tokens", async () => {
+    handoffCookie = "different-nonce";
+    const nativeReturnTo = "cmux-dev-jmux://auth-callback?cmux_auth_state=state-jmux";
+
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+    const body = await response.text();
+    expect(body).not.toContain("stack_refresh");
+    expect(body).not.toContain("stack_access");
+    expect(body).not.toContain("cmux-dev-jmux://");
+  });
+
+  test("rejects verified cmux-dev-other handoffs on the deployed host", async () => {
+    handoffCookie = "handoff-nonce";
+    const nativeReturnTo = "cmux-dev-other://auth-callback?cmux_auth_state=state-other";
+
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+    const body = await response.text();
+    expect(body).not.toContain("stack_refresh");
+    expect(body).not.toContain("stack_access");
+  });
 });
 
 describe("sign out and sign back in", () => {


### PR DESCRIPTION
**jmux Login against live cmux**

I dug into a tagged Debug Login that opened a dead `localhost:9160` page (`ERR_CONNECTION_REFUSED`) with `native_app_return_to=cmux-dev-jmux://auth-callback`. Pointing the Mac app at live cmux.com is a local deploy-script change. Completing Login still needs the production after-sign-in host to accept that tagged callback.

## What I found

On a deployed host, `isAllowedNativeScheme` only allows `cmux` / `cmux-nightly`. `cmux-dev-*` is localhost-only, so after-sign-in redirects tagged Login returns to `/` even when the native handoff nonce matches.

I confirmed it by the existing allow-list:

> `cmux-dev-*` requires `isLocalRequest(request)` ([native-callback.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/app/lib/native-callback.ts#L43-L51))

and by after-sign-in only building a native href after that allow-list or a purchase signature ([handler.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/app/handler/after-sign-in/handler.ts#L351-L363)).

## What you'll get

- After Sign In on the production host accepts `cmux-dev-jmux://auth-callback` when the native handoff nonce/cookie matches, and redirects into the app with tokens.
- Unmatched or tampered tagged returns redirect home with no tokens in the body or Location (no HTML token page for this exception).
- Other tagged schemes (`cmux-dev-other`) stay rejected on the deployed host unless they already have a signed purchase return.

**What you won't get from this change:** a default of production auth for every agent Debug tag, or widening `isAllowedNativeScheme` on production (that would enable the no-handoff HTML token page). Personal-app bake (`jmux-reload --prod-auth`) stays on the fork.

## How you'll know it worked

- Verified `cmux-dev-jmux` handoff on the `cmux.test` host in `bun test` returns 307 to `cmux-dev-jmux://auth-callback` with `stack_refresh` / `stack_access`.
- Mismatched handoff and `cmux-dev-other` return 307 to `/` with no `stack_refresh` / `stack_access` in the body.
- Existing `cmux://` HTML fallback and signed purchase tagged returns still pass.

Verified locally: `bun test tests/after-sign-in-route.test.ts` — 18 pass, 0 fail (this branch on origin/main). The new accept test fails without the handler change (RED then GREEN, two commits).

## What I'm touching

- [`web/app/handler/after-sign-in/handler.ts`](https://github.com/manaflow-ai/cmux/blob/5b3e5c85c77c7f1a2fa6520d3621c7e04f879056/web/app/handler/after-sign-in/handler.ts) — exact-scheme `cmux-dev-jmux` + `verifiedNativeHandoff` then `nativeRedirectResponse`; otherwise `/` with no token HTML.
- [`web/tests/after-sign-in-route.test.ts`](https://github.com/manaflow-ai/cmux/blob/5b3e5c85c77c7f1a2fa6520d3621c7e04f879056/web/tests/after-sign-in-route.test.ts) — accept / reject-without-handoff / reject-other-tag.

## What else I considered

**A smaller script-only bake** — would have opened cmux.com and then dropped users on `/` after Stack. I measured that the production scheme gate rejects `cmux-dev-jmux` today; this web change is required.

**Widening `isAllowedNativeScheme`** — would have given the same Login completion. I am not doing that: it enables the no-handoff HTML token page on cmux.com. My judgment, not a separate exploit write-up; the gate order is in [handler.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/app/handler/after-sign-in/handler.ts#L351-L360).

## What a second reviewer pushed back on

I had a second reviewer poke holes in this. They confirmed `--prod-auth` alone does not finish Login, because the deployed-host allow-list still rejects `cmux-dev-*` ([native-callback.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/app/lib/native-callback.ts#L43-L51)), and that accept must stay handoff-bound in after-sign-in rather than a shared allow-list widen ([handler.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/app/handler/after-sign-in/handler.ts#L351-L360)).

## Security

On production hosts, `cmux-dev-jmux` is accepted iff `verifiedNativeHandoff`; otherwise redirect home with no tokens in body/Location ([this PR's handler](https://github.com/manaflow-ai/cmux/blob/5b3e5c85c77c7f1a2fa6520d3621c7e04f879056/web/app/handler/after-sign-in/handler.ts)). I am not binding the return URL into the handoff cookie (pre-existing; exact-scheme allow-list is the mitigation here) — my judgment on residual phishing-start risk, not measured.

## Shortcuts I'm taking on purpose

- Reuse `verifiedNativeHandoff` instead of purchase-style HMAC for Login. Worth revisiting if legitimate Login is still rejected after this, or if we want URL-binding in the cookie.

## What I'm not doing now

- Defaulting every ephemeral `--tag` Debug build to production auth — adjacent DX, not this Login failure.
- Changing `scripts/jmux-reload.sh` on this PR — that file is fork-only and already deployed locally.

## Related work

I didn't find a tracker ticket to link. The signed tagged purchase path is the existing deployed-host exception this Login path parallels ([after-sign-in-route.test.ts](https://github.com/manaflow-ai/cmux/blob/17466308a5/web/tests/after-sign-in-route.test.ts) "accepts only signed tagged purchase callbacks on the deployed host").

---
*Written by an automated planning workflow run by @justincrich. The investigation and this write-up are mine; the scope decision was theirs.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790093569&installation_model_id=21920&pr_number=10610&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10610&signature=ce7dbc1c5c3ae3ce7fcaeeba473ffcbe72a191e5ae54f99aa5bb8dbde3c63979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts handoff-bound `cmux-dev-jmux://auth-callback` Login returns on `cmux.com` so jmux Debug builds can complete auth against production. Previously, deployed hosts rejected all `cmux-dev-*` schemes and redirected to `/`; now production accepts `cmux-dev-jmux` only when the native handoff nonce matches and issues a 307 into the app with tokens. Rejections still fail closed and never emit HTML tokens.

**Review notes**
- Add exact match for `cmux-dev-jmux://auth-callback` and gate by `verifiedNativeHandoff`; on success, emit only `nativeRedirectResponse`; otherwise redirect to `/` with no tokens.
- Leave `isAllowedNativeScheme` unchanged; other `cmux-dev-*` schemes remain rejected unless already allowed by the signed purchase path; no HTML token fallback for this exception.
- Add tests for verified accept, unverified reject-without-leak, and rejection of other tagged schemes.

<sup>Written for commit 5b3e5c85c77c7f1a2fa6520d3621c7e04f879056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for native authentication callbacks by validating handoffs before issuing token-bearing redirects.
  * Prevented unverified or unsupported callbacks from exposing authentication tokens or callback URLs.
  * Ensured valid native callbacks redirect correctly after sign-in.

* **Tests**
  * Added coverage for verified, unverified, and unsupported native callback scenarios across deployed hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->