### PR TITLE
cloud-testflight: bake lane crash-reporting flag into fleet archives

### DIFF
--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -142,11 +142,16 @@ LANE_DISPLAY_NAME=""
 case "$LANE" in
   beta)
     : "${BETA_BUNDLE_ID:=dev.cmux.app.beta}"
+    export CMUX_CRASH_REPORTING_ENABLED="YES"
     ;;
   appstore|prod)
     BETA_BUNDLE_ID="com.cmux.app"
     LANE_DISPLAY_NAME="cmux"
     [[ "$TAG" == "beta" ]] && TAG="appstore"
+    # The App Store lane ships with crash reporting off. upload-testflight.sh
+    # enforces this at export time, so the fleet archive must bake it in (the
+    # hq cloud script forwards this env into the remote xcodebuild archive).
+    export CMUX_CRASH_REPORTING_ENABLED="NO"
     ;;
   *)
     die "unsupported lane: $LANE (expected beta or appstore)"


### PR DESCRIPTION
The App Store lane requires `CMUXCrashReportingEnabled=NO` and `upload-testflight.sh` refuses to export otherwise, but fleet archives from `cloud-testflight.sh --lane appstore` baked the workspace default (YES) — hit live on 2026-08-24 building com.cmux.app 20260825045906. Export the lane's value per lane (beta=YES, appstore=NO); the hq script forwards it into the remote archive via https://github.com/manaflow-ai/cmuxterm-hq/pull/321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790228886&installation_model_id=21920&pr_number=10693&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10693&signature=30d2f6002c45348c447466d837d63977105548d3f7641c6a13114e387b995f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bakes per-lane crash-reporting into `cloud-testflight.sh` archives to satisfy `upload-testflight.sh` export checks. Old behavior: App Store archives baked CMUXCrashReportingEnabled=YES and were rejected; new behavior: App Store sets NO and Beta sets YES, so App Store builds ship with crash reporting off.

<sup>Written for commit 55fbd01893e05adb9e6524da75f70152660ae329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crash reporting is now enabled for beta builds and disabled for App Store and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->