### PR TITLE
ios: clearer sort-mode tiles and a section title in workspace view options

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -88,7 +88,7 @@ extension MobileWorkspaceSortMode {
         case .automatic:
             return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Last Opened")
         case .computerPriority:
-            return L10n.string("mobile.workspaces.sort.connectionOrder", defaultValue: "Computer Order")
+            return L10n.string("mobile.workspaces.sort.connectionOrder", defaultValue: "Custom Order")
         case .recentActivity:
             return L10n.string("mobile.workspaces.sort.recentActivity", defaultValue: "Recent Activity")
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -103,6 +103,7 @@ struct WorkspaceListViewOptionsPopover: View {
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 14)
             .padding(.top, 8)
+            .padding(.bottom, 4)
             .accessibilityAddTraits(.isHeader)
             .accessibilityIdentifier("MobileWorkspaceSortTitle")
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -33,6 +33,7 @@ struct WorkspaceListViewOptionsPopover: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 if let sortMode, let setSortMode = actions.setSortMode {
+                    sortSectionTitle
                     sortTiles(selected: sortMode) { picked in
                         setSortMode(picked)
                     }
@@ -90,6 +91,20 @@ struct WorkspaceListViewOptionsPopover: View {
             .fill(Color(.separator).opacity(0.5))
             .frame(height: 6)
             .padding(.vertical, 4)
+    }
+
+    /// Centered card-style section header: weightier than a UIMenu footnote
+    /// header so it titles the tile row, but secondary-colored so the tiles
+    /// stay the loudest thing on the card.
+    private var sortSectionTitle: some View {
+        Text(L10n.string("mobile.workspaces.sort", defaultValue: "Sort By"))
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 14)
+            .padding(.top, 8)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityIdentifier("MobileWorkspaceSortTitle")
     }
 
     @ViewBuilder
@@ -194,11 +209,13 @@ struct WorkspaceSortModeTile: View {
 
 /// The miniature list rendering for one sort mode. Two computers are drawn in
 /// distinct tints; the shapes carry the meaning, no text:
-/// - automatic: computer-headed sections, first computer's section leading.
-/// - computerPriority: the same sections with rank badges and drag grips —
-///   the order is yours.
-/// - recentActivity: whole group sections ranked beside ungrouped rows by
-///   activity, with clocks marking the time-based order.
+/// - automatic: the computer you used last floats up — its section leads in a
+///   highlighted chip with a rise arrow while the other computer waits dimmed
+///   below.
+/// - computerPriority: the same computer sections as rankable cells, each with
+///   a numbered badge and a drag grip — the order is yours.
+/// - recentActivity: one flat timeline interleaving both computers' rows,
+///   newest at the top by the clock, older rows fading with age.
 struct WorkspaceSortModeSchematic: View {
     let mode: MobileWorkspaceSortMode
 
@@ -209,22 +226,22 @@ struct WorkspaceSortModeSchematic: View {
         VStack(alignment: .leading, spacing: 4) {
             switch mode {
             case .automatic:
-                header(tint: firstTint, symbol: "laptopcomputer")
+                header(tint: firstTint, symbol: "laptopcomputer", lifted: true)
                 rowBar; rowBar
-                header(tint: secondTint, symbol: "desktopcomputer")
-                rowBar
+                // The trailing computer reads as "waiting its turn": dimming
+                // the whole section is what makes the leading one look risen.
+                Group {
+                    header(tint: secondTint, symbol: "desktopcomputer")
+                    rowBar
+                }
+                .opacity(0.45)
             case .computerPriority:
                 header(tint: secondTint, symbol: "desktopcomputer", rank: 1, grip: true)
                 rowBar
                 header(tint: firstTint, symbol: "laptopcomputer", rank: 2, grip: true)
                 rowBar; rowBar
             case .recentActivity:
-                timedRow(tint: secondTint, width: 0.8)
-                header(tint: firstTint, symbol: "folder.fill")
-                timedRow(tint: firstTint, width: 0.9, indented: true)
-                timedRow(tint: firstTint, width: 0.65, indented: true)
-                header(tint: secondTint, symbol: "folder.fill")
-                timedRow(tint: secondTint, width: 0.75, indented: true)
+                activityTimeline
             }
         }
         .padding(.vertical, 8)
@@ -233,7 +250,13 @@ struct WorkspaceSortModeSchematic: View {
     }
 
     @ViewBuilder
-    private func header(tint: Color, symbol: String, rank: Int? = nil, grip: Bool = false) -> some View {
+    private func header(
+        tint: Color,
+        symbol: String,
+        rank: Int? = nil,
+        grip: Bool = false,
+        lifted: Bool = false
+    ) -> some View {
         // Rank badges read as part of the miniature content, not the frame, so
         // they take an extra indent off the tile border.
         HStack(spacing: 3) {
@@ -252,12 +275,29 @@ struct WorkspaceSortModeSchematic: View {
                 .fill(tint.opacity(0.55))
                 .frame(width: 18, height: 5)
             Spacer(minLength: 0)
+            if lifted {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(tint)
+            }
             if grip {
                 Image(systemName: "line.3.horizontal")
-                    .font(.system(size: 7))
-                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 8))
+                    .foregroundStyle(.secondary)
             }
         }
+        // The lifted chip paints outward from the content (pad, fill, unpad)
+        // so its glyph and bar stay column-aligned with the plain headers.
+        .padding(.horizontal, lifted ? 3 : 0)
+        .padding(.vertical, lifted ? 2 : 0)
+        .background {
+            if lifted {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(tint.opacity(0.16))
+            }
+        }
+        .padding(.horizontal, lifted ? -3 : 0)
+        .padding(.vertical, lifted ? -2 : 0)
     }
 
     private var rowBar: some View {
@@ -267,22 +307,44 @@ struct WorkspaceSortModeSchematic: View {
             .padding(.leading, 8)
     }
 
+    /// One flat cross-computer list ranked by recency: interleaved tint dots
+    /// share a timeline spine, the newest row carries the clock, and rows fade
+    /// as they age.
+    private var activityTimeline: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            activityRow(tint: secondTint, width: 0.85, age: 0)
+            activityRow(tint: firstTint, width: 0.7, age: 1)
+            activityRow(tint: firstTint, width: 0.9, age: 2)
+            activityRow(tint: secondTint, width: 0.6, age: 3)
+            activityRow(tint: firstTint, width: 0.75, age: 4)
+        }
+        .background(alignment: .leading) {
+            Rectangle()
+                .fill(Color(.separator))
+                .frame(width: 1)
+                .padding(.vertical, 3)
+                .padding(.leading, 2.5)
+        }
+    }
+
     @ViewBuilder
-    private func timedRow(tint: Color, width: CGFloat, indented: Bool = false) -> some View {
-        HStack(spacing: 3) {
+    private func activityRow(tint: Color, width: CGFloat, age: Int) -> some View {
+        HStack(spacing: 4) {
             Circle()
-                .fill(tint.opacity(0.8))
-                .frame(width: 5, height: 5)
+                .fill(tint)
+                .frame(width: 6, height: 6)
             RoundedRectangle(cornerRadius: 2)
                 .fill(Color(.tertiarySystemFill))
                 .frame(height: 7)
                 .frame(maxWidth: .infinity)
                 .scaleEffect(x: width, y: 1, anchor: .leading)
-            Image(systemName: "clock")
-                .font(.system(size: 6))
-                .foregroundStyle(.tertiary)
+            if age == 0 {
+                Image(systemName: "clock")
+                    .font(.system(size: 7, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
         }
-        .padding(.leading, indented ? 8 : 0)
+        .opacity(1.0 - 0.15 * Double(age))
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 /// The workspace list's view-options card: Mail-style illustrated sort tiles
 /// on top (each schematic renders what the mode actually does to the list, so
-/// "Computer Order" needs no explanation), then the read-state and machine
+/// "Custom Order" needs no explanation), then the read-state and machine
 /// filter rows.
 ///
 /// A native `Menu` bridges to UIMenu, whose rows only render text plus an
@@ -25,7 +25,7 @@ struct WorkspaceListViewOptionsPopover: View {
 
     /// The order editor presents from the popover itself: a parent-level sheet
     /// cannot present while this popover owns the presentation slot. It opens
-    /// only from the explicit row below the tiles — selecting the Computer
+    /// only from the explicit row below the tiles — selecting the Custom
     /// Order tile just selects; no surprise navigation.
     @State private var showingOrderEditor = false
 
@@ -97,7 +97,7 @@ struct WorkspaceListViewOptionsPopover: View {
     /// header so it titles the tile row, but secondary-colored so the tiles
     /// stay the loudest thing on the card.
     private var sortSectionTitle: some View {
-        Text(L10n.string("mobile.workspaces.sort", defaultValue: "Sort By"))
+        Text(L10n.string("mobile.workspaces.sort", defaultValue: "Sort Computers By"))
             .font(.subheadline.weight(.semibold))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity)

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -14605,13 +14605,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sort By"
+            "value": "Sort Computers By"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "並べ替え"
+            "value": "コンピュータの並べ替え"
           }
         }
       }
@@ -20041,7 +20041,7 @@
     "mobile.connections.visibilityToggle": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Show this computer on this iPhone"}},"ja":{"stringUnit":{"state":"translated","value":"このコンピュータをこのiPhoneに表示"}}}},
     "mobile.workspaces.macPicker.allConnections": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"All Computers"}},"ja":{"stringUnit":{"state":"translated","value":"すべてのコンピュータ"}}}},
     "mobile.workspaces.macPicker.connectionLabel": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Computer"}},"ja":{"stringUnit":{"state":"translated","value":"コンピュータ"}}}},
-    "mobile.workspaces.sort.connectionOrder": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Computer Order"}},"ja":{"stringUnit":{"state":"translated","value":"コンピュータ順"}}}},
+    "mobile.workspaces.sort.connectionOrder": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Custom Order"}},"ja":{"stringUnit":{"state":"translated","value":"カスタム順"}}}},
     "mobile.connections.empty": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"No computers yet. Iroh finds Macs running cmux 0.64.20 or later. Both devices must be signed in to the same cmux account, and the Mac must keep cmux running while both devices are online. If any requirement is missing, the Mac will not appear automatically. To use Tailscale instead, choose Tailscale in the computer's configuration."}},"ja":{"stringUnit":{"state":"translated","value":"コンピュータがありません。Irohで表示されるのは、Mac版cmux 0.64.20以降を実行しているMacです。両方のデバイスで同じcmuxアカウントにサインインし、cmuxを起動したまま両方のデバイスをオンラインにしてください。いずれかの条件を満たしていない場合、Macは自動的には表示されません。代わりにTailscaleを使うには、コンピュータの設定でTailscaleを選択してください。"}}}},
     "mobile.connections.footer": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Each computer connects using the method set in its own configuration. Turning a computer off hides its workspaces on this iPhone; it stays signed in to your account."}},"ja":{"stringUnit":{"state":"translated","value":"各コンピュータは、それぞれの設定で選んだ接続方法で接続します。コンピュータをオフにすると、そのワークスペースがこのiPhoneで非表示になります。コンピュータはアカウントにサインインしたままです。"}}}},
     "mobile.connections.method.debug": {"extractionState":"manual","localizations":{"en":{"stringUnit":{"state":"translated","value":"Debug"}},"ja":{"stringUnit":{"state":"translated","value":"デバッグ"}}}},

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1881,7 +1881,7 @@ final class cmuxUITests: XCTestCase {
         let selectedProbeID =
             "MobileWorkspaceListPreviewSelection-workspace-mixed-alpha-inactive"
         let computerOrderTileID = "MobileWorkspaceSortTile-computerPriority"
-        let computerOrderTileLabel = "Computer Order"
+        let computerOrderTileLabel = "Custom Order"
         let recentTileID = "MobileWorkspaceSortTile-recentActivity"
         let recentTileLabel = "Recent Activity"
         let automaticTileID = "MobileWorkspaceSortTile-automatic"
@@ -1971,7 +1971,7 @@ final class cmuxUITests: XCTestCase {
         ]
         guard let computerFrames = orderedFrames(
             computerOrder,
-            state: "Computer Order"
+            state: "Custom Order"
         ) else { return }
         XCTAssertFalse(element(alphaAnchorID).exists)
         XCTAssertFalse(element(betaAnchorID).exists)


### PR DESCRIPTION
The workspace view-options popover's three sort tiles drew near-identical miniature lists, so the pictures didn't explain the modes, and nothing said what the tile row chooses.

Now each schematic draws its mode's actual behavior:

- **Last Opened**: the just-used computer's section leads inside a tinted chip with a rise arrow; the other computer's section waits dimmed below.
- **Computer Order**: unchanged structure (rank badges per computer section) with stronger drag grips, matching the editor it pairs with.
- **Recent Activity**: one flat timeline interleaving both computers' rows on a spine of tinted dots, newest row marked by a clock, older rows fading with age.

A centered, secondary "Sort By" header (existing `mobile.workspaces.sort` key, en+ja already translated) titles the tile row so users know what the picker is for.

HIG pages checked: [Menus](https://developer.apple.com/design/human-interface-guidelines/menus) (group logically related items, uniform visual treatment within a group, title-style capitalization) and [Popovers](https://developer.apple.com/design/human-interface-guidelines/popovers) (limit a popover to a few related tasks; selection keeps the popover open so the list re-sorts live behind it, which the tiles rely on).

No new strings, no identifier changes; XCUITest hooks (`MobileWorkspaceSortPicker`, `MobileWorkspaceSortTile-*`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790234212&installation_model_id=21920&pr_number=10709&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10709&signature=3f6780c2ceb7351a583b7db9c4adc36505c95fcc06ab21888fbf6121edc2cfa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the iOS workspace view-options sort picker and adds a centered "Sort By" title so users know what the row controls. Tiles now depict each mode’s behavior instead of generic lists; no breaking changes, no new strings, and existing XCUITest identifiers remain unchanged.

**New Features**
- Last Opened: lifts the last-used computer’s section in a tinted chip with an up arrow; the other section is dimmed.
- Computer Order: keeps ranked per-computer sections and strengthens drag grips to match the editor.
- Recent Activity: shows a single interleaved timeline with tinted dots; the newest row is marked by a clock and older rows fade.
- Adds a secondary "Sort By" header using `mobile.workspaces.sort`, with an accessibility header trait and `MobileWorkspaceSortTitle` identifier.

<sup>Written for commit 2c8221997071bb208fd398c6a86fd5acd715c986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centered “Sort Computers By” heading to the workspace sorting menu.
  * Renamed “Computer Order” to “Custom Order” for clearer sorting controls.
  * Improved automatic sorting visuals with a lifted leading computer indicator and clearer dimming for trailing items.
  * Added a recent-activity timeline with a spine, newest-item clock indicator, and age-based fading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->