### PR TITLE
iOS: keep the terminal surface keyboard-invariant across keyboard toggles

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileTerminalSafeArea.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileTerminalSafeArea.swift
@@ -42,6 +42,10 @@ private struct MobileCompactLandscapeTerminalSafeAreaCompensation: ViewModifier 
         // on every toggle, which resizes the terminal grid (a shared-PTY
         // renegotiation with the Mac) and produces a stale one-cell gap at
         // the top plus reflow row-blanking while the round trip settles.
+        // Ignoring the keyboard here is necessary but NOT sufficient: while
+        // the keyboard is up the home-indicator band is re-attributed to the
+        // CONTAINER region, which the terminal leaf ignores itself (see
+        // `WorkspaceDetailView.terminalArtifactSurface`).
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .background {
             MobileTerminalWindowOrientationReader { orientation in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+TerminalKeyboardGeometryProbe.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+TerminalKeyboardGeometryProbe.swift
@@ -1,0 +1,38 @@
+#if os(iOS)
+import CmuxMobileDiagnostics
+import SwiftUI
+
+/// DEBUG bisect probe for keyboard-coupled hosting geometry: logs the labeled
+/// node's height and bottom safe-area inset whenever either changes, so a
+/// `kb.swiftui` trace shows exactly which span of the terminal's modifier
+/// stack absorbs or re-introduces a bottom inset across keyboard toggles.
+/// Compiles to a no-op outside DEBUG.
+private struct TerminalKeyboardGeometryProbe: ViewModifier {
+    let label: String
+
+    func body(content: Content) -> some View {
+        #if DEBUG
+        content.background {
+            GeometryReader { proxy in
+                let signature = "h=\(Int(proxy.size.height)) sabB=\(Int(proxy.safeAreaInsets.bottom))"
+                Color.clear
+                    .onChange(of: signature, initial: true) { _, value in
+                        MobileDebugLog.anchormux("kb.swiftui \(label) \(value)")
+                    }
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
+        #else
+        content
+        #endif
+    }
+}
+
+extension View {
+    /// Logs `kb.swiftui <label> h=… sabB=…` on every geometry change (DEBUG).
+    func terminalKeyboardGeometryProbe(_ label: String) -> some View {
+        modifier(TerminalKeyboardGeometryProbe(label: label))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
@@ -118,13 +118,25 @@ extension WorkspaceDetailView {
     .onDisappear {
         visibleArtifactCount = 0
     }
+    .terminalKeyboardGeometryProbe("leaf-inside")
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(store.activeTerminalTheme.terminalBackgroundColor)
     // The surface positions its grid + docked toolbar from
     // `keyboardHeight` directly, so opt out of SwiftUI keyboard
     // avoidance; otherwise the view ALSO shrinks for the keyboard
     // and the reservation double-counts (extra gap when open).
-    .ignoresSafeArea(.keyboard, edges: .bottom)
+    //
+    // The CONTAINER bottom region must be ignored here too, in every
+    // orientation: while the keyboard is up, the home-indicator band is
+    // re-attributed from the keyboard region to the container region at
+    // this node, so ignoring only the keyboard still shrank the surface by
+    // that band on every toggle — which resized the terminal grid (a
+    // shared-PTY renegotiation with the Mac) and retargeted the render
+    // after the keyboard had settled. With the keyboard down the ancestors
+    // already extend this view under the home indicator, so the extra
+    // ignore changes nothing in the steady state.
+    .ignoresSafeArea([.container, .keyboard], edges: .bottom)
+    .terminalKeyboardGeometryProbe("leaf-outside")
     // Keep the grid clear of the Dynamic Island and nav bar.
     .padding(.top, terminalTopPadding)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -549,10 +549,12 @@ struct WorkspaceDetailView: View {
         #if os(iOS)
         // The whole bottom dock is owned by `GhosttySurfaceView` in one
         // coordinate system, so composer growth pushes only the terminal up.
+        .terminalKeyboardGeometryProbe("detail-inside")
         .mobileTerminalSafeAreaExpansion(
             context: safeAreaContext,
             includesBottom: true
         )
+        .terminalKeyboardGeometryProbe("detail-outside")
         .background {
             // Fill under translucent chrome with the terminal's own color.
             store.activeTerminalTheme.terminalBackgroundColor

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2728,6 +2728,23 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutZoomOverlay()
         MobileDebugLog.anchormux("surface.layout bounds=\(Int(bounds.width))x\(Int(bounds.height)) window=\(window != nil)")
         if bounds.size != lastLayoutGeometrySyncSize {
+            #if DEBUG
+            // Ancestor-frame dump on every size change: pinpoints which hosting
+            // view reshaped the surface (e.g. keyboard-coupled SwiftUI safe-area
+            // churn). Fires only on actual size changes, so it is quiet in
+            // steady state.
+            var chainNode: UIView? = self
+            var chain: [String] = []
+            while let node = chainNode {
+                chain.append(
+                    "\(String(describing: type(of: node)).prefix(38)) "
+                    + "y=\(Int(node.frame.minY)) h=\(Int(node.frame.height)) "
+                    + "sab=\(Int(node.safeAreaInsets.bottom))"
+                )
+                chainNode = node.superview
+            }
+            MobileDebugLog.anchormux("kb.chain " + chain.joined(separator: " | "))
+            #endif
             lastLayoutGeometrySyncSize = bounds.size
             setNeedsGeometrySync()
         }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -9374,6 +9374,85 @@ final class cmuxUITests: XCTestCase {
         )
     }
 
+    /// A keyboard toggle must not reshape the terminal surface or its grid:
+    /// the hosting bounds, the grid viewport, and the render size are
+    /// keyboard-invariant by contract (the render slides on the dock; nothing
+    /// resizes). Regression: SwiftUI's keyboard safe area shaved the
+    /// home-indicator band off the surface on every toggle, which resized the
+    /// shared PTY grid, re-measured the blank band mid-leg, and retargeted the
+    /// render after the keyboard had already settled (a visible one-band
+    /// shift on every toggle).
+    @MainActor
+    func testKeyboardToggleKeepsTerminalSurfaceGeometryInvariant() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+
+        let baseline = waitForDock(in: app, describe: "settled keyboard-down geometry") {
+            (Int($0["boundsHeight"] ?? "") ?? 0) > 0
+                && (Int($0["viewportHeight"] ?? "") ?? 0) > 0
+                && (Int($0["renderHeight"] ?? "") ?? 0) > 0
+        }
+        guard let baselineBounds = Int(baseline["boundsHeight"] ?? ""),
+              let baselineViewport = Int(baseline["viewportHeight"] ?? ""),
+              let baselineRender = Int(baseline["renderHeight"] ?? "") else {
+            XCTFail("Missing baseline surface geometry. dock=\(baseline)")
+            return
+        }
+
+        let composerField = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(composerField.waitForExistence(timeout: 4))
+        composerField.tap()
+
+        guard waitForSoftwareKeyboardKeyPlane(
+            in: app,
+            minimumOverlap: 120,
+            timeout: 4
+        ) != nil else { return }
+        let up = waitForDock(in: app, describe: "keyboard-up geometry") {
+            ($0["keyboardHeight"].flatMap(Double.init) ?? 0) > 120
+        }
+        XCTAssertEqual(
+            Int(up["boundsHeight"] ?? ""),
+            baselineBounds,
+            "The keyboard must not reshape the terminal surface. up=\(up) baseline=\(baseline)"
+        )
+        XCTAssertEqual(
+            Int(up["viewportHeight"] ?? ""),
+            baselineViewport,
+            "The keyboard must not resize the grid viewport. up=\(up) baseline=\(baseline)"
+        )
+        XCTAssertEqual(
+            Int(up["renderHeight"] ?? ""),
+            baselineRender,
+            "The keyboard must not resize the render. up=\(up) baseline=\(baseline)"
+        )
+
+        dismissKeyboard(in: app)
+        let down = waitForDock(in: app, describe: "keyboard-down geometry restored") {
+            ($0["keyboardHeight"].flatMap(Double.init) ?? 1) < 1
+        }
+        XCTAssertEqual(
+            Int(down["boundsHeight"] ?? ""),
+            baselineBounds,
+            "Dismissal must return the identical surface bounds. down=\(down) baseline=\(baseline)"
+        )
+        XCTAssertEqual(
+            Int(down["viewportHeight"] ?? ""),
+            baselineViewport,
+            "Dismissal must return the identical grid viewport. down=\(down) baseline=\(baseline)"
+        )
+        XCTAssertEqual(
+            Int(down["renderHeight"] ?? ""),
+            baselineRender,
+            "Dismissal must return the identical render size. down=\(down) baseline=\(baseline)"
+        )
+    }
+
     /// The Settings > Developer "Rebuilt Keyboard Pinning" toggle persists
     /// `cmux.mobile.debug.forceRebuildKeyboardDock.v1` and the terminal host
     /// snapshots it at mount. Drive the same defaults key through the launch


### PR DESCRIPTION
## Problem

Every keyboard toggle in the workspace terminal produced a small vertical shift of the rendered terminal: the content briefly detached from the composer bar, then settled back (report: screen recording from Aziz's iPhone, 08-24 22:40).

Frame-by-frame measurement of the recording plus the on-device `anchormux` log localized it:

- The terminal surface's SwiftUI frame is keyboard-dependent: `surface.layout bounds=440x836` (keyboard down) vs `440x802` (keyboard up). While the keyboard is up, SwiftUI re-attributes the home-indicator band (34pt) from the keyboard safe-area region to the **container** region at the terminal leaf, and the leaf ignored only `.keyboard`.
- That 34pt reshape cascaded: the grid container flipped 714↔680pt, the shared PTY grid renegotiated 61↔58 rows with the Mac on every toggle (`natural=72x61`↔`72x58`), `kb.renderRect` re-framed the render unanimated mid-animation (±34pt snaps), and the blank-below-content measurement flipped 11↔0pt, whose throttled async re-application retargeted the render ~250ms **after** the keyboard had settled — the visible shift.

## Fix

The terminal leaf ignores both bottom regions: `.ignoresSafeArea([.container, .keyboard], edges: .bottom)` in `WorkspaceDetailView.terminalArtifactSurface`. With the keyboard down the ancestors already extend the surface under the home indicator, so steady-state geometry is unchanged; this only removes the keyboard-coupled reshape. An outer-node container ignore was tried first and empirically does not fix the leaf (the inset re-applies at the leaf), which is why the fix lives there.

Commit 1 adds the failing UITest (probe-based: `boundsHeight`/`viewportHeight`/`renderHeight` must be identical before, during, and after a toggle); commit 2 fixes it and adds DEBUG diagnostics (`kb.chain` UIKit ancestor dump on surface size change, `kb.swiftui` per-node geometry probes) that localize any future regression of this class.

## Verification

On an isolated simulator (cmux-dev-kbseam, paired to the kbseam Mac): before the fix, four keyboard toggles produced `geom container` flips 632↔598, grid renegotiations `eff=66x53`↔`66x50`, and `kb.renderRect 0->±34` snaps. After the fix, the same drive shows `surface.layout bounds=402x754` and `geom container=402x632 eff=66x53` constant across all toggles, with zero `kb.renderRect`/`kb.contentRows` events. Screenshots confirm the render bottom stays glued to the composer bar in both states.

HIG: reviewed the Keyboards page (keep content visible while the onscreen keyboard is up); cmux keeps the content above the keyboard via its own dock pinning, no deviation. No user-facing strings changed (localization audit: none needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790235210&installation_model_id=21920&pr_number=10713&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10713&signature=e663e7d962b8bd98dd84cb886188955b6c9c19f3f8d80c857791667ff47c2e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the iOS workspace terminal from shifting during software keyboard toggles by keeping the surface and grid keyboard-invariant. Previously, toggling the keyboard reattributed the home-indicator band, shrank the surface, renegotiated the PTY grid, and caused a visible snap; now the terminal leaf ignores both `.container` and `.keyboard` bottom safe areas so geometry stays constant.

- Bug Fixes
  - Add a UITest that asserts `boundsHeight`, `viewportHeight`, and `renderHeight` remain identical before, during, and after a toggle.
  - Add DEBUG-only geometry probes: `kb.chain` (UIView ancestor frame dump on surface size changes) and `kb.swiftui` (per-node height and bottom inset logs) to localize regressions.

<sup>Written for commit 05e4a4c48a1175d78da4212b6774c8ca6c5acfa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout handling when the software keyboard appears, preserving terminal surface and viewport dimensions.
  * Ensured terminal safe-area behavior remains consistent while the keyboard is shown and dismissed.

* **Tests**
  * Added end-to-end coverage verifying terminal geometry remains stable during keyboard toggling.
  * Added DEBUG diagnostics to help identify keyboard-related layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->