### PR TITLE
iOS markdown parity: render docs with the shared markdown-viewer web shell

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownRemoteImageLoader.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownRemoteImageLoader.swift
@@ -3,16 +3,21 @@ import Foundation
 import Network
 import Security
 
-struct MarkdownRemoteImageFetchResult {
-    let data: Data
-    let mimeType: String
+public struct MarkdownRemoteImageFetchResult: Sendable {
+    public let data: Data
+    public let mimeType: String
+
+    public init(data: Data, mimeType: String) {
+        self.data = data
+        self.mimeType = mimeType
+    }
 }
 
-enum MarkdownRemoteImageSecurity {
-    static let maximumRemoteImageBytes = 8 * 1024 * 1024
+public enum MarkdownRemoteImageSecurity {
+    public static let maximumRemoteImageBytes = 8 * 1024 * 1024
 
-    static func remoteImageURL(from requestURL: URL) -> URL? {
-        guard requestURL.scheme?.lowercased() == MarkdownWebRenderer.remoteImageURLScheme,
+    public static func remoteImageURL(from requestURL: URL) -> URL? {
+        guard requestURL.scheme?.lowercased() == MarkdownWebViewerScheme.remoteImage,
               let components = URLComponents(url: requestURL, resolvingAgainstBaseURL: false),
               let rawRemoteURL = components.queryItems?.first(where: { $0.name == "url" })?.value,
               let remoteURL = URL(string: rawRemoteURL),
@@ -22,11 +27,11 @@ enum MarkdownRemoteImageSecurity {
         return remoteURL
     }
 
-    static func isPotentiallySafeRemoteImageURL(_ url: URL) -> Bool {
+    public static func isPotentiallySafeRemoteImageURL(_ url: URL) -> Bool {
         isSafeRemoteImageURL(url, resolveHost: false)
     }
 
-    static func isSafeRemoteImageURL(_ url: URL, resolveHost: Bool = true) -> Bool {
+    public static func isSafeRemoteImageURL(_ url: URL, resolveHost: Bool = true) -> Bool {
         guard url.scheme?.lowercased() == "https",
               url.user == nil,
               url.password == nil,
@@ -38,7 +43,7 @@ enum MarkdownRemoteImageSecurity {
         return !resolveHost || hostResolvesOnlyToAllowedAddresses(host)
     }
 
-    static func pinnedFetchTargets(for url: URL) -> [MarkdownRemoteImageFetchTarget] {
+    public static func pinnedFetchTargets(for url: URL) -> [MarkdownRemoteImageFetchTarget] {
         guard isPotentiallySafeRemoteImageURL(url),
               let host = url.host(percentEncoded: false),
               let endpoints = resolvedAllowedEndpoints(for: host),
@@ -50,7 +55,7 @@ enum MarkdownRemoteImageSecurity {
         }
     }
 
-    static func pathAndQuery(for url: URL) -> String {
+    public static func pathAndQuery(for url: URL) -> String {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         var value = components?.percentEncodedPath.isEmpty == false ? components?.percentEncodedPath ?? "/" : "/"
         if let query = components?.percentEncodedQuery, !query.isEmpty {
@@ -59,7 +64,7 @@ enum MarkdownRemoteImageSecurity {
         return value
     }
 
-    static func requestBytes(for url: URL, host: String) -> Data? {
+    public static func requestBytes(for url: URL, host: String) -> Data? {
         guard let hostHeader = httpHostHeaderValue(for: host) else { return nil }
         let request = [
             "GET \(pathAndQuery(for: url)) HTTP/1.1",
@@ -73,7 +78,7 @@ enum MarkdownRemoteImageSecurity {
         return request.data(using: .utf8)
     }
 
-    static func remoteImageConsentHost(for url: URL) -> String? {
+    public static func remoteImageConsentHost(for url: URL) -> String? {
         guard isPotentiallySafeRemoteImageURL(url),
               let host = url.host(percentEncoded: false) else {
             return nil
@@ -82,7 +87,7 @@ enum MarkdownRemoteImageSecurity {
         return normalized.isEmpty ? nil : normalized
     }
 
-    static func canonicalImageMIMEType(_ raw: String?) -> String? {
+    public static func canonicalImageMIMEType(_ raw: String?) -> String? {
         let mimeType = String(raw ?? "")
             .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
             .first?
@@ -269,15 +274,22 @@ enum MarkdownRemoteImageSecurity {
     }
 }
 
-struct MarkdownRemoteImageFetchTarget {
-    let url: URL
-    let serverName: String
-    let endpointHost: NWEndpoint.Host
-    let port: UInt16
+public struct MarkdownRemoteImageFetchTarget: Sendable {
+    public let url: URL
+    public let serverName: String
+    public let endpointHost: NWEndpoint.Host
+    public let port: UInt16
+
+    init(url: URL, serverName: String, endpointHost: NWEndpoint.Host, port: UInt16) {
+        self.url = url
+        self.serverName = serverName
+        self.endpointHost = endpointHost
+        self.port = port
+    }
 }
 
-enum MarkdownRemoteImageFetcher {
-    static func fetch(_ url: URL) async -> MarkdownRemoteImageFetchResult? {
+public enum MarkdownRemoteImageFetcher {
+    public static func fetch(_ url: URL) async -> MarkdownRemoteImageFetchResult? {
         guard !Task.isCancelled,
               let approvedHost = MarkdownRemoteImageSecurity.remoteImageConsentHost(for: url) else {
             return nil
@@ -328,7 +340,9 @@ private enum MarkdownRemoteImageLoadOutcome {
     case redirect(URL)
 }
 
-private final class MarkdownPinnedRemoteImageLoader {
+/// Thread-safe by construction: all mutable state is guarded by `lock` and
+/// connection callbacks run on the private serial `queue`.
+private final class MarkdownPinnedRemoteImageLoader: @unchecked Sendable {
     private let maximumBytes: Int
     private let target: MarkdownRemoteImageFetchTarget
     private let lock = NSLock()
@@ -598,8 +612,8 @@ private final class MarkdownPinnedRemoteImageLoader {
     }
 }
 
-enum MarkdownHTTPChunkedBodyDecoder {
-    static func decode(_ data: Data, maximumBytes: Int) -> Data? {
+public enum MarkdownHTTPChunkedBodyDecoder {
+    public static func decode(_ data: Data, maximumBytes: Int) -> Data? {
         let bytes = Array(data)
         var offset = 0
         var decoded = Data()

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownViewerAssetCompression.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownViewerAssetCompression.swift
@@ -1,0 +1,59 @@
+import Foundation
+import zlib
+
+/// Inflates the zlib-deflated markdown viewer JS assets produced by
+/// `scripts/compress-markdown-viewer-assets.sh` at build time. Shared by the
+/// macOS and iOS asset loaders so both bundles use the identical format.
+public enum MarkdownViewerAssetCompression {
+    public static func inflate(_ data: Data) -> Data? {
+        guard !data.isEmpty else {
+            return Data()
+        }
+
+        var stream = z_stream()
+        let initResult = inflateInit_(
+            &stream,
+            ZLIB_VERSION,
+            Int32(MemoryLayout<z_stream>.size)
+        )
+        guard initResult == Z_OK else {
+            return nil
+        }
+        defer { inflateEnd(&stream) }
+
+        return data.withUnsafeBytes { inputBuffer in
+            guard let inputBase = inputBuffer.bindMemory(to: Bytef.self).baseAddress else {
+                return nil
+            }
+            stream.next_in = UnsafeMutablePointer<Bytef>(mutating: inputBase)
+            stream.avail_in = uInt(data.count)
+
+            var output = Data()
+            let chunkSize = 64 * 1024
+            var chunk = [UInt8](repeating: 0, count: chunkSize)
+
+            while true {
+                let result = chunk.withUnsafeMutableBytes { outputBuffer -> Int32 in
+                    stream.next_out = outputBuffer.bindMemory(to: Bytef.self).baseAddress
+                    stream.avail_out = uInt(chunkSize)
+                    return zlib.inflate(&stream, Z_NO_FLUSH)
+                }
+
+                let produced = chunkSize - Int(stream.avail_out)
+                if produced > 0 {
+                    output.append(chunk, count: produced)
+                }
+
+                if result == Z_STREAM_END {
+                    return output
+                }
+                if result != Z_OK {
+                    return nil
+                }
+                if stream.avail_in == 0 && produced == 0 {
+                    return nil
+                }
+            }
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownWebViewerScheme.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/MarkdownViewer/MarkdownWebViewerScheme.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Custom WKWebView URL schemes used by the shared markdown viewer shell.
+///
+/// The shell (`Resources/markdown-viewer/shell.html`) rewrites image sources
+/// to these schemes so the host app mediates every image byte: local images
+/// stay confined to the markdown file's directory and remote images go
+/// through the consent-gated HTTPS-only loader. Both the macOS panel and the
+/// iOS renderer register handlers for the same scheme strings.
+public enum MarkdownWebViewerScheme {
+    public static let localImage = "cmux-local-image"
+    public static let remoteImage = "cmux-remote-image"
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/MarkdownViewerAssetCompressionTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/MarkdownViewerAssetCompressionTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+import zlib
+
+@testable import CmuxAgentChat
+
+@Suite("Markdown viewer asset compression")
+struct MarkdownViewerAssetCompressionTests {
+    @Test("inflates zlib-deflated assets back to the original bytes")
+    func roundTripsDeflatedAsset() throws {
+        let original = Data(String(repeating: "window.__cmuxRenderMarkdown = function(md) {};\n", count: 500).utf8)
+        let deflated = try deflate(original)
+        #expect(deflated.count < original.count)
+
+        let inflated = MarkdownViewerAssetCompression.inflate(deflated)
+        #expect(inflated == original)
+    }
+
+    @Test("empty input inflates to empty output")
+    func emptyInput() {
+        #expect(MarkdownViewerAssetCompression.inflate(Data()) == Data())
+    }
+
+    @Test("garbage input fails instead of returning partial bytes")
+    func garbageInput() {
+        #expect(MarkdownViewerAssetCompression.inflate(Data([0xDE, 0xAD, 0xBE, 0xEF])) == nil)
+    }
+
+    private func deflate(_ data: Data) throws -> Data {
+        var destinationLength = uLong(compressBound(uLong(data.count)))
+        var destination = [UInt8](repeating: 0, count: Int(destinationLength))
+        let status = data.withUnsafeBytes { source -> Int32 in
+            guard let base = source.bindMemory(to: Bytef.self).baseAddress else { return Z_BUF_ERROR }
+            return compress2(&destination, &destinationLength, base, uLong(data.count), 9)
+        }
+        try #require(status == Z_OK)
+        return Data(destination.prefix(Int(destinationLength)))
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
@@ -16,7 +16,7 @@ struct ChatArtifactMarkdownView: View {
     @Environment(\.openURL) private var openURL
 
     var body: some View {
-        if MarkdownWebViewerAssets.shared.isAvailable {
+        if MarkdownWebViewerAssets.shared.isUsable {
             MarkdownWebContentView(
                 markdown: markdown,
                 theme: .resolve(isDark: colorScheme == .dark),

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
@@ -1,8 +1,63 @@
 import Foundation
 import SwiftUI
 
-/// Renders document-level Markdown with Foundation's native syntax support.
+/// Renders document-level Markdown.
+///
+/// Preferred path is the shared cmux markdown-viewer web shell (identical
+/// pipeline to the macOS markdown panel: marked.js + highlight.js + GitHub
+/// CSS + mermaid/vega). When the host bundle lacks the viewer assets
+/// (unit-test hosts, previews) it falls back to the native block renderer.
 struct ChatArtifactMarkdownView: View {
+    let markdown: String
+
+#if canImport(UIKit)
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        if MarkdownWebViewerAssets.shared.isAvailable {
+            MarkdownWebContentView(
+                markdown: markdown,
+                theme: .resolve(isDark: colorScheme == .dark),
+                pageZoom: Self.pageZoom(for: dynamicTypeSize),
+                openURL: openURL
+            )
+            .ignoresSafeArea(.keyboard)
+        } else {
+            ChatArtifactMarkdownNativeView(markdown: markdown)
+        }
+    }
+
+    /// Maps the reader's Dynamic Type size onto a page zoom so the shell's
+    /// 16px GitHub typography tracks the system body text size (17pt = 1.0).
+    static func pageZoom(for size: DynamicTypeSize) -> CGFloat {
+        let bodyPointSize: CGFloat = switch size {
+        case .xSmall: 14
+        case .small: 15
+        case .medium: 16
+        case .large: 17
+        case .xLarge: 19
+        case .xxLarge: 21
+        case .xxxLarge: 23
+        case .accessibility1: 28
+        case .accessibility2: 33
+        case .accessibility3: 40
+        case .accessibility4: 47
+        case .accessibility5: 53
+        @unknown default: 17
+        }
+        return bodyPointSize / 17
+    }
+#else
+    var body: some View {
+        ChatArtifactMarkdownNativeView(markdown: markdown)
+    }
+#endif
+}
+
+/// Native fallback renderer built on Foundation's inline markdown support.
+struct ChatArtifactMarkdownNativeView: View {
     let markdown: String
 
     var body: some View {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebContentView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebContentView.swift
@@ -207,10 +207,16 @@ struct MarkdownWebContentView: UIViewRepresentable {
         }
 
         private static func renderMarkdownScript(_ markdown: String) -> String? {
-            guard let data = try? JSONSerialization.data(withJSONObject: [markdown]),
+            let failureMessage = String(
+                localized: "markdown.web.rendererInitFailed",
+                defaultValue: "Markdown renderer failed to initialize. Showing raw source.",
+                bundle: .module
+            )
+            guard let data = try? JSONSerialization.data(withJSONObject: [markdown, failureMessage]),
                   let arrayLiteral = String(data: data, encoding: .utf8) else { return nil }
             return """
-            (function(md) {
+            (function(args) {
+              var md = args[0];
               if (window.__cmuxRenderMarkdown) {
                 window.__cmuxRenderMarkdown(md);
                 return;
@@ -221,8 +227,8 @@ struct MarkdownWebContentView: UIViewRepresentable {
                 div.textContent = String(s == null ? '' : s);
                 return div.innerHTML;
               }
-              el.innerHTML = '<pre style=\"color:#f85149;white-space:pre-wrap\">Markdown renderer failed to initialize. Showing raw source.\\n\\n' + esc(md) + '</pre>';
-            })(\(arrayLiteral)[0]);
+              el.innerHTML = '<pre style=\"color:#f85149;white-space:pre-wrap\">' + esc(args[1]) + '\\n\\n' + esc(md) + '</pre>';
+            })(\(arrayLiteral));
             """
         }
 
@@ -258,41 +264,42 @@ struct MarkdownWebContentView: UIViewRepresentable {
         }
 
         private func handleLibRequest(_ lib: String) {
-            guard let webView else { return }
             if requestedLibs.contains(lib) { return }
             requestedLibs.insert(lib)
 
-            let assets = MarkdownWebViewerAssets.shared
-            let sources: [String?]
+            let specs: [(name: String, ext: String)]
             switch lib {
             case "mermaid":
-                sources = [assets.asset(name: "mermaid.min", ext: "js")]
+                specs = [("mermaid.min", "js")]
             case "vega-lite":
-                sources = [
-                    assets.asset(name: "vega.min", ext: "js"),
-                    assets.asset(name: "vega-lite.min", ext: "js"),
-                    assets.asset(name: "vega-embed.min", ext: "js"),
-                ]
+                specs = [("vega.min", "js"), ("vega-lite.min", "js"), ("vega-embed.min", "js")]
             default:
                 return
             }
 
-            var injection = ""
-            for case let src? in sources where !src.isEmpty {
-                injection += src
-                injection += "\n;"
-            }
-            guard !injection.isEmpty else {
-                requestedLibs.remove(lib)
-                return
-            }
-            let libLiteral = (try? JSONSerialization.data(withJSONObject: [lib]))
-                .flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
-            let suffix = "\nwindow.__cmuxLibLoaded && window.__cmuxLibLoaded(\(libLiteral)[0]);"
-            webView.evaluateJavaScript(injection + suffix) { [weak self] _, error in
-                if error != nil {
-                    Task { @MainActor [weak self] in
-                        self?.requestedLibs.remove(lib)
+            // The diagram bundles are megabytes; read and inflate them off the
+            // main actor, then inject on main.
+            Task { [weak self] in
+                guard let sources = await MarkdownWebViewerAssets.shared.assets(specs),
+                      sources.contains(where: { !$0.isEmpty }) else {
+                    self?.requestedLibs.remove(lib)
+                    return
+                }
+                guard let self, let webView = self.webView else { return }
+
+                var injection = ""
+                for src in sources where !src.isEmpty {
+                    injection += src
+                    injection += "\n;"
+                }
+                let libLiteral = (try? JSONSerialization.data(withJSONObject: [lib]))
+                    .flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
+                let suffix = "\nwindow.__cmuxLibLoaded && window.__cmuxLibLoaded(\(libLiteral)[0]);"
+                webView.evaluateJavaScript(injection + suffix) { [weak self] _, error in
+                    if error != nil {
+                        Task { @MainActor [weak self] in
+                            self?.requestedLibs.remove(lib)
+                        }
                     }
                 }
             }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebContentView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebContentView.swift
@@ -1,0 +1,462 @@
+#if canImport(UIKit)
+import CmuxAgentChat
+import SwiftUI
+import UIKit
+import WebKit
+
+/// Renders document markdown with the shared cmux markdown-viewer web shell —
+/// the same marked.js + highlight.js + GitHub CSS pipeline as the macOS
+/// markdown panel, so both platforms produce identical documents.
+///
+/// iOS deviations from the macOS coordinator: there is no backing file on the
+/// phone, so `.md` link resolution answers "missing" (links degrade to inert
+/// text) and local relative images stay unresolved. Remote images keep the
+/// consent-gated HTTPS-only loader. Activated links leave through the system
+/// opener.
+struct MarkdownWebContentView: UIViewRepresentable {
+    let markdown: String
+    let theme: MarkdownWebTheme
+    /// Body zoom factor derived from the reader's Dynamic Type size.
+    let pageZoom: CGFloat
+    let openURL: OpenURLAction
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.suppressesIncrementalRendering = false
+        config.userContentController.add(
+            MarkdownWebWeakScriptMessageHandler(context.coordinator),
+            name: "cmuxLib"
+        )
+        config.setURLSchemeHandler(context.coordinator, forURLScheme: MarkdownWebViewerScheme.localImage)
+        config.setURLSchemeHandler(context.coordinator, forURLScheme: MarkdownWebViewerScheme.remoteImage)
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.allowsBackForwardNavigationGestures = false
+        webView.allowsLinkPreview = false
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+#if DEBUG
+        webView.isInspectable = true
+#endif
+        webView.overrideUserInterfaceStyle = theme.isDark ? .dark : .light
+
+        context.coordinator.webView = webView
+        context.coordinator.openURL = openURL
+        context.coordinator.setPageZoom(pageZoom)
+        context.coordinator.loadShell(theme: theme, initialMarkdown: markdown)
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.openURL = openURL
+        webView.overrideUserInterfaceStyle = theme.isDark ? .dark : .light
+        context.coordinator.setPageZoom(pageZoom)
+        context.coordinator.update(markdown: markdown, theme: theme)
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.close()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, @preconcurrency WKNavigationDelegate, @preconcurrency WKUIDelegate,
+        @preconcurrency WKScriptMessageHandler, @preconcurrency WKURLSchemeHandler {
+        weak var webView: WKWebView?
+        var openURL: OpenURLAction?
+
+        private var pendingMarkdown: String = ""
+        private var pendingTheme: MarkdownWebTheme = .resolve(isDark: false)
+        private var lastMarkdown: String?
+        private var lastTheme: MarkdownWebTheme?
+        private var lastPageZoom: CGFloat = 1
+        private var isLoaded = false
+        private var isShellLoading = false
+        private var webContentProcessRecoveryAttempts = 0
+        private let maxWebContentProcessRecoveryAttempts = 2
+        private var requestedLibs: Set<String> = []
+
+        private final class ImageLoad {
+            var reader: Task<MarkdownRemoteImageFetchResult?, Never>?
+            var sender: Task<Void, Never>?
+
+            func cancel() {
+                reader?.cancel()
+                sender?.cancel()
+            }
+        }
+        private var imageLoads: [ObjectIdentifier: ImageLoad] = [:]
+
+        func close() {
+            if let webView {
+                webView.stopLoading()
+                webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
+                webView.navigationDelegate = nil
+                webView.uiDelegate = nil
+            }
+            webView = nil
+            isLoaded = false
+            isShellLoading = false
+            webContentProcessRecoveryAttempts = 0
+            requestedLibs.removeAll()
+            cancelImageLoads()
+        }
+
+        func loadShell(theme: MarkdownWebTheme, initialMarkdown: String) {
+            pendingMarkdown = initialMarkdown
+            pendingTheme = theme
+            lastTheme = theme
+            requestedLibs.removeAll()
+            isLoaded = false
+            guard let html = MarkdownWebViewerAssets.shared.shellHTML() else {
+                isShellLoading = false
+                return
+            }
+            isShellLoading = true
+            webView?.loadHTMLString(html, baseURL: nil)
+        }
+
+        func update(markdown: String, theme: MarkdownWebTheme) {
+            let themeChanged = lastTheme != theme
+            let contentChanged = lastMarkdown != markdown
+            let shellNeedsReload = !isLoaded && !isShellLoading
+            guard themeChanged || contentChanged || shellNeedsReload else { return }
+
+            pendingMarkdown = markdown
+            pendingTheme = theme
+
+            if themeChanged {
+                lastTheme = theme
+                if isLoaded {
+                    applyTheme(theme)
+                    if !contentChanged {
+                        pushMarkdown(lastMarkdown ?? pendingMarkdown)
+                    }
+                }
+            }
+
+            if contentChanged {
+                webContentProcessRecoveryAttempts = 0
+                lastMarkdown = markdown
+                if isLoaded {
+                    pushMarkdown(markdown)
+                } else if shellNeedsReload {
+                    loadShell(theme: theme, initialMarkdown: markdown)
+                }
+            } else if shellNeedsReload {
+                if webContentProcessRecoveryAttempts < maxWebContentProcessRecoveryAttempts {
+                    loadShell(theme: theme, initialMarkdown: markdown)
+                }
+            }
+        }
+
+        func setPageZoom(_ zoom: CGFloat) {
+            lastPageZoom = zoom
+            applyPageZoom()
+        }
+
+        private func applyPageZoom(forceShellSync: Bool = false) {
+            guard let webView else { return }
+            let zoom = lastPageZoom
+            let shouldSyncShell = forceShellSync || abs(webView.pageZoom - zoom) > 0.0001
+            if abs(webView.pageZoom - zoom) > 0.0001 { webView.pageZoom = zoom }
+            if shouldSyncShell {
+                webView.evaluateJavaScript(
+                    "window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)), \(Double(webView.bounds.width)));",
+                    completionHandler: nil
+                )
+            }
+        }
+
+        private func applyTheme(_ theme: MarkdownWebTheme) {
+            guard let webView else { return }
+            let payload = [
+                "--bgColor-default": theme.background,
+                "--bgColor-muted": theme.mutedBackground,
+                "--bgColor-neutral-muted": theme.neutralMutedBackground,
+                "--borderColor-default": theme.border,
+                "--borderColor-muted": theme.mutedBorder,
+                "--borderColor-neutral-muted": theme.mutedBorder
+            ]
+            guard let data = try? JSONSerialization.data(withJSONObject: payload),
+                  let json = String(data: data, encoding: .utf8) else { return }
+            let js = """
+            (function(vars) {
+              var content = document.getElementById('content');
+              if (!content) { return; }
+              Object.keys(vars).forEach(function(name) {
+                content.style.setProperty(name, vars[name]);
+              });
+              content.style.background = 'transparent';
+              if (window.__cmuxApplyTheme) { window.__cmuxApplyTheme(); }
+            })(\(json));
+            """
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
+
+        private func pushMarkdown(_ markdown: String) {
+            guard let webView else { return }
+            guard let js = Self.renderMarkdownScript(markdown) else { return }
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
+
+        private static func renderMarkdownScript(_ markdown: String) -> String? {
+            guard let data = try? JSONSerialization.data(withJSONObject: [markdown]),
+                  let arrayLiteral = String(data: data, encoding: .utf8) else { return nil }
+            return """
+            (function(md) {
+              if (window.__cmuxRenderMarkdown) {
+                window.__cmuxRenderMarkdown(md);
+                return;
+              }
+              var el = document.getElementById('content') || document.body;
+              function esc(s) {
+                var div = document.createElement('div');
+                div.textContent = String(s == null ? '' : s);
+                return div.innerHTML;
+              }
+              el.innerHTML = '<pre style=\"color:#f85149;white-space:pre-wrap\">Markdown renderer failed to initialize. Showing raw source.\\n\\n' + esc(md) + '</pre>';
+            })(\(arrayLiteral)[0]);
+            """
+        }
+
+        // MARK: WKScriptMessageHandler
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == "cmuxLib",
+                  let body = message.body as? [String: Any] else { return }
+            if let lib = body["lib"] as? String {
+                handleLibRequest(lib)
+                return
+            }
+            guard let action = body["action"] as? String else { return }
+            switch action {
+            case "resolveMarkdownFile":
+                // No backing file system on the phone: answer "missing" so
+                // `.md`-looking links stay inert instead of navigating.
+                guard let requestId = body["requestId"] as? String,
+                      let webView else { return }
+                let payload: [String: Any] = ["requestId": requestId, "exists": false, "path": ""]
+                guard let data = try? JSONSerialization.data(withJSONObject: payload),
+                      let json = String(data: data, encoding: .utf8) else { return }
+                webView.evaluateJavaScript(
+                    "window.__cmuxMarkdownFileResolved && window.__cmuxMarkdownFileResolved(\(json));",
+                    completionHandler: nil
+                )
+            default:
+                break
+            }
+        }
+
+        private func handleLibRequest(_ lib: String) {
+            guard let webView else { return }
+            if requestedLibs.contains(lib) { return }
+            requestedLibs.insert(lib)
+
+            let assets = MarkdownWebViewerAssets.shared
+            let sources: [String?]
+            switch lib {
+            case "mermaid":
+                sources = [assets.asset(name: "mermaid.min", ext: "js")]
+            case "vega-lite":
+                sources = [
+                    assets.asset(name: "vega.min", ext: "js"),
+                    assets.asset(name: "vega-lite.min", ext: "js"),
+                    assets.asset(name: "vega-embed.min", ext: "js"),
+                ]
+            default:
+                return
+            }
+
+            var injection = ""
+            for case let src? in sources where !src.isEmpty {
+                injection += src
+                injection += "\n;"
+            }
+            guard !injection.isEmpty else {
+                requestedLibs.remove(lib)
+                return
+            }
+            let libLiteral = (try? JSONSerialization.data(withJSONObject: [lib]))
+                .flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
+            let suffix = "\nwindow.__cmuxLibLoaded && window.__cmuxLibLoaded(\(libLiteral)[0]);"
+            webView.evaluateJavaScript(injection + suffix) { [weak self] _, error in
+                if error != nil {
+                    Task { @MainActor [weak self] in
+                        self?.requestedLibs.remove(lib)
+                    }
+                }
+            }
+        }
+
+        // MARK: WKURLSchemeHandler
+
+        func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+            guard let requestURL = urlSchemeTask.request.url else {
+                urlSchemeTask.didFailWithError(NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL))
+                return
+            }
+
+            let taskId = ObjectIdentifier(urlSchemeTask as AnyObject)
+            let load = ImageLoad()
+            imageLoads[taskId] = load
+
+            let reader: Task<MarkdownRemoteImageFetchResult?, Never>
+            if requestURL.scheme?.lowercased() == MarkdownWebViewerScheme.remoteImage,
+               let remoteURL = MarkdownRemoteImageSecurity.remoteImageURL(from: requestURL) {
+                reader = Task.detached(priority: .userInitiated) {
+                    await MarkdownRemoteImageFetcher.fetch(remoteURL)
+                }
+            } else {
+                // Local images cannot resolve on the phone — the document's
+                // files live on the Mac. Serve empty bytes so the shell's
+                // placeholder handling keeps the layout stable.
+                reader = Task { nil }
+            }
+            load.reader = reader
+
+            let sender = Task { [weak self, weak load] in
+                defer {
+                    if let load, self?.imageLoads[taskId] === load {
+                        self?.imageLoads[taskId] = nil
+                    }
+                }
+                let result = await reader.value
+                guard !Task.isCancelled else { return }
+                let data = result?.data ?? Data()
+                let response = URLResponse(
+                    url: requestURL,
+                    mimeType: result?.mimeType ?? "image/png",
+                    expectedContentLength: data.count,
+                    textEncodingName: nil
+                )
+                urlSchemeTask.didReceive(response)
+                if !data.isEmpty {
+                    urlSchemeTask.didReceive(data)
+                }
+                urlSchemeTask.didFinish()
+            }
+            load.sender = sender
+        }
+
+        func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+            let taskId = ObjectIdentifier(urlSchemeTask as AnyObject)
+            guard let load = imageLoads.removeValue(forKey: taskId) else { return }
+            load.cancel()
+        }
+
+        private func cancelImageLoads() {
+            let loads = imageLoads.values
+            imageLoads.removeAll()
+            for load in loads {
+                load.cancel()
+            }
+        }
+
+        // MARK: WKNavigationDelegate
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isShellLoading = false
+            isLoaded = true
+            applyPageZoom(forceShellSync: true)
+            applyTheme(lastTheme ?? pendingTheme)
+            let md = lastMarkdown ?? pendingMarkdown
+            lastMarkdown = md
+            pushMarkdown(md)
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            handleShellNavigationFailure()
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            handleShellNavigationFailure()
+        }
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            guard let currentWebView = self.webView, currentWebView === webView else { return }
+            isShellLoading = false
+            guard webContentProcessRecoveryAttempts < maxWebContentProcessRecoveryAttempts else {
+                isLoaded = false
+                requestedLibs.removeAll()
+                return
+            }
+            webContentProcessRecoveryAttempts += 1
+            loadShell(
+                theme: lastTheme ?? pendingTheme,
+                initialMarkdown: lastMarkdown ?? pendingMarkdown
+            )
+        }
+
+        private func handleShellNavigationFailure() {
+            guard isShellLoading else { return }
+            isShellLoading = false
+            isLoaded = false
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.navigationType == .linkActivated,
+               let url = navigationAction.request.url {
+                if MarkdownWebLinkPolicy.isInPageFragment(url) {
+                    decisionHandler(.allow)
+                    return
+                }
+                if let external = MarkdownWebLinkPolicy.externalURL(for: url) {
+                    openURL?(external)
+                }
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            if let url = navigationAction.request.url,
+               let external = MarkdownWebLinkPolicy.externalURL(for: url) {
+                openURL?(external)
+            }
+            return nil
+        }
+    }
+}
+
+/// Breaks the retain cycle between WKUserContentController and its message
+/// handler (the controller retains handlers strongly).
+private final class MarkdownWebWeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    private weak var delegate: (any WKScriptMessageHandler)?
+
+    init(_ delegate: any WKScriptMessageHandler) {
+        self.delegate = delegate
+        super.init()
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        delegate?.userContentController(userContentController, didReceive: message)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebLinkPolicy.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebLinkPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Classifies navigation targets inside the iOS markdown web renderer.
+///
+/// The shell is loaded with `loadHTMLString(_:baseURL: nil)`, so heading
+/// anchors resolve as `about:blank#fragment`; those must stay inside the
+/// WebView while every other activated link leaves the app through the
+/// system opener. Pure so it can be unit-tested without WebKit.
+enum MarkdownWebLinkPolicy {
+    /// Same-document fragment navigation (heading anchors) that the WebView
+    /// should perform natively.
+    static func isInPageFragment(_ url: URL) -> Bool {
+        guard url.fragment != nil else { return false }
+        if url.scheme == nil || url.scheme == "about" {
+            return (url.host ?? "").isEmpty
+        }
+        return false
+    }
+
+    /// Whether the system opener may handle an activated link. Anything the
+    /// phone can't represent (relative paths against about:blank) is dropped.
+    static func externalURL(for url: URL) -> URL? {
+        if isInPageFragment(url) { return nil }
+        guard let scheme = url.scheme?.lowercased(), !scheme.isEmpty, scheme != "about" else {
+            return nil
+        }
+        return url
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebTheme.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebTheme.swift
@@ -1,0 +1,129 @@
+#if canImport(UIKit)
+import UIKit
+
+/// CSS variable overrides pushed into the markdown shell so GitHub's
+/// stylesheet blends with the surrounding surface. Mirrors the macOS
+/// `MarkdownWebTheme`, resolved from the iOS system background instead of the
+/// terminal background.
+struct MarkdownWebTheme: Equatable {
+    let isDark: Bool
+    let background: String
+    let mutedBackground: String
+    let neutralMutedBackground: String
+    let border: String
+    let mutedBorder: String
+
+    static func resolve(isDark: Bool) -> MarkdownWebTheme {
+        let traits = UITraitCollection(userInterfaceStyle: isDark ? .dark : .light)
+        let base = UIColor.systemBackground.resolvedColor(with: traits).markdownOpaqueSRGB
+        let overlay: UIColor = isDark ? .white : .black
+        let muted = base.markdownThemeOverlay(
+            targetContrast: isDark ? 1.09 : 1.06,
+            of: overlay
+        )
+        let neutralMuted = base.markdownThemeOverlay(
+            targetContrast: isDark ? 1.35 : 1.20,
+            of: overlay
+        )
+        let border = base.markdownThemeOverlay(
+            targetContrast: isDark ? 1.92 : 1.43,
+            of: overlay
+        )
+        return MarkdownWebTheme(
+            isDark: isDark,
+            background: "transparent",
+            mutedBackground: muted.markdownCSSColor,
+            neutralMutedBackground: neutralMuted.markdownCSSColor,
+            border: border.markdownCSSColor,
+            mutedBorder: border.markdownWithAlphaScaled(0.70).markdownCSSColor
+        )
+    }
+}
+
+extension UIColor {
+    var markdownOpaqueSRGB: UIColor {
+        withAlphaComponent(1)
+    }
+
+    var markdownSRGBComponents: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 1
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (red, green, blue, alpha)
+    }
+
+    var markdownCSSColor: String {
+        let (red, green, blue, alpha) = markdownSRGBComponents
+        let r = min(255, max(0, Int((red * 255).rounded())))
+        let g = min(255, max(0, Int((green * 255).rounded())))
+        let b = min(255, max(0, Int((blue * 255).rounded())))
+        let a = min(1, max(0, alpha))
+        return String(format: "rgba(%d, %d, %d, %.3f)", r, g, b, Double(a))
+    }
+
+    func markdownWithAlphaScaled(_ factor: CGFloat) -> UIColor {
+        let (_, _, _, alpha) = markdownSRGBComponents
+        return withAlphaComponent(alpha * factor)
+    }
+
+    func markdownBlended(withFraction fraction: CGFloat, of other: UIColor) -> UIColor {
+        let a = markdownSRGBComponents
+        let b = other.markdownSRGBComponents
+        let f = min(1, max(0, fraction))
+        return UIColor(
+            red: a.red + (b.red - a.red) * f,
+            green: a.green + (b.green - a.green) * f,
+            blue: a.blue + (b.blue - a.blue) * f,
+            alpha: a.alpha + (b.alpha - a.alpha) * f
+        )
+    }
+
+    /// Finds the smallest overlay fraction of `color` whose blend against the
+    /// base reaches the target WCAG contrast ratio — same math as the macOS
+    /// theme so both platforms land on matching CSS variables.
+    func markdownThemeOverlay(targetContrast: CGFloat, of color: UIColor) -> UIColor {
+        let base = markdownOpaqueSRGB
+        let overlay = color.markdownOpaqueSRGB
+        var low: CGFloat = 0
+        var high: CGFloat = 1
+        var result: CGFloat = 1
+
+        for _ in 0..<18 {
+            let mid = (low + high) / 2
+            let candidate = base.markdownBlended(withFraction: mid, of: overlay)
+            if candidate.markdownContrastRatio(with: base) < Double(targetContrast) {
+                low = mid
+            } else {
+                high = mid
+                result = mid
+            }
+        }
+
+        return overlay.withAlphaComponent(result)
+    }
+
+    var markdownRelativeLuminance: Double {
+        let (red, green, blue, _) = markdownSRGBComponents
+
+        func linear(_ component: CGFloat) -> Double {
+            let value = Double(component)
+            if value <= 0.04045 {
+                return value / 12.92
+            }
+            return pow((value + 0.055) / 1.055, 2.4)
+        }
+
+        return (0.2126 * linear(red)) + (0.7152 * linear(green)) + (0.0722 * linear(blue))
+    }
+
+    func markdownContrastRatio(with other: UIColor) -> Double {
+        let first = markdownRelativeLuminance
+        let second = other.markdownRelativeLuminance
+        let lighter = max(first, second)
+        let darker = min(first, second)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebViewerAssets.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebViewerAssets.swift
@@ -1,0 +1,151 @@
+import CmuxAgentChat
+import Foundation
+
+/// Loads the bundled markdown web renderer assets from the app bundle's
+/// `markdown-viewer` directory — the same shell, marked.js, highlight.js, and
+/// GitHub CSS the macOS panel renders with, copied into the iOS app by its
+/// resources build phase.
+///
+/// Unlike the macOS loader this one is non-fatal: when the host app does not
+/// bundle the assets (unit-test hosts, previews), `isAvailable` is false and
+/// callers fall back to the native block renderer.
+@MainActor
+final class MarkdownWebViewerAssets {
+    static let shared = MarkdownWebViewerAssets(bundle: .main)
+
+    private let bundle: Bundle
+    private var cache: [String: String] = [:]
+
+    /// True when every asset the shell template splices in is present.
+    let isAvailable: Bool
+
+    init(bundle: Bundle) {
+        self.bundle = bundle
+        isAvailable = Self.requiredAssets.allSatisfy { name, ext in
+            Self.assetURL(name: name, ext: ext, bundle: bundle) != nil
+        }
+    }
+
+    private static let requiredAssets: [(String, String)] = [
+        ("shell", "html"),
+        ("marked.min", "js"),
+        ("highlight.min", "js"),
+        ("highlight-github", "css"),
+        ("highlight-github-dark", "css"),
+        ("github-markdown", "css"),
+        ("viewer-navigation", "js"),
+    ]
+
+    func shellHTML() -> String? {
+        guard isAvailable,
+              let shell = asset(name: "shell", ext: "html"),
+              let githubCSS = asset(name: "github-markdown", ext: "css"),
+              let highlightLight = asset(name: "highlight-github", ext: "css"),
+              let highlightDark = asset(name: "highlight-github-dark", ext: "css"),
+              let marked = asset(name: "marked.min", ext: "js"),
+              let highlight = asset(name: "highlight.min", ext: "js"),
+              let viewerNavigation = asset(name: "viewer-navigation", ext: "js") else {
+            return nil
+        }
+        return shell
+            .replacingOccurrences(of: "{{githubMarkdownCSS}}", with: githubCSS)
+            .replacingOccurrences(of: "{{highlightLightCSS}}", with: highlightLight)
+            .replacingOccurrences(of: "{{highlightDarkCSS}}", with: highlightDark)
+            .replacingOccurrences(of: "{{markedJS}}", with: marked)
+            .replacingOccurrences(of: "{{highlightJS}}", with: highlight)
+            .replacingOccurrences(of: "{{viewerNavigationJS}}", with: viewerNavigation)
+            .replacingOccurrences(of: "{{localizedStringsJSON}}", with: Self.localizedStringsJSON())
+    }
+
+    /// Load and cache a bundled asset on demand (mermaid / vega lazy libs).
+    func asset(name: String, ext: String) -> String? {
+        let key = "\(name).\(ext)"
+        if let cached = cache[key] {
+            return cached
+        }
+        guard let url = Self.assetURL(name: name, ext: ext, bundle: bundle),
+              let source = Self.loadAsset(url: url) else {
+            return nil
+        }
+        cache[key] = source
+        return source
+    }
+
+    private static func assetURL(name: String, ext: String, bundle: Bundle) -> URL? {
+        bundle.url(forResource: name, withExtension: "\(ext).deflate", subdirectory: "markdown-viewer")
+            ?? bundle.url(forResource: name, withExtension: "\(ext).deflate")
+            ?? bundle.url(forResource: name, withExtension: ext, subdirectory: "markdown-viewer")
+            ?? bundle.url(forResource: name, withExtension: ext)
+    }
+
+    private static func loadAsset(url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        if url.lastPathComponent.hasSuffix(".deflate") {
+            guard let inflated = MarkdownViewerAssetCompression.inflate(data) else { return nil }
+            return String(data: inflated, encoding: .utf8)
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Same keys and copy as the macOS viewer; localized from this package's
+    /// string catalog so the shell's remote-image consent UI reads correctly.
+    private static func localizedStringsJSON() -> String {
+        let strings = [
+            "remoteImageBlocked": String(
+                localized: "markdown.web.remoteImageBlocked",
+                defaultValue: "Remote image blocked",
+                bundle: .module
+            ),
+            "remoteImageConsentMessage": String(
+                localized: "markdown.web.remoteImageConsentMessage",
+                defaultValue: "cmux will not contact this image URL until you load this image.",
+                bundle: .module
+            ),
+            "remoteImageLoadImage": String(
+                localized: "markdown.web.remoteImageLoadImage",
+                defaultValue: "Load this image",
+                bundle: .module
+            ),
+            "remoteImageLoading": String(
+                localized: "markdown.web.remoteImageLoading",
+                defaultValue: "Loading",
+                bundle: .module
+            ),
+            "remoteImageHTTPSOnly": String(
+                localized: "markdown.web.remoteImageHTTPSOnly",
+                defaultValue: "Only HTTPS remote images can be loaded in the viewer.",
+                bundle: .module
+            ),
+            "remoteImageCopyURL": String(
+                localized: "markdown.web.remoteImageCopyURL",
+                defaultValue: "Copy image URL",
+                bundle: .module
+            ),
+            "remoteImageCopied": String(
+                localized: "markdown.web.remoteImageCopied",
+                defaultValue: "Copied",
+                bundle: .module
+            ),
+            "remoteImageOpenURL": String(
+                localized: "markdown.web.remoteImageOpenURL",
+                defaultValue: "Open image URL",
+                bundle: .module
+            ),
+            "remoteImageNotAllowed": String(
+                localized: "markdown.web.remoteImageNotAllowed",
+                defaultValue: "This remote image URL cannot be loaded in the viewer.",
+                bundle: .module
+            ),
+            "remoteImageURL": String(
+                localized: "markdown.web.remoteImageURL",
+                defaultValue: "Image URL: {url}",
+                bundle: .module
+            )
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: strings),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebViewerAssets.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Markdown/MarkdownWebViewerAssets.swift
@@ -15,9 +15,18 @@ final class MarkdownWebViewerAssets {
 
     private let bundle: Bundle
     private var cache: [String: String] = [:]
+    private var cachedShellHTML: String??
 
     /// True when every asset the shell template splices in is present.
     let isAvailable: Bool
+
+    /// True when the spliced shell actually loads and decodes, so choosing the
+    /// web renderer can never strand the reader on a blank pane when an asset
+    /// is present but corrupt. The result (including the spliced shell) is
+    /// computed once and cached.
+    var isUsable: Bool {
+        shellHTML() != nil
+    }
 
     init(bundle: Bundle) {
         self.bundle = bundle
@@ -37,6 +46,15 @@ final class MarkdownWebViewerAssets {
     ]
 
     func shellHTML() -> String? {
+        if let cachedShellHTML {
+            return cachedShellHTML
+        }
+        let spliced = splicedShellHTML()
+        cachedShellHTML = spliced
+        return spliced
+    }
+
+    private func splicedShellHTML() -> String? {
         guard isAvailable,
               let shell = asset(name: "shell", ext: "html"),
               let githubCSS = asset(name: "github-markdown", ext: "css"),
@@ -71,14 +89,38 @@ final class MarkdownWebViewerAssets {
         return source
     }
 
-    private static func assetURL(name: String, ext: String, bundle: Bundle) -> URL? {
+    /// Off-main variant for the multi-megabyte lazy diagram libraries, so the
+    /// first mermaid/vega render doesn't inflate them on the main actor.
+    /// Returns nil when any requested asset is missing or corrupt.
+    func assets(_ specs: [(name: String, ext: String)]) async -> [String]? {
+        var sources: [String] = []
+        for spec in specs {
+            let key = "\(spec.name).\(spec.ext)"
+            if let cached = cache[key] {
+                sources.append(cached)
+                continue
+            }
+            guard let url = Self.assetURL(name: spec.name, ext: spec.ext, bundle: bundle) else {
+                return nil
+            }
+            let loaded = await Task.detached(priority: .userInitiated) {
+                Self.loadAsset(url: url)
+            }.value
+            guard let loaded else { return nil }
+            cache[key] = loaded
+            sources.append(loaded)
+        }
+        return sources
+    }
+
+    private nonisolated static func assetURL(name: String, ext: String, bundle: Bundle) -> URL? {
         bundle.url(forResource: name, withExtension: "\(ext).deflate", subdirectory: "markdown-viewer")
             ?? bundle.url(forResource: name, withExtension: "\(ext).deflate")
             ?? bundle.url(forResource: name, withExtension: ext, subdirectory: "markdown-viewer")
             ?? bundle.url(forResource: name, withExtension: ext)
     }
 
-    private static func loadAsset(url: URL) -> String? {
+    private nonisolated static func loadAsset(url: URL) -> String? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         if url.lastPathComponent.hasSuffix(".deflate") {
             guard let inflated = MarkdownViewerAssetCompression.inflate(data) else { return nil }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -1721,6 +1721,76 @@
           }
         }
       }
+    },
+    "markdown.web.remoteImageBlocked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Remote image blocked" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "リモート画像をブロックしました" } }
+      }
+    },
+    "markdown.web.remoteImageConsentMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "cmux will not contact this image URL until you load this image." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "この画像を読み込むまで、cmux はこの画像 URL に接続しません。" } }
+      }
+    },
+    "markdown.web.remoteImageCopied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Copied" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コピーしました" } }
+      }
+    },
+    "markdown.web.remoteImageCopyURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Copy image URL" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像 URL をコピー" } }
+      }
+    },
+    "markdown.web.remoteImageHTTPSOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Only HTTPS remote images can be loaded in the viewer." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ビューアー内で読み込めるのは HTTPS のリモート画像のみです。" } }
+      }
+    },
+    "markdown.web.remoteImageLoadImage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Load this image" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "この画像を読み込む" } }
+      }
+    },
+    "markdown.web.remoteImageLoading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Loading" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "読み込み中" } }
+      }
+    },
+    "markdown.web.remoteImageNotAllowed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This remote image URL cannot be loaded in the viewer." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このリモート画像 URL はビューアー内で読み込めません。" } }
+      }
+    },
+    "markdown.web.remoteImageOpenURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Open image URL" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像 URL を開く" } }
+      }
+    },
+    "markdown.web.remoteImageURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Image URL: {url}" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像 URL: {url}" } }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -1791,6 +1791,13 @@
         "en": { "stringUnit": { "state": "translated", "value": "Image URL: {url}" } },
         "ja": { "stringUnit": { "state": "translated", "value": "画像 URL: {url}" } }
       }
+    },
+    "markdown.web.rendererInitFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Markdown renderer failed to initialize. Showing raw source." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Markdownレンダラーの初期化に失敗しました。元のテキストを表示しています。" } }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebLinkPolicyTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebLinkPolicyTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Markdown web link policy")
+struct MarkdownWebLinkPolicyTests {
+    @Test("heading anchors resolved against about:blank stay in the page")
+    func inPageFragments() throws {
+        #expect(MarkdownWebLinkPolicy.isInPageFragment(try #require(URL(string: "about:blank#usage"))))
+        #expect(MarkdownWebLinkPolicy.isInPageFragment(try #require(URL(string: "#top"))))
+    }
+
+    @Test("links with hosts or real schemes are not in-page fragments")
+    func externalFragments() throws {
+        #expect(!MarkdownWebLinkPolicy.isInPageFragment(try #require(URL(string: "https://example.com/#section"))))
+        #expect(!MarkdownWebLinkPolicy.isInPageFragment(try #require(URL(string: "https://example.com/docs"))))
+        #expect(!MarkdownWebLinkPolicy.isInPageFragment(try #require(URL(string: "file:///tmp/other.md#part"))))
+    }
+
+    @Test("web and app-scheme links route to the system opener")
+    func externalRouting() throws {
+        #expect(MarkdownWebLinkPolicy.externalURL(for: try #require(URL(string: "https://example.com"))) != nil)
+        #expect(MarkdownWebLinkPolicy.externalURL(for: try #require(URL(string: "mailto:a@b.c"))) != nil)
+    }
+
+    @Test("in-page anchors and unresolvable relative paths never leave the app")
+    func inertTargets() throws {
+        #expect(MarkdownWebLinkPolicy.externalURL(for: try #require(URL(string: "about:blank#usage"))) == nil)
+        #expect(MarkdownWebLinkPolicy.externalURL(for: try #require(URL(string: "about:blank"))) == nil)
+        #expect(MarkdownWebLinkPolicy.externalURL(for: try #require(URL(string: "docs/other.md"))) == nil)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebRendererConfigurationTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebRendererConfigurationTests.swift
@@ -39,7 +39,7 @@ struct MarkdownWebRendererConfigurationTests {
 
     @Test("missing bundle assets disable the web renderer instead of crashing")
     @MainActor
-    func missingAssetsFallBack() throws {
+    func missingAssetsFallBack() async throws {
         let emptyBundleDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-assets-test-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: emptyBundleDir, withIntermediateDirectories: true)
@@ -48,8 +48,10 @@ struct MarkdownWebRendererConfigurationTests {
         let bundle = try #require(Bundle(url: emptyBundleDir))
         let assets = MarkdownWebViewerAssets(bundle: bundle)
         #expect(!assets.isAvailable)
+        #expect(!assets.isUsable)
         #expect(assets.shellHTML() == nil)
         #expect(assets.asset(name: "mermaid.min", ext: "js") == nil)
+        #expect(await assets.assets([(name: "mermaid.min", ext: "js")]) == nil)
     }
 #endif
 }

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebRendererConfigurationTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/MarkdownWebRendererConfigurationTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Markdown web renderer configuration")
+struct MarkdownWebRendererConfigurationTests {
+#if canImport(UIKit)
+    @Test("page zoom tracks the Dynamic Type body size with 1.0 at .large")
+    func pageZoomMapping() {
+        #expect(ChatArtifactMarkdownView.pageZoom(for: .large) == 1)
+        #expect(ChatArtifactMarkdownView.pageZoom(for: .xSmall) < 1)
+        #expect(ChatArtifactMarkdownView.pageZoom(for: .accessibility5) > 3)
+
+        let ordered: [DynamicTypeSize] = [
+            .xSmall, .small, .medium, .large, .xLarge, .xxLarge, .xxxLarge,
+            .accessibility1, .accessibility2, .accessibility3, .accessibility4, .accessibility5,
+        ]
+        let zooms = ordered.map { ChatArtifactMarkdownView.pageZoom(for: $0) }
+        #expect(zooms == zooms.sorted())
+    }
+
+    @Test("theme resolves parity CSS variables for both appearances")
+    @MainActor
+    func themeResolution() {
+        let light = MarkdownWebTheme.resolve(isDark: false)
+        let dark = MarkdownWebTheme.resolve(isDark: true)
+
+        #expect(!light.isDark)
+        #expect(dark.isDark)
+        #expect(light.background == "transparent")
+        #expect(dark.background == "transparent")
+        for value in [light.mutedBackground, light.border, dark.mutedBackground, dark.border] {
+            #expect(value.hasPrefix("rgba("))
+        }
+        #expect(light != dark)
+    }
+
+    @Test("missing bundle assets disable the web renderer instead of crashing")
+    @MainActor
+    func missingAssetsFallBack() throws {
+        let emptyBundleDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-assets-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: emptyBundleDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: emptyBundleDir) }
+
+        let bundle = try #require(Bundle(url: emptyBundleDir))
+        let assets = MarkdownWebViewerAssets(bundle: bundle)
+        #expect(!assets.isAvailable)
+        #expect(assets.shellHTML() == nil)
+        #expect(assets.asset(name: "mermaid.min", ext: "js") == nil)
+    }
+#endif
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceChrome.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacSurfaceChrome.swift
@@ -6,67 +6,6 @@ import SwiftUI
 import UIKit
 #endif
 
-/// Rounded-rect kind glyph shared by surface headers, cards, and rows.
-struct MacSurfaceIconBadge: View {
-    let kind: MobileSurfacePreview.Kind
-    var side: CGFloat = 34
-
-    var body: some View {
-        Image(systemName: kind.systemImage)
-            .font(.system(size: side * 0.52, weight: .medium))
-            .foregroundStyle(kind.tint)
-            .frame(width: side, height: side)
-            .accessibilityHidden(true)
-    }
-}
-
-/// Compact chrome row above a native Mac-surface renderer.
-///
-/// Keeps every surface's top edge consistent: kind badge, surface title,
-/// contextual subtitle, and an optional surface-specific accessory.
-struct MacSurfaceHeader<Accessory: View>: View {
-    let kind: MobileSurfacePreview.Kind
-    let title: String
-    let subtitle: String?
-    @ViewBuilder var accessory: Accessory
-
-    var body: some View {
-        HStack(spacing: 12) {
-            MacSurfaceIconBadge(kind: kind)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                    .font(.headline)
-                    .lineLimit(1)
-                if let subtitle, !subtitle.isEmpty {
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-            }
-            Spacer(minLength: 8)
-            accessory
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(.bar)
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
-    }
-}
-
-extension MacSurfaceHeader where Accessory == EmptyView {
-    init(
-        kind: MobileSurfacePreview.Kind,
-        title: String,
-        subtitle: String?
-    ) {
-        self.init(kind: kind, title: title, subtitle: subtitle) { EmptyView() }
-    }
-}
-
 /// Centered inline state (loading complement, error, empty) for surfaces.
 struct MacSurfaceMessageView: View {
     let systemImage: String

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MarkdownSurfaceView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MarkdownSurfaceView.swift
@@ -20,14 +20,7 @@ struct MarkdownSurfaceView: View {
     @State private var retryCount = 0
 
     var body: some View {
-        VStack(spacing: 0) {
-            MacSurfaceHeader(
-                kind: surface.kind,
-                title: surface.title,
-                subtitle: MacSurfaceFileContext.subtitle(title: surface.title, path: path)
-            )
-            content
-        }
+        content
         // Path changes reload outright; title churn with a stable path re-runs
         // the load so a rewritten file re-renders (same-title edits stay stale
         // until the next descriptor emission — wave-0 accepted residual).

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PanelFileSurfaceView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PanelFileSurfaceView.swift
@@ -7,8 +7,8 @@ import SwiftUI
 /// Routes the panel's displayed file through the shared artifact preview
 /// (text with syntax highlighting, image, PDF, media, Quick Look) using the
 /// panel-scoped loader; read-only in v1. The embedded preview owns its
-/// loading and failure states, so this view only contributes the surface
-/// chrome.
+/// loading and failure states; the navigation bar already names the surface,
+/// so the pane renders content edge to edge with no extra chrome.
 struct PanelFileSurfaceView: View {
     let surface: MobileSurfacePreview
     let path: String
@@ -16,34 +16,12 @@ struct PanelFileSurfaceView: View {
     let connectionStatus: MobileMacConnectionStatus
 
     var body: some View {
-        VStack(spacing: 0) {
-            MacSurfaceHeader(
-                kind: surface.kind,
-                title: surface.title,
-                subtitle: MacSurfaceFileContext.subtitle(title: surface.title, path: path)
-            )
-            ChatArtifactEmbeddedPreview(
-                path: path,
-                scope: .panel,
-                loader: loader,
-                refreshToken: surface.title,
-                connectionHint: connectionStatus.artifactConnectionHint
-            )
-        }
-    }
-}
-
-/// Derives the header subtitle for file-backed surfaces.
-enum MacSurfaceFileContext {
-    /// The file name when the title doesn't already show it, otherwise the
-    /// parent directory name so a duplicated line never appears.
-    static func subtitle(title: String, path: String) -> String? {
-        let url = URL(fileURLWithPath: path)
-        let fileName = url.lastPathComponent
-        guard !fileName.isEmpty else { return nil }
-        if title != fileName { return fileName }
-        let parent = url.deletingLastPathComponent().lastPathComponent
-        guard !parent.isEmpty, parent != "/" else { return nil }
-        return parent
+        ChatArtifactEmbeddedPreview(
+            path: path,
+            scope: .panel,
+            loader: loader,
+            refreshToken: surface.title,
+            connectionHint: connectionStatus.artifactConnectionHint
+        )
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TodoSurfaceView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TodoSurfaceView.swift
@@ -33,11 +33,16 @@ struct TodoSurfaceView: View {
     var body: some View {
         let snapshot = model.snapshot
         VStack(spacing: 0) {
-            MacSurfaceHeader(
-                kind: .todo,
-                title: surface.title,
-                subtitle: progressSubtitle(snapshot)
-            ) {
+            // The navigation bar already names the surface; the pane keeps
+            // only the functional chrome (status control + progress).
+            HStack(spacing: 12) {
+                if let subtitle = progressSubtitle(snapshot) {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
                 TodoStatusMenu(
                     status: snapshot.status,
                     statusHidden: snapshot.statusHidden,
@@ -45,6 +50,8 @@ struct TodoSurfaceView: View {
                     setStatus: { run(.setStatus($0)) }
                 )
             }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
             if let progress = completionProgress(snapshot) {
                 ProgressView(value: progress)
                     .progressViewStyle(.linear)

--- a/Sources/Panels/MarkdownViewerAssets.swift
+++ b/Sources/Panels/MarkdownViewerAssets.swift
@@ -1,5 +1,5 @@
+import CmuxAgentChat
 import Foundation
-import zlib
 
 /// Loads the bundled markdown web renderer assets from Resources/markdown-viewer.
 /// The heavy diagram libraries are still read lazily so ordinary markdown files
@@ -136,61 +136,9 @@ final class MarkdownViewerAssets {
 
     private static func loadDeflatedTextAsset(url: URL) -> String? {
         guard let compressed = try? Data(contentsOf: url),
-              let decompressed = inflateZlib(compressed) else {
+              let decompressed = MarkdownViewerAssetCompression.inflate(compressed) else {
             return nil
         }
         return String(data: decompressed, encoding: .utf8)
-    }
-
-    private static func inflateZlib(_ data: Data) -> Data? {
-        guard !data.isEmpty else {
-            return Data()
-        }
-
-        var stream = z_stream()
-        let initResult = inflateInit_(
-            &stream,
-            ZLIB_VERSION,
-            Int32(MemoryLayout<z_stream>.size)
-        )
-        guard initResult == Z_OK else {
-            return nil
-        }
-        defer { inflateEnd(&stream) }
-
-        return data.withUnsafeBytes { inputBuffer in
-            guard let inputBase = inputBuffer.bindMemory(to: Bytef.self).baseAddress else {
-                return nil
-            }
-            stream.next_in = UnsafeMutablePointer<Bytef>(mutating: inputBase)
-            stream.avail_in = uInt(data.count)
-
-            var output = Data()
-            let chunkSize = 64 * 1024
-            var chunk = [UInt8](repeating: 0, count: chunkSize)
-
-            while true {
-                let result = chunk.withUnsafeMutableBytes { outputBuffer -> Int32 in
-                    stream.next_out = outputBuffer.bindMemory(to: Bytef.self).baseAddress
-                    stream.avail_out = uInt(chunkSize)
-                    return inflate(&stream, Z_NO_FLUSH)
-                }
-
-                let produced = chunkSize - Int(stream.avail_out)
-                if produced > 0 {
-                    output.append(chunk, count: produced)
-                }
-
-                if result == Z_STREAM_END {
-                    return output
-                }
-                if result != Z_OK {
-                    return nil
-                }
-                if stream.avail_in == 0 && produced == 0 {
-                    return nil
-                }
-            }
-        }
     }
 }

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -1,10 +1,11 @@
 import AppKit
+import CmuxAgentChat
 import SwiftUI
 import WebKit
 
 struct MarkdownWebRenderer: NSViewRepresentable {
-    static let localImageURLScheme = "cmux-local-image"
-    static let remoteImageURLScheme = "cmux-remote-image"
+    static let localImageURLScheme = MarkdownWebViewerScheme.localImage
+    static let remoteImageURLScheme = MarkdownWebViewerScheme.remoteImage
 
     let markdown: String
     let theme: MarkdownWebTheme

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -15748,10 +15748,19 @@ class TerminalController {
 
         let surfaceId: UUID?
         if let requestedSurfaceId {
-            guard let target = workspace.terminalInputTarget(forPanelID: requestedSurfaceId) else {
+            if let target = workspace.terminalInputTarget(forPanelID: requestedSurfaceId) {
+                surfaceId = target.surfaceID
+            } else if !requireTerminal,
+                      workspace.controlSurfaceTarget(for: requestedSurfaceId) != nil {
+                // Non-terminal panel surfaces (markdown, file preview) have no
+                // terminal input target; callers that don't require a terminal
+                // (mobile.panel.artifact.*) resolve the workspace-owned surface
+                // itself. Hidden remote-tmux mirror wrappers still fail closed
+                // inside controlSurfaceTarget.
+                surfaceId = requestedSurfaceId
+            } else {
                 return nil
             }
-            surfaceId = target.surfaceID
         } else if requireTerminal {
             surfaceId = workspace.focusedTerminalInputTarget()?.surfaceID
                 ?? mobileTerminalPanels(in: workspace).first?.id

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1373,7 +1373,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
-		A50014F7 /* MarkdownRemoteImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F6 /* MarkdownRemoteImageLoader.swift */; };
 		F5168A020000000000000001 /* MarkdownTypographyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A020000000000000002 /* MarkdownTypographyControl.swift */; };
 		F5168A060000000000000001 /* MarkdownTypographyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
@@ -4189,7 +4188,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
-		A50014F6 /* MarkdownRemoteImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownRemoteImageLoader.swift; sourceTree = "<group>"; };
 		F5168A020000000000000002 /* MarkdownTypographyControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyControl.swift; sourceTree = "<group>"; };
 		F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyDefaults.swift; sourceTree = "<group>"; };
 		A50014F1 /* MarkdownViewerAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownViewerAssets.swift; sourceTree = "<group>"; };
@@ -7314,7 +7312,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F5168A020000000000000002 /* MarkdownTypographyControl.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
 				A50014F4 /* MarkdownWebRenderer.swift */,
-				A50014F6 /* MarkdownRemoteImageLoader.swift */,
 				A50014F8 /* MarkdownWebSupport.swift */,
 				A50014F1 /* MarkdownViewerAssets.swift */,
 				C0DE86520000000000000010 /* FilePreviewFileState.swift */,
@@ -8783,6 +8780,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001262 /* Bonsplit */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
 				CC0033E15A1B2C3D4E5F0011 /* CmuxDiffComments */,
+				AC4A6E7C4A700001AC4A0004 /* CmuxAgentChat */,
 			);
 			productName = cmuxTests;
 			productReference = F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */;
@@ -9843,7 +9841,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
-				A50014F7 /* MarkdownRemoteImageLoader.swift in Sources */,
 				F5168A020000000000000001 /* MarkdownTypographyControl.swift in Sources */,
 				F5168A060000000000000001 /* MarkdownTypographyDefaults.swift in Sources */,
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
@@ -12473,6 +12470,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = 53750001A0B1C2D3E4F50001 /* XCLocalSwiftPackageReference "CmuxAuthRuntime" */;
 			productName = CmuxAuthRuntime;
+		};
+		AC4A6E7C4A700001AC4A0004 /* CmuxAgentChat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AC4A6E7C4A700001AC4A0003 /* XCLocalSwiftPackageReference "CmuxAgentChat" */;
+			productName = CmuxAgentChat;
 		};
 		AC4A6E7C4A700001AC4A0002 /* CmuxAgentChat */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1466,6 +1466,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C1A070000000000000000006 /* MobilePairingView+Connected.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000016 /* MobilePairingView+Connected.swift */; };
 		A2538FE83AE79539E3BF9248 /* MobilePairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */; };
 		18A8E29E9BD87E184983527C /* MobilePairingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */; };
+				ABMDPARTRES0000000000001 /* MobilePanelArtifactResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABMDPARTRES0000000000002 /* MobilePanelArtifactResolutionTests.swift */; };
 		EB30348C60CC4F7CA12C0931 /* MobileRemoteControlPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80AFFF3844843A789F89241 /* MobileRemoteControlPolicy.swift */; };
 		9916B44C7A9914E172D112D4 /* MobileRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */; };
 		F33100000000000000000002 /* MobileSimulatorDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33100000000000000000001 /* MobileSimulatorDiagnostics.swift */; };
@@ -4246,7 +4247,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C1A071000000000000000013 /* MobileHostConnectionLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostConnectionLifecycleTests.swift; sourceTree = "<group>"; };
 		C1A070000000000000000018 /* MobileHostConnectionRegistry+Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Debug/MobileHostConnectionRegistry+Debug.swift"; sourceTree = "<group>"; };
 		B8B056D90000000000000002 /* MobileHostIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentity.swift; sourceTree = "<group>"; };
-		B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
+B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
 		C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAdmissionTests.swift; sourceTree = "<group>"; };
 		A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohApplicationLaneRouter.swift; sourceTree = "<group>"; };
 		C1A070000000000000000012 /* MobileHostIrohAuthObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAuthObserver.swift; sourceTree = "<group>"; };
@@ -4280,6 +4281,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C1A070000000000000000016 /* MobilePairingView+Connected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingView+Connected.swift"; sourceTree = "<group>"; };
 		F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingView.swift"; sourceTree = "<group>"; };
 		5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingWindowController.swift"; sourceTree = "<group>"; };
+		ABMDPARTRES0000000000002 /* MobilePanelArtifactResolutionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobilePanelArtifactResolutionTests.swift; sourceTree = "<group>"; };
 		D80AFFF3844843A789F89241 /* MobileRemoteControlPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileRemoteControlPolicy.swift; sourceTree = "<group>"; };
 		7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileRouteResolver.swift; sourceTree = "<group>"; };
 		F33100000000000000000001 /* MobileSimulatorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSimulatorDiagnostics.swift; sourceTree = "<group>"; };
@@ -8562,6 +8564,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A1B2C3D4E5F60718293A4C04 /* MobileHostOrderedInputTests.swift */,
 				F33200000000000000000001 /* MobileSimulatorReaderAttachmentTests.swift */,
 				C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */,
+				ABMDPARTRES0000000000002 /* MobilePanelArtifactResolutionTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
 				A7C0F0010000000000000001 /* MacPairedMacBackupPublisherScopeTests.swift */,
 				5E2701030000000000000002 /* MacSentryStartupPolicyTests.swift */,
@@ -11479,6 +11482,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7A1B2C3D4E5F60718293A4B6 /* MobileHostTerminalThemeTests.swift in Sources */,
 				C0DE73840000000000000001 /* MobileHostWorkspaceTicketAuthorizationTests.swift in Sources */,
 				9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */,
+				ABMDPARTRES0000000000001 /* MobilePanelArtifactResolutionTests.swift in Sources */,
 				F33200000000000000000002 /* MobileSimulatorReaderAttachmentTests.swift in Sources */,
 				1055FA010000000000000001 /* MobileSurfaceKindMappingTests.swift in Sources */,
 				D1B800000000000000000005 /* MobileTaskDirectoryListServiceTests.swift in Sources */,

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxAgentChat
 import Combine
 import WebKit
 import XCTest

--- a/cmuxTests/MobilePanelArtifactResolutionTests.swift
+++ b/cmuxTests/MobilePanelArtifactResolutionTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the phone's markdown / file-preview panel surface:
+/// `mobile.panel.artifact.*` requests carry the PANEL surface id, which is not
+/// a terminal, so workspace/surface resolution must not require a terminal
+/// input target. When it does, the Mac answers `not_found` and the phone shows
+/// "Panel closed" for a panel that is plainly open.
+@MainActor
+struct MobilePanelArtifactResolutionTests {
+    @Test
+    func statResolvesMarkdownPanelSurface() async throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+        let workspace = try #require(manager.selectedWorkspace)
+
+        let contents = "# Panel surface stat\n"
+        let fileURL = try temporaryMarkdownFile(contents: contents)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let firstPane = try #require(workspace.bonsplitController.allPaneIds.first)
+        let panel = try #require(workspace.newMarkdownSurface(
+            inPane: firstPane,
+            filePath: fileURL.path,
+            focus: false
+        ))
+
+        let resolved = TerminalController.shared.mobileResolveWorkspaceAndSurface(
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": panel.id.uuidString,
+            ],
+            requireTerminal: false
+        )
+        #expect(resolved?.surfaceId == panel.id)
+
+        let result = await TerminalController.shared.v2MobilePanelArtifactStat(params: [
+            "workspace_id": workspace.id.uuidString,
+            "surface_id": panel.id.uuidString,
+            "path": fileURL.path,
+        ])
+        switch result {
+        case .ok(let payload):
+            let stat = try #require(payload as? [String: Any])
+            let size = try #require(stat["size"] as? NSNumber).int64Value
+            #expect(size == Int64(contents.utf8.count))
+        case .err(let code, let message, _):
+            Issue.record("stat failed: \(code) \(message)")
+        }
+    }
+
+    @Test
+    func terminalResolutionStillRequiresTerminalTargets() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+        let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+        let workspace = try #require(manager.selectedWorkspace)
+
+        let fileURL = try temporaryMarkdownFile(contents: "# Not a terminal\n")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let firstPane = try #require(workspace.bonsplitController.allPaneIds.first)
+        let panel = try #require(workspace.newMarkdownSurface(
+            inPane: firstPane,
+            filePath: fileURL.path,
+            focus: false
+        ))
+
+        // Terminal-only callers (input, replay) must keep failing closed for a
+        // markdown panel rather than resolving it as an input target.
+        let resolved = TerminalController.shared.mobileResolveWorkspaceAndSurface(
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": panel.id.uuidString,
+            ],
+            requireTerminal: true
+        )
+        #expect(resolved == nil)
+    }
+
+    private func temporaryMarkdownFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("md")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func window(withId windowId: UUID) -> NSWindow? {
+        let identifier = "cmux.main.\(windowId.uuidString)"
+        return NSApp.windows.first(where: { $0.identifier?.rawValue == identifier })
+    }
+
+    private func closeWindow(withId windowId: UUID) {
+        guard let window = window(withId: windowId) else { return }
+        window.performClose(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+}

--- a/ios/cmux-ios.xcodeproj/project.pbxproj
+++ b/ios/cmux-ios.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 				8B41F6412DEDD0D5001A66F9 /* Sources */,
 				8B41F6422DEDD0D5001A66F9 /* Frameworks */,
 				8B41F6432DEDD0D5001A66F9 /* Resources */,
+				8BMDVWR0COPYASSETS0001AA /* Copy Markdown Viewer Assets */,
 			);
 			buildRules = (
 			);
@@ -252,6 +253,32 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		8BMDVWR0COPYASSETS0001AA /* Copy Markdown Viewer Assets */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../Resources/markdown-viewer",
+				"$(SRCROOT)/scripts/copy-markdown-viewer-assets.sh",
+				"$(SRCROOT)/../scripts/compress-markdown-viewer-assets.sh",
+			);
+			name = "Copy Markdown Viewer Assets";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/scripts/copy-markdown-viewer-assets.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
 		8B41F6432DEDD0D5001A66F9 /* Resources */ = {

--- a/ios/cmux-ios.xcodeproj/project.pbxproj
+++ b/ios/cmux-ios.xcodeproj/project.pbxproj
@@ -272,7 +272,17 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/shell.html",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/highlight-github.css",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/highlight-github-dark.css",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/github-markdown.css",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/marked.min.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/highlight.min.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/viewer-navigation.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/mermaid.min.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/vega.min.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/vega-lite.min.js.deflate",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/markdown-viewer/vega-embed.min.js.deflate",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/cmux-ios.xcodeproj/project.pbxproj
+++ b/ios/cmux-ios.xcodeproj/project.pbxproj
@@ -266,7 +266,6 @@
 			inputPaths = (
 				"$(SRCROOT)/../Resources/markdown-viewer",
 				"$(SRCROOT)/scripts/copy-markdown-viewer-assets.sh",
-				"$(SRCROOT)/../scripts/compress-markdown-viewer-assets.sh",
 			);
 			name = "Copy Markdown Viewer Assets";
 			outputFileListPaths = (

--- a/ios/scripts/copy-markdown-viewer-assets.sh
+++ b/ios/scripts/copy-markdown-viewer-assets.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Copies the shared markdown-viewer web shell (Resources/markdown-viewer) into
+# the iOS app bundle and deflate-compresses the JS, matching the macOS app's
+# resource layout so MarkdownWebViewerAssets loads identical bytes on both
+# platforms. Only the shell's own files ship; the diff-viewer and webviews-app
+# React bundles are macOS-only and are excluded.
+set -eu
+
+SRC_DIR="${SRCROOT}/../Resources/markdown-viewer"
+DEST_DIR="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/markdown-viewer"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "error: markdown viewer assets not found at $SRC_DIR" >&2
+  exit 1
+fi
+
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+
+for name in \
+  shell.html \
+  marked.min.js \
+  highlight.min.js \
+  highlight-github.css \
+  highlight-github-dark.css \
+  github-markdown.css \
+  viewer-navigation.js \
+  mermaid.min.js \
+  vega.min.js \
+  vega-lite.min.js \
+  vega-embed.min.js
+do
+  if [ ! -f "$SRC_DIR/$name" ]; then
+    echo "error: missing markdown viewer asset $SRC_DIR/$name" >&2
+    exit 1
+  fi
+  cp "$SRC_DIR/$name" "$DEST_DIR/$name"
+done
+
+"${SRCROOT}/../scripts/compress-markdown-viewer-assets.sh" "$DEST_DIR"

--- a/ios/scripts/copy-markdown-viewer-assets.sh
+++ b/ios/scripts/copy-markdown-viewer-assets.sh
@@ -4,37 +4,40 @@
 # resource layout so MarkdownWebViewerAssets loads identical bytes on both
 # platforms. Only the shell's own files ship; the diff-viewer and webviews-app
 # React bundles are macOS-only and are excluded.
+#
+# Xcode user-script sandboxing only permits writing files declared in the
+# phase's outputPaths, so compression happens in DERIVED_FILE_DIR scratch and
+# each final bundle file is copied (and declared) individually.
 set -eu
 
 SRC_DIR="${SRCROOT}/../Resources/markdown-viewer"
 DEST_DIR="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/markdown-viewer"
+STAGE_DIR="${DERIVED_FILE_DIR}/markdown-viewer"
 
 if [ ! -d "$SRC_DIR" ]; then
   echo "error: markdown viewer assets not found at $SRC_DIR" >&2
   exit 1
 fi
 
-rm -rf "$DEST_DIR"
-mkdir -p "$DEST_DIR"
+PLAIN_ASSETS="shell.html highlight-github.css highlight-github-dark.css github-markdown.css"
+JS_ASSETS="marked.min.js highlight.min.js viewer-navigation.js mermaid.min.js vega.min.js vega-lite.min.js vega-embed.min.js"
 
-for name in \
-  shell.html \
-  marked.min.js \
-  highlight.min.js \
-  highlight-github.css \
-  highlight-github-dark.css \
-  github-markdown.css \
-  viewer-navigation.js \
-  mermaid.min.js \
-  vega.min.js \
-  vega-lite.min.js \
-  vega-embed.min.js
-do
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR" "$DEST_DIR"
+
+for name in $PLAIN_ASSETS $JS_ASSETS; do
   if [ ! -f "$SRC_DIR/$name" ]; then
     echo "error: missing markdown viewer asset $SRC_DIR/$name" >&2
     exit 1
   fi
-  cp "$SRC_DIR/$name" "$DEST_DIR/$name"
+  cp "$SRC_DIR/$name" "$STAGE_DIR/$name"
 done
 
-"${SRCROOT}/../scripts/compress-markdown-viewer-assets.sh" "$DEST_DIR"
+"${SRCROOT}/../scripts/compress-markdown-viewer-assets.sh" "$STAGE_DIR"
+
+for name in $PLAIN_ASSETS; do
+  cp -f "$STAGE_DIR/$name" "$DEST_DIR/$name"
+done
+for name in $JS_ASSETS; do
+  cp -f "$STAGE_DIR/$name.deflate" "$DEST_DIR/$name.deflate"
+done

--- a/ios/scripts/copy-markdown-viewer-assets.sh
+++ b/ios/scripts/copy-markdown-viewer-assets.sh
@@ -1,43 +1,58 @@
 #!/bin/sh
 # Copies the shared markdown-viewer web shell (Resources/markdown-viewer) into
-# the iOS app bundle and deflate-compresses the JS, matching the macOS app's
+# the iOS app bundle, deflate-compressing the JS to match the macOS app's
 # resource layout so MarkdownWebViewerAssets loads identical bytes on both
 # platforms. Only the shell's own files ship; the diff-viewer and webviews-app
 # React bundles are macOS-only and are excluded.
 #
-# Xcode user-script sandboxing only permits writing files declared in the
-# phase's outputPaths, so compression happens in DERIVED_FILE_DIR scratch and
-# each final bundle file is copied (and declared) individually.
+# Xcode user-script sandboxing permits writes only to files declared in the
+# phase's outputPaths (no scratch dirs), so every artifact is produced in one
+# write directly at its declared destination: plain files are copied, JS is
+# zlib-deflated straight from source (same format as
+# scripts/compress-markdown-viewer-assets.sh and
+# MarkdownViewerAssetCompression.inflate).
 set -eu
 
 SRC_DIR="${SRCROOT}/../Resources/markdown-viewer"
 DEST_DIR="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/markdown-viewer"
-STAGE_DIR="${DERIVED_FILE_DIR}/markdown-viewer"
 
 if [ ! -d "$SRC_DIR" ]; then
   echo "error: markdown viewer assets not found at $SRC_DIR" >&2
   exit 1
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required to compress markdown viewer assets" >&2
+  exit 1
+fi
+
 PLAIN_ASSETS="shell.html highlight-github.css highlight-github-dark.css github-markdown.css"
 JS_ASSETS="marked.min.js highlight.min.js viewer-navigation.js mermaid.min.js vega.min.js vega-lite.min.js vega-embed.min.js"
-
-rm -rf "$STAGE_DIR"
-mkdir -p "$STAGE_DIR" "$DEST_DIR"
 
 for name in $PLAIN_ASSETS $JS_ASSETS; do
   if [ ! -f "$SRC_DIR/$name" ]; then
     echo "error: missing markdown viewer asset $SRC_DIR/$name" >&2
     exit 1
   fi
-  cp "$SRC_DIR/$name" "$STAGE_DIR/$name"
 done
 
-"${SRCROOT}/../scripts/compress-markdown-viewer-assets.sh" "$STAGE_DIR"
+mkdir -p "$DEST_DIR"
 
 for name in $PLAIN_ASSETS; do
-  cp -f "$STAGE_DIR/$name" "$DEST_DIR/$name"
+  cp -f "$SRC_DIR/$name" "$DEST_DIR/$name"
 done
-for name in $JS_ASSETS; do
-  cp -f "$STAGE_DIR/$name.deflate" "$DEST_DIR/$name.deflate"
-done
+
+python3 - "$SRC_DIR" "$DEST_DIR" $JS_ASSETS <<'PY'
+import pathlib
+import sys
+import zlib
+
+src = pathlib.Path(sys.argv[1])
+dest = pathlib.Path(sys.argv[2])
+
+for name in sys.argv[3:]:
+    raw = (src / name).read_bytes()
+    compressed = zlib.compress(raw, 9)
+    (dest / (name + ".deflate")).write_bytes(compressed)
+    print(f"compressed markdown viewer asset: {name} ({len(raw)} -> {len(compressed)} bytes)")
+PY


### PR DESCRIPTION
The iOS markdown view (artifact viewer rendered mode and the Mac markdown-panel surface) used a hand-rolled block parser: no syntax highlighting, tables as monospaced text rows, task lists as literal `[ ]`, no images, no mermaid/vega, no nested lists or quotes. Aziz's phone recording vs Mac comparison ("md viewer" / "looks normal on computer") is this gap.

iOS now renders documents with the same web shell as the macOS markdown panel: `Resources/markdown-viewer/shell.html` with marked.js (GFM), highlight.js, github-markdown.css, and lazy mermaid + vega, inside a `UIViewRepresentable` WKWebView. Both platforms execute literally the same renderer bytes, so output is identical by construction.

How it works:

- `MarkdownWebContentView` (new, `CmuxAgentChatUI`) is a UIKit port of the macOS `MarkdownWebRenderer` coordinator: same shell load/push/theme bridge (`__cmuxRenderMarkdown`, `__cmuxApplyTheme`, `__cmuxSetMarkdownZoom`), same lazy `cmuxLib` injection for mermaid/vega, same WebContent-crash recovery budget.
- The SSRF-hardened consent-gated remote image loader moved from the macOS app target into the shared `CmuxAgentChat` package (`MarkdownViewer/`), so iOS reuses the DNS-pinned HTTPS-only fetch instead of duplicating it. macOS now imports it from there; scheme strings live in shared `MarkdownWebViewerScheme`. The zlib inflate helper for the deflate-compressed JS assets is shared the same way.
- The iOS app bundles the shell via a new build phase (`ios/scripts/copy-markdown-viewer-assets.sh`) that copies the 4 plain assets and deflates the 7 JS bundles directly at their declared output paths (Xcode script sandboxing allows no other writes). The macOS-only `diff-viewer/` and `webviews-app/` React bundles are excluded.
- Dynamic Type maps to page zoom (body size 17pt = 1.0). Dark/light follows the system scheme through `overrideUserInterfaceStyle` plus the same CSS-variable theme math as macOS (ported to UIColor). Activated links open through the system opener; heading anchors stay in-page.
- The native block renderer remains as fallback when the viewer assets are absent (unit-test hosts, previews).

Deliberate v1 residuals (files live on the Mac, not the phone): `.md` cross-file links are inert, and local relative images render empty. Remote images keep the consent placeholder + load flow.

Tests: new package tests for the deflate round-trip (`CmuxAgentChat`), link policy, Dynamic Type zoom mapping, theme resolution, and missing-asset fallback (`CmuxAgentChatUI`). Existing `MarkdownPanelTests` cover the macOS refactor; note the hosted `test-e2e.yml` lane for `cmuxTests/MarkdownPanelTests` currently fails on `main` with the same pre-existing app-host linker error (`ld: symbol(s) not found` for `CmuxAuthRuntime`), verified by dispatching the identical filter against `main` ([branch run](https://github.com/manaflow-ai/cmux/actions/runs/32700155744) vs [main baseline](https://github.com/manaflow-ai/cmux/actions/runs/32701535948)).

HIG: consulted the Web views page (per `Packages/iOS/AGENTS.md`); web views are the sanctioned way to show rich document content in-app (Mail precedent), back/forward navigation is intentionally not exposed for a single-document viewer, and the viewer deliberately does not grow browser chrome. Localization audit: the shell's ten `markdown.web.*` remote-image consent strings were added to `CmuxAgentChatUI`'s catalog in en and ja, copied from the macOS catalog; no other user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154886&installation_model_id=21920&pr_number=10638&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10638&signature=65fd2a922b923daab3d102c246ef839a2e2d1cc3b9897990471a93d4b02153b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
iOS renders Markdown with the same WKWebView shell as macOS, replacing the native block parser. Old: plain text blocks without syntax highlighting, images, or diagrams. New: identical output across platforms (marked.js, highlight.js, GitHub CSS, lazy mermaid/vega) with a safe native fallback when assets are missing or invalid.

- Adds a UIKit `WKWebView` renderer (`MarkdownWebContentView`) that mirrors the macOS bridge (`__cmuxRenderMarkdown`, `__cmuxApplyTheme`, `__cmuxSetMarkdownZoom`) and registers shared URL schemes from `MarkdownWebViewerScheme`.
- Moves the SSRF-hardened HTTPS-only remote image loader to `CmuxAgentChat`; macOS and iOS now import the same loader and scheme constants. Shares zlib inflate via `MarkdownViewerAssetCompression`.
- iOS bundles the shell via `ios/scripts/copy-markdown-viewer-assets.sh`, copying CSS/HTML and deflating JS directly to declared outputs to satisfy Xcode’s script sandbox.
- Behavior: Dynamic Type maps to page zoom; dark/light follows system; heading anchors stay in-page; other links open via the system; `.md` cross-file links and local relative images are inert on iOS.
- Safety hardening: gate renderer choice on an actually spliced shell (`isUsable`) to avoid blank panes if assets are present but corrupt; load mermaid/vega off the main actor; localize the renderer-init failure message (en, ja).
- UI: remove the redundant in-pane title band on iOS Mac-surface panes; markdown and file panes render edge to edge; the todo pane keeps a slim status row.
- Fix: resolve non-terminal panel surfaces for mobile panel-artifact requests; terminal-only callers still fail closed for non-terminal panels.
- Tests cover asset compression round-trip, link policy, zoom mapping, theme resolution, missing-asset fallback, and panel-artifact surface resolution.

- Rollout/migration:
  - iOS builds require `python3` for the asset copy/compress phase.
  - Use `MarkdownWebViewerScheme` and import the shared remote image loader from `CmuxAgentChat`.

<sup>Written for commit c0b4326fce574d7c9122cb75e98f06fe11aa5823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an enhanced iOS Markdown viewer with web rendering, syntax highlighting, Mermaid/Vega support, theme adaptation, and Dynamic Type zoom.
  - Added improved link handling, remote-image consent controls, localized English and Japanese messaging, and automatic native-renderer fallback.
  - Added compressed bundled viewer assets for faster loading.
  - Updated Markdown and file-preview surfaces with cleaner edge-to-edge layouts.

- **Bug Fixes**
  - Improved viewer recovery when content processes fail or assets are unavailable.
  - Improved mobile artifact resolution for Markdown and file-preview panels.
  - Standardized local and remote image handling across Markdown viewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Round 3 (dogfood feedback):** removed the redundant in-pane title band from all iOS Mac-surface panes (markdown, file preview, todo). The navigation bar already names the surface, so the band added no information and cost vertical space. Markdown and file panes render edge to edge; the todo pane keeps its functional chrome (progress subtitle + status menu) in a slim row. `MacSurfaceHeader`, `MacSurfaceIconBadge`, and `MacSurfaceFileContext` are now unused and deleted.
