### PR TITLE
fix(ios): extend mobile auth-gate readiness deadline

### DIFF
--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -431,7 +431,9 @@ print(time.clock_gettime_ns(time.CLOCK_MONOTONIC) // 1_000_000)
 # verifier's 45-second cold-start budget, while retaining an explicit override
 # for environments that need a different bound.
 cmux_attach_resolve_readiness_timeout() {
-  printf '%s' "${CMUX_ATTACH_READY_TIMEOUT_SECONDS:-45}"
+  # Preserve an explicitly empty override so the caller's validation rejects it
+  # instead of silently treating it as the default.
+  printf '%s' "${CMUX_ATTACH_READY_TIMEOUT_SECONDS-45}"
 }
 
 # Terminate one exact tagged Mac bundle through LaunchServices. The helper uses

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -426,6 +426,14 @@ print(time.clock_gettime_ns(time.CLOCK_MONOTONIC) // 1_000_000)
 '
 }
 
+# A clean-slate staging sign-in can take longer than the transport setup that
+# follows it. Keep the normal auth gate aligned with the credential-free iPhone
+# verifier's 45-second cold-start budget, while retaining an explicit override
+# for environments that need a different bound.
+cmux_attach_resolve_readiness_timeout() {
+  printf '%s' "${CMUX_ATTACH_READY_TIMEOUT_SECONDS:-45}"
+}
+
 # Terminate one exact tagged Mac bundle through LaunchServices. The helper uses
 # NSRunningApplication plus NSWorkspace termination notifications, so callers
 # never infer process identity from a command-line regex or a sleep loop.

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -160,7 +160,11 @@ function monotonicMilliseconds() {
 }
 
 function resolveReadinessTimeout(extraEnv = {}) {
-  return run(
+  const env = { ...process.env, ...extraEnv };
+  if (!Object.prototype.hasOwnProperty.call(extraEnv, "CMUX_ATTACH_READY_TIMEOUT_SECONDS")) {
+    delete env.CMUX_ATTACH_READY_TIMEOUT_SECONDS;
+  }
+  return spawnSync(
     "bash",
     [
       "-c",
@@ -168,7 +172,11 @@ function resolveReadinessTimeout(extraEnv = {}) {
       "mobile-readiness-timeout-test",
       validator,
     ],
-    extraEnv,
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env,
+    },
   );
 }
 
@@ -539,11 +547,29 @@ test("dogfood auth readiness leaves headroom for a cold staging sign-in", () => 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "45");
 
+  const empty = resolveReadinessTimeout({
+    CMUX_ATTACH_READY_TIMEOUT_SECONDS: "",
+  });
+  assert.equal(empty.status, 0, empty.stderr);
+  assert.equal(empty.stdout, "");
+
   const override = resolveReadinessTimeout({
     CMUX_ATTACH_READY_TIMEOUT_SECONDS: "7",
   });
   assert.equal(override.status, 0, override.stderr);
   assert.equal(override.stdout, "7");
+});
+
+test("launcher validation uses product-level readiness wording", () => {
+  const result = run(
+    "bash",
+    [path.join(repoRoot, "scripts/mobile-dev-launch.sh"), "--tag", "ready"],
+    { CMUX_ATTACH_READY_TIMEOUT_SECONDS: "invalid-secret-value" },
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /attach readiness timeout must be a positive integer/);
+  assert.doesNotMatch(result.stderr, /CMUX_ATTACH_READY_TIMEOUT_SECONDS/);
+  assert.doesNotMatch(result.stderr, /invalid-secret-value/);
 });
 
 test("dogfood readiness blocks on the post-launch usable RPC event", () => {

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -159,6 +159,19 @@ function monotonicMilliseconds() {
   ]);
 }
 
+function resolveReadinessTimeout(extraEnv = {}) {
+  return run(
+    "bash",
+    [
+      "-c",
+      'source "$1"; cmux_attach_resolve_readiness_timeout',
+      "mobile-readiness-timeout-test",
+      validator,
+    ],
+    extraEnv,
+  );
+}
+
 function extractShellFunction(source, name) {
   const start = source.indexOf(`${name}() {`);
   assert.notEqual(start, -1, `missing shell function ${name}`);
@@ -518,6 +531,19 @@ test("dogfood readiness clock is stable across helper processes", () => {
     secondMilliseconds >= firstMilliseconds,
     `expected monotonic clock, got ${firstMilliseconds} -> ${secondMilliseconds}`,
   );
+});
+
+test("dogfood auth readiness leaves headroom for a cold staging sign-in", () => {
+  const result = resolveReadinessTimeout();
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "45");
+
+  const override = resolveReadinessTimeout({
+    CMUX_ATTACH_READY_TIMEOUT_SECONDS: "7",
+  });
+  assert.equal(override.status, 0, override.stderr);
+  assert.equal(override.stdout, "7");
 });
 
 test("dogfood readiness blocks on the post-launch usable RPC event", () => {

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -212,7 +212,7 @@ source "$SCRIPT_DIR/lib/dev-secrets.sh"
 source "$SCRIPT_DIR/lib/mobile-attach.sh"
 ATTACH_READY_TIMEOUT_SECONDS="$(cmux_attach_resolve_readiness_timeout)"
 if [[ ! "$ATTACH_READY_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "error: CMUX_ATTACH_READY_TIMEOUT_SECONDS must be a positive integer" >&2
+  echo "error: attach readiness timeout must be a positive integer" >&2
   exit 2
 fi
 credential_args=(--profile "$AUTH_PROFILE")

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -88,7 +88,6 @@ EXPECTED_ACCOUNT=""
 CHECK_AUTH_CONTRACT=0
 ATTACH_TTL_SECONDS="${CMUX_ATTACH_TTL_SECONDS:-600}"
 ATTACH_MINT_MAX_ATTEMPTS="${CMUX_ATTACH_MINT_MAX_ATTEMPTS:-20}"
-ATTACH_READY_TIMEOUT_SECONDS="${CMUX_ATTACH_READY_TIMEOUT_SECONDS:-15}"
 
 usage() { sed -n '2,58p' "$0"; }
 
@@ -175,10 +174,6 @@ if [[ ! "$ATTACH_MINT_MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: CMUX_ATTACH_MINT_MAX_ATTEMPTS must be a positive integer" >&2
   exit 2
 fi
-if [[ ! "$ATTACH_READY_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "error: CMUX_ATTACH_READY_TIMEOUT_SECONDS must be a positive integer" >&2
-  exit 2
-fi
 if [[ "$DETACH" -eq 1 && "$TARGET" != "simulator" ]]; then
   echo "error: --detach is supported only with simulator launches" >&2
   usage >&2
@@ -215,6 +210,11 @@ REPO_ROOT="${CMUX_MOBILE_SOURCE_CHECKOUT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 source "$SCRIPT_DIR/lib/dev-secrets.sh"
 # shellcheck source=scripts/lib/mobile-attach.sh
 source "$SCRIPT_DIR/lib/mobile-attach.sh"
+ATTACH_READY_TIMEOUT_SECONDS="$(cmux_attach_resolve_readiness_timeout)"
+if [[ ! "$ATTACH_READY_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: CMUX_ATTACH_READY_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
 credential_args=(--profile "$AUTH_PROFILE")
 [[ -n "$AUTH_CREDENTIALS_FILE" ]] && credential_args+=(--credentials-file "$AUTH_CREDENTIALS_FILE")
 [[ -n "$EXPECTED_ACCOUNT" ]] && credential_args+=(--expected-account "$EXPECTED_ACCOUNT")


### PR DESCRIPTION
Fixes #10379

## Summary

- Give the normal mobile-dev-launch auth gate a 45-second cold-start readiness budget, matching the credential-free iPhone verifier.
- Keep `CMUX_ATTACH_READY_TIMEOUT_SECONDS` as an explicit override through one shared resolver.
- Add behavior-level coverage for the default and override, with the failing test kept in its own commit.

## Regression commits

1. `455e482a77` — add the failing cold-start readiness test.
2. `64620327fc` — add the shared 45-second resolver and wire mobile-dev-launch to it.

## Verification

- `node --test scripts/lib/mobile-attach.test.mjs` — 46 passed.
- `tests/test_iphone_install_queue.sh` — passed.
- `node --test scripts/lib/dev-secrets.test.mjs` — 7 passed.
- `python3 scripts/check-test-determinism.py --strict` — 0 findings.
- `bash -n scripts/mobile-dev-launch.sh scripts/lib/mobile-attach.sh scripts/verify-iphone-auth.sh` — passed.
- PBX wiring/normalization, package-resolved policy, and workspace-group checks — passed.

No local Xcode build, XCUITest, tagged reload, or app launch was run, per the task instructions; this change is confined to shell tooling and its Node/shell behavior tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223132&installation_model_id=21920&pr_number=10671&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10671&signature=baf7c4902734775a6c3081ae1f4e4b1fab97e59315275dc502c7b3b6d950a01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the mobile auth-gate readiness window from 15s to 45s to allow cold staging sign-ins and match the credential-free verifier. Keeps the explicit `CMUX_ATTACH_READY_TIMEOUT_SECONDS` override and centralizes timeout resolution in a shared function to ensure consistent behavior.

- Introduces `cmux_attach_resolve_readiness_timeout` in `scripts/lib/mobile-attach.sh` and uses it in `scripts/mobile-dev-launch.sh`, with validation on the resolved value.
- Adds test coverage for the 45s default and for the environment override.
- Migration: environments that depended on the old 15s default should set `CMUX_ATTACH_READY_TIMEOUT_SECONDS=15` to retain the previous behavior.

<sup>Written for commit 64620327fc9c62c3a789a8d42927be3b3d523797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable readiness timeout handling for mobile development launches.
  * Uses a 45-second default timeout when no custom value is provided.
  * Supports overriding the timeout with the `CMUX_ATTACH_READY_TIMEOUT_SECONDS` environment variable.

* **Bug Fixes**
  * Improved timeout validation and resolution.
  * Invalid timeout values now produce clearer launch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->