### PR TITLE
perf: defer custom-sidebar context-menu evaluation

### DIFF
--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/DeferredRenderContent.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/DeferredRenderContent.swift
@@ -1,0 +1,22 @@
+/// A view-builder payload that is retained without evaluating its body.
+///
+/// SwiftUI's menu APIs accept an escaping content builder and do not ask for
+/// that content while the row itself is being rendered. Keeping the builder as
+/// an immutable payload lets the interpreter preserve that boundary instead of
+/// expanding every menu on every sidebar refresh.
+///
+/// The unchecked conformance is safe because the captured syntax and
+/// environment are read-only after the interpreter returns; each invocation
+/// snapshots the environment into a fresh scope before mutating it locally.
+struct DeferredRenderContent: @unchecked Sendable {
+    private let builder: () -> [RenderNode]
+
+    init(builder: @escaping () -> [RenderNode]) {
+        self.builder = builder
+    }
+
+    /// Evaluates the payload when the surrounding menu asks for its body.
+    func materialize() -> [RenderNode] {
+        builder()
+    }
+}

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/EvalEnvironment.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/EvalEnvironment.swift
@@ -69,4 +69,41 @@ public final class EvalEnvironment {
     public func makeChild() -> EvalEnvironment {
         EvalEnvironment(parent: self)
     }
+
+    /// Copies the visible values and functions into a fresh root scope for a
+    /// deferred view-builder body. The fresh budget is important: evaluating a
+    /// menu later must not consume the row tree's node budget, and a menu that
+    /// is opened after the row render must still have a full bounded budget.
+    func snapshotForDeferredContent() -> EvalEnvironment {
+        let snapshot: EvalEnvironment
+        if let resolver = rootResolver() {
+            snapshot = EvalEnvironment(values: flattenedValues(), resolver: resolver)
+        } else {
+            snapshot = EvalEnvironment(values: flattenedValues())
+        }
+        for (name, function) in flattenedFunctions() {
+            snapshot.defineFunction(name, function)
+        }
+        return snapshot
+    }
+
+    private func flattenedValues() -> [String: SwiftValue] {
+        var result = parent?.flattenedValues() ?? [:]
+        for (name, value) in values {
+            result[name] = value
+        }
+        return result
+    }
+
+    private func flattenedFunctions() -> [String: FunctionDeclSyntax] {
+        var result = parent?.flattenedFunctions() ?? [:]
+        for (name, function) in functions {
+            result[name] = function
+        }
+        return result
+    }
+
+    private func rootResolver() -> ((String) -> SwiftValue?)? {
+        parent?.rootResolver() ?? externalResolver
+    }
 }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderModifier.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/RenderModifier.swift
@@ -8,11 +8,75 @@ public struct RenderModifier: Codable, Sendable, Equatable {
     /// `.overlay { ... }` / `.background { ... }` / `.mask { ... }`. Empty for
     /// value-only modifiers.
     public let children: [RenderNode]
+    private let deferredContent: DeferredRenderContent?
 
     public init(name: String, args: [ModifierArg] = [], children: [RenderNode] = []) {
         self.name = name
         self.args = args
         self.children = children
+        self.deferredContent = nil
+    }
+
+    init(
+        name: String,
+        args: [ModifierArg] = [],
+        children: [RenderNode] = [],
+        deferredContent: DeferredRenderContent?
+    ) {
+        self.name = name
+        self.args = args
+        self.children = children
+        self.deferredContent = deferredContent
+    }
+
+    /// Whether this modifier has content that can be attached without
+    /// evaluating a deferred builder. This deliberately does not materialize
+    /// the builder; callers use it while constructing the surrounding row.
+    public var hasContent: Bool {
+        !children.isEmpty || deferredContent != nil
+    }
+
+    /// Whether the trailing closure was retained for lazy evaluation.
+    public var hasDeferredContent: Bool {
+        deferredContent != nil
+    }
+
+    /// Returns static children directly, or evaluates a deferred builder when requested.
+    public func materializedChildren() -> [RenderNode] {
+        children.isEmpty ? (deferredContent?.materialize() ?? []) : children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case args
+        case children
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        args = try container.decodeIfPresent([ModifierArg].self, forKey: .args) ?? []
+        children = try container.decodeIfPresent([RenderNode].self, forKey: .children) ?? []
+        deferredContent = nil
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(args, forKey: .args)
+        // The out-of-process worker must send a fully serializable tree. Its
+        // JSON boundary is therefore the intentional eager-materialization
+        // point; the host-side in-process renderer never encodes this payload.
+        try container.encode(materializedChildren(), forKey: .children)
+    }
+
+    public static func == (lhs: RenderModifier, rhs: RenderModifier) -> Bool {
+        // Deferred builders are runtime-only payloads and must not be invoked
+        // while comparing render snapshots. Their empty `children` arrays are
+        // intentionally compared as-is, preserving a lazy equality path.
+        lhs.name == rhs.name
+            && lhs.args == rhs.args
+            && lhs.children == rhs.children
     }
 
     /// The first unlabeled argument value (or the first argument), for

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
@@ -138,23 +138,23 @@ public struct SwiftViewInterpreter: Sendable {
                 node.action = parseAction(closure, env)
                 return node
             }
-            // Child-bearing modifiers carry their trailing closure's views as a
-            // subtree (`.overlay { ... }`, `.background { ... }`, `.mask { ... }`,
-            // `.safeAreaInset(edge:) { ... }`), so arbitrary nested content
-            // composes, not just colors.
+            // Child-bearing modifiers preserve trailing closures; context-menu bodies defer until presentation.
             let childBearing: Set<String> = ["overlay", "background", "mask", "safeAreaInset", "contextMenu"]
             if childBearing.contains(name), let closure = call.trailingClosure {
+                let deferredContent = name == "contextMenu"
+                    ? DeferredRenderContent { self.evalItems(closure.statements, env.snapshotForDeferredContent()) }
+                    : nil
                 node.modifiers.append(RenderModifier(
                     name: name,
                     args: modifierArgs(call.arguments, env),
-                    children: evalItems(closure.statements, env)
+                    children: deferredContent == nil ? evalItems(closure.statements, env) : [],
+                    deferredContent: deferredContent
                 ))
                 return node
             }
             node.modifiers.append(RenderModifier(name: name, args: modifierArgs(call.arguments, env)))
             return node
         }
-
         guard let ref = call.calledExpression.as(DeclReferenceExprSyntax.self) else { return nil }
         switch ref.baseName.text {
         case "Text":

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/DeferredContextMenuTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/DeferredContextMenuTests.swift
@@ -29,7 +29,7 @@ import Testing
         #expect(modifiers.allSatisfy { $0.children.isEmpty })
     }
 
-    @Test func contextMenuBodyMaterializesOnceAndPreservesBindings() throws {
+    @Test func contextMenuBodyMaterializesOnDemandAndPreservesBindings() throws {
         let node = try #require(interpreter.evaluate("""
         VStack {
             ForEach(0..<2) { i in

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/DeferredContextMenuTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/DeferredContextMenuTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import CmuxSwiftRender
+
+/// Context-menu bodies are view-builder closures in SwiftUI. The interpreter
+/// must retain those closures without walking them during every row render.
+@Suite struct DeferredContextMenuTests {
+    private let interpreter = SwiftViewInterpreter()
+
+    @Test func contextMenuBodyIsNotEvaluatedWithTheRow() {
+        let node = interpreter.evaluate("""
+        VStack {
+            ForEach(0..<30) { i in
+                Text("Row \\(i)").contextMenu {
+                    Button("Open \\(i)") { cmux("workspace.select", workspace_id: \\(i)) }
+                    Menu("Color") {
+                        Button("Blue") { cmux("workspace.color", color: "blue") }
+                    }
+                }
+            }
+        }
+        """)
+
+        let modifiers = node?.children.compactMap { child in
+            child.modifiers.first { $0.name == "contextMenu" }
+        } ?? []
+        #expect(modifiers.count == 30)
+        #expect(modifiers.allSatisfy { $0.hasDeferredContent })
+        #expect(modifiers.allSatisfy { $0.children.isEmpty })
+    }
+
+    @Test func contextMenuBodyMaterializesOnceAndPreservesBindings() throws {
+        let node = try #require(interpreter.evaluate("""
+        VStack {
+            ForEach(0..<2) { i in
+                Text("Row \\(i)").contextMenu {
+                    Button("Open \\(i)") { cmux("workspace.select", workspace_id: \\(i)) }
+                }
+            }
+        }
+        """))
+        let modifier = try #require(node.children[1].modifiers.first { $0.name == "contextMenu" })
+
+        let first = modifier.materializedChildren()
+        let second = modifier.materializedChildren()
+        #expect(first == second)
+        #expect(first.first?.text == "Open 1")
+        #expect(first.first?.action?.commands.count == 1)
+    }
+
+    @Test func encodingMaterializesDeferredContentForTransport() throws {
+        let node = try #require(interpreter.evaluate("""
+        Text("Row").contextMenu {
+            Button("Open") { cmux("workspace.select") }
+        }
+        """))
+        let data = try JSONEncoder().encode(node)
+        let decoded = try JSONDecoder().decode(RenderNode.self, from: data)
+        let modifier = try #require(decoded.modifiers.first { $0.name == "contextMenu" })
+
+        #expect(!modifier.hasDeferredContent)
+        #expect(modifier.children.first?.text == "Open")
+    }
+}

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -514,7 +514,7 @@ import Testing
         }
         """)
         let cm = ctx?.modifiers.first { $0.name == "contextMenu" }
-        #expect(cm?.children.first?.kind == .button)
+        #expect(cm?.materializedChildren().first?.kind == .button)
     }
 
     @Test func gridRowsAndViewThatFits() {

--- a/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/DeferredContextMenuContent.swift
+++ b/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/DeferredContextMenuContent.swift
@@ -1,0 +1,24 @@
+import CmuxSwiftRender
+import SwiftUI
+
+/// Bridges a deferred interpreter payload to SwiftUI's own lazy menu builder.
+/// Constructing this view is cheap; the retained menu nodes are materialized
+/// only when SwiftUI asks for the context-menu content.
+struct DeferredContextMenuContent: View {
+    let modifier: RenderModifier
+
+    var body: some View {
+        // The surrounding context-menu closure is escaping and lazy, so this
+        // walk starts only when SwiftUI asks for the presented menu's body.
+        let children = modifier.materializedChildren()
+        if children.count == 1 {
+            RenderNodeView(node: children[0])
+        } else {
+            ZStack {
+                ForEach(Array(children.enumerated()), id: \.offset) { _, child in
+                    RenderNodeView(node: child)
+                }
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeView.swift
+++ b/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeView.swift
@@ -279,8 +279,8 @@ struct RenderNodeView: View {
         case "symbolVariant":
             return AnyView(view.symbolVariant(dslSymbolVariant(token)))
         case "contextMenu":
-            if !modifier.children.isEmpty {
-                return AnyView(view.contextMenu { modifierChildren(modifier) })
+            if modifier.hasContent {
+                return AnyView(view.contextMenu { DeferredContextMenuContent(modifier: modifier) })
             }
             return view
         case "help":


### PR DESCRIPTION
## Summary
- defer `.contextMenu { ... }` bodies in the Swift custom-sidebar interpreter until SwiftUI requests the menu
- keep the in-process render tree lazy while materializing deferred content at the JSON worker boundary
- add regression coverage for per-row laziness, loop bindings, and transport encoding

Fixes #7345.

## Regression history
- `a0a537dc63` adds the behavior-level regression tests only (expected red on the base)
- the follow-up implementation commit makes the tests pass

## Focused verification
- `swift test` in `Packages/macOS/CmuxSwiftRender`
- `swift test --filter CustomSidebarValidationTests` in `Packages/macOS/CmuxSwiftRenderUI`
- `swift test --filter RenderWorkerClientTests` in `Packages/macOS/CmuxSidebarInterpreterService`

No tagged app build or XCUITest was run locally; app verification is left to the approved CI/fleet lanes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790231190&installation_model_id=21920&pr_number=10703&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10703&signature=800bc6d9447f21cf4e3049a97c23b3ebccad29d9b0af67759052e43bf0f4701d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers evaluation of `.contextMenu { ... }` in the Swift custom-sidebar interpreter until SwiftUI requests the menu, removing eager per-row work and fixing the perf leak (Fixes #7345).

- Keeps the in-process render tree lazy; materializes menu children only at the JSON transport boundary and snapshots a fresh evaluation scope and node budget for deferred menus.
- Adds regression tests for per-row laziness, loop-bound value capture, and transport encoding.
- No menu behavior change; contents and actions are identical when the menu opens.

<sup>Written for commit a43600015975c59519853d5347a76079bc84fdd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

