### PR TITLE
test(web): replace auth cache expiry sleep

### DIFF
--- a/web/tests/vm-auth-cache.test.ts
+++ b/web/tests/vm-auth-cache.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 const getUser = mock(async (): Promise<unknown> => null);
 
@@ -42,6 +50,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setSystemTime();
   if (originalTtl === undefined) delete process.env.CMUX_VM_AUTH_CACHE_TTL_MS;
   else process.env.CMUX_VM_AUTH_CACHE_TTL_MS = originalTtl;
 });
@@ -97,8 +106,9 @@ describe("native auth verification cache", () => {
   test("entries expire after the TTL", async () => {
     process.env.CMUX_VM_AUTH_CACHE_TTL_MS = "20";
 
+    setSystemTime(0);
     await verifyRequest(nativeRequest("access-1"));
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    setSystemTime(21);
     await verifyRequest(nativeRequest("access-1"));
 
     expect(getUser).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Replace the 40 ms wall-clock sleep in the VM auth cache expiry test with Bun virtual time. The test now advances Date.now deterministically past the 20 ms TTL and restores the real clock after each case.

Checks:
- bun test web/tests/vm-auth-cache.test.ts
- python3 scripts/check-test-determinism.py --strict --roots web/tests/vm-auth-cache.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790236316&installation_model_id=21920&pr_number=10718&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10718&signature=c3b111232b79e8a630086284e42e893cd152baa3424405ac10736351e815949d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the 40 ms wall‑clock sleep in the VM auth cache expiry test with virtual time via `bun:test`’s `setSystemTime`, making the test deterministic and faster. Old: sleep 40 ms to exceed a 20 ms TTL; new: advance the clock past the TTL and restore the real clock after each test to avoid leaks.

- Refactors
  - Remove `setTimeout` and use `setSystemTime(...)` to jump from 0 ms to 21 ms.
  - Set `CMUX_VM_AUTH_CACHE_TTL_MS` to 20 ms for this case.
  - Test-only change; no production behavior.

<sup>Written for commit 983e8f568b3d4e874516d342b49cc70d76d880ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication cache expiration tests with deterministic time control.
  * Ensured mocked system time is reset after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->