### PR TITLE
iOS: make the terminal arrow pad discoverable

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalArrowNubView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalArrowNubView.swift
@@ -32,6 +32,16 @@ final class TerminalArrowNubView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityIdentifier = "terminal.inputAccessory.arrowPad"
+        accessibilityLabel = String(
+            localized: "mobile.terminal.arrowPad.label",
+            defaultValue: "Arrow pad"
+        )
+        accessibilityHint = String(
+            localized: "mobile.terminal.arrowPad.hint",
+            defaultValue: "Drag in a direction to send arrow keys."
+        )
         backgroundColor = UIColor.white.withAlphaComponent(0.16)
         layer.cornerRadius = nubSize / 2
 

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/TerminalArrowNubAccessibilityTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/TerminalArrowNubAccessibilityTests.swift
@@ -1,0 +1,15 @@
+#if canImport(UIKit)
+import Testing
+import UIKit
+@testable import CmuxMobileTerminal
+
+@MainActor
+@Test func terminalArrowNubIsDiscoverable() {
+    let nub = TerminalArrowNubView()
+
+    #expect(nub.isAccessibilityElement)
+    #expect(nub.accessibilityIdentifier == "terminal.inputAccessory.arrowPad")
+    #expect(!(nub.accessibilityLabel ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    #expect(!(nub.accessibilityHint ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+}
+#endif

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -10232,6 +10232,23 @@
         }
       }
     },
+    "mobile.terminal.arrowPad.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag in a direction to send arrow keys."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "方向にドラッグして矢印キーを送信します。"
+          }
+        }
+      }
+    },
     "mobile.terminal.inputPlaceholder": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Closes #9900

## What changed
The circular drag arrow pad beside the keyboard control was a plain, unlabeled UIView. A short tap intentionally emits no key, so the control appeared inert and gave VoiceOver users no explanation.

This adds a stable accessibility identifier, the existing localized “Arrow pad” label, and a localized drag hint explaining that directional drags send arrow keys. The behavior is covered by a UIKit metadata regression test. The drag/repeat implementation is unchanged.

## Verification
- Regression commit (test first): `08345b642a`
- Fix commit: `71baa62a8c`
- `git diff --check origin/main..HEAD`
- `python3 -m json.tool ios/cmux/Resources/Localizable.xcstrings`
- `python3 scripts/check-package-resolved-policy.py` (pass)
- `scripts/lint-pbxproj-test-wiring.sh` (pass; 703 test files)
- `swiftc -parse` on the changed Swift files (pass)
- Focused iOS workflow: [run 32808834348](https://github.com/manaflow-ai/cmux/actions/runs/32808834348) checked out the pushed HEAD, provisioned GhosttyKit, built `TerminalArrowNubView.swift` and `TerminalArrowNubAccessibilityTests.swift`, then stopped at an unchanged pre-existing error: `VerifiedReplayPresentationTests.swift:91` cannot find `CACurrentMediaTime` (exit 65). The new test produced no diagnostics and did not execute because the target build failed.
- The workflow’s package-conventions lint also reports existing violations in unrelated files; no changed file is named in those errors.

The checkout has no Swift file-length budget script/TSV (removed historically); both touched Swift files remain under 500 lines. Localization was audited for English and Japanese entries. No tagged app build or launch was performed, and no local Xcode/XCUITest was run per task instructions.