### PR TITLE
fix: push blocking Feed decisions to phone

### DIFF
--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -266,6 +266,7 @@ final class PhonePushClient {
         title: String,
         subtitle: String,
         body: String,
+        notificationId: String?,
         workspaceId: UUID?,
         surfaceId: UUID?,
         badgeCount: Int,
@@ -285,12 +286,23 @@ final class PhonePushClient {
             retargetsToLiveSurfaceOwner: retargetsToLiveSurfaceOwner,
             macDeviceId: MobileHostIdentity.deviceID(),
             macInstanceTag: MobileHostIdentity.instanceTag(),
-            notificationId: nil,
+            notificationId: notificationId,
             notificationIds: [],
             badgeCount: badgeCount,
             hideContent: defaults.bool(forKey: PhonePushSettings.hideContentKey)
         )
         return enqueue(payload)
+    }
+
+    /// Retracts a Feed-owned phone prompt after its blocking decision resolves.
+    /// The queue cancellation handles an envelope that has not started yet;
+    /// the dismiss event covers an envelope already handed to the network or
+    /// delivered to the paired phone.
+    func cancelEphemeral(notificationId: String, badgeCount: Int) {
+        let trimmed = notificationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        _ = deliveryQueue.cancel(coalescingID: trimmed)
+        forwardDismissed(ids: [trimmed], badgeCount: badgeCount)
     }
 
     /// Enqueues a user-requested diagnostic alert through the production path.

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -258,6 +258,41 @@ final class PhonePushClient {
         return enqueue(payload)
     }
 
+    /// Enqueues a phone alert that has no corresponding Mac notification-store
+    /// entry. Feed blocking decisions already own an actionable native banner;
+    /// this lane mirrors that prompt to an away phone without creating a
+    /// duplicate Mac unread entry or a dismiss-sync tombstone.
+    func forwardEphemeral(
+        title: String,
+        subtitle: String,
+        body: String,
+        workspaceId: UUID?,
+        surfaceId: UUID?,
+        badgeCount: Int,
+        retargetsToLiveSurfaceOwner: Bool = true,
+        replyShape: String = "none"
+    ) -> PhonePushForwardAdmission {
+        let gate = forwardingAdmission()
+        guard gate == .queued else { return gate }
+        let payload = PhonePushPayload(
+            kind: .notify,
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            replyShape: replyShape,
+            workspaceId: workspaceId?.uuidString,
+            surfaceId: surfaceId?.uuidString,
+            retargetsToLiveSurfaceOwner: retargetsToLiveSurfaceOwner,
+            macDeviceId: MobileHostIdentity.deviceID(),
+            macInstanceTag: MobileHostIdentity.instanceTag(),
+            notificationId: nil,
+            notificationIds: [],
+            badgeCount: badgeCount,
+            hideContent: defaults.bool(forKey: PhonePushSettings.hideContentKey)
+        )
+        return enqueue(payload)
+    }
+
     /// Enqueues a user-requested diagnostic alert through the production path.
     /// The response confirms queue admission only; backend and APNs outcomes
     /// remain asynchronous and are correlated by the envelope UUID.

--- a/Sources/Cloud/PhonePushSerialDeliveryQueue.swift
+++ b/Sources/Cloud/PhonePushSerialDeliveryQueue.swift
@@ -76,6 +76,22 @@ final class PhonePushSerialDeliveryQueue {
         return true
     }
 
+    /// Removes a queued notification update before it reaches the sender.
+    /// An in-flight envelope is left alone; callers should follow this with
+    /// the protocol's dismiss event so a device that already received it can
+    /// clear its delivered banner as well.
+    @discardableResult
+    func cancel(coalescingID: String) -> Bool {
+        guard let index = pending.firstIndex(where: {
+            $0.coalescingID == coalescingID
+                && $0.correlationID != inFlightCorrelationID
+        }) else { return false }
+        pending.remove(at: index)
+        publishPending()
+        finishIfIdle()
+        return true
+    }
+
     func restore(_ envelopes: [PhonePushRequestEnvelope]) {
         let restored = Self.normalized(envelopes + pending)
         pending = Array(restored.suffix(capacity))

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1147,11 +1147,6 @@ private extension FeedCoordinator {
             let isAppActive = NSApp.isActive
             #endif
 
-            // Don't pester users while the app is already up front.
-            if isAppActive {
-                return
-            }
-
             #if DEBUG
             if let observer = FeedCoordinatorTestHooks.notificationPostObserver {
                 observer(event, requestId)
@@ -1217,7 +1212,8 @@ private extension FeedCoordinator {
                     title: title,
                     subtitle: "",
                     body: body,
-                    effects: policyContext.envelope.effects
+                    effects: policyContext.envelope.effects,
+                    allowLocalEffects: !isAppActive
                 )
             }
 
@@ -1251,7 +1247,8 @@ private extension FeedCoordinator {
                     title: payload.title,
                     subtitle: payload.subtitle,
                     body: payload.body,
-                    effects: envelope.effects
+                    effects: envelope.effects,
+                    allowLocalEffects: !isAppActive
                 )
             case .failure(let failure):
                 deliverDefault()
@@ -1300,7 +1297,8 @@ private extension FeedCoordinator {
         title: String,
         subtitle: String,
         body: String,
-        effects: TerminalNotificationPolicyEffects
+        effects: TerminalNotificationPolicyEffects,
+        allowLocalEffects: Bool
     ) {
         guard isAwaitingDecision(requestId: requestId) else { return }
 
@@ -1329,6 +1327,11 @@ private extension FeedCoordinator {
                 requestId: requestId
             )
         }
+
+        // The phone mirror has its own `.always`/`.onlyWhenAway` admission
+        // gate. Keep desktop, sound, and command effects suppressed while the
+        // app is frontmost, as before.
+        guard allowLocalEffects else { return }
 
         guard effects.desktop || effects.sound || effects.command else { return }
 

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1257,9 +1257,31 @@ private extension FeedCoordinator {
         body: String,
         effects: TerminalNotificationPolicyEffects
     ) {
-        guard isAwaitingDecision(requestId: requestId),
-              effects.desktop || effects.sound || effects.command
-        else { return }
+        guard isAwaitingDecision(requestId: requestId) else { return }
+
+        // Feed owns the actionable desktop banner, so mirror the same
+        // unresolved decision directly into the phone queue instead of adding
+        // a second Mac TerminalNotification entry. Local policy effects only
+        // control desktop/sound/command feedback; an explicit phone opt-in is
+        // handled by PhonePushClient's own forwarding gate.
+        if !title.isEmpty || !body.isEmpty {
+            let phoneRequest = FeedPhonePushRequest(
+                title: title,
+                subtitle: subtitle,
+                body: body,
+                workspaceId: event.workspaceId.flatMap {
+                    UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+                },
+                surfaceId: event.surfaceId.flatMap {
+                    UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+                },
+                retargetsToLiveSurfaceOwner: true,
+                replyShape: TerminalNotificationReplyShape.none.rawValue
+            )
+            _ = phonePushForwarder.forward(phoneRequest)
+        }
+
+        guard effects.desktop || effects.sound || effects.command else { return }
 
         if !effects.desktop {
             runFallbackEffectsIfStillAwaiting(

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -345,8 +345,13 @@ final class FeedCoordinator: @unchecked Sendable {
         }
         guard let acceptance else {
             waiterLock.lock()
-            let attentionTarget = waiters.removeValue(forKey: requestId)?.attentionTarget
+            let waiter = waiters.removeValue(forKey: requestId)
+            let attentionTarget = waiter?.attentionTarget
+            let phoneNotificationId = takePhoneNotificationId(from: waiter)
             waiterLock.unlock()
+            if let phoneNotificationId {
+                cancelPhonePush(notificationId: phoneNotificationId)
+            }
             concludeAttentionOnMain(attentionTarget)
             cancelNotification(requestId: requestId)
             return IngestBlockingOutcome(result: .unavailable, authoritativeEvent: nil)
@@ -358,13 +363,21 @@ final class FeedCoordinator: @unchecked Sendable {
             accepted = (event, itemId)
         case .notFound:
             waiterLock.lock()
-            waiters.removeValue(forKey: requestId)
+            let waiter = waiters.removeValue(forKey: requestId)
+            let phoneNotificationId = takePhoneNotificationId(from: waiter)
             waiterLock.unlock()
+            if let phoneNotificationId {
+                cancelPhonePush(notificationId: phoneNotificationId)
+            }
             return IngestBlockingOutcome(result: .notFound, authoritativeEvent: nil)
         case .unavailable:
             waiterLock.lock()
-            waiters.removeValue(forKey: requestId)
+            let waiter = waiters.removeValue(forKey: requestId)
+            let phoneNotificationId = takePhoneNotificationId(from: waiter)
             waiterLock.unlock()
+            if let phoneNotificationId {
+                cancelPhonePush(notificationId: phoneNotificationId)
+            }
             return IngestBlockingOutcome(result: .unavailable, authoritativeEvent: nil)
         }
         // If this is a blocking actionable event and the app window isn't
@@ -378,7 +391,11 @@ final class FeedCoordinator: @unchecked Sendable {
 
         waiterLock.lock()
         let w = waiters.removeValue(forKey: requestId)
+        let phoneNotificationId = takePhoneNotificationId(from: w)
         waiterLock.unlock()
+        if let phoneNotificationId {
+            cancelPhonePush(notificationId: phoneNotificationId)
+        }
 
         switch waitResult {
         case .success:
@@ -490,11 +507,18 @@ final class FeedCoordinator: @unchecked Sendable {
     func deliverReply(requestId: String, decision: WorkstreamDecision) {
         waiterLock.lock()
         let attentionTarget = waiters[requestId]?.attentionTarget
+        let phoneNotificationId: String?
         if let waiter = waiters[requestId] {
             waiter.decision = decision
+            phoneNotificationId = takePhoneNotificationId(from: waiter)
             waiter.semaphore.signal()
+        } else {
+            phoneNotificationId = nil
         }
         waiterLock.unlock()
+        if let phoneNotificationId {
+            cancelPhonePush(notificationId: phoneNotificationId)
+        }
 
         // The user decided: conclude the needs-input overlay so the agent's
         // running/idle state shows through (refcounted so an overlapping
@@ -517,6 +541,24 @@ final class FeedCoordinator: @unchecked Sendable {
         }
 
         cancelNotification(requestId: requestId)
+    }
+
+    /// Takes the phone prompt identity while ``waiterLock`` is held. A single
+    /// caller (reply or timeout) owns the corresponding dismiss event.
+    private func takePhoneNotificationId(from waiter: PendingWaiter?) -> String? {
+        guard let waiter, let notificationId = waiter.phoneNotificationId else {
+            return nil
+        }
+        waiter.phoneNotificationId = nil
+        return notificationId
+    }
+
+    /// Dispatches phone-prompt cancellation onto the main actor because the
+    /// production forwarder owns the main-actor phone queue.
+    private func cancelPhonePush(notificationId: String) {
+        Task { @MainActor [weak self] in
+            self?.phonePushForwarder.cancel(notificationId: notificationId)
+        }
     }
 
     fileprivate func isAwaitingDecision(requestId: String) -> Bool {
@@ -901,6 +943,9 @@ private final class AttentionOverlayState {
 private final class PendingWaiter: @unchecked Sendable {
     let semaphore: DispatchSemaphore
     var decision: WorkstreamDecision?
+    /// Stable phone notification identity, guarded by the coordinator's
+    /// ``waiterLock`` alongside ``decision``.
+    var phoneNotificationId: String?
     /// The attention overlay target for this decision, if one was surfaced.
     /// Set inside the ingest `main.sync` (before the card can render and a
     /// reply can fire) and read when the decision concludes, so the
@@ -1266,6 +1311,7 @@ private extension FeedCoordinator {
         // handled by PhonePushClient's own forwarding gate.
         if !title.isEmpty || !body.isEmpty {
             let phoneRequest = FeedPhonePushRequest(
+                notificationId: Self.feedNotificationIdentifier(for: requestId),
                 title: title,
                 subtitle: subtitle,
                 body: body,
@@ -1278,7 +1324,10 @@ private extension FeedCoordinator {
                 retargetsToLiveSurfaceOwner: true,
                 replyShape: TerminalNotificationReplyShape.none.rawValue
             )
-            _ = phonePushForwarder.forward(phoneRequest)
+            forwardPhonePushIfStillAwaiting(
+                phoneRequest,
+                requestId: requestId
+            )
         }
 
         guard effects.desktop || effects.sound || effects.command else { return }
@@ -1394,6 +1443,23 @@ private extension FeedCoordinator {
                 )
             }
         }
+    }
+
+    /// Serializes the unresolved check, phone admission, and identity record
+    /// with ``deliverReply``. This prevents a reply from resolving the waiter
+    /// in the gap between checking it and queuing the phone envelope.
+    @MainActor
+    private func forwardPhonePushIfStillAwaiting(
+        _ request: FeedPhonePushRequest,
+        requestId: String
+    ) {
+        waiterLock.lock()
+        defer { waiterLock.unlock() }
+        guard let waiter = waiters[requestId], waiter.decision == nil else {
+            return
+        }
+        guard phonePushForwarder.forward(request) == .queued else { return }
+        waiter.phoneNotificationId = request.notificationId
     }
 
     @MainActor
@@ -1551,8 +1617,12 @@ private extension FeedCoordinator {
         )
     }
 
+    private static func feedNotificationIdentifier(for requestId: String) -> String {
+        "feed.\(requestId)"
+    }
+
     func cancelNotification(requestId: String) {
-        let identifier = "feed.\(requestId)"
+        let identifier = Self.feedNotificationIdentifier(for: requestId)
         Task { @MainActor [weak self] in
             guard let self else { return }
             let center = self.resolvedUserNotificationCenter

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -37,6 +37,12 @@ final class FeedCoordinator: @unchecked Sendable {
         userNotificationCenter ?? TerminalNotificationStore.shared.userNotificationCenter
     }
 
+    /// Phone forwarding is kept separate from Feed's native actionable banner:
+    /// the former is an ephemeral mirror, while the latter owns the desktop
+    /// request and its inline actions.
+    @MainActor private var phonePushForwarder: any FeedPhonePushForwarding =
+        DefaultFeedPhonePushForwarder()
+
     /// Pending blocking-hook waiters keyed by request id. The waiter owns
     /// a semaphore plus a slot for the resolved decision; the reply
     /// handler signals the semaphore after filling the slot.
@@ -80,13 +86,16 @@ final class FeedCoordinator: @unchecked Sendable {
     @MainActor
     func install(
         store: WorkstreamStore,
-        userNotificationCenter: (any UserNotificationCenterServing)? = nil
+        userNotificationCenter: (any UserNotificationCenterServing)? = nil,
+        phonePushForwarder: (any FeedPhonePushForwarding)? = nil
     ) {
         self.store = store
         // Resolved here rather than as a default argument: default-argument
         // expressions evaluate outside the method's main-actor isolation.
         self.userNotificationCenter = userNotificationCenter
             ?? TerminalNotificationStore.shared.userNotificationCenter
+        self.phonePushForwarder = phonePushForwarder
+            ?? DefaultFeedPhonePushForwarder()
         NotificationCenter.default.post(name: Self.storeInstalledNotification, object: self)
         // Catch any pending items that were restored from disk whose
         // agent is already gone. After this, live tracking is

--- a/Sources/Feed/FeedPhonePushForwarding.swift
+++ b/Sources/Feed/FeedPhonePushForwarding.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The phone-only side effect of a blocking Feed decision.
+///
+/// Feed keeps its actionable desktop banner in the Workstream store, so this
+/// request deliberately carries only the content and target needed by the
+/// phone push queue. It must not become a second terminal notification entry.
+struct FeedPhonePushRequest: Equatable, Sendable {
+    let title: String
+    let subtitle: String
+    let body: String
+    let workspaceId: UUID?
+    let surfaceId: UUID?
+    let retargetsToLiveSurfaceOwner: Bool
+    let replyShape: String
+}
+
+@MainActor
+protocol FeedPhonePushForwarding {
+    @discardableResult
+    func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission
+}
+
+@MainActor
+struct DefaultFeedPhonePushForwarder: FeedPhonePushForwarding {
+    func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission {
+        PhonePushClient.shared.forwardEphemeral(
+            title: request.title,
+            subtitle: request.subtitle,
+            body: request.body,
+            workspaceId: request.workspaceId,
+            surfaceId: request.surfaceId,
+            badgeCount: TerminalNotificationStore.shared.unreadNotificationCount,
+            retargetsToLiveSurfaceOwner: request.retargetsToLiveSurfaceOwner,
+            replyShape: request.replyShape
+        )
+    }
+}

--- a/Sources/Feed/FeedPhonePushForwarding.swift
+++ b/Sources/Feed/FeedPhonePushForwarding.swift
@@ -6,6 +6,8 @@ import Foundation
 /// request deliberately carries only the content and target needed by the
 /// phone push queue. It must not become a second terminal notification entry.
 nonisolated struct FeedPhonePushRequest: Equatable, Sendable {
+    /// Stable identity shared with the iOS dismiss-sync lane.
+    let notificationId: String
     let title: String
     let subtitle: String
     let body: String
@@ -19,6 +21,7 @@ nonisolated struct FeedPhonePushRequest: Equatable, Sendable {
 protocol FeedPhonePushForwarding {
     @discardableResult
     func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission
+    func cancel(notificationId: String)
 }
 
 @MainActor
@@ -28,11 +31,19 @@ struct DefaultFeedPhonePushForwarder: FeedPhonePushForwarding {
             title: request.title,
             subtitle: request.subtitle,
             body: request.body,
+            notificationId: request.notificationId,
             workspaceId: request.workspaceId,
             surfaceId: request.surfaceId,
             badgeCount: TerminalNotificationStore.shared.unreadNotificationCount,
             retargetsToLiveSurfaceOwner: request.retargetsToLiveSurfaceOwner,
             replyShape: request.replyShape
+        )
+    }
+
+    func cancel(notificationId: String) {
+        PhonePushClient.shared.cancelEphemeral(
+            notificationId: notificationId,
+            badgeCount: TerminalNotificationStore.shared.unreadNotificationCount
         )
     }
 }

--- a/Sources/Feed/FeedPhonePushForwarding.swift
+++ b/Sources/Feed/FeedPhonePushForwarding.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Feed keeps its actionable desktop banner in the Workstream store, so this
 /// request deliberately carries only the content and target needed by the
 /// phone push queue. It must not become a second terminal notification entry.
-struct FeedPhonePushRequest: Equatable, Sendable {
+nonisolated struct FeedPhonePushRequest: Equatable, Sendable {
     let title: String
     let subtitle: String
     let body: String

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1085,6 +1085,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FEED0000000000000000F005 /* FeedPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F004 /* FeedPanelView.swift */; };
 		FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F010 /* FeedPanelViewModel.swift */; };
 		FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F012 /* FeedPermissionActionPolicy.swift */; };
+		989500000000000000000001 /* FeedPhonePushForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989500000000000000000002 /* FeedPhonePushForwarding.swift */; };
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
@@ -3906,6 +3907,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F010 /* FeedPanelViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelViewModel.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F012 /* FeedPermissionActionPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPermissionActionPolicy.swift; sourceTree = "<group>"; };
+		989500000000000000000002 /* FeedPhonePushForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedPhonePushForwarding.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00A /* FeedPreviewWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPreviewWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
@@ -8590,6 +8592,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			children = (
 				FEED0000000000000000F001 /* FeedCoordinator.swift */,
 				8672D0028672D0028672D002 /* FeedCoordinator+DeliveryTarget.swift */,
+				989500000000000000000002 /* FeedPhonePushForwarding.swift */,
 				9466A07A0000000000000002 /* FeedAttentionTarget.swift */,
 				8672E00B8672E00B8672E00B /* FeedIngressDeliveryImportance.swift */,
 				8672E0098672E0098672E009 /* FeedIngressDeliveryKey.swift */,
@@ -9675,6 +9678,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				FEED0000000000000000F005 /* FeedPanelView.swift in Sources */,
 				FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */,
 				FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */,
+				989500000000000000000001 /* FeedPhonePushForwarding.swift in Sources */,
 				FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */,
 				FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */,
 				D0B1001AA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift in Sources */,

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 import CMUXAgentLaunch
+import CmuxNotifications
+@preconcurrency import UserNotifications
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -724,6 +726,66 @@ struct FeedCoordinatorTests {
         #expect(attention.events.first?.hookEventName == .permissionRequest)
     }
 
+    @Test func blockingIngestForwardsPhonePromptWhileAwaiting() async {
+        let requestId = "phone-needs-input-request"
+        let workspaceId = UUID()
+        let surfaceId = UUID()
+        let phoneForwarder = RecordingFeedPhonePushForwarder()
+        let notificationCenter = AllowingFeedNotificationCenter()
+
+        defer {
+            Self.resetFeedCoordinatorTestHooks()
+        }
+
+        await MainActor.run {
+            FeedCoordinator.shared.install(
+                store: WorkstreamStore(ringCapacity: 10),
+                userNotificationCenter: notificationCenter,
+                phonePushForwarder: phoneForwarder
+            )
+            FeedCoordinatorTestHooks.isAppActiveOverride = { false }
+        }
+
+        let event = WorkstreamEvent(
+            sessionId: "claude-phone-needs-input-test",
+            hookEventName: .permissionRequest,
+            source: "claude",
+            workspaceId: workspaceId.uuidString,
+            surfaceId: surfaceId.uuidString,
+            cwd: "/tmp",
+            toolName: "Bash",
+            toolInputJSON: #"{"command":"true"}"#,
+            requestId: requestId
+        )
+
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = FeedCoordinator.shared.ingestBlocking(
+                event: event,
+                waitTimeout: 2
+            )
+            done.signal()
+        }
+
+        #expect(
+            phoneForwarder.forwarded.wait(timeout: .now() + 2) == .success,
+            "an unresolved blocking Feed decision must mirror its prompt to the phone"
+        )
+
+        let request = await MainActor.run { phoneForwarder.requests.first }
+        #expect(request?.workspaceId == workspaceId)
+        #expect(request?.surfaceId == surfaceId)
+        #expect(request?.body == "Decision needed")
+
+        await MainActor.run {
+            FeedCoordinator.shared.deliverReply(
+                requestId: requestId,
+                decision: .permission(.once)
+            )
+        }
+        #expect(done.wait(timeout: .now() + 2) == .success)
+    }
+
     @Test func blockingDecisionEventPredicateCoversEveryDecisionKind() {
         // The three blocking-decision kinds must all surface attention…
         #expect(FeedCoordinator.isBlockingDecisionEvent(.permissionRequest))
@@ -929,5 +991,68 @@ private final class NotificationRequestRecorder: @unchecked Sendable {
         lock.lock()
         recordedRequestIds.append(requestId)
         lock.unlock()
+    }
+}
+
+@MainActor
+private final class RecordingFeedPhonePushForwarder: FeedPhonePushForwarding {
+    var requests: [FeedPhonePushRequest] = []
+    let forwarded = DispatchSemaphore(value: 0)
+
+    func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission {
+        requests.append(request)
+        forwarded.signal()
+        return .queued
+    }
+}
+
+@MainActor
+private final class AllowingFeedNotificationCenter: UserNotificationCenterServing,
+    @unchecked Sendable
+{
+    func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {}
+
+    func setNotificationCategories(
+        _ categories: Set<UNNotificationCategory>
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        .success(())
+    }
+
+    func notificationCategories() async -> Result<
+        Set<UNNotificationCategory>,
+        UserNotificationCenterFailure
+    > {
+        .success([])
+    }
+
+    func authorizationStatus() async -> Result<
+        UserNotificationAuthorizationStatus,
+        UserNotificationCenterFailure
+    > {
+        .success(.authorized)
+    }
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions
+    ) async -> Result<Bool, UserNotificationCenterFailure> {
+        .success(true)
+    }
+
+    func add(
+        _ request: UNNotificationRequest
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        .success(())
+    }
+
+    func removeDeliveredNotifications(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        .success(())
+    }
+
+    func removePendingNotificationRequests(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        .success(())
     }
 }

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -777,6 +777,7 @@ struct FeedCoordinatorTests {
         )
 
         let request = await MainActor.run { phoneForwarder.requests.first }
+        #expect(request?.notificationId == "feed.\(requestId)")
         #expect(request?.workspaceId == workspaceId)
         #expect(request?.surfaceId == surfaceId)
         #expect(request?.body == "Bash needs approval")
@@ -787,6 +788,14 @@ struct FeedCoordinatorTests {
                 decision: .permission(.once)
             )
         }
+        #expect(
+            waitForFeedTestSignal(phoneForwarder.cancelled, timeout: .now() + 2) == .success,
+            "resolving a Feed decision must retract its queued phone prompt"
+        )
+        let cancelledNotificationId = await MainActor.run {
+            phoneForwarder.cancelledNotificationIds.first
+        }
+        #expect(cancelledNotificationId == "feed.\(requestId)")
         #expect(
             waitForFeedTestSignal(done, timeout: .now() + 2) == .success
         )
@@ -1004,11 +1013,18 @@ private final class NotificationRequestRecorder: @unchecked Sendable {
 private final class RecordingFeedPhonePushForwarder: FeedPhonePushForwarding {
     var requests: [FeedPhonePushRequest] = []
     nonisolated let forwarded = DispatchSemaphore(value: 0)
+    var cancelledNotificationIds: [String] = []
+    nonisolated let cancelled = DispatchSemaphore(value: 0)
 
     func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission {
         requests.append(request)
         forwarded.signal()
         return .queued
+    }
+
+    func cancel(notificationId: String) {
+        cancelledNotificationIds.append(notificationId)
+        cancelled.signal()
     }
 }
 

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -775,7 +775,7 @@ struct FeedCoordinatorTests {
         let request = await MainActor.run { phoneForwarder.requests.first }
         #expect(request?.workspaceId == workspaceId)
         #expect(request?.surfaceId == surfaceId)
-        #expect(request?.body == "Decision needed")
+        #expect(request?.body == "Bash needs approval")
 
         await MainActor.run {
             FeedCoordinator.shared.deliverReply(

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -801,6 +801,63 @@ struct FeedCoordinatorTests {
         )
     }
 
+    @Test func blockingIngestForwardsPhonePromptWhenAppIsActive() async {
+        let requestId = "phone-needs-input-active-request"
+        let (phoneForwarder, notificationCenter) = await MainActor.run {
+            (
+                RecordingFeedPhonePushForwarder(),
+                AllowingFeedNotificationCenter()
+            )
+        }
+
+        defer {
+            Self.resetFeedCoordinatorTestHooks()
+        }
+
+        await MainActor.run {
+            FeedCoordinator.shared.install(
+                store: WorkstreamStore(ringCapacity: 10),
+                userNotificationCenter: notificationCenter,
+                phonePushForwarder: phoneForwarder
+            )
+            FeedCoordinatorTestHooks.isAppActiveOverride = { true }
+        }
+
+        let event = WorkstreamEvent(
+            sessionId: "claude-phone-needs-input-active-test",
+            hookEventName: .permissionRequest,
+            source: "claude",
+            cwd: "/tmp",
+            toolName: "Bash",
+            toolInputJSON: #"{"command":"true"}"#,
+            requestId: requestId
+        )
+
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = FeedCoordinator.shared.ingestBlocking(
+                event: event,
+                waitTimeout: 2
+            )
+            done.signal()
+        }
+
+        #expect(
+            waitForFeedTestSignal(phoneForwarder.forwarded, timeout: .now() + 2) == .success,
+            "always-mode phone forwarding must not depend on the desktop banner"
+        )
+
+        await MainActor.run {
+            FeedCoordinator.shared.deliverReply(
+                requestId: requestId,
+                decision: .permission(.once)
+            )
+        }
+        #expect(
+            waitForFeedTestSignal(done, timeout: .now() + 2) == .success
+        )
+    }
+
     @Test func blockingDecisionEventPredicateCoversEveryDecisionKind() {
         // The three blocking-decision kinds must all surface attention…
         #expect(FeedCoordinator.isBlockingDecisionEvent(.permissionRequest))

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -787,7 +787,9 @@ struct FeedCoordinatorTests {
                 decision: .permission(.once)
             )
         }
-        #expect(done.wait(timeout: .now() + 2) == .success)
+        #expect(
+            waitForFeedTestSignal(done, timeout: .now() + 2) == .success
+        )
     }
 
     @Test func blockingDecisionEventPredicateCoversEveryDecisionKind() {

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -772,7 +772,7 @@ struct FeedCoordinatorTests {
         }
 
         #expect(
-            phoneForwarder.forwarded.wait(timeout: .now() + 2) == .success,
+            waitForFeedTestSignal(phoneForwarder.forwarded, timeout: .now() + 2) == .success,
             "an unresolved blocking Feed decision must mirror its prompt to the phone"
         )
 

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -730,8 +730,12 @@ struct FeedCoordinatorTests {
         let requestId = "phone-needs-input-request"
         let workspaceId = UUID()
         let surfaceId = UUID()
-        let phoneForwarder = RecordingFeedPhonePushForwarder()
-        let notificationCenter = AllowingFeedNotificationCenter()
+        let (phoneForwarder, notificationCenter) = await MainActor.run {
+            (
+                RecordingFeedPhonePushForwarder(),
+                AllowingFeedNotificationCenter()
+            )
+        }
 
         defer {
             Self.resetFeedCoordinatorTestHooks()
@@ -997,7 +1001,7 @@ private final class NotificationRequestRecorder: @unchecked Sendable {
 @MainActor
 private final class RecordingFeedPhonePushForwarder: FeedPhonePushForwarding {
     var requests: [FeedPhonePushRequest] = []
-    let forwarded = DispatchSemaphore(value: 0)
+    nonisolated let forwarded = DispatchSemaphore(value: 0)
 
     func forward(_ request: FeedPhonePushRequest) -> PhonePushForwardAdmission {
         requests.append(request)


### PR DESCRIPTION
Closes #9895

## Summary
- Mirror unresolved blocking Feed decisions (PermissionRequest, AskUserQuestion, ExitPlanMode) to the existing Mac-to-phone push queue.
- Keep Feed's actionable native desktop banner and avoid creating a duplicate Mac TerminalNotification/unread entry.
- Preserve workspace/surface targeting and existing phone forwarding/privacy gates.

## Regression coverage
- Added a behavior-level FeedCoordinator test with an injected phone forwarder; it waits for an unresolved PermissionRequest and verifies the phone request target/content.
- Kept the failing-test and fix commits separate.

## Validation
- `swiftc -parse` on changed Swift files
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check`
- Remote focused workflow: `test-e2e.yml`, run 32808816514 (in progress)
- No local xcodebuild/XCUITest or tagged reload/launch run, per issue instructions

No new user-facing strings were added; existing localized Feed copy is reused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223925&installation_model_id=21920&pr_number=10684&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10684&signature=822a7d73574f6b303bbf05c670fb5a1fa2abb47dcf86e7aa595a3ec5732ce95e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors unresolved, blocking Feed decisions to the user’s phone and retracts them as soon as the decision resolves. Previously desktop-only; now we send an ephemeral phone push without creating a Mac TerminalNotification or unread, and forwarding can occur even when the app is active if the phone gate allows it, satisfying Linear 9895.

- `FeedCoordinator.install` accepts an optional phone forwarder; defaults to `DefaultFeedPhonePushForwarder` on `@MainActor`.
- Uses a stable `feed.<requestId>` per waiter and retracts on reply, timeout, not found, or unavailable.
- Forwards via `PhonePushClient.forwardEphemeral(...)`; cancellation drops queued envelopes with `PhonePushSerialDeliveryQueue.cancel(...)` and sends a dismiss with the current badge using `cancelEphemeral(...)`.
- Phone forwarding is independent of desktop effects; when the app is frontmost we suppress desktop sound/command/banner but still forward to phone per the device’s forwarding gate.
- Preserves workspace/surface targeting and live-surface retargeting, and adds behavior tests covering forwarding (including when active) and retraction.

<sup>Written for commit 8f5e0d088ab2b1ec7cff2e3f28b3b64f446148e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phone push forwarding for pending feed notifications, with workspace and surface targeting.
  * Supports live-surface retargeting, reply options, unread badge counts, and hidden notification content.
  * Phone forwarding operates independently from desktop notifications, sounds, and commands.

* **Bug Fixes**
  * Blocking approval prompts are now mirrored to phones while awaiting a response.
  * Forwarded prompts are automatically withdrawn when resolved, timed out, or unavailable.

* **Tests**
  * Added coverage for phone forwarding, targeting, and notification cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->