### PR TITLE
fix: cycle visible workspaces across groups

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
@@ -35,6 +35,15 @@ extension WorkspacesModel {
         switch scope {
         case .window:
             candidates = tabs
+        case .visibleWorkspaceRows:
+            let groupsById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
+            candidates = tabs.filter { tab in
+                guard let groupId = tab.groupId else {
+                    return true
+                }
+                guard let group = groupsById[groupId] else { return true }
+                return tab.id != group.anchorWorkspaceId && !group.isCollapsed
+            }
         case .focusedGroupMembers:
             if let groupId = currentWorkspace.groupId,
                let group = workspaceGroups.first(where: { $0.id == groupId }) {
@@ -46,11 +55,15 @@ extension WorkspacesModel {
             }
         }
 
-        return cycleDestination(
-            from: currentWorkspaceId,
-            direction: direction,
-            candidates: candidates
-        )
+        if case .visibleWorkspaceRows = scope,
+           !candidates.contains(where: { $0.id == currentWorkspaceId }) {
+            return nearestCycleDestination(
+                from: currentWorkspaceId,
+                direction: direction,
+                candidates: candidates
+            )
+        }
+        return cycleDestination(from: currentWorkspaceId, direction: direction, candidates: candidates)
     }
 
     private func cycleDestination(
@@ -71,5 +84,27 @@ extension WorkspacesModel {
         case .previous: (currentIndex - 1 + candidates.count) % candidates.count
         }
         return candidates[destinationIndex].id
+    }
+
+    private func nearestCycleDestination(
+        from currentWorkspaceId: UUID,
+        direction: WorkspaceCycleDirection,
+        candidates: [Tab]
+    ) -> UUID? {
+        guard !candidates.isEmpty,
+              let currentIndex = tabs.firstIndex(where: { $0.id == currentWorkspaceId }) else {
+            return nil
+        }
+        let candidateIds = Set(candidates.map(\.id))
+        for offset in 1...tabs.count {
+            let index = switch direction {
+            case .next: (currentIndex + offset) % tabs.count
+            case .previous: (currentIndex - offset + tabs.count) % tabs.count
+            }
+            if candidateIds.contains(tabs[index].id) {
+                return tabs[index].id
+            }
+        }
+        return nil
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
@@ -66,6 +66,7 @@ extension WorkspacesModel {
         return cycleDestination(from: currentWorkspaceId, direction: direction, candidates: candidates)
     }
 
+    /// Advances through an already-filtered candidate order, wrapping at either end.
     private func cycleDestination(
         from currentWorkspaceId: UUID,
         direction: WorkspaceCycleDirection,
@@ -86,6 +87,7 @@ extension WorkspacesModel {
         return candidates[destinationIndex].id
     }
 
+    /// Finds the nearest eligible tab when the current workspace row is hidden.
     private func nearestCycleDestination(
         from currentWorkspaceId: UUID,
         direction: WorkspaceCycleDirection,

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+Cycling.swift
@@ -41,7 +41,7 @@ extension WorkspacesModel {
                 guard let groupId = tab.groupId else {
                     return true
                 }
-                guard let group = groupsById[groupId] else { return true }
+                guard let group = groupsById[groupId] else { return false }
                 return tab.id != group.anchorWorkspaceId && !group.isCollapsed
             }
         case .focusedGroupMembers:

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCycleScope.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCycleScope.swift
@@ -3,6 +3,9 @@ public enum WorkspaceCycleScope: Sendable {
     /// Cycles through every workspace in the window.
     case window
 
+    /// Cycles through ordinary workspace rows rendered in the sidebar.
+    case visibleWorkspaceRows
+
     /// Cycles through the focused group's non-anchor member workspaces.
     case focusedGroupMembers
 }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCycleDestinationTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCycleDestinationTests.swift
@@ -6,6 +6,7 @@ import Testing
 @MainActor
 @Suite("Workspace cycle destinations")
 struct WorkspaceCycleDestinationTests {
+    /// Verifies focused-group cycling wraps through non-anchor members.
     @Test("group scope wraps through members without selecting the anchor")
     func groupScopeWrapsThroughMembers() {
         let fixture = makeFixture()
@@ -27,6 +28,7 @@ struct WorkspaceCycleDestinationTests {
         ) == fixture.secondMember.id)
     }
 
+    /// Verifies an anchor enters the focused-group cycle from either direction.
     @Test("group anchor enters the member cycle in the requested direction")
     func groupAnchorEntersMemberCycle() {
         let fixture = makeFixture()
@@ -43,6 +45,7 @@ struct WorkspaceCycleDestinationTests {
         ) == fixture.secondMember.id)
     }
 
+    /// Verifies an ungrouped workspace uses the window order for focused-group scope.
     @Test("ungrouped workspace falls back to the window-wide order")
     func ungroupedWorkspaceFallsBackToWindowOrder() {
         let fixture = makeFixture()
@@ -59,6 +62,7 @@ struct WorkspaceCycleDestinationTests {
         ) == fixture.ungroupedAfter.id)
     }
 
+    /// Verifies the explicit window scope retains flat tab-order behavior.
     @Test("window scope preserves flat cycling across group boundaries")
     func windowScopePreservesFlatCycling() {
         let fixture = makeFixture()
@@ -75,6 +79,7 @@ struct WorkspaceCycleDestinationTests {
         ) == fixture.ungroupedAfter.id)
     }
 
+    /// Verifies an anchor-only group cannot produce a member destination.
     @Test("group with only an anchor has no member destination")
     func anchorOnlyGroupHasNoDestination() {
         let groupId = UUID()
@@ -98,6 +103,69 @@ struct WorkspaceCycleDestinationTests {
         ) == nil)
     }
 
+    /// Verifies that cycling skips every row hidden inside a collapsed group.
+    @Test("visible-row scope skips a collapsed group between visible workspaces")
+    func visibleRowsSkipCollapsedGroup() {
+        let fixture = makeFixture()
+        fixture.model.workspaceGroups[0].isCollapsed = true
+
+        #expect(fixture.model.cycleDestination(
+            from: fixture.ungroupedBefore.id,
+            direction: .next,
+            scope: .visibleWorkspaceRows
+        ) == fixture.ungroupedAfter.id)
+        #expect(fixture.model.cycleDestination(
+            from: fixture.ungroupedAfter.id,
+            direction: .previous,
+            scope: .visibleWorkspaceRows
+        ) == fixture.ungroupedBefore.id)
+    }
+
+    /// Verifies that cycling from a hidden member exits toward the nearest visible row.
+    @Test("visible-row scope exits a collapsed group in the requested direction")
+    func visibleRowsExitCollapsedGroup() {
+        let fixture = makeFixture()
+        fixture.model.workspaceGroups[0].isCollapsed = true
+
+        #expect(fixture.model.cycleDestination(
+            from: fixture.firstMember.id,
+            direction: .next,
+            scope: .visibleWorkspaceRows
+        ) == fixture.ungroupedAfter.id)
+        #expect(fixture.model.cycleDestination(
+            from: fixture.firstMember.id,
+            direction: .previous,
+            scope: .visibleWorkspaceRows
+        ) == fixture.ungroupedBefore.id)
+    }
+
+    /// Verifies that unresolved group metadata cannot make a workspace appear visible.
+    @Test("visible-row scope excludes workspaces whose group metadata is missing")
+    func visibleRowsExcludeWorkspaceWithMissingGroup() {
+        let ungroupedBefore = CoordinatorStubTab()
+        let missingGroupMember = CoordinatorStubTab(groupId: UUID())
+        let ungroupedAfter = CoordinatorStubTab()
+        let model = WorkspacesModel<CoordinatorStubTab>()
+        model.tabs = [ungroupedBefore, missingGroupMember, ungroupedAfter]
+
+        #expect(model.cycleDestination(
+            from: ungroupedBefore.id,
+            direction: .next,
+            scope: .visibleWorkspaceRows
+        ) == ungroupedAfter.id)
+        #expect(model.cycleDestination(
+            from: ungroupedAfter.id,
+            direction: .previous,
+            scope: .visibleWorkspaceRows
+        ) == ungroupedBefore.id)
+        #expect(model.cycleDestination(
+            from: missingGroupMember.id,
+            direction: .next,
+            scope: .visibleWorkspaceRows
+        ) == ungroupedAfter.id)
+    }
+
+    /// Builds a tab order containing ungrouped rows around one expanded group.
     private func makeFixture() -> (
         model: WorkspacesModel<CoordinatorStubTab>,
         ungroupedBefore: CoordinatorStubTab,
@@ -134,6 +202,7 @@ struct WorkspaceCycleDestinationTests {
         )
     }
 
+    /// Builds the group metadata used by the cycle fixtures.
     private func workspaceGroup(id: UUID, anchorWorkspaceId: UUID) -> WorkspaceGroup {
         WorkspaceGroup(
             id: id,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3702,14 +3702,17 @@ class TabManager: ObservableObject {
         workspace.surfaceOwnershipTarget(for: surfaceOrPanelId)?.containerPanelID
     }
 
+    /// Selects the next workspace in the requested sidebar cycle scope.
     func selectNextTab(scope: WorkspaceCycleScope = .visibleWorkspaceRows) {
         cycleWorkspace(direction: .next, scope: scope)
     }
 
+    /// Selects the previous workspace in the requested sidebar cycle scope.
     func selectPreviousTab(scope: WorkspaceCycleScope = .visibleWorkspaceRows) {
         cycleWorkspace(direction: .previous, scope: scope)
     }
 
+    /// Resolves and selects a workspace in one directional cycle step.
     private func cycleWorkspace(
         direction: WorkspaceCycleDirection,
         scope: WorkspaceCycleScope

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3702,11 +3702,11 @@ class TabManager: ObservableObject {
         workspace.surfaceOwnershipTarget(for: surfaceOrPanelId)?.containerPanelID
     }
 
-    func selectNextTab(scope: WorkspaceCycleScope = .window) {
+    func selectNextTab(scope: WorkspaceCycleScope = .visibleWorkspaceRows) {
         cycleWorkspace(direction: .next, scope: scope)
     }
 
-    func selectPreviousTab(scope: WorkspaceCycleScope = .window) {
+    func selectPreviousTab(scope: WorkspaceCycleScope = .visibleWorkspaceRows) {
         cycleWorkspace(direction: .previous, scope: scope)
     }
 

--- a/cmuxTests/WorkspaceGroupCycleShortcutTests.swift
+++ b/cmuxTests/WorkspaceGroupCycleShortcutTests.swift
@@ -13,6 +13,7 @@ import Testing
 @MainActor
 @Suite("Workspace group cycle shortcuts", .serialized)
 struct WorkspaceGroupCycleShortcutTests {
+    /// Verifies that focused-group cycle actions are configurable but unbound by default.
     @Test func actionsAreVisibleAndUnboundByDefault() throws {
         let actions: [KeyboardShortcutSettings.Action] = [
             .nextSidebarTabInGroup,
@@ -29,6 +30,7 @@ struct WorkspaceGroupCycleShortcutTests {
         }
     }
 
+    /// Verifies that focused-group shortcuts wrap through members without selecting the anchor.
     @Test func configuredActionsCycleMembersWithoutSelectingAnchor() throws {
         let appDelegate = try #require(AppDelegate.shared)
         let originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
@@ -105,6 +107,7 @@ struct WorkspaceGroupCycleShortcutTests {
         #expect(manager.selectedTabId == group.anchorWorkspaceId)
     }
 
+    /// Verifies that window shortcuts traverse visible rows across workspace groups.
     @Test func windowActionsCycleAcrossGroupsWithoutSelectingAnchors() throws {
         let appDelegate = try #require(AppDelegate.shared)
         let originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
@@ -184,6 +187,7 @@ struct WorkspaceGroupCycleShortcutTests {
         #expect(manager.selectedTabId == firstMember.id)
     }
 
+    /// Creates the synthetic keyboard event used by shortcut-routing tests.
     private func keyEvent(
         key: String,
         keyCode: UInt16,

--- a/cmuxTests/WorkspaceGroupCycleShortcutTests.swift
+++ b/cmuxTests/WorkspaceGroupCycleShortcutTests.swift
@@ -105,6 +105,85 @@ struct WorkspaceGroupCycleShortcutTests {
         #expect(manager.selectedTabId == group.anchorWorkspaceId)
     }
 
+    @Test func windowActionsCycleAcrossGroupsWithoutSelectingAnchors() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
+            prefix: "cmux-workspace-window-cycle"
+        )
+        KeyboardShortcutSettings.resetAll()
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "nextSidebarTab": "ctrl+opt+cmd+j",
+              "prevSidebarTab": "ctrl+opt+cmd+k"
+            }
+          }
+        }
+        """.write(
+            to: KeyboardShortcutSettings.settingsFileStore.settingsFileURLForEditing(),
+            atomically: true,
+            encoding: .utf8
+        )
+        KeyboardShortcutSettings.settingsFileStore.reload()
+        appDelegate.debugResetShortcutRoutingStateForTesting()
+        defer {
+            KeyboardShortcutSettings.resetAll()
+            KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+            appDelegate.debugResetShortcutRoutingStateForTesting()
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { appDelegate.discardMainWindowWithoutClosedHistory(windowId: windowId) }
+        let context = try #require(appDelegate.mainWindowContexts.values.first { $0.windowId == windowId })
+        let window = try #require(context.window)
+        let manager = context.tabManager
+        let firstMember = manager.addTab(select: false)
+        let firstGroupId = try #require(manager.createWorkspaceGroup(
+            name: "Mac",
+            childWorkspaceIds: [firstMember.id]
+        ))
+        let firstAnchorId = try #require(
+            manager.workspaceGroups.first { $0.id == firstGroupId }?.anchorWorkspaceId
+        )
+        let secondMember = manager.addTab(select: false)
+        let secondGroupId = try #require(manager.createWorkspaceGroup(
+            name: "General",
+            childWorkspaceIds: [secondMember.id]
+        ))
+        let secondAnchor = try #require(manager.tabs.first {
+            $0.id == manager.workspaceGroups.first { $0.id == secondGroupId }?.anchorWorkspaceId
+        })
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        let nextEvent = try #require(keyEvent(
+            key: "j",
+            keyCode: 38,
+            windowNumber: window.windowNumber
+        ))
+        let previousEvent = try #require(keyEvent(
+            key: "k",
+            keyCode: 40,
+            windowNumber: window.windowNumber
+        ))
+
+        manager.selectWorkspace(firstMember)
+        #expect(appDelegate.debugHandleCustomShortcut(event: nextEvent))
+        #expect(manager.selectedTabId == secondMember.id)
+        #expect(manager.selectedTabId != firstAnchorId)
+
+        #expect(appDelegate.debugHandleCustomShortcut(event: previousEvent))
+        #expect(manager.selectedTabId == firstMember.id)
+
+        manager.selectWorkspace(secondAnchor)
+        #expect(appDelegate.debugHandleCustomShortcut(event: nextEvent))
+        #expect(manager.selectedTabId == secondMember.id)
+        manager.selectWorkspace(secondAnchor)
+        #expect(appDelegate.debugHandleCustomShortcut(event: previousEvent))
+        #expect(manager.selectedTabId == firstMember.id)
+    }
+
     private func keyEvent(
         key: String,
         keyCode: UInt16,


### PR DESCRIPTION
## Summary

- Make Cmd+Up/Down and shared next/previous workspace actions follow the globally visible sidebar-row order.
- Skip group anchors and children of collapsed groups, while preserving focused-group shortcuts.
- Fail closed when a workspace references missing group metadata, and choose the nearest visible row when the current workspace is hidden.

## Testing

- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-test-determinism.py --strict`
- Added package-level regression coverage for collapsed groups, hidden-current navigation, and stale group IDs.
- The focused Swift package test requires the repository's Xcode toolchain; this Mac has Command Line Tools only and rejects the package's Swift 6 language-mode manifest setting. CI should run the supported build/test matrix.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not available in this environment; automated behavior coverage is included above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cycling through visible workspace rows in the sidebar.
  - Next/previous workspace actions now skip group anchors and collapsed groups by default.
  - Cycling smoothly exits hidden workspaces and continues across groups.
  - Explicit cycling scopes remain available when broader navigation is needed.

- **Bug Fixes**
  - Improved navigation when the current workspace is not visible or lacks group metadata.
  - Prevented cycling from selecting group anchor workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
