### PR TITLE
fix(tui): reject empty TypeScript socket paths

### DIFF
--- a/cmux-tui/bindings/typescript/src/node-transport.ts
+++ b/cmux-tui/bindings/typescript/src/node-transport.ts
@@ -29,6 +29,10 @@ export function envSocketPath(): string | undefined {
   return process.env.CMUX_TUI_SOCKET || process.env.CMUX_MUX_SOCKET;
 }
 
+export function validateSocketPath(socketPath: string): void {
+  if (socketPath.length === 0) throw new TypeError("socketPath must be a non-empty path");
+}
+
 export interface UnixSocketTransportOptions {
   maxInboundMessageBytes?: number;
   maxOutboundMessageBytes?: number;

--- a/cmux-tui/bindings/typescript/src/node.ts
+++ b/cmux-tui/bindings/typescript/src/node.ts
@@ -2,6 +2,7 @@ import { Client as ResourceClient, type ClientOptions as ResourceClientOptions }
 import {
   defaultSocketPath,
   envSocketPath,
+  validateSocketPath,
   UnixSocketTransport,
   type UnixSocketTransportOptions,
 } from "./node-transport.js";
@@ -29,6 +30,7 @@ export class NodeClient extends ResourceClient {
       options.socketPath
       ?? envSocketPath()
       ?? defaultSocketPath(options.session ?? "main");
+    validateSocketPath(socketPath);
     super({
       transport: new UnixSocketTransport(socketPath, options),
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),

--- a/cmux-tui/bindings/typescript/src/raw/node-client.ts
+++ b/cmux-tui/bindings/typescript/src/raw/node-client.ts
@@ -3,7 +3,7 @@ import {
   type CmuxClientOptions,
 } from "./client.js";
 import type { CmuxAuthority } from "./generated/metadata.js";
-import { defaultSocketPath, envSocketPath, UnixSocketTransport } from "../node-transport.js";
+import { defaultSocketPath, envSocketPath, UnixSocketTransport, validateSocketPath } from "../node-transport.js";
 import { validateRequestTimeout } from "../internal/request-timeout.js";
 import type { Transport } from "../transport.js";
 import { RENDER_ATTACH_MAX_ENCODED_CHARS } from "../transport-limits.js";
@@ -41,6 +41,7 @@ export class CmuxClient extends TransportCmuxClient {
   constructor(options: ClientOptions = {}) {
     const timeoutMs = validateRequestTimeout(options.timeoutMs ?? 10_000);
     const socketPath = options.socketPath ?? envSocketPath() ?? defaultSocketPath(options.session ?? "main");
+    validateSocketPath(socketPath);
     const rawTransport = (): UnixSocketTransport => new UnixSocketTransport(socketPath, {
       maxInboundMessageBytes: RENDER_ATTACH_MAX_ENCODED_CHARS,
     });

--- a/cmux-tui/bindings/typescript/test/unix-transport.test.ts
+++ b/cmux-tui/bindings/typescript/test/unix-transport.test.ts
@@ -31,6 +31,16 @@ const RESOURCE_SESSION = sessionId(`session_${"a".repeat(32)}`);
 const RESOURCE_WORKSPACE = workspaceId(`ws_${"b".repeat(32)}`);
 const RESOURCE_TERMINAL = terminalId(`term_${"c".repeat(32)}`);
 
+test("explicit empty socket paths fail with a typed validation error", () => {
+  const message = "socketPath must be a non-empty path";
+  assert.throws(() => new NodeClient({ socketPath: "" }), (error: unknown) =>
+    error instanceof TypeError && error.message === message,
+  );
+  assert.throws(() => new CmuxClient({ socketPath: "" }), (error: unknown) =>
+    error instanceof TypeError && error.message === message,
+  );
+});
+
 interface DelayedUnixFixture {
   readonly transport: UnixSocketTransport;
   readonly received: string[];


### PR DESCRIPTION
Reject an explicit empty `socketPath` in both TypeScript Node clients before Node starts an IPC connection. Callers now receive a clear `TypeError` instead of a low-level connection failure.

Adds regression coverage for the resource and raw clients.

Checks: TypeScript generated-source check and `git diff --check`. The full npm build was not run because this worktree has no installed `node_modules` or `tsc`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790094148&installation_model_id=21920&pr_number=10611&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10611&signature=b9cf6251f697ce0ee0da2170fcd39a2d878100e7105a6d2badbba0b468d76ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty socketPath in the TypeScript Node clients to fail fast with a clear error. Previously an empty string reached Node IPC and failed with a low‑level connection error; now we throw TypeError("socketPath must be a non-empty path") before connecting.

- Adds validateSocketPath in node-transport and invokes it in NodeClient and the raw CmuxClient; includes regression tests.

**Migration**
- Do not pass socketPath: "". Provide a valid path or omit socketPath to use the default.

<sup>Written for commit 75f4192d2adcbee1a5118cb5efee8f8b2a2fdfaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject empty Unix socket paths when creating clients.
  - Improved error handling for invalid socket configuration.

- **Tests**
  - Added regression coverage confirming both supported client types report the expected error for an empty socket path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->