### PR TITLE
iOS: per-tag Mac pairing by default with a runtime compatible-tags allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,27 @@ scripts/verify-remote.sh capacity             # all-purpose slots
 
 Boot a local simulator only when all-purpose `capacity` reports no free slot, and keep at most 3 local sims booted. Scripted XCUITests go through the hosted `test-e2e.yml` lane when appropriate. The physical-iPhone signing/install leg stays local via the install queue; its archive build may use any healthy fleet slot. Verify leases carry a description and TTL, so a crashed agent frees its slot automatically; see `skills/infra/macfleet/references/verify-remote.md` in cmuxterm-hq for the shared-pool contract and host onboarding.
 
+## Cross-tag Mac access for DEV iPhone builds
+
+A DEV iPhone build pairs only with the Mac DEV build sharing its tag. When a task needs
+the phone to also see other Mac dev builds (multi-Mac verification, dogfooding another
+task's Mac from an existing phone build), grant those tags at runtime through the
+same-tag Mac's debug socket instead of rebuilding or re-pairing the phone:
+
+```bash
+CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags add <mac-tag> [more-tags]
+CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags list
+CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags remove <mac-tag>
+CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags clear
+```
+
+The grant set persists on that Mac and on the phone (per phone build tag), pushes live
+to a connected phone, and otherwise applies on the phone's next connect. Removing a tag
+disconnects and hides that Mac on the phone. Release lanes (`default`, `nightly`, `rc`,
+`staging`) are never grantable, and only the phone's exact-tag Mac can change its grant
+set. Use this whenever the user asks to let another Mac dev build connect to their
+iPhone build; do not mint a shared tag or rebuild the phone for that.
+
 ## iOS dev auth
 
 `~/.secrets/cmuxterm-dev.env` is the only mobile dev credential file. `CMUX_DOGFOOD_STACK_*` is the `personal` profile for physical iPhone dogfood. `CMUX_UITEST_STACK_*` is the `agent` profile for isolated Simulators. Run `scripts/setup-team-dev.sh` once to verify and merge the personal pair without deleting the agent pair. Use `scripts/mobile-dev-launch.sh --check-auth-contract --auth-profile personal` or `--auth-profile agent` for a mutation-free preflight. Never substitute one profile when the requested profile is incomplete.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4828,6 +4828,10 @@ struct CMUXCLI {
                 localized: "cli.mobile.setFont.usage",
                 defaultValue: "Usage: cmux mobile set-font <points> [--surface <id>] [--workspace <id>]"
             )
+            let compatibleTagsUsage = String(
+                localized: "cli.mobile.compatibleTags.usage",
+                defaultValue: "Usage: cmux mobile compatible-tags [list|set <tags...>|add <tags...>|remove <tags...>|clear]"
+            )
             switch sub {
             case "set-font":
                 guard let sizeArg = rest.first(where: { !$0.hasPrefix("--") }),
@@ -4860,8 +4864,74 @@ struct CMUXCLI {
                         sizeArg
                     ))
                 }
+            case "compatible-tags":
+                let action = rest.first?.lowercased() ?? "list"
+                let requestedTags = Array(rest.dropFirst())
+                    .flatMap { $0.split(separator: ",").map(String.init) }
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .filter { !$0.isEmpty }
+                func currentTags() throws -> [String] {
+                    let response = try client.sendV2(method: "mobile.compatible_tags.get", params: [:])
+                    return (response["tags"] as? [String]) ?? []
+                }
+                if action == "list" {
+                    let tags = try currentTags()
+                    if jsonOutput {
+                        print(jsonString(["tags": tags]))
+                    } else if tags.isEmpty {
+                        print(String(
+                            localized: "cli.mobile.compatibleTags.empty",
+                            defaultValue: "No additional Mac dev tags are granted to this Mac's paired phones."
+                        ))
+                    } else {
+                        print(tags.joined(separator: "\n"))
+                    }
+                    break
+                }
+                let resolvedTags: [String]
+                switch action {
+                case "set":
+                    guard !requestedTags.isEmpty else { throw CLIError(message: compatibleTagsUsage) }
+                    resolvedTags = requestedTags
+                case "add":
+                    guard !requestedTags.isEmpty else { throw CLIError(message: compatibleTagsUsage) }
+                    resolvedTags = Array(Set(try currentTags()).union(requestedTags))
+                case "remove":
+                    guard !requestedTags.isEmpty else { throw CLIError(message: compatibleTagsUsage) }
+                    resolvedTags = Array(Set(try currentTags()).subtracting(requestedTags))
+                case "clear":
+                    resolvedTags = []
+                default:
+                    throw CLIError(message: compatibleTagsUsage)
+                }
+                let response = try client.sendV2(
+                    method: "mobile.compatible_tags.set",
+                    params: ["tags": resolvedTags]
+                )
+                if jsonOutput {
+                    print(jsonString(response))
+                    break
+                }
+                let stored = (response["tags"] as? [String]) ?? []
+                let delivered = (response["delivered"] as? Bool) ?? false
+                let storedList = stored.isEmpty
+                    ? String(localized: "cli.mobile.compatibleTags.none", defaultValue: "(none)")
+                    : stored.joined(separator: ", ")
+                if delivered {
+                    print(localizedFormat(
+                        "cli.mobile.compatibleTags.applied",
+                        defaultValue: "Granted Mac dev tags for paired phones: %@ (pushed to connected device(s)).",
+                        storedList
+                    ))
+                } else {
+                    print(localizedFormat(
+                        "cli.mobile.compatibleTags.appliedNoDevice",
+                        defaultValue: "Granted Mac dev tags for paired phones: %@ (applies when a phone next connects).",
+                        storedList
+                    ))
+                }
             default:
-                throw CLIError(message: mobileUsage)
+                throw CLIError(message: mobileUsage + "\n" + compatibleTagsUsage)
             }
 
         case "rpc":

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
@@ -28,6 +28,10 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
     /// The Mac app bundle namespace used by the trust broker. `nil` from older
     /// Macs that predate namespace-aware authenticated host status.
     public let macClientNamespace: String?
+    /// The sibling Mac dev tags this Mac grants to its paired development
+    /// phones (`cmux mobile compatible-tags`). `nil` from Macs that predate
+    /// the field; the phone then keeps its persisted grant set.
+    public let macCompatibleMacTags: [String]?
     /// Process-unique epoch for the Mac's terminal-theme revision counter.
     /// A changed value tells iOS that low revisions belong to a new producer.
     public let terminalThemeRevisionEpoch: String?
@@ -53,6 +57,7 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
         case macDeviceID = "mac_device_id"
         case macInstanceTag = "mac_instance_tag"
         case macClientNamespace = "mac_client_namespace"
+        case macCompatibleMacTags = "mac_compatible_mac_tags"
         case terminalThemeRevisionEpoch = "terminal_theme_revision_epoch"
         case macAppVersion = "mac_app_version"
         case macAppBuild = "mac_app_build"
@@ -69,6 +74,12 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
             .map(cmxCanonicalDeviceID)
         macInstanceTag = try container.decodeIfPresent(String.self, forKey: .macInstanceTag)
         macClientNamespace = try container.decodeIfPresent(String.self, forKey: .macClientNamespace)
+        // A malformed grant list must not fail the whole status decode; the
+        // phone just keeps its persisted grant set, like an older Mac.
+        macCompatibleMacTags = (try? container.decodeIfPresent(
+            [String].self,
+            forKey: .macCompatibleMacTags
+        )) ?? nil
         terminalThemeRevisionEpoch = try container.decodeIfPresent(String.self, forKey: .terminalThemeRevisionEpoch)
         macAppVersion = try container.decodeIfPresent(String.self, forKey: .macAppVersion)
         macAppBuild = try container.decodeIfPresent(String.self, forKey: .macAppBuild)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -15,23 +15,72 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
         "staging",
     ]
 
-    /// A development iOS build may use any authenticated development Mac tag.
-    /// The exact tag remains part of each Mac's identity; this case only defines
-    /// the development build lane.
-    case development
+    /// A tagged development build may use its matching Mac tag plus the tags in
+    /// its runtime allowlist. The allowlist starts empty, preserving per-tag
+    /// isolation for ordinary development builds; this build's exact-tag Mac
+    /// grants additional tags at runtime (`cmux mobile compatible-tags`),
+    /// which mutates the shared allowlist reference in place so every policy
+    /// consumer sees the change without recomposition.
+    case development(
+        expectedInstanceTag: String,
+        additionalInstanceTags: MobileMacTagAllowlist
+    )
     /// A distributed iOS build may use Stable and Nightly Mac releases.
     case official
 
+    public static func development(
+        expectedInstanceTag: String
+    ) -> MobileMacBuildCompatibilityPolicy {
+        .development(
+            expectedInstanceTag: expectedInstanceTag,
+            additionalInstanceTags: MobileMacTagAllowlist()
+        )
+    }
+
     /// Resolves the policy compiled into the running iOS app.
     ///
-    /// - Returns: Development-lane compatibility for DEBUG builds and official
+    /// - Parameters:
+    ///   - buildScope: The tagged development scope, when this is a tagged DEBUG build.
+    ///   - additionalInstanceTags: The runtime-granted sibling Mac tags this
+    ///     development build may also use.
+    /// - Returns: Explicit development compatibility for DEBUG builds and official
     ///   compatibility for distributed builds.
-    public static func current() -> MobileMacBuildCompatibilityPolicy {
+    public static func current(
+        buildScope: MobileIOSBuildScope?,
+        additionalInstanceTags: MobileMacTagAllowlist = MobileMacTagAllowlist()
+    ) -> MobileMacBuildCompatibilityPolicy {
         #if DEBUG
-        return .development
+        return .development(
+            expectedInstanceTag: buildScope?.value ?? "dev",
+            additionalInstanceTags: additionalInstanceTags
+        )
         #else
         return .official
         #endif
+    }
+
+    /// The runtime allowlist backing a development policy, for the grant
+    /// application path. `nil` for distributed builds.
+    public var developmentAdditionalInstanceTags: MobileMacTagAllowlist? {
+        guard case let .development(_, additionalInstanceTags) = self else {
+            return nil
+        }
+        return additionalInstanceTags
+    }
+
+    /// The exact Mac tag a development policy is bound to. `nil` for
+    /// distributed builds.
+    public var developmentExpectedInstanceTag: String? {
+        guard case let .development(expectedInstanceTag, _) = self else {
+            return nil
+        }
+        return expectedInstanceTag
+    }
+
+    /// Whether a normalized tag names a release lane no development build may
+    /// use or grant.
+    public static func isNonDevelopmentTag(_ normalizedTag: String) -> Bool {
+        nonDevelopmentTags.contains(normalizedTag)
     }
 
     /// Returns whether an authenticated Mac instance belongs to this policy.
@@ -47,13 +96,19 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
     ) -> Bool {
         guard let normalizedTag = Self.normalized(instanceTag) else { return false }
         switch self {
-        case .development:
+        case let .development(expectedInstanceTag, additionalInstanceTags):
             if let clientNamespace,
                clientNamespace != "legacy",
                !Self.isDevelopmentMacNamespace(clientNamespace) {
                 return false
             }
-            return !Self.nonDevelopmentTags.contains(normalizedTag)
+            guard !Self.nonDevelopmentTags.contains(normalizedTag) else {
+                return false
+            }
+            if normalizedTag == Self.normalized(expectedInstanceTag) {
+                return true
+            }
+            return additionalInstanceTags.contains(normalizedTag: normalizedTag)
         case .official:
             if let clientNamespace,
                clientNamespace != "legacy",
@@ -119,10 +174,29 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
         MobileMacCompatiblePairedMacStore(inner: store, policy: self)
     }
 
+    /// Two development policies are equal when they enforce the same expected
+    /// tag against the same live allowlist instance. Identity (not contents)
+    /// is deliberate: the allowlist mutates at runtime, and equality by
+    /// snapshot would let two policies compare equal now and diverge later.
+    public static func == (
+        lhs: MobileMacBuildCompatibilityPolicy,
+        rhs: MobileMacBuildCompatibilityPolicy
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case let (
+            .development(lhsTag, lhsAllowlist),
+            .development(rhsTag, rhsAllowlist)
+        ):
+            return normalized(lhsTag) == normalized(rhsTag)
+                && lhsAllowlist === rhsAllowlist
+        case (.official, .official):
+            return true
+        default:
+            return false
+        }
+    }
+
     private static func normalized(_ value: String?) -> String? {
-        let normalized = value?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() ?? ""
-        return normalized.isEmpty ? nil : normalized
+        MobileMacTagAllowlist.normalized(value)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
@@ -280,15 +280,14 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         )
     }
 
+    /// Forward the sign-out wipe down the rail TAG-BLIND, like
+    /// `removeExactScope`. Enumerating this store's own compatibility-filtered
+    /// view would strand rows a since-revoked allowlist grant persisted: they
+    /// are invisible to this build until re-granted, and a sign-out that
+    /// reports success while another account's pairings survive on disk is a
+    /// broken wipe.
     func removeAll() async throws {
-        for mac in try await loadAll(stackUserID: nil, teamID: nil) {
-            try await inner.remove(
-                macDeviceID: mac.macDeviceID,
-                instanceTag: mac.instanceTag,
-                stackUserID: mac.stackUserID,
-                teamID: mac.teamID
-            )
-        }
+        try await inner.removeAll()
     }
 
     func authorizeUserTailscaleRoutes(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacTagAllowlist.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacTagAllowlist.swift
@@ -1,0 +1,94 @@
+public import Foundation
+
+/// The runtime-mutable set of additional Mac development tags one development
+/// iOS build may use beyond its own tag.
+///
+/// One instance is created at app launch and shared by reference through
+/// ``MobileMacBuildCompatibilityPolicy``, so persistence scoping, registry and
+/// presence projection, discovery filtering, and live connection validation
+/// all read the same grant set: a mutation is visible to every consumer on its
+/// next policy evaluation, without re-plumbing the composition graph.
+///
+/// The set is granted at runtime by this build's exact-tag Mac (over the
+/// authenticated control connection) rather than baked in at compile time, and
+/// it persists across launches in the tagged bundle's own `UserDefaults`.
+public final class MobileMacTagAllowlist: @unchecked Sendable {
+    /// Bounds a hostile or runaway grant set; discovery admission is already
+    /// bounded per pass, so this only caps persistence and filtering cost.
+    public static let maximumTagCount = 32
+
+    /// The tagged iOS bundle id already isolates `UserDefaults` per build
+    /// scope, so one fixed key is per-tag by construction.
+    public static let defaultsKey = "CMUXCompatibleMacTags"
+
+    private let lock = NSLock()
+    private var storage: Set<String>
+    private let defaults: UserDefaults?
+
+    /// An in-memory allowlist. Used by tests and as the empty default.
+    public init(tags: some Sequence<String> = [String]()) {
+        storage = Self.sanitized(tags)
+        defaults = nil
+    }
+
+    private init(defaults: UserDefaults) {
+        let persistedTags = defaults.stringArray(forKey: Self.defaultsKey) ?? []
+        storage = Self.sanitized(persistedTags)
+        self.defaults = defaults
+    }
+
+    /// The allowlist persisted for this app install, loading any grant set a
+    /// previous launch stored.
+    public static func persisted(
+        defaults: UserDefaults = .standard
+    ) -> MobileMacTagAllowlist {
+        MobileMacTagAllowlist(defaults: defaults)
+    }
+
+    /// Whether a normalized Mac instance tag is granted by this allowlist.
+    public func contains(normalizedTag: String) -> Bool {
+        lock.withLock { storage.contains(normalizedTag) }
+    }
+
+    /// A point-in-time copy of the granted tags.
+    public var tags: Set<String> {
+        lock.withLock { storage }
+    }
+
+    /// Replaces the grant set, returning whether anything changed. Input is
+    /// normalized, deduplicated, capped, and stripped of release-lane tags
+    /// before comparison, so a semantically identical advertisement is a no-op.
+    @discardableResult
+    public func replace(with tags: some Sequence<String>) -> Bool {
+        let sanitized = Self.sanitized(tags)
+        let changed: Bool = lock.withLock {
+            guard storage != sanitized else { return false }
+            storage = sanitized
+            return true
+        }
+        guard changed else { return false }
+        defaults?.set(sanitized.sorted(), forKey: Self.defaultsKey)
+        return true
+    }
+
+    /// Trim-and-lowercase tag normalization shared with the compatibility
+    /// policy, so grant comparison and policy checks can never disagree.
+    public static func normalized(_ value: String?) -> String? {
+        let normalized = value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func sanitized(_ tags: some Sequence<String>) -> Set<String> {
+        var sanitized: Set<String> = []
+        for tag in tags {
+            guard let normalized = normalized(tag),
+                  !MobileMacBuildCompatibilityPolicy.isNonDevelopmentTag(normalized)
+            else { continue }
+            sanitized.insert(normalized)
+            if sanitized.count == maximumTagCount { break }
+        }
+        return sanitized
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+CompatibleMacTags.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+CompatibleMacTags.swift
@@ -1,0 +1,69 @@
+internal import CmuxMobileRPC
+internal import Foundation
+internal import OSLog
+
+private let compatibleMacTagsLog = Logger(
+    subsystem: "com.cmuxterm.mobile",
+    category: "compatible-mac-tags"
+)
+
+/// The `mobile.compatible_tags.changed` event payload: the Mac's full grant
+/// set after a change, so application is idempotent and order-independent.
+private struct MobileCompatibleMacTagsEvent: Decodable {
+    let tags: [String]
+
+    static func decode(_ data: Data) throws -> Self {
+        try JSONDecoder().decode(Self.self, from: data)
+    }
+}
+
+@MainActor
+extension MobileShellComposite {
+    /// Applies a live grant-set change pushed by the connected foreground Mac.
+    func handleCompatibleMacTagsChangedEvent(
+        _ event: MobileEventEnvelope
+    ) async {
+        guard
+            let json = event.payloadJSON,
+            let payload = try? MobileCompatibleMacTagsEvent.decode(json)
+        else { return }
+        await applyAdvertisedCompatibleMacTags(
+            payload.tags,
+            reportedInstanceTag: activeMacInstanceTag
+        )
+    }
+
+    /// Adopts the Mac-advertised sibling-tag grant set into this build's
+    /// runtime allowlist, then reconciles everything the policy gates.
+    ///
+    /// Only this build's exact-tag Mac is a grant authority: a sibling Mac
+    /// admitted through the allowlist must not be able to extend the allowlist
+    /// further, so a mismatched reporter is ignored rather than applied.
+    ///
+    /// On a real change, one full aggregation pass both prunes (a revoked
+    /// tag's Mac drops out of the policy-scoped store load, so its
+    /// subscription and cached UI state tear down) and admits (zero-touch
+    /// discovery dials newly granted tags).
+    func applyAdvertisedCompatibleMacTags(
+        _ tags: [String]?,
+        reportedInstanceTag: String?
+    ) async {
+        guard let tags,
+              let policy = buildCompatibilityPolicy,
+              let allowlist = policy.developmentAdditionalInstanceTags,
+              let expectedTag = policy.developmentExpectedInstanceTag,
+              let normalizedReportedTag = MobileMacTagAllowlist.normalized(
+                  reportedInstanceTag
+              ),
+              normalizedReportedTag == MobileMacTagAllowlist.normalized(
+                  expectedTag
+              )
+        else { return }
+        guard allowlist.replace(with: tags) else { return }
+        compatibleMacTagsLog.info(
+            "compatible mac tags updated tags=\(allowlist.tags.sorted().joined(separator: ","), privacy: .public)"
+        )
+        await loadPairedMacs()
+        scheduleSecondaryAggregation(discoverLivePeers: true)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -60,6 +60,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     "terminal.bytes", "terminal.render_grid", "terminal.set_font",
                     "notification.dismissed", "notification.badge", "notification.feed.changed",
                     "phone_push.status.changed", "caffeine.status.changed",
+                    "mobile.compatible_tags.changed",
                     "browser.frame", "browser.state", "browser.closed", "browser.dialog", "browser.dialog.resolved",
                     "simulator.frame", "simulator.state", "simulator.closed",
                 ]
@@ -69,6 +70,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     "terminal.render_grid", "terminal.set_font",
                     "notification.dismissed", "notification.badge", "notification.feed.changed",
                     "phone_push.status.changed", "caffeine.status.changed",
+                    "mobile.compatible_tags.changed",
                     "browser.frame", "browser.state", "browser.closed", "browser.dialog", "browser.dialog.resolved",
                     "simulator.frame", "simulator.state", "simulator.closed",
                 ]
@@ -78,6 +80,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     "terminal.bytes", "terminal.set_font",
                     "notification.dismissed", "notification.badge", "notification.feed.changed",
                     "phone_push.status.changed", "caffeine.status.changed",
+                    "mobile.compatible_tags.changed",
                     "browser.frame", "browser.state", "browser.closed", "browser.dialog", "browser.dialog.resolved",
                     "simulator.frame", "simulator.state", "simulator.closed",
                 ]
@@ -4239,7 +4242,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 displayName: payload.macDisplayName,
                 instanceTag: payload.macInstanceTag,
                 clientNamespace: payload.macClientNamespace,
-                macAppVersion: payload.macAppVersion
+                macAppVersion: payload.macAppVersion,
+                compatibleMacTags: payload.macCompatibleMacTags
             )
         }
     }
@@ -4261,7 +4265,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         displayName: String?,
         instanceTag: String?,
         clientNamespace: String? = nil,
-        macAppVersion: String? = nil
+        macAppVersion: String? = nil,
+        compatibleMacTags: [String]? = nil
     ) async {
         guard remoteClient === client,
               let rawReportedID = deviceID?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -4353,6 +4358,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         adoptForegroundMacIdentity(
             reportedID,
             previousKey: foregroundKeyBeforeTagAdoption
+        )
+        // Adopt the anchor Mac's sibling-tag grant set only after this
+        // connection's identity was accepted, so an incompatible or
+        // mismatched Mac can never influence the allowlist.
+        await applyAdvertisedCompatibleMacTags(
+            compatibleMacTags,
+            reportedInstanceTag: resolvedTag
         )
     }
 
@@ -11864,7 +11876,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 displayName: payload.macDisplayName,
                 instanceTag: payload.macInstanceTag,
                 clientNamespace: payload.macClientNamespace,
-                macAppVersion: payload.macAppVersion
+                macAppVersion: payload.macAppVersion,
+                compatibleMacTags: payload.macCompatibleMacTags
             )
             guard isCurrentRemoteConnection(
                 client: client,
@@ -12077,6 +12090,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         client: client,
                         generation: listenerConnectionGeneration
                     )
+                } else if event.topic == "mobile.compatible_tags.changed" {
+                    await self.handleCompatibleMacTagsChangedEvent(event)
                 } else if event.topic == "browser.frame" {
                     self.handleMobileBrowserFrameEvent(event)
                 } else if event.topic == "browser.state" {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -126,8 +126,10 @@ import Testing
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
-        let feature = MobileMacBuildCompatibilityPolicy.development
-            .scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
+        let feature = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "feature",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["other"])
+        ).scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
 
         try await feature.upsert(
             macDeviceID: "mac-a",
@@ -172,7 +174,10 @@ import Testing
             inner: inner,
             scope: try #require(MobileIOSBuildScope("phand1"))
         )
-        let production = MobileMacBuildCompatibilityPolicy.development.scoping(scoped)
+        let production = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "phand1",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["phand2", "phand3"])
+        ).scoping(scoped)
 
         for (index, tag) in ["phand1", "phand2", "phand3"].enumerated() {
             try await production.upsert(
@@ -200,8 +205,10 @@ import Testing
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
-        let feature = MobileMacBuildCompatibilityPolicy.development
-            .scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
+        let feature = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "feature",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["feature-b"])
+        ).scoping(IOSBuildScopedPairedMacStore(inner: inner, scope: scope))
         try await feature.upsert(
             macDeviceID: "mac-a",
             displayName: "Selected",
@@ -465,7 +472,9 @@ import Testing
         defer { try? FileManager.default.removeItem(at: directory) }
         let scope = try #require(MobileIOSBuildScope("feature"))
         let scoped = IOSBuildScopedPairedMacStore(inner: inner, scope: scope)
-        let stack = MobileMacBuildCompatibilityPolicy.development.scoping(scoped)
+        let stack = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "feature"
+        ).scoping(scoped)
 
         // A team-scoped row for the device, written through the full rail.
         try await stack.upsert(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -283,7 +283,10 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
-            buildCompatibilityPolicy: .development,
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "phand1",
+                additionalInstanceTags: MobileMacTagAllowlist(tags: ["phand2", "phand3"])
+            ),
             personalIrohDiscovery: ScriptedIrohDiscovery(
                 snapshots: [candidates]
             ),
@@ -325,6 +328,128 @@ struct IrohZeroTouchDiscoveryTests {
         #expect(Set(factory.attemptedRouteIDs()) == [
             "iroh-phand1", "iroh-phand2", "iroh-phand3",
         ])
+    }
+
+    /// Per-tag isolation is the default; a runtime grant from the exact-tag
+    /// anchor Mac admits a sibling live, and revocation prunes it, all without
+    /// a rebuild or re-pair.
+    @Test
+    func runtimeGrantAdmitsAndRevocationPrunesSiblingInstances() async throws {
+        let candidates = [
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "a",
+                instanceTag: "phand1",
+                routeID: "iroh-phand1"
+            ),
+            try candidate(
+                deviceID: "shared-mac",
+                endpointByte: "b",
+                instanceTag: "phand2",
+                routeID: "iroh-phand2"
+            ),
+        ]
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        var routers: [String: LivenessHostRouter] = [:]
+        for candidate in candidates {
+            let router = LivenessHostRouter()
+            await router.setHostIdentity(
+                deviceID: candidate.deviceID,
+                instanceTag: candidate.instanceTag,
+                displayName: candidate.displayName
+            )
+            routers[candidate.routes[0].id] = router
+        }
+        let factory = RoutedZeroTouchFactory(routers: routers)
+        let discovery = ScriptedIrohDiscovery(snapshots: [candidates])
+        let defaults = UserDefaults(
+            suiteName: "iroh-runtime-grant-\(UUID().uuidString)"
+        )!
+        defaults.set(true, forKey: "multiMacAggregation")
+        let allowlist = MobileMacTagAllowlist()
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "phand1",
+            additionalInstanceTags: allowlist
+        )
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Self.fixedNow },
+                supportedRouteKinds: [.iroh]
+            ),
+            isSignedIn: true,
+            // The production rail scopes persistence through the policy
+            // (CMUXMobileRootScene); revocation pruning depends on it.
+            pairedMacStore: policy.scoping(store),
+            buildCompatibilityPolicy: policy,
+            personalIrohDiscovery: discovery,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: defaults,
+            multiMacAggregationDefaults: defaults
+        )
+        defer {
+            for (_, subscription) in shell.secondaryMacSubscriptions {
+                subscription.cancel()
+            }
+            Task { await shell.remoteClient?.disconnect() }
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let foreground = candidates[0]
+        try await store.upsert(
+            macDeviceID: foreground.deviceID,
+            displayName: foreground.displayName,
+            routes: foreground.routes,
+            instanceTag: foreground.instanceTag,
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: foreground.lastSeenAt
+        )
+        await shell.loadPairedMacs()
+
+        #expect(await shell.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        // Default per-tag isolation: after the post-connect discovery pass has
+        // run, the ungranted sibling was neither dialed nor persisted.
+        #expect(try await pollUntil { discovery.callCount() >= 1 })
+        #expect(shell.pairedMacs.count == 1)
+        #expect(!factory.attemptedRouteIDs().contains("iroh-phand2"))
+
+        // A non-anchor reporter must not be able to extend the grant set.
+        await shell.applyAdvertisedCompatibleMacTags(
+            ["phand2"],
+            reportedInstanceTag: "phand2"
+        )
+        #expect(allowlist.tags.isEmpty)
+
+        // The anchor Mac's grant admits the sibling live.
+        await shell.applyAdvertisedCompatibleMacTags(
+            ["phand2"],
+            reportedInstanceTag: "phand1"
+        )
+        #expect(allowlist.tags == ["phand2"])
+        #expect(try await pollUntil {
+            shell.liveMacConnections.count == 2
+                && shell.pairedMacs.count == 2
+        })
+
+        // Revocation prunes the sibling's subscription and its projection.
+        await shell.applyAdvertisedCompatibleMacTags(
+            [],
+            reportedInstanceTag: "phand1"
+        )
+        #expect(try await pollUntil {
+            shell.pairedMacs.count == 1
+                && shell.liveMacConnections.count == 1
+        })
     }
 
     @Test
@@ -374,7 +499,10 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
-            buildCompatibilityPolicy: .development,
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "phand1",
+                additionalInstanceTags: MobileMacTagAllowlist(tags: ["phand2"])
+            ),
             personalIrohDiscovery: ScriptedIrohDiscovery(
                 snapshots: [candidates]
             ),
@@ -472,7 +600,10 @@ struct IrohZeroTouchDiscoveryTests {
             ),
             isSignedIn: true,
             pairedMacStore: store,
-            buildCompatibilityPolicy: .development,
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "phand1",
+                additionalInstanceTags: MobileMacTagAllowlist(tags: ["phand2", "phand3"])
+            ),
             personalIrohDiscovery: ScriptedIrohDiscovery(
                 snapshots: [candidates]
             ),

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -6,35 +6,111 @@ import Testing
 @testable import CmuxMobileShell
 
 @Suite struct MobileMacBuildCompatibilityPolicyTests {
-    @Test func developmentAllowsSiblingTagsWithoutBuildMetadata() {
-        let policy = MobileMacBuildCompatibilityPolicy.development
+    @Test func developmentDefaultsToExactTagIsolation() {
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap"
+        )
 
         #expect(policy.allows(instanceTag: "icap"))
         #expect(policy.allows(instanceTag: " ICAP "))
-        #expect(policy.allows(instanceTag: "tsmig"))
+        #expect(!policy.allows(instanceTag: "tsmig"))
         #expect(!policy.allows(instanceTag: "default"))
         #expect(!policy.allows(instanceTag: "nightly"))
         #expect(!policy.allows(instanceTag: "rc"))
         #expect(!policy.allows(instanceTag: "staging"))
         #expect(!policy.allows(instanceTag: nil))
+    }
+
+    @Test func developmentAllowlistGrantsSiblingTags() {
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["tsmig", " Phand2 "])
+        )
+
+        #expect(policy.allows(instanceTag: "tsmig"))
+        #expect(policy.allows(instanceTag: "phand2"))
+        #expect(policy.allows(instanceTag: " TSMIG "))
+        #expect(!policy.allows(instanceTag: "unrelated"))
+        // Release lanes are never grantable, even if advertised.
+        let reserved = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["default", "nightly", "rc", "staging"])
+        )
+        #expect(!reserved.allows(instanceTag: "default"))
+        #expect(!reserved.allows(instanceTag: "nightly"))
+        #expect(!reserved.allows(instanceTag: "rc"))
+        #expect(!reserved.allows(instanceTag: "staging"))
+    }
+
+    @Test func developmentKeepsMacNamespaceGating() {
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "sibling",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["granted"])
+        )
+
         #expect(policy.allows(
             instanceTag: "sibling",
             clientNamespace: "mac:com.cmuxterm.app.debug.sibling"
+        ))
+        #expect(policy.allows(
+            instanceTag: "granted",
+            clientNamespace: "mac:com.cmuxterm.app.debug.granted"
         ))
         #expect(!policy.allows(
             instanceTag: "sibling",
             clientNamespace: "mac:com.cmuxterm.app.staging.sibling"
         ))
+        #expect(!policy.allows(
+            instanceTag: "granted",
+            clientNamespace: "mac:com.cmuxterm.app"
+        ))
     }
 
-    @Test func currentDevelopmentPolicyNeedsNoBuildMetadata() {
-        let policy = MobileMacBuildCompatibilityPolicy.current()
+    @Test func runtimeAllowlistMutationIsVisibleToTheSamePolicyValue() {
+        let allowlist = MobileMacTagAllowlist()
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap",
+            additionalInstanceTags: allowlist
+        )
 
-        #expect(policy.allows(instanceTag: "phand1"))
-        #expect(policy.allows(instanceTag: "phand2"))
-        #expect(policy.allows(instanceTag: "phand3"))
-        #expect(policy.allows(instanceTag: "unrelated"))
+        #expect(!policy.allows(instanceTag: "tsmig"))
+        allowlist.replace(with: ["tsmig"])
+        #expect(policy.allows(instanceTag: "tsmig"))
+        allowlist.replace(with: [])
+        #expect(!policy.allows(instanceTag: "tsmig"))
+    }
+
+    @Test func allowlistPersistsAcrossInstances() throws {
+        let suiteName = "mac-tag-allowlist-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let first = MobileMacTagAllowlist.persisted(defaults: defaults)
+        #expect(first.tags.isEmpty)
+        #expect(first.replace(with: [" TSMIG ", "phand2", "default", ""]))
+        #expect(first.tags == ["phand2", "tsmig"])
+        // An equal advertisement after normalization is a no-op.
+        #expect(!first.replace(with: ["tsmig", "PHAND2"]))
+
+        let second = MobileMacTagAllowlist.persisted(defaults: defaults)
+        #expect(second.tags == ["phand2", "tsmig"])
+    }
+
+    @Test func currentDevelopmentPolicyBindsToTheBuildScope() throws {
+        let allowlist = MobileMacTagAllowlist(tags: ["granted"])
+        let policy = MobileMacBuildCompatibilityPolicy.current(
+            buildScope: try #require(MobileIOSBuildScope("feature")),
+            additionalInstanceTags: allowlist
+        )
+
+        #expect(policy.allows(instanceTag: "feature"))
+        #expect(policy.allows(instanceTag: "granted"))
+        #expect(!policy.allows(instanceTag: "unrelated"))
         #expect(!policy.allows(instanceTag: "default"))
+
+        let untagged = MobileMacBuildCompatibilityPolicy.current(buildScope: nil)
+        #expect(untagged.allows(instanceTag: "dev"))
+        #expect(!untagged.allows(instanceTag: "unrelated"))
     }
 
     @Test func officialKeepsStableAndNightlyAsDistinctAllowedIdentities() {
@@ -80,7 +156,10 @@ import Testing
 
     @Test func legacyExceptionNeverWeakensTaggedOrDevelopmentIdentity() {
         let official = MobileMacBuildCompatibilityPolicy.official
-        let development = MobileMacBuildCompatibilityPolicy.development
+        let development = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "mine",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["sibling"])
+        )
 
         #expect(official.allowsAuthenticatedHost(
             instanceTag: "default",
@@ -97,6 +176,7 @@ import Testing
             macAppVersion: "0.64.17",
             usesLocallyAuthorizedTailscaleRoute: true
         ))
+        // Development direct pairing still requires the Mac bundle namespace.
         #expect(!development.allowsAuthenticatedHost(
             instanceTag: "sibling",
             macAppVersion: nil,
@@ -109,6 +189,12 @@ import Testing
             usesLocallyAuthorizedTailscaleRoute: false
         ))
         #expect(!development.allowsAuthenticatedHost(
+            instanceTag: "ungranted",
+            clientNamespace: "mac:com.cmuxterm.app.debug.ungranted",
+            macAppVersion: nil,
+            usesLocallyAuthorizedTailscaleRoute: false
+        ))
+        #expect(!development.allowsAuthenticatedHost(
             instanceTag: "sibling",
             clientNamespace: "mac:com.cmuxterm.app.staging.sibling",
             macAppVersion: nil,
@@ -116,7 +202,7 @@ import Testing
         ))
     }
 
-    @Test func scopedDevelopmentStorePreservesSiblingRows() async throws {
+    @Test func scopedDevelopmentStoreHidesUngrantedSiblingsUntilGranted() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -141,28 +227,30 @@ import Testing
                 now: Date(timeIntervalSince1970: seen)
             )
         }
-        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
+        let allowlist = MobileMacTagAllowlist()
+        let scoped = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "tsmig",
+            additionalInstanceTags: allowlist
+        ).scoping(raw)
 
+        // Default: only the exact-tag Mac projects.
         #expect(Set(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
-        ).compactMap(\.instanceTag)) == ["icap", "tsmig"])
+        ).compactMap(\.instanceTag)) == ["tsmig"])
         #expect(try await scoped.activeMac(
             stackUserID: "user-1", teamID: "team-a"
         )?.instanceTag == "tsmig")
 
-        try await scoped.upsert(
-            macDeviceID: "other-mac",
-            displayName: "Other",
-            routes: [route],
-            instanceTag: "tsmig",
-            markActive: true,
-            stackUserID: "user-1",
-            teamID: "team-a",
-            now: Date(timeIntervalSince1970: 3)
-        )
-        #expect(try await raw.loadAll(
+        // A runtime grant makes the stored sibling row visible with no
+        // re-pair; revocation hides it again.
+        allowlist.replace(with: ["icap"])
+        #expect(Set(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
-        ).contains { $0.macDeviceID == "other-mac" && $0.instanceTag == "tsmig" })
+        ).compactMap(\.instanceTag)) == ["icap", "tsmig"])
+        allowlist.replace(with: [])
+        #expect(Set(try await scoped.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).compactMap(\.instanceTag)) == ["tsmig"])
     }
 
     @Test func scopedStoreKeepsUnclaimedLegacyRowsMigratable() async throws {
@@ -193,7 +281,9 @@ import Testing
             teamID: "team-a",
             now: Date(timeIntervalSince1970: 1)
         )
-        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
+        let scoped = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap"
+        ).scoping(raw)
 
         #expect(try await scoped.loadAll(
             stackUserID: "user-1", teamID: "team-a"
@@ -240,7 +330,9 @@ import Testing
                 now: Date(timeIntervalSince1970: seenAt)
             )
         }
-        let scoped = MobileMacBuildCompatibilityPolicy.development.scoping(raw)
+        let scoped = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap"
+        ).scoping(raw)
 
         try await scoped.removeAll()
 
@@ -282,9 +374,13 @@ import Testing
     }
 
     @MainActor
-    @Test func registryProjectionKeepsEveryDevelopmentInstance() {
+    @Test func registryProjectionKeepsOnlyExpectedAndGrantedInstances() {
+        let allowlist = MobileMacTagAllowlist()
         let store = MobileShellComposite(
-            buildCompatibilityPolicy: .development
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "tsmig",
+                additionalInstanceTags: allowlist
+            )
         )
         let device = RegistryDevice(
             deviceId: "shared-mac",
@@ -301,17 +397,25 @@ import Testing
             ]
         )
 
-        let projected = store.compatibleRegistryDevices([device])
+        let isolated = store.compatibleRegistryDevices([device])
+        #expect(isolated.count == 1)
+        #expect(isolated[0].instances.map(\.tag) == ["tsmig"])
 
-        #expect(projected.count == 1)
-        #expect(projected[0].instances.map(\.tag) == ["icap", "tsmig"])
-        #expect(projected[0].lastSeenAt == Date(timeIntervalSince1970: 20))
+        allowlist.replace(with: ["icap"])
+        let granted = store.compatibleRegistryDevices([device])
+        #expect(granted.count == 1)
+        #expect(granted[0].instances.map(\.tag) == ["icap", "tsmig"])
+        #expect(granted[0].lastSeenAt == Date(timeIntervalSince1970: 20))
     }
 
     @MainActor
-    @Test func presenceProjectionKeepsEveryDevelopmentInstance() {
+    @Test func presenceProjectionKeepsOnlyExpectedAndGrantedInstances() {
+        let allowlist = MobileMacTagAllowlist(tags: ["icap"])
         let store = MobileShellComposite(
-            buildCompatibilityPolicy: .development
+            buildCompatibilityPolicy: .development(
+                expectedInstanceTag: "tsmig",
+                additionalInstanceTags: allowlist
+            )
         )
         let icap = PresenceInstance(
             deviceId: "shared-mac",
@@ -352,5 +456,14 @@ import Testing
         #expect(snapshot.devices[0].online)
         #expect(snapshot.devices[0].lastSeenAt == 20)
         #expect(store.compatiblePresenceUpdate(.online(tsmig)) == .online(tsmig))
+
+        // Revoking the grant filters the sibling out of the same update.
+        allowlist.replace(with: [])
+        guard case .snapshot(let isolated)? = store.compatiblePresenceUpdate(update) else {
+            Issue.record("expected a compatible presence snapshot")
+            return
+        }
+        #expect(isolated.devices[0].instances.map(\.tag) == ["tsmig"])
+        #expect(store.compatiblePresenceUpdate(.online(icap)) == nil)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgetWildcardBreadthTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgetWildcardBreadthTests.swift
@@ -598,7 +598,9 @@ private struct EnumerationFailingStore: MobilePairedMacStoring {
         // Development rail: the Stable row is incompatible, visible to the
         // cleanup enumeration but historically
         // silently skipped by the compatibility guard on exact-scope deletes.
-        let compatible = MobileMacBuildCompatibilityPolicy.development.scoping(base)
+        let compatible = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "feature"
+        ).scoping(base)
         let store = MobileShellComposite(
             isSignedIn: true,
             connectionState: .connected,

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -104,6 +104,10 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         // routes it to the main-actor processV2Command switch, which lacks the
         // case, and the control socket returns method_not_found.
         "mobile.terminal.set_font",
+        // Same profile as set_font: UserDefaults reads/writes plus a push
+        // event through thread-safe MobileHostService statics.
+        "mobile.compatible_tags.get",
+        "mobile.compatible_tags.set",
         // Panel artifact reads are mobile data-plane file IO for non-terminal
         // surfaces. Keep them on the worker lane so markdown/file-preview panes
         // reach TerminalController's mobile.panel.artifact.* dispatcher instead

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -35,6 +35,7 @@ struct ControlCommandExecutionPolicyTests {
             "debug.sidebar.simulate_drag", "debug.mobile.transport.disconnect",
             "debug.window.screenshot", "mobile.attach_ticket.create",
             "mobile.terminal.set_font", "mobile.task.models.list",
+            "mobile.compatible_tags.get", "mobile.compatible_tags.set",
             "mobile.panel.artifact.stat", "mobile.panel.artifact.fetch",
             "mobile.panel.artifact.thumbnail",
             // JavaScript-evaluating browser methods block on page JS and must

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -49471,6 +49471,91 @@
         }
       }
     },
+    "cli.mobile.compatibleTags.applied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Granted Mac dev tags for paired phones: %@ (pushed to connected device(s))."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペアリング済みの iPhone に許可した Mac 開発タグ: %@（接続中のデバイスへ送信済み）。"
+          }
+        }
+      }
+    },
+    "cli.mobile.compatibleTags.appliedNoDevice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Granted Mac dev tags for paired phones: %@ (applies when a phone next connects)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペアリング済みの iPhone に許可した Mac 開発タグ: %@（次回接続時に適用されます）。"
+          }
+        }
+      }
+    },
+    "cli.mobile.compatibleTags.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No additional Mac dev tags are granted to this Mac's paired phones."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac のペアリング済み iPhone に追加で許可された Mac 開発タグはありません。"
+          }
+        }
+      }
+    },
+    "cli.mobile.compatibleTags.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(none)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（なし）"
+          }
+        }
+      }
+    },
+    "cli.mobile.compatibleTags.usage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage: cmux mobile compatible-tags [list|set <tags...>|add <tags...>|remove <tags...>|clear]"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使い方: cmux mobile compatible-tags [list|set <タグ...>|add <タグ...>|remove <タグ...>|clear]"
+          }
+        }
+      }
+    },
     "cli.mobile.setFont.applied": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -97,6 +97,63 @@ private enum MobileHostEventSubscriptionTracker {
     #endif
 }
 
+/// The sibling Mac dev tags this Mac grants to its paired development phones.
+///
+/// A DEV iPhone build pairs only with its exact-tag Mac by default. This grant
+/// set — edited with `cmux mobile compatible-tags` against this Mac's debug
+/// socket — is advertised in authenticated host status and pushed live over
+/// `mobile.compatible_tags.changed`, so the phone can also discover the listed
+/// sibling Mac tags without a rebuild or re-pair. The tagged debug bundle id
+/// isolates `UserDefaults` per Mac tag, so one fixed key is per-tag already.
+enum MobileCompatibleMacTags {
+    static let defaultsKey = "CMUXMobileCompatibleMacTags"
+    /// Mirrors the phone-side allowlist bound (`MobileMacTagAllowlist`).
+    static let maximumTagCount = 32
+    /// Release lanes are never grantable to a development phone.
+    private static let reservedTags: Set<String> = [
+        "default", "nightly", "rc", "staging",
+    ]
+
+    /// The granted tags, sorted for stable payloads and CLI output.
+    nonisolated static func tags(in defaults: UserDefaults = .standard) -> [String] {
+        sanitized(defaults.stringArray(forKey: defaultsKey) ?? []).sorted()
+    }
+
+    /// Replaces the grant set and returns the sanitized result actually stored.
+    nonisolated static func set(
+        _ tags: [String],
+        in defaults: UserDefaults = .standard
+    ) -> [String] {
+        let sanitizedTags = sanitized(tags).sorted()
+        defaults.set(sanitizedTags, forKey: defaultsKey)
+        return sanitizedTags
+    }
+
+    /// Normalized rejects from the last `sanitized` pass, so the CLI can tell
+    /// the caller which requested tags were refused instead of silently
+    /// dropping them.
+    nonisolated static func rejectedTags(from tags: [String]) -> [String] {
+        var rejected: [String] = []
+        for tag in tags {
+            let normalized = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { continue }
+            if reservedTags.contains(normalized) { rejected.append(normalized) }
+        }
+        return rejected.sorted()
+    }
+
+    private nonisolated static func sanitized(_ tags: [String]) -> Set<String> {
+        var sanitized: Set<String> = []
+        for tag in tags {
+            let normalized = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty, !reservedTags.contains(normalized) else { continue }
+            sanitized.insert(normalized)
+            if sanitized.count == maximumTagCount { break }
+        }
+        return sanitized
+    }
+}
+
 enum MobileHostRequestActivity {
     private static let lock = NSLock()
     private nonisolated(unsafe) static var activeRequestCount = 0
@@ -285,6 +342,12 @@ final class MobileHostService {
         )?.rawValue {
             payload["mac_client_namespace"] = clientNamespace
         }
+        // The sibling-tag grant set for development phones. Only this Mac's
+        // exact-tag phone adopts it (the phone ignores the field from any
+        // other reporter), so advertising it unconditionally is safe.
+        payload["mac_compatible_mac_tags"] = MobileCompatibleMacTags.tags(
+            in: phonePushDefaults
+        )
         payload["phone_push"] = [
             "forwarding_enabled": PhonePushConfiguration.forwardingEnabled(
                 in: phonePushDefaults

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1530,6 +1530,10 @@ class TerminalController {
             }
         case "mobile.terminal.set_font":
             return v2Result(id: request.id, v2MobileTerminalSetFont(params: request.params))
+        case "mobile.compatible_tags.get":
+            return v2Result(id: request.id, v2MobileCompatibleTagsGet())
+        case "mobile.compatible_tags.set":
+            return v2Result(id: request.id, v2MobileCompatibleTagsSet(params: request.params))
         case "system.ping":
             return v2Ok(id: request.id, result: ["pong": true])
         case "system.capabilities":
@@ -2752,6 +2756,8 @@ class TerminalController {
             "mobile.host.status",
             "mobile.attach_ticket.create",
             "mobile.terminal.set_font",
+            "mobile.compatible_tags.get",
+            "mobile.compatible_tags.set",
             "mobile.task.attachment.upload",
             "mobile.task.models.list",
             "mobile.workspace.list",
@@ -14786,6 +14792,47 @@ class TerminalController {
         return .ok([
             "ok": true,
             "font_size": fontSize,
+            "delivered": hasSubscribers,
+        ])
+    }
+
+    /// Returns the sibling Mac dev tags this Mac grants to its paired
+    /// development phones (`cmux mobile compatible-tags list`).
+    nonisolated func v2MobileCompatibleTagsGet() -> V2CallResult {
+        .ok(["tags": MobileCompatibleMacTags.tags()])
+    }
+
+    /// Replaces the sibling-tag grant set and pushes the new set to every
+    /// subscribed phone over `mobile.compatible_tags.changed`, so a connected
+    /// phone re-runs discovery (grant) or prunes (revoke) without a rebuild.
+    /// A phone that is offline right now adopts the set from authenticated
+    /// host status on its next connect.
+    ///
+    /// Params: `{ "tags": [String] }` — the FULL grant set (the CLI implements
+    /// add/remove as read-modify-write), so application is idempotent.
+    nonisolated func v2MobileCompatibleTagsSet(params: [String: Any]) -> V2CallResult {
+        guard let rawTags = params["tags"] as? [String] else {
+            return .err(
+                code: "invalid_params",
+                message: "Missing or invalid tags array",
+                data: nil
+            )
+        }
+        let rejected = MobileCompatibleMacTags.rejectedTags(from: rawTags)
+        guard rejected.isEmpty else {
+            return .err(
+                code: "invalid_params",
+                message: "Release-lane tags cannot be granted to a development phone",
+                data: ["rejected": rejected]
+            )
+        }
+        let stored = MobileCompatibleMacTags.set(rawTags)
+        let topic = "mobile.compatible_tags.changed"
+        let hasSubscribers = MobileHostService.hasEventSubscribers(topic: topic)
+        MobileHostService.emitEvent(topic: topic, payload: ["tags": stored])
+        return .ok([
+            "ok": true,
+            "tags": stored,
             "delivered": hasSubscribers,
         ])
     }

--- a/cmuxTests/MobileHostIdentityTests.swift
+++ b/cmuxTests/MobileHostIdentityTests.swift
@@ -156,12 +156,38 @@ struct MobileHostIdentityTests {
         #expect(payload["mac_instance_tag"] as? String == "future-one")
         #expect((payload["mac_client_namespace"] as? String)?.hasPrefix("mac:") == true)
         #expect(!(payload["terminal_theme_revision_epoch"] as? String ?? "").isEmpty)
+        #expect(payload["mac_compatible_mac_tags"] as? [String] != nil)
+    }
+
+    @Test func authenticatedStatusAdvertisesGrantedCompatibleMacTags() throws {
+        let suiteName = "mobile-host-compatible-tags-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Reserved release lanes and duplicates never make it into the grant
+        // set; what is stored is exactly what authenticated status advertises.
+        let stored = MobileCompatibleMacTags.set(
+            [" IRPLY ", "hello", "irply", "default", "nightly", "rc", "staging", ""],
+            in: defaults
+        )
+        #expect(stored == ["hello", "irply"])
+        #expect(MobileCompatibleMacTags.tags(in: defaults) == ["hello", "irply"])
+        #expect(MobileCompatibleMacTags.rejectedTags(
+            from: ["default", "hello", "RC"]
+        ) == ["default", "rc"])
+
+        let payload = MobileHostService.identityStatusPayload(
+            routes: [],
+            phonePushDefaults: defaults
+        )
+        #expect(payload["mac_compatible_mac_tags"] as? [String] == ["hello", "irply"])
     }
 
     @Test func publicStatusOmitsInstanceTag() {
         let payload = MobileHostService.publicStatusPayload(routes: [])
         #expect(payload["mac_instance_tag"] == nil)
         #expect(payload["terminal_theme_revision_epoch"] == nil)
+        #expect(payload["mac_compatible_mac_tags"] == nil)
     }
 
     @Test func authenticatedStatusReportsLivePhoneForwardingGateAndOrigin() throws {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6297,13 +6297,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use a DEV iPhone build with any DEV Mac build."
+            "value": "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use this DEV iPhone build with its same-tag DEV Mac build or a granted tag."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "BETA、INTERNAL、または App Store アプリは Stable または Nightly と一緒に使用してください。DEV iPhone ビルドは任意の DEV Mac ビルドと一緒に使用できます。"
+            "value": "BETA、INTERNAL、または App Store アプリは Stable または Nightly と一緒に使用してください。この DEV iPhone ビルドは同じタグの DEV Mac ビルド、または許可されたタグと一緒に使用できます。"
           }
         }
       }
@@ -6331,13 +6331,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DEV iPhone builds connect to any DEV Mac build. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
+            "value": "A DEV iPhone build connects to its same-tag DEV Mac build, plus tags granted with 'cmux mobile compatible-tags'. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "DEV iPhone ビルドは任意の DEV Mac ビルドに接続できます。BETA、INTERNAL、App Store ビルドは Stable または Nightly にのみ接続できます。"
+            "value": "DEV iPhone ビルドは同じタグの DEV Mac ビルドと、「cmux mobile compatible-tags」で許可されたタグに接続できます。BETA、INTERNAL、App Store ビルドは Stable または Nightly にのみ接続できます。"
           }
         }
       }

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -31,7 +31,13 @@ struct cmuxApp: App {
             reachability: reachability,
             diagnosticLog: diagnosticLog
         )
-        let buildCompatibilityPolicy = MobileMacBuildCompatibilityPolicy.current()
+        // Per-tag isolation by default: this build pairs only with its own
+        // Mac tag plus the runtime grant set its anchor Mac advertises
+        // (`cmux mobile compatible-tags`), persisted across launches.
+        let buildCompatibilityPolicy = MobileMacBuildCompatibilityPolicy.current(
+            buildScope: MobileIOSBuildScope.current(),
+            additionalInstanceTags: MobileMacTagAllowlist.persisted()
+        )
         let iroh = MobileIrohRuntimeComposition(
             apiBaseURL: auth.config.apiBaseURL,
             reachability: reachability,

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -517,15 +517,26 @@ struct MobileIrohRuntimeCompositionTests {
         await catalog.activate(scope: 4)
         await catalog.replace(with: discovery, scope: 4)
 
+        let lanePolicy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "lane-a",
+            additionalInstanceTags: MobileMacTagAllowlist(tags: ["lane-b"])
+        )
         let development = await catalog.liveMacCandidates(
             preferredTag: "lane-a",
-            compatibleWith: .development
+            compatibleWith: lanePolicy
         )
         #expect(development.map(\.instanceTag) == ["lane-a", "lane-b"])
 
+        // Without a grant the sibling lane is filtered out entirely.
+        let isolated = await catalog.liveMacCandidates(
+            preferredTag: "lane-a",
+            compatibleWith: .development(expectedInstanceTag: "lane-a")
+        )
+        #expect(isolated.map(\.instanceTag) == ["lane-a"])
+
         let boundedDevelopment = await catalog.liveMacCandidates(
             preferredTag: "lane-a",
-            compatibleWith: .development,
+            compatibleWith: lanePolicy,
             limit: 1
         )
         #expect(boundedDevelopment.map(\.instanceTag) == ["lane-a"])


### PR DESCRIPTION
## Summary

[#10519](https://github.com/manaflow-ai/cmux/pull/10519) let a DEV iPhone build use ANY debug-namespace Mac tag, so every tagged Mac DEV build signed into the account appears in the phone's Computers list (bounded only by the 4-candidate discovery cap). The intended default is per-tag isolation; cross-tag access should be an explicit, injectable grant.

This PR restores `.development(expectedInstanceTag:additionalInstanceTags:)` per-tag isolation and replaces #10519's blanket lane (and the pre-#10519 compile-time `CMUX_COMPATIBLE_MAC_TAGS` allowlist) with a runtime grant set:

- `MobileMacTagAllowlist`: a persisted, runtime-mutable grant set shared by reference inside the policy value, so persistence scoping, registry/presence projection, discovery filtering, and live connection validation all see a mutation immediately, with no recomposition.
- Mac side: `cmux mobile compatible-tags [list|set|add|remove|clear]` against the Mac's debug socket stores the grant set (`MobileCompatibleMacTags`, per-tag UserDefaults), advertises it as `mac_compatible_mac_tags` in authenticated host status, and pushes changes live over a new `mobile.compatible_tags.changed` event (`mobile.terminal.set_font` pattern).
- Phone side: only the exact-tag anchor Mac is a grant authority (a granted sibling cannot extend the set transitively). On a change the phone persists the set, reloads the paired-Mac projection, and runs one full aggregation pass: a grant admits the sibling via zero-touch discovery; a revoke tears down its subscription and hides it. A phone that was offline adopts the set on next connect from host status.
- `MobileMacCompatiblePairedMacStore.removeAll` now forwards the sign-out wipe tag-blind (like `removeExactScope`) so rows persisted under a since-revoked grant cannot survive sign-out.
- Namespace gating from #10519 is kept (dev lane still requires the debug Mac bundle namespace; release lanes `default`/`nightly`/`rc`/`staging` are never grantable).
- Pairing guidance strings (en/ja) updated back to per-tag semantics; new CLI strings localized (en/ja).
- Agent docs: new CLAUDE.md section "Cross-tag Mac access for DEV iPhone builds" with the exact commands.

Web broker is unchanged: it already allows the whole DEV lane and enforcement is on-device. Known seam (pre-existing, also true before #10519): broker `canIOSBindingForgetMac` stays exact-tag, so forgetting a granted sibling removes/hides it locally without revoking the broker binding.

## Usage (agents / humans)

```bash
CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags add <mac-tag> [...]
CMUX_TAG=<phone-tag> scripts/cmux-debug-cli.sh mobile compatible-tags list | remove <tag> | clear
```

Applies live to a connected phone; no rebuild, no re-pair, persists across launches on both sides.

## Tests

- `MobileMacBuildCompatibilityPolicyTests` rewritten: exact-tag default, grant admission, reserved-tag refusal, namespace gating, runtime mutation visibility through one policy value, allowlist persistence round-trip.
- `IrohZeroTouchDiscoveryTests`: #10519's cross-tag fixtures now carry explicit grants; new `runtimeGrantAdmitsAndRevocationPrunesSiblingInstances` proves default-deny → non-anchor reporter deny → live grant admission → revocation prune end to end on the production store rail.
- Store/catalog/forget suites updated for the policy shape.
- `MobileHostIdentityTests`: authenticated status advertises the sanitized grant set; public status omits it; reserved tags rejected.

The two-commit red/green convention is inapplicable here: the regression tests are written against the restored policy API, which does not exist on main, so a test-only first commit cannot compile.

Pre-existing on main (unrelated, verified on clean origin/main): `MobileShellCompositeForgetWildcardBreadthTests` fails with 8 issues.

## Verification

- `swift test --package-path Packages/iOS/CmuxMobileShell` focused suites green locally (policy, zero-touch discovery, build-scoped store).
- macOS + iOS tagged builds (`mtags`) from this head; preflight of the grant flow via the debug socket recorded in the PR conversation.
- Localization audit: touched `mobile.pairing.guidance.authEnvironment` and `mobile.pairing.guidance.buildIncompatible` (iOS catalog) and added `cli.mobile.compatibleTags.*` (Mac catalog), each with en and ja values. No UI layout changes (no HIG surface).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790125843&installation_model_id=21920&pr_number=10619&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10619&signature=4e7e176b4d1dc42516600cef2f8bca68506af2db277b552b37ba3582f724c47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-tag pairing for DEV iOS builds and adds a runtime allowlist for cross‑tag Macs. Previously any debug‑namespace tag was compatible; now only the same tag is allowed by default, and additional tags must be granted at runtime. Macs that appeared before may be hidden until granted; no rebuild or re‑pair is needed.

- Introduces `MobileMacTagAllowlist` and `MobileMacBuildCompatibilityPolicy.development(expectedInstanceTag:additionalInstanceTags:)` in `CmuxMobileShell`. Allowlist persists per build scope and updates in place so discovery, registry/presence, and connection checks react immediately. `removeAll` is now tag‑blind to avoid stranding rows from revoked grants.
- Adds Mac‑side CLI in `cmux`: `cmux mobile compatible-tags [list|set|add|remove|clear]`. Tags store in `UserDefaults`, advertise in authenticated status as `mac_compatible_mac_tags`, and push live via `mobile.compatible_tags.changed` from `TerminalController`/`MobileHostService` (`CmuxControlSocket` allows the new methods).
- iOS accepts allowlist changes only from the exact‑tag “anchor” Mac, persists them per build tag, admits siblings via zero‑touch discovery, and prunes on revoke. DEV namespace gating remains; release lanes (`default`, `nightly`, `rc`, `staging`) are never grantable.
- Updates pairing guidance and CLI strings (en/ja) and adds concise docs. Test suites cover default isolation, runtime grant/revoke flow, persistence, namespace gating, authenticated status fields, and store behavior.

<sup>Written for commit e52727d83d1bb58cfdaaaf15bfec59692621861e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support to list, add, remove, set, or clear compatible Mac development tags.
  * DEV iPhone builds can now connect to same-tag Macs or explicitly granted compatible development builds.
  * Grants persist across reconnects and update connected devices when changes are delivered.
  * Added English and Japanese localization for the new commands and pairing guidance.

* **Bug Fixes**
  * Reserved release lanes remain restricted and cannot be granted as development tags.
  * Tag inputs are normalized, deduplicated, and safely limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->