### PR TITLE
fix: mark the active workspace color in the submenu

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
@@ -4,12 +4,13 @@ import SwiftUI
 /// Builds the named palette rows shared by the native sidebar color submenu.
 /// Arbitrary custom colors remain unmarked unless they match a palette entry.
 @MainActor
-enum SidebarWorkspaceRowColorMenu {
-    static func addPaletteItems(
+struct SidebarWorkspaceRowColorMenu {
+    let currentColorHex: String?
+    let colorScheme: ColorScheme
+
+    func addPaletteItems(
         to menu: NSMenu,
         palette: [WorkspaceTabColorEntry],
-        currentColorHex: String?,
-        colorScheme: ColorScheme,
         apply: @escaping (String) -> Void
     ) {
         for entry in palette {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
@@ -1,0 +1,32 @@
+import AppKit
+import SwiftUI
+
+/// Builds the named palette rows shared by the native sidebar color submenu.
+/// Arbitrary custom colors remain unmarked unless they match a palette entry.
+@MainActor
+enum SidebarWorkspaceRowColorMenu {
+    static func addPaletteItems(
+        to menu: NSMenu,
+        palette: [WorkspaceTabColorEntry],
+        currentColorHex: String?,
+        colorScheme: ColorScheme,
+        apply: @escaping (String) -> Void
+    ) {
+        for entry in palette {
+            let colorItem = SidebarRowMenuActionItem(title: entry.name) {
+                apply(entry.hex)
+            }
+            colorItem.state = WorkspaceTabColorSettings.paletteEntryMatches(
+                currentHex: currentColorHex,
+                entryHex: entry.hex
+            ) ? .on : .off
+            let swatch = WorkspaceTabColorSettings.displayNSColor(
+                hex: entry.hex,
+                colorScheme: colorScheme,
+                forceBright: false
+            ) ?? NSColor(hex: entry.hex) ?? .gray
+            colorItem.image = SidebarWorkspaceRowMenuBuilder.coloredCircleImage(color: swatch)
+            menu.addItem(colorItem)
+        }
+    }
+}

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift
@@ -8,6 +8,7 @@ struct SidebarWorkspaceRowColorMenu {
     let currentColorHex: String?
     let colorScheme: ColorScheme
 
+    /// Adds one menu item per palette entry and marks the matching current value.
     func addPaletteItems(
         to menu: NSMenu,
         palette: [WorkspaceTabColorEntry],

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -319,7 +319,7 @@ struct SidebarWorkspaceRowMenuBuilder {
         }
         addRenameAndDescriptionItems(to: menu, tabManager: tabManager)
         addRemoteSection(to: menu, tabManager: tabManager)
-        addColorMenu(to: menu, tabManager: tabManager)
+        addColorMenu(to: menu)
         addSSHErrorItem(to: menu)
         menu.addItem(.separator())
         addMoveItems(to: menu, tabManager: tabManager)
@@ -573,7 +573,7 @@ struct SidebarWorkspaceRowMenuBuilder {
         })
     }
 
-    private func addColorMenu(to menu: NSMenu, tabManager: TabManager) {
+    private func addColorMenu(to menu: NSMenu) {
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         let palette = WorkspaceTabColorSettings.palette()
@@ -599,18 +599,15 @@ struct SidebarWorkspaceRowMenuBuilder {
         if !palette.isEmpty {
             submenu.addItem(.separator())
         }
-        for entry in palette {
-            let colorItem = item(entry.name) { [commands] in
-                commands.applyTabColor(entry.hex)
+        SidebarWorkspaceRowColorMenu.addPaletteItems(
+            to: submenu,
+            palette: palette,
+            currentColorHex: tab.customColor,
+            colorScheme: commands.colorScheme,
+            apply: { [commands] hex in
+                commands.applyTabColor(hex)
             }
-            let swatch = WorkspaceTabColorSettings.displayNSColor(
-                hex: entry.hex,
-                colorScheme: commands.colorScheme,
-                forceBright: false
-            ) ?? NSColor(hex: entry.hex) ?? .gray
-            colorItem.image = SidebarWorkspaceRowMenuBuilder.coloredCircleImage(color: swatch)
-            submenu.addItem(colorItem)
-        }
+        )
         let parent = item(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {}
         parent.submenu = submenu
         menu.addItem(parent)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -599,11 +599,12 @@ struct SidebarWorkspaceRowMenuBuilder {
         if !palette.isEmpty {
             submenu.addItem(.separator())
         }
-        SidebarWorkspaceRowColorMenu.addPaletteItems(
+        SidebarWorkspaceRowColorMenu(
+            currentColorHex: tab.customColor,
+            colorScheme: commands.colorScheme
+        ).addPaletteItems(
             to: submenu,
             palette: palette,
-            currentColorHex: tab.customColor,
-            colorScheme: commands.colorScheme,
             apply: { [commands] hex in
                 commands.applyTabColor(hex)
             }

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -141,6 +141,9 @@ extension TabItemView {
 
         Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
             let tabColorPalette = WorkspaceTabColorSettings.palette()
+            let currentColorHex = workspaceSnapshot.customColorHex.flatMap {
+                WorkspaceTabColorSettings.normalizedHex($0)
+            }
 
             if workspaceSnapshot.customColorHex != nil {
                 Button {
@@ -161,13 +164,19 @@ extension TabItemView {
             }
 
             ForEach(tabColorPalette, id: \.id) { entry in
+                let isSelected = WorkspaceTabColorSettings.paletteEntryMatches(
+                    currentHex: currentColorHex,
+                    entryHex: entry.hex
+                )
                 Button {
                     applyTabColor(entry.hex, targetIds: targetIds)
                 } label: {
-                    Label {
-                        Text(entry.name)
-                    } icon: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark")
+                            .opacity(isSelected ? 1 : 0)
+                            .frame(width: 12)
                         Image(nsImage: coloredCircleImage(color: tabColorSwatchColor(for: entry.hex)))
+                        Text(entry.name)
                     }
                 }
             }

--- a/Sources/WorkspaceTabColorSettings.swift
+++ b/Sources/WorkspaceTabColorSettings.swift
@@ -134,6 +134,7 @@ enum WorkspaceTabColorSettings {
         return "#" + body.uppercased()
     }
 
+    /// Compares normalized hex values so persisted formatting cannot hide a match.
     static func paletteEntryMatches(currentHex: String?, entryHex: String) -> Bool {
         guard let currentHex,
               let normalizedCurrent = normalizedHex(currentHex),

--- a/Sources/WorkspaceTabColorSettings.swift
+++ b/Sources/WorkspaceTabColorSettings.swift
@@ -134,6 +134,15 @@ enum WorkspaceTabColorSettings {
         return "#" + body.uppercased()
     }
 
+    static func paletteEntryMatches(currentHex: String?, entryHex: String) -> Bool {
+        guard let currentHex,
+              let normalizedCurrent = normalizedHex(currentHex),
+              let normalizedEntry = normalizedHex(entryHex) else {
+            return false
+        }
+        return normalizedCurrent == normalizedEntry
+    }
+
     static func displayColor(
         hex: String,
         colorScheme: ColorScheme,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2101,6 +2101,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		6707F0076707F0076707F007 /* SidebarWorkspaceRowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0086707F0086707F008 /* SidebarWorkspaceRowActions.swift */; };
 		B804A0240000000000000024 /* SidebarWorkspaceRowCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */; };
 		B804A02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */; };
+		970900020000000000000001 /* SidebarWorkspaceRowColorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */; };
 		B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */; };
 		B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */; };
 		6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */; };
@@ -4918,6 +4919,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		6707F0086707F0086707F008 /* SidebarWorkspaceRowActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowActions.swift; sourceTree = "<group>"; };
 		B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift; sourceTree = "<group>"; };
 		B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowChecklistSection.swift; sourceTree = "<group>"; };
+		970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift; sourceTree = "<group>"; };
 		B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift; sourceTree = "<group>"; };
 		B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInlineRenameTests.swift; sourceTree = "<group>"; };
 		6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInput.swift; sourceTree = "<group>"; };
@@ -6322,6 +6324,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B804B0170000000000000017 /* SidebarWorkspaceTableViewportAnchor.swift */,
 				B804B0200000000000000020 /* SidebarGroupHeaderRowModel.swift */,
 				B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */,
+				970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */,
 				B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */,
 				961300000000000000000004 /* AttributedString+SidebarRowLinks.swift */,
 				961300000000000000000002 /* SidebarWorkspaceDescriptionText.swift */,
@@ -10373,6 +10376,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				6707F0076707F0076707F007 /* SidebarWorkspaceRowActions.swift in Sources */,
 				B804A0240000000000000024 /* SidebarWorkspaceRowCellView.swift in Sources */,
 				B804A02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift in Sources */,
+				970900020000000000000001 /* SidebarWorkspaceRowColorMenu.swift in Sources */,
 				B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */,
 				6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */,
 				B804A0230000000000000023 /* SidebarWorkspaceRowModel.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2715,6 +2715,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B2929B53F4CC4C9D972771EC /* WorkspaceChecklistAttachmentQuickLookController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3981070E40BA4F53B8406CE4 /* WorkspaceChecklistAttachmentQuickLookController.swift */; };
 		D7AB3605C10DEF0000000003 /* WorkspaceCloseTabsBatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB3605C10DEF0000000004 /* WorkspaceCloseTabsBatching.swift */; };
 		D7AB3605C10DEF0000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */; };
+		970900030000000000000001 /* WorkspaceColorMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970900030000000000000002 /* WorkspaceColorMenuTests.swift */; };
 		A5FB1203 /* WorkspaceConfigActionCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1204 /* WorkspaceConfigActionCapture.swift */; };
 		5732A0045732A0045732A004 /* WorkspaceContentMinimalModeSafeAreaModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5732B0045732B0045732B004 /* WorkspaceContentMinimalModeSafeAreaModifier.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
@@ -5524,6 +5525,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		3981070E40BA4F53B8406CE4 /* WorkspaceChecklistAttachmentQuickLookController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceChecklistAttachmentQuickLookController.swift; sourceTree = "<group>"; };
 		D7AB3605C10DEF0000000004 /* WorkspaceCloseTabsBatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCloseTabsBatching.swift; sourceTree = "<group>"; };
 		D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCloseTabsContextMenuTests.swift; sourceTree = "<group>"; };
+		970900030000000000000002 /* WorkspaceColorMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceColorMenuTests.swift; sourceTree = "<group>"; };
 		A5FB1204 /* WorkspaceConfigActionCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceConfigActionCapture.swift; sourceTree = "<group>"; };
 		5732B0045732B0045732B004 /* WorkspaceContentMinimalModeSafeAreaModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentMinimalModeSafeAreaModifier.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
@@ -8185,6 +8187,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F0ACC0DF0000000000000002 /* SharedLiveAgentIndexAgentLivenessTests.swift */,
 				F0ACC0DE0000000000000006 /* WorkspaceForkConversationContextMenuTests.swift */,
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
+				970900030000000000000002 /* WorkspaceColorMenuTests.swift */,
 				CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */,
 				901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */,
 				C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */,
@@ -11819,6 +11822,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */,
 				A11EAE000000000000000000 /* WorkspaceAppearanceConfigResolutionTests.swift in Sources */,
 				D7AB3605C10DEF0000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */,
+				970900030000000000000001 /* WorkspaceColorMenuTests.swift in Sources */,
 				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 				D1A700000000000000000008 /* WorkspaceCreateIdempotencyRecoveryTests.swift in Sources */,
 				C0DE00000000000000000D38 /* WorkspaceCreateIdempotencyTombstoneTests.swift in Sources */,

--- a/cmuxTests/WorkspaceColorMenuTests.swift
+++ b/cmuxTests/WorkspaceColorMenuTests.swift
@@ -18,11 +18,12 @@ struct WorkspaceColorMenuTests {
             WorkspaceTabColorEntry(name: "Blue", hex: "#1565C0"),
         ]
 
-        SidebarWorkspaceRowColorMenu.addPaletteItems(
+        SidebarWorkspaceRowColorMenu(
+            currentColorHex: "  #006b6b ",
+            colorScheme: .light
+        ).addPaletteItems(
             to: menu,
             palette: palette,
-            currentColorHex: "  #006b6b ",
-            colorScheme: .light,
             apply: { _ in }
         )
 
@@ -39,11 +40,12 @@ struct WorkspaceColorMenuTests {
             WorkspaceTabColorEntry(name: "Blue", hex: "#1565C0"),
         ]
 
-        SidebarWorkspaceRowColorMenu.addPaletteItems(
+        SidebarWorkspaceRowColorMenu(
+            currentColorHex: "#123456",
+            colorScheme: .light
+        ).addPaletteItems(
             to: menu,
             palette: palette,
-            currentColorHex: "#123456",
-            colorScheme: .light,
             apply: { _ in }
         )
 

--- a/cmuxTests/WorkspaceColorMenuTests.swift
+++ b/cmuxTests/WorkspaceColorMenuTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct WorkspaceColorMenuTests {
+    @Test
+    func namedPaletteColorMarksTheMatchingMenuItem() {
+        let menu = NSMenu()
+        let palette = [
+            WorkspaceTabColorEntry(name: "Teal", hex: "#006B6B"),
+            WorkspaceTabColorEntry(name: "Blue", hex: "#1565C0"),
+        ]
+
+        SidebarWorkspaceRowColorMenu.addPaletteItems(
+            to: menu,
+            palette: palette,
+            currentColorHex: "  #006b6b ",
+            colorScheme: .light,
+            apply: { _ in }
+        )
+
+        #expect(menu.items.map(\.state) == [.on, .off])
+        #expect(menu.items.map(\.title) == ["Teal", "Blue"])
+        #expect(menu.items.allSatisfy { $0.image != nil })
+    }
+
+    @Test
+    func unmatchedCustomColorLeavesNamedPaletteItemsUnmarked() {
+        let menu = NSMenu()
+        let palette = [
+            WorkspaceTabColorEntry(name: "Teal", hex: "#006B6B"),
+            WorkspaceTabColorEntry(name: "Blue", hex: "#1565C0"),
+        ]
+
+        SidebarWorkspaceRowColorMenu.addPaletteItems(
+            to: menu,
+            palette: palette,
+            currentColorHex: "#123456",
+            colorScheme: .light,
+            apply: { _ in }
+        )
+
+        #expect(menu.items.allSatisfy { $0.state == .off })
+    }
+}


### PR DESCRIPTION
## Summary

- mark the currently applied named palette color with a native checkmark in the AppKit Workspace Color submenu
- mirror the selected state in the legacy SwiftUI sidebar menu
- leave arbitrary custom colors unmarked when they do not match a palette entry

## Tests

- Added `WorkspaceColorMenuTests` covering normalized named-color selection and unmatched custom colors.
- `swiftc -parse` on all changed Swift files
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`

Local Xcode builds/UI tests were intentionally not run per task instructions; focused remote verification is being dispatched.

Closes #9709

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790235517&installation_model_id=21920&pr_number=10716&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10716&signature=d702306fb20e71d49eeee4e8d137e77df50929cd660c5c7ba2cdabee4ae8cefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the active workspace color in both the AppKit submenu and the SwiftUI context menu so users can see which palette color is applied. Previously nothing was marked; now the matching palette entry shows a checkmark, and custom colors not in the palette stay unmarked.

- Bug Fixes
- Normalizes hex input (case and whitespace) when comparing palette entries.

- Refactors
- Extracts a stateful `SidebarWorkspaceRowColorMenu` to render palette items and selection across menus.
- Documents palette matching rules in `WorkspaceTabColorSettings`.

<sup>Written for commit 5518914cfb03d04d600f1fffc94452170197db53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

