### PR TITLE
Fix descriptor-backed artifact thumbnail decoding

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader+Thumbnail.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader+Thumbnail.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+extension ArtifactByteReader {
+    /// Decodes a thumbnail from an already-verified descriptor without consulting its pathname.
+    func thumbnail(
+        verifiedFile: (handle: FileHandle, size: Int64),
+        maxDimension: Int
+    ) throws -> ChatArtifactThumbnail {
+        let provider = try ArtifactImageDataProvider(
+            fileDescriptor: verifiedFile.handle.fileDescriptor,
+            size: verifiedFile.size
+        )
+        guard let source = CGImageSourceCreateWithDataProvider(provider.value, nil) else {
+            throw ArtifactByteReader.Error.corruptMedia
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimension,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            throw ArtifactByteReader.Error.corruptMedia
+        }
+        guard let destinationData = CFDataCreateMutable(nil, 0),
+              let destination = CGImageDestinationCreateWithData(
+                destinationData,
+                UTType.jpeg.identifier as CFString,
+                1,
+                nil
+              ) else {
+            throw ArtifactByteReader.Error.previewFailed
+        }
+        CGImageDestinationAddImage(destination, image, [
+            kCGImageDestinationLossyCompressionQuality: 0.82,
+        ] as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            throw ArtifactByteReader.Error.previewFailed
+        }
+        return ChatArtifactThumbnail(
+            data: destinationData as Data,
+            pixelWidth: image.width,
+            pixelHeight: image.height
+        )
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader.swift
@@ -1,6 +1,5 @@
 import Darwin
 import Foundation
-import ImageIO
 import UniformTypeIdentifiers
 
 /// Reads already-authorized artifact bytes and metadata from the local filesystem.
@@ -90,42 +89,20 @@ public struct ArtifactByteReader: Sendable {
     /// Generates a JPEG thumbnail for an already-authorized image path.
     public func thumbnail(path: String, maxDimension: Int) throws -> ChatArtifactThumbnail {
         let opened = try openVerifiedRegularFile(path: path)
-        try? opened.handle.close()
-        guard kind(path: path, isDirectory: false) == .image else {
+        defer { try? opened.handle.close() }
+        // Thumbnail eligibility is extension-derived; never sniff the pathname
+        // after the descriptor has been verified.
+        guard kind(
+            path: path,
+            isDirectory: false,
+            isRegularFile: true,
+            shouldSniffUnknownRegularFile: false
+        ) == .image else {
             throw Error.unsupportedMedia
         }
-        let url = URL(fileURLWithPath: path)
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-            _ = try attributes(path: path)
-            throw Error.corruptMedia
-        }
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxDimension,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-        ]
-        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-            throw Error.corruptMedia
-        }
-        guard let destinationData = CFDataCreateMutable(nil, 0),
-              let destination = CGImageDestinationCreateWithData(
-                destinationData,
-                UTType.jpeg.identifier as CFString,
-                1,
-                nil
-              ) else {
-            throw Error.previewFailed
-        }
-        CGImageDestinationAddImage(destination, image, [
-            kCGImageDestinationLossyCompressionQuality: 0.82,
-        ] as CFDictionary)
-        guard CGImageDestinationFinalize(destination) else {
-            throw Error.previewFailed
-        }
-        return ChatArtifactThumbnail(
-            data: destinationData as Data,
-            pixelWidth: image.width,
-            pixelHeight: image.height
+        return try thumbnail(
+            verifiedFile: opened,
+            maxDimension: maxDimension
         )
     }
 
@@ -186,7 +163,8 @@ public struct ArtifactByteReader: Sendable {
     private func kind(
         path: String,
         isDirectory: Bool,
-        isRegularFile: Bool?
+        isRegularFile: Bool?,
+        shouldSniffUnknownRegularFile: Bool = true
     ) -> ChatArtifactKind {
         if isDirectory { return .directory }
         if isRegularFile == false { return .binary }
@@ -201,6 +179,7 @@ public struct ArtifactByteReader: Sendable {
                 verifiedRegularFile = (attributes?[.type] as? FileAttributeType) == .typeRegular
             }
             guard verifiedRegularFile else { return .binary }
+            guard shouldSniffUnknownRegularFile else { return .binary }
             return isUTF8Text(path: path) ? .text : .binary
         }
         if type.conforms(to: .image) { return .image }

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactImageDataProvider.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactImageDataProvider.swift
@@ -1,0 +1,56 @@
+import CoreGraphics
+import Darwin
+
+/// Owns a descriptor-backed ImageIO data provider for the lifetime of a decode.
+final class ArtifactImageDataProvider {
+    private final class Context {
+        let fileDescriptor: Int32
+
+        init(fileDescriptor: Int32) {
+            self.fileDescriptor = fileDescriptor
+        }
+
+        deinit {
+            _ = Darwin.close(fileDescriptor)
+        }
+    }
+
+    let value: CGDataProvider
+
+    init(fileDescriptor: Int32, size: Int64) throws {
+        guard size >= 0 else {
+            throw ArtifactByteReader.Error.readFailed
+        }
+        let duplicate = Darwin.fcntl(fileDescriptor, F_DUPFD_CLOEXEC, 0)
+        guard duplicate >= 0 else {
+            throw ArtifactByteReader.Error.readFailed
+        }
+        let info = Unmanaged.passRetained(Context(fileDescriptor: duplicate)).toOpaque()
+        var callbacks = CGDataProviderDirectCallbacks(
+            version: 0,
+            getBytePointer: nil,
+            releaseBytePointer: nil,
+            getBytesAtPosition: { info, buffer, position, count in
+                guard let info, position >= 0, count > 0 else { return 0 }
+                let context = Unmanaged<Context>.fromOpaque(info).takeUnretainedValue()
+                let result = Darwin.pread(context.fileDescriptor, buffer, count, position)
+                return result > 0 ? result : 0
+            },
+            releaseInfo: { info in
+                guard let info else { return }
+                _ = Unmanaged<Context>.fromOpaque(info).takeRetainedValue()
+            }
+        )
+        guard let provider = withUnsafePointer(to: &callbacks, {
+            CGDataProvider(
+                directInfo: info,
+                size: off_t(size),
+                callbacks: $0
+            )
+        }) else {
+            Unmanaged<Context>.fromOpaque(info).release()
+            throw ArtifactByteReader.Error.readFailed
+        }
+        self.value = provider
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ArtifactByteReaderTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ArtifactByteReaderTests.swift
@@ -77,6 +77,28 @@ struct ArtifactByteReaderTests {
         }
     }
 
+    @Test("thumbnail decodes the verified descriptor after its pathname is replaced")
+    func thumbnailUsesVerifiedDescriptor() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("preview.png")
+            try Self.onePixelPNG.write(to: file)
+            let reader = ArtifactByteReader()
+            let opened = try reader.openVerifiedRegularFile(path: file.path)
+            defer { try? opened.handle.close() }
+
+            try FileManager.default.removeItem(at: file)
+            try #require(Darwin.mkfifo(file.path, 0o600) == 0)
+
+            let thumbnail = try reader.thumbnail(
+                verifiedFile: opened,
+                maxDimension: 128
+            )
+
+            #expect(thumbnail.pixelWidth == 1)
+            #expect(thumbnail.pixelHeight == 1)
+        }
+    }
+
     @Test("extensionless UTF-8 text is classified as text")
     func extensionlessUTF8Text() throws {
         try withTemporaryDirectory { directory in
@@ -256,4 +278,8 @@ struct ArtifactByteReaderTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         try operation(directory)
     }
+
+    private static let onePixelPNG = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
 }


### PR DESCRIPTION
## Summary

- Keep `ArtifactByteReader`’s verified regular-file descriptor open through thumbnail classification and ImageIO decoding.
- Decode through a `CGDataProvider` backed by a duplicated descriptor and positional reads, so pathname replacement cannot redirect the decode or block on a FIFO.
- Add a regression test that replaces the validated PNG pathname with a FIFO and still decodes the original descriptor.
- PR #9961 already covers the Iroh transfer FIFO validation on current main; this PR addresses the remaining thumbnail close-and-reopen TOCTOU tracked by #8581.

Fixes #8581

## Testing

- `swift test --package-path Packages/Shared/CmuxAgentChat --filter ArtifactByteReaderTests` — 18 passed.
- `swift test --package-path Packages/Shared/CmuxAgentChat` — 273 passed in 32 suites.
- The first commit is test-only (`de4823744b`); the second contains the fix (`ee04ffec6f`).
- No local Xcode app build or XCUITest was run, per workspace instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790230891&installation_model_id=21920&pr_number=10701&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10701&signature=a8b97d0db5b47b17517a98f1ef7292b1dc927099fab450f7f4270b6a1e30035f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes thumbnail decoding to read directly from the verified file descriptor instead of reopening by path. This removes the TOCTOU window that allowed pathname swaps to FIFOs and could block or redirect decoding (fixes #8581).

**Bug Fixes**
- Decode via `CGDataProvider` backed by a duplicated descriptor with positional reads, using `ArtifactImageDataProvider`.
- Keep the verified descriptor open for the entire operation and never consult the pathname after verification.
- For thumbnails, disable unknown-regular-file sniffing; eligibility is extension-based only (extensionless images won’t be thumbnailed).
- Add a regression test that replaces the validated PNG path with a FIFO and still decodes from the original descriptor.

<sup>Written for commit ee04ffec6f7ce3df2a9d75d3f1b2a6a0d6f8d652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

