### PR TITLE
Fix cached Iroh activation refresh race

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -391,6 +391,10 @@ extension CmxIrohHostRuntime {
     func handleConnectivityNetworkChange(revision: UInt64) async {
         guard lifecycleRevision == revision,
               lifecyclePhase.ownsNetworkOperation else { return }
+        // Capture retry ownership before the LAN callback suspends. The retry
+        // may finish while that callback is running, but it still owns this
+        // network event because it re-reads the endpoint before publishing.
+        let retryScheduledBeforeLANRefresh = registrationRetryScheduled
         await handleLANRefresh()
         guard lifecycleRevision == revision,
               lifecyclePhase.ownsNetworkOperation else { return }
@@ -401,7 +405,8 @@ extension CmxIrohHostRuntime {
         // A cached activation already owns a forced registration retry. The
         // retry re-reads the endpoint, so starting another round here would
         // race that owner and arm duplicate renewal deadlines.
-        guard !registrationRetryScheduled else { return }
+        guard !retryScheduledBeforeLANRefresh,
+              !registrationRetryScheduled else { return }
         scheduleRegistrationRefresh(revision: revision)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -398,6 +398,10 @@ extension CmxIrohHostRuntime {
             registrationRefreshPending = true
             return
         }
+        // A cached activation already owns a forced registration retry. The
+        // retry re-reads the endpoint, so starting another round here would
+        // race that owner and arm duplicate renewal deadlines.
+        guard !registrationRetryScheduled else { return }
         scheduleRegistrationRefresh(revision: revision)
     }
 
@@ -432,6 +436,7 @@ extension CmxIrohHostRuntime {
     ) {
         registrationRenewalTask?.cancel()
         registrationRenewalTask = nil
+        registrationRetryScheduled = false
         guard lifecyclePhase.ownsNetworkOperation,
               lifecycleRevision == revision,
               let deadline = Self.registrationRenewalDeadline(
@@ -455,6 +460,7 @@ extension CmxIrohHostRuntime {
         } catch {
             return
         }
+        registrationRetryScheduled = false
         guard lifecyclePhase == .active,
               lifecycleRevision == revision,
               !Task.isCancelled else { return }
@@ -482,6 +488,7 @@ extension CmxIrohHostRuntime {
         )
         registrationRenewalTask?.cancel()
         let deadline = registrationClock.now().addingTimeInterval(delay)
+        registrationRetryScheduled = true
         registrationRenewalTask = Task { [weak self] in
             await self?.runRegistrationRenewal(
                 revision: revision,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
@@ -82,6 +82,7 @@ extension CmxIrohHostRuntime {
         registrationRefreshTask = nil
         registrationRenewalTask?.cancel()
         registrationRenewalTask = nil
+        registrationRetryScheduled = false
         registrationRefreshPending = false
         registrationRefreshPendingForcesPublication = false
         registrationRefreshEnabled = false

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -97,6 +97,7 @@ public actor CmxIrohHostRuntime {
     var lanPublicationGeneration: UInt64 = 0
     var registrationRefreshTask: Task<Void, Never>?
     var registrationRenewalTask: Task<Void, Never>?
+    var registrationRetryScheduled = false
     var registrationRefreshPending = false
     var registrationRefreshPendingForcesPublication = false
     var registrationRefreshEnabled = false
@@ -171,6 +172,7 @@ public actor CmxIrohHostRuntime {
         let revision = lifecycleRevision
         registrationRefreshPending = false
         registrationRefreshPendingForcesPublication = false
+        registrationRetryScheduled = false
         registrationRefreshEnabled = false
         registrationRefreshFailureCount = 0
         currentSnapshot = CmxIrohHostRuntimeSnapshot(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeCachedActivationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeCachedActivationTests.swift
@@ -63,4 +63,100 @@ extension CmxIrohHostRuntimeTests {
 
         await runtime.stop()
     }
+
+    @Test
+    func cachedActivationRetryOwnsNetworkChangeAcrossSuspendedLANRefresh() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let retryDeadline = now.addingTimeInterval(600)
+        let endpoint = TestIrohEndpoint(
+            identity: fixture.endpointID,
+            directAddresses: ["0.0.0.0:55123"]
+        )
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            preflightErrors: [
+                CmxIrohBrokerCooldownError(retryAfterSeconds: 600),
+            ]
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let lanGate = CachedActivationLANRefreshGate()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(
+                cachedHostPolicy: try cachedFixture.policy()
+            ),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() },
+            handleLANRefresh: { await lanGate.suspend() }
+        )
+
+        try await runtime.start()
+        await clock.waitUntilSleepCount(1)
+        await endpoint.emit(.networkChanged)
+        await lanGate.waitUntilSuspended()
+
+        clock.advance(to: retryDeadline)
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(1)))
+        await clock.waitUntilSleepCount(2)
+        await endpoint.setDirectAddresses(["0.0.0.0:55124"])
+
+        await lanGate.resume()
+        await lanGate.waitUntilFinished()
+        #expect(await runtime.localDirectAddresses() == ["0.0.0.0:55124"])
+        #expect(
+            !(await broker.waitForRegistrationCount(2, timeout: .milliseconds(200))),
+            "A network event held in LAN refresh must not start a second registration"
+        )
+        let renewalDeadline = try #require(
+            CmxIrohHostRuntime.registrationRenewalDeadline(
+                binding: fixture.binding,
+                now: retryDeadline
+            )
+        )
+        #expect(clock.observedSleepDeadlines() == [retryDeadline, renewalDeadline])
+
+        await runtime.stop()
+    }
+}
+
+private actor CachedActivationLANRefreshGate {
+    private var suspended = false
+    private var finished = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var finishedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resumeWaiter: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        suspended = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { resumeWaiter = $0 }
+        finished = true
+        let completions = finishedWaiters
+        finishedWaiters.removeAll(keepingCapacity: false)
+        for waiter in completions { waiter.resume() }
+    }
+
+    func waitUntilSuspended() async {
+        if suspended { return }
+        await withCheckedContinuation { suspensionWaiters.append($0) }
+    }
+
+    func resume() {
+        resumeWaiter?.resume()
+        resumeWaiter = nil
+    }
+
+    func waitUntilFinished() async {
+        if finished { return }
+        await withCheckedContinuation { finishedWaiters.append($0) }
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeCachedActivationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeCachedActivationTests.swift
@@ -1,0 +1,66 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+
+@testable import CmuxIrohTransport
+
+extension CmxIrohHostRuntimeTests {
+    @Test
+    func cachedActivationCoalescesNetworkRefreshWithRegistrationRetry() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let retryDeadline = now.addingTimeInterval(600)
+        let endpoint = TestIrohEndpoint(
+            identity: fixture.endpointID,
+            directAddresses: ["0.0.0.0:55_123"]
+        )
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            preflightErrors: [
+                CmxIrohBrokerCooldownError(retryAfterSeconds: 600),
+            ]
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let lanRefreshes = HostRuntimeLANRefreshRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(
+                cachedHostPolicy: try cachedFixture.policy()
+            ),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() },
+            handleLANRefresh: { await lanRefreshes.record() }
+        )
+
+        try await runtime.start()
+        await clock.waitUntilSleepCount(1)
+        #expect(clock.observedSleepDeadlines() == [retryDeadline])
+
+        await endpoint.emit(.networkChanged)
+        #expect(await lanRefreshes.waitForRefresh(timeout: .seconds(1)))
+        #expect(
+            !(await broker.waitForRegistrationCount(1, timeout: .milliseconds(200))),
+            "A cached activation must keep network refreshes behind its retry deadline"
+        )
+        #expect(clock.observedSleepDeadlines() == [retryDeadline])
+
+        clock.advance(to: retryDeadline)
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(1)))
+        await clock.waitUntilSleepCount(2)
+        let renewalDeadline = try #require(
+            CmxIrohHostRuntime.registrationRenewalDeadline(
+                binding: fixture.binding,
+                now: retryDeadline
+            )
+        )
+        #expect(clock.observedSleepDeadlines() == [retryDeadline, renewalDeadline])
+
+        await runtime.stop()
+    }
+}


### PR DESCRIPTION
## Summary

- coalesce connectivity-triggered registration refreshes while cached activation has a lifecycle-owned broker retry pending
- add a behavior-level regression test for a network change arriving after cached activation

The retry re-reads the live endpoint, so a network event no longer starts a concurrent registration round that can arm duplicate renewal deadlines.

Fixes #9857

## Validation

- focused CmuxIrohTransport Swift Testing filters, including the new regression and existing renewal/refresh coverage
- `python3 scripts/check-package-resolved-policy.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-test-determinism.py --strict`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223705&installation_model_id=21920&pr_number=10682&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10682&signature=5296c7f3952237e7998c4ce0881777c95e63f3542a094b218ef40e9ed7ccab12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces network-triggered registration refreshes when a cached activation already scheduled a registration retry, preventing duplicate renewal deadlines. Previously, a network change could start a concurrent registration round; now the refresh is skipped until the pending retry runs and re-reads the endpoint.

- Introduces `registrationRetryScheduled` to guard refresh scheduling; set when a retry is scheduled and cleared on completion, cancellation, sign-out, and lifecycle reset.
- Adds a behavior-level regression test (`cachedActivationCoalescesNetworkRefreshWithRegistrationRetry`) to ensure network changes do not start a competing registration while the retry is pending.

<sup>Written for commit 74117bc98ce44387c7039eac838564e58413d161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

