### PR TITLE
fix(ios): use live alias color on Computers screen

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+LiveMachineColor.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+LiveMachineColor.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension MobileShellComposite {
+    /// Resolve an automatic avatar slot from the supplied pairing ids, but only
+    /// when the pairing is currently represented in the live workspace state.
+    ///
+    /// ``machineColorIndex`` intentionally retains historical assignments so a
+    /// transient Mac switch cannot recolor an existing workspace. Consumers that
+    /// reconcile stored aliases, such as the Computers screen, must therefore
+    /// filter that lifetime map through ``workspacesByMac`` before choosing a
+    /// color for one logical Mac.
+    public func liveMachineColorIndex(for pairingIDs: [String]) -> Int? {
+        let livePairingIDs = Set(
+            workspacesByMac.keys
+                .filter { $0 != .anonymousForeground }
+                .map(\.pairingID)
+        )
+        for pairingID in pairingIDs where livePairingIDs.contains(pairingID) {
+            if let colorIndex = machineColorIndex[pairingID] {
+                return colorIndex
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -29,6 +29,12 @@ extension MacComputerSnapshot {
                 for: mac.macDeviceID,
                 instanceTag: mac.instanceTag
             )
+            let aliasPairingIDs = aliases.map {
+                MobilePairedMac.pairingID(
+                    macDeviceID: $0,
+                    instanceTag: mac.instanceTag
+                )
+            }
             let summary = store.presenceSummary(
                 for: mac.macDeviceID,
                 instanceTag: mac.instanceTag
@@ -55,13 +61,11 @@ extension MacComputerSnapshot {
                 instanceTag: mac.instanceTag,
                 title: buildScope?.computerDisplayName(mac.resolvedName) ?? mac.resolvedName,
                 platform: "mac",
-                colorIndex: colorIndex[mac.id]
-                    ?? aliases.compactMap {
-                        colorIndex[MobilePairedMac.pairingID(
-                            macDeviceID: $0,
-                            instanceTag: mac.instanceTag
-                        )]
-                    }.first,
+                colorIndex: store.liveMachineColorIndex(
+                    for: [mac.id] + aliasPairingIDs
+                )
+                    ?? colorIndex[mac.id]
+                    ?? aliasPairingIDs.compactMap { colorIndex[$0] }.first,
                 customColor: mac.customColor,
                 customIcon: mac.customIcon,
                 connectionStatus: exactConnectionStatus,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotBuildScopeTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotBuildScopeTests.swift
@@ -52,7 +52,7 @@ import Testing
             MacWorkspaceState(
                 macDeviceID: macDeviceID,
                 workspaces: [MobileWorkspacePreview(
-                    id: "workspace-\(macDeviceID)",
+                    id: MobileWorkspacePreview.ID(rawValue: "workspace-\(macDeviceID)"),
                     macDeviceID: macDeviceID,
                     name: macDeviceID,
                     terminals: []

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotBuildScopeTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotBuildScopeTests.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobilePairedMac
 @testable import CmuxMobileShell
 import CmuxMobileShellModel
@@ -22,6 +23,64 @@ import Testing
         ])
     }
 
+    @Test func computerSnapshotUsesTheLiveAliasColor() async throws {
+        let sharedRoute = try CmxAttachRoute(
+            id: "shared-route",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.82.214.112", port: 50922)
+        )
+        let store = await shellStore(pairedMacs: [
+            pairedMac(
+                id: "mac-old",
+                name: "MacBook Pro",
+                lastSeenAt: 20,
+                isActive: true,
+                routes: [sharedRoute]
+            ),
+            pairedMac(
+                id: "mac-fresh",
+                name: "MacBook Pro",
+                lastSeenAt: 10,
+                routes: [sharedRoute]
+            ),
+        ])
+        let oldPairingID = MobilePairedMac.pairingID(macDeviceID: "mac-old", instanceTag: nil)
+        let freshPairingID = MobilePairedMac.pairingID(macDeviceID: "mac-fresh", instanceTag: nil)
+        #expect(store.displayPairedMacs.first?.id == oldPairingID)
+
+        func state(for macDeviceID: String) -> MacWorkspaceState {
+            MacWorkspaceState(
+                macDeviceID: macDeviceID,
+                workspaces: [MobileWorkspacePreview(
+                    id: "workspace-\(macDeviceID)",
+                    macDeviceID: macDeviceID,
+                    name: macDeviceID,
+                    terminals: []
+                )],
+                status: .connected
+            )
+        }
+
+        // Keep the old alias in the additive-only slot table, then simulate the
+        // re-paired Mac's live workspace state moving to the fresh alias.
+        store.setWorkspaceStatesForTesting([
+            oldPairingID: state(for: "mac-old"),
+            freshPairingID: state(for: "mac-fresh"),
+        ], foregroundMacDeviceID: "mac-old")
+        let oldColor = try #require(store.machineColorIndex[oldPairingID])
+        let freshColor = try #require(store.machineColorIndex[freshPairingID])
+        #expect(oldColor != freshColor)
+
+        store.setWorkspaceStatesForTesting([
+            freshPairingID: state(for: "mac-fresh"),
+        ], foregroundMacDeviceID: "mac-fresh")
+        let workspaceColor = try #require(store.workspaces.first?.machineColorIndex)
+        let snapshot = try #require(MacComputerSnapshot.snapshots(from: store).first)
+
+        #expect(workspaceColor == freshColor)
+        #expect(snapshot.colorIndex == workspaceColor)
+    }
+
     private func shellStore(pairedMacs: [MobilePairedMac]) async -> CMUXMobileShellStore {
         let suiteName = "MacComputerSnapshotBuildScopeTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard
@@ -38,14 +97,20 @@ import Testing
         return store
     }
 
-    private func pairedMac(id: String, name: String, lastSeenAt: TimeInterval) -> MobilePairedMac {
+    private func pairedMac(
+        id: String,
+        name: String,
+        lastSeenAt: TimeInterval,
+        isActive: Bool = false,
+        routes: [CmxAttachRoute] = []
+    ) -> MobilePairedMac {
         MobilePairedMac(
             macDeviceID: id,
             displayName: name,
-            routes: [],
+            routes: routes,
             createdAt: Date(timeIntervalSince1970: 0),
             lastSeenAt: Date(timeIntervalSince1970: lastSeenAt),
-            isActive: false,
+            isActive: isActive,
             stackUserID: "user-1",
             teamID: "team-a"
         )


### PR DESCRIPTION
## Summary
- add a behavioral regression test for stale alias color selection on the iOS Computers screen
- prefer a live workspace alias when resolving a computer's automatic avatar color

Fixes #7961.

## Reproduction
A Mac re-paired across dev builds can leave an old device-UUID alias in the paired-Mac history. The additive-only `stableMacColorSlots` map retains that old slot, while the live workspace state is keyed by the replacement alias. The Computers snapshot must use the live alias color so it matches the workspace list.

## Testing
- [ ] Focused `CmuxMobileShellUITests` regression test via approved CI/AWS builder
- [ ] `python3 scripts/swift_file_length_budget.py` (not present on this branch; removed by an earlier main commit)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790229746&installation_model_id=21920&pr_number=10695&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10695&signature=bd51cc9d357d3c2c2a6d870f630a56f517080570e03ac3e808f85eb23d978943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Computers screen avatar color on iOS by preferring the live workspace alias, so it matches the workspace list. Previously re‑paired Macs could show a stale color from an old alias; now the color follows the live assignment and may update once after re‑pair. Fixes #7961.

- Bug Fixes
- Adds `liveMachineColorIndex` in `CmuxMobileShell` and uses it in `CmuxMobileShellUI` when building computer snapshots, with fallbacks to historical slots.
- Adds a regression test covering re‑pair alias divergence and shared‑route cases; test fixtures now use typed workspace IDs.

<sup>Written for commit 47d498ea95d4f89523bf236253ace6221968a46a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

