### PR TITLE
iOS: cut workspace-list emission cost (off-main decode, coalesced projection, deduped derivations)

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
@@ -483,11 +483,22 @@ extension MobileShellComposite {
             visibleBrowserPanelsRefreshFollowUpWorkspaceID = workspaceID
             return
         }
+        let refreshID = UUID()
+        visibleBrowserPanelsRefreshID = refreshID
         visibleBrowserPanelsRefreshTask = Task { @MainActor [weak self] in
-            defer { self?.visibleBrowserPanelsRefreshTask = nil }
+            defer {
+                if let self, self.visibleBrowserPanelsRefreshID == refreshID {
+                    self.visibleBrowserPanelsRefreshTask = nil
+                    self.visibleBrowserPanelsRefreshID = nil
+                }
+            }
             var nextWorkspaceID: String? = workspaceID
             while let currentWorkspaceID = nextWorkspaceID, let self {
                 await self.refreshMobileBrowserPanels(workspaceID: currentWorkspaceID)
+                // A teardown/client-swap cancellation already cleared the
+                // follow-up state for its successor; consuming it here would
+                // issue an RPC on the replacement connection.
+                guard !Task.isCancelled else { return }
                 nextWorkspaceID = self.visibleBrowserPanelsRefreshFollowUpWorkspaceID
                 self.visibleBrowserPanelsRefreshFollowUpWorkspaceID = nil
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
@@ -473,7 +473,25 @@ extension MobileShellComposite {
 
     func refreshVisibleMobileBrowserPanels() {
         guard let workspaceID = selectedWorkspace?.rpcWorkspaceID.rawValue else { return }
-        Task { await refreshMobileBrowserPanels(workspaceID: workspaceID) }
+        // Single-flight with one trailing rerun: `workspace.updated` arrives
+        // up to once per 80ms while agents stream, and stacking one panel-list
+        // RPC per event contends with delta/list traffic on the same control
+        // transport. The newest requested workspace wins the trailing slot,
+        // and the trailing rerun sees post-burst state, so the result
+        // converges exactly as the per-event version did.
+        if visibleBrowserPanelsRefreshTask != nil {
+            visibleBrowserPanelsRefreshFollowUpWorkspaceID = workspaceID
+            return
+        }
+        visibleBrowserPanelsRefreshTask = Task { @MainActor [weak self] in
+            defer { self?.visibleBrowserPanelsRefreshTask = nil }
+            var nextWorkspaceID: String? = workspaceID
+            while let currentWorkspaceID = nextWorkspaceID, let self {
+                await self.refreshMobileBrowserPanels(workspaceID: currentWorkspaceID)
+                nextWorkspaceID = self.visibleBrowserPanelsRefreshFollowUpWorkspaceID
+                self.visibleBrowserPanelsRefreshFollowUpWorkspaceID = nil
+            }
+        }
     }
 
     func restartActiveMobileBrowserStreams() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -999,13 +999,9 @@ extension MobileShellComposite {
             // on this path and previously blocked the runloop that renders
             // scrolling. The staleness guards below already ran after an
             // await, so they cover this suspension too.
-            let decoderTask = Task.detached(priority: .userInitiated) {
-                try MobileSyncWorkspaceListResponse.decode(data)
+            let response = try await Self.decodeOffMain(data) {
+                try MobileSyncWorkspaceListResponse.decode($0)
             }
-            let response = try await withTaskCancellationHandler(
-                operation: { try await decoderTask.value },
-                onCancel: { decoderTask.cancel() }
-            )
             guard remoteClient === client, connectionState == .connected else {
                 recordAppEvent(
                     .workspaceListRefreshFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -995,7 +995,17 @@ extension MobileShellComposite {
                 request,
                 timeoutNanoseconds: timeoutNanoseconds ?? runtime?.rpcRequestTimeoutNanoseconds
             )
-            let response = try MobileSyncWorkspaceListResponse.decode(data)
+            // Decode off the main actor: the full list is the largest payload
+            // on this path and previously blocked the runloop that renders
+            // scrolling. The staleness guards below already ran after an
+            // await, so they cover this suspension too.
+            let decoderTask = Task.detached(priority: .userInitiated) {
+                try MobileSyncWorkspaceListResponse.decode(data)
+            }
+            let response = try await withTaskCancellationHandler(
+                operation: { try await decoderTask.value },
+                onCancel: { decoderTask.cancel() }
+            )
             guard remoteClient === client, connectionState == .connected else {
                 recordAppEvent(
                     .workspaceListRefreshFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
@@ -54,7 +54,7 @@ extension MobileShellComposite {
         // client mid-decode; this old stream's delta must then be dropped
         // (the new authority snapshot-fetched its own state).
         let entryAuthorityClientID = stateSyncAuthorityClientID
-        guard let header = try? await mobileShellDecodeOffMain(
+        guard let header = try? await Self.decodeOffMain(
             MobileSyncDeltaEventHeader.self, from: payload
         ) else {
             scheduleStateSyncRepairIfActive()
@@ -66,7 +66,7 @@ extension MobileShellComposite {
         let removedWorkspaceIDs: [String]
         switch header.collection {
         case .workspaces:
-            guard let delta = try? await mobileShellDecodeOffMain(
+            guard let delta = try? await Self.decodeOffMain(
                 MobileSyncDeltaEvent<WorkspaceSyncRecord>.self, from: payload
             ) else {
                 // A delta we KNOW is for a mirrored collection but cannot
@@ -81,7 +81,7 @@ extension MobileShellComposite {
             changesSummaryRefreshScope = .workspaceDelta(delta.records.map(\.id))
             removedWorkspaceIDs = delta.removedIDs
         case .groups:
-            guard let delta = try? await mobileShellDecodeOffMain(
+            guard let delta = try? await Self.decodeOffMain(
                 MobileSyncDeltaEvent<GroupSyncRecord>.self, from: payload
             ) else {
                 scheduleStateSyncRepairIfActive()
@@ -260,7 +260,7 @@ extension MobileShellComposite {
                 timeoutNanoseconds: timeoutNanoseconds ?? runtime?.rpcRequestTimeoutNanoseconds
             )
             guard remoteClient === client, connectionState == .connected, !Task.isCancelled else { return false }
-            let response = try await mobileShellDecodeOffMain(
+            let response = try await Self.decodeOffMain(
                 MobileSyncFetchResponse.self, from: data
             )
             // The decode suspended off-main; nothing below may run for a

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
@@ -29,8 +29,9 @@ extension MobileShellComposite {
 
     /// Handles one `mobile.sync.delta` event from the foreground event stream.
     /// The caller already proved the event belongs to the current client and a
-    /// connected session.
-    func handleStateSyncDeltaEvent(_ event: MobileEventEnvelope) {
+    /// connected session. Async because the JSON decode runs off the main
+    /// actor; the event loop awaits it, so delta ordering is preserved.
+    func handleStateSyncDeltaEvent(_ event: MobileEventEnvelope) async {
         // Deltas apply only while v2 is authoritative for the CURRENT client
         // (after a legacy fallback the list has a legacy writer, and mirror
         // projections must stop until renegotiation). During NEGOTIATION —
@@ -48,7 +49,14 @@ extension MobileShellComposite {
             scheduleStateSyncRepairIfActive()
             return
         }
-        guard let header = try? JSONDecoder().decode(MobileSyncDeltaEventHeader.self, from: payload) else {
+        // The authority that vouched for this delta at entry. The off-main
+        // decode suspends the main actor, so authority may move to a NEW
+        // client mid-decode; this old stream's delta must then be dropped
+        // (the new authority snapshot-fetched its own state).
+        let entryAuthorityClientID = stateSyncAuthorityClientID
+        guard let header = try? await mobileShellDecodeOffMain(
+            MobileSyncDeltaEventHeader.self, from: payload
+        ) else {
             scheduleStateSyncRepairIfActive()
             return
         }
@@ -58,7 +66,7 @@ extension MobileShellComposite {
         let removedWorkspaceIDs: [String]
         switch header.collection {
         case .workspaces:
-            guard let delta = try? JSONDecoder().decode(
+            guard let delta = try? await mobileShellDecodeOffMain(
                 MobileSyncDeltaEvent<WorkspaceSyncRecord>.self, from: payload
             ) else {
                 // A delta we KNOW is for a mirrored collection but cannot
@@ -67,17 +75,19 @@ extension MobileShellComposite {
                 scheduleStateSyncRepairIfActive()
                 return
             }
+            guard stateSyncActive, stateSyncAuthorityClientID == entryAuthorityClientID else { return }
             result = stateSyncMirror.workspaces.apply(delta: delta)
             appliedRevision = delta.toRev
             changesSummaryRefreshScope = .workspaceDelta(delta.records.map(\.id))
             removedWorkspaceIDs = delta.removedIDs
         case .groups:
-            guard let delta = try? JSONDecoder().decode(
+            guard let delta = try? await mobileShellDecodeOffMain(
                 MobileSyncDeltaEvent<GroupSyncRecord>.self, from: payload
             ) else {
                 scheduleStateSyncRepairIfActive()
                 return
             }
+            guard stateSyncActive, stateSyncAuthorityClientID == entryAuthorityClientID else { return }
             result = stateSyncMirror.groups.apply(delta: delta)
             appliedRevision = delta.toRev
             changesSummaryRefreshScope = .groupOnlyDelta
@@ -96,7 +106,7 @@ extension MobileShellComposite {
             )
             #endif
             evictWorkspaceChangesSummaryState(workspaceIDs: removedWorkspaceIDs)
-            applyStateSyncProjection(
+            queueStateSyncProjectionFlush(
                 changesSummaryRefreshScope: changesSummaryRefreshScope
             )
         case .staleIgnored:
@@ -159,6 +169,10 @@ extension MobileShellComposite {
         stateSyncAuthorityClientID = nil
         stateSyncFetchClientID = nil
         stateSyncFetchFollowUpRequested = false
+        stateSyncProjectionFlushTask?.cancel()
+        stateSyncProjectionFlushTask = nil
+        stateSyncProjectionFlushID = nil
+        stateSyncPendingProjectionScope = nil
         stateSyncMirror.reset()
     }
 
@@ -246,7 +260,13 @@ extension MobileShellComposite {
                 timeoutNanoseconds: timeoutNanoseconds ?? runtime?.rpcRequestTimeoutNanoseconds
             )
             guard remoteClient === client, connectionState == .connected, !Task.isCancelled else { return false }
-            let response = try JSONDecoder().decode(MobileSyncFetchResponse.self, from: data)
+            let response = try await mobileShellDecodeOffMain(
+                MobileSyncFetchResponse.self, from: data
+            )
+            // The decode suspended off-main; nothing below may run for a
+            // stale client, connection, or superseded fetch generation.
+            guard remoteClient === client, connectionState == .connected, !Task.isCancelled,
+                  stateSyncFetchGeneration == generation else { return false }
             // The response shape tolerates missing sections for forward
             // compatibility, but v2 must never become authoritative on a
             // partial answer: projecting an empty workspace mirror would
@@ -360,12 +380,64 @@ extension MobileShellComposite {
         }
     }
 
+    /// One coalescing window for burst deltas. Steady-state emissions are
+    /// already spaced by the Mac's 80ms observer throttle and always project;
+    /// the window only merges same-tick collection pairs and catch-up floods
+    /// (reconnect backlogs), bounding projections to at most one per window.
+    static let stateSyncProjectionCoalescingWindow: Duration = .milliseconds(16)
+
+    /// Accumulates one applied delta's changes-summary scope and arms the
+    /// single-flight flush loop. The mirror already holds the delta; only the
+    /// projection (full-list rebuild + apply + SwiftUI invalidation) is
+    /// deferred, by at most one coalescing window.
+    private func queueStateSyncProjectionFlush(
+        changesSummaryRefreshScope scope: WorkspaceChangesSummaryRefreshScope
+    ) {
+        stateSyncPendingProjectionScope =
+            stateSyncPendingProjectionScope?.coalesced(with: scope) ?? scope
+        guard stateSyncProjectionFlushTask == nil else { return }
+        let flushID = UUID()
+        stateSyncProjectionFlushID = flushID
+        stateSyncProjectionFlushTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.stateSyncProjectionFlushID == flushID {
+                    self.stateSyncProjectionFlushTask = nil
+                    self.stateSyncProjectionFlushID = nil
+                }
+            }
+            while let self, !Task.isCancelled {
+                try? await self.stateSyncProjectionClock.sleep(
+                    for: Self.stateSyncProjectionCoalescingWindow
+                )
+                guard !Task.isCancelled else { return }
+                guard let scope = self.stateSyncPendingProjectionScope else { return }
+                self.stateSyncPendingProjectionScope = nil
+                // Authority may have moved to legacy (fetch failure fallback)
+                // or a new client mid-window. The mirror is then no longer
+                // the list's writer, so projecting would clobber the legacy
+                // apply; the pending scope is dropped with it because the
+                // legacy path schedules its own summary refresh.
+                guard self.stateSyncActive else { return }
+                self.applyStateSyncProjection(changesSummaryRefreshScope: scope)
+            }
+        }
+    }
+
     /// Projects the mirror into the legacy full-list response shape and hands
     /// it to the shared apply path. The mirror always holds full records, so
     /// the projection is always a complete, ordered list.
+    ///
+    /// A synchronous fetch-path projection absorbs any delta scope still
+    /// waiting on the flush loop: the mirror already contains those deltas,
+    /// so this projection renders them, and merging keeps their
+    /// changes-summary refresh from being lost.
     private func applyStateSyncProjection(
         changesSummaryRefreshScope: WorkspaceChangesSummaryRefreshScope
     ) {
+        let changesSummaryRefreshScope = stateSyncPendingProjectionScope
+            .map { $0.coalesced(with: changesSummaryRefreshScope) }
+            ?? changesSummaryRefreshScope
+        stateSyncPendingProjectionScope = nil
         let workspaces = stateSyncMirror.workspaces.orderedRecords.map { record in
             MobileSyncWorkspaceListResponse.Workspace(
                 id: record.id,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1207,6 +1207,26 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Identifies the fetch generation that owns ``stateSyncFetchTask``, so a
     /// cancelled predecessor's deferred cleanup cannot clear its replacement.
     var stateSyncFetchGeneration = UUID()
+    /// Changes-summary scope accumulated by delta applies that are waiting for
+    /// the next coalesced projection flush, merged with `coalesced(with:)`.
+    /// The mirror itself stays delta-exact; only the projection is batched.
+    @ObservationIgnored var stateSyncPendingProjectionScope: WorkspaceChangesSummaryRefreshScope?
+    /// Single-flight handle for the frame-coalesced state-sync projection
+    /// flush. Non-nil exactly while a flush loop is scheduled or running.
+    @ObservationIgnored var stateSyncProjectionFlushTask: Task<Void, Never>?
+    /// Identifies the flush loop that owns ``stateSyncProjectionFlushTask``,
+    /// so a cancelled predecessor's deferred cleanup cannot clear a successor.
+    @ObservationIgnored var stateSyncProjectionFlushID: UUID?
+    /// Injected clock for the delta-projection coalescing window so tests can
+    /// drive flush timing deterministically.
+    @ObservationIgnored let stateSyncProjectionClock: any Clock<Duration>
+    /// Single-flight handle for the event-driven visible-workspace browser
+    /// panel refresh; bursts coalesce onto one in-flight RPC plus at most one
+    /// trailing rerun instead of stacking a task per `workspace.updated`.
+    @ObservationIgnored var visibleBrowserPanelsRefreshTask: Task<Void, Never>?
+    /// The workspace the trailing browser-panel rerun should target (the
+    /// newest requested one wins), or `nil` when no rerun is pending.
+    @ObservationIgnored var visibleBrowserPanelsRefreshFollowUpWorkspaceID: String?
     /// Number of deadline-abandoned reconnect dials that have not yet
     /// resolved. Bounds automatic retry scheduling (see
     /// ``registerAbandonedReconnectDial(_:)``).
@@ -1632,6 +1652,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         workspaceSortStore: MobileWorkspaceSortStore = MobileWorkspaceSortStore(),
         workspaceChangesHintDismissalStore: MobileWorkspaceChangesHintDismissalStore = MobileWorkspaceChangesHintDismissalStore(),
         workspaceChangesSchedulingClock: any Clock<Duration> = ContinuousClock(),
+        stateSyncProjectionClock: any Clock<Duration> = ContinuousClock(),
         controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock(),
         connectionHandoffDrainTimeoutNanoseconds: UInt64 = 3_000_000_000,
         terminalInputAckResubscribeClock: any Clock<Duration> = ContinuousClock(),
@@ -1650,6 +1671,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.workspaceComputerPriority = workspaceSortStore.computerPriority
         self.workspaceChangesHintDismissalStore = workspaceChangesHintDismissalStore
         self.workspaceChangesSchedulingClock = workspaceChangesSchedulingClock
+        self.stateSyncProjectionClock = stateSyncProjectionClock
         self.controlPlaneSchedulingClock = controlPlaneSchedulingClock
         self.connectionHandoffDrainTimeoutNanoseconds =
             connectionHandoffDrainTimeoutNanoseconds
@@ -1852,12 +1874,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public static func preview(
         runtime: (any MobileSyncRuntime)? = nil,
         terminalInputAckResubscribeClock: any Clock<Duration> = ContinuousClock(),
-        controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock()
+        controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock(),
+        stateSyncProjectionClock: any Clock<Duration> = ContinuousClock()
     ) -> CMUXMobileShellStore {
         CMUXMobileShellStore(
             runtime: runtime,
             workspaces: PreviewMobileHost.workspaces,
             deliveredNotificationClearer: NoopDeliveredNotificationClearer(),
+            stateSyncProjectionClock: stateSyncProjectionClock,
             controlPlaneSchedulingClock: controlPlaneSchedulingClock,
             terminalInputAckResubscribeClock: terminalInputAckResubscribeClock
         )
@@ -6832,6 +6856,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard var state = workspacesByMac[ownerKey] else { return }
         state.status = .unavailable
         state.workspaceGroupsAreAuthoritative = false
+        guard workspacesByMac[ownerKey] != state else { return }
         workspacesByMac[ownerKey] = state
     }
 
@@ -6996,7 +7021,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     refreshShouldRetry = false
                     break refreshLoop
                 }
-                self.workspacesByMac[ownerKey] = MacWorkspaceState(
+                let refreshedState = MacWorkspaceState(
                     macDeviceID: macID,
                     instanceTag: subscription.storedInstanceTag,
                     displayName: displayName ?? subscription.displayName,
@@ -7011,6 +7036,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     status: .connected,
                     actionCapabilities: subscription.actionCapabilities
                 )
+                // Publishing an IDENTICAL snapshot would still fire the
+                // `workspacesByMac` didSet (full re-derivation plus an
+                // Observation invalidation of every list view) with nothing
+                // to show for it; churn coalescing upstream makes repeated
+                // identical snapshots common under a hot event stream.
+                if self.workspacesByMac[ownerKey] != refreshedState {
+                    self.workspacesByMac[ownerKey] = refreshedState
+                }
                 // One owner performs a leading pass plus at most one trailing
                 // pass. The trailing host snapshot represents churn queued
                 // during either request without creating an unbounded scan
@@ -7332,6 +7365,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             from: supportedHostCapabilities,
             allowsMacScopedMutations: allowsMacScopedWorkspaceMutations
         )
+        guard workspacesByMac[foregroundMacKey] != state else { return }
         workspacesByMac[foregroundMacKey] = state
     }
 
@@ -7414,7 +7448,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return copy
             }
         }
-        workspaces = derived
+        // Assigning an equal array would still invalidate every Observation
+        // client of `workspaces` (and bump the topology version) with nothing
+        // rendered differently; frequent per-Mac emissions often re-derive an
+        // identical aggregate.
+        if workspaces != derived {
+            workspaces = derived
+        }
         let terminalNames = derived.reduce(into: [String: String]()) { names, workspace in
             for terminal in workspace.terminals {
                 names[terminal.id.rawValue] = terminal.name
@@ -7453,7 +7493,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             foregroundMacDeviceID: foregroundKey,
             macIDsInDisplayOrder: macIDsInDisplayOrder
         )
-        workspaceGroups = groupCollapseStore.apply(to: derivedGroups)
+        let collapsedGroups = groupCollapseStore.apply(to: derivedGroups)
+        if workspaceGroups != collapsedGroups {
+            workspaceGroups = collapsedGroups
+        }
     }
 
     /// Set the user's per-Mac customizations (name / color / icon), persist them
@@ -7758,6 +7801,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             instanceTag: key.normalizedInstanceTag
         )
         body(&state.workspaces)
+        // A no-op mutation (optimistic write matching current state) must not
+        // fire the didSet re-derivation; a missing entry still writes because
+        // nil != state.
+        guard workspacesByMac[key] != state else { return }
         workspacesByMac[key] = state
     }
     /// Create a workspace locally or through the connected Mac, then select it.
@@ -12214,7 +12261,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     self.scheduleWorkspaceListRefreshFromEvent()
                     self.refreshVisibleMobileBrowserPanels()
                 } else if event.topic == "mobile.sync.delta" {
-                    self.handleStateSyncDeltaEvent(event)
+                    await self.handleStateSyncDeltaEvent(event)
                 } else if event.topic == "terminal.render_grid" {
                     self.handleTerminalRenderGridEvent(event)
                 } else if event.topic == "terminal.set_font" {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1224,6 +1224,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// panel refresh; bursts coalesce onto one in-flight RPC plus at most one
     /// trailing rerun instead of stacking a task per `workspace.updated`.
     @ObservationIgnored var visibleBrowserPanelsRefreshTask: Task<Void, Never>?
+    /// Identifies the loop that owns ``visibleBrowserPanelsRefreshTask``, so a
+    /// cancelled predecessor's deferred cleanup cannot clear a successor.
+    @ObservationIgnored var visibleBrowserPanelsRefreshID: UUID?
     /// The workspace the trailing browser-panel rerun should target (the
     /// newest requested one wins), or `nil` when no rerun is pending.
     @ObservationIgnored var visibleBrowserPanelsRefreshFollowUpWorkspaceID: String?
@@ -1855,6 +1858,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         workspaceChangesSummaryTrailingTask?.cancel()
         pullToRefreshTask?.cancel()
         foregroundWorkspaceMutationRefreshTask?.cancel()
+        visibleBrowserPanelsRefreshTask?.cancel()
+        stateSyncProjectionFlushTask?.cancel()
         for task in computerVisibilityMutationTasksByID.values {
             task.cancel()
         }
@@ -10527,6 +10532,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         foregroundWorkspaceMutationRefreshTask = nil
         foregroundWorkspaceMutationRefreshPending = false
         foregroundWorkspaceMutationRefreshGeneration = UUID()
+        // A refresh in flight on the outgoing client must not occupy the
+        // single-flight slot into the replacement connection's lifetime, or
+        // post-swap `workspace.updated` events would only queue follow-ups
+        // behind a dead RPC.
+        visibleBrowserPanelsRefreshTask?.cancel()
+        visibleBrowserPanelsRefreshTask = nil
+        visibleBrowserPanelsRefreshID = nil
+        visibleBrowserPanelsRefreshFollowUpWorkspaceID = nil
         cancelAllTerminalReplayTasks()
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellOffMainJSONDecoding.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellOffMainJSONDecoding.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Decodes one JSON payload on the global concurrent executor instead of the
+/// caller's actor.
+///
+/// Workspace-list deltas, cursor-fetch snapshots, and the legacy full-list
+/// response all arrive on `@MainActor` paths that previously ran `JSONDecoder`
+/// inline, so every list emission taxed the same runloop that renders
+/// scrolling. Callers must re-validate their connection/authority guards after
+/// the suspension, exactly like any other await in those paths.
+func mobileShellDecodeOffMain<T: Decodable & Sendable>(
+    _ type: T.Type,
+    from data: Data
+) async throws -> T {
+    let decoderTask = Task.detached(priority: .userInitiated) {
+        try JSONDecoder().decode(T.self, from: data)
+    }
+    return try await withTaskCancellationHandler(
+        operation: { try await decoderTask.value },
+        onCancel: { decoderTask.cancel() }
+    )
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellOffMainJSONDecoding.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellOffMainJSONDecoding.swift
@@ -1,22 +1,40 @@
 import Foundation
 
-/// Decodes one JSON payload on the global concurrent executor instead of the
-/// caller's actor.
-///
-/// Workspace-list deltas, cursor-fetch snapshots, and the legacy full-list
-/// response all arrive on `@MainActor` paths that previously ran `JSONDecoder`
-/// inline, so every list emission taxed the same runloop that renders
-/// scrolling. Callers must re-validate their connection/authority guards after
-/// the suspension, exactly like any other await in those paths.
-func mobileShellDecodeOffMain<T: Decodable & Sendable>(
-    _ type: T.Type,
-    from data: Data
-) async throws -> T {
-    let decoderTask = Task.detached(priority: .userInitiated) {
-        try JSONDecoder().decode(T.self, from: data)
+extension MobileShellComposite {
+    /// Decodes one JSON payload on the global concurrent executor instead of
+    /// the caller's actor.
+    ///
+    /// Workspace-list deltas, cursor-fetch snapshots, and the legacy full-list
+    /// response all arrive on `@MainActor` paths that previously ran
+    /// `JSONDecoder` inline, so every list emission taxed the same runloop
+    /// that renders scrolling. Callers must re-validate their
+    /// connection/authority guards after the suspension, exactly like any
+    /// other await in those paths.
+    nonisolated static func decodeOffMain<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from data: Data
+    ) async throws -> T {
+        let decoderTask = Task.detached(priority: .userInitiated) {
+            try JSONDecoder().decode(T.self, from: data)
+        }
+        return try await withTaskCancellationHandler(
+            operation: { try await decoderTask.value },
+            onCancel: { decoderTask.cancel() }
+        )
     }
-    return try await withTaskCancellationHandler(
-        operation: { try await decoderTask.value },
-        onCancel: { decoderTask.cancel() }
-    )
+
+    /// Same executor contract for types with a bespoke `decode(_:)` (wire
+    /// shapes with custom key mapping), used by the legacy full-list path.
+    nonisolated static func decodeOffMain<T: Sendable>(
+        _ data: Data,
+        as decode: @escaping @Sendable (Data) throws -> T
+    ) async throws -> T {
+        let decoderTask = Task.detached(priority: .userInitiated) {
+            try decode(data)
+        }
+        return try await withTaskCancellationHandler(
+            operation: { try await decoderTask.value },
+            onCancel: { decoderTask.cancel() }
+        )
+    }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellListEmissionCoalescingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellListEmissionCoalescingTests.swift
@@ -1,0 +1,251 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+// Behavior tests for the workspace-list emission cost work: delta-projection
+// coalescing (one projection per window for a burst), equality-guarded store
+// writes (no Observation churn for no-op emissions), and the single-flight
+// browser-panel refresh (bounded RPCs under a workspace.updated burst).
+
+private func coalescingWorkspaceRecord(
+    id: String,
+    title: String,
+    sortIndex: Int
+) -> WorkspaceSyncRecord {
+    WorkspaceSyncRecord(
+        id: id,
+        windowID: "win-1",
+        title: title,
+        customDescription: nil,
+        customDescriptionIsTruncated: false,
+        customColorHex: nil,
+        currentDirectory: nil,
+        isSelected: false,
+        isPinned: false,
+        groupID: nil,
+        preview: nil,
+        previewAt: nil,
+        lastActivityAt: 1.0,
+        hasUnread: false,
+        sortIndex: sortIndex,
+        terminals: [],
+        surfaces: nil
+    )
+}
+
+private func coalescingSnapshotData(
+    epoch: String,
+    rev: UInt64,
+    records: [WorkspaceSyncRecord]
+) throws -> Data {
+    let response = MobileSyncFetchResponse(
+        epoch: epoch,
+        workspaces: MobileSyncCollectionPayload(
+            mode: .snapshot,
+            rev: rev,
+            fromRev: nil,
+            records: records,
+            removedIDs: []
+        ),
+        groups: MobileSyncCollectionPayload(
+            mode: .snapshot,
+            rev: rev,
+            fromRev: nil,
+            records: [],
+            removedIDs: []
+        )
+    )
+    return try JSONEncoder().encode(response)
+}
+
+private func coalescingDeltaFrame(
+    epoch: String,
+    fromRev: UInt64,
+    toRev: UInt64,
+    records: [WorkspaceSyncRecord]
+) throws -> Data {
+    let event = MobileSyncDeltaEvent(
+        epoch: epoch,
+        collection: .workspaces,
+        fromRev: fromRev,
+        toRev: toRev,
+        records: records,
+        removedIDs: []
+    )
+    let envelope: [String: Any] = [
+        "kind": "event",
+        "topic": "mobile.sync.delta",
+        "payload": try MobileSyncFrameCoder().jsonObject(from: event),
+    ]
+    return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+}
+
+private func coalescingWorkspaceUpdatedFrame() throws -> Data {
+    let envelope: [String: Any] = [
+        "kind": "event",
+        "topic": "workspace.updated",
+        "payload": [String: Any](),
+    ]
+    return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+}
+
+@MainActor
+struct MobileShellListEmissionCoalescingTests {
+    /// A burst of contiguous deltas landing inside one coalescing window must
+    /// produce exactly one projection (one foreground apply, one Observation
+    /// invalidation) whose content reflects the NEWEST delta.
+    @Test func burstDeltasProjectOncePerCoalescingWindow() async throws {
+        let workspaceID = UUID().uuidString
+        let router = LivenessHostRouter()
+        await router.scriptSyncFetchResult(
+            jsonData: try coalescingSnapshotData(
+                epoch: "epoch-1",
+                rev: 3,
+                records: [coalescingWorkspaceRecord(id: workspaceID, title: "base", sortIndex: 0)]
+            )
+        )
+        let box = TransportBox()
+        let clock = TestClock()
+        let projectionClock = ControlPoolManualClock()
+        let store = try await makeConnectedStore(
+            router: router,
+            box: box,
+            clock: clock,
+            stateSyncProjectionClock: projectionClock
+        )
+        let negotiated = try await pollUntil {
+            store.stateSyncActive && store.workspaces.map(\.name).contains("base")
+        }
+        #expect(negotiated, "v2 negotiation must complete before the burst")
+
+        let revisionBefore = store.foregroundWorkspaceStateRevision
+        let transport = try #require(box.get())
+        for step in UInt64(3)..<6 {
+            await transport.deliver(try coalescingDeltaFrame(
+                epoch: "epoch-1",
+                fromRev: step,
+                toRev: step + 1,
+                records: [coalescingWorkspaceRecord(
+                    id: workspaceID,
+                    title: "rev-\(step + 1)",
+                    sortIndex: 0
+                )]
+            ))
+        }
+        let mirrored = try await pollUntil {
+            store.stateSyncMirror.workspaces.rev == 6
+        }
+        #expect(mirrored, "all three deltas must reach the mirror")
+        // The mirror is delta-exact but nothing projected yet: the flush loop
+        // is still sleeping on the held manual clock.
+        #expect(
+            store.foregroundWorkspaceStateRevision == revisionBefore,
+            "no projection may run before the coalescing window elapses"
+        )
+        #expect(!store.workspaces.map(\.name).contains("rev-6"))
+
+        // The flush task must reach its sleep before the clock advances, or
+        // the wake-up deadline lands beyond this advance.
+        let flushArmed = try await pollUntil { projectionClock.sleeperCount == 1 }
+        #expect(flushArmed, "the coalescing flush must be sleeping on the injected clock")
+        projectionClock.advance(by: MobileShellComposite.stateSyncProjectionCoalescingWindow)
+        let projected = try await pollUntil {
+            store.workspaces.map(\.name).contains("rev-6")
+        }
+        #expect(projected, "the flush must project the newest delta content")
+        #expect(
+            store.foregroundWorkspaceStateRevision == revisionBefore &+ 1,
+            "a three-delta burst must cost exactly one projection"
+        )
+        // Wake the trailing sleep so the flush loop can observe the empty
+        // pending scope and exit.
+        _ = try await pollUntil { projectionClock.sleeperCount == 1 }
+        projectionClock.advance(by: MobileShellComposite.stateSyncProjectionCoalescingWindow)
+        let flushEnded = try await pollUntil { store.stateSyncProjectionFlushTask == nil }
+        #expect(flushEnded, "an empty pending scope must end the flush loop")
+    }
+
+    /// Writing an unchanged foreground state through the optimistic-mutation
+    /// seam must not invalidate the derived `workspaces` (no topology bump).
+    @Test func noOpForegroundMutationDoesNotInvalidateWorkspaces() async throws {
+        let store = MobileShellComposite.preview()
+        let mutatedVersion: UInt64
+        do {
+            let versionBefore = store.workspaceTopologyVersion
+            store.mutateForegroundWorkspaces { workspaces in
+                workspaces = workspaces
+            }
+            #expect(
+                store.workspaceTopologyVersion == versionBefore,
+                "a no-op foreground mutation must not fire the didSet re-derivation"
+            )
+            mutatedVersion = versionBefore
+        }
+        // A REAL change still propagates (the guard compares content, it does
+        // not swallow writes).
+        store.mutateForegroundWorkspaces { workspaces in
+            workspaces = []
+        }
+        #expect(
+            store.workspaceTopologyVersion != mutatedVersion,
+            "a real foreground mutation must still re-derive the aggregate"
+        )
+    }
+
+    /// A `workspace.updated` burst must coalesce browser-panel refreshes onto
+    /// one in-flight RPC plus at most one trailing rerun, instead of one RPC
+    /// per event.
+    @Test func workspaceUpdatedBurstCoalescesBrowserPanelRefreshes() async throws {
+        let workspaceID = UUID().uuidString
+        let router = LivenessHostRouter()
+        await router.setCapabilities([
+            "events.v1",
+            MobileShellComposite.browserStreamCapability,
+        ])
+        await router.scriptSyncFetchResult(
+            jsonData: try coalescingSnapshotData(
+                epoch: "epoch-1",
+                rev: 3,
+                records: [coalescingWorkspaceRecord(id: workspaceID, title: "base", sortIndex: 0)]
+            )
+        )
+        let box = TransportBox()
+        let clock = TestClock()
+        let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+        let ready = try await pollUntil {
+            store.stateSyncActive
+                && store.selectedWorkspace != nil
+                && store.supportsBrowserStream
+        }
+        #expect(ready, "the store must have a selected workspace and browser capability")
+        // Let any connect-time panel refresh settle so the held burst below
+        // owns the single-flight slot from a clean state.
+        let settled = try await pollUntil { store.visibleBrowserPanelsRefreshTask == nil }
+        #expect(settled, "no panel refresh may be in flight before the burst")
+
+        await router.holdBrowserListRequests()
+        let listCallsBefore = await router.count(of: "mobile.browser.list")
+        let transport = try #require(box.get())
+        for _ in 0..<5 {
+            await transport.deliver(try coalescingWorkspaceUpdatedFrame())
+        }
+        // All five events land while the first refresh is parked at the
+        // router: exactly one RPC is in flight, the rest merged into the
+        // trailing slot.
+        let inFlight = try await pollUntil {
+            await router.count(of: "mobile.browser.list") == listCallsBefore + 1
+        }
+        #expect(inFlight, "the burst must start exactly one in-flight panel refresh")
+        await router.releaseBrowserListRequests()
+        let drained = try await pollUntil { store.visibleBrowserPanelsRefreshTask == nil }
+        #expect(drained, "the single-flight loop must clear its handle after the trailing rerun")
+        let issued = await router.count(of: "mobile.browser.list") - listCallsBefore
+        #expect(
+            issued == 2,
+            "five workspace.updated events must issue one in-flight refresh plus one trailing rerun, got \(issued)"
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -71,6 +71,7 @@ actor LivenessHostRouter {
     private var heldReplayResponsesRemaining = 0
     private var syncFetchRequestCount = 0
     private var heldSyncFetchRequestNumbers: Set<Int> = []
+    private var holdBrowserList = false
     private var viewportRequestCount = 0
     private var heldViewportRequestNumbers: Set<Int> = []
     private var hasActiveSubscription = false
@@ -116,6 +117,18 @@ actor LivenessHostRouter {
     /// issue another refresh request while a cursor fetch is still in flight.
     func holdSyncFetchRequest(number: Int) {
         heldSyncFetchRequestNumbers.insert(number)
+    }
+
+    /// Park every `mobile.browser.list` request until
+    /// ``releaseBrowserListRequests()``, so tests can pile events onto one
+    /// in-flight panel refresh deterministically.
+    func holdBrowserListRequests() {
+        holdBrowserList = true
+    }
+
+    func releaseBrowserListRequests() {
+        holdBrowserList = false
+        releaseAllHeld()
     }
 
     func record(
@@ -487,6 +500,7 @@ actor LivenessHostRouter {
         heldReplayRequestNumbers = []
         heldReplayResponsesRemaining = 0
         heldSyncFetchRequestNumbers = []
+        holdBrowserList = false
         heldViewportRequestNumbers = []
         let continuations = heldContinuations
         heldContinuations = []
@@ -749,6 +763,11 @@ actor LivenessHostRouter {
             return try? Self.resultFrame(id: id, result: [
                 "terminal_seq": terminalSequence,
             ])
+        case "mobile.browser.list":
+            if holdBrowserList {
+                await park()
+            }
+            return try? Self.resultFrame(id: id, result: ["panels": [[String: Any]]()])
         default:
             return try? Self.errorFrame(id: id, message: "Unexpected method \(method ?? "nil")")
         }
@@ -1008,7 +1027,8 @@ func makeConnectedStore(
     clock: TestClock,
     probeTimeoutNanoseconds: UInt64 = 200_000_000,
     inputAckRetryClock: any Clock<Duration> = ContinuousClock(),
-    controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock()
+    controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock(),
+    stateSyncProjectionClock: any Clock<Duration> = ContinuousClock()
 ) async throws -> MobileShellComposite {
     let runtime = LivenessTestRuntime(
         transportFactory: LivenessTransportFactory(router: router, box: box),
@@ -1018,7 +1038,8 @@ func makeConnectedStore(
     let store = MobileShellComposite.preview(
         runtime: runtime,
         terminalInputAckResubscribeClock: inputAckRetryClock,
-        controlPlaneSchedulingClock: controlPlaneSchedulingClock
+        controlPlaneSchedulingClock: controlPlaneSchedulingClock,
+        stateSyncProjectionClock: stateSyncProjectionClock
     )
     store.signIn()
     let ticket = try makeTicket(clock: clock)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
@@ -12,25 +12,42 @@ extension WorkspaceListView {
     static let maxPipelinedWorkspaceMoves = 3
 
     var enablesWorkspaceReorder: Bool {
+        enablesWorkspaceReorder(
+            canMutateForegroundGroups: canMutateForegroundGroupsForSelection,
+            appliesRecencySort: appliesRecencySort,
+            reorderableWorkspaces: reorderableWorkspaces,
+            flatContainsPinned: rendersGroupedSections
+                ? false
+                : filteredWorkspaces.contains(where: \.isPinned)
+        )
+    }
+
+    /// Input-threaded variant for `body`, which resolves the scope-derived
+    /// gate, recency flag, and filtered/grouped projections once per
+    /// evaluation. Autoclosures keep the property wrapper above as lazy as
+    /// the original single expression (nothing filters when `moveWorkspace`
+    /// is nil).
+    func enablesWorkspaceReorder(
+        canMutateForegroundGroups: @autoclosure () -> Bool,
+        appliesRecencySort: @autoclosure () -> Bool,
+        reorderableWorkspaces: @autoclosure () -> [MobileWorkspacePreview],
+        flatContainsPinned: @autoclosure () -> Bool
+    ) -> Bool {
         moveWorkspace != nil
             && pendingWorkspaceMoveCount < Self.maxPipelinedWorkspaceMoves
-            && canMutateForegroundGroupsForSelection
+            && canMutateForegroundGroups()
             && trimmedQuery.isEmpty
             && filter.readState == .all
             && filter.machines.isEmpty
             // The recency order is derived from timestamps, so a drag has no
             // spatial position to send to the Mac.
-            && !appliesRecencySort
-            && reorderableWorkspaces.hasSingleKnownWindow
-            && (rendersGroupedSections || !filteredWorkspaces.contains(where: \.isPinned))
+            && !appliesRecencySort()
+            && reorderableWorkspaces().hasSingleKnownWindow
+            && !flatContainsPinned()
     }
 
     var reorderableWorkspaces: [MobileWorkspacePreview] {
         rendersGroupedSections ? groupedWorkspaces : filteredWorkspaces
-    }
-
-    var filteredWorkspaceOrderKey: [WorkspaceListStableOrderKey] {
-        filteredWorkspaces.map { WorkspaceListStableOrderKey(workspace: $0) }
     }
 
     var canCreateWorkspaceInGroups: Bool {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -48,8 +48,15 @@ extension WorkspaceListView {
     }
 
     var liveMachineSnapshots: WorkspaceMachineSnapshots {
-        let scope = macSelectionScope
-        return WorkspaceMachineSnapshots(
+        liveMachineSnapshots(scope: macSelectionScope)
+    }
+
+    /// Scope-threaded variant for `body`, which computes one
+    /// ``WorkspaceMacSelectionScope`` per evaluation and reuses it; the
+    /// convenience properties above stay for event handlers, which run once
+    /// per interaction rather than once per render pass.
+    func liveMachineSnapshots(scope: WorkspaceMacSelectionScope) -> WorkspaceMachineSnapshots {
+        WorkspaceMachineSnapshots(
             workspaces: workspaces,
             filterMachineIDFor: { scope.aliasIndex.representativeID(for: $0) },
             macPickerMachineIDs: scope.machineIDs,
@@ -104,7 +111,11 @@ extension WorkspaceListView {
     }
 
     var filterMenuPresentMachineIDs: [String] {
-        let aliasIndex = macSelectionScope.aliasIndex
+        filterMenuPresentMachineIDs(scope: macSelectionScope)
+    }
+
+    func filterMenuPresentMachineIDs(scope: WorkspaceMacSelectionScope) -> [String] {
+        let aliasIndex = scope.aliasIndex
         var seen = Set<String>()
         var present: [String] = []
         for id in MobileWorkspaceListFilter.machineIDs(in: workspaces) {
@@ -134,6 +145,10 @@ extension WorkspaceListView {
 
     #if os(iOS)
     var canMutateForegroundGroupsForSelection: Bool {
+        canMutateForegroundGroupsForSelection(scope: macSelectionScope)
+    }
+
+    func canMutateForegroundGroupsForSelection(scope: WorkspaceMacSelectionScope) -> Bool {
         #if DEBUG
         // The store-free layout fixture has no foreground Mac, so the
         // foreground-mutation gate can never pass there. Allow its isolated
@@ -142,7 +157,7 @@ extension WorkspaceListView {
             return true
         }
         #endif
-        return macSelectionScope.canMutateForegroundGroupsForSelection
+        return scope.canMutateForegroundGroupsForSelection
     }
 
     func macTitlePickerTitle(machineSnapshots: WorkspaceMachineSnapshots) -> String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
@@ -4,15 +4,10 @@ import CmuxMobileSupport
 import SwiftUI
 
 extension WorkspaceListView {
-    var showsWorkspaceTableFilterEmptyRow: Bool {
-        activeFilter.isActive
-            && trimmedQuery.isEmpty
-            && filteredWorkspaces.isEmpty
-            && !workspaces.isEmpty
-    }
-
     func workspaceTableItems(
-        groupedItems: [MobileWorkspaceListItem]
+        groupedItems: [MobileWorkspaceListItem],
+        displayedFlatWorkspaces: [MobileWorkspacePreview],
+        showsFilterEmptyRow: Bool
     ) -> [WorkspaceListTableItem] {
         var items: [WorkspaceListTableItem] = []
         switch connectionChrome {
@@ -37,7 +32,7 @@ extension WorkspaceListView {
                     .workspace(workspace.id, indented: indented)
                 }
             })
-        } else if showsWorkspaceTableFilterEmptyRow {
+        } else if showsFilterEmptyRow {
             items.append(.filterEmpty)
         } else {
             items.append(contentsOf: displayedFlatWorkspaces.map {
@@ -61,10 +56,13 @@ extension WorkspaceListView {
 
     func workspaceTable(
         groupedItems: [MobileWorkspaceListItem],
-        workspacesByID: [MobileWorkspacePreview.ID: MobileWorkspacePreview]
+        workspacesByID: [MobileWorkspacePreview.ID: MobileWorkspacePreview],
+        activeFilter: MobileWorkspaceListFilter,
+        displayedFlatWorkspaces: [MobileWorkspacePreview],
+        showsFilterEmptyRow: Bool,
+        enablesReorder: Bool
     ) -> WorkspaceListTable {
         let grouped = rendersGroupedSections
-        let enablesReorder = enablesWorkspaceReorder
         // Bound outside the member-wise init: the ternary between `nil` and a
         // closure literal inside this large expression overwhelms the type
         // checker ("failed to produce diagnostic").
@@ -75,7 +73,11 @@ extension WorkspaceListView {
                     openWorkspaceChanges(workspace)
                 }
         return WorkspaceListTable(
-            items: workspaceTableItems(groupedItems: groupedItems),
+            items: workspaceTableItems(
+                groupedItems: groupedItems,
+                displayedFlatWorkspaces: displayedFlatWorkspaces,
+                showsFilterEmptyRow: showsFilterEmptyRow
+            ),
             workspacesByID: workspacesByID,
             groupsByID: groupsByID,
             groupHasUnreadByID: workspaceTableGroupHasUnreadByID(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -270,8 +270,12 @@ struct WorkspaceListView: View {
     /// scope keeps that Mac's own order — the sort exists to make the
     /// cross-computer order deterministic, not to rewrite one Mac's sidebar.
     var appliesRecencySort: Bool {
+        appliesRecencySort(visibleSelection: visibleMacSelection)
+    }
+
+    func appliesRecencySort(visibleSelection: WorkspaceMacSelection) -> Bool {
         guard workspaceSortMode == .recentActivity else { return false }
-        switch visibleMacSelection {
+        switch visibleSelection {
         case .all, .automatic:
             return true
         case .machine:
@@ -395,8 +399,19 @@ struct WorkspaceListView: View {
 
     /// Filtered workspaces for flat presentation, pinned first and otherwise stable.
     var filteredWorkspaces: [MobileWorkspacePreview] {
+        filteredWorkspaces(
+            activeFilter: activeFilter,
+            appliesRecencySort: appliesRecencySort
+        )
+    }
+
+    /// Input-threaded variant for `body`, which resolves the active filter and
+    /// recency flag once per evaluation instead of once per caller.
+    func filteredWorkspaces(
+        activeFilter currentFilter: MobileWorkspaceListFilter,
+        appliesRecencySort: Bool
+    ) -> [MobileWorkspacePreview] {
         let query = trimmedQuery
-        let currentFilter = activeFilter
         let parsedMachines = MobileWorkspaceListFilter.parsedMachineEntries(
             currentFilter.machines
         )
@@ -466,7 +481,12 @@ struct WorkspaceListView: View {
     }
 
     var groupedWorkspaces: [MobileWorkspacePreview] {
-        let currentFilter = activeFilter
+        groupedWorkspaces(activeFilter: activeFilter)
+    }
+
+    func groupedWorkspaces(
+        activeFilter currentFilter: MobileWorkspaceListFilter
+    ) -> [MobileWorkspacePreview] {
         let parsedMachines = MobileWorkspaceListFilter.parsedMachineEntries(
             currentFilter.machines
         )
@@ -476,9 +496,19 @@ struct WorkspaceListView: View {
     }
 
     var body: some View {
-        let currentMachineSnapshots = liveMachineSnapshots
-        let currentVisibleMacSelection = visibleMacSelection
-        let currentFilterMenuPresentMachineIDs = filterMenuPresentMachineIDs
+        // One selection scope, active filter, and filtered/grouped projection
+        // per body evaluation. Before this hoist each was a computed property
+        // re-resolved by every caller, so a single pass rebuilt the scope
+        // ~10x and re-filtered/re-sorted the workspaces up to 5x — pure
+        // main-thread overhead on every live list emission.
+        let currentScope = macSelectionScope
+        let currentMachineSnapshots = liveMachineSnapshots(scope: currentScope)
+        let currentVisibleMacSelection = currentScope.visibleSelection
+        let currentFilterMenuPresentMachineIDs = filterMenuPresentMachineIDs(scope: currentScope)
+        let currentActiveFilter = currentScope.activeFilter(base: filter)
+        let currentAppliesRecencySort = appliesRecencySort(
+            visibleSelection: currentVisibleMacSelection
+        )
         let displayedMachineSnapshots = machineSnapshots ?? currentMachineSnapshots
         let displayedFilterMachines = filterMenuMachines(
             machineSnapshots: displayedMachineSnapshots,
@@ -488,8 +518,14 @@ struct WorkspaceListView: View {
         // Keep displayed and authoritative caches separate so a pending
         // optimistic drag cannot evict the rendered projection on every pass.
         let currentGroupedWorkspaces = rendersGroupedSections
-            ? groupedWorkspaces
+            ? groupedWorkspaces(activeFilter: currentActiveFilter)
             : []
+        let currentFilteredWorkspaces = rendersGroupedSections
+            ? []
+            : filteredWorkspaces(
+                activeFilter: currentActiveFilter,
+                appliesRecencySort: currentAppliesRecencySort
+            )
         let currentDisplayedGroupedWorkspaces = rendersGroupedSections
             ? (optimisticGroupedState.optimisticOrder?
                 .materializedWorkspaces(from: currentGroupedWorkspaces)
@@ -499,12 +535,12 @@ struct WorkspaceListView: View {
             ? displayedGroupedProjectionCache.items(
                 workspaces: currentDisplayedGroupedWorkspaces,
                 groups: groups,
-                appliesRecencySort: appliesRecencySort
+                appliesRecencySort: currentAppliesRecencySort
             )
             : []
-        let currentFilteredWorkspaceOrderKey = rendersGroupedSections
-            ? []
-            : filteredWorkspaceOrderKey
+        let currentFilteredWorkspaceOrderKey = currentFilteredWorkspaces.map {
+            WorkspaceListStableOrderKey(workspace: $0)
+        }
         // Reconciliation must observe the authoritative host order while an
         // optimistic drag is pending. Once optimism clears, the displayed and
         // authoritative projections are identical, so reuse the render snapshot.
@@ -514,7 +550,7 @@ struct WorkspaceListView: View {
                 : authoritativeGroupedProjectionCache.items(
                     workspaces: currentGroupedWorkspaces,
                     groups: groups,
-                    appliesRecencySort: appliesRecencySort
+                    appliesRecencySort: currentAppliesRecencySort
                 ))
             : []
         let currentGroupedWorkspaceOrderKey = currentAuthoritativeGroupedListItems.map {
@@ -525,9 +561,31 @@ struct WorkspaceListView: View {
             uniquingKeysWith: { first, _ in first }
         )
         #if os(iOS)
+        let currentEnablesReorder = enablesWorkspaceReorder(
+            canMutateForegroundGroups: canMutateForegroundGroupsForSelection(scope: currentScope),
+            appliesRecencySort: currentAppliesRecencySort,
+            reorderableWorkspaces: rendersGroupedSections
+                ? currentGroupedWorkspaces
+                : currentFilteredWorkspaces,
+            flatContainsPinned: rendersGroupedSections
+                ? false
+                : currentFilteredWorkspaces.contains(where: \.isPinned)
+        )
         let baseList = workspaceTable(
             groupedItems: currentDisplayedGroupedListItems,
-            workspacesByID: currentWorkspacesByID
+            workspacesByID: currentWorkspacesByID,
+            activeFilter: currentActiveFilter,
+            displayedFlatWorkspaces: rendersGroupedSections
+                ? []
+                : (optimisticFlatState.optimisticOrder?
+                    .materializedWorkspaces(from: currentFilteredWorkspaces)
+                    ?? currentFilteredWorkspaces),
+            showsFilterEmptyRow: !rendersGroupedSections
+                && currentActiveFilter.isActive
+                && trimmedQuery.isEmpty
+                && currentFilteredWorkspaces.isEmpty
+                && !workspaces.isEmpty,
+            enablesReorder: currentEnablesReorder
         )
             .modifier(WorkspaceListBarUnderlap())
         #else


### PR DESCRIPTION
Occasional workspace-list lag on iOS correlates with live agent churn: the Mac emits list updates up to once per 80ms, and each emission taxed the main actor even when nothing visible changed. This lands the strictly non-regressing tier of the fix (same rendered output, less work); the UIKit apply-mechanics tier (batch updates instead of `reloadData`, changes-chip height-key quantization) is deliberately deferred.

What each emission used to cost on the main actor, and what changed:

- **JSON decode on the main actor** (`mobile.sync.delta`, `mobile.sync.fetch`, `mobile.workspace.list`): now decoded via `Task.detached` (the notification-feed decode pattern). Post-await guards re-validate client identity, connection, fetch generation, and sync authority, so a client swap or account reset mid-decode drops the stale payload.
- **One full mirror projection per delta**: projections now coalesce behind a 16ms injected-clock window. The mirror stays delta-exact (gap detection unchanged); a burst costs one projection. Fetch-path projections remain synchronous and absorb any pending delta scope, so pull-to-refresh semantics and changes-summary refreshes are unchanged.
- **Observation invalidation for no-op writes**: `workspacesByMac` writes (secondary snapshot publish, unavailable downgrade, capability refresh, optimistic no-op) and the derived `workspaces`/`workspaceGroups` assignments are equality-guarded, so an identical emission no longer re-renders every list observer.
- **One browser-panel RPC per `workspace.updated`**: `refreshVisibleMobileBrowserPanels` is single-flight with one trailing rerun (newest workspace wins), converging to the same final state without stacking RPCs on the control transport during bursts.
- **4-6 redundant filter/sort passes and ~10 `WorkspaceMacSelectionScope` rebuilds per SwiftUI body evaluation**: `WorkspaceListView.body` now computes one scope, one active filter, one filtered projection, and one grouped projection per pass and threads them into the UIKit table config. The computed properties remain as thin wrappers so event handlers and the macOS preview path are byte-for-byte identical in behavior.

No functionality is removed and no user-visible behavior changes; the one flagged tradeoff is the 16ms projection window, which delays a delta's render by at most one frame.

Tests: `MobileShellListEmissionCoalescingTests` (burst → exactly one projection with newest content, flush-loop teardown; no-op mutation → no topology bump, real mutation still propagates; 5-event burst → exactly 1 in-flight + 1 trailing browser RPC via a new deterministic router hold) plus the existing `MobileShellStateSyncTests` suite (negotiation, gap repair, legacy fallback, eviction) — 11/11 green locally via `swift test`.

HIG note: no UI addition or visual change (perf plumbing only), so no HIG page applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790142837&installation_model_id=21920&pr_number=10635&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10635&signature=f4f15f58b103f78d9a57872da1cbf2add31bb2ef31ab08fadbc7f0afb2e99655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts iOS workspace-list main-thread load by moving JSON decode off-main, coalescing delta projections, deduping state derivations, and single‑flighting browser-panel refreshes. Old behavior: per-emission main-thread decode, one projection per delta, redundant state writes, and one RPC per workspace.updated; new behavior: off-main decode, at most one projection per 16ms window, equality-guarded writes, and one in-flight RPC with a trailing rerun. UI output is identical; during bursts a delta may render up to one frame (≤16ms) later.

- Off-main JSON decoding for mobile.sync.delta, mobile.sync.fetch, and mobile.workspace.list via nonisolated helpers on `MobileShellComposite`; post-await guards re-validate client, connection, fetch generation, and sync authority; cancellation-safe. Delta handler is async to preserve ordering while decoding off-main.
- Delta projection coalescing: 16ms injected `stateSyncProjectionClock` window; mirror stays delta-exact; synchronous fetch projections absorb any pending delta scope. Flush task cancels on teardown/client swap.
- Eliminates no-op emission churn: equality-guarded writes to workspacesByMac and deduped assignments of derived workspaces and workspaceGroups.
- Browser-panel refresh is single-flight with one trailing rerun; newest workspace wins. Cancels on client swap/teardown so an outgoing client cannot occupy the slot or issue a stale rerun.
- WorkspaceListView computes selection scope, active filter, and filtered/grouped projections once per body pass and threads them into the table config; event handlers and macOS preview behavior are unchanged.
- Tests: MobileShellListEmissionCoalescingTests cover burst coalescing, no-op mutation guarding, and RPC single-flight; existing state sync tests remain green. No migration or UI changes.

<sup>Written for commit e8fdc7fbf0fa54f0b72a043904bd1a20c92b3876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved workspace and browser-panel updates by combining rapid successive refreshes and state changes.
  * Moved data processing off the main interface thread for a more responsive app.

* **Reliability**
  * Prevented stale workspace or state updates when connections, requests, or sessions change.
  * Improved cancellation handling during workspace synchronization and recovery.

* **UI Improvements**
  * Workspace filtering, grouping, sorting, and reordering now use consistent results during each update.
  * Avoided unnecessary interface refreshes when workspace values have not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->