### PR TITLE
cmux Cloud: 5-second machine creates, box-type glyphs

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3222,7 +3222,10 @@ struct CMUXCLI {
         // create can finish before the app has focused the new workspace, and an
         // untargeted split would land in whatever was focused before. Without a
         // target (a later "open desktop"), the split goes where the person is.
-        var params: [String: Any] = ["url": openUrl + "&autoconnect=1&resize=remote"]
+        // reconnect: autoconnect only covers the first load — without it a machine
+        // sleeping, waking, or any dropped websocket leaves the pane parked on
+        // noVNC's disconnected screen until someone reopens the desktop.
+        var params: [String: Any] = ["url": openUrl + "&autoconnect=1&resize=remote&reconnect=1&reconnect_delay=2000"]
         if let workspaceId {
             params["workspace_id"] = workspaceId
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3229,6 +3229,26 @@ struct CMUXCLI {
         let opened = try? client.sendV2(method: "browser.open_split", params: params)
         return opened != nil
     }
+
+    /// The workspace already attached to a managed Cloud VM, so a later desktop
+    /// open lands beside that machine's shell instead of wherever focus happens
+    /// to be. Nil when the machine has no open workspace.
+    private func vmAttachedWorkspaceId(vmId: String, client: SocketClient) -> String? {
+        guard let response = try? client.sendV2(method: "workspace.list"),
+              let workspaces = response["workspaces"] as? [[String: Any]] else {
+            return nil
+        }
+        for workspace in workspaces {
+            let remote = workspace["remote"] as? [String: Any]
+            guard let attached = remote?["managed_cloud_vm_id"] as? String,
+                  attached == vmId,
+                  let id = workspace["id"] as? String else {
+                continue
+            }
+            return id
+        }
+        return nil
+    }
     /// One-line activity-monitor reading: `swift-gecko  awake · CPU 12% · Mem 1.1/4.0 GB · Disk 2.3/5.0 GB · load 0.42 (2 cpus)`.
     static func formatVMStatsLine(id: String, payload: [String: Any]) -> String {
         func number(_ key: String) -> Double? {
@@ -4732,9 +4752,10 @@ struct CMUXCLI {
                 }
 
             case "desktop", "vnc":
-                // The machine's screen, on demand: the noVNC desktop opens as a new browser
-                // pane in the workspace you are in (or the one named by --workspace). The
-                // create-time layout puts it beside the shell; later opens follow you.
+                // The machine's screen, on demand: the noVNC desktop opens as a browser
+                // pane in the machine's own workspace when it has one open (beside its
+                // shell), in the workspace named by --workspace, or where you are when
+                // the machine has no open workspace.
                 let (workspaceOpt, vmArgs) = parseOption(rest, name: "--workspace")
                 guard let vmId = vmArgs.first else {
                     throw CLIError(message: """
@@ -4744,7 +4765,8 @@ struct CMUXCLI {
                           cmux vm ls
                         """)
                 }
-                guard try openVMDesktopSplit(vmId: vmId, client: client, workspaceId: workspaceOpt) else {
+                let desktopWorkspace = workspaceOpt ?? vmAttachedWorkspaceId(vmId: vmId, client: client)
+                guard try openVMDesktopSplit(vmId: vmId, client: client, workspaceId: desktopWorkspace) else {
                     throw CLIError(message: String(
                         localized: "cli.vm.desktop.unavailable",
                         defaultValue: "\(vmId) has no desktop to show. New machines boot a screen; this one was created shell-only (`--base`)."
@@ -4872,7 +4894,7 @@ struct CMUXCLI {
                           cmux vm ls
                         """)
                 }
-                try vmOpenShell(
+                let shellWorkspaceId = try vmOpenShell(
                     id: vmId,
                     workspaceName: "vm:\(vmId)",
                     windowRaw: windowOpt ?? windowId,
@@ -4885,7 +4907,10 @@ struct CMUXCLI {
                 if let status = try? client.sendV2(method: "vm.status", params: ["id": vmId], responseTimeout: 30),
                    let image = status["image"] as? String,
                    Self.cloudVMImageHasDesktop(image) {
-                    _ = try? openVMDesktopSplit(vmId: vmId, client: client)
+                    // The screen belongs beside the shell it was opened with, not in
+                    // whatever workspace holds focus once the attach settles.
+                    let desktopWorkspace = shellWorkspaceId ?? vmAttachedWorkspaceId(vmId: vmId, client: client)
+                    _ = try? openVMDesktopSplit(vmId: vmId, client: client, workspaceId: desktopWorkspace)
                 }
 
             case "rename":

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
@@ -66,6 +66,16 @@ public struct BetaFeaturesCatalogSection: SettingCatalogSection {
         userDefaultsKey: "sidebarWorkspaceTodosChecklistStyle"
     )
 
+    /// Cloud Machines: the Cloud tab in the right sidebar plus every other
+    /// Cloud VM surface (Settings section, palette commands, titlebar button,
+    /// new-workspace menu). Defaults off; the remote rollout flag can also
+    /// enable the same surfaces, so this opt-in only ever adds availability.
+    public let cloudMachines = DefaultsKey<Bool>(
+        id: "cloud.beta.machines.enabled",
+        defaultValue: false,
+        userDefaultsKey: "cloud.beta.machines.enabled"
+    )
+
     /// Remote tmux: mirror a remote host's tmux sessions in the cmux sidebar
     /// over `ssh … tmux -CC` (iTerm2-style control mode). Sessions appear as
     /// sidebar workspaces, tmux windows as tabs, and tmux panes as splits;

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -296,6 +296,17 @@ extension Array where Element == CuratedSettingEntry {
             // Beta
             .init(section: .betaFeatures, id: "feed", title: "Feed", synonyms: "feed right sidebar agent decisions permissions questions approval beta unstable"),
             .init(section: .betaFeatures, id: "dock", title: "Dock", synonyms: "dock right sidebar terminal controls tui beta unstable"),
+            .init(
+                section: .betaFeatures,
+                id: "cloudMachines",
+                title: String(localized: "settings.betaFeatures.cloudMachines", defaultValue: "Cloud Machines"),
+                detailText: [
+                    String(localized: "settings.betaFeatures.cloudMachines.subtitleOn", defaultValue: "Shows Cloud in the right sidebar plus the Cloud Machines settings, palette commands, and new-workspace entries."),
+                    String(localized: "settings.betaFeatures.cloudMachines.subtitleOff", defaultValue: "Hides every Cloud Machines surface unless remote rollout enables it."),
+                ].joined(separator: " "),
+                paths: ["cloud.beta.machines.enabled"],
+                synonyms: "cloud machines vm virtual machine right sidebar persistent computer beta unstable"
+            ),
             .init(section: .betaFeatures, id: "customSidebars", title: "Custom Sidebars", synonyms: "custom sidebars swift json interpreted vibe beta unstable"),
             .init(section: .betaFeatures, id: "remoteTmux", title: "Remote tmux", synonyms: "remote tmux ssh control mode -CC mirror session window pane sidebar workspace beta unstable"),
             .init(

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -46,7 +46,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .textBox: return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
         case .sleepyMode: return String(localized: "settings.section.sleepyMode", defaultValue: "Sleepy Mode")
         case .mobile: return String(localized: "settings.section.mobile", defaultValue: "Mobile")
-        case .cloudMachines: return String(localized: "settings.section.cloudMachines", defaultValue: "Cloud Machines")
+        case .cloudMachines: return String(localized: "settings.section.cloudMachines", defaultValue: "Cloud")
         case .networking: return String(localized: "settings.section.networking", defaultValue: "Networking")
         case .sidebarAppearance: return "Sidebar"
         case .customSidebars: return String(localized: "settings.section.customSidebars", defaultValue: "Custom Sidebars")
@@ -71,7 +71,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .textBox: return "textformat"
         case .sleepyMode: return "moon.zzz"
         case .mobile: return "iphone"
-        case .cloudMachines: return "server.rack"
+        case .cloudMachines: return "cloud"
         case .networking: return "network"
         case .sidebarAppearance: return "sidebar.left"
         case .customSidebars: return "sidebar.squares.left"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -33,6 +33,10 @@ public struct SettingsWindowRoot: View {
     // there is no SwiftUI scene to store into (cmux issue #7777).
     @AppStorage("selectedSettingsSection") private var selectedSectionRaw: String = SettingsSectionID.account.rawValue
     @AppStorage("selectedSettingsSidebarEntry") private var selectedSidebarEntryID: String = "section:\(SettingsSectionID.account.rawValue)"
+    // Mirrors BetaFeaturesCatalogSection.cloudMachines so flipping the Beta
+    // Features toggle shows/hides the Cloud sidebar row without reopening
+    // Settings; the host folds in the remote rollout flag.
+    @AppStorage("cloud.beta.machines.enabled") private var cloudMachinesBetaEnabled = false
     // Legacy `SettingsRootView` binds `NavigationSplitView`'s
     // `columnVisibility` so the user can collapse the sidebar via the
     // toolbar button (or the SidebarCommands menu) and have that state
@@ -161,10 +165,24 @@ public struct SettingsWindowRoot: View {
         navigate(to: target, preferSectionSelection: !shouldPreserveSearchSelection)
     }
 
+    /// The Cloud section stays out of the sidebar (and search) until the
+    /// remote rollout flag or the Beta Features opt-in makes its surfaces
+    /// real; its pane already renders nothing while unavailable.
+    private func isEntryVisible(_ entry: SettingsSearchIndex.Entry) -> Bool {
+        let cloudAvailable = hostActions.isCloudMachinesAvailable || cloudMachinesBetaEnabled
+        guard !cloudAvailable else { return true }
+        switch entry.kind {
+        case .section:
+            return entry.id != "section:\(SettingsSectionID.cloudMachines.rawValue)"
+        case .setting(let parent):
+            return parent != .cloudMachines
+        }
+    }
+
     @ViewBuilder
     private var sidebar: some View {
         List(selection: sidebarSelectionBinding) {
-            let matches = sidebarEntries(matching: searchText)
+            let matches = sidebarEntries(matching: searchText).filter(isEntryVisible)
             if matches.isEmpty {
                 Text(String(localized: "settings.search.noResults", defaultValue: "No Results"))
                     .foregroundStyle(.secondary)

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
@@ -9,6 +9,7 @@ import SwiftUI
 public struct BetaFeaturesSection: View {
     @State private var feed: DefaultsValueModel<Bool>
     @State private var dock: DefaultsValueModel<Bool>
+    @State private var cloudMachines: DefaultsValueModel<Bool>
     @State private var extensions: DefaultsValueModel<Bool>
     @State private var customSidebars: DefaultsValueModel<Bool>
     @State private var remoteTmux: DefaultsValueModel<Bool>
@@ -18,6 +19,7 @@ public struct BetaFeaturesSection: View {
     public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog) {
         _feed = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarFeed))
         _dock = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarDock))
+        _cloudMachines = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.cloudMachines))
         _extensions = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.extensions))
         _customSidebars = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.customSidebars))
         _remoteTmux = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.remoteTmux))
@@ -37,6 +39,8 @@ public struct BetaFeaturesSection: View {
                 SettingsCardDivider()
                 dockRow
                 SettingsCardDivider()
+                cloudMachinesRow
+                SettingsCardDivider()
                 extensionsRow
                 SettingsCardDivider()
                 customSidebarsRow
@@ -55,6 +59,7 @@ public struct BetaFeaturesSection: View {
         let models: [any SettingObservationStarting] = [
             feed,
             dock,
+            cloudMachines,
             extensions,
             customSidebars,
             remoteTmux,
@@ -136,6 +141,23 @@ public struct BetaFeaturesSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsBetaDockToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var cloudMachinesRow: some View {
+        SettingsCardRow(
+            configurationReview: .json("cloud.beta.machines.enabled"),
+            searchAnchorID: "setting:betaFeatures:cloudMachines",
+            String(localized: "settings.betaFeatures.cloudMachines", defaultValue: "Cloud Machines"),
+            subtitle: cloudMachines.current
+                ? String(localized: "settings.betaFeatures.cloudMachines.subtitleOn", defaultValue: "Shows Cloud in the right sidebar plus the Cloud Machines settings, palette commands, and new-workspace entries.")
+                : String(localized: "settings.betaFeatures.cloudMachines.subtitleOff", defaultValue: "Hides every Cloud Machines surface unless remote rollout enables it.")
+        ) {
+            Toggle("", isOn: Binding(get: { cloudMachines.current }, set: { cloudMachines.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsBetaCloudMachinesToggle")
         }
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CloudMachinesSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CloudMachinesSection.swift
@@ -18,7 +18,7 @@ public struct CloudMachinesSection: View {
     public var body: some View {
         if hostActions.isCloudMachinesAvailable {
             SettingsSectionHeader(
-                String(localized: "settings.section.cloudMachines", defaultValue: "Cloud Machines"),
+                String(localized: "settings.section.cloudMachines", defaultValue: "Cloud"),
                 section: .cloudMachines
             )
             SettingsCard {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -201167,13 +201167,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cloud Machines"
+            "value": "Cloud"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "クラウドマシン"
+            "value": "クラウド"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -171822,6 +171822,57 @@
         }
       }
     },
+    "settings.betaFeatures.cloudMachines": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Machines"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドマシン"
+          }
+        }
+      }
+    },
+    "settings.betaFeatures.cloudMachines.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hides every Cloud Machines surface unless remote rollout enables it."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートロールアウトで有効化されない限り、クラウドマシンのすべての画面を非表示にします。"
+          }
+        }
+      }
+    },
+    "settings.betaFeatures.cloudMachines.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows Cloud in the right sidebar plus the Cloud Machines settings, palette commands, and new-workspace entries."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバーにクラウドを表示し、クラウドマシンの設定、パレットコマンド、新規ワークスペースの項目も有効にします。"
+          }
+        }
+      }
+    },
     "settings.betaFeatures.customSidebars": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -479,9 +479,11 @@ enum AgentHibernationTrackingGate {
 enum RightSidebarBetaFeatureSettings {
     static let feedEnabledKey = "rightSidebar.beta.feed.enabled"
     static let dockEnabledKey = "rightSidebar.beta.dock.enabled"
+    static let cloudMachinesEnabledKey = "cloud.beta.machines.enabled"
 
     static let defaultFeedEnabled = false
     static let defaultDockEnabled = false
+    static let defaultCloudMachinesEnabled = false
 
     nonisolated static func isFeedEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: feedEnabledKey) != nil else { return defaultFeedEnabled }
@@ -491,6 +493,11 @@ enum RightSidebarBetaFeatureSettings {
     nonisolated static func isDockEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: dockEnabledKey) != nil else { return defaultDockEnabled }
         return defaults.bool(forKey: dockEnabledKey)
+    }
+
+    nonisolated static func isCloudMachinesEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: cloudMachinesEnabledKey) != nil else { return defaultCloudMachinesEnabled }
+        return defaults.bool(forKey: cloudMachinesEnabledKey)
     }
 }
 

--- a/Sources/AppDelegate+NewWorkspaceContextMenu.swift
+++ b/Sources/AppDelegate+NewWorkspaceContextMenu.swift
@@ -75,7 +75,7 @@ extension AppDelegate {
         let model = NewWorkspaceMenuModel.build(
             newWorkspaceContextMenuItems: cmuxConfigStore.newWorkspaceContextMenuItems,
             agentChatAction: resolvedBuiltInNewAgentChatAction(cmuxConfigStore: cmuxConfigStore),
-            cloudSectionEnabled: CmuxFeatureFlags.shared.isCloudVMUIEnabled,
+            cloudSectionEnabled: CloudMachinesFeature.isEnabled,
             templateNames: savedLayoutNames(),
             loadedActions: cmuxConfigStore.loadedActions,
             newWorkspaceActionID: cmuxConfigStore.newWorkspaceActionID,

--- a/Sources/Cloud/CloudMachinesFeature.swift
+++ b/Sources/Cloud/CloudMachinesFeature.swift
@@ -13,8 +13,8 @@ enum CloudMachinesFeature {
     }
 
     /// Off-main mirror for the right-sidebar mode availability path.
-    nonisolated static var offMainIsEnabled: Bool {
-        CmuxFeatureFlags.offMainIsCloudVMUIEnabled || localOptIn(defaults: .standard)
+    nonisolated static func offMainIsEnabled(defaults: UserDefaults = .standard) -> Bool {
+        CmuxFeatureFlags.offMainIsCloudVMUIEnabled || localOptIn(defaults: defaults)
     }
 
     nonisolated static func isEnabled(defaults: UserDefaults, remoteEnabled: Bool) -> Bool {

--- a/Sources/Cloud/CloudMachinesFeature.swift
+++ b/Sources/Cloud/CloudMachinesFeature.swift
@@ -1,0 +1,29 @@
+import CmuxSettings
+import Foundation
+
+/// Whether the Cloud Machines surfaces are available: the remote rollout flag
+/// or the local Beta Features opt-in. Every entry point (right-sidebar Cloud
+/// tab, Settings section, command palette, titlebar button, new-workspace
+/// menu) funnels through this gate so a nightly user who flips the beta
+/// toggle gets exactly the surfaces a remote rollout would enable.
+enum CloudMachinesFeature {
+    @MainActor
+    static var isEnabled: Bool {
+        isEnabled(defaults: .standard, remoteEnabled: CmuxFeatureFlags.shared.isCloudVMUIEnabled)
+    }
+
+    /// Off-main mirror for the right-sidebar mode availability path.
+    nonisolated static var offMainIsEnabled: Bool {
+        CmuxFeatureFlags.offMainIsCloudVMUIEnabled || localOptIn(defaults: .standard)
+    }
+
+    nonisolated static func isEnabled(defaults: UserDefaults, remoteEnabled: Bool) -> Bool {
+        remoteEnabled || localOptIn(defaults: defaults)
+    }
+
+    nonisolated static func localOptIn(defaults: UserDefaults) -> Bool {
+        let key = BetaFeaturesCatalogSection().cloudMachines
+        guard defaults.object(forKey: key.userDefaultsKey) != nil else { return key.defaultValue }
+        return defaults.bool(forKey: key.userDefaultsKey)
+    }
+}

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -720,10 +720,18 @@ private struct MachineRow: View, Equatable {
                     .foregroundColor(.primary.opacity(0.92))
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Text(subtitle)
-                    .cmuxFont(size: 11)
-                    .foregroundColor(.secondary.opacity(0.75))
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    // A box's type at a glance: a desktop machine has its screen,
+                    // a base machine is shell-only.
+                    Image(systemName: machine.isDesktop ? "display" : "terminal")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(.secondary.opacity(0.6))
+                    Text(subtitle)
+                        .cmuxFont(size: 11)
+                        .foregroundColor(.secondary.opacity(0.75))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
                 if let stats = machine.stats {
                     MachineStatsLine(stats: stats)
                         .padding(.top, 2)

--- a/Sources/ContentView+AuthCommandPalette.swift
+++ b/Sources/ContentView+AuthCommandPalette.swift
@@ -75,7 +75,7 @@ extension ContentView {
     static func commandPaletteCloudCommandContributions() -> [CommandPaletteCommandContribution] {
         // Feature-gated: hide every Cloud VM command from the palette when the
         // Cloud VM UI flag is off, matching the dropdown and shortcut gates.
-        guard CmuxFeatureFlags.shared.isCloudVMUIEnabled else { return [] }
+        guard CloudMachinesFeature.isEnabled else { return [] }
         func constant(_ value: String) -> (CommandPaletteContextSnapshot) -> String {
             { _ in value }
         }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -266,7 +266,7 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     var isCloudMachinesAvailable: Bool {
-        CmuxFeatureFlags.shared.isCloudVMUIEnabled
+        CloudMachinesFeature.isEnabled
     }
 
     func cloudMachinesPlanSummary() async -> CloudMachinesPlanSummary? {

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -25,7 +25,7 @@ extension RightSidebarMode {
         availableModes(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
             dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
-            machinesEnabled: CmuxFeatureFlags.offMainIsCloudVMUIEnabled
+            machinesEnabled: CloudMachinesFeature.offMainIsEnabled
         )
     }
 
@@ -43,7 +43,7 @@ extension RightSidebarMode {
         isAvailable(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
             dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
-            machinesEnabled: CmuxFeatureFlags.offMainIsCloudVMUIEnabled
+            machinesEnabled: CloudMachinesFeature.offMainIsEnabled
         )
     }
 

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -25,7 +25,7 @@ extension RightSidebarMode {
         availableModes(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
             dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
-            machinesEnabled: CloudMachinesFeature.offMainIsEnabled
+            machinesEnabled: CloudMachinesFeature.offMainIsEnabled(defaults: defaults)
         )
     }
 
@@ -43,7 +43,7 @@ extension RightSidebarMode {
         isAvailable(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
             dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
-            machinesEnabled: CloudMachinesFeature.offMainIsEnabled
+            machinesEnabled: CloudMachinesFeature.offMainIsEnabled(defaults: defaults)
         )
     }
 

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -141,6 +141,8 @@ struct RightSidebarPanelView: View {
     private var feedEnabled = RightSidebarBetaFeatureSettings.defaultFeedEnabled
     @AppStorage(RightSidebarBetaFeatureSettings.dockEnabledKey)
     private var dockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
+    @AppStorage(RightSidebarBetaFeatureSettings.cloudMachinesEnabledKey)
+    private var cloudMachinesBetaEnabled = RightSidebarBetaFeatureSettings.defaultCloudMachinesEnabled
 
     // Re-reading the observable store inside modeBar causes SwiftUI to
     // track the pending count so the badge updates live when hooks push
@@ -153,7 +155,7 @@ struct RightSidebarPanelView: View {
         RightSidebarMode.availableModes(
             feedEnabled: feedEnabled,
             dockEnabled: dockEnabled,
-            machinesEnabled: CmuxFeatureFlags.shared.isCloudVMUIEnabled
+            machinesEnabled: CmuxFeatureFlags.shared.isCloudVMUIEnabled || cloudMachinesBetaEnabled
         )
     }
 
@@ -225,6 +227,7 @@ struct RightSidebarPanelView: View {
         }
         .onChange(of: feedEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
         .onChange(of: dockEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
+        .onChange(of: cloudMachinesBetaEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
     }
 
     private var modeBar: some View {

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -38,7 +38,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .mobile:
             return String(localized: "settings.section.mobile", defaultValue: "Mobile")
         case .cloudMachines:
-            return String(localized: "settings.section.cloudMachines", defaultValue: "Cloud Machines")
+            return String(localized: "settings.section.cloudMachines", defaultValue: "Cloud")
         case .networking:
             return String(localized: "settings.section.networking", defaultValue: "Networking")
         case .workspaceColors:

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -81,7 +81,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .mobile:
             return "iphone"
         case .cloudMachines:
-            return "server.rack"
+            return "cloud"
         case .networking:
             return "network"
         case .workspaceColors:
@@ -436,6 +436,7 @@ enum SettingsSearchIndex {
         setting(.customSidebars, "renderer", String(localized: "settings.customSidebars.renderer", defaultValue: "Renderer"), "renderer in-process in app remote worker isolated process hover focus typing input"),
         setting(.betaFeatures, "feed", String(localized: "settings.betaFeatures.feed", defaultValue: "Feed"), "feed right sidebar agent decisions permissions questions"),
         setting(.betaFeatures, "dock", String(localized: "settings.betaFeatures.dock", defaultValue: "Dock"), "dock right sidebar terminal controls tui"),
+        setting(.betaFeatures, "cloudMachines", String(localized: "settings.betaFeatures.cloudMachines", defaultValue: "Cloud Machines"), "cloud machines vm right sidebar beta virtual machine persistent computer"),
         setting(.betaFeatures, "workspace-todo-controls", String(localized: "settings.betaFeatures.workspaceTodoControls", defaultValue: "Workspace Todo Controls"), "workspace todo todos task status checklist add item controls beta"),
         setting(.betaFeatures, "workspace-todos-checklist-style", String(localized: "settings.betaFeatures.workspaceTodosChecklistStyle", defaultValue: "Checklist Style"), "workspace todo todos task status checklist popover inline presentation style beta"),
         setting(.automation, "socket-mode", String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"), "unix socket api access password auth"),

--- a/Sources/Update/TitlebarCloudVMButton.swift
+++ b/Sources/Update/TitlebarCloudVMButton.swift
@@ -361,13 +361,13 @@ struct TitlebarCloudVMButton: View {
 
     @MainActor
     static func showCloudVMMenu(anchorView: NSView, event: NSEvent) {
-        guard CmuxFeatureFlags.shared.isCloudVMUIEnabled else { return }
+        guard CloudMachinesFeature.isEnabled else { return }
         NSMenu.popUpContextMenu(makeCloudVMMenu(), with: event, for: anchorView)
     }
 
     @MainActor
     static func showCloudVMMenu(anchorView: NSView) {
-        guard CmuxFeatureFlags.shared.isCloudVMUIEnabled else { return }
+        guard CloudMachinesFeature.isEnabled else { return }
         let menu = makeCloudVMMenu()
         menu.popUp(
             positioning: nil,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1338,6 +1338,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
 		7690848956F4C55873F767F6 /* MachinesPanelModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */; };
 		E879C292A2D38E3DDBCB004D /* MachinesPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08610D114C8CF23877176D7E /* MachinesPanelView.swift */; };
+		0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9143D900F124494A55F859F /* CloudMachinesFeature.swift */; };
 		D7E6477A2FC01DCCF353840D /* MachinesPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */; };
 		D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */; };
 		D1F0A00700000000000000C1 /* MacPairedMacBackupOpWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */; };
@@ -4162,6 +4163,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
 		78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelModelTests.swift; sourceTree = "<group>"; };
 		08610D114C8CF23877176D7E /* MachinesPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelView.swift; sourceTree = "<group>"; };
+		D9143D900F124494A55F859F /* CloudMachinesFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachinesFeature.swift; sourceTree = "<group>"; };
 		68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelViewModel.swift; sourceTree = "<group>"; };
 		D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupBody.swift; sourceTree = "<group>"; };
 		D1F0A00700000000000000C2 /* MacPairedMacBackupOpWire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupOpWire.swift; sourceTree = "<group>"; };
@@ -6043,6 +6045,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D1F0A00800000000000000C2 /* MacPairedMacBackupRecordWire.swift */,
 				D1F0A00100000000000000B4 /* PresenceSettings.swift */,
 				9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */,
+				D9143D900F124494A55F859F /* CloudMachinesFeature.swift */,
 				08610D114C8CF23877176D7E /* MachinesPanelView.swift */,
 				68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */,
 			);
@@ -9850,6 +9853,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
 				8561C0128561C0128561C012 /* KeyboardShortcutSettingsObserver.swift in Sources */,
 				53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */,
+				0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */,
 				E879C292A2D38E3DDBCB004D /* MachinesPanelView.swift in Sources */,
 				D7E6477A2FC01DCCF353840D /* MachinesPanelViewModel.swift in Sources */,
 				D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */,

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -391,12 +391,19 @@ export class BlaxelProvider implements VMProvider {
           // A machine that failed to bootstrap must not survive as an orphaned
           // sandbox (its previews die with it); the durable home volume is kept —
           // a retried create with the same volume reattaches it.
+          // A rollback failure means the sandbox is now leaked on the provider:
+          // log it loudly (the original create error still propagates) so the
+          // orphan is findable instead of silently accumulating.
+          const rollback = () =>
+            this.destroy(name).catch((cleanupErr) => {
+              console.error(`[blaxel] create rollback failed; sandbox ${name} may be orphaned`, cleanupErr);
+            });
           if (bootstrapResult.status === "rejected") {
-            await this.destroy(name).catch(() => undefined);
+            await rollback();
             throw bootstrapResult.reason;
           }
           if (previewResult.status === "rejected") {
-            await this.destroy(name).catch(() => undefined);
+            await rollback();
             throw previewResult.reason;
           }
           const previewUrl = previewResult.value;

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -380,19 +380,26 @@ export class BlaxelProvider implements VMProvider {
           // rather than an opaque hash it would then keep for life. The preview lives on
           // the control plane and only needs the sandbox to exist, so it is created in
           // parallel with the in-sandbox daemon bootstrap.
-          let previewUrl: string;
-          try {
-            [, previewUrl] = await Promise.all([
-              timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl)),
-              timedStep("ensure_preview", () => this.ensurePreview(name)),
-            ]);
-          } catch (err) {
-            // A machine that failed to bootstrap must not survive as an orphaned
-            // sandbox (its previews die with it); the durable home volume is kept —
-            // a retried create with the same volume reattaches it.
+          // Both branches settle before any rollback (allSettled, not all): a
+          // fast-failing bootstrap must not start deleting the sandbox while the
+          // preview POST is still in flight, or the late preview recreates the
+          // orphaned branded route the rollback exists to remove.
+          const [bootstrapResult, previewResult] = await Promise.allSettled([
+            timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl)),
+            timedStep("ensure_preview", () => this.ensurePreview(name)),
+          ]);
+          // A machine that failed to bootstrap must not survive as an orphaned
+          // sandbox (its previews die with it); the durable home volume is kept —
+          // a retried create with the same volume reattaches it.
+          if (bootstrapResult.status === "rejected") {
             await this.destroy(name).catch(() => undefined);
-            throw err;
+            throw bootstrapResult.reason;
           }
+          if (previewResult.status === "rejected") {
+            await this.destroy(name).catch(() => undefined);
+            throw previewResult.reason;
+          }
+          const previewUrl = previewResult.value;
           span.setAttribute("cmux.vm.id", name);
           return {
             provider: "blaxel",

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -317,6 +317,11 @@ function daemonBinaryBase64Gzip(): Promise<string> {
   return cachedDaemonB64;
 }
 
+// Warm the payload cache at module init so the first create after a boot does not
+// pay the read+encode on its critical path. A missing daemon config just leaves the
+// cache empty here; create() surfaces the real configuration error to the caller.
+void daemonBinaryBase64Gzip().catch(() => undefined);
+
 export class BlaxelProvider implements VMProvider {
   readonly id = "blaxel" as const;
 
@@ -370,11 +375,15 @@ export class BlaxelProvider implements VMProvider {
           if (!sandboxUrl) {
             throw new Error("create response is missing metadata.url for the sandbox API");
           }
-          await timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl));
           // The daemon preview is minted through the same branded path attach uses, so a
           // machine is born at https://<name>.vm.cmux.sh (or <name>-cmux.preview.bl.run)
-          // rather than an opaque hash it would then keep for life.
-          const previewUrl = await timedStep("ensure_preview", () => this.ensurePreview(name));
+          // rather than an opaque hash it would then keep for life. The preview lives on
+          // the control plane and only needs the sandbox to exist, so it is created in
+          // parallel with the in-sandbox daemon bootstrap.
+          const [, previewUrl] = await Promise.all([
+            timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl)),
+            timedStep("ensure_preview", () => this.ensurePreview(name)),
+          ]);
           span.setAttribute("cmux.vm.id", name);
           return {
             provider: "blaxel",
@@ -395,19 +404,23 @@ export class BlaxelProvider implements VMProvider {
 
   private async bootstrapDaemon(name: string, sandboxUrl: string): Promise<void> {
     const b64 = await timedStep("daemon_binary_encode", () => daemonBinaryBase64Gzip());
-    await timedStep("daemon_upload", () => blaxelFetch(
-      "PUT",
-      // Leading slash after /filesystem: relative paths root at /blaxel, absolute paths need
-      // the extra separator (`/filesystem//tmp/...`).
-      `${sandboxUrl}/filesystem//tmp/cmuxd.b64`,
-      { content: b64, permissions: "0600" },
-      { timeoutMs: 180_000 },
-    ));
-    await blaxelFetch(
-      "PUT",
-      `${sandboxUrl}/filesystem/${SMART_SLEEP_PATH}`,
-      { content: SMART_SLEEP_SCRIPT, permissions: "0755" },
-    );
+    // Both filesystem writes are independent; the install exec below is the barrier
+    // that needs them on disk.
+    await Promise.all([
+      timedStep("daemon_upload", () => blaxelFetch(
+        "PUT",
+        // Leading slash after /filesystem: relative paths root at /blaxel, absolute paths need
+        // the extra separator (`/filesystem//tmp/...`).
+        `${sandboxUrl}/filesystem//tmp/cmuxd.b64`,
+        { content: b64, permissions: "0600" },
+        { timeoutMs: 180_000 },
+      )),
+      blaxelFetch(
+        "PUT",
+        `${sandboxUrl}/filesystem/${SMART_SLEEP_PATH}`,
+        { content: SMART_SLEEP_SCRIPT, permissions: "0755" },
+      ),
+    ]);
     const install = await timedStep("daemon_install", () => this.sandboxExec(
       sandboxUrl,
       `base64 -d /tmp/cmuxd.b64 | gunzip > ${CMUXD_BINARY_PATH} && chmod 755 ${CMUXD_BINARY_PATH} && rm /tmp/cmuxd.b64 && chmod 755 ${SMART_SLEEP_PATH} && mkdir -p /tmp/cmux && chmod 700 /tmp/cmux && ${CMUXD_BINARY_PATH} version`,
@@ -415,19 +428,25 @@ export class BlaxelProvider implements VMProvider {
     if (install.exitCode !== 0) {
       throw new ProviderError("blaxel", `daemon install in ${name} failed: ${install.stderr || install.stdout}`);
     }
-    await timedStep("daemon_start", () => this.startDaemonProcess(sandboxUrl));
-    await timedStep("watcher_start", () => this.startWatcherProcess(sandboxUrl));
-    // Runtime state, so it re-applies on resurrection too (this method runs on both paths).
-    // Must precede the VNC heal: the heal only succeeds once the hostname resolves.
-    await timedStep("hostname_setup", () => this.sandboxExec(sandboxUrl, hostnameSetupCommand(name)).catch(() => undefined));
-    await timedStep("vnc_heal_start", () => this.startDesktopVncHeal(sandboxUrl));
-    // Agents and dev essentials come with the machine, installed in the background so attach
-    // is never delayed. The .bashrc seed is write-once: /root persists, and a user's edits win.
-    await blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
-      name: "cmux-provision",
-      command: CMUX_PROVISION_COMMAND,
-      waitForCompletion: false,
-    }).catch(() => undefined);
+    // Everything after the install is mutually independent: the daemon and watcher
+    // processes, the hostname→VNC-heal chain (ordered within itself — the heal only
+    // succeeds once the hostname resolves; runtime state, so it re-applies on
+    // resurrection too), and the background provision process (agents and dev
+    // essentials come with the machine without delaying attach; the .bashrc seed is
+    // write-once — /root persists, and a user's edits win).
+    await Promise.all([
+      timedStep("daemon_start", () => this.startDaemonProcess(sandboxUrl)),
+      timedStep("watcher_start", () => this.startWatcherProcess(sandboxUrl)),
+      (async () => {
+        await timedStep("hostname_setup", () => this.sandboxExec(sandboxUrl, hostnameSetupCommand(name)).catch(() => undefined));
+        await timedStep("vnc_heal_start", () => this.startDesktopVncHeal(sandboxUrl));
+      })(),
+      blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
+        name: "cmux-provision",
+        command: CMUX_PROVISION_COMMAND,
+        waitForCompletion: false,
+      }).catch(() => undefined),
+    ]);
   }
 
   // The daemon itself is NOT keepAlive: while every shell is idle and no client is attached,

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -380,10 +380,19 @@ export class BlaxelProvider implements VMProvider {
           // rather than an opaque hash it would then keep for life. The preview lives on
           // the control plane and only needs the sandbox to exist, so it is created in
           // parallel with the in-sandbox daemon bootstrap.
-          const [, previewUrl] = await Promise.all([
-            timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl)),
-            timedStep("ensure_preview", () => this.ensurePreview(name)),
-          ]);
+          let previewUrl: string;
+          try {
+            [, previewUrl] = await Promise.all([
+              timedStep("bootstrap_daemon", () => this.bootstrapDaemon(name, sandboxUrl)),
+              timedStep("ensure_preview", () => this.ensurePreview(name)),
+            ]);
+          } catch (err) {
+            // A machine that failed to bootstrap must not survive as an orphaned
+            // sandbox (its previews die with it); the durable home volume is kept —
+            // a retried create with the same volume reattaches it.
+            await this.destroy(name).catch(() => undefined);
+            throw err;
+          }
           span.setAttribute("cmux.vm.id", name);
           return {
             provider: "blaxel",


### PR DESCRIPTION
Follow-up to #10478 focused on startup speed and Machines-panel polish.

## Startup speed (measured, not guessed)

Step-level timings (`CMUX_VM_DEBUG_TIMINGS=1`, added in #10478) attribute every phase of a create. On top of the gzip fix from #10478 (23s → 2.7s encode), this PR:

- mints the branded preview **in parallel** with the in-sandbox daemon bootstrap
- uploads the daemon payload and smart-sleep script **together**
- fans out everything after the install exec (daemon start, watcher, hostname→VNC heal chain, background provision)
- **warms the daemon payload cache at module init**, so the first create after a boot skips the read+encode

| | before #10478 | after #10478 | this PR |
|---|---|---|---|
| `cmux vm new --detach` | 22–36s | ~10s | **~5s** |
| + button → attached workspace | 15–30s+ | — | **~10s** |

Remaining fixed cost is the ~2.7s daemon upload per create. Follow-up that removes it: fetch the daemon from R2 **inside** the sandbox (`CMUX_VM_BLAXEL_DAEMON_URL`) or bake it into the image. Blaxel-side `create_sandbox` still varies 1–30s on cold provisioning, outside our control in-line.

## Right boxes, right images

Verified live: default `vm new` (CLI and the panel's + button) creates `blaxel/xfce-vnc:latest` — vncserver on :5901, noVNC, and xfce confirmed running in a fresh box — born on its own `https://<name>.vm.cmux.sh` URL. `vm new --base` picks the shell-only `blaxel/base-image:latest`.

## Machines panel

Each row's subtitle now leads with a display/terminal glyph so desktop boxes and shell-only base boxes read at a glance. (The narrow-panel gauge-wrapping fix already landed in #10478.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790230578&installation_model_id=21920&pr_number=10698&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10698&signature=8ceae4e1c6b33d10ed46d2e1a3eef2f216f9968b9a67c1d150d713adc89c7fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Machine creates in cmux Cloud now complete in ~5s detached (~10s when attaching) by parallelizing startup, and desktops open in the machine’s workspace beside its shell instead of the currently focused workspace. If no workspace is open we fall back to focus; --workspace still overrides, and failed bootstrap/preview tears down the sandbox while keeping the durable home volume.

**Refactors**
- Mint the branded preview in parallel with the in-sandbox daemon bootstrap and settle both before any rollback.
- Upload the daemon payload and smart-sleep script together, then fan out post-install tasks.
- Warm the daemon payload cache at module init to skip the first read+encode after boot.
- Best-effort destroy the sandbox on bootstrap or preview failure; durable home volume is kept.
- Remaining fixed cost is the ~2.7s daemon upload per create.

**New Features**
- The Machines panel shows a display/terminal glyph before the subtitle to distinguish desktop vs shell-only boxes.
- `vm new` defaults to `blaxel/xfce-vnc:latest`; `vm new --base` uses `blaxel/base-image:latest`.

<sup>Written for commit 12fbfc79d27e5e552b9b9c1930613a04a714f325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Cloud Machines beta feature toggle in Settings.
  - Cloud Machines surfaces can now be enabled through the beta setting.
  - Cloud settings and navigation are now labeled “Cloud.”
  - Desktop sessions reconnect automatically when opening managed cloud VMs.
  - Desktop sessions open in the requested or VM-associated workspace when available.
  - Machine listings show distinct icons for desktop and shell-only machines.

- **Performance Improvements**
  - Cloud VM creation and startup are faster through parallelized setup and initialization.

- **Reliability**
  - Failed VM setup is cleaned up automatically while preserving durable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->