### PR TITLE
iOS: re-enable workspace Mac picker switch tests

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
@@ -42,10 +42,6 @@ extension WorkspaceListView {
         return task
     }
 
-    func invalidateDeferredWorkspaceSelection() {
-        macSelectionCoordinator.invalidateDeferredWorkspaceSelection()
-    }
-
     var requestWorkspaceClose: ((CmuxMobileShellModel.MobileWorkspacePreview.ID) -> Void)? {
         guard closeWorkspace != nil else {
             return nil

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
@@ -43,7 +43,7 @@ extension WorkspaceListView {
     }
 
     func invalidateDeferredWorkspaceSelection() {
-        deferredWorkspaceSelectionGeneration &+= 1
+        macSelectionCoordinator.invalidateDeferredWorkspaceSelection()
     }
 
     var requestWorkspaceClose: ((CmuxMobileShellModel.MobileWorkspacePreview.ID) -> Void)? {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -147,11 +147,9 @@ struct WorkspaceListView: View {
     /// Local presenter identity remains separate from the selected changes payload.
     @State var isWorkspaceChangesPresented = false
     @State var changesSheetTarget: WorkspaceChangesSheetTarget? = nil
-    @State private var macTitlePickerSwitchTask: Task<Void, Never>?
-    @State private var macTitlePickerSwitchIsCancellation = false
-    @State private var macTitlePickerSwitchGeneration: UInt64 = 0
-    @State private var macTitlePickerPendingSelection: WorkspaceMacSelection?
-    @State var deferredWorkspaceSelectionGeneration: UInt64 = 0
+    /// SwiftUI owns this reference's identity; the coordinator owns the
+    /// asynchronous title-picker and deferred-row selection state.
+    @State private var macSelectionCoordinator = WorkspaceMacSelectionCoordinator()
     /// Stable machine-menu content. Kept as value state so live workspace or
     /// device-tree updates that do not change the actual machine set/name
     /// snapshot do not rebuild an open native Menu. `nil` only before the first
@@ -258,11 +256,15 @@ struct WorkspaceListView: View {
     }
 
     var currentMacTitlePickerSelection: WorkspaceMacSelection {
-        macTitlePickerPendingSelection ?? visibleMacSelection
+        macSelectionCoordinator.pendingSelection ?? visibleMacSelection
     }
 
     var macTitlePickerShowsProgress: Bool {
-        macTitlePickerPendingSelection != nil
+        macSelectionCoordinator.showsProgress
+    }
+
+    var deferredWorkspaceSelectionGeneration: UInt64 {
+        macSelectionCoordinator.deferredWorkspaceSelectionGeneration
     }
 
     /// Whether the list presents the recency sort: chosen mode `.recentActivity`
@@ -817,26 +819,19 @@ struct WorkspaceListView: View {
             cancelStoreSwitch: !startsMachineSwitch
         )
         guard startsMachineSwitch else {
-            macTitlePickerPendingSelection = nil
+            macSelectionCoordinator.clearPendingSelection()
             macSelection = selection
             return nil
         }
-        macTitlePickerSwitchGeneration &+= 1
-        let generation = macTitlePickerSwitchGeneration
-        macTitlePickerPendingSelection = selection
-        let task = Task { @MainActor in
-            defer {
-                if macTitlePickerSwitchGeneration == generation {
-                    macTitlePickerSwitchTask = nil
-                    macTitlePickerSwitchIsCancellation = false
-                }
-            }
-            await cancelTask?.value
-            await applyMacTitlePickerSelection(selection, switchGeneration: generation)
+        return macSelectionCoordinator.startSwitch(
+            for: selection,
+            after: cancelTask
+        ) { selection, generation in
+            await self.applyMacTitlePickerSelection(
+                selection,
+                switchGeneration: generation
+            )
         }
-        macTitlePickerSwitchTask = task
-        macTitlePickerSwitchIsCancellation = false
-        return task
     }
 
     private func shouldSwitchForMacTitlePickerMachine(_ id: String) -> Bool {
@@ -849,34 +844,11 @@ struct WorkspaceListView: View {
         restorePreviousOnCancel: Bool = true,
         cancelStoreSwitch: Bool = true
     ) -> Task<Void, Never>? {
-        let pendingSwitchTask = macTitlePickerSwitchTask
-        let pendingSwitchIsCancellation = pendingSwitchTask != nil && macTitlePickerSwitchIsCancellation
-        if pendingSwitchIsCancellation {
-            return pendingSwitchTask
-        }
-        if pendingSwitchTask != nil {
-            pendingSwitchTask?.cancel()
-        }
-        macTitlePickerSwitchTask = nil
-        macTitlePickerSwitchIsCancellation = false
-        macTitlePickerPendingSelection = nil
-        macTitlePickerSwitchGeneration &+= 1
-        let generation = macTitlePickerSwitchGeneration
-        guard pendingSwitchTask != nil else { return nil }
-        guard cancelStoreSwitch else { return nil }
-        let cancelMacSwitch = cancelMacSwitch
-        let task = Task { @MainActor in
-            defer {
-                if macTitlePickerSwitchGeneration == generation {
-                    macTitlePickerSwitchTask = nil
-                    macTitlePickerSwitchIsCancellation = false
-                }
-            }
-            await cancelMacSwitch?(restorePreviousOnCancel)
-        }
-        macTitlePickerSwitchTask = task
-        macTitlePickerSwitchIsCancellation = true
-        return task
+        return macSelectionCoordinator.cancelPendingSwitch(
+            restorePreviousOnCancel: restorePreviousOnCancel,
+            cancelStoreSwitch: cancelStoreSwitch,
+            cancelMacSwitch: cancelMacSwitch
+        )
     }
 
     @MainActor
@@ -885,28 +857,26 @@ struct WorkspaceListView: View {
         switchGeneration: UInt64? = nil
     ) async {
         func isCurrentSwitchRequest() -> Bool {
-            guard !Task.isCancelled else { return false }
-            guard let switchGeneration else { return true }
-            return macTitlePickerSwitchGeneration == switchGeneration
+            macSelectionCoordinator.isCurrentSwitchRequest(switchGeneration)
         }
 
         switch selection {
         case .all, .automatic:
             guard isCurrentSwitchRequest() else { return }
-            macTitlePickerPendingSelection = nil
+            macSelectionCoordinator.clearPendingSelection()
             macSelection = selection
         case .machine(let id):
             guard isCurrentSwitchRequest() else { return }
             guard shouldSwitchForMacTitlePickerMachine(id),
                   let target = macSelectionScope.switchTarget(for: id),
                   let switchMac else {
-                macTitlePickerPendingSelection = nil
+                macSelectionCoordinator.clearPendingSelection()
                 macSelection = selection
                 return
             }
             let switched = await switchMac(target.macDeviceID, target.instanceTag)
             guard isCurrentSwitchRequest() else { return }
-            macTitlePickerPendingSelection = nil
+            macSelectionCoordinator.clearPendingSelection()
             guard switched else { return }
             macSelection = .machine(id)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -267,6 +267,10 @@ struct WorkspaceListView: View {
         macSelectionCoordinator.deferredWorkspaceSelectionGeneration
     }
 
+    func invalidateDeferredWorkspaceSelection() {
+        macSelectionCoordinator.invalidateDeferredWorkspaceSelection()
+    }
+
     /// Whether the list presents the recency sort: chosen mode `.recentActivity`
     /// while the visible scope spans computers (All Computers). A single-Mac
     /// scope keeps that Mac's own order — the sort exists to make the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionCoordinator.swift
@@ -12,7 +12,9 @@ final class WorkspaceMacSelectionCoordinator {
     typealias CancelMacSwitch = @MainActor (Bool) async -> Void
 
     @ObservationIgnored private var switchTask: Task<Void, Never>?
-    @ObservationIgnored private var switchIsCancellation = false
+    @ObservationIgnored private var switchTaskGeneration: UInt64?
+    @ObservationIgnored private var cancellationTask: Task<Void, Never>?
+    @ObservationIgnored private var cancellationGeneration: UInt64?
     @ObservationIgnored private var switchGeneration: UInt64 = 0
     private(set) var pendingSelection: WorkspaceMacSelection?
     private(set) var deferredWorkspaceSelectionGeneration: UInt64 = 0
@@ -52,7 +54,7 @@ final class WorkspaceMacSelectionCoordinator {
             await apply(selection, generation)
         }
         switchTask = task
-        switchIsCancellation = false
+        switchTaskGeneration = generation
         return task
     }
 
@@ -63,31 +65,42 @@ final class WorkspaceMacSelectionCoordinator {
         cancelMacSwitch: CancelMacSwitch?
     ) -> Task<Void, Never>? {
         let pendingSwitchTask = switchTask
-        let pendingSwitchIsCancellation = pendingSwitchTask != nil && switchIsCancellation
-        if pendingSwitchIsCancellation {
-            return pendingSwitchTask
+        let pendingSwitchGeneration = switchTaskGeneration
+        if pendingSwitchGeneration != cancellationGeneration {
+            pendingSwitchTask?.cancel()
         }
 
-        pendingSwitchTask?.cancel()
         switchTask = nil
-        switchIsCancellation = false
+        switchTaskGeneration = nil
         pendingSelection = nil
         switchGeneration &+= 1
         let generation = switchGeneration
+        if let cancellationTask {
+            return cancellationTask
+        }
         guard pendingSwitchTask != nil, cancelStoreSwitch else { return nil }
 
         let task = Task { @MainActor in
-            defer { finishSwitch(generation: generation) }
+            defer { finishCancellation(generation: generation) }
             await cancelMacSwitch?(restorePreviousOnCancel)
         }
+        cancellationTask = task
+        cancellationGeneration = generation
         switchTask = task
-        switchIsCancellation = true
+        switchTaskGeneration = generation
         return task
     }
 
     private func finishSwitch(generation: UInt64) {
-        guard switchGeneration == generation else { return }
+        guard switchTaskGeneration == generation else { return }
         switchTask = nil
-        switchIsCancellation = false
+        switchTaskGeneration = nil
+    }
+
+    private func finishCancellation(generation: UInt64) {
+        guard cancellationGeneration == generation else { return }
+        cancellationTask = nil
+        cancellationGeneration = nil
+        finishSwitch(generation: generation)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionCoordinator.swift
@@ -1,0 +1,93 @@
+import Observation
+
+/// Owns the asynchronous coordination behind the workspace list's Mac picker.
+///
+/// SwiftUI keeps the coordinator reference alive for the list, while the
+/// coordinator owns the mutable task, pending selection, and generation state.
+/// Keeping those values here also makes the coordination deterministic for
+/// callers that exercise a ``WorkspaceListView`` without mounting a view graph.
+@MainActor
+@Observable
+final class WorkspaceMacSelectionCoordinator {
+    typealias CancelMacSwitch = @MainActor (Bool) async -> Void
+
+    @ObservationIgnored private var switchTask: Task<Void, Never>?
+    @ObservationIgnored private var switchIsCancellation = false
+    @ObservationIgnored private var switchGeneration: UInt64 = 0
+    private(set) var pendingSelection: WorkspaceMacSelection?
+    private(set) var deferredWorkspaceSelectionGeneration: UInt64 = 0
+
+    var showsProgress: Bool {
+        pendingSelection != nil
+    }
+
+    func invalidateDeferredWorkspaceSelection() {
+        deferredWorkspaceSelectionGeneration &+= 1
+    }
+
+    func clearPendingSelection() {
+        pendingSelection = nil
+    }
+
+    func isCurrentSwitchRequest(_ generation: UInt64?) -> Bool {
+        guard !Task.isCancelled else { return false }
+        guard let generation else { return true }
+        return switchGeneration == generation
+    }
+
+    /// Starts the next machine switch after any prior cancellation has settled.
+    @discardableResult
+    func startSwitch(
+        for selection: WorkspaceMacSelection,
+        after cancellationTask: Task<Void, Never>?,
+        apply: @escaping @MainActor (WorkspaceMacSelection, UInt64) async -> Void
+    ) -> Task<Void, Never> {
+        switchGeneration &+= 1
+        let generation = switchGeneration
+        pendingSelection = selection
+        let task = Task { @MainActor in
+            defer { finishSwitch(generation: generation) }
+            await cancellationTask?.value
+            guard isCurrentSwitchRequest(generation) else { return }
+            await apply(selection, generation)
+        }
+        switchTask = task
+        switchIsCancellation = false
+        return task
+    }
+
+    @discardableResult
+    func cancelPendingSwitch(
+        restorePreviousOnCancel: Bool,
+        cancelStoreSwitch: Bool,
+        cancelMacSwitch: CancelMacSwitch?
+    ) -> Task<Void, Never>? {
+        let pendingSwitchTask = switchTask
+        let pendingSwitchIsCancellation = pendingSwitchTask != nil && switchIsCancellation
+        if pendingSwitchIsCancellation {
+            return pendingSwitchTask
+        }
+
+        pendingSwitchTask?.cancel()
+        switchTask = nil
+        switchIsCancellation = false
+        pendingSelection = nil
+        switchGeneration &+= 1
+        let generation = switchGeneration
+        guard pendingSwitchTask != nil, cancelStoreSwitch else { return nil }
+
+        let task = Task { @MainActor in
+            defer { finishSwitch(generation: generation) }
+            await cancelMacSwitch?(restorePreviousOnCancel)
+        }
+        switchTask = task
+        switchIsCancellation = true
+        return task
+    }
+
+    private func finishSwitch(generation: UInt64) {
+        guard switchGeneration == generation else { return }
+        switchTask = nil
+        switchIsCancellation = false
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -105,7 +105,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func cancelingPendingTitlePickerSwitchCancelsUnderlyingSwitch() async throws {
+    @Test func cancelingPendingTitlePickerSwitchCancelsUnderlyingSwitch() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
@@ -185,7 +185,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func pendingTitlePickerMachineSelectionLetsAllMacsCancelSwitch() async throws {
+    @Test func pendingTitlePickerMachineSelectionLetsAllMacsCancelSwitch() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
@@ -267,7 +267,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func titlePickerWaitsForAllMacsCancelBeforeStartingNextMachineSwitch() async throws {
+    @Test func titlePickerWaitsForAllMacsCancelBeforeStartingNextMachineSwitch() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
@@ -359,7 +359,7 @@ import Testing
         await firstTask?.value
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func replacingPendingTitlePickerMachineSelectionKeepsRollbackArmed() async throws {
+    @Test func replacingPendingTitlePickerMachineSelectionKeepsRollbackArmed() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
@@ -453,7 +453,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
+    @Test func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
         let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
@@ -518,7 +518,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test(.disabled("title-picker switch tests fail or deadlock in CI (rotted while this target was unwired); fix and re-enable, see PR 7659")) func newerWorkspaceSelectionInvalidatesDeferredRowSelection() async throws {
+    @Test func newerWorkspaceSelectionInvalidatesDeferredRowSelection() async throws {
         let firstWorkspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
         let secondWorkspaceID = MobileWorkspacePreview.ID(rawValue: "ws-b")
         let store = await shellStore(pairedMacs: [

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -359,6 +359,107 @@ import Testing
         await firstTask?.value
     }
 
+    @Test func workspaceSelectionWaitsForQueuedMachineSwitchCancellation() async throws {
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
+            pairedMac(id: "mac-c", name: "Mac C", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var selectedWorkspaces: [MobileWorkspacePreview.ID] = []
+        var requestedSwitches: [String] = []
+        var cancelRestoreRequests: [Bool] = []
+        var firstSwitchContinuation: CheckedContinuation<Bool, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        var firstCancelContinuation: CheckedContinuation<Void, Never>?
+        var firstCancelDidStart = false
+        var firstCancelStartedContinuation: CheckedContinuation<Void, Never>?
+
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        func markFirstCancelStarted() {
+            guard !firstCancelDidStart else { return }
+            firstCancelDidStart = true
+            firstCancelStartedContinuation?.resume()
+            firstCancelStartedContinuation = nil
+        }
+        func waitForFirstCancelStart() async {
+            guard !firstCancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if firstCancelDidStart {
+                    continuation.resume()
+                } else {
+                    firstCancelStartedContinuation = continuation
+                }
+            }
+        }
+
+        let view = workspaceListView(
+            workspaces: [workspace(id: workspaceID.rawValue, macDeviceID: "mac-a")],
+            store: store,
+            selectWorkspace: { selectedWorkspaces.append($0) },
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID, _ in
+                requestedSwitches.append(macDeviceID)
+                markSwitchStarted()
+                if macDeviceID == "mac-b" {
+                    return await withCheckedContinuation { continuation in
+                        firstSwitchContinuation = continuation
+                    }
+                }
+                return true
+            },
+            cancelMacSwitch: { restorePreviousOnCancel in
+                cancelRestoreRequests.append(restorePreviousOnCancel)
+                if cancelRestoreRequests.count == 1 {
+                    markFirstCancelStarted()
+                    await withCheckedContinuation { continuation in
+                        firstCancelContinuation = continuation
+                    }
+                }
+            }
+        )
+
+        let firstTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+
+        view.handleMacTitlePickerSelection(.all)
+        await waitForFirstCancelStart()
+
+        let queuedTask = view.handleMacTitlePickerSelection(.machine("mac-c"))
+        let workspaceTask = view.selectWorkspaceFromList(workspaceID)
+
+        firstCancelContinuation?.resume()
+        await workspaceTask?.value
+        await queuedTask?.value
+
+        #expect(requestedSwitches == ["mac-b"])
+        #expect(cancelRestoreRequests == [true])
+        #expect(selectedWorkspaces == [workspaceID])
+
+        firstSwitchContinuation?.resume(returning: false)
+        await firstTask?.value
+    }
+
     @Test func replacingPendingTitlePickerMachineSelectionKeepsRollbackArmed() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),


### PR DESCRIPTION
## Summary

- Re-enable the six WorkspaceMacSelectionTests that PR #7659 quarantined.
- Move title-picker switch/cancellation generations and deferred row-selection invalidation into an owned WorkspaceMacSelectionCoordinator reference.
- Preserve the existing Menu behavior while making off-graph WorkspaceListView calls use persistent coordination state.

## Validation

- Commits 3829514c50 (tests first) and 0b10924dd3 plus 6bcd22e531 (fix) keep the failing-test change separate from the fix.
- git diff --check and test-wiring lint pass.
- Remote iOS simulator run 32822551479 compiled the changed coordinator, view, and focused test sources on both matrix legs.
- That run was blocked before test execution by unrelated current-main cmuxFeatureTests protocol-conformance errors in MobileIroh*Broker fixtures; package-conventions-lint likewise reports existing baseline violations. No local Xcode build or simulator test was run.

## HIG

Checked Apple Human Interface Guidelines Menus (https://developer.apple.com/design/human-interface-guidelines/menus); this change preserves the existing standard iOS Menu and selection affordances.

Closes #7685