### PR TITLE
fix(tui): satisfy clippy in provider menu tests

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -38079,7 +38079,7 @@ mod tests {
         app.focus = FocusTarget::MachineRail;
         app.config.keys.apply_for_test(&HashMap::from([(
             "provider-menu".to_string(),
-            serde_json::Value::String("x".to_string()),
+            Value::String("x".to_string()),
         )]));
 
         app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)).unwrap();
@@ -38095,7 +38095,7 @@ mod tests {
         app.sync_layout((100, 16));
         app.config.keys.apply_for_test(&HashMap::from([(
             "provider-menu".to_string(),
-            serde_json::Value::String("j".to_string()),
+            Value::String("j".to_string()),
         )]));
 
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)).unwrap();


### PR DESCRIPTION
Follow-up for the clippy regression introduced by #10704.

The two provider-menu tests use `serde_json::Value` through the existing test-module import. Remove the redundant module qualification so the Linux and macOS `cargo clippy --workspace --all-targets --locked -- -D warnings` jobs pass.

This is separate from the merged relay wire fix in #10723. Hosted cmux-tui verification only; no local Rust or Zig commands were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790243839&installation_model_id=21920&pr_number=10729&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10729&signature=d234f1f796ca62d097b85f91081cec03f45ad56b5fb4b9ee701526248d37c61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Clippy lints in the TUI provider-menu tests by using the imported `Value` instead of `serde_json::Value`. This removes redundant module qualification.

- Restores passing `cargo clippy --workspace --all-targets --locked -- -D warnings` on Linux and macOS CI.
- Tests only; no runtime behavior changes.

<sup>Written for commit 0fa12145a53bfefed41fd79c91b94bfdf70237c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration values to use a more concise representation.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->