### PR TITLE
fix(browser): scope cookie clears by URL

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -35245,6 +35245,74 @@
         }
       }
     },
+    "cli.browser.cookies.clearRequiresScope": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear requires exactly one of --all or a cookie scope"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear には --all または Cookie スコープを1つだけ指定してください"
+          }
+        }
+      }
+    },
+    "cli.browser.cookies.invalidExpires": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear --expires must be an integer Unix timestamp"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear --expires には Unix 時刻の整数を指定してください"
+          }
+        }
+      }
+    },
+    "cli.browser.cookies.invalidFilter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear received an invalid cookie filter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear に無効な Cookie フィルターが指定されました"
+          }
+        }
+      }
+    },
+    "cli.browser.cookies.invalidURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear --url requires a valid URL with a host"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser cookies clear --url にはホストを含む有効な URL を指定してください"
+          }
+        }
+      }
+    },
     "cli.browser.error.tabManagerUnavailable": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -420,7 +420,7 @@ extension CmuxWebView {
         }
     }
 
-    static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {
+    nonisolated static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {
         let now = Date.now
 
         return cookies.filter { cookieMatchesURL($0, url: url, now: now) }
@@ -431,7 +431,7 @@ extension CmuxWebView {
     /// Cookie clearing and scripted-download cookie forwarding share this
     /// predicate so URL scoping cannot silently drift between mutation and
     /// request paths.
-    static func cookieMatchesURL(_ cookie: HTTPCookie, url: URL, now: Date = .now) -> Bool {
+    nonisolated static func cookieMatchesURL(_ cookie: HTTPCookie, url: URL, now: Date = .now) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let requestPath = url.path.isEmpty ? "/" : url.path
         let isHTTPS = url.scheme?.caseInsensitiveCompare("https") == .orderedSame
@@ -443,7 +443,7 @@ extension CmuxWebView {
     }
 
     /// Returns whether a stored cookie domain is within a requested domain scope.
-    static func cookieDomainMatchesFilter(_ cookieDomain: String, filter: String) -> Bool {
+    nonisolated static func cookieDomainMatchesFilter(_ cookieDomain: String, filter: String) -> Bool {
         let normalizedCookieDomain = cookieDomain.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
         let normalizedFilter = filter.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
         guard !normalizedCookieDomain.isEmpty, !normalizedFilter.isEmpty else { return false }
@@ -451,14 +451,14 @@ extension CmuxWebView {
     }
 
     /// Returns whether a cookie path matches a request path under RFC cookie rules.
-    static func cookiePathMatches(_ cookiePath: String, requestPath: String) -> Bool {
+    nonisolated static func cookiePathMatches(_ cookiePath: String, requestPath: String) -> Bool {
         let normalized = cookiePath.isEmpty ? "/" : cookiePath
         if normalized == "/" || requestPath == normalized { return true }
         guard requestPath.hasPrefix(normalized) else { return false }
         return normalized.hasSuffix("/") || requestPath.dropFirst(normalized.count).first == "/"
     }
 
-    private static func cookieDomainMatchesHost(_ cookieDomain: String, host: String) -> Bool {
+    nonisolated private static func cookieDomainMatchesHost(_ cookieDomain: String, host: String) -> Bool {
         let normalized = cookieDomain.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
         guard !normalized.isEmpty else { return false }
         if cookieDomain.hasPrefix(".") {

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -421,33 +421,50 @@ extension CmuxWebView {
     }
 
     static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {
-        guard let host = url.host?.lowercased() else { return [] }
-        let requestPath = url.path.isEmpty ? "/" : url.path
-        let isHTTPS = url.scheme?.caseInsensitiveCompare("https") == .orderedSame
         let now = Date.now
 
-        return cookies.filter { cookie in
-            if cookie.isSecure && !isHTTPS { return false }
-            if let expires = cookie.expiresDate, expires <= now { return false }
-            guard domain(cookie.domain, matches: host) else { return false }
-            return path(cookie.path, matches: requestPath)
-        }
+        return cookies.filter { cookieMatchesURL($0, url: url, now: now) }
     }
 
-    private static func domain(_ cookieDomain: String, matches host: String) -> Bool {
+    /// Returns whether a cookie would be sent with a request to the URL.
+    ///
+    /// Cookie clearing and scripted-download cookie forwarding share this
+    /// predicate so URL scoping cannot silently drift between mutation and
+    /// request paths.
+    static func cookieMatchesURL(_ cookie: HTTPCookie, url: URL, now: Date = .now) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        let requestPath = url.path.isEmpty ? "/" : url.path
+        let isHTTPS = url.scheme?.caseInsensitiveCompare("https") == .orderedSame
+
+        if cookie.isSecure && !isHTTPS { return false }
+        if let expires = cookie.expiresDate, expires <= now { return false }
+        guard cookieDomainMatchesHost(cookie.domain, host: host) else { return false }
+        return cookiePathMatches(cookie.path, requestPath: requestPath)
+    }
+
+    /// Returns whether a stored cookie domain is within a requested domain scope.
+    static func cookieDomainMatchesFilter(_ cookieDomain: String, filter: String) -> Bool {
+        let normalizedCookieDomain = cookieDomain.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        let normalizedFilter = filter.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        guard !normalizedCookieDomain.isEmpty, !normalizedFilter.isEmpty else { return false }
+        return normalizedCookieDomain == normalizedFilter || normalizedCookieDomain.hasSuffix(".\(normalizedFilter)")
+    }
+
+    /// Returns whether a cookie path matches a request path under RFC cookie rules.
+    static func cookiePathMatches(_ cookiePath: String, requestPath: String) -> Bool {
+        let normalized = cookiePath.isEmpty ? "/" : cookiePath
+        if normalized == "/" || requestPath == normalized { return true }
+        guard requestPath.hasPrefix(normalized) else { return false }
+        return normalized.hasSuffix("/") || requestPath.dropFirst(normalized.count).first == "/"
+    }
+
+    private static func cookieDomainMatchesHost(_ cookieDomain: String, host: String) -> Bool {
         let normalized = cookieDomain.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
         guard !normalized.isEmpty else { return false }
         if cookieDomain.hasPrefix(".") {
             return host == normalized || host.hasSuffix(".\(normalized)")
         }
         return host == normalized
-    }
-
-    private static func path(_ cookiePath: String, matches requestPath: String) -> Bool {
-        let normalized = cookiePath.isEmpty ? "/" : cookiePath
-        if normalized == "/" || requestPath == normalized { return true }
-        guard requestPath.hasPrefix(normalized) else { return false }
-        return normalized.hasSuffix("/") || requestPath.dropFirst(normalized.count).first == "/"
     }
 
     private static let sharedScriptedDownloadMessageHandler = ScriptedDownloadMessageHandler()

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10377,17 +10377,121 @@ class TerminalController {
             let store = v2MainSync {
                 ctx.webView.configuration.websiteDataStore.httpCookieStore
             }
+            let clearRequiresScopeMessage = String(
+                localized: "cli.browser.cookies.clearRequiresScope",
+                defaultValue: "browser cookies clear requires exactly one of --all or a cookie scope"
+            )
+            let invalidFilterMessage = String(
+                localized: "cli.browser.cookies.invalidFilter",
+                defaultValue: "browser cookies clear received an invalid cookie filter"
+            )
+            let invalidURLMessage = String(
+                localized: "cli.browser.cookies.invalidURL",
+                defaultValue: "browser cookies clear --url requires a valid URL with a host"
+            )
+            let invalidExpiresMessage = String(
+                localized: "cli.browser.cookies.invalidExpires",
+                defaultValue: "browser cookies clear --expires must be an integer Unix timestamp"
+            )
+            let name = v2String(params, "name")
+            let value = v2String(params, "value")
+            let urlString = v2String(params, "url")
+            let domain = v2String(params, "domain")
+            let path = v2String(params, "path")
+
+            for key in ["name", "value", "domain", "path"] where
+                v2HasNonNullParam(params, key) && v2String(params, key) == nil {
+                return .err(code: "invalid_params", message: invalidFilterMessage, data: ["param": key])
+            }
+
+            if v2HasNonNullParam(params, "url"), urlString == nil {
+                return .err(
+                    code: "invalid_params",
+                    message: invalidURLMessage,
+                    data: ["param": "url"]
+                )
+            }
+            let url: URL?
+            if let urlString {
+                guard let parsedURL = URL(string: urlString), parsedURL.host != nil else {
+                    return .err(
+                        code: "invalid_params",
+                        message: invalidURLMessage,
+                        data: ["param": "url"]
+                    )
+                }
+                url = parsedURL
+            } else {
+                url = nil
+            }
+
+            let expires: Int?
+            if v2HasNonNullParam(params, "expires") {
+                guard let parsedExpires = v2Int(params, "expires") else {
+                    return .err(
+                        code: "invalid_params",
+                        message: invalidExpiresMessage,
+                        data: ["param": "expires"]
+                    )
+                }
+                expires = parsedExpires
+            } else {
+                expires = nil
+            }
+
+            let secure: Bool?
+            if v2HasNonNullParam(params, "secure") {
+                guard let parsedSecure = v2Bool(params, "secure") else {
+                    return .err(code: "invalid_params", message: invalidFilterMessage, data: ["param": "secure"])
+                }
+                secure = parsedSecure
+            } else {
+                secure = nil
+            }
+
+            let all: Bool
+            if v2HasNonNullParam(params, "all") {
+                guard let parsedAll = v2Bool(params, "all") else {
+                    return .err(code: "invalid_params", message: invalidFilterMessage, data: ["param": "all"])
+                }
+                all = parsedAll
+            } else {
+                all = false
+            }
+
+            let hasFilter = name != nil || value != nil || url != nil || domain != nil || path != nil ||
+                expires != nil || secure != nil
+            guard all || hasFilter else {
+                return .err(
+                    code: "invalid_params",
+                    message: clearRequiresScopeMessage,
+                    data: ["param": "scope"]
+                )
+            }
+            guard !(all && hasFilter) else {
+                return .err(
+                    code: "invalid_params",
+                    message: clearRequiresScopeMessage,
+                    data: ["param": "scope"]
+                )
+            }
+
             guard let cookies = v2BrowserCookieStoreAll(store) else {
                 return .err(code: "timeout", message: "Timed out reading cookies", data: nil)
             }
 
-            let name = v2String(params, "name")
-            let domain = v2String(params, "domain")
-            let clearAll = params["all"] == nil && name == nil && domain == nil
             let targets = cookies.filter { cookie in
-                if clearAll { return true }
+                if all { return true }
                 if let name, cookie.name != name { return false }
-                if let domain, !cookie.domain.contains(domain) { return false }
+                if let value, cookie.value != value { return false }
+                if let url, !CmuxWebView.cookieMatchesURL(cookie, url: url) { return false }
+                if let domain, !CmuxWebView.cookieDomainMatchesFilter(cookie.domain, filter: domain) { return false }
+                if let path, cookie.path != path { return false }
+                if let expires,
+                   cookie.expiresDate.map({ Int($0.timeIntervalSince1970) }) != expires {
+                    return false
+                }
+                if let secure, cookie.isSecure != secure { return false }
                 return true
             }
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -343,7 +343,7 @@ Browser subcommands:
 | `browser download` | Wait for or save downloads. |
 | `browser profiles` | List, add, rename, clear, or delete cmux browser profiles. `clear` refuses to wipe active profiles unless `--force` is passed. |
 | `browser import` | Open the browser import wizard. In detected coding-agent environments, defaults to non-interactive cookie import; pass `--interactive` to force the wizard. Non-interactive import supports `--from`, `--profile`, `--all-profiles`, `--to-profile`, `--create-profile`, and `--domain`. |
-| `browser cookies` | Get, set, or clear cookies. |
+| `browser cookies` | Get, set, or clear cookies. `clear` requires an explicit scope such as `--url`, `--domain`, `--name`, or `--all`, and returns the removed count as `cleared` in JSON output. |
 | `browser storage` | Get, set, or clear local/session storage. |
 | `browser tab` | Create, list, switch, or close browser tabs. |
 | `browser console`, `browser errors` | List or clear console messages and errors. |

--- a/skills/cmux-browser/references/authentication.md
+++ b/skills/cmux-browser/references/authentication.md
@@ -83,6 +83,6 @@ fi
 Never commit state files; they contain auth tokens. Take credentials from environment variables. Clear state after sensitive tasks:
 
 ```bash
-cmux browser surface:7 cookies clear
+cmux browser surface:7 cookies clear --all
 rm -f ./auth-state.json
 ```

--- a/skills/cmux-browser/references/commands.md
+++ b/skills/cmux-browser/references/commands.md
@@ -65,6 +65,9 @@ Design mode lets a user select page elements and copy their DOM, style, URL, and
 
 ```bash
 cmux browser <surface> cookies get|set|clear ...
+cmux browser <surface> cookies clear --url https://app.example.com/
+cmux browser <surface> cookies clear --domain app.example.com
+cmux browser <surface> cookies clear --all
 cmux browser <surface> storage local|session get|set|clear ...
 cmux browser <surface> tab list|new|switch|close ...
 cmux browser <surface> state save|load <path>
@@ -74,6 +77,11 @@ cmux browser <surface> highlight <selector>
 cmux browser <surface> screenshot
 cmux browser <surface> download wait --timeout-ms 10000
 ```
+
+`cookies clear` requires an explicit scope (`--url`, `--domain`, `--name`,
+`--path`, another cookie filter, or `--all`). URL scope follows cookie
+domain/path, secure, and expiration matching for the requested URL. JSON
+responses include the number of removed cookies as `cleared`.
 
 ## Agent reliability
 

--- a/tests_v2/test_browser_cli_agent_port.py
+++ b/tests_v2/test_browser_cli_agent_port.py
@@ -243,7 +243,48 @@ def main() -> int:
         _run_cli_json(cli, ["browser", surface, "cookies", "set", "cli_cookie", "cookie_val", "--url", "https://example.com"])
         cookies_get = _run_cli_json(cli, ["browser", surface, "cookies", "get", "--name", "cli_cookie"])
         _must(any(str(row.get("name")) == "cli_cookie" for row in (cookies_get.get("cookies") or [])), f"Expected cli_cookie via CLI: {cookies_get}")
-        _run_cli_json(cli, ["browser", surface, "cookies", "clear", "--name", "cli_cookie"])
+        cleared_cookie = _run_cli_json(cli, ["browser", surface, "cookies", "clear", "--name", "cli_cookie"])
+        _must(int(cleared_cookie.get("cleared") or 0) == 1, f"Expected cookies clear to report one cleared cookie: {cleared_cookie}")
+
+        scoped_cookie_names = {
+            "a": "cmux_scope_cookie_a",
+            "b": "cmux_scope_cookie_b",
+            "c": "cmux_scope_cookie_c",
+        }
+        for host, name in scoped_cookie_names.items():
+            _run_cli_json(
+                cli,
+                [
+                    "browser",
+                    surface,
+                    "cookies",
+                    "set",
+                    name,
+                    "cookie_value",
+                    "--url",
+                    f"https://{host}.example.com/",
+                ],
+            )
+
+        _run_cli_expect_failure(
+            cli,
+            ["browser", surface, "cookies", "clear"],
+            ["scope", "--all", "invalid_params"],
+        )
+        url_cleared = _run_cli_json(
+            cli,
+            ["browser", surface, "cookies", "clear", "--url", "https://b.example.com/"],
+        )
+        _must(int(url_cleared.get("cleared") or 0) == 1, f"Expected URL clear to report one cleared cookie: {url_cleared}")
+
+        for host, name in scoped_cookie_names.items():
+            remaining = _run_cli_json(cli, ["browser", surface, "cookies", "get", "--name", name])
+            present = any(str(row.get("name")) == name for row in (remaining.get("cookies") or []))
+            expected = host != "b"
+            _must(present == expected, f"URL-scoped clear changed the wrong cookie ({host}): {remaining}")
+
+        for name in scoped_cookie_names.values():
+            _run_cli_json(cli, ["browser", surface, "cookies", "clear", "--name", name])
 
         _run_cli_json(cli, ["browser", surface, "storage", "local", "set", "alpha", "one"])
         storage_get = _run_cli_json(cli, ["browser", surface, "storage", "local", "get", "alpha"])


### PR DESCRIPTION
Fixes #10529

Cookie clears currently ignore --url and treat missing filters as an implicit --all, which can wipe the shared browser profile. This PR adds a CLI regression covering URL scoping, explicit scope requirements, and the cleared count, then fixes the shared predicate.

The regression test is intentionally the first commit so CI can verify it fails on the pre-fix behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790132038&installation_model_id=21920&pr_number=10626&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10626&signature=4377021c9bd1dcc2a84f4f4cfebfbc691e0d5e135f18e6ab208feac77b998355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes browser cookie clears by URL and enforces explicit scoping to prevent accidental profile-wide deletes. Previously, cookies clear ignored --url and treated missing filters as --all; now it requires exactly one of --all or a cookie filter and returns a cleared count.

- URL scope shares the same predicate as request sending and scripted-download forwarding, matching domain/path, secure, and expiration.
- Validates filters and types: --url must include a host, --expires must be an integer, and mixing --all with filters returns invalid_params (localized).
- Requires an explicit scope: use --url, --domain, --name, --path, --value, --secure, --expires, or --all; JSON includes cleared.
- Keeps cookie matching off the main actor for consistency and performance; tests cover scoped clears and docs add examples and the new requirement.

<sup>Written for commit 4345096237fa31df840b099ec9c8c2e837646788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

