### PR TITLE
settings: make the Pairing Port row describe both listeners (TCP pairing + Iroh UDP)

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
@@ -48,14 +48,20 @@ public struct MobileCatalogSection: SettingCatalogSection {
     private static let iOSPairingHostDefault = false
     #endif
 
-    /// TCP port the Mac-side iOS pairing listener prefers to bind.
+    /// Port both Mac-side iOS listeners prefer to bind: the legacy TCP
+    /// pairing listener and the Iroh endpoint's UDP socket (the port Direct
+    /// addresses dial).
     ///
-    /// This is a *preference*: if the port is already in use the listener
-    /// falls back to an OS-assigned ephemeral port, and the iOS app is always
-    /// handed the actual bound port (so pairing still works). Configure a fixed
-    /// port when you need predictable firewall rules or to avoid a conflict.
-    /// The default mirrors `CmxMobileDefaults.defaultHostPort`, the protocol
-    /// default mobile clients dial when a pairing payload omits a port.
+    /// This is a *preference*: when the port is already in use each listener
+    /// independently falls back to an OS-assigned ephemeral port. The TCP
+    /// listener hands the iOS app its actual bound port, and the Iroh
+    /// endpoint registers its actual socket addresses with the broker, so
+    /// pairing still works either way. Applying a change rebinds the TCP
+    /// listener live; the Iroh endpoint adopts the new port the next time it
+    /// activates (in practice, app relaunch). Configure a fixed port when you
+    /// need predictable firewall rules or to avoid a conflict. The default
+    /// mirrors `CmxMobileDefaults.defaultHostPort`, the protocol default
+    /// mobile clients dial when a pairing payload omits a port.
     public let iOSPairingPort = DefaultsKey<Int>(
         id: "mobile.iOSPairingHost.port",
         defaultValue: 58_465,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingRoute.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingRoute.swift
@@ -21,7 +21,8 @@ public struct MobilePairingRoute: Sendable, Equatable, Identifiable {
     /// The host or IP address the phone connects to.
     public let host: String
 
-    /// The TCP port the phone connects to.
+    /// The port the phone connects to (TCP for listener routes, UDP for Iroh
+    /// direct addresses).
     public let port: Int
 
     /// Creates a pairing-route descriptor.
@@ -30,7 +31,7 @@ public struct MobilePairingRoute: Sendable, Equatable, Identifiable {
     ///   - id: Stable identifier used as the list identity.
     ///   - kindLabel: Localized transport label.
     ///   - host: Host or IP address the phone connects to.
-    ///   - port: TCP port the phone connects to.
+    ///   - port: Port the phone connects to.
     public init(id: String, kindLabel: String, host: String, port: Int) {
         self.id = id
         self.kindLabel = kindLabel

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingStatusSnapshot.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingStatusSnapshot.swift
@@ -7,7 +7,10 @@ import Foundation
 /// listener binds an OS-assigned ephemeral port instead, and the iOS app is
 /// handed the actual ``boundPort``. The settings UI uses this snapshot to show
 /// the real bound port and warn when it differs from ``configuredPort`` so a
-/// configured port can never silently fail to take effect.
+/// configured port can never silently fail to take effect. ``boundPort`` and
+/// ``usesEphemeralFallback`` describe the TCP pairing listener; the Iroh
+/// endpoint's actual UDP socket addresses appear as Iroh entries in
+/// ``routes``.
 ///
 /// The host supplies the snapshot through
 /// ``SettingsHostActions/mobilePairingStatus()`` and pushes updates through

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
@@ -499,7 +499,7 @@ public struct MobileSection: View {
             if snapshot.routes.isEmpty {
                 SettingsCardNote(String(
                     localized: "settings.mobile.routes.empty",
-                    defaultValue: "No reachable addresses yet. Iroh routes need this Mac signed in; Tailscale routes need Tailscale running on this Mac."
+                    defaultValue: "No reachable addresses yet. Iroh routes need this Mac signed in to your cmux account; Tailscale routes need Tailscale running on this Mac."
                 ))
             } else {
                 VStack(alignment: .leading, spacing: 4) {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
@@ -111,7 +111,10 @@ public struct MobileSection: View {
                     displayNameRow
                     SettingsCardDivider()
                     artifactFolderAccessRow
-                    if iOSPairingHost.current {
+                    // The Iroh endpoint hosts for every signed-in Mac even when
+                    // the legacy pairing listener is toggled off, so diagnostics
+                    // follow the live snapshot rather than the toggle alone.
+                    if iOSPairingHost.current || status.current?.isRunning == true {
                         SettingsCardDivider()
                         diagnostics
                     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
@@ -117,7 +117,7 @@ public struct MobileSection: View {
                     }
                     SettingsCardNote(String(
                         localized: "settings.mobile.port.note",
-                        defaultValue: "Click Apply to change the port. cmux checks the port is free first: if it's in use, the current listener keeps running untouched; if it's free, it rebinds and connected devices reconnect on the new port."
+                        defaultValue: "Click Apply to change the port. cmux checks the port is free first: if it's in use, the current listener keeps running untouched; if it's free, the pairing listener rebinds now and connected devices reconnect. The Iroh endpoint adopts the new port the next time cmux starts."
                     ))
                 }
                 .disabled(remoteControlManagedByPolicy)
@@ -289,7 +289,7 @@ public struct MobileSection: View {
             configurationReview: .settingsOnly,
             searchAnchorID: "setting:mobile:iOSPairingPort",
             String(localized: "settings.mobile.port", defaultValue: "Pairing Port"),
-            subtitle: String(localized: "settings.mobile.port.subtitle", defaultValue: "Preferred TCP port for the iOS pairing listener (1–65535).")
+            subtitle: String(localized: "settings.mobile.port.subtitle", defaultValue: "Preferred port for the iOS pairing listener (TCP) and the Iroh endpoint that Direct addresses dial (UDP), 1–65535.")
         ) {
             HStack(spacing: 8) {
                 TextField(
@@ -349,7 +349,7 @@ public struct MobileSection: View {
                 Label(
                     String(
                         localized: "settings.mobile.port.apply.inUse",
-                        defaultValue: "Port \(requested) is in use. Still listening on \(status.current?.boundPort ?? requested)."
+                        defaultValue: "Port \(requested) is in use. The pairing listener is still on \(status.current?.boundPort ?? requested)."
                     ),
                     systemImage: "exclamationmark.triangle.fill"
                 )
@@ -360,7 +360,7 @@ public struct MobileSection: View {
             // the actual listening port instead of this saved-for-later note.
             statusCaption {
                 Label(
-                    String(localized: "settings.mobile.port.apply.saved", defaultValue: "Saved. Will use port \(saved) when iOS Pairing is on."),
+                    String(localized: "settings.mobile.port.apply.saved", defaultValue: "Saved. The pairing listener will use port \(saved) when iOS Pairing is on."),
                     systemImage: "checkmark.circle.fill"
                 )
                 .foregroundStyle(.secondary)
@@ -388,14 +388,14 @@ public struct MobileSection: View {
             Label(
                 String(
                     localized: "settings.mobile.port.status.fallback",
-                    defaultValue: "Port \(snapshot.configuredPort) is in use. Listening on \(bound) instead."
+                    defaultValue: "Port \(snapshot.configuredPort) is in use. The pairing listener is on \(bound) instead."
                 ),
                 systemImage: "exclamationmark.triangle.fill"
             )
             .foregroundStyle(.orange)
         } else if let bound = snapshot.boundPort {
             Label(
-                String(localized: "settings.mobile.port.status.ok", defaultValue: "Listening on port \(bound)."),
+                String(localized: "settings.mobile.port.status.ok", defaultValue: "Pairing listener on port \(bound)."),
                 systemImage: "checkmark.circle.fill"
             )
             .foregroundStyle(.secondary)
@@ -496,7 +496,7 @@ public struct MobileSection: View {
             if snapshot.routes.isEmpty {
                 SettingsCardNote(String(
                     localized: "settings.mobile.routes.empty",
-                    defaultValue: "No reachable addresses yet. Pairing over the network needs Tailscale running on this Mac."
+                    defaultValue: "No reachable addresses yet. Iroh routes need this Mac signed in; Tailscale routes need Tailscale running on this Mac."
                 ))
             } else {
                 VStack(alignment: .leading, spacing: 4) {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -178984,13 +178984,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No reachable addresses yet. Iroh routes need this Mac signed in; Tailscale routes need Tailscale running on this Mac."
+            "value": "No reachable addresses yet. Iroh routes need this Mac signed in to your cmux account; Tailscale routes need Tailscale running on this Mac."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "到達可能なアドレスがまだありません。Iroh 経路にはこの Mac へのサインインが、Tailscale 経路にはこの Mac で Tailscale が動作していることが必要です。"
+            "value": "到達可能なアドレスがまだありません。Iroh 経路にはこの Mac が cmux アカウントにサインインしていることが、Tailscale 経路にはこの Mac で Tailscale が動作していることが必要です。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -178780,13 +178780,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Port %lld is in use. Still listening on %lld."
+            "value": "Port %lld is in use. The pairing listener is still on %lld."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ポート %lld は使用中です。引き続きポート %lld で待ち受けています。"
+            "value": "ポート %lld は使用中です。ペアリングリスナーは引き続きポート %lld で待ち受けています。"
           }
         }
       }
@@ -178797,13 +178797,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saved. Will use port %lld when iOS Pairing is on."
+            "value": "Saved. The pairing listener will use port %lld when iOS Pairing is on."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存しました。iOS ペアリングを有効にするとポート %lld を使用します。"
+            "value": "保存しました。iOS ペアリングを有効にするとペアリングリスナーはポート %lld を使用します。"
           }
         }
       }
@@ -178814,13 +178814,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Click Apply to change the port. cmux checks the port is free first: if it's in use, the current listener keeps running untouched; if it's free, it rebinds and connected devices reconnect on the new port."
+            "value": "Click Apply to change the port. cmux checks the port is free first: if it's in use, the current listener keeps running untouched; if it's free, the pairing listener rebinds now and connected devices reconnect. The Iroh endpoint adopts the new port the next time cmux starts."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ポートを変更するには「適用」をクリックします。cmux はまずポートが空いているか確認します。使用中の場合は現在のリスナーをそのまま維持し、空いている場合は再バインドして、接続中のデバイスは新しいポートで再接続します。"
+            "value": "ポートを変更するには「適用」をクリックします。cmux はまずポートが空いているか確認します。使用中の場合は現在のリスナーをそのまま維持し、空いている場合はペアリングリスナーを直ちに再バインドして、接続中のデバイスは新しいポートで再接続します。Iroh エンドポイントは次回の cmux 起動時に新しいポートを使用します。"
           }
         }
       }
@@ -178831,13 +178831,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Port %lld is in use. Listening on %lld instead."
+            "value": "Port %lld is in use. The pairing listener is on %lld instead."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ポート %lld は使用中です。代わりにポート %lld で待ち受けています。"
+            "value": "ポート %lld は使用中です。ペアリングリスナーは代わりにポート %lld で待ち受けています。"
           }
         }
       }
@@ -178865,13 +178865,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Listening on port %lld."
+            "value": "Pairing listener on port %lld."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ポート %lld で待ち受けています。"
+            "value": "ペアリングリスナーはポート %lld で待ち受けています。"
           }
         }
       }
@@ -178899,13 +178899,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Preferred TCP port for the iOS pairing listener (1–65535)."
+            "value": "Preferred port for the iOS pairing listener (TCP) and the Iroh endpoint that Direct addresses dial (UDP), 1–65535."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "iOS ペアリングリスナーの優先 TCP ポート（1〜65535）。"
+            "value": "iOS ペアリングリスナー（TCP）と、Direct アドレスの接続先となる Iroh エンドポイント（UDP）の優先ポート（1〜65535）。"
           }
         }
       }
@@ -178984,13 +178984,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No reachable addresses yet. Pairing over the network needs Tailscale running on this Mac."
+            "value": "No reachable addresses yet. Iroh routes need this Mac signed in; Tailscale routes need Tailscale running on this Mac."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "到達可能なアドレスがまだありません。ネットワーク経由のペアリングには、この Mac で Tailscale が動作している必要があります。"
+            "value": "到達可能なアドレスがまだありません。Iroh 経路にはこの Mac へのサインインが、Tailscale 経路にはこの Mac で Tailscale が動作していることが必要です。"
           }
         }
       }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -451,7 +451,7 @@ final class HostSettingsActions: SettingsHostActions {
     /// Foundation-only ``MobilePairingStatusSnapshot``. Static so the status
     /// stream's forwarding task does not retain this host bridge. Internal
     /// (not private) so the mapping is unit-testable.
-    static func mobilePairingSnapshot(
+    nonisolated static func mobilePairingSnapshot(
         from status: MobileHostServiceStatus,
         now: Date = Date()
     ) -> MobilePairingStatusSnapshot {
@@ -499,7 +499,7 @@ final class HostSettingsActions: SettingsHostActions {
     /// Splits an Iroh direct-address hint (`203.0.113.7:58465` or
     /// `[2001:db8::7]:58465`) into the host and port ``MobilePairingRoute``
     /// renders, or `nil` for anything else. Internal for unit tests.
-    static func splitSocketAddress(_ value: String) -> (host: String, port: Int)? {
+    nonisolated static func splitSocketAddress(_ value: String) -> (host: String, port: Int)? {
         let hostPart: Substring
         let portPart: Substring
         if value.hasPrefix("[") {
@@ -559,7 +559,7 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     /// Localized transport label for a pairing route shown in diagnostics.
-    private static func routeKindLabel(_ kind: CmxAttachTransportKind) -> String {
+    nonisolated private static func routeKindLabel(_ kind: CmxAttachTransportKind) -> String {
         switch kind {
         case .tailscale:
             return String(localized: "settings.mobile.route.tailscale", defaultValue: "Tailscale")

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -449,16 +449,42 @@ final class HostSettingsActions: SettingsHostActions {
 
     /// Maps the host's ``MobileHostServiceStatus`` into the settings package's
     /// Foundation-only ``MobilePairingStatusSnapshot``. Static so the status
-    /// stream's forwarding task does not retain this host bridge.
-    private static func mobilePairingSnapshot(from status: MobileHostServiceStatus) -> MobilePairingStatusSnapshot {
-        let routes = status.routes.compactMap { route -> MobilePairingRoute? in
-            guard case let .hostPort(host, port) = route.endpoint else { return nil }
-            return MobilePairingRoute(
-                id: route.id,
-                kindLabel: routeKindLabel(route.kind),
-                host: host,
-                port: port
-            )
+    /// stream's forwarding task does not retain this host bridge. Internal
+    /// (not private) so the mapping is unit-testable.
+    static func mobilePairingSnapshot(
+        from status: MobileHostServiceStatus,
+        now: Date = Date()
+    ) -> MobilePairingStatusSnapshot {
+        var seenEndpoints = Set<String>()
+        let routes = status.routes.flatMap { route -> [MobilePairingRoute] in
+            switch route.endpoint {
+            case let .hostPort(host, port):
+                return [MobilePairingRoute(
+                    id: route.id,
+                    kindLabel: routeKindLabel(route.kind),
+                    host: host,
+                    port: port
+                )]
+            case let .peer(_, pathHints):
+                // The Iroh endpoint's registered UDP socket addresses: the
+                // port Direct addresses actually dial, which can differ from
+                // the configured preference when that UDP port was taken.
+                return pathHints.compactMap { hint in
+                    guard hint.kind == .directAddress,
+                          hint.isUsable(at: now),
+                          seenEndpoints.insert(hint.value).inserted,
+                          let address = splitSocketAddress(hint.value)
+                    else { return nil }
+                    return MobilePairingRoute(
+                        id: "\(route.id):\(hint.value)",
+                        kindLabel: routeKindLabel(route.kind),
+                        host: address.host,
+                        port: address.port
+                    )
+                }
+            case .url:
+                return []
+            }
         }
         return MobilePairingStatusSnapshot(
             isRunning: status.isRunning,
@@ -468,6 +494,30 @@ final class HostSettingsActions: SettingsHostActions {
             activeConnectionCount: status.activeConnectionCount,
             routes: routes
         )
+    }
+
+    /// Splits an Iroh direct-address hint (`203.0.113.7:58465` or
+    /// `[2001:db8::7]:58465`) into the host and port ``MobilePairingRoute``
+    /// renders, or `nil` for anything else. Internal for unit tests.
+    static func splitSocketAddress(_ value: String) -> (host: String, port: Int)? {
+        let hostPart: Substring
+        let portPart: Substring
+        if value.hasPrefix("[") {
+            guard let closing = value.firstIndex(of: "]") else { return nil }
+            hostPart = value[value.index(after: value.startIndex)..<closing]
+            let remainder = value[value.index(after: closing)...]
+            guard remainder.first == ":" else { return nil }
+            portPart = remainder.dropFirst()
+        } else {
+            guard let separator = value.lastIndex(of: ":"),
+                  !value[..<separator].contains(":") else { return nil }
+            hostPart = value[..<separator]
+            portPart = value[value.index(after: separator)...]
+        }
+        guard !hostPart.isEmpty,
+              let port = Int(portPart),
+              (1...65535).contains(port) else { return nil }
+        return (String(hostPart), port)
     }
 
     private static func desktopNotificationAuthorizationState(

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -706,13 +706,15 @@ final class MobileHostService {
     /// User-default key for the preferred iOS pairing listener port.
     nonisolated static let portDefaultsKey = SettingCatalog().mobile.iOSPairingPort.userDefaultsKey
 
-    /// The preferred TCP port the listener should try to bind, read from
-    /// settings.
+    /// The preferred port read from settings. Both iOS listeners try to bind
+    /// it: the legacy TCP pairing listener here and the Iroh endpoint's UDP
+    /// socket (`MobileHostIrohRuntime` passes it as the endpoint bind
+    /// preference).
     ///
     /// Falls back to the catalog default (which mirrors
     /// `CmxMobileDefaults.defaultHostPort`) when unset or outside the valid
-    /// `1...65535` range. The listener still falls back to an OS-assigned
-    /// ephemeral port if this port is unavailable at bind time.
+    /// `1...65535` range. Each listener still falls back independently to an
+    /// OS-assigned ephemeral port if this port is unavailable at bind time.
     nonisolated static func configuredPort(defaults: UserDefaults = .standard) -> Int {
         let fallback = SettingCatalog().mobile.iOSPairingPort.defaultValue
         guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -234,6 +234,79 @@ struct MobileHostServiceSettingsTests {
         // Running but the applied port is unknown: restart to reconcile.
         #expect(MobileHostService.syncDecision(enabled: true, listenerRunning: true, desiredPort: 58465, appliedPort: nil) == .restart)
     }
+
+    @Test func mobilePairingSnapshotShowsIrohDirectAddressesAlongsideHostPortRoutes() throws {
+        let now = Date(timeIntervalSince1970: 1_756_000_000)
+        let identity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "a", count: 64)
+        )
+        let ipv4 = try CmxIrohPathHint(
+            kind: .directAddress,
+            value: "93.184.216.34:58465",
+            source: .native,
+            privacyScope: .publicInternet
+        )
+        let ipv6 = try CmxIrohPathHint(
+            kind: .directAddress,
+            value: "[2606:4700::6810:1]:60001",
+            source: .native,
+            privacyScope: .publicInternet
+        )
+        let expired = try CmxIrohPathHint(
+            kind: .directAddress,
+            value: "93.184.216.35:58465",
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: now.addingTimeInterval(-200),
+            expiresAt: now.addingTimeInterval(-100)
+        )
+        let status = MobileHostServiceStatus(
+            isRunning: true,
+            port: 58_465,
+            configuredPort: 58_465,
+            usesEphemeralFallback: false,
+            routes: [
+                try CmxAttachRoute(
+                    id: "tailscale",
+                    kind: .tailscale,
+                    endpoint: .hostPort(host: "100.64.0.1", port: 58_465),
+                    priority: 10
+                ),
+                try CmxAttachRoute(
+                    id: "iroh",
+                    kind: .iroh,
+                    endpoint: .peer(identity: identity, pathHints: [ipv4, ipv6, expired, ipv4]),
+                    priority: 0
+                ),
+            ],
+            activeConnectionCount: 0,
+            lastErrorDescription: nil
+        )
+
+        let snapshot = HostSettingsActions.mobilePairingSnapshot(from: status, now: now)
+
+        // TCP listener routes keep their row; the Iroh endpoint contributes one
+        // row per usable direct-address hint, deduplicated, expired hints dropped.
+        #expect(snapshot.routes.map(\.endpoint) == [
+            "100.64.0.1:58465",
+            "93.184.216.34:58465",
+            "[2606:4700::6810:1]:60001",
+        ])
+        #expect(Set(snapshot.routes.map(\.id)).count == snapshot.routes.count)
+    }
+
+    @Test func splitSocketAddressParsesSocketLiteralsOnly() throws {
+        let v4 = try #require(HostSettingsActions.splitSocketAddress("93.184.216.34:58465"))
+        #expect(v4.host == "93.184.216.34")
+        #expect(v4.port == 58_465)
+        let v6 = try #require(HostSettingsActions.splitSocketAddress("[2606:4700::6810:1]:443"))
+        #expect(v6.host == "2606:4700::6810:1")
+        #expect(v6.port == 443)
+        #expect(HostSettingsActions.splitSocketAddress("no-port")?.host == nil)
+        #expect(HostSettingsActions.splitSocketAddress("2606:4700::6810:1:443")?.host == nil)
+        #expect(HostSettingsActions.splitSocketAddress("[2606:4700::6810:1]443")?.host == nil)
+        #expect(HostSettingsActions.splitSocketAddress("93.184.216.34:0")?.host == nil)
+    }
 }
 
 #if DEBUG


### PR DESCRIPTION
The Pairing Port preference in Settings > Mobile is bound by two listeners: the legacy TCP pairing listener and the Iroh endpoint's UDP socket, which is the port iOS Direct addresses dial. The Settings copy claimed TCP only, the Apply note said connected devices reconnect on the new port (true for the TCP listener, while the Iroh endpoint only adopts the new port on its next activation, in practice app relaunch), and the Reachable-at diagnostics dropped the Iroh route entirely because it is a peer endpoint rather than host:port.

This PR makes the section reflect the true state:

- Port row subtitle names both bindings: pairing listener (TCP) and the Iroh endpoint that Direct addresses dial (UDP).
- The Apply note states the split: the pairing listener rebinds now, the Iroh endpoint adopts the new port the next time cmux starts.
- The live status strings are scoped to the pairing listener so they cannot be read as covering the UDP bind.
- The Reachable-at list now renders the Iroh route's usable direct-address path hints as Iroh rows (deduplicated, expired hints dropped), so the UDP port actually in effect is visible, including when the preferred port was taken and iroh silently fell back to an ephemeral one.
- The stale routes-empty hint no longer claims Tailscale is required for network pairing.
- Doc comments on the catalog key, `configuredPort`, and the settings snapshot models updated to match; en and ja localizations updated for every changed string.

Known limitation: the Iroh rows show the broker-registered public-disclosure hints, so LAN-scoped addresses do not appear there; surfacing the local bind directly would need new plumbing from the Iroh runtime into the status cache and is left as a follow-up.

Localization audit: changed keys `settings.mobile.port.subtitle`, `settings.mobile.port.note`, `settings.mobile.port.apply.inUse`, `settings.mobile.port.apply.saved`, `settings.mobile.port.status.ok`, `settings.mobile.port.status.fallback`, `settings.mobile.routes.empty` in both en and ja; no new keys.

Tests: `MobileHostServiceSettingsTests` gains coverage for the snapshot mapping (host:port rows preserved, Iroh direct-address rows added, dedupe, expired-hint filtering) and the socket-literal parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790198523&installation_model_id=21920&pr_number=10659&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10659&signature=20560c776d0439244ac253669cbcc130d7539a590e0da837e541d2de4126ad70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settings > Mobile: Pairing Port now covers both listeners (TCP pairing and Iroh UDP) and shows Iroh direct-address routes. Previously it claimed TCP-only and implied instant apply everywhere; now TCP rebinds immediately while Iroh adopts the new port on next activation.

- UI copy: updated subtitle and Apply note; live status labels are scoped to the TCP pairing listener; “routes empty” hint clarifies Iroh sign-in vs Tailscale.
- Diagnostics: Reachable-at now includes Iroh peer direct-address hints (UDP), deduped and expired hints filtered, so the actual UDP port is visible even after fallback.
- Implementation: `HostSettingsActions.mobilePairingSnapshot` made internal and extended to map peer endpoints; added `splitSocketAddress` to parse socket literals.
- Docs/localization: doc comments updated; `en`/`ja` changed keys (`settings.mobile.port.subtitle`, `settings.mobile.port.note`, `settings.mobile.port.apply.inUse`, `settings.mobile.port.apply.saved`, `settings.mobile.port.status.ok`, `settings.mobile.port.status.fallback`, `settings.mobile.routes.empty`); no new keys.
- Tests: added coverage for snapshot mapping (host:port preserved, Iroh rows added, dedupe, expiry) and the socket-literal parser.
- Limitation: Iroh rows reflect broker-registered public hints; LAN-scoped addresses are not shown.

<sup>Written for commit fd9398836bb2dd9262a5cbfad88ac57c1ed94d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile pairing status now displays usable direct Iroh UDP addresses alongside existing host-and-port routes.
  * Supports direct IPv4 and IPv6 pairing addresses.
  * Duplicate or expired direct addresses are excluded from pairing information.
  * Iroh diagnostics remain available when the legacy pairing listener is disabled.

* **Documentation**
  * Clarified TCP and Iroh UDP port usage, independent fallback ports, listener rebinding, and route requirements.
  * Updated English and Japanese settings text to distinguish Iroh sign-in requirements from Tailscale availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->