### PR TITLE
iOS: report Sentry telemetry to the cmux-ios project

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -643,6 +643,8 @@ jobs:
         with:
           name: ios-dsyms-${{ needs.decide.outputs.variant }}-${{ steps.upload.outputs.final_build_number }}
           path: ${{ runner.temp }}/cmux-ios-upload/cmux.xcarchive/dSYMs
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload dSYMs to Sentry
         # Sentry symbolicates crashes server-side from its own dSYM store; the
@@ -664,8 +666,6 @@ jobs:
           fi
           SENTRY_CLI="$(./scripts/ensure-sentry-cli.sh)"
           "$SENTRY_CLI" debug-files upload "$RUNNER_TEMP/cmux-ios-upload/cmux.xcarchive/dSYMs"
-          if-no-files-found: error
-          retention-days: 30
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -643,6 +643,27 @@ jobs:
         with:
           name: ios-dsyms-${{ needs.decide.outputs.variant }}-${{ steps.upload.outputs.final_build_number }}
           path: ${{ runner.temp }}/cmux-ios-upload/cmux.xcarchive/dSYMs
+
+      - name: Upload dSYMs to Sentry
+        # Sentry symbolicates crashes server-side from its own dSYM store; the
+        # Symbols/ files inside the IPA only serve App Store Connect. Same gate
+        # as the artifact step above: once the IPA reached TestFlight, symbols
+        # must reach Sentry even if a later step fails, or every crash for this
+        # build shows raw addresses. No --include-sources: the archive builds
+        # on a fleet Mac, so its DWARF source paths do not exist on this
+        # runner.
+        if: ${{ !cancelled() && steps.upload.outcome == 'success' && steps.distribution.outputs.assign_internal_group == '1' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: manaflow
+          SENTRY_PROJECT: cmux-ios
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
+            exit 0
+          fi
+          SENTRY_CLI="$(./scripts/ensure-sentry-cli.sh)"
+          "$SENTRY_CLI" debug-files upload "$RUNNER_TEMP/cmux-ios-upload/cmux.xcarchive/dSYMs"
           if-no-files-found: error
           retention-days: 30
 

--- a/Packages/iOS/CmuxMobileCrashReporting/Sources/CmuxMobileCrashReporting/MobileCrashReporter.swift
+++ b/Packages/iOS/CmuxMobileCrashReporting/Sources/CmuxMobileCrashReporting/MobileCrashReporter.swift
@@ -191,7 +191,11 @@ public struct MobileCrashReporter {
         }
     }
 
-    private static let dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"
+    // The dedicated cmux-ios Sentry project. The macOS app reports to
+    // cmuxterm-macos; keeping the platforms in separate projects gives iOS its
+    // own rate limits, alerts, and dSYM store instead of sharing the macOS
+    // project's.
+    private static let dsn = "https://834d19a3077c4adbff534dca1e93de4f@o4507547940749312.ingest.us.sentry.io/4510604800491520"
     private static let debugCrashArgument = "--cmux-test-crash"
     private static let testEnvironmentKeys = [
         "XCTestConfigurationFilePath",

--- a/Packages/iOS/CmuxMobileCrashReporting/Tests/CmuxMobileCrashReportingTests/MobileCrashReporterTests.swift
+++ b/Packages/iOS/CmuxMobileCrashReporting/Tests/CmuxMobileCrashReportingTests/MobileCrashReporterTests.swift
@@ -71,7 +71,7 @@ private struct FixedConsent: AnalyticsConsentProviding {
     @Test func optionsFactoryMatchesMobileContract() {
         let options = MobileCrashReporter().makeOptions()
 
-        #expect(options.dsn == "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416")
+        #expect(options.dsn == "https://834d19a3077c4adbff534dca1e93de4f@o4507547940749312.ingest.us.sentry.io/4510604800491520")
         #expect(options.tracesSampleRate?.doubleValue == 0.0)
         #expect(options.sendDefaultPii == false)
         #expect(options.attachStacktrace == true)


### PR DESCRIPTION
The iOS app has reused the macOS Sentry DSN since https://github.com/manaflow-ai/cmux/pull/7649, so every iOS event and structured log lands in the `cmuxterm-macos` project and the `cmux-ios` project has sat empty ("Waiting for this project's first log"). This points `MobileCrashReporter` at the `cmux-ios` DSN so iOS telemetry gets its own project: per-platform rate limits and spike protection (a macOS log flood can no longer crowd iOS), separate alerts and dashboards, and a platform-correct issue stream. The `ios-production` / `ios-development` environment names stay as-is so existing saved queries keep working.

Also adds a Sentry dSYM upload to the TestFlight workflow (`SENTRY_PROJECT: cmux-ios`), mirroring the macOS step in release.yml. Until now archive dSYMs only went to App Store Connect and a run artifact, so Sentry-side iOS release crashes were unsymbolicatable. The step uses the same gate as the dSYM artifact step (upload succeeded + internal group), because override/external builds archive on a fleet Mac and their dSYMs never exist on the runner. No `--include-sources` for the same reason: DWARF source paths point at the fleet Mac.

Transition note: phones on older builds keep reporting into `cmuxterm-macos` until they update; expect `ios-*` events there to tail off. Alert rules on `cmuxterm-macos` that filter `environment:ios-*` should be recreated on `cmux-ios`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790230691&installation_model_id=21920&pr_number=10700&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10700&signature=184a9ab63c64e646b589ddb9210257782d614c400a4da8d8d5120974f0bf6e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route iOS Sentry telemetry to the `cmux-ios` project and upload iOS dSYMs during TestFlight builds so crashes symbolicate and iOS is isolated from macOS. Previously iOS used the macOS DSN (`cmuxterm-macos`); now `MobileCrashReporter` points at the `cmux-ios` DSN, giving iOS its own rate limits, alerts, dashboards, and dSYM store.

**Migration**
- Older builds will keep sending `ios-*` events to `cmuxterm-macos` until users update.
- Recreate any `environment:ios-*` alert rules on `cmux-ios`; environment names (`ios-production`, `ios-development`) are unchanged.
- Ensure `SENTRY_AUTH_TOKEN` is set in CI; otherwise the dSYM upload step is skipped.

<sup>Written for commit 76fd176932a68e49aa522ad40f51f5ab0ff655c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved iOS crash reporting by routing diagnostics to a dedicated monitoring project.
  * iOS release builds now automatically upload debug symbols when crash-reporting credentials are available.
* **Bug Fixes**
  * Updated crash-reporting configuration to ensure iOS crash reports are correctly associated with the new project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->