### PR TITLE
fix(iOS): find resumed Claude transcripts by session ID

### DIFF
--- a/Sources/Mobile/AgentChat/AgentChatFallbackTranscriptResolutionCoordinator.swift
+++ b/Sources/Mobile/AgentChat/AgentChatFallbackTranscriptResolutionCoordinator.swift
@@ -169,16 +169,20 @@ final class AgentChatFallbackTranscriptResolutionCoordinator {
         continuation.resume(returning: nil)
     }
 
-    #if compiler(>=6.2)
-    @concurrent
-    #else
-    @Sendable
-    #endif
+    /// Runs the synchronous filesystem resolver on a utility executor because
+    /// this coordinator owns the caller-facing state on ``MainActor``.
     nonisolated private static func resolveTranscriptPath(
         resolver: AgentChatTranscriptResolver,
         record: AgentChatSessionRecord,
         deadline: ContinuousClock.Instant
     ) async -> String? {
-        resolver.transcriptPath(for: record, deadline: deadline)
+        let scanTask = Task.detached(priority: .utility) {
+            resolver.transcriptPath(for: record, deadline: deadline)
+        }
+        return await withTaskCancellationHandler {
+            await scanTask.value
+        } onCancel: {
+            scanTask.cancel()
+        }
     }
 }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -12,9 +12,6 @@ struct AgentChatTranscriptResolver: Sendable {
     private let claudeConfigRoot: URL
     /// Config-dir root for Codex (`$CODEX_HOME` or `~/.codex`).
     private let codexConfigRoot: URL
-    /// Bounds the exact-session Claude fallback scan when a resumed session's
-    /// current working directory no longer names its original project folder.
-    private static let maximumClaudeFallbackEntries = 4096
 
     /// Creates a resolver.
     ///
@@ -71,10 +68,12 @@ struct AgentChatTranscriptResolver: Sendable {
         switch record.agentKind {
         case .claude:
             return claudeFallbackPath(record: record)
-                ?? claudeTranscriptPathInAnyProject(
-                    sessionID: record.hookStoreLookupSessionID,
-                    deadline: deadline
-                )
+                ?? deadline.flatMap {
+                    claudeTranscriptPathInAnyProject(
+                        sessionID: record.hookStoreLookupSessionID,
+                        deadline: $0
+                    )
+                }
         case .codex:
             return codexFallbackPath(sessionID: record.sessionID, deadline: deadline)
         case .other:
@@ -118,64 +117,45 @@ struct AgentChatTranscriptResolver: Sendable {
 
     /// Finds a Claude transcript by its exact session filename when the
     /// cwd-derived project directory is stale (the usual `claude --resume`
-    /// case). This runs only on the explicit history fallback path, never on
-    /// the main-actor session-list path.
+    /// case). The caller must provide a deadline; the lookup is intentionally
+    /// reserved for the explicit history fallback path and never the
+    /// main-actor session-list path.
     private func claudeTranscriptPathInAnyProject(
         sessionID: String,
-        deadline: ContinuousClock.Instant?
+        deadline: ContinuousClock.Instant
     ) -> String? {
-        guard Self.isSafeSessionFilename(sessionID), Self.scanCanContinue(deadline: deadline) else {
+        guard Self.isSafeSessionFilename(sessionID),
+              !Task.isCancelled,
+              ContinuousClock.now < deadline else {
             return nil
         }
         let fileManager = FileManager.default
         let projectsRoot = claudeConfigRoot.appendingPathComponent("projects", isDirectory: true)
-        guard let projectDirectories = try? fileManager.contentsOfDirectory(
+        guard let enumerator = fileManager.enumerator(
             at: projectsRoot,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
         ) else {
             return nil
         }
 
         let targetFilename = "\(sessionID).jsonl"
-        var visitedEntries = 0
-        for projectDirectory in projectDirectories.sorted(by: { $0.path < $1.path }) {
-            guard Self.scanCanContinue(deadline: deadline) else { return nil }
-            visitedEntries += 1
-            guard visitedEntries <= Self.maximumClaudeFallbackEntries else { return nil }
-            guard (try? projectDirectory.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+        var bestPath: String?
+        while let candidate = enumerator.nextObject() as? URL {
+            guard !Task.isCancelled else { return nil }
+            if ContinuousClock.now >= deadline {
+                return nil
+            }
+            guard candidate.lastPathComponent == targetFilename,
+                  (try? candidate.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) != true,
+                  fileManager.fileExists(atPath: candidate.path) else {
                 continue
             }
-
-            let directCandidate = projectDirectory.appendingPathComponent(targetFilename)
-            if fileManager.fileExists(atPath: directCandidate.path) {
-                return directCandidate.path
-            }
-
-            // Claude workflow sessions can keep the JSONL under a sidecar
-            // directory (`<session-id>/messages/<session-id>.jsonl`). Search
-            // only within this project directory and stop at the same global
-            // entry bound so a malformed config tree cannot monopolize lookup.
-            guard let enumerator = fileManager.enumerator(
-                at: projectDirectory,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles, .skipsPackageDescendants]
-            ) else {
-                continue
-            }
-            for case let candidate as URL in enumerator {
-                guard Self.scanCanContinue(deadline: deadline) else { return nil }
-                visitedEntries += 1
-                guard visitedEntries <= Self.maximumClaudeFallbackEntries else { return nil }
-                guard candidate.lastPathComponent == targetFilename,
-                      (try? candidate.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) != true,
-                      fileManager.fileExists(atPath: candidate.path) else {
-                    continue
-                }
-                return candidate.path
+            if bestPath == nil || candidate.path < bestPath! {
+                bestPath = candidate.path
             }
         }
-        return nil
+        return bestPath
     }
 
     private static func isSafeSessionFilename(_ sessionID: String) -> Bool {
@@ -184,11 +164,6 @@ struct AgentChatTranscriptResolver: Sendable {
             && sessionID != ".."
             && !sessionID.contains("/")
             && !sessionID.contains("\\")
-    }
-
-    private static func scanCanContinue(deadline: ContinuousClock.Instant?) -> Bool {
-        guard !Task.isCancelled else { return false }
-        return deadline.map { ContinuousClock.now < $0 } ?? true
     }
 
     /// Codex rollout files are named `rollout-<timestamp>-<session-uuid>.jsonl`

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -12,6 +12,9 @@ struct AgentChatTranscriptResolver: Sendable {
     private let claudeConfigRoot: URL
     /// Config-dir root for Codex (`$CODEX_HOME` or `~/.codex`).
     private let codexConfigRoot: URL
+    /// Bounds the exact-session Claude fallback scan when a resumed session's
+    /// current working directory no longer names its original project folder.
+    private static let maximumClaudeFallbackEntries = 4096
 
     /// Creates a resolver.
     ///
@@ -68,6 +71,10 @@ struct AgentChatTranscriptResolver: Sendable {
         switch record.agentKind {
         case .claude:
             return claudeFallbackPath(record: record)
+                ?? claudeTranscriptPathInAnyProject(
+                    sessionID: record.hookStoreLookupSessionID,
+                    deadline: deadline
+                )
         case .codex:
             return codexFallbackPath(sessionID: record.sessionID, deadline: deadline)
         case .other:
@@ -107,6 +114,81 @@ struct AgentChatTranscriptResolver: Sendable {
             .appendingPathComponent("\(record.hookStoreLookupSessionID).jsonl", isDirectory: false)
             .path
         return fileManager.fileExists(atPath: path) ? path : nil
+    }
+
+    /// Finds a Claude transcript by its exact session filename when the
+    /// cwd-derived project directory is stale (the usual `claude --resume`
+    /// case). This runs only on the explicit history fallback path, never on
+    /// the main-actor session-list path.
+    private func claudeTranscriptPathInAnyProject(
+        sessionID: String,
+        deadline: ContinuousClock.Instant?
+    ) -> String? {
+        guard Self.isSafeSessionFilename(sessionID), Self.scanCanContinue(deadline: deadline) else {
+            return nil
+        }
+        let fileManager = FileManager.default
+        let projectsRoot = claudeConfigRoot.appendingPathComponent("projects", isDirectory: true)
+        guard let projectDirectories = try? fileManager.contentsOfDirectory(
+            at: projectsRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        let targetFilename = "\(sessionID).jsonl"
+        var visitedEntries = 0
+        for projectDirectory in projectDirectories.sorted(by: { $0.path < $1.path }) {
+            guard Self.scanCanContinue(deadline: deadline) else { return nil }
+            visitedEntries += 1
+            guard visitedEntries <= Self.maximumClaudeFallbackEntries else { return nil }
+            guard (try? projectDirectory.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+                continue
+            }
+
+            let directCandidate = projectDirectory.appendingPathComponent(targetFilename)
+            if fileManager.fileExists(atPath: directCandidate.path) {
+                return directCandidate.path
+            }
+
+            // Claude workflow sessions can keep the JSONL under a sidecar
+            // directory (`<session-id>/messages/<session-id>.jsonl`). Search
+            // only within this project directory and stop at the same global
+            // entry bound so a malformed config tree cannot monopolize lookup.
+            guard let enumerator = fileManager.enumerator(
+                at: projectDirectory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            ) else {
+                continue
+            }
+            for case let candidate as URL in enumerator {
+                guard Self.scanCanContinue(deadline: deadline) else { return nil }
+                visitedEntries += 1
+                guard visitedEntries <= Self.maximumClaudeFallbackEntries else { return nil }
+                guard candidate.lastPathComponent == targetFilename,
+                      (try? candidate.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) != true,
+                      fileManager.fileExists(atPath: candidate.path) else {
+                    continue
+                }
+                return candidate.path
+            }
+        }
+        return nil
+    }
+
+    private static func isSafeSessionFilename(_ sessionID: String) -> Bool {
+        !sessionID.isEmpty
+            && sessionID != "."
+            && sessionID != ".."
+            && !sessionID.contains("/")
+            && !sessionID.contains("\\")
+    }
+
+    private static func scanCanContinue(deadline: ContinuousClock.Instant?) -> Bool {
+        guard !Task.isCancelled else { return false }
+        return deadline.map { ContinuousClock.now < $0 } ?? true
     }
 
     /// Codex rollout files are named `rollout-<timestamp>-<session-uuid>.jsonl`

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -381,6 +381,19 @@ final class AgentChatTranscriptService {
         registry.record(sessionID: sessionID)
     }
 
+    /// Resolves a session's transcript path, keeping broad filesystem fallback
+    /// work behind the coordinator's cancellable off-main boundary.
+    ///
+    /// - Parameter record: The session whose transcript should be resolved.
+    /// - Returns: An existing transcript path, or `nil` when none is found
+    ///   before the configured fallback deadline.
+    func resolvedTranscriptPath(for record: AgentChatSessionRecord) async -> String? {
+        if let boundedPath = resolver.boundedTranscriptPath(for: record) {
+            return boundedPath
+        }
+        return await fallbackResolutionCoordinator.resolve(for: record)
+    }
+
     /// Whether an ended session can still serve history without expensive
     /// fallback scans. Live sessions stay visible before their JSONL exists;
     /// ended sessions with missing JSONL only open to an unrecoverable error.
@@ -464,13 +477,7 @@ final class AgentChatTranscriptService {
             tailer = existing
         } else {
             let resolver = resolver
-            let initialPath = resolver.boundedTranscriptPath(for: record)
-            let fallbackPath: String?
-            if let initialPath {
-                fallbackPath = initialPath
-            } else {
-                fallbackPath = await fallbackResolutionCoordinator.resolve(for: record)
-            }
+            let fallbackPath = await resolvedTranscriptPath(for: record)
             guard let currentRecord = registry.record(sessionID: sessionID) else { return nil }
             failedResolutions.remove(sessionID)
             guard let resolvedTailer = ensureTailer(for: currentRecord, resolvePath: {

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -87,7 +87,7 @@ extension TerminalController {
         guard let record = service.sessionRecord(sessionID: sessionID) else {
             throw MobileChatArtifactIndexError.sessionNotFound
         }
-        guard let transcriptPath = service.resolver.transcriptPath(for: record) else {
+        guard let transcriptPath = await service.resolvedTranscriptPath(for: record) else {
             throw MobileChatArtifactIndexError.sessionUnavailable
         }
         let snapshot = try await TerminalControllerChatArtifactIndexProvider.shared.snapshot(
@@ -306,7 +306,7 @@ extension TerminalController {
         guard let record = service.sessionRecord(sessionID: sessionID) else {
             return .failure(mobileChatArtifactError(.notFound, path: requestedPath))
         }
-        guard let transcriptPath = service.resolver.transcriptPath(for: record) else {
+        guard let transcriptPath = await service.resolvedTranscriptPath(for: record) else {
             return .failure(mobileChatArtifactError(.sessionUnavailable, path: requestedPath))
         }
         do {

--- a/cmuxTests/AgentChatFallbackTranscriptResolutionCoordinatorTests.swift
+++ b/cmuxTests/AgentChatFallbackTranscriptResolutionCoordinatorTests.swift
@@ -260,6 +260,50 @@ struct AgentChatFallbackTranscriptResolutionCoordinatorTests {
     }
 
     @MainActor
+    @Test func claudeHistoryFindsSessionAfterLargeProjectTree() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-agent-chat-claude-large-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+        let projectsRoot = home.appendingPathComponent(".claude/projects", isDirectory: true)
+        try fileManager.createDirectory(at: projectsRoot, withIntermediateDirectories: true)
+        for index in 0..<4_100 {
+            try fileManager.createDirectory(
+                at: projectsRoot.appendingPathComponent("project-\(index)", isDirectory: true),
+                withIntermediateDirectories: false
+            )
+        }
+        let sessionID = UUID().uuidString.lowercased()
+        let transcript = projectsRoot
+            .appendingPathComponent("project-z", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("messages", isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl")
+        try fileManager.createDirectory(
+            at: transcript.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "{}\n".write(to: transcript, atomically: true, encoding: .utf8)
+
+        let service = AgentChatTranscriptService(
+            registry: AgentChatSessionRegistry(),
+            resolver: AgentChatTranscriptResolver(homeDirectory: home, environment: [:]),
+            hasEventSubscribers: { false },
+            emitEventPayload: { _ in },
+            fallbackResolutionTimeout: .seconds(10)
+        )
+        service.noteHookEvent(WorkstreamEvent(
+            sessionId: sessionID,
+            hookEventName: .sessionStart,
+            source: "claude",
+            cwd: "/Users/current-project"
+        ))
+
+        #expect(await service.history(sessionID: sessionID, beforeSeq: nil, limit: 50) != nil)
+        #expect(service.sessionRecord(sessionID: sessionID)?.transcriptPath == transcript.path)
+    }
+
+    @MainActor
     @Test func expiredDeadlineSkipsCodexFallbackEnumeration() throws {
         let fixture = try makeCodexFixture()
         defer { try? FileManager.default.removeItem(at: fixture.home) }

--- a/cmuxTests/AgentChatFallbackTranscriptResolutionCoordinatorTests.swift
+++ b/cmuxTests/AgentChatFallbackTranscriptResolutionCoordinatorTests.swift
@@ -224,6 +224,42 @@ struct AgentChatFallbackTranscriptResolutionCoordinatorTests {
     }
 
     @MainActor
+    @Test func claudeHistoryFindsResumedSessionOutsideCurrentWorkingDirectory() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-agent-chat-claude-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let sessionID = UUID().uuidString.lowercased()
+        let transcript = home
+            .appendingPathComponent(".claude/projects/-Users-example-project", isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl")
+        try FileManager.default.createDirectory(
+            at: transcript.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "{}\n".write(to: transcript, atomically: true, encoding: .utf8)
+
+        let service = AgentChatTranscriptService(
+            registry: AgentChatSessionRegistry(),
+            resolver: AgentChatTranscriptResolver(homeDirectory: home, environment: [:]),
+            hasEventSubscribers: { false },
+            emitEventPayload: { _ in }
+        )
+        service.noteHookEvent(WorkstreamEvent(
+            sessionId: sessionID,
+            hookEventName: .sessionStart,
+            source: "claude",
+            workspaceId: UUID().uuidString,
+            surfaceId: UUID().uuidString,
+            cwd: home.path
+        ))
+
+        let history = await service.history(sessionID: sessionID, beforeSeq: nil, limit: 50)
+
+        #expect(history != nil)
+        #expect(service.sessionRecord(sessionID: sessionID)?.transcriptPath == transcript.path)
+    }
+
+    @MainActor
     @Test func expiredDeadlineSkipsCodexFallbackEnumeration() throws {
         let fixture = try makeCodexFixture()
         defer { try? FileManager.default.removeItem(at: fixture.home) }


### PR DESCRIPTION
Fixes #9898

## Root cause
The iOS history fallback only checked the Claude project directory encoded from the session record's current working directory. A resumed `claude --resume` session can be reported in the home directory while its JSONL remains under the original project directory, so history returned the transcript-not-found error.

## Fix
Keep the cheap cwd-derived lookup for the session list, then on an explicit history fallback search Claude project directories for the exact session ID. The scan is bounded, cancellation/deadline-aware, and supports nested workflow transcript paths.

## Verification
- `cd1ea0890f`: behavior-level regression test (fails before the fix).
- `e966ebcafb`: resolver fix.
- `swiftc -parse` for changed Swift files.
- PBX test wiring, pbxproj, workspace grouping, package-resolved policy, and strict test-determinism checks pass.
- Local Xcode/XCUITest and remote fleet execution were unavailable by repository policy/environment; CI should run the focused suite.
- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223517&installation_model_id=21920&pr_number=10677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10677&signature=1cb70d4a368e82ff91019794d76220a05fd38732d4587e518db8774843a0f3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing history for resumed Claude sessions on iOS by resolving transcripts by session ID (Fixes #9898). Previously the history fallback checked only a cwd-derived project directory; now, if that misses, the resolver scans Claude project directories for <session-id>.jsonl, including nested workflow paths, under a bounded, deadline-aware search.

- Runs the exact-ID scan only on explicit history fallback; keeps the cheap cwd-derived lookup for the session list path.
- Bounds enumeration to 4096 entries, respects cancellation/deadlines, and validates safe session filenames.
- Adds a regression test that finds a resumed session whose transcript remains under the original project directory.

<sup>Written for commit e966ebcafbaa5e2a0e43cd0c56094791267ab97c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude transcript recovery when a session’s transcript is stored outside the current working directory.
  * Added support for locating transcripts in nested project directories and resumed sessions.
  * Transcript searches now respect cancellation and time limits while avoiding excessive directory scanning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->