### PR TITLE
iOS: reserve first-pass title space for every structural trailing item

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -91,6 +91,16 @@ struct MobileLeadingToolbarTitleWidth {
                 + unmeasured * Self.unmeasuredTrailingItemReserve
         }
         guard hasTrailingCluster else { return 0 }
+        // Nothing measured yet: the first layout pass after a (re)mount. The
+        // structural item count is already known, so reserve fallback space
+        // for every item beyond the cluster (the Changes chip on a connected
+        // workspace), or the title over-claims on that first pass and the
+        // system folds trailing items, sometimes the title itself, into the
+        // More menu. A collapse born on the first pass never produces the
+        // attach-then-detach signature the recovery ratchet watches for, so
+        // it would stick until the next full remount.
+        let extraStructuralItems = CGFloat(max(trailingItemCount - 1, 0))
         return Self.trailingReserveBase
+            + extraStructuralItems * Self.unmeasuredTrailingItemReserve
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -84,6 +84,31 @@ import Testing
         #expect(measured.cap < constantOnly)
     }
 
+    @Test func zeroMeasurementReservesEveryStructuralItem() {
+        // Remount repro: a workspace reopens straight into a browser with the
+        // Changes chip structurally present but nothing measured yet. The
+        // first pass must reserve for the chip too, or the title over-claims
+        // and the system folds the picker (or the title itself) into the More
+        // menu; a collapse born on the first pass never produces the
+        // attach-then-detach signature the recovery ratchet watches, so it
+        // sticks until the next remount.
+        let clusterOnly = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            trailingItemCount: 1
+        )
+        let clusterPlusChip = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            trailingItemCount: 2
+        )
+
+        #expect(clusterOnly.cap - clusterPlusChip.cap
+            == MobileLeadingToolbarTitleWidth.unmeasuredTrailingItemReserve)
+    }
+
     @Test func zeroMeasurementFallsBackToConstants() {
         let unmeasured = MobileLeadingToolbarTitleWidth(
             contentWidth: 393,


### PR DESCRIPTION
Dogfood on cmux INTERNAL (build containing https://github.com/manaflow-ai/cmux/pull/10620): reopening a workspace that restores directly into a browser pane shows the More "…" menu immediately, holding the picker, and with longer titles the workspace title item too, before any scrolling. Reproduced on an isolated simulator from main: open workspace → New Browser → load a page → back to the list → reopen; the picker sat in "…" from the first frame while the title pill and Changes chip stayed in the bar.

Mechanism: at (re)mount the trailing-item measurement dictionary is empty, and `MobileLeadingToolbarTitleWidth`'s zero-measurement fallback reserved only `trailingReserveBase` (the picker cluster), nothing for the structurally present Changes item, so the title claimed that space on the first layout pass and the bar over-committed. Severity scales with the title/page-name widths, which is why only some browser panes show it. Worse, a collapse present from the first frame never produces the attach-then-detach signature that the recovery ratchet from #10620 watches for, so it never self-heals within the screen's lifetime.

Fix: the zero-measurement fallback now adds `unmeasuredTrailingItemReserve` for each structural trailing item beyond the cluster (the structural count is already known at mount). Measured widths replace the estimate one layout pass later exactly as before. Regression test pins the reserve delta.

Verified on an isolated simulator: the remount-into-browser path keeps picker, Changes chip, and the workspace-name/tab-title pill all in the bar with no "…" (screenshots in the dogfood thread).

No user-facing strings changed (localization audit: none needed). HIG reference for bar behavior: Navigation bars (https://developer.apple.com/design/human-interface-guidelines/navigation-bars), all controls remain visible and reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790189670&installation_model_id=21920&pr_number=10646&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10646&signature=3799885ad29a1ffc8fd7c6d5331a819915901f598488705ceee4d5300665a800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents iOS nav bar items from collapsing into the “…” menu on the first layout pass after mount/remount by reserving title space for every structural trailing item. Previously, the fallback reserved only the trailing cluster; now it adds a per-item reserve and replaces it with measured widths on the next pass.

- **Review notes**
  - Updates the zero-measurement path in `MobileLeadingToolbarTitleWidth` to compute `extraStructuralItems = max(trailingItemCount - 1, 0)` and add `unmeasuredTrailingItemReserve` per item beyond the cluster.
  - Adds `zeroMeasurementReservesEveryStructuralItem` test to pin the reserve delta to `unmeasuredTrailingItemReserve`.

<sup>Written for commit 9baa98c67bb5bf4c1abf079ec0ccb298e65fa597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolbar title layout when trailing items have no measured width.
  * Ensured space is reserved for each structural trailing item, preventing overlap or incorrect title sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->