### PR TITLE
fix: retract recovered SSH connection errors from the sidebar on reconnect

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2844,6 +2844,23 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Retracts connection-state failures after the transport has published
+    /// an authoritative `.connected`.
+    ///
+    /// The sidebar row renders the latest log entry, so a recovered
+    /// `SSH error (target): …` or `SSH reconnect paused …` line (both
+    /// appended with source "remote") would otherwise keep a Connected
+    /// workspace flagged red forever.  Proxy-only and daemon entries have
+    /// their own retraction paths (`clearProxyOnlyRemoteSidebarArtifacts`,
+    /// `clearRecoveredRemoteDaemonSidebarArtifacts`); this covers the
+    /// non-proxy connection seam those paths deliberately leave alone.
+    /// https://github.com/manaflow-ai/cmux/issues/10640
+    func clearRecoveredRemoteConnectionSidebarArtifacts() {
+        logEntries.removeAll { $0.source == "remote" }
+        statusEntries.removeValue(forKey: Self.remoteErrorStatusKey)
+        remoteLastErrorFingerprint = nil
+    }
+
     private func remoteNotificationCooldownKey(target: String) -> String? {
         let rawTarget = (remoteConfiguration?.destination ?? target)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -7263,6 +7280,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
         if state == .connected {
             clearProxyOnlyRemoteSidebarArtifacts()
+            clearRecoveredRemoteConnectionSidebarArtifacts()
             clearRecoveredRemoteDaemonSidebarArtifacts()
         }
     }

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -125,4 +125,100 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             "A recovered bootstrap log must not remain the sidebar's latest error"
         )
     }
+
+    /// https://github.com/manaflow-ai/cmux/issues/10640: a non-proxy SSH
+    /// failure ("ssh: connect to host …") is logged with source "remote".
+    /// Once the transport publishes an authoritative `.connected`, that
+    /// recovered failure must not stay pinned as the sidebar row's latest
+    /// (red) log entry.
+    @Test
+    func connectedRetractsRecoveredSSHConnectionError() {
+        let workspace = Workspace()
+        let target = "dev@example.com"
+        let config = WorkspaceRemoteConfiguration(
+            destination: target,
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_023,
+            relayID: String(repeating: "a", count: 16),
+            relayToken: String(repeating: "b", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test-ssh-error.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .error,
+            detail: "ssh: connect to host example.com port 22: Operation timed out (retry 3 in 8s)",
+            target: target
+        )
+
+        #expect(workspace.logEntries.last?.source == "remote")
+        #expect(workspace.logEntries.last?.level == .error)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to \(target)",
+            target: target
+        )
+
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote" }) == nil,
+            "A recovered SSH connection error must be retracted on .connected"
+        )
+        #expect(
+            workspace.logEntries.last?.level != .error,
+            "The workspace row must not keep rendering a recovered SSH error while Connected"
+        )
+        #expect(workspace.statusEntries["remote.error"] == nil)
+    }
+
+    /// https://github.com/manaflow-ai/cmux/issues/10640: the suspended-state
+    /// warning ("SSH reconnect paused …", source "remote") must likewise be
+    /// retracted once the connection recovers to `.connected`.
+    @Test
+    func connectedRetractsRecoveredSuspendedWarning() {
+        let workspace = Workspace()
+        let target = "dev@example.com"
+        let config = WorkspaceRemoteConfiguration(
+            destination: target,
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_024,
+            relayID: String(repeating: "1", count: 16),
+            relayToken: String(repeating: "2", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test-suspended.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .suspended,
+            detail: "Reconnect budget exhausted",
+            target: target
+        )
+
+        #expect(workspace.logEntries.last?.source == "remote")
+        #expect(workspace.statusEntries["remote.error"] != nil)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to \(target)",
+            target: target
+        )
+
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote" }) == nil,
+            "A recovered reconnect-paused warning must be retracted on .connected"
+        )
+        #expect(workspace.statusEntries["remote.error"] == nil)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/10640

## Problem

The sidebar workspace row renders `logEntries.last`, so any error entry that is never retracted pins a red line on the row forever. `applyRemoteConnectionStateUpdate` appends `"SSH error (target): …"` (`.error`) and `"SSH reconnect paused …"` (`.warning`) entries with `source: "remote"`, but the `.connected` retraction path only runs:

- `clearProxyOnlyRemoteSidebarArtifacts()` — removes log entries matching the proxy-only message pattern only
- `clearRecoveredRemoteDaemonSidebarArtifacts()` (#10555) — removes `source == "remote-daemon"` entries only

A recovered non-proxy SSH failure (e.g. `ssh: connect to host … Operation timed out`) matches neither, so a workspace that reconnects successfully keeps showing a red error line while its state reads **Connected**.

This is the connection-seam sibling of #8917 / #10541 (daemon seam, fixed by #10555).

## Fix

On authoritative `.connected`, additionally retract the recovered connection-seam artifacts: all `source == "remote"` log entries, the `remote.error` status entry, and the error fingerprint (`clearRecoveredRemoteConnectionSidebarArtifacts`). Proxy-only and daemon entries keep their existing dedicated retraction paths.

## Regression test policy

Two commits per the repo policy, so the Commits tab proves the tests catch the bug:

1. `test:` failing tests only — `connectedRetractsRecoveredSSHConnectionError` and `connectedRetractsRecoveredSuspendedWarning` in the existing (wired) `cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift` (CI red)
2. `fix:` the retraction (CI green)

## Localization audit

No user-facing strings added or changed — the fix only removes already-rendered log/status entries; new code is a doc comment and an internal helper. No `Localizable.xcstrings` / web message changes needed.

## Notes

- Local `cmux-unit` test runs on this machine fail at link time with pre-existing undefined `CmuxAuthRuntime`/`CMUXAuthCore` symbols in the `cmuxTests` bundle (Xcode 26.2; unrelated to these commits — a test-method addition cannot drop auth symbols from the link, and CI links the same bundle fine), so red/green is demonstrated by CI rather than a local run.
- The daemon-flavored variant of this symptom (`Remote daemon error (host): …` sticking after reconnect) was already fixed by #10555; feature branches based on `main` before 2026-08-21 still show it until rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169105&installation_model_id=21920&pr_number=10641&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10641&signature=f1ed046961418eee28c26c3f55f11cc447532095a19293f5269ba2f48d1aacd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retracts recovered SSH connection errors and suspended warnings from the sidebar when the transport reports .connected, so Connected workspaces no longer show a stale red error line. Previously, `source: "remote"` entries and the `remote.error` status were never retracted; now they are cleared on authoritative `.connected` without affecting proxy-only or daemon retraction paths.

**Review notes**
- Add `Workspace.clearRecoveredRemoteConnectionSidebarArtifacts()` and invoke it on `.connected` alongside `clearProxyOnlyRemoteSidebarArtifacts()` and `clearRecoveredRemoteDaemonSidebarArtifacts()`.
- Scope: remove `source == "remote"` log entries, clear `statusEntries["remote.error"]`, and reset the error fingerprint; proxy-only and daemon flows unchanged.
- Tests: `connectedRetractsRecoveredSSHConnectionError` and `connectedRetractsRecoveredSuspendedWarning`.
- Fixes #10640. No migrations or user-facing string changes.

<sup>Written for commit 6f867cd63f3ac3b9fbdbda2ae02f87d4293565bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved lingering remote connection errors after an SSH connection successfully reconnects.
  * Removed outdated connection warnings, error indicators, and related activity entries once connectivity is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->