### PR TITLE
cmux-tui docs: one dedicated session per product built on cmux-tui

### DIFF
--- a/cmux-tui/docs/README.md
+++ b/cmux-tui/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Contents
 
-- [Getting started](getting-started.md): build prerequisites, local and headless runs, sockets, detach and attach.
+- [Getting started](getting-started.md): build prerequisites, local and headless runs, sockets, detach and attach, session isolation for products built on cmux-tui.
 - [Concepts](concepts.md): session tree, focus, collapse behavior, tab naming, smart split, terminals, and browsers.
 - [Keyboard](keyboard.md): prefix model, modeless Alt layer, default bindings, and `cmux-tui.json` key remapping.
 - [Mouse](mouse.md): clickable UI, drag reorder, resize, scrollbars, menus, selection, pointer shape, and dialogs.

--- a/cmux-tui/docs/getting-started.md
+++ b/cmux-tui/docs/getting-started.md
@@ -86,6 +86,20 @@ $TMPDIR/cmux-tui-<uid>/<session>.sock
 
 The usual default is `$XDG_RUNTIME_DIR/cmux-tui-<uid>/main.sock` when `XDG_RUNTIME_DIR` is set, then `$TMPDIR/cmux-tui-<uid>/main.sock`, then `/tmp/cmux-tui-<uid>/main.sock`. `--session <name>` changes the final file name. `--socket <path>` bypasses the session-derived path. Server-started child processes receive both `CMUX_TUI_SOCKET` and legacy `CMUX_MUX_SOCKET` with the socket path.
 
+## Isolated products on top of cmux-tui
+
+A program that builds its own product on cmux-tui, such as an agent orchestrator or a test harness, must own a dedicated session. It must not share `main` or a person's interactive session. The session is the isolation unit: each session has its own control socket, workspace tree, and durable state subtree, so `server stop`, `session reset-state`, or a crash in one session never touches another.
+
+```bash
+cmux server start --session <product>-<instance> --headless
+cmux --session <product>-<instance> workspace create --name task-1
+cmux server stop --session <product>-<instance>
+```
+
+Put the product name and an instance discriminator in the session name, for example `firstmate-a1b2c3`. Two installations of one product then coexist on one machine without cross-matching each other's workspaces. Address every call with `--session <name>` or the exact `--socket` path, and store the typed resource IDs a mutation returns instead of resolving by display name later.
+
+The default config path is shared with the person's own cmux-tui and can enable a machine provider or key remaps the product does not expect. Point `CMUX_TUI_CONFIG` at a product-owned config file. Sessions already keep separate state subtrees under the platform state directory; pass `--state <path>` only when the product must keep its state out of the shared root entirely.
+
 ## Platforms and XDG
 
 cmux-tui supports macOS and Linux; Windows support via ConPTY is planned for phase 2. The TUI config path resolves `CMUX_TUI_CONFIG`, then legacy `CMUX_MUX_CONFIG`, then `$XDG_CONFIG_HOME/cmux/cmux-tui.json` or `~/.config/cmux/cmux-tui.json`. Existing `mux.json` files remain supported and are used when `cmux-tui.json` is absent.


### PR DESCRIPTION
Agents and programs that build isolated products on top of cmux-tui (agent orchestrators, test harnesses, firstmate-style crews) were given no guidance on session ownership, so the natural failure mode is squatting the shared \`main\` session or a person's interactive session.

This adds an "Isolated products on top of cmux-tui" section to \`docs/getting-started.md\`: one dedicated session per product instance, product+instance session naming, addressing by \`--session\`/\`--socket\`, storing typed IDs instead of display names, \`CMUX_TUI_CONFIG\` for config isolation, and when \`--state\` is actually needed. Also advertises the section from the docs index.

Docs-only; no runtime change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790226510&installation_model_id=21920&pr_number=10690&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10690&signature=055836f8d2c2f5046b108202b88903867ab1c4752371fa00fce34bc437d642f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents session isolation for products built on `cmux-tui` and links it from the docs index, so orchestrators and harnesses stop using shared `main` or interactive sessions. This reduces cross-session interference and clarifies config/state isolation.

- Use one dedicated session per product instance; do not share `main` or a user’s session. Sessions isolate the control socket, workspace tree, and durable state.
- Name sessions `<product>-<instance>` (e.g., `firstmate-a1b2c3`) to let multiple installations coexist.
- Address every call with `--session <name>` or `--socket <path>` and store typed resource IDs from mutations instead of resolving by display name later.
- Set `CMUX_TUI_CONFIG` to a product-owned config; use `--state <path>` only if product state must live outside the shared root.
- Docs-only; no runtime changes.

<sup>Written for commit d31e40d34097563f246d3ceddf9f45b92606a13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Getting Started guide with guidance for isolated product sessions.
  * Documented unique naming, explicit session or socket addressing, typed resource IDs, and product-owned configuration.
  * Added details on isolating sockets, workspace trees, and durable state.
  * Included commands for starting, using, and stopping headless sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->