### PR TITLE
fix: honor TextBox focus for created terminals

### DIFF
--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -175,7 +175,7 @@ extension TerminalController {
                 initialDividerPosition: dividerPosition,
                 remotePTYSessionID: inputs.remotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: useLocalContext,
-                allowTextBoxFocusDefault: false
+                allowTextBoxFocusDefault: focus
             ) {
             case .created(let panel):
                 newId = panel.id

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -175,7 +175,7 @@ extension TerminalController {
                 initialDividerPosition: dividerPosition,
                 remotePTYSessionID: inputs.remotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: useLocalContext,
-                allowTextBoxFocusDefault: focus
+                allowTextBoxFocusDefault: false
             ) {
             case .created(let panel):
                 newId = panel.id
@@ -408,7 +408,7 @@ extension TerminalController {
                 remotePTYSessionID: inputs.remotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: useLocalContext,
                 inheritWorkingDirectoryFallback: true,
-                allowTextBoxFocusDefault: false
+                allowTextBoxFocusDefault: focus
             ) {
             case .created(let panel):
                 newPanelId = panel.id

--- a/cmuxTests/WorkspaceTerminalTabWorkingDirectoryTests.swift
+++ b/cmuxTests/WorkspaceTerminalTabWorkingDirectoryTests.swift
@@ -463,7 +463,7 @@ struct WorkspaceTerminalTabWorkingDirectoryTests {
     }
 
     @MainActor
-    @Test("surface.create honors the TextBox focus preference")
+    @Test("surface.create honors the TextBox focus preference only when focused")
     func surfaceCreateHonorsTextBoxFocusPreference() throws {
         let defaults = UserDefaults.standard
         let showKey = TerminalTextBoxInputSettings.showOnNewTerminalsKey
@@ -508,6 +508,23 @@ struct WorkspaceTerminalTabWorkingDirectoryTests {
         let createdPanel = try #require(workspace.terminalPanel(for: createdPanelId))
         #expect(createdPanel.isTextBoxActive)
         #expect(createdPanel.preferredFocusIntentForActivation() == .terminal(.textBoxInput))
+
+        let backgroundResponse = try v2SocketResponse(
+            method: "surface.create",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "type": "terminal",
+                "focus": false,
+            ]
+        )
+
+        #expect(backgroundResponse["ok"] as? Bool == true)
+        let backgroundResult = try #require(backgroundResponse["result"] as? [String: Any])
+        let backgroundSurfaceIdString = try #require(backgroundResult["surface_id"] as? String)
+        let backgroundPanelId = try #require(UUID(uuidString: backgroundSurfaceIdString))
+        let backgroundPanel = try #require(workspace.terminalPanel(for: backgroundPanelId))
+        #expect(backgroundPanel.isTextBoxActive)
+        #expect(backgroundPanel.preferredFocusIntentForActivation() != .terminal(.textBoxInput))
     }
 
     @MainActor

--- a/cmuxTests/WorkspaceTerminalTabWorkingDirectoryTests.swift
+++ b/cmuxTests/WorkspaceTerminalTabWorkingDirectoryTests.swift
@@ -463,6 +463,54 @@ struct WorkspaceTerminalTabWorkingDirectoryTests {
     }
 
     @MainActor
+    @Test("surface.create honors the TextBox focus preference")
+    func surfaceCreateHonorsTextBoxFocusPreference() throws {
+        let defaults = UserDefaults.standard
+        let showKey = TerminalTextBoxInputSettings.showOnNewTerminalsKey
+        let focusKey = TerminalTextBoxInputSettings.focusOnNewTerminalsKey
+        let previousShowValue = defaults.object(forKey: showKey)
+        let previousFocusValue = defaults.object(forKey: focusKey)
+        let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        defer {
+            if let previousShowValue {
+                defaults.set(previousShowValue, forKey: showKey)
+            } else {
+                defaults.removeObject(forKey: showKey)
+            }
+            if let previousFocusValue {
+                defaults.set(previousFocusValue, forKey: focusKey)
+            } else {
+                defaults.removeObject(forKey: focusKey)
+            }
+            TerminalController.shared.setActiveTabManager(previousManager)
+        }
+
+        defaults.set(false, forKey: showKey)
+        defaults.set(true, forKey: focusKey)
+
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let response = try v2SocketResponse(
+            method: "surface.create",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "type": "terminal",
+                "focus": true,
+            ]
+        )
+
+        #expect(response["ok"] as? Bool == true)
+        let result = try #require(response["result"] as? [String: Any])
+        let createdSurfaceIdString = try #require(result["surface_id"] as? String)
+        let createdPanelId = try #require(UUID(uuidString: createdSurfaceIdString))
+        let createdPanel = try #require(workspace.terminalPanel(for: createdPanelId))
+        #expect(createdPanel.isTextBoxActive)
+        #expect(createdPanel.preferredFocusIntentForActivation() == .terminal(.textBoxInput))
+    }
+
+    @MainActor
     private func v2SocketResponse(
         method: String,
         params: [String: Any],


### PR DESCRIPTION
## Summary

- Let focused `surface.create` terminals honor `terminal.focusTextBoxOnNewTerminals`.
- Keep background terminal creation focus-neutral.
- Cover the socket command path with a regression test.

## Why

Custom sidebars create terminal tabs through `surface.create`. The handler currently disables the TextBox focus default even when the request includes `focus: true`, so the TextBox opens but the terminal keeps keyboard focus.

## Tests

- `swiftc -frontend -parse Sources/TerminalController+ControlSurfaceContext2.swift`
- `swiftc -frontend -parse cmuxTests/WorkspaceTerminalTabWorkingDirectoryTests.swift`
- `CMUX_CLI_BIN=/Applications/cmux.app/Contents/Resources/bin/cmux python3 Tests/test_cli_layout_focus_contract.py`

The focused Xcode test did not start because the local disk filled while Xcode extracted Sentry package artifacts. No compile or test failure was reached.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790182842&installation_model_id=21920&pr_number=10644&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10644&signature=53f5c0bb0ade9ac4879847e7d7ce4c5fe0761d39f664966aa6249a37498abe91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Focused terminal creation via `surface.create` now respects the user’s TextBox focus preference. Previously, focused creations always disabled TextBox focus (keyboard stayed in the terminal); now, when `focus: true`, the TextBox can take keyboard focus per the preference, while unfocused/background creations remain focus-neutral.

- Passes allowTextBoxFocusDefault = focus during terminal creation from `surface.create`.
- Adds a socket-path regression test verifying TextBox activation and focus intent, including when TextBox display is disabled.

<sup>Written for commit f9db2993844e9306435979e67cca6abe5f42bf25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Terminal splits now honor the requested TextBox focus preference instead of always disabling default focus.
  - Newly created terminals activate TextBox input when focus is enabled, even when TextBox display is disabled.

- **Tests**
  - Added coverage for terminal creation and preferred focus behavior across focused and background terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->