### PR TITLE
fix(ios): compile scrollInteractionActive in Release builds

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -386,6 +386,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         view.delegate = self
         return view
     }()
+    /// Whether a scroll gesture or its deceleration currently owns the
+    /// scroll mechanics view. Runtime seam: the local pixel-scroll path uses
+    /// it to hold position through replays mid-gesture, so it must compile in
+    /// every configuration, not just DEBUG.
+    var scrollInteractionActive: Bool {
+        scrollMechanicsView.isTracking
+            || scrollMechanicsView.isDragging
+            || scrollMechanicsView.isDecelerating
+    }
     #if DEBUG
     private var lastInputTimestamp: CFTimeInterval = 0
     private var latencySamples: [Double] = []
@@ -455,13 +464,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         var loggedDisplayInfo = false
     }
     var debugScrollFrameRateStats = DebugScrollFrameRateStats()
-    /// Whether a scroll gesture or its deceleration currently owns the
-    /// scroll mechanics view (narrow seam for the frame-rate audit).
-    var scrollInteractionActive: Bool {
-        scrollMechanicsView.isTracking
-            || scrollMechanicsView.isDragging
-            || scrollMechanicsView.isDecelerating
-    }
     var debugScrollScriptDone = false
 
     /// The live `key=value;…` description of the bottom dock, read by


### PR DESCRIPTION
The CMUX INTERNAL TestFlight lane has failed on every run since https://github.com/manaflow-ai/cmux/pull/10592 merged (last green 2026-08-24 21:54 UTC, 13+ consecutive failures): `error: cannot find 'scrollInteractionActive' in scope`, exit 65.

Root cause: #10592 declared `scrollInteractionActive` inside the `#if DEBUG` block of `GhosttySurfaceView.swift` (lines 389-594) but references it unguarded from `GhosttySurfaceView+LocalPixelScroll.swift:39,69`. Debug dev builds define DEBUG so they compile; the TestFlight lane builds Release and fails. PR CI never builds iOS Release, which is how it merged green.

Fix: move the property out of the DEBUG block, next to `scrollMechanicsView` (its only dependency, already unconditional). It is a runtime seam, the pixel-scroll path uses it to hold scroll position through replays mid-gesture, so guarding the call sites instead would strip #10592's product behavior from Release.

Verification: structural. The lane's error names exactly this symbol (2 hits = the two unguarded references); the moved property touches only unconditional members. A local iOS Release cross-compile of the package is not feasible on this machine (SPM host-tool SDK mixing), and the lane only runs against main, so the proving gate is the next scheduled CMUX INTERNAL run (polls main every 20 minutes) going green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223394&installation_model_id=21920&pr_number=10673&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10673&signature=87a8790a523959b06ec66efff6fde184cf7e0c68fcaaf0b5a5fdcb41a20be8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles scrollInteractionActive in iOS Release builds by moving it out of the DEBUG guard. Release builds failed with “cannot find 'scrollInteractionActive' in scope”; this fix preserves the pixel‑scroll path behavior in Release.

**Review notes**
- Define scrollInteractionActive unconditionally next to scrollMechanicsView; remove the DEBUG-scoped copy.
- Keep existing call sites in GhosttySurfaceView+LocalPixelScroll.swift; they use it to maintain scroll position during gesture replays.
- No behavior or API changes; resolves TestFlight lane Release build failures.

<sup>Written for commit df5bd77b7d92a59c65379bf4ca6d17c8ce8d0a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll interaction state handling across all app configurations.
  * Scrolling behavior now consistently recognizes active tracking, dragging, and deceleration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->