### PR TITLE
iOS: suspend the terminal output consumer on the app lifecycle (0x8BADF00D watchdog kill)

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -305,6 +305,26 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// (previews, isolated harnesses). Lazy so production mounts, which
         /// receive the composition root's tracker, never build one.
         lazy var fallbackKeyboardFrameTracker = MobileKeyboardFrameTracker()
+        /// Last presentation value SwiftUI delivered through `updateUIView`.
+        /// Kept separate from the effective flag so the application lifecycle
+        /// can suspend the consumer without a scene update having to run, and
+        /// so returning to the foreground restores exactly what SwiftUI asked
+        /// for rather than an unconditional "active".
+        private var desiredPresentationIsActive: Bool
+        /// Driven by the UIApplication lifecycle notifications below. The
+        /// mounted output consumer pumps every chunk on the main actor; its
+        /// only shutdown path used to be the SwiftUI `scenePhase` prop, which
+        /// arrives *as* a scene update. Backgrounding a chatty terminal then
+        /// had to win a race against the main actor the consumer was
+        /// saturating, and losing it is a `0x8BADF00D` scene-update watchdog
+        /// kill. The render side already suspends on these notifications
+        /// (`GhosttySurfaceView`); the consumer must do the same.
+        ///
+        /// Seeded from the live application state rather than `false`: adding
+        /// the observers does not replay the notifications that already fired,
+        /// so a coordinator built while the app is inactive would otherwise
+        /// start its consumer straight back into the watchdog path.
+        private var applicationIsBackgrounded = UIApplication.shared.applicationState != .active
 
         init(
             workspaceID: String,
@@ -329,6 +349,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             self.surfaceID = surfaceID
             self.store = store
             self.terminalPresentationIsActive = terminalPresentationIsActive
+            self.desiredPresentationIsActive = terminalPresentationIsActive
             self.artifactFilesEnabled = artifactFilesEnabled
             self.terminalFolderTapEnabled = terminalFolderTapEnabled
             self.artifactChipGate = TerminalArtifactChipFeatureGate(
@@ -347,6 +368,54 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             self.outputConsumerRestartClock = outputConsumerRestartClock
             self.outputConsumerRecoveryClock = outputConsumerRecoveryClock
             super.init()
+            observeApplicationLifecycle()
+        }
+
+        /// Suspend the output consumer on `willResignActive` (which fires
+        /// before `didEnterBackground`, while the scene update that would
+        /// otherwise carry the SwiftUI prop is still cheap to run), with
+        /// `didEnterBackground` as an idempotent backstop. This mirrors the
+        /// render-side suspension in `GhosttySurfaceView` so both halves of a
+        /// terminal stop on the same signal instead of one of them waiting on
+        /// SwiftUI.
+        private func observeApplicationLifecycle() {
+            let center = NotificationCenter.default
+            center.addObserver(
+                self,
+                selector: #selector(handleAppWillResignActive),
+                name: UIApplication.willResignActiveNotification,
+                object: nil
+            )
+            center.addObserver(
+                self,
+                selector: #selector(handleAppDidEnterBackground),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+            center.addObserver(
+                self,
+                selector: #selector(handleAppDidBecomeActive),
+                name: UIApplication.didBecomeActiveNotification,
+                object: nil
+            )
+        }
+
+        @objc private func handleAppWillResignActive() {
+            setApplicationBackgrounded(true)
+        }
+
+        @objc private func handleAppDidEnterBackground() {
+            setApplicationBackgrounded(true)
+        }
+
+        @objc private func handleAppDidBecomeActive() {
+            setApplicationBackgrounded(false)
+        }
+
+        private func setApplicationBackgrounded(_ isBackgrounded: Bool) {
+            guard applicationIsBackgrounded != isBackgrounded else { return }
+            applicationIsBackgrounded = isBackgrounded
+            applyPresentationState()
         }
 
         func attach(surfaceView: GhosttySurfaceView) {
@@ -937,6 +1006,17 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         }
 
         func setTerminalPresentationActive(_ isActive: Bool) {
+            guard desiredPresentationIsActive != isActive else { return }
+            desiredPresentationIsActive = isActive
+            applyPresentationState()
+        }
+
+        /// A backgrounded application never presents a terminal, so the
+        /// lifecycle wins over whatever SwiftUI last asked for. Folding both
+        /// inputs here keeps one mutation path: the notification handlers and
+        /// `updateUIView` cannot disagree about whether the consumer runs.
+        private func applyPresentationState() {
+            let isActive = desiredPresentationIsActive && !applicationIsBackgrounded
             guard terminalPresentationIsActive != isActive else { return }
             terminalPresentationIsActive = isActive
             guard let surfaceView else { return }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -320,11 +320,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// kill. The render side already suspends on these notifications
         /// (`GhosttySurfaceView`); the consumer must do the same.
         ///
-        /// Seeded from the live application state rather than `false`: adding
-        /// the observers does not replay the notifications that already fired,
-        /// so a coordinator built while the app is inactive would otherwise
-        /// start its consumer straight back into the watchdog path.
-        private var applicationIsBackgrounded = UIApplication.shared.applicationState != .active
+        /// Seeded from the live application state rather than `false`, and
+        /// folded into the effective flag before `init` returns: adding the
+        /// observers does not replay the notifications that already fired, so
+        /// a coordinator built while the app is inactive would otherwise
+        /// attach and start its consumer straight back into the watchdog path.
+        /// Injected so that seed is testable without driving `UIApplication`.
+        private var applicationIsBackgrounded: Bool
 
         init(
             workspaceID: String,
@@ -343,7 +345,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             onArtifactGalleryRefreshSignal: @escaping @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void,
             artifactChipHideClock: any Clock<Duration> = ContinuousClock(),
             outputConsumerRestartClock: any Clock<Duration> = ContinuousClock(),
-            outputConsumerRecoveryClock: any Clock<Duration> = ContinuousClock()
+            outputConsumerRecoveryClock: any Clock<Duration> = ContinuousClock(),
+            applicationIsBackgrounded: Bool = UIApplication.shared.applicationState != .active
         ) {
             self.workspaceID = workspaceID
             self.surfaceID = surfaceID
@@ -367,8 +370,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             self.artifactChipHideClock = artifactChipHideClock
             self.outputConsumerRestartClock = outputConsumerRestartClock
             self.outputConsumerRecoveryClock = outputConsumerRecoveryClock
+            self.applicationIsBackgrounded = applicationIsBackgrounded
             super.init()
             observeApplicationLifecycle()
+            // Fold the seed in now. `attach(surfaceView:)` guards on the
+            // effective flag, so leaving it stale until the first notification
+            // or scene update would let a coordinator built in the background
+            // mount a consumer immediately.
+            applyPresentationState()
         }
 
         /// Suspend the output consumer on `willResignActive` (which fires

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalOutputBackgroundSuspensionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalOutputBackgroundSuspensionTests.swift
@@ -1,0 +1,193 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import CmuxMobileTerminal
+import CmuxMobileShellModel
+import SwiftUI
+import Testing
+import UIKit
+@testable import CmuxMobileShell
+@testable import CmuxMobileShellUI
+
+/// The mounted output consumer pumps every terminal chunk on the main actor.
+/// Its only shutdown path used to be the SwiftUI `scenePhase` prop arriving
+/// through `updateUIView` — which is itself a scene update. Backgrounding a
+/// chatty terminal therefore had to win a race against the very main actor the
+/// consumer was saturating, and losing it is a `0x8BADF00D` scene-update
+/// watchdog kill (observed on TestFlight 1.0.4: `WatchdogEvent: scene-update`,
+/// `ProcessVisibility: Background`, faulting frame inside the output loop).
+///
+/// The consumer must therefore release on the UIApplication lifecycle
+/// notifications directly, exactly as the render side already does in
+/// `GhosttySurfaceView`, without depending on a scene update running first.
+@Suite("Terminal output background suspension", .serialized)
+struct TerminalOutputBackgroundSuspensionTests {
+    @MainActor
+    @Test("backgrounding releases the output consumer without a scene update")
+    func backgroundingReleasesOutputConsumerWithoutSceneUpdate() async throws {
+        let store = MobileShellComposite.preview()
+        let workspace = try #require(store.workspaces.first { !$0.terminals.isEmpty })
+        let terminal = try #require(workspace.terminals.first)
+        let surfaceID = terminal.id.rawValue
+        let coordinator = GhosttySurfaceRepresentable.Coordinator(
+            workspaceID: workspace.id.rawValue,
+            surfaceID: surfaceID,
+            store: store,
+            artifactFilesEnabled: false,
+            terminalFolderTapEnabled: false,
+            terminalFilesChipEnabled: false,
+            sessionArtifactCountEnabled: false,
+            visibleArtifactCount: 0,
+            onArtifactFilesRequested: { _ in },
+            onArtifactPathTapped: { _ in },
+            onVisibleArtifactCountChanged: { _ in },
+            onArtifactGalleryRefreshSignal: { _ in }
+        )
+        let surfaceView = GhosttySurfaceView(
+            runtime: try GhosttyRuntime.shared(),
+            delegate: coordinator
+        )
+        let host = UIViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        coordinator.attach(surfaceView: surfaceView)
+        defer {
+            surfaceView.removeFromSuperview()
+            coordinator.detach()
+            surfaceView.prepareForDismantle()
+            window.isHidden = true
+        }
+
+        surfaceView.frame = host.view.bounds
+        host.view.addSubview(surfaceView)
+        coordinator.ghosttySurfaceView(
+            surfaceView,
+            didResize: TerminalGridSize(
+                columns: 72,
+                rows: 61,
+                pixelWidth: 1_296,
+                pixelHeight: 2_135
+            ),
+            reportID: 1
+        )
+        let mounted = await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] != nil
+        }
+        #expect(mounted)
+
+        // The scene update never runs: no `setTerminalPresentationActive(false)`
+        // call, which is what `updateUIView` would deliver. Backgrounding alone
+        // has to release the consumer.
+        NotificationCenter.default.post(
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.post(
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+
+        let released = await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] == nil
+        }
+        #expect(released)
+    }
+
+    @MainActor
+    @Test("returning to the foreground remounts the output consumer")
+    func returningToForegroundRemountsOutputConsumer() async throws {
+        let store = MobileShellComposite.preview()
+        let workspace = try #require(store.workspaces.first { !$0.terminals.isEmpty })
+        let terminal = try #require(workspace.terminals.first)
+        let surfaceID = terminal.id.rawValue
+        let coordinator = GhosttySurfaceRepresentable.Coordinator(
+            workspaceID: workspace.id.rawValue,
+            surfaceID: surfaceID,
+            store: store,
+            artifactFilesEnabled: false,
+            terminalFolderTapEnabled: false,
+            terminalFilesChipEnabled: false,
+            sessionArtifactCountEnabled: false,
+            visibleArtifactCount: 0,
+            onArtifactFilesRequested: { _ in },
+            onArtifactPathTapped: { _ in },
+            onVisibleArtifactCountChanged: { _ in },
+            onArtifactGalleryRefreshSignal: { _ in }
+        )
+        let surfaceView = GhosttySurfaceView(
+            runtime: try GhosttyRuntime.shared(),
+            delegate: coordinator
+        )
+        let host = UIViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        coordinator.attach(surfaceView: surfaceView)
+        defer {
+            surfaceView.removeFromSuperview()
+            coordinator.detach()
+            surfaceView.prepareForDismantle()
+            window.isHidden = true
+        }
+
+        surfaceView.frame = host.view.bounds
+        host.view.addSubview(surfaceView)
+        coordinator.ghosttySurfaceView(
+            surfaceView,
+            didResize: TerminalGridSize(
+                columns: 72,
+                rows: 61,
+                pixelWidth: 1_296,
+                pixelHeight: 2_135
+            ),
+            reportID: 1
+        )
+        #expect(await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] != nil
+        })
+        let firstToken = try #require(store.terminalOutputStreamTokensBySurfaceID[surfaceID])
+
+        NotificationCenter.default.post(
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        #expect(await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] == nil
+        })
+
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        coordinator.ghosttySurfaceView(
+            surfaceView,
+            didResize: TerminalGridSize(
+                columns: 72,
+                rows: 61,
+                pixelWidth: 1_296,
+                pixelHeight: 2_135
+            ),
+            reportID: 2
+        )
+        let remounted = await waitUntil {
+            guard let token = store.terminalOutputStreamTokensBySurfaceID[surfaceID] else {
+                return false
+            }
+            return token != firstToken
+        }
+        #expect(remounted)
+    }
+
+    @MainActor
+    private func waitUntil(
+        attempts: Int = 100,
+        _ predicate: () -> Bool
+    ) async -> Bool {
+        for _ in 0..<attempts {
+            if predicate() { return true }
+            await Task.yield()
+        }
+        return predicate()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalOutputBackgroundSuspensionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalOutputBackgroundSuspensionTests.swift
@@ -179,6 +179,84 @@ struct TerminalOutputBackgroundSuspensionTests {
     }
 
     @MainActor
+    @Test("a coordinator built while backgrounded never starts a consumer on attach")
+    func coordinatorBuiltWhileBackgroundedDoesNotStartConsumerOnAttach() async throws {
+        let store = MobileShellComposite.preview()
+        let workspace = try #require(store.workspaces.first { !$0.terminals.isEmpty })
+        let terminal = try #require(workspace.terminals.first)
+        let surfaceID = terminal.id.rawValue
+        // Registering the observers does not replay notifications that already
+        // fired, so the seed is the only thing standing between a background
+        // launch and a main-actor consumer nobody asked for.
+        let coordinator = GhosttySurfaceRepresentable.Coordinator(
+            workspaceID: workspace.id.rawValue,
+            surfaceID: surfaceID,
+            store: store,
+            artifactFilesEnabled: false,
+            terminalFolderTapEnabled: false,
+            terminalFilesChipEnabled: false,
+            sessionArtifactCountEnabled: false,
+            visibleArtifactCount: 0,
+            onArtifactFilesRequested: { _ in },
+            onArtifactPathTapped: { _ in },
+            onVisibleArtifactCountChanged: { _ in },
+            onArtifactGalleryRefreshSignal: { _ in },
+            applicationIsBackgrounded: true
+        )
+        let surfaceView = GhosttySurfaceView(
+            runtime: try GhosttyRuntime.shared(),
+            delegate: coordinator
+        )
+        let host = UIViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        coordinator.attach(surfaceView: surfaceView)
+        defer {
+            surfaceView.removeFromSuperview()
+            coordinator.detach()
+            surfaceView.prepareForDismantle()
+            window.isHidden = true
+        }
+
+        surfaceView.frame = host.view.bounds
+        host.view.addSubview(surfaceView)
+        coordinator.ghosttySurfaceView(
+            surfaceView,
+            didResize: TerminalGridSize(
+                columns: 72,
+                rows: 61,
+                pixelWidth: 1_296,
+                pixelHeight: 2_135
+            ),
+            reportID: 1
+        )
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+        #expect(store.terminalOutputStreamTokensBySurfaceID[surfaceID] == nil)
+
+        // The same coordinator must still come up once the app is active.
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        coordinator.ghosttySurfaceView(
+            surfaceView,
+            didResize: TerminalGridSize(
+                columns: 72,
+                rows: 61,
+                pixelWidth: 1_296,
+                pixelHeight: 2_135
+            ),
+            reportID: 2
+        )
+        #expect(await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] != nil
+        })
+    }
+
+    @MainActor
     private func waitUntil(
         attempts: Int = 100,
         _ predicate: () -> Bool


### PR DESCRIPTION
## What breaks

A backgrounded terminal can kill the app with a `0x8BADF00D` scene-update watchdog transgression. Reproduced from a device crash report on TestFlight 1.0.4 (iOS 27.0 `24A5408d`) — nine reports on one device, four of them inside six minutes, i.e. a relaunch/crash loop:

```
exception   : EXC_CRASH / SIGKILL
termination : FRONTBOARD 0x8BADF00D
              scene-update watchdog transgression: exhausted real
              (wall clock) time allowance of 10.00 seconds
WatchdogEvent      : scene-update
WatchdogVisibility : Background
ProcessVisibility  : Background
ProcessState       : Running
CPU                : 25.010s total (user 19.290, system 5.720)
```

Symbolicated faulting thread 0 (dSYM rebuilt from the crashing source revision; `__TEXT,__text` matches the crashed slice at addr `0x100004000` size `0x1fcebf8`):

```
swift::AsyncTask::getPreferredTaskExecutor(bool)
swift_task_switch(..., swift::SerialExecutorRef)
  await resume partial function for closure #4 () async -> () in
  GhosttySurfaceRepresentable.Coordinator.startMountedTasks(surfaceView:)
completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*)
```

## Why

The mounted output consumer pumps every terminal chunk on the main actor. Its only shutdown path is the SwiftUI `scenePhase` prop arriving through `updateUIView` — **which is itself a scene update**. So backgrounding a chatty terminal has to win a race against the very main actor the consumer is saturating. Lose the race and the watchdog fires; the mechanism meant to stop the loop is starved by the loop.

The asymmetry is visible in the tree today: the render half already suspends directly on `willResignActive` / `didEnterBackground` (`GhosttySurfaceView`), the consumer half does not.

## Change

`terminalPresentationIsActive` stays the effective flag the output loop already guards on, so the loop body is untouched. It is now *derived*:

- `desiredPresentationIsActive` — what SwiftUI last asked for
- `applicationIsBackgrounded` — driven by the UIApplication lifecycle notifications
- `applyPresentationState()` — folds both into one mutation path

A backgrounded application never presents a terminal, so the lifecycle wins; returning to the foreground restores exactly what SwiftUI asked for rather than an unconditional "active". `willResignActive` fires first (while a scene update is still cheap), `didEnterBackground` repeats it idempotently as a backstop. Both funnel through the existing `stopMountedTasks()`, so the bounded restart budget, the recovery alert, and the viewport release behave exactly as for a SwiftUI-driven deactivation.

## Tests

Two commits, per the repo's regression policy — the Commits tab shows the test red before the fix:

1. `a565faa` adds `TerminalOutputBackgroundSuspensionTests` (red)
2. `076e12c` adds the fix (green)

The suite posts the lifecycle notifications **without** any `setTerminalPresentationActive` call, so it fails unless the consumer stops depending on a scene update.

```
✘ backgrounding releases the output consumer without a scene update  → Expectation failed: released
✘ returning to the foreground remounts the output consumer           → 2 issues
```
after:
```
✔ backgrounding releases the output consumer without a scene update  (0.310s)
✔ returning to the foreground remounts the output consumer           (0.089s)
✔ off-window terminal does not claim the output stream               (0.405s)
✔ terminal primes current viewport before claiming output on each mount (0.135s)
✔ a terminated output stream is reclaimed while the surface remains mounted (0.075s)
** TEST SUCCEEDED **  (5 tests, 2 suites)
```

Run on iOS Simulator (iPhone 17, iOS 27.0) with Xcode 26.3.

## Notes for reviewers

- **Drive-by, required to build:** `VerifiedReplayPresentationTests.swift` was missing `import QuartzCore`, so the iOS test bundle would not compile locally at all (`cannot find 'CACurrentMediaTime' in scope`). One import, in commit 1.
- **Not fixed here, but you should know:** `ios/cmuxPackage/Tests/cmuxFeatureTests` does not compile on `main` — `MobileIrohRuntimeComposition{,Cooldown}Tests` (protocol conformance) and `TerminalRowCapacityFitTests` (changed signatures). Since `-only-testing:` still builds every test target in the scheme, this blocks any local iOS test run. I parked that directory to get the red/green signal above and restored it before committing; nothing from it is in this PR. Fixing it means guessing at intended behavior, so I left it alone.
- **Deliberately not done:** adding `await Task.yield()` inside the chunk loop. `for await chunk in …` already suspends every iteration, so an extra hop buys nothing while adding latency on a path `CLAUDE.md` flags as latency-sensitive.
- **Localization:** no user-facing strings added, changed, or removed — nothing to audit in `Localizable.xcstrings` or the web catalogs.
- **HIG:** this is a lifecycle/behavior change with no visual surface, so no HIG page governs it. The controlling guidance is [Managing your app's life cycle](https://developer.apple.com/documentation/uikit/managing-your-app-s-life-cycle) — "Prepare your UI for the background" — which is what the render side already follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790190138&installation_model_id=21920&pr_number=10647&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10647&signature=e75661417efd66b7a784215f4bc48ff9cd40544fb612be9db85165fd46f5002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suspend the iOS terminal output consumer on app lifecycle to prevent `0x8BADF00D` scene-update watchdog kills when backgrounded. Previously it stopped only after a SwiftUI scene update; now it suspends on `UIApplication` lifecycle and resumes on foreground.

- Derives effective `terminalPresentationIsActive` from `desiredPresentationIsActive` and `applicationIsBackgrounded`, folded by `applyPresentationState()` and seeded at init so a coordinator built in the background never mounts a consumer.
- Observes `willResignActive` and `didEnterBackground` to suspend, and `didBecomeActive` to resume, mirroring `GhosttySurfaceView`; loop body and teardown are unchanged.
- Adds `TerminalOutputBackgroundSuspensionTests` for release, remount, and backgrounded-at-birth cases; adds `import QuartzCore` to `VerifiedReplayPresentationTests` to fix the test build.

<sup>Written for commit 1b6b5467c0649cdad1706ca1813911d557bf56a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal output now pauses when the app is backgrounded, reducing unnecessary activity.
  * Terminal output automatically resumes when the app returns to the foreground.
  * Terminal surfaces correctly restore output after resizing or lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->