### PR TITLE
ios: animate computer visibility toggles on the Computers lists

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -26,6 +26,7 @@ struct DeviceTreeView: View {
     /// Present the add-device (pairing) flow. `nil` hides the add affordance.
     var showAddDevice: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Live app routes dismiss through the root modal owner. Standalone hosts
     /// leave this nil and retain the environment dismissal fallback.
     var dismissAction: (() -> Void)? = nil
@@ -42,6 +43,18 @@ struct DeviceTreeView: View {
     /// list shows exactly the same computer set.
     private var computers: [MacComputerSnapshot] {
         MacComputerSnapshot.snapshots(from: store)
+    }
+
+    /// Which row lives in which section (method sections + Hidden Computers).
+    /// The visibility switches mutate the store asynchronously, so the row's
+    /// section move lands after the toggle's own transaction has ended;
+    /// animating the list on this key keeps that move smooth. Keyed on
+    /// membership only, so the 10s presence refresh (same rows, new status
+    /// text) doesn't animate.
+    private var rowMembership: [String] {
+        MacComputerListSection.sections(from: computers).flatMap { section in
+            [section.id] + section.computers.map(\.id)
+        } + ["hidden"] + store.hiddenComputers.map(\.id)
     }
 
     var body: some View {
@@ -95,6 +108,7 @@ struct DeviceTreeView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .animation(reduceMotion ? nil : .smooth(duration: 0.3), value: rowMembership)
             .navigationDestination(for: MacConnectionRef.self) { ref in
                 if let computer = computers.first(where: { $0.id == ref.pairingID }) {
                     MacComputerDetailView(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -56,6 +56,7 @@ struct DisconnectedWorkspaceShellView: View {
     }
 
     #if os(iOS)
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The computer a reconnect attempt is in flight for. Also the re-entry
     /// guard: while non-nil, row taps are ignored.
     @State private var connectingMacID: String?
@@ -213,6 +214,15 @@ struct DisconnectedWorkspaceShellView: View {
             }
         }
         .listStyle(.insetGrouped)
+        // The visibility switches mutate the store asynchronously, so a row's
+        // move between the shown and hidden runs of the section lands after
+        // the toggle's own transaction has ended; animating on membership
+        // keeps that reorder smooth. Keyed on ids only, so the 10s presence
+        // refresh (same rows, new status text) doesn't animate.
+        .animation(
+            reduceMotion ? nil : .smooth(duration: 0.3),
+            value: computers.map(\.id) + ["hidden"] + (store?.hiddenComputers.map(\.id) ?? [])
+        )
         .refreshable {
             // Same refresh the 10s loop performs (plus registry), so a pull
             // updates the presence/last-seen the rows lead with, not just the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -37,6 +37,20 @@ private enum ComputerVisibilityRowItem: Identifiable {
     }
 }
 
+/// Insertion/removal phase for a row copy crossing sections: a transitioning
+/// copy is invisible AND untouchable until the phase ends. SwiftUI still hit
+/// tests zero-opacity views, so a bare opacity transition would leave an
+/// invisible, enabled switch tappable during the sequenced fade-in delay.
+private struct ComputerRowTransitionPhase: ViewModifier {
+    let shown: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(shown ? 1 : 0)
+            .allowsHitTesting(shown)
+    }
+}
+
 /// A stable computer row whose trailing visibility switch survives transitions
 /// between visible and hidden content.
 ///
@@ -49,6 +63,7 @@ private struct ComputerVisibilityRow: View {
     var style: MacComputerRow.Style
     let connect: @MainActor (MacComputerSnapshot) -> Void
     let isConnecting: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var isBusy: Bool { isVisibilityMutating }
 
     var body: some View {
@@ -69,10 +84,17 @@ private struct ComputerVisibilityRow: View {
         // copy gone before the incoming copy appears) keeps the two switches
         // from blending into one malformed half-on ghost. Within a single
         // ForEach (disconnected shell) toggles reorder in place, so this
-        // transition never fires there.
-        .transition(.asymmetric(
-            insertion: .opacity.animation(.easeIn(duration: 0.15).delay(0.25)),
-            removal: .opacity.animation(.easeOut(duration: 0.12))
+        // transition never fires there. Reduce Motion swaps rows instantly,
+        // matching the owning lists' nil animation.
+        .transition(reduceMotion ? .identity : .asymmetric(
+            insertion: AnyTransition.modifier(
+                active: ComputerRowTransitionPhase(shown: false),
+                identity: ComputerRowTransitionPhase(shown: true)
+            ).animation(.easeIn(duration: 0.15).delay(0.25)),
+            removal: AnyTransition.modifier(
+                active: ComputerRowTransitionPhase(shown: false),
+                identity: ComputerRowTransitionPhase(shown: true)
+            ).animation(.easeOut(duration: 0.12))
         ))
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -63,6 +63,17 @@ private struct ComputerVisibilityRow: View {
             )
         }
         .padding(.vertical, item.isVisible ? 0 : 4)
+        // A toggle that moves a row across sections (Computers screen) is a
+        // remove+insert of two row copies: identity carries a Toggle through a
+        // model update only within one ForEach. Sequencing the fades (outgoing
+        // copy gone before the incoming copy appears) keeps the two switches
+        // from blending into one malformed half-on ghost. Within a single
+        // ForEach (disconnected shell) toggles reorder in place, so this
+        // transition never fires there.
+        .transition(.asymmetric(
+            insertion: .opacity.animation(.easeIn(duration: 0.15).delay(0.25)),
+            removal: .opacity.animation(.easeOut(duration: 0.12))
+        ))
     }
 
     @ViewBuilder


### PR DESCRIPTION
Toggling a computer's visibility switch on the Computers screen (and on the disconnected shell's Your Computers list) made the row snap between the visible section and Hidden Computers with no animation.

Cause: `ComputerVisibilityToggle` wraps `setVisible` in an animated transaction, but the store mutation is asynchronous (`requestHideStoredPairedMacEntries` / `requestUnhideMacDeviceID` enqueue a task), so the actual row move lands on a later update outside that transaction. The debug fixture (`HiddenComputersPreviewView`) mutates synchronously, which is why it animates while the real screens snap.

Fix: animate the two owning `List`s on row membership, `.animation(.smooth(duration: 0.3), value:)` keyed to section/row ids only. Hide/unhide moves (and add/forget row changes) animate smoothly; the 10s presence refresh changes only row text, leaves the key unchanged, and stays animation-free. Gated on the Reduce Motion accessibility setting, matching the repo idiom (`OnboardingPageViewport`).

HIG: checked Motion (https://developer.apple.com/design/human-interface-guidelines/motion) — motion is purposeful feedback tied to the user's action, brief (0.3s), and optional via Reduce Motion. This also restores the system-standard behavior of animated list edits.

No behavioral logic changes; no new user-facing strings (localization audit: none needed). No practical behavior-level test for animation transactions; the existing visibility-persistence UI tests cover the toggle's state path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790188609&installation_model_id=21920&pr_number=10645&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10645&signature=0a7d55abc6a61378c726c91d73f044ec9b23257b8dea217435d76aa71044d279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smoothly animates visibility toggles on iOS Computers lists and eliminates ghosting and phantom taps when rows move across sections. Previously, toggling snapped rows and could crossfade two switches; now membership moves animate (0.3s), cross-section fades are sequenced, and invisible copies don’t receive taps, all respecting Reduce Motion.

- Animates `List` updates keyed to section/row membership in the Computers screen and the disconnected shell; hide/unhide and add/forget moves animate, while the 10s presence refresh does not.
- Sequences cross-section transitions with a modifier that pairs opacity with allowsHitTesting so only one switch is visible and tappable; under Reduce Motion, both the list animation and row transition are disabled. 
- No behavior logic or string changes.

<sup>Written for commit 93b2042722bcf1f375febc91d51d9797a95f1b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Respects the system’s Reduce Motion setting by disabling movement and fade animations when enabled.

* **UI Improvements**
  * Added smooth animations when saved computers and workspace rows are reordered or moved between visible and hidden sections.
  * Added subtle fade transitions when rows appear or disappear.
  * Status and presence updates refresh without triggering unnecessary row animations.
  * Invisible transitioning rows cannot be selected during fade-in effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->