### PR TITLE
fix(agent-chat): wait for Pi agent_settled before ending turns

### DIFF
--- a/agent-chat/adapters/pi.ts
+++ b/agent-chat/adapters/pi.ts
@@ -351,6 +351,10 @@ function handleLine(sess: SessionCtx, line: string) {
       });
       break;
     case "agent_end":
+      // A low-level run can end before Pi has finished retrying, compacting, or
+      // draining a queued follow-up. Keep the turn active until agent_settled.
+      break;
+    case "agent_settled":
       finishTurn(sess);
       break;
     case "error":

--- a/agent-chat/test/pi-settled.test.ts
+++ b/agent-chat/test/pi-settled.test.ts
@@ -41,9 +41,13 @@ function doneEvents() {
   return events.filter((evt) => evt.kind === "done");
 }
 
+function currentStatus(): SessionStatus {
+  return sess.status;
+}
+
 send({ type: "agent_start" });
 send({ type: "agent_end", willRetry: true });
-if (sess.status !== "running") throw new Error(`retrying Pi run should remain running, got ${sess.status}`);
+if (currentStatus() !== "running") throw new Error(`retrying Pi run should remain running, got ${currentStatus()}`);
 if (doneEvents().length !== 0) throw new Error("agent_end with a retry should not finalize the turn");
 if (piNextSendTypeForTest(sess) !== "steer") throw new Error("message before settlement should steer the active turn");
 if ((piAdapter as any).attributionMode(sess) !== "current-turn") {
@@ -52,11 +56,11 @@ if ((piAdapter as any).attributionMode(sess) !== "current-turn") {
 
 send({ type: "agent_start" });
 send({ type: "agent_end", willRetry: false });
-if (sess.status !== "running") throw new Error(`unsettled Pi run should remain running, got ${sess.status}`);
+if (currentStatus() !== "running") throw new Error(`unsettled Pi run should remain running, got ${currentStatus()}`);
 if (doneEvents().length !== 0) throw new Error("agent_end before settlement should not emit done");
 
 send({ type: "agent_settled" });
-if (sess.status !== "idle") throw new Error(`settled Pi run should become idle, got ${sess.status}`);
+if (currentStatus() !== "idle") throw new Error(`settled Pi run should become idle, got ${currentStatus()}`);
 const done = doneEvents();
 if (done.length !== 1) throw new Error(`settlement should emit exactly one done, got ${JSON.stringify(events)}`);
 if ((done[0] as AgentEvent & { generation?: number }).generation !== 7) {

--- a/agent-chat/test/pi-settled.test.ts
+++ b/agent-chat/test/pi-settled.test.ts
@@ -1,0 +1,72 @@
+import { piHandleLineForTest, piNextSendTypeForTest, piAdapter } from "../adapters/pi";
+import type { AgentEvent, SessionCtx, SessionStatus } from "../types";
+
+const events: AgentEvent[] = [];
+const sess: SessionCtx = {
+  id: "pi-settled-test",
+  provider: "pi",
+  cwd: "/tmp",
+  title: "pi settled test",
+  autoApprove: true,
+  startOptions: {},
+  status: "running",
+  events,
+  internal: {
+    pi: {
+      nextId: 1,
+      pending: new Map(),
+      model: "",
+      modelChoices: [],
+      thinking: "minimal",
+      thinkingNormalized: true,
+      commands: [],
+      initialApplied: true,
+      activeTurn: true,
+      activeGeneration: 7,
+    },
+  },
+  emit(evt) {
+    events.push(evt);
+  },
+  setStatus(status: SessionStatus) {
+    this.status = status;
+  },
+};
+
+function send(event: Record<string, unknown>) {
+  piHandleLineForTest(sess, JSON.stringify(event));
+}
+
+function doneEvents() {
+  return events.filter((evt) => evt.kind === "done");
+}
+
+send({ type: "agent_start" });
+send({ type: "agent_end", willRetry: true });
+if (sess.status !== "running") throw new Error(`retrying Pi run should remain running, got ${sess.status}`);
+if (doneEvents().length !== 0) throw new Error("agent_end with a retry should not finalize the turn");
+if (piNextSendTypeForTest(sess) !== "steer") throw new Error("message before settlement should steer the active turn");
+if ((piAdapter as any).attributionMode(sess) !== "current-turn") {
+  throw new Error("message before settlement should use current-turn attribution");
+}
+
+send({ type: "agent_start" });
+send({ type: "agent_end", willRetry: false });
+if (sess.status !== "running") throw new Error(`unsettled Pi run should remain running, got ${sess.status}`);
+if (doneEvents().length !== 0) throw new Error("agent_end before settlement should not emit done");
+
+send({ type: "agent_settled" });
+if (sess.status !== "idle") throw new Error(`settled Pi run should become idle, got ${sess.status}`);
+const done = doneEvents();
+if (done.length !== 1) throw new Error(`settlement should emit exactly one done, got ${JSON.stringify(events)}`);
+if ((done[0] as AgentEvent & { generation?: number }).generation !== 7) {
+  throw new Error(`settlement should preserve generation 7, got ${JSON.stringify(done[0])}`);
+}
+if (piNextSendTypeForTest(sess) !== "prompt") throw new Error("message after settlement should start a new prompt");
+
+send({ type: "agent_settled" });
+if (doneEvents().length !== 1) throw new Error("duplicate settlement should not emit another done");
+
+console.log("pi settled lifecycle assertions passed");
+
+export {};


### PR DESCRIPTION
## Summary

- Treat Pi `agent_end` as the end of one low-level run, not the chat-turn boundary.
- Finalize the agent-chat turn on `agent_settled`, preserving the existing generation and process-exit/error fallbacks.
- Add a protocol-sequence regression covering retry/continuation, steer attribution before settlement, one settled `done`, and generation preservation.

Closes #8726.

## Validation

- `bun test test/pi-settled.test.ts`
- `bun test test/pi-error.test.ts`
- `bun test test/server-utils.test.ts`
- `bun x tsc --noEmit`
- `bun run check`
- `git diff --check`

No local Xcode build, app launch, or XCUITest was run. The requested `scripts/swift_file_length_budget.py` is not present in this clone or `HEAD`; no Swift files changed.

## Scope audit

The active #9021 and merged #8574 Pi settlement changes touch only the generated Pi extension. The active #9586/#9585 native lifecycle work explicitly defers Pi and has no `agent-chat` adapter changes. The current Pi adapter and reachable branch history were checked before implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790234773&installation_model_id=21920&pr_number=10710&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10710&signature=c42dff949d9bb757cbab4776bfa361b45f3e63c905937ae50288c0000bc7c6aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes Pi agent-chat turns on `agent_settled` instead of `agent_end` to avoid closing a turn while Pi is retrying or compacting. This prevents premature `done`/idle transitions and fixes message attribution during unsettled runs.

- Keeps the session running through retries; settlement emits exactly one `done` and preserves the existing `generation`.
- Pre-settlement messages steer the current turn with current-turn attribution; post-settlement messages start a new prompt.
- Duplicate settlements are ignored; error/process-exit fallbacks continue to finalize as before.
- Adds `agent-chat/test/pi-settled.test.ts` to cover retry/continuation, attribution, single `done`, and generation preservation.

<sup>Written for commit 79a7140b90f1dbcaafd73370e064aeb68fb4cebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion handling so conversations remain active while retries, compaction, or queued follow-ups are still in progress.
  * Prevented turns from completing prematurely before processing has fully settled.

* **Tests**
  * Added coverage for retrying, unsettled, settled, and duplicate completion events.
  * Verified status transitions, event delivery, generation handling, and message attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->