### PR TITLE
fix(ssh): retract stale connection sidebar errors after reconnect

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2844,6 +2844,22 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
     }
 
+    /// Retracts connection-state failures after the transport has published
+    /// an authoritative `.connected`.
+    ///
+    /// The sidebar row renders the latest log entry, so a recovered
+    /// `SSH error (target): …` or `SSH reconnect paused …` line (both
+    /// appended with source "remote") would otherwise keep a Connected
+    /// workspace flagged red forever. Proxy-only and daemon entries have
+    /// their own retraction paths; this covers the non-proxy connection seam
+    /// those paths deliberately leave alone.
+    /// https://github.com/manaflow-ai/cmux/issues/10640
+    func clearRecoveredRemoteConnectionSidebarArtifacts() {
+        logEntries.removeAll { $0.source == "remote" }
+        statusEntries.removeValue(forKey: Self.remoteErrorStatusKey)
+        remoteLastErrorFingerprint = nil
+    }
+
     private func remoteNotificationCooldownKey(target: String) -> String? {
         let rawTarget = (remoteConfiguration?.destination ?? target)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -7263,6 +7279,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
         if state == .connected {
             clearProxyOnlyRemoteSidebarArtifacts()
+            clearRecoveredRemoteConnectionSidebarArtifacts()
             clearRecoveredRemoteDaemonSidebarArtifacts()
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2858,6 +2858,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         logEntries.removeAll { $0.source == "remote" }
         statusEntries.removeValue(forKey: Self.remoteErrorStatusKey)
         remoteLastErrorFingerprint = nil
+        if let key = remoteNotificationCooldownKey(target: remoteDisplayTarget ?? "") {
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, correlationKey: key)
+        }
     }
 
     private func remoteNotificationCooldownKey(target: String) -> String? {

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -125,4 +125,150 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             "A recovered bootstrap log must not remain the sidebar's latest error"
         )
     }
+
+    /// https://github.com/manaflow-ai/cmux/issues/10640: a non-proxy SSH
+    /// failure ("ssh: connect to host …") is logged with source "remote".
+    /// Once the transport publishes an authoritative `.connected`, that
+    /// recovered failure must not stay pinned as the sidebar row's latest
+    /// (red) log entry.
+    @Test
+    func connectedRetractsRecoveredSSHConnectionError() {
+        let workspace = Workspace()
+        let target = "dev@example.com"
+        let config = WorkspaceRemoteConfiguration(
+            destination: target,
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_023,
+            relayID: String(repeating: "a", count: 16),
+            relayToken: String(repeating: "b", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test-ssh-error.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+        workspace.logEntries.append(
+            SidebarLogEntry(
+                message: "User-visible note",
+                level: .info,
+                source: "user",
+                timestamp: Date()
+            )
+        )
+
+        let failureDetail =
+            "ssh: connect to host example.com port 22: Operation timed out (retry 3 in 8s)"
+        workspace.applyRemoteConnectionStateUpdate(
+            .error,
+            detail: failureDetail,
+            target: target
+        )
+
+        #expect(workspace.logEntries.last?.source == "remote")
+        #expect(workspace.logEntries.last?.level == .error)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to \(target)",
+            target: target
+        )
+
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote" }) == nil,
+            "A recovered SSH connection error must be retracted on .connected"
+        )
+        #expect(
+            workspace.logEntries.contains { $0.message == "User-visible note" },
+            "Recovery must preserve unrelated sidebar log entries"
+        )
+        #expect(
+            workspace.logEntries.last?.level != .error,
+            "The workspace row must not keep rendering a recovered SSH error while Connected"
+        )
+        #expect(workspace.statusEntries["remote.error"] == nil)
+
+        let logCountAfterRecovery = workspace.logEntries.count
+        workspace.applyRemoteConnectionStateUpdate(
+            .error,
+            detail: failureDetail,
+            target: target
+        )
+        #expect(
+            workspace.logEntries.count == logCountAfterRecovery + 1,
+            "Recovery must reset the connection error fingerprint"
+        )
+    }
+
+    /// https://github.com/manaflow-ai/cmux/issues/10640: the suspended-state
+    /// warning ("SSH reconnect paused …", source "remote") must likewise be
+    /// retracted once the connection recovers to `.connected`.
+    @Test
+    func connectedRetractsRecoveredSuspendedWarning() {
+        let workspace = Workspace()
+        let target = "dev@example.com"
+        let config = WorkspaceRemoteConfiguration(
+            destination: target,
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_024,
+            relayID: String(repeating: "1", count: 16),
+            relayToken: String(repeating: "2", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test-suspended.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+        workspace.logEntries.append(
+            SidebarLogEntry(
+                message: "User-visible note",
+                level: .info,
+                source: "user",
+                timestamp: Date()
+            )
+        )
+
+        let suspendedDetail = "Reconnect budget exhausted"
+        workspace.applyRemoteConnectionStateUpdate(
+            .suspended,
+            detail: suspendedDetail,
+            target: target
+        )
+
+        #expect(workspace.logEntries.last?.source == "remote")
+        #expect(workspace.logEntries.last?.level == .warning)
+        #expect(workspace.statusEntries["remote.error"] != nil)
+
+        workspace.applyRemoteConnectionStateUpdate(
+            .connected,
+            detail: "Connected to \(target)",
+            target: target
+        )
+
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote" }) == nil,
+            "A recovered reconnect-paused warning must be retracted on .connected"
+        )
+        #expect(
+            workspace.logEntries.contains { $0.message == "User-visible note" },
+            "Recovery must preserve unrelated sidebar log entries"
+        )
+        #expect(workspace.statusEntries["remote.error"] == nil)
+
+        let logCountAfterRecovery = workspace.logEntries.count
+        workspace.applyRemoteConnectionStateUpdate(
+            .suspended,
+            detail: suspendedDetail,
+            target: target
+        )
+        #expect(
+            workspace.logEntries.count == logCountAfterRecovery + 1,
+            "Recovery must reset the suspended connection fingerprint"
+        )
+    }
 }


### PR DESCRIPTION
Closes #10640

## Root cause

`Workspace.applyRemoteConnectionStateUpdate` appends non-proxy SSH failures and suspended reconnect warnings to the sidebar with `source: "remote"`. The row renders `workspace.logEntries.last`, but the `.connected` path only retracts proxy-only and remote-daemon entries, so a recovered connection seam can leave a stale red line while the workspace is Connected.

## Fix

Add a Workspace-owned connection-seam retraction helper and invoke it on authoritative `.connected`. It removes recovered `source == "remote"` log entries, clears the `remote.error` status, and resets the connection error fingerprint while leaving unrelated log sources intact. Regression coverage covers both `.error -> .connected` and `.suspended -> .connected`, including preservation of unrelated history and fingerprint reset.

This is the connection-state counterpart to the daemon recovery fix in #10555.

https://github.com/manaflow-ai/cmux/issues/10640

The commits intentionally land in test-first order: regression tests, then production fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790196174&installation_model_id=21920&pr_number=10652&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10652&signature=aeb5c72dde5552d84bc61dee545e188cde30530867702d32320827809798b2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale SSH sidebar errors and reconnect-paused warnings after recovery and clears the recovery notification cooldown. Previously, non-proxy SSH failures or suspended warnings with source "remote" could remain the latest red row after `.connected` and suppress new notifications.

- On authoritative `.connected`, remove recovered `source: "remote"` log entries, clear `remote.error`, reset the connection-error fingerprint, and clear the per-target notification cooldown; proxy-only and daemon artifacts keep their existing retraction paths.
- Add regression tests for `.error -> .connected` and `.suspended -> .connected`, preserving unrelated history and asserting fingerprint reset.

<sup>Written for commit 75cd2a39ee553947beb3f9fd3b409f6afd97b311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared recovered remote connection errors and warnings from the sidebar when the connection is restored.
  * Removed associated remote error status indicators after successful reconnection.
  * Preserved unrelated user log entries and prevented duplicate messages when connection issues recur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->