### PR TITLE
iOS tests: prevent rotating wall-clock wait victims (#8143)

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -248,7 +248,7 @@ extension ReconnectRouteSelectionTests {
         let first = try #require(fixture.box.get())
         await first.close()
 
-        let recoveredWithoutServer = try await pollUntil(attempts: 100) {
+        let recoveredWithoutServer = try await pollUntil {
             guard let replacement = fixture.store.remoteClient else { return false }
             return replacement !== firstClient && fixture.store.connectionState == .connected
         }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
@@ -1090,7 +1090,7 @@ extension ReconnectRouteSelectionTests {
         clock.advance(by: 61)
         store.resumeForegroundRefresh()
 
-        let recovered = try await pollUntil(attempts: 100) {
+        let recovered = try await pollUntil {
             guard let current = box.get() else { return false }
             return current !== firstTransport
                 && store.connectionState == .connected

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/LivenessHostRouter+WallClockWaits.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/LivenessHostRouter+WallClockWaits.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+extension LivenessHostRouter {
+    @discardableResult
+    func waitForCount(
+        of method: String,
+        atLeast expectedCount: Int,
+        timeoutNanoseconds: UInt64 = MobileShellWallClockWaitPolicy.defaultWaitTimeoutNanoseconds,
+        recordIssueOnTimeout: Bool = true
+    ) async -> Bool {
+        let effectiveTimeoutNanoseconds = MobileShellWallClockWaitPolicy
+            .timeoutNanoseconds(for: timeoutNanoseconds)
+        let operation: @Sendable () async throws -> Bool = {
+            try Task.checkCancellation()
+            return await withTaskGroup(of: Bool.self) { group in
+                group.addTask {
+                    await self.waitUntilCountReached(of: method, atLeast: expectedCount)
+                    return true
+                }
+                group.addTask {
+                    // Test assertion deadline only; request arrival is signaled by record().
+                    try? await Task.sleep(nanoseconds: effectiveTimeoutNanoseconds)
+                    return false
+                }
+                let reached = await group.next() ?? false
+                group.cancelAll()
+                return reached
+            }
+        }
+        let reached: Bool
+        if MobileShellWallClockWaitPolicy.shouldSerializeWait(
+            timeoutNanoseconds: timeoutNanoseconds
+        ) {
+            reached = (try? await MobileShellWallClockWaitGate.processWide.withLock(operation)) ?? false
+        } else {
+            reached = (try? await operation()) ?? false
+        }
+        if !reached, recordIssueOnTimeout {
+            Issue.record("timed out waiting for \(method) count >= \(expectedCount)")
+        }
+        return reached
+    }
+
+    /// Waits for the transport's real replay-request admission signal. This
+    /// is used by tests that need to distinguish an already-started request
+    /// from one that must wait for an output acknowledgement.
+    @discardableResult
+    func waitForReplayRequestStart(
+        after existingCount: Int,
+        timeoutNanoseconds: UInt64 = 250_000_000
+    ) async -> Bool {
+        await waitForCount(
+            of: "mobile.terminal.replay",
+            atLeast: existingCount + 1,
+            timeoutNanoseconds: timeoutNanoseconds,
+            recordIssueOnTimeout: false
+        )
+    }
+
+    func waitUntilCountReached(of method: String, atLeast expectedCount: Int) async {
+        guard count(of: method) < expectedCount else { return }
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                countWaiters.append((
+                    id: waiterID,
+                    method: method,
+                    expectedCount: expectedCount,
+                    continuation: continuation
+                ))
+                resumeSatisfiedCountWaiters()
+            }
+        } onCancel: {
+            Task { await self.cancelCountWaiter(id: waiterID) }
+        }
+    }
+
+    func resumeSatisfiedCountWaiters() {
+        var remaining: [(
+            id: UUID,
+            method: String,
+            expectedCount: Int,
+            continuation: CheckedContinuation<Void, Never>
+        )] = []
+        var satisfied: [CheckedContinuation<Void, Never>] = []
+        for waiter in countWaiters {
+            if count(of: waiter.method) >= waiter.expectedCount {
+                satisfied.append(waiter.continuation)
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        countWaiters = remaining
+        for continuation in satisfied {
+            continuation.resume()
+        }
+    }
+
+    func cancelCountWaiter(id: UUID) {
+        guard let index = countWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = countWaiters.remove(at: index)
+        waiter.continuation.resume()
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellPolling.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellPolling.swift
@@ -1,0 +1,24 @@
+/// Poll until `condition` is true, bounded at `attempts` x 10ms. The default
+/// budget is intentionally generous for whole-suite scheduling; callers that
+/// assert bounded absence can keep an explicit shorter attempt count. Returns
+/// the final value so tests can assert both presence and (bounded) absence.
+@MainActor
+func pollUntil(
+    attempts: Int = MobileShellWallClockWaitPolicy.defaultPollAttempts,
+    _ condition: @MainActor () async -> Bool
+) async throws -> Bool {
+    let operation: @Sendable () async throws -> Bool = {
+        try Task.checkCancellation()
+        for _ in 0..<attempts {
+            if await condition() {
+                return true
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await condition()
+    }
+    if MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: attempts) {
+        return try await MobileShellWallClockWaitGate.processWide.withLock(operation)
+    }
+    return try await operation()
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellPolling.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellPolling.swift
@@ -5,7 +5,7 @@
 @MainActor
 func pollUntil(
     attempts: Int = MobileShellWallClockWaitPolicy.defaultPollAttempts,
-    _ condition: @MainActor () async -> Bool
+    _ condition: @escaping @MainActor @Sendable () async -> Bool
 ) async throws -> Bool {
     let operation: @Sendable () async throws -> Bool = {
         try Task.checkCancellation()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -175,23 +175,28 @@ actor LivenessHostRouter {
     func waitForCount(
         of method: String,
         atLeast expectedCount: Int,
-        timeoutNanoseconds: UInt64 = 3_000_000_000,
+        timeoutNanoseconds: UInt64 = MobileShellWallClockWaitPolicy.defaultWaitTimeoutNanoseconds,
         recordIssueOnTimeout: Bool = true
     ) async -> Bool {
-        let reached = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await self.waitUntilCountReached(of: method, atLeast: expectedCount)
-                return true
+        let effectiveTimeoutNanoseconds = MobileShellWallClockWaitPolicy
+            .timeoutNanoseconds(for: timeoutNanoseconds)
+        let reached = (try? await MobileShellWallClockWaitGate.processWide.withLock {
+            try Task.checkCancellation()
+            return await withTaskGroup(of: Bool.self) { group in
+                group.addTask {
+                    await self.waitUntilCountReached(of: method, atLeast: expectedCount)
+                    return true
+                }
+                group.addTask {
+                    // Test assertion deadline only; request arrival is signaled by record().
+                    try? await Task.sleep(nanoseconds: effectiveTimeoutNanoseconds)
+                    return false
+                }
+                let reached = await group.next() ?? false
+                group.cancelAll()
+                return reached
             }
-            group.addTask {
-                // Test assertion deadline only; request arrival is signaled by record().
-                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
-                return false
-            }
-            let reached = await group.next() ?? false
-            group.cancelAll()
-            return reached
-        }
+        }) ?? false
         if !reached, recordIssueOnTimeout {
             Issue.record("timed out waiting for \(method) count >= \(expectedCount)")
         }
@@ -973,20 +978,25 @@ func attachURL(for ticket: CmxAttachTicket) throws -> String {
     return "cmux-ios://attach?v=\(ticket.version)&payload=\(payload)"
 }
 
-/// Poll until `condition` is true, bounded at `attempts` x 10ms. Returns the
-/// final value so tests can assert both presence and (bounded) absence.
+/// Poll until `condition` is true, bounded at `attempts` x 10ms. The default
+/// budget is intentionally generous for whole-suite scheduling; callers that
+/// assert bounded absence can keep an explicit shorter attempt count. Returns
+/// the final value so tests can assert both presence and (bounded) absence.
 @MainActor
 func pollUntil(
-    attempts: Int = 300,
+    attempts: Int = MobileShellWallClockWaitPolicy.defaultPollAttempts,
     _ condition: @MainActor () async -> Bool
 ) async throws -> Bool {
-    for _ in 0..<attempts {
-        if await condition() {
-            return true
+    try await MobileShellWallClockWaitGate.processWide.withLock {
+        try Task.checkCancellation()
+        for _ in 0..<attempts {
+            if await condition() {
+                return true
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
         }
-        try await Task.sleep(nanoseconds: 10_000_000)
+        return await condition()
     }
-    return await condition()
 }
 
 @MainActor

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -36,7 +36,7 @@ actor LivenessHostRouter {
 
     private var recorded: [RecordedRequest] = []
     private var attachTicketFailuresRemaining = 0
-    private var countWaiters: [(
+    var countWaiters: [(
         id: UUID,
         method: String,
         expectedCount: Int,
@@ -169,109 +169,6 @@ actor LivenessHostRouter {
 
     func replayResponsesServed() -> Int {
         replayResponseCount
-    }
-
-    @discardableResult
-    func waitForCount(
-        of method: String,
-        atLeast expectedCount: Int,
-        timeoutNanoseconds: UInt64 = MobileShellWallClockWaitPolicy.defaultWaitTimeoutNanoseconds,
-        recordIssueOnTimeout: Bool = true
-    ) async -> Bool {
-        let effectiveTimeoutNanoseconds = MobileShellWallClockWaitPolicy
-            .timeoutNanoseconds(for: timeoutNanoseconds)
-        let operation: @Sendable () async throws -> Bool = {
-            try Task.checkCancellation()
-            return await withTaskGroup(of: Bool.self) { group in
-                group.addTask {
-                    await self.waitUntilCountReached(of: method, atLeast: expectedCount)
-                    return true
-                }
-                group.addTask {
-                    // Test assertion deadline only; request arrival is signaled by record().
-                    try? await Task.sleep(nanoseconds: effectiveTimeoutNanoseconds)
-                    return false
-                }
-                let reached = await group.next() ?? false
-                group.cancelAll()
-                return reached
-            }
-        }
-        let reached: Bool
-        if MobileShellWallClockWaitPolicy.shouldSerializeWait(
-            timeoutNanoseconds: timeoutNanoseconds
-        ) {
-            reached = (try? await MobileShellWallClockWaitGate.processWide.withLock(operation)) ?? false
-        } else {
-            reached = (try? await operation()) ?? false
-        }
-        if !reached, recordIssueOnTimeout {
-            Issue.record("timed out waiting for \(method) count >= \(expectedCount)")
-        }
-        return reached
-    }
-
-    /// Waits for the transport's real replay-request admission signal. This
-    /// is used by tests that need to distinguish an already-started request
-    /// from one that must wait for an output acknowledgement.
-    @discardableResult
-    func waitForReplayRequestStart(
-        after existingCount: Int,
-        timeoutNanoseconds: UInt64 = 250_000_000
-    ) async -> Bool {
-        await waitForCount(
-            of: "mobile.terminal.replay",
-            atLeast: existingCount + 1,
-            timeoutNanoseconds: timeoutNanoseconds,
-            recordIssueOnTimeout: false
-        )
-    }
-
-    private func waitUntilCountReached(of method: String, atLeast expectedCount: Int) async {
-        guard count(of: method) < expectedCount else { return }
-        let waiterID = UUID()
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                countWaiters.append((
-                    id: waiterID,
-                    method: method,
-                    expectedCount: expectedCount,
-                    continuation: continuation
-                ))
-                resumeSatisfiedCountWaiters()
-            }
-        } onCancel: {
-            Task { await self.cancelCountWaiter(id: waiterID) }
-        }
-    }
-
-    private func resumeSatisfiedCountWaiters() {
-        var remaining: [(
-            id: UUID,
-            method: String,
-            expectedCount: Int,
-            continuation: CheckedContinuation<Void, Never>
-        )] = []
-        var satisfied: [CheckedContinuation<Void, Never>] = []
-        for waiter in countWaiters {
-            if count(of: waiter.method) >= waiter.expectedCount {
-                satisfied.append(waiter.continuation)
-            } else {
-                remaining.append(waiter)
-            }
-        }
-        countWaiters = remaining
-        for continuation in satisfied {
-            continuation.resume()
-        }
-    }
-
-    private func cancelCountWaiter(id: UUID) {
-        guard let index = countWaiters.firstIndex(where: { $0.id == id }) else {
-            return
-        }
-        let waiter = countWaiters.remove(at: index)
-        waiter.continuation.resume()
     }
 
     func topics(for method: String) -> [[String]] {
@@ -984,31 +881,6 @@ func attachURL(for ticket: CmxAttachTicket) throws -> String {
         .replacingOccurrences(of: "/", with: "_")
         .replacingOccurrences(of: "=", with: "")
     return "cmux-ios://attach?v=\(ticket.version)&payload=\(payload)"
-}
-
-/// Poll until `condition` is true, bounded at `attempts` x 10ms. The default
-/// budget is intentionally generous for whole-suite scheduling; callers that
-/// assert bounded absence can keep an explicit shorter attempt count. Returns
-/// the final value so tests can assert both presence and (bounded) absence.
-@MainActor
-func pollUntil(
-    attempts: Int = MobileShellWallClockWaitPolicy.defaultPollAttempts,
-    _ condition: @MainActor () async -> Bool
-) async throws -> Bool {
-    let operation: @Sendable () async throws -> Bool = {
-        try Task.checkCancellation()
-        for _ in 0..<attempts {
-            if await condition() {
-                return true
-            }
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
-        return await condition()
-    }
-    if MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: attempts) {
-        return try await MobileShellWallClockWaitGate.processWide.withLock(operation)
-    }
-    return try await operation()
 }
 
 @MainActor

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -180,7 +180,7 @@ actor LivenessHostRouter {
     ) async -> Bool {
         let effectiveTimeoutNanoseconds = MobileShellWallClockWaitPolicy
             .timeoutNanoseconds(for: timeoutNanoseconds)
-        let reached = (try? await MobileShellWallClockWaitGate.processWide.withLock {
+        let operation: @Sendable () async throws -> Bool = {
             try Task.checkCancellation()
             return await withTaskGroup(of: Bool.self) { group in
                 group.addTask {
@@ -196,7 +196,15 @@ actor LivenessHostRouter {
                 group.cancelAll()
                 return reached
             }
-        }) ?? false
+        }
+        let reached: Bool
+        if MobileShellWallClockWaitPolicy.shouldSerializeWait(
+            timeoutNanoseconds: timeoutNanoseconds
+        ) {
+            reached = (try? await MobileShellWallClockWaitGate.processWide.withLock(operation)) ?? false
+        } else {
+            reached = (try? await operation()) ?? false
+        }
         if !reached, recordIssueOnTimeout {
             Issue.record("timed out waiting for \(method) count >= \(expectedCount)")
         }
@@ -987,7 +995,7 @@ func pollUntil(
     attempts: Int = MobileShellWallClockWaitPolicy.defaultPollAttempts,
     _ condition: @MainActor () async -> Bool
 ) async throws -> Bool {
-    try await MobileShellWallClockWaitGate.processWide.withLock {
+    let operation: @Sendable () async throws -> Bool = {
         try Task.checkCancellation()
         for _ in 0..<attempts {
             if await condition() {
@@ -997,6 +1005,10 @@ func pollUntil(
         }
         return await condition()
     }
+    if MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: attempts) {
+        return try await MobileShellWallClockWaitGate.processWide.withLock(operation)
+    }
+    return try await operation()
 }
 
 @MainActor

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
@@ -52,13 +52,22 @@ enum MobileShellWallClockWaitPolicy {
     static let defaultPollAttempts = 3_000
     static let defaultWaitTimeoutNanoseconds: UInt64 = 30_000_000_000
 
-    private static let headroomThresholdNanoseconds: UInt64 = 3_000_000_000
+    private static let suiteScaleThresholdNanoseconds: UInt64 = 3_000_000_000
+    private static let pollIntervalNanoseconds: UInt64 = 10_000_000
 
     /// Preserve intentionally short assertion windows while giving every
     /// suite-scale wait enough time to survive a busy shared executor.
     static func timeoutNanoseconds(for requested: UInt64) -> UInt64 {
-        guard requested >= headroomThresholdNanoseconds else { return requested }
+        guard shouldSerializeWait(timeoutNanoseconds: requested) else { return requested }
         return max(requested, defaultWaitTimeoutNanoseconds)
+    }
+
+    static func shouldSerializeWait(timeoutNanoseconds: UInt64) -> Bool {
+        timeoutNanoseconds >= suiteScaleThresholdNanoseconds
+    }
+
+    static func shouldSerializePoll(attempts: Int) -> Bool {
+        attempts >= Int(suiteScaleThresholdNanoseconds / pollIntervalNanoseconds)
     }
 }
 
@@ -167,4 +176,7 @@ func mobileShellWallClockWaitPolicyProvidesSuiteHeadroom() {
         MobileShellWallClockWaitPolicy.timeoutNanoseconds(for: 200_000_000)
             == 200_000_000
     )
+    #expect(!MobileShellWallClockWaitPolicy.shouldSerializeWait(timeoutNanoseconds: 250_000_000))
+    #expect(!MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 100))
+    #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 3_000))
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
@@ -1,0 +1,170 @@
+import Testing
+
+/// Keeps test-only wall-clock waiters from flooding the shared MainActor
+/// executor while the rest of CmuxMobileShellTests runs in parallel.
+///
+/// This gate is deliberately scoped to the polling/count helpers rather than
+/// the whole test target: tests that do not need a wall-clock assertion keep
+/// their normal parallelism.
+actor MobileShellWallClockWaitGate {
+    // Swift Testing has independent root suites, so a process-wide gate is
+    // the only way to serialize their wall-clock waiters without serializing
+    // unrelated test bodies.
+    static let processWide = MobileShellWallClockWaitGate()
+
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func withLock<Value: Sendable>(
+        _ operation: @Sendable () async throws -> Value
+    ) async throws -> Value {
+        await acquire()
+        do {
+            let value = try await operation()
+            release()
+            return value
+        } catch {
+            release()
+            throw error
+        }
+    }
+
+    private func acquire() async {
+        guard isHeld else {
+            isHeld = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    private func release() {
+        guard !waiters.isEmpty else {
+            isHeld = false
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+}
+
+enum MobileShellWallClockWaitPolicy {
+    /// Three seconds is shorter than a loaded whole-suite run. Keep the
+    /// default poll budget comfortably above that scheduling window.
+    static let defaultPollAttempts = 3_000
+    static let defaultWaitTimeoutNanoseconds: UInt64 = 30_000_000_000
+
+    private static let headroomThresholdNanoseconds: UInt64 = 3_000_000_000
+
+    /// Preserve intentionally short assertion windows while giving every
+    /// suite-scale wait enough time to survive a busy shared executor.
+    static func timeoutNanoseconds(for requested: UInt64) -> UInt64 {
+        guard requested >= headroomThresholdNanoseconds else { return requested }
+        return max(requested, defaultWaitTimeoutNanoseconds)
+    }
+}
+
+private actor MobileShellWaitGateProbe {
+    private var activeCount = 0
+    private var maximumActiveCount = 0
+    private var firstEntered = false
+    private var secondAttempted = false
+    private var firstReleased = false
+    private var firstEnteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var secondAttemptedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func enter() {
+        activeCount += 1
+        maximumActiveCount = max(maximumActiveCount, activeCount)
+        if !firstEntered {
+            firstEntered = true
+            resume(&firstEnteredWaiters)
+        }
+    }
+
+    func leave() {
+        activeCount -= 1
+    }
+
+    func markSecondAttempted() {
+        secondAttempted = true
+        resume(&secondAttemptedWaiters)
+    }
+
+    func waitUntilFirstEntered() async {
+        guard !firstEntered else { return }
+        await withCheckedContinuation { firstEnteredWaiters.append($0) }
+    }
+
+    func waitUntilSecondAttempted() async {
+        guard !secondAttempted else { return }
+        await withCheckedContinuation { secondAttemptedWaiters.append($0) }
+    }
+
+    func holdFirstOperation() async {
+        guard !firstReleased else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func releaseFirstOperation() {
+        firstReleased = true
+        resume(&releaseWaiters)
+    }
+
+    func maximumActive() -> Int {
+        maximumActiveCount
+    }
+
+    private func resume(_ waiters: inout [CheckedContinuation<Void, Never>]) {
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+}
+
+@Test("mobile shell wall-clock waits are serialized without serializing other tests")
+func mobileShellWallClockWaitGateSerializesConcurrentWaits() async {
+    let gate = MobileShellWallClockWaitGate()
+    let probe = MobileShellWaitGateProbe()
+
+    let first = Task {
+        _ = try? await gate.withLock {
+            await probe.enter()
+            await probe.holdFirstOperation()
+            await probe.leave()
+        }
+    }
+    await probe.waitUntilFirstEntered()
+
+    let second = Task {
+        await probe.markSecondAttempted()
+        _ = try? await gate.withLock {
+            await probe.enter()
+            await probe.leave()
+        }
+    }
+    await probe.waitUntilSecondAttempted()
+
+    let maximumBeforeRelease = await probe.maximumActive()
+    #expect(maximumBeforeRelease == 1)
+
+    await probe.releaseFirstOperation()
+    _ = await first.value
+    _ = await second.value
+
+    let maximumOverall = await probe.maximumActive()
+    #expect(maximumOverall == 1)
+}
+
+@Test("mobile shell long waits retain suite scheduling headroom")
+func mobileShellWallClockWaitPolicyProvidesSuiteHeadroom() {
+    #expect(
+        MobileShellWallClockWaitPolicy.timeoutNanoseconds(for: 10_000_000_000)
+            == MobileShellWallClockWaitPolicy.defaultWaitTimeoutNanoseconds
+    )
+    #expect(
+        MobileShellWallClockWaitPolicy.timeoutNanoseconds(for: 200_000_000)
+            == 200_000_000
+    )
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
@@ -47,13 +47,13 @@ actor MobileShellWallClockWaitGate {
 }
 
 enum MobileShellWallClockWaitPolicy {
-    /// One second is already long enough for a short assertion to be delayed
-    /// by a loaded suite. Keep the default poll budget comfortably above that
-    /// scheduling window.
+    /// A three-second threshold separates intentionally short assertions from
+    /// waits that need serialization. Keep the default poll budget comfortably
+    /// above the loaded-suite scheduling window.
     static let defaultPollAttempts = 3_000
     static let defaultWaitTimeoutNanoseconds: UInt64 = 30_000_000_000
 
-    private static let suiteScaleThresholdNanoseconds: UInt64 = 1_000_000_000
+    private static let suiteScaleThresholdNanoseconds: UInt64 = 3_000_000_000
     private static let pollIntervalNanoseconds: UInt64 = 10_000_000
 
     /// Preserve intentionally short assertion windows while giving every
@@ -178,6 +178,6 @@ func mobileShellWallClockWaitPolicyProvidesSuiteHeadroom() {
             == 200_000_000
     )
     #expect(!MobileShellWallClockWaitPolicy.shouldSerializeWait(timeoutNanoseconds: 250_000_000))
-    #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 100))
-    #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 3_000))
+    #expect(!MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 100))
+    #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 300))
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWallClockWaitGate.swift
@@ -47,12 +47,13 @@ actor MobileShellWallClockWaitGate {
 }
 
 enum MobileShellWallClockWaitPolicy {
-    /// Three seconds is shorter than a loaded whole-suite run. Keep the
-    /// default poll budget comfortably above that scheduling window.
+    /// One second is already long enough for a short assertion to be delayed
+    /// by a loaded suite. Keep the default poll budget comfortably above that
+    /// scheduling window.
     static let defaultPollAttempts = 3_000
     static let defaultWaitTimeoutNanoseconds: UInt64 = 30_000_000_000
 
-    private static let suiteScaleThresholdNanoseconds: UInt64 = 3_000_000_000
+    private static let suiteScaleThresholdNanoseconds: UInt64 = 1_000_000_000
     private static let pollIntervalNanoseconds: UInt64 = 10_000_000
 
     /// Preserve intentionally short assertion windows while giving every
@@ -177,6 +178,6 @@ func mobileShellWallClockWaitPolicyProvidesSuiteHeadroom() {
             == 200_000_000
     )
     #expect(!MobileShellWallClockWaitPolicy.shouldSerializeWait(timeoutNanoseconds: 250_000_000))
-    #expect(!MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 100))
+    #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 100))
     #expect(MobileShellWallClockWaitPolicy.shouldSerializePoll(attempts: 3_000))
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -12,7 +12,7 @@ import Testing
 /// selection must prefer the real route there — otherwise tapping a saved Mac
 /// dials the phone's own loopback and silently fails to connect.
 @MainActor
-@Suite struct ReconnectRouteSelectionTests {
+@Suite(.serialized) struct ReconnectRouteSelectionTests {
     func loopback(_ port: Int = 50906) throws -> CmxAttachRoute {
         try CmxAttachRoute(
             id: "debug_loopback",


### PR DESCRIPTION
## Summary

Fixes #8143 by making the shared CmuxMobileShell test wait helpers resilient to whole-suite MainActor scheduling:

- serialize only `pollUntil`/`waitForCount` wall-clock wait sections through a FIFO actor gate; unrelated tests remain parallel
- give suite-scale waits 30 seconds of scheduling headroom while preserving intentional sub-3-second assertion windows
- serialize `ReconnectRouteSelectionTests`, the recovery/replay suite implicated by the rotating victims
- add continuation-driven gate and budget diagnostics with no arbitrary sleeps

## Verification

- `swiftc -parse` passed for all changed Swift files
- approved GitHub Actions Blacksmith run: https://github.com/manaflow-ai/cmux/actions/runs/32823375372
- that run is blocked before CmuxMobileShell: pre-existing `CMUXMobileCore` and package-conventions jobs fail on the current baseline; the same workflow has failed on `main`. The affected package step was skipped.
- local xcodebuild/XCUITest was not run, per issue instructions.

Never merge without a successful focused `swift test --package-path Packages/iOS/CmuxMobileShell` on the approved builder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790237137&installation_model_id=21920&pr_number=10721&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10721&signature=a47426d50ee01dd6307bbaa1fde2f929b3a72cad04c1ad738f1c8671c2108a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes iOS tests by serializing only wall‑clock waits and giving long waits suite‑scale headroom to avoid MainActor contention. Short waits keep their deadlines, and unrelated tests stay parallel.

- Adds a process‑wide MobileShellWallClockWaitGate used by pollUntil and LivenessHostRouter.waitForCount, and moves these helpers into dedicated files to stay under per‑file budgets.
- Raises the default pollUntil budget to 3,000 attempts at 10 ms and normalizes long waits to 30 s via MobileShellWallClockWaitPolicy.
- Skips serialization and timeout inflation for sub‑3 s waits.
- Marks ReconnectRouteSelectionTests as @Suite(.serialized).
- Updates reconnect tests to use the default pollUntil budget (drops explicit 100 attempts) to cover short recovery polls without tightening deadlines.

**Migration**
- For fast failure, pass a smaller attempts to pollUntil or a shorter timeout to waitForCount.
- Merge only after a successful focused swift test --package-path Packages/iOS/CmuxMobileShell on the approved builder.

<sup>Written for commit 373395abc5a7d6149e1fcdc5c8e0ec2efe36b58d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test waiting with configurable polling, timeout handling, cancellation, and final condition checks.
  * Added safeguards to serialize longer-running wall-clock waits and prevent concurrent test interference.
  * Updated reconnection tests to use standardized polling behavior.
  * Ensured reconnect route selection tests run serially for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->