### PR TITLE
Raise client-config poll interval from 5 to 30 minutes

### DIFF
--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -434,7 +434,7 @@ final class CmuxFeatureFlags {
     func start() {
         guard refreshTimer == nil else { return }
         refreshRemoteFlags()
-        refreshTimer = Timer.scheduledTimer(withTimeInterval: 5 * 60, repeats: true) { [weak self] _ in
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 30 * 60, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.refreshRemoteFlags() }
         }
     }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileFeatureFlags.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileFeatureFlags.swift
@@ -28,7 +28,9 @@ public final class MobileFeatureFlags {
         "cmux.mobile.flags.remote." + keyboardDockRebuildRevertFlag.key
     }
     /// Delay between foreground refresh opportunities when the app remains active.
-    private static let refreshInterval: Duration = .seconds(5 * 60)
+    /// Thirty minutes bounds steady-state control-plane traffic across the fleet;
+    /// launch and scene-active refreshes keep flag propagation fast where it matters.
+    private static let refreshInterval: Duration = .seconds(30 * 60)
 
     /// Whether the chip and its count-only artifact scan are enabled.
     public private(set) var terminalFilesChipEnabled: Bool
@@ -79,7 +81,7 @@ public final class MobileFeatureFlags {
         ) ?? Self.keyboardDockRebuildRevertFlag.defaultValue
     }
 
-    /// Starts an immediate refresh and a cancellation-aware five-minute scheduler.
+    /// Starts an immediate refresh and a cancellation-aware thirty-minute scheduler.
     /// Calling this again is a no-op.
     public func start() {
         guard !isStarted else { return }


### PR DESCRIPTION
Every running macOS and iOS app POSTs `/api/client-config` on a fixed 5-minute timer, forever. A live sample of cmux.com production traffic shows this one endpoint is 54% of all requests, and each request bills a Vercel edge request, a function invocation, fluid CPU, and several Observability Plus events. It is the largest single driver of the current Vercel bill.

This raises the steady-state timer to 30 minutes on both platforms (`Sources/FeatureFlags.swift`, `ios/cmuxPackage/Sources/cmuxFeature/MobileFeatureFlags.swift`). Launch refresh (both platforms) and scene-active refresh (iOS) are unchanged, so a flag flip still reaches an app immediately on start or foreground. Worst-case propagation to an idle, long-running app moves from 5 to 30 minutes, which is acceptable for the rollout and kill-switch flags this control plane serves.

No test changes: the existing `MobileFeatureFlags` tests drive `refresh()` directly with injected clocks and do not pin the interval, and a constant-value assertion would be a source-shape test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790240576&installation_model_id=21920&pr_number=10722&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10722&signature=eaa5f4c6b73d9c1183bf16297cb8b7e584a05a7d0c2cc7c1fc2e90a405381792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the client-config poll interval from 5 minutes to 30 minutes on macOS and iOS to cut steady-state traffic and reduce Vercel costs. Launch and scene-active refreshes stay the same; only the background timer slows, so worst-case flag propagation for idle apps increases from 5 to 30 minutes.

<sup>Written for commit 2ed3a099b43fcb0200d693d4e3065f91e53c72ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated remote feature-flag refreshes to run every 30 minutes instead of every 5 minutes.
  * Updated related documentation to reflect the new refresh schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->