### PR TITLE
tui-publish-npm: allow first-time package publishes and idempotent retries

### DIFF
--- a/.github/workflows/relay-publish-npm.yml
+++ b/.github/workflows/relay-publish-npm.yml
@@ -174,7 +174,9 @@ jobs:
           )
           for package in "${packages[@]}"; do
             echo "Publishing $package@$DIST_TAG"
-            if ! npm publish --provenance --tag "$DIST_TAG" "dist/npm-packages/$package"; then
+            # --access public is required to publish a NEW unscoped package
+            # with --provenance; every cmux-relay platform package starts new.
+            if ! npm publish --provenance --access public --tag "$DIST_TAG" "dist/npm-packages/$package"; then
               cat >&2 <<'EOF'
           npm publish failed.
 
@@ -204,7 +206,7 @@ jobs:
       - name: Publish relay launcher package
         env:
           DIST_TAG: ${{ needs.version.outputs.dist_tag }}
-        run: npm publish --provenance --tag "$DIST_TAG" dist/npm-packages/cmux-relay
+        run: npm publish --provenance --access public --tag "$DIST_TAG" dist/npm-packages/cmux-relay
 
       - name: Smoke install from the registry
         env:

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -219,6 +219,8 @@ jobs:
       # (relay-publish-npm.yml), so a routine TUI release can never take over
       # cmux-relay@latest from the shipping relay.
       - name: Publish platform packages
+        env:
+          PUBLISH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           packages=(
@@ -229,8 +231,16 @@ jobs:
             cmux-tui-win32-x64
           )
           for package in "${packages[@]}"; do
+            # A retried run must not fail on the packages an earlier attempt
+            # already published at this exact version.
+            if [[ "$(npm view "$package@$PUBLISH_VERSION" version 2>/dev/null || true)" == "$PUBLISH_VERSION" ]]; then
+              echo "Skipping $package@$PUBLISH_VERSION: already published"
+              continue
+            fi
             echo "Publishing $package"
-            if ! npm publish --provenance "dist/npm-packages/$package"; then
+            # --access public is required to publish a NEW unscoped package
+            # with --provenance and is a no-op for the existing public ones.
+            if ! npm publish --provenance --access public "dist/npm-packages/$package"; then
               cat >&2 <<'EOF'
           npm publish failed.
 
@@ -251,8 +261,14 @@ jobs:
           done
 
       - name: Publish launcher package
+        env:
+          PUBLISH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          if [[ "$(npm view "cmux@$PUBLISH_VERSION" version 2>/dev/null || true)" == "$PUBLISH_VERSION" ]]; then
+            echo "Skipping cmux@$PUBLISH_VERSION: already published"
+            exit 0
+          fi
           # Deliberately do not pass --tag: this coordinated TUI publish takes
           # over the cmux latest dist-tag from the old 0.8.3 CLI when version > 0.8.3.
-          npm publish --provenance dist/npm-packages/cmux
+          npm publish --provenance --access public dist/npm-packages/cmux

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1510,7 +1510,12 @@ def test_relay_publisher_is_tag_bound_rc_aware_and_attested() -> None:
     assert 'dist_tag="next"' in text
     assert 'dist_tag="latest"' in text
     assert 'if [[ "$version" == *-rc.* ]]' in text
-    assert text.count('npm publish --provenance --tag "$DIST_TAG"') == 2
+    # --access public is required for the first publish of each new unscoped
+    # cmux-relay package name under --provenance and is a no-op afterwards.
+    assert text.count('npm publish --provenance --access public --tag "$DIST_TAG"') == 2
+    assert 'npm publish --provenance --tag "$DIST_TAG"' not in text.replace(
+        'npm publish --provenance --access public --tag "$DIST_TAG"', ""
+    )
     assert "npm publish --provenance dist/npm-packages" not in text
 
     # Same provenance posture as the TUI publisher: trusted-publisher


### PR DESCRIPTION
The v0.12.0 npm publish (run 32832102274) failed on cmux-relay-darwin-arm64 with `npm error Can't generate provenance for new or private package, you must set access to public`. Six of the twelve packages in the publish list have never been on npm (all five cmux-relay platform packages plus cmux-tui-win32-x64), so every stable cut fails there until this lands. `--access public` satisfies npm's requirement for a first-time unscoped package under `--provenance` and is a no-op for the existing public packages.

The publish steps also now skip any package whose exact version is already on the registry, so a retried or re-cut publish does not fail-closed on the packages an earlier attempt shipped (four cmux-tui platform packages are already live at 0.12.0).

Publishers execute the workflow definition from the dispatched tag ref, so this fix takes effect with the next release cut (v0.12.1). tests/test_tui_publish_workflow_security.py: 50/50 pass; actionlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790242877&installation_model_id=21920&pr_number=10727&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10727&signature=b2bc149f75666778d5eed1271207304eca71f1b89e42dbe1a5f34b3fc85c2f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the TUI and relay npm publish workflows succeed for first-time unscoped packages and safe to retry. Previously, `--provenance` publishes failed on new packages and reruns failed on versions already shipped; now we set `--access public` and, for TUI, skip packages already at the target version.

- Adds `--access public` to all `npm publish --provenance` calls in both workflows; required for first-time unscoped publishes and a no-op for existing public packages.
- TUI publisher skips each platform package and the `cmux` launcher if the exact `inputs.version` is already on the registry.
- Updates the relay contract test to pin the new publish command and guard against regressions.
- Takes effect on the next release cut because publishers run from the dispatched tag ref.

<sup>Written for commit 41351c98e4703fd888290023ed9084ffb8ac6c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm publishing reliability for public packages, including provenance-enabled releases.
  * Retried publishing workflows now safely skip package versions that are already available instead of failing.
  * Added safeguards to ensure release commands use the required public access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->