### PR TITLE
fix(browser): keep Copy Image JavaScript callbacks safe

### DIFF
--- a/Sources/Panels/BrowserJavaScriptCompletionBridge.swift
+++ b/Sources/Panels/BrowserJavaScriptCompletionBridge.swift
@@ -1,0 +1,14 @@
+/// Delivers a WebKit JavaScript result on the actor promised by the browser
+/// focus repository, even when the Objective-C callback arrives off-actor.
+struct BrowserJavaScriptCompletionBridge: Sendable {
+    /// Schedules one raw WebKit result/error pair on the main actor.
+    func deliver(
+        result: Any?,
+        error: (any Error)?,
+        to completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    ) {
+        Task { @MainActor in
+            completion(result, error)
+        }
+    }
+}

--- a/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
+++ b/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
@@ -23,9 +23,11 @@ final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
             return
         }
         panel.webView.evaluateJavaScript(script) { result, error in
-            MainActor.assumeIsolated {
-                completion(result, error)
-            }
+            // WebKit's completion is UI-actor isolated. Deliver its raw result
+            // and error directly so nested menu tracking cannot trip a runtime
+            // `MainActor.assumeIsolated` assertion before the repository can
+            // classify the outcome.
+            completion(result, error)
         }
     }
 }

--- a/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
+++ b/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
@@ -1,0 +1,31 @@
+import CmuxBrowser
+import WebKit
+
+/// Bridges the omnibar page-focus repository to a panel's live web view.
+///
+/// The panel is held weakly so the repository and adapter do not form a retain
+/// cycle. The current web view is read at evaluation time because a panel can
+/// replace it during navigation or profile changes.
+@MainActor
+final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
+    private weak var panel: BrowserPanel?
+
+    init(panel: BrowserPanel) {
+        self.panel = panel
+    }
+
+    func evaluateOmnibarPageFocusScript(
+        _ script: String,
+        completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    ) {
+        guard let panel else {
+            completion(nil, nil)
+            return
+        }
+        panel.webView.evaluateJavaScript(script) { result, error in
+            MainActor.assumeIsolated {
+                completion(result, error)
+            }
+        }
+    }
+}

--- a/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
+++ b/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
@@ -23,11 +23,13 @@ final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
             return
         }
         panel.webView.evaluateJavaScript(script) { result, error in
-            // WebKit's completion is UI-actor isolated. Deliver its raw result
-            // and error directly so nested menu tracking cannot trip a runtime
-            // `MainActor.assumeIsolated` assertion before the repository can
-            // classify the outcome.
-            completion(result, error)
+            // WebKit may invoke an Objective-C completion without an active
+            // main-actor executor during nested menu tracking. Hop explicitly
+            // so the repository can classify the raw result/error without
+            // racing its main-actor state or touching AppKit off-actor.
+            Task { @MainActor in
+                completion(result, error)
+            }
         }
     }
 }

--- a/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
+++ b/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
@@ -1,20 +1,6 @@
 import CmuxBrowser
 import WebKit
 
-/// Delivers a WebKit JavaScript result on the actor promised by the browser
-/// focus repository, even when the Objective-C callback arrives off-actor.
-struct BrowserJavaScriptCompletionBridge: Sendable {
-    func deliver(
-        result: Any?,
-        error: (any Error)?,
-        to completion: @escaping @MainActor (Any?, (any Error)?) -> Void
-    ) {
-        Task { @MainActor in
-            completion(result, error)
-        }
-    }
-}
-
 /// Bridges the omnibar page-focus repository to a panel's live web view.
 ///
 /// The panel is held weakly so the repository and adapter do not form a retain

--- a/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
+++ b/Sources/Panels/BrowserOmnibarPageFocusAdapter.swift
@@ -1,6 +1,20 @@
 import CmuxBrowser
 import WebKit
 
+/// Delivers a WebKit JavaScript result on the actor promised by the browser
+/// focus repository, even when the Objective-C callback arrives off-actor.
+struct BrowserJavaScriptCompletionBridge: Sendable {
+    func deliver(
+        result: Any?,
+        error: (any Error)?,
+        to completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    ) {
+        Task { @MainActor in
+            completion(result, error)
+        }
+    }
+}
+
 /// Bridges the omnibar page-focus repository to a panel's live web view.
 ///
 /// The panel is held weakly so the repository and adapter do not form a retain
@@ -22,14 +36,13 @@ final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
             completion(nil, nil)
             return
         }
+        let bridge = BrowserJavaScriptCompletionBridge()
         panel.webView.evaluateJavaScript(script) { result, error in
             // WebKit may invoke an Objective-C completion without an active
-            // main-actor executor during nested menu tracking. Hop explicitly
-            // so the repository can classify the raw result/error without
-            // racing its main-actor state or touching AppKit off-actor.
-            Task { @MainActor in
-                completion(result, error)
-            }
+            // main-actor executor during nested menu tracking. The bridge
+            // preserves the raw result/error while hopping to the repository's
+            // promised actor.
+            bridge.deliver(result: result, error: error, to: completion)
         }
     }
 }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -11353,33 +11353,3 @@ extension BrowserPanel {
 #endif
     }
 }
-
-/// Bridges `BrowserOmnibarPageFocusRepository` to a panel's live `WKWebView`.
-///
-/// Holds the panel weakly so the panel (which owns the repository, which owns
-/// this adapter) does not form a retain cycle. Always reads `panel.webView` at
-/// call time because the panel reassigns its web view across navigations and
-/// profile switches.
-@MainActor
-private final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
-    private weak var panel: BrowserPanel?
-
-    init(panel: BrowserPanel) {
-        self.panel = panel
-    }
-
-    func evaluateOmnibarPageFocusScript(
-        _ script: String,
-        completion: @escaping @MainActor (Any?, (any Error)?) -> Void
-    ) {
-        guard let panel else {
-            completion(nil, nil)
-            return
-        }
-        panel.webView.evaluateJavaScript(script) { result, error in
-            MainActor.assumeIsolated {
-                completion(result, error)
-            }
-        }
-    }
-}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B05F00000000000000000002 /* BrowserOffscreenRenderHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F00000000000000000001 /* BrowserOffscreenRenderHost.swift */; };
 		B05F00000000000000000004 /* BrowserOffscreenRenderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F00000000000000000003 /* BrowserOffscreenRenderPanel.swift */; };
 		B0A501000000000000000001 /* BrowserOmnibarAppKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */; };
+		D7C0DE00000000000000A107 /* BrowserOmnibarPageFocusAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A106 /* BrowserOmnibarPageFocusAdapter.swift */; };
 		B0A500000000000000000001 /* BrowserOmnibarPerformanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */; };
 		C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */; };
 		27DA3BE42CBF4AAFB6DE69C5 /* BrowserOmnibarSubmitSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D07ED88D244B1B02FAF3C /* BrowserOmnibarSubmitSupport.swift */; };
@@ -3297,6 +3298,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B05F00000000000000000001 /* BrowserOffscreenRenderHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOffscreenRenderHost.swift; sourceTree = "<group>"; };
 		B05F00000000000000000003 /* BrowserOffscreenRenderPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOffscreenRenderPanel.swift; sourceTree = "<group>"; };
 		B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarAppKitBridge.swift; sourceTree = "<group>"; };
+		D7C0DE00000000000000A106 /* BrowserOmnibarPageFocusAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarPageFocusAdapter.swift; sourceTree = "<group>"; };
 		B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarPerformanceSupport.swift; sourceTree = "<group>"; };
 		C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarPerformanceSupportTests.swift; sourceTree = "<group>"; };
 		C76D07ED88D244B1B02FAF3C /* BrowserOmnibarSubmitSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarSubmitSupport.swift; sourceTree = "<group>"; };
@@ -7156,6 +7158,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8054A0060000000000000006 /* BrowserAutomationProbeChannel.swift */,
 				8054A0080000000000000008 /* BrowserAutomationSnapshotResult.swift */,
 				8054A00A000000000000000A /* BrowserJavaScriptEvaluationResult.swift */,
+				D7C0DE00000000000000A106 /* BrowserOmnibarPageFocusAdapter.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				B05F00000000000000000001 /* BrowserOffscreenRenderHost.swift */,
 				B05F00000000000000000003 /* BrowserOffscreenRenderPanel.swift */,
@@ -9365,6 +9368,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B05F00000000000000000002 /* BrowserOffscreenRenderHost.swift in Sources */,
 				B05F00000000000000000004 /* BrowserOffscreenRenderPanel.swift in Sources */,
 				B0A501000000000000000001 /* BrowserOmnibarAppKitBridge.swift in Sources */,
+				D7C0DE00000000000000A107 /* BrowserOmnibarPageFocusAdapter.swift in Sources */,
 				B0A500000000000000000001 /* BrowserOmnibarPerformanceSupport.swift in Sources */,
 				27DA3BE42CBF4AAFB6DE69C5 /* BrowserOmnibarSubmitSupport.swift in Sources */,
 				D0B1002EA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D35A0000000000000000000F /* BrowserInsecureHTTPNavigationResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000000F /* BrowserInsecureHTTPNavigationResolution.swift */; };
 		B1F0C0010000000000000001 /* BrowserInspectorFocusHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0010000000000000002 /* BrowserInspectorFocusHandoff.swift */; };
 		B1F0C0020000000000000001 /* BrowserInspectorFocusHandoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0020000000000000002 /* BrowserInspectorFocusHandoffTests.swift */; };
+		D7C0DE00000000000000A109 /* BrowserJavaScriptCompletionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A108 /* BrowserJavaScriptCompletionBridge.swift */; };
 		8054A0090000000000000009 /* BrowserJavaScriptEvaluationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8054A00A000000000000000A /* BrowserJavaScriptEvaluationResult.swift */; };
 		BCBC0A0E0000000000000F01 /* BrowserMediaActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000F02 /* BrowserMediaActivity.swift */; };
 		BCBC0A0E0000000000000E11 /* BrowserMediaActivityAggregationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000E12 /* BrowserMediaActivityAggregationTests.swift */; };
@@ -3283,6 +3284,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D35B0000000000000000000F /* BrowserInsecureHTTPNavigationResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserInsecureHTTPNavigationResolution.swift; sourceTree = "<group>"; };
 		B1F0C0010000000000000002 /* BrowserInspectorFocusHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/BrowserInspectorFocusHandoff.swift; sourceTree = "<group>"; };
 		B1F0C0020000000000000002 /* BrowserInspectorFocusHandoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserInspectorFocusHandoffTests.swift; sourceTree = "<group>"; };
+		D7C0DE00000000000000A108 /* BrowserJavaScriptCompletionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserJavaScriptCompletionBridge.swift; sourceTree = "<group>"; };
 		8054A00A000000000000000A /* BrowserJavaScriptEvaluationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserJavaScriptEvaluationResult.swift; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000F02 /* BrowserMediaActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserMediaActivity.swift; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000E12 /* BrowserMediaActivityAggregationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserMediaActivityAggregationTests.swift; sourceTree = "<group>"; };
@@ -7158,6 +7160,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8054A0060000000000000006 /* BrowserAutomationProbeChannel.swift */,
 				8054A0080000000000000008 /* BrowserAutomationSnapshotResult.swift */,
 				8054A00A000000000000000A /* BrowserJavaScriptEvaluationResult.swift */,
+				D7C0DE00000000000000A108 /* BrowserJavaScriptCompletionBridge.swift */,
 				D7C0DE00000000000000A106 /* BrowserOmnibarPageFocusAdapter.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				B05F00000000000000000001 /* BrowserOffscreenRenderHost.swift */,
@@ -9356,6 +9359,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A28B087F0000000000000011 /* BrowserImageCopyPasteboardPayload.swift in Sources */,
 				D35A0000000000000000000F /* BrowserInsecureHTTPNavigationResolution.swift in Sources */,
 				B1F0C0010000000000000001 /* BrowserInspectorFocusHandoff.swift in Sources */,
+				D7C0DE00000000000000A109 /* BrowserJavaScriptCompletionBridge.swift in Sources */,
 				8054A0090000000000000009 /* BrowserJavaScriptEvaluationResult.swift in Sources */,
 				BCBC0A0E0000000000000F01 /* BrowserMediaActivity.swift in Sources */,
 				A500MH01 /* BrowserMediaPlaybackMessageHandler.swift in Sources */,

--- a/cmuxTests/CmuxWebViewContextMenuLinkCaptureTests.swift
+++ b/cmuxTests/CmuxWebViewContextMenuLinkCaptureTests.swift
@@ -11,6 +11,28 @@ import WebKit
 @MainActor
 @Suite(.serialized)
 struct CmuxWebViewContextMenuLinkCaptureTests {
+    /// The WebKit bridge must safely hop a callback arriving from a worker
+    /// context and deliver exactly one result on the main actor.
+    @Test
+    func javascriptCompletionBridgeHopsOffActorExactlyOnce() async {
+        let bridge = BrowserJavaScriptCompletionBridge()
+        let outcome = await withCheckedContinuation {
+            (continuation: CheckedContinuation<(Any?, (any Error)?), Never>) in
+            Task.detached {
+                bridge.deliver(
+                    result: nil,
+                    error: ContextMenuLinkCaptureTestError.synthetic,
+                    to: { result, error in
+                        continuation.resume(returning: (result, error))
+                    }
+                )
+            }
+        }
+
+        #expect(outcome.0 == nil)
+        #expect(outcome.1 is ContextMenuLinkCaptureTestError)
+    }
+
     /// Regression coverage for the browser Copy Image crash path: an
     /// evaluation failure from WebKit must reach the page-focus repository as
     /// data, not trip an actor assertion in the completion bridge.
@@ -221,6 +243,10 @@ struct CmuxWebViewContextMenuLinkCaptureTests {
         }
         return opened.url
     }
+}
+
+private enum ContextMenuLinkCaptureTestError: Error, Sendable {
+    case synthetic
 }
 
 @MainActor

--- a/cmuxTests/CmuxWebViewContextMenuLinkCaptureTests.swift
+++ b/cmuxTests/CmuxWebViewContextMenuLinkCaptureTests.swift
@@ -11,6 +11,31 @@ import WebKit
 @MainActor
 @Suite(.serialized)
 struct CmuxWebViewContextMenuLinkCaptureTests {
+    /// Regression coverage for the browser Copy Image crash path: an
+    /// evaluation failure from WebKit must reach the page-focus repository as
+    /// data, not trip an actor assertion in the completion bridge.
+    @Test
+    func omnibarPageFocusAdapterForwardsJavaScriptErrors() async throws {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            renderInitialNavigation: false
+        )
+        defer { panel.close() }
+
+        let adapter = BrowserOmnibarPageFocusAdapter(panel: panel)
+        let outcome = await withCheckedContinuation {
+            (continuation: CheckedContinuation<(Any?, (any Error)?), Never>) in
+            adapter.evaluateOmnibarPageFocusScript(
+                "throw new Error('copy image regression')"
+            ) { result, error in
+                continuation.resume(returning: (result, error))
+            }
+        }
+
+        #expect(outcome.0 == nil)
+        #expect(outcome.1 != nil)
+    }
+
     // Regression test: "Open Link in Default Browser" must open the link the
     // user actually right-clicked (the DOM contextmenu target), not whatever a
     // later elementFromPoint hit test finds at the AppKit event coordinates.


### PR DESCRIPTION
Fixes #10664

## Summary

- Prevent Copy Image crashes when WebKit invokes JavaScript completions off the main actor.
- Deliver the raw JavaScript result/error on `@MainActor` through a dedicated bridge.
- Keep the browser page-focus adapter independently wired and behavior-tested.

## Testing

- `./scripts/lint-pbxproj-test-wiring.sh` — passed (702 test files checked).
- `./scripts/check-pbxproj.sh` — passed.
- HQ `autoreview --mode branch --base origin/main` — clean; cmux policy check — clean.
- Official tagged build workflow [reload-build 32804407641](https://github.com/manaflow-ai/cmux/actions/runs/32804407641) — passed in 9m31s against commit `3651958487`, including the tagged macOS app build and artifact upload.
- Remote Depot `cmux-unit` workflow [32805163749](https://github.com/manaflow-ai/cmux/actions/runs/32805163749) reached the unit-test step but hit its fixed 20-minute job timeout before producing test output; it reported no test failure.
- Local tagged reload was attempted twice but could not finish because the shared host ran out of disk space while Xcode wrote dependency artifacts.

## Demo Video

Not captured: this is a crash fix with automated WebKit behavior coverage and no new UI surface.

## Review Trigger

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally (tagged build blocked by host ENOSPC)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after the latest commit
- [x] All code review bot comments are resolved or non-actionable
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
