### PR TITLE
Bring back the picker's recent-directory chips without breaking the scroll edge effect

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
@@ -180,7 +180,20 @@ public struct TaskComposerAccessibilityPreviewView: View {
                     TaskTemplateFormView(template: nil, onSave: { _ in })
                 } else if presentsDirectoryPicker {
                     TaskComposerDirectoryPickerView(
-                        candidates: [],
+                        candidates: [
+                            MobileTaskDirectoryCandidate(
+                                path: "/Users/ui/recent-alpha",
+                                source: .recentSuccessful,
+                                context: nil,
+                                lastUsedAt: Date(timeIntervalSince1970: 2_000)
+                            ),
+                            MobileTaskDirectoryCandidate(
+                                path: "/Users/ui/recent-beta",
+                                source: .recentSuccessful,
+                                context: nil,
+                                lastUsedAt: Date(timeIntervalSince1970: 1_000)
+                            ),
+                        ],
                         selectedPath: selectedDirectory ?? "~",
                         select: { selectedDirectory = $0 },
                         searchMac: Self.searchPreviewDirectories,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
@@ -103,6 +103,14 @@ public struct TaskComposerAccessibilityPreviewView: View {
                 macDeviceID: Self.previewMac.macDeviceID
             )
         }
+        if presentsDirectoryScrollStress {
+            // Gives the long-listing fixture one remembered directory so the
+            // chips bar renders above the scrolling rows.
+            templateStore.setLastDirectory(
+                "/Users/ui/folder-00",
+                macDeviceID: Self.previewMac.macDeviceID
+            )
+        }
         let catalogData = environment["CMUX_UITEST_TASK_MODEL_CATALOG_JSON"]?
             .data(using: .utf8)
         let catalogClient = MobileTaskModelCatalogClient(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryBrowseScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryBrowseScreen.swift
@@ -12,6 +12,7 @@ struct TaskComposerDirectoryBrowseScreen: View {
     let requestedPath: String
     let selectedPathID: MobileTaskDirectoryPathID
     let suggestionIndex: MobileTaskDirectorySuggestionIndex
+    let recents: [MobileTaskDirectoryCandidate]
     let choose: (String) -> Void
     let cancel: () -> Void
     let searchMac: (
@@ -30,6 +31,7 @@ struct TaskComposerDirectoryBrowseScreen: View {
         requestedPath: String,
         selectedPathID: MobileTaskDirectoryPathID,
         suggestionIndex: MobileTaskDirectorySuggestionIndex,
+        recents: [MobileTaskDirectoryCandidate],
         choose: @escaping (String) -> Void,
         cancel: @escaping () -> Void,
         searchMac: @escaping (
@@ -43,6 +45,7 @@ struct TaskComposerDirectoryBrowseScreen: View {
         self.requestedPath = requestedPath
         self.selectedPathID = selectedPathID
         self.suggestionIndex = suggestionIndex
+        self.recents = recents
         self.choose = choose
         self.cancel = cancel
         self.searchMac = searchMac
@@ -81,6 +84,7 @@ struct TaskComposerDirectoryBrowseScreen: View {
         .toolbar {
             TaskComposerDirectoryCancelToolbar(cancel: cancel)
         }
+        .taskComposerRecentChipsBar(recents: recents, isVisible: !isSearchActive)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if !isSearchActive, let currentPath = browse.snapshot?.currentPath {
                 TaskComposerDirectoryChooseButton(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryPickerView.swift
@@ -45,7 +45,7 @@ struct TaskComposerDirectoryPickerView: View {
         suggested = index.suggestions(matching: "", limit: 6)
         // Home and Computer are permanent locations on the picker root, so
         // the quick chips only carry real remembered directories.
-        recents = suggested.prefix(5).filter { $0.path != "~" && $0.path != "/" }
+        recents = Array(suggested.filter { $0.path != "~" && $0.path != "/" }.prefix(5))
         self.selectedPath = selectedPath
         selectedPathID = MobileTaskDirectoryPathID(path: selectedPath)
         self.select = select

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryPickerView.swift
@@ -15,6 +15,7 @@ struct TaskComposerDirectoryPickerView: View {
     @State private var path: [TaskComposerDirectoryBrowseDestination]
 
     private let suggested: [MobileTaskDirectoryCandidate]
+    private let recents: [MobileTaskDirectoryCandidate]
     private let suggestionIndex: MobileTaskDirectorySuggestionIndex
     private let selectedPath: String
     private let selectedPathID: MobileTaskDirectoryPathID
@@ -42,6 +43,9 @@ struct TaskComposerDirectoryPickerView: View {
         let index = MobileTaskDirectorySuggestionIndex(candidates: candidates)
         suggestionIndex = index
         suggested = index.suggestions(matching: "", limit: 6)
+        // Home and Computer are permanent locations on the picker root, so
+        // the quick chips only carry real remembered directories.
+        recents = suggested.prefix(5).filter { $0.path != "~" && $0.path != "/" }
         self.selectedPath = selectedPath
         selectedPathID = MobileTaskDirectoryPathID(path: selectedPath)
         self.select = select
@@ -56,6 +60,7 @@ struct TaskComposerDirectoryPickerView: View {
         NavigationStack(path: $path) {
             TaskComposerDirectoryLocationsScreen(
                 suggested: suggested,
+                recents: recents,
                 suggestionIndex: suggestionIndex,
                 selectedPath: selectedPath,
                 selectedPathID: selectedPathID,
@@ -68,6 +73,7 @@ struct TaskComposerDirectoryPickerView: View {
                     requestedPath: destination.path,
                     selectedPathID: selectedPathID,
                     suggestionIndex: suggestionIndex,
+                    recents: recents,
                     choose: choose,
                     cancel: { dismiss() },
                     searchMac: searchMac,
@@ -86,6 +92,7 @@ struct TaskComposerDirectoryPickerView: View {
 /// The picker's root: suggested folders and the browse entry points.
 private struct TaskComposerDirectoryLocationsScreen: View {
     let suggested: [MobileTaskDirectoryCandidate]
+    let recents: [MobileTaskDirectoryCandidate]
     let suggestionIndex: MobileTaskDirectorySuggestionIndex
     let selectedPath: String
     let selectedPathID: MobileTaskDirectoryPathID
@@ -135,6 +142,7 @@ private struct TaskComposerDirectoryLocationsScreen: View {
         .toolbar {
             TaskComposerDirectoryCancelToolbar(cancel: cancel)
         }
+        .taskComposerRecentChipsBar(recents: recents, isVisible: !isSearchActive)
         .overlay {
             if isSearchActive {
                 TaskComposerDirectorySearchStatusOverlay(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryRecentChipsRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerDirectoryRecentChipsRow.swift
@@ -1,0 +1,85 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+extension View {
+    /// Mounts the recent-directory chips as a top accessory bar under the
+    /// search field. On iOS 26 the chips join the navigation bar's scroll
+    /// edge effect, so list content slides beneath them through the system
+    /// glass edge instead of hitting an opaque strip; earlier systems fall
+    /// back to a pinned inset on the grouped background.
+    @ViewBuilder
+    func taskComposerRecentChipsBar(
+        recents: [MobileTaskDirectoryCandidate],
+        isVisible: Bool
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            safeAreaBar(edge: .top, spacing: 0) {
+                if isVisible, !recents.isEmpty {
+                    TaskComposerDirectoryRecentChipsRow(recents: recents)
+                }
+            }
+        } else {
+            safeAreaInset(edge: .top, spacing: 0) {
+                if isVisible, !recents.isEmpty {
+                    TaskComposerDirectoryRecentChipsRow(recents: recents)
+                        .background(Color(uiColor: .systemGroupedBackground))
+                }
+            }
+        }
+    }
+}
+
+/// The horizontally scrolling liquid-glass chips of recently used
+/// directories, shown under the search bar of a picker screen. Tapping a
+/// chip pushes that folder onto the browse stack.
+struct TaskComposerDirectoryRecentChipsRow: View {
+    let recents: [MobileTaskDirectoryCandidate]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Array(recents.enumerated()), id: \.element.id) { index, candidate in
+                    TaskComposerDirectoryRecentChip(
+                        candidate: candidate,
+                        identifier: "MobileTaskDirectoryRecent\(index)"
+                    )
+                }
+            }
+        }
+        .contentMargins(.horizontal, 20, for: .scrollContent)
+        .contentMargins(.vertical, 8, for: .scrollContent)
+    }
+}
+
+private struct TaskComposerDirectoryRecentChip: View {
+    let candidate: MobileTaskDirectoryCandidate
+    let identifier: String
+
+    var body: some View {
+        NavigationLink(value: TaskComposerDirectoryBrowseDestination(path: candidate.path)) {
+            Label(
+                TaskComposerDirectoryDisplayPath(path: candidate.path).name,
+                systemImage: "clock.arrow.circlepath"
+            )
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+            .padding(.horizontal, 12)
+            .frame(minHeight: 38)
+            .mobileGlassPill()
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(TaskComposerDirectoryDisplayPath(path: candidate.path).name)
+        .accessibilityValue(candidate.path)
+        .accessibilityHint(
+            L10n.string(
+                "mobile.taskComposer.directoryPicker.browse.open.hint",
+                defaultValue: "Shows the folders inside this folder."
+            )
+        )
+        .accessibilityIdentifier(identifier)
+    }
+}
+#endif

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -5693,6 +5693,17 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Projects.app"].exists)
         XCTAssertTrue(app.buttons["mobile-link"].exists)
 
+        // Recently used directories surface as quick chips under the search
+        // bar, and tapping one browses into that folder.
+        let recentChip = app.buttons["MobileTaskDirectoryRecent0"]
+        XCTAssertTrue(recentChip.exists)
+        let chipName = recentChip.label
+        XCTAssertTrue(["recent-alpha", "recent-beta"].contains(chipName))
+        tap(recentChip, in: app)
+        XCTAssertTrue(app.navigationBars[chipName].waitForExistence(timeout: 4))
+        tap(app.navigationBars.buttons["ui"], in: app)
+        XCTAssertTrue(hidden.waitForExistence(timeout: 4))
+
         tap(app.buttons["mobile-root"], in: app)
         XCTAssertTrue(app.buttons["Sources"].waitForExistence(timeout: 4))
 


### PR DESCRIPTION
Round 2 of the recents chips from https://github.com/manaflow-ai/cmux/pull/10622 dogfood. The liquid-glass chips return under the directory picker's search bar on both the Choose Folder root and every browse level, but instead of the opaque pinned strip that flattened the scroll edge, they mount through `safeAreaBar` on iOS 26 so they participate in the navigation bar's scroll edge effect: list content slides beneath the chips through the system glass edge. Pre-26 devices fall back to a pinned inset on the grouped background. Tapping a chip pushes that folder onto the browse stack; chips hide while a search is active.

Apple HIG consulted (per `Packages/iOS/AGENTS.md`): [Scroll views › Scroll edge effects](https://developer.apple.com/design/human-interface-guidelines/scroll-views) (an edge effect separates floating elements from scrolling content, one per view, prefer the automatic style) — mounting the chips as a bar accessory rather than an opaque inset follows that guidance. No new strings; the chips reuse existing localization.

The drill-down UI test taps a chip and asserts it lands in that folder before walking back up; the preview harness seeds two deterministic recents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790218693&installation_model_id=21920&pr_number=10667&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10667&signature=06127b4b26d2344643bb3ecceaaf003539f4a13073977cf42c89b9c7914c0c8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings back recent-directory chips in the directory picker without flattening the scroll edge. Previously an opaque pinned strip broke the scroll edge; now on iOS 26 chips mount as a top accessory bar that joins the system glass edge, with a pinned inset fallback on earlier iOS.

- Chips appear under the search bar on root and browse, hide during search, and navigate on tap.
- Shows up to 5 remembered directories; filters out "~" and "/" before capping to keep the row full; stable accessibility IDs MobileTaskDirectoryRecent{index}; no new strings.
- Adds `TaskComposerDirectoryRecentChipsRow` and `.taskComposerRecentChipsBar`, integrated into Locations and Browse.
- UITest verifies chip navigation; previews seed two deterministic recents; the scroll-stress fixture seeds one remembered directory to validate the edge effect deterministically.

<sup>Written for commit 754f7553b40f502c74785b9ffa96282c1d9bd135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added quick-access chips for recently used directories in the directory picker.
  - Displays up to five recent directories while browsing, excluding Home and Computer.
  - Selecting a recent directory opens it directly.
  - Recent directory options are accessible and adapt to supported iOS versions.

- **Tests**
  - Added UI coverage verifying recent-directory chips, selection, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->