### PR TITLE
web: relay access-control hook POST /api/relay/allow (iroh-relay HTTP access mode)

### DIFF
--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -1,0 +1,163 @@
+// Per-connection access-control hook for the self-hosted relay fleet.
+// iroh-relay 1.0.3 HTTP access mode: the relay POSTs for each connecting
+// endpoint and grants access only on HTTP 200 with response text exactly
+// `true`; every other status or body is a deny. JSON `true`/`false` IS that
+// exact text, so the body stays JSON without breaking the contract.
+//
+// Auth is a shared-secret HMAC (CMUX_RELAY_ALLOW_HMAC_SECRET_B64): base64url
+// HMAC-SHA256 over the raw request body. Upstream iroh-relay sends an empty
+// body and can only attach a static bearer token, so the fleet is configured
+// with `bearer_token = relayAllowSignature(secret, empty)`; a relay-side
+// caller that sends the JSON body form signs that body instead. Unset secret
+// means 503: admissions of NEW endpoints fail closed, the relay side carries
+// availability through its allow cache.
+
+import { env } from "../../../env";
+import { jsonResponse } from "../../../../services/relay/http";
+import {
+  RELAY_ALLOW_SIGNATURE_HEADER,
+  parseRelayAllowSecret,
+  relayAllowAdmission,
+  verifyRelayAllowSignature,
+  type RelayAllowAdmission,
+} from "../../../../services/relay/allow";
+
+const MAX_BODY_BYTES = 4 * 1_024;
+// Suggested relay-side cache TTLs, surfaced as standard cache hints. Allow
+// decisions are safe to reuse for an hour; denials stay short so a fresh
+// registration or an un-wedged account is admitted quickly.
+const ALLOW_CACHE_SECONDS = 3_600;
+const DENY_CACHE_SECONDS = 60;
+// iroh-relay 1.0.3 sends the hex EndpointId in this header (constant
+// X_IROH_ENDPOINT_ID = "X-Iroh-NodeId" in its src/main.rs).
+const ENDPOINT_ID_HEADER = "x-iroh-nodeid";
+const ENDPOINT_ID_RE = /^[0-9a-f]{64}$/;
+
+export interface RelayAllowDeps {
+  readonly secretBase64: () => string | undefined;
+  readonly admission: (endpointId: string) => Promise<RelayAllowAdmission>;
+}
+
+const productionDeps: RelayAllowDeps = {
+  secretBase64: () => env.CMUX_RELAY_ALLOW_HMAC_SECRET_B64,
+  admission: relayAllowAdmission,
+};
+
+export async function handleRelayAllowRequest(
+  request: Request,
+  deps: RelayAllowDeps,
+): Promise<Response> {
+  const secret = parseRelayAllowSecret(deps.secretBase64());
+  if (!secret) return jsonResponse({ error: "relay_allow_not_configured" }, 503);
+
+  const body = await readBoundedBody(request);
+  if (!body.ok) return body.response;
+
+  const provided = providedSignature(request);
+  if (!provided || !verifyRelayAllowSignature(secret, body.bytes, provided)) {
+    return jsonResponse({ error: "invalid_relay_allow_signature" }, 401);
+  }
+
+  const endpointId = extractEndpointId(request, body.bytes);
+  if (endpointId instanceof Response) return endpointId;
+
+  try {
+    return admissionResponse(await deps.admission(endpointId));
+  } catch {
+    // Never log EndpointIDs; the route and failure class are enough.
+    console.error("relay allow admission failed", { failure: "unexpected" });
+    return jsonResponse({ error: "relay_allow_unavailable" }, 503);
+  }
+}
+
+function providedSignature(request: Request): string | null {
+  const header = request.headers.get(RELAY_ALLOW_SIGNATURE_HEADER)?.trim();
+  if (header) return header;
+  const authorization = request.headers.get("authorization")?.trim();
+  if (!authorization || !/^bearer /i.test(authorization)) return null;
+  return authorization.slice("bearer ".length).trim() || null;
+}
+
+function extractEndpointId(
+  request: Request,
+  bodyBytes: Uint8Array,
+): string | Response {
+  const header = request.headers.get(ENDPOINT_ID_HEADER)?.trim().toLowerCase();
+  if (header) {
+    return ENDPOINT_ID_RE.test(header)
+      ? header
+      : jsonResponse({ error: "invalid_endpoint_id" }, 400);
+  }
+  if (bodyBytes.byteLength === 0) {
+    return jsonResponse({ error: "missing_endpoint_id" }, 400);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(bodyBytes).toString("utf8"));
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, 400);
+  }
+  const candidate = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>).endpointId
+    : undefined;
+  if (typeof candidate !== "string") {
+    return jsonResponse({ error: "missing_endpoint_id" }, 400);
+  }
+  const endpointId = candidate.trim().toLowerCase();
+  return ENDPOINT_ID_RE.test(endpointId)
+    ? endpointId
+    : jsonResponse({ error: "invalid_endpoint_id" }, 400);
+}
+
+function admissionResponse(admission: RelayAllowAdmission): Response {
+  const allow = admission === "allow";
+  // The body MUST be exactly `true` to grant; JSON true serializes to that
+  // exact text. Cache hints let the relay honor server-suggested TTLs.
+  return new Response(allow ? "true" : "false", {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": `max-age=${allow ? ALLOW_CACHE_SECONDS : DENY_CACHE_SECONDS}`,
+    },
+  });
+}
+
+async function readBoundedBody(request: Request): Promise<
+  | { readonly ok: true; readonly bytes: Uint8Array }
+  | { readonly ok: false; readonly response: Response }
+> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > MAX_BODY_BYTES) {
+      return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+    }
+  }
+  const reader = request.body?.getReader();
+  // iroh-relay's access-mode POST carries no body at all.
+  if (!reader) return { ok: true, bytes: new Uint8Array() };
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        await reader.cancel();
+        return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+      }
+      chunks.push(next.value);
+    }
+  } catch {
+    return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
+  }
+  return {
+    ok: true,
+    bytes: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total),
+  };
+}
+
+export function POST(request: Request): Promise<Response> {
+  return handleRelayAllowRequest(request, productionDeps);
+}

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -124,13 +124,11 @@ function extractEndpointId(
   bodyBytes: Uint8Array,
 ): string | Response {
   const header = request.headers.get(ENDPOINT_ID_HEADER)?.trim().toLowerCase();
-  if (header) {
-    return ENDPOINT_ID_RE.test(header)
-      ? header
-      : jsonResponse({ error: "invalid_endpoint_id" }, 400);
+  if (header && !ENDPOINT_ID_RE.test(header)) {
+    return jsonResponse({ error: "invalid_endpoint_id" }, 400);
   }
   if (bodyBytes.byteLength === 0) {
-    return jsonResponse({ error: "missing_endpoint_id" }, 400);
+    return header ? header : jsonResponse({ error: "missing_endpoint_id" }, 400);
   }
   let parsed: unknown;
   try {
@@ -145,9 +143,17 @@ function extractEndpointId(
     return jsonResponse({ error: "missing_endpoint_id" }, 400);
   }
   const endpointId = candidate.trim().toLowerCase();
-  return ENDPOINT_ID_RE.test(endpointId)
-    ? endpointId
-    : jsonResponse({ error: "invalid_endpoint_id" }, 400);
+  if (!ENDPOINT_ID_RE.test(endpointId)) {
+    return jsonResponse({ error: "invalid_endpoint_id" }, 400);
+  }
+  // The HMAC covers only the raw body, so a non-empty signed body is the
+  // authoritative identity source. An unsigned header that disagrees would
+  // let a captured body-signed request be re-targeted to a different
+  // endpoint; reject the conflict instead of picking either side.
+  if (header && header !== endpointId) {
+    return jsonResponse({ error: "conflicting_endpoint_id" }, 400);
+  }
+  return endpointId;
 }
 
 function admissionResponse(admission: RelayAllowAdmission): Response {

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -23,9 +23,14 @@ import {
 } from "../../../../services/relay/allow";
 
 const MAX_BODY_BYTES = 4 * 1_024;
-// Bound the admission lookup so a stalled database query cannot hold the
-// relay's per-connection access check (and with it every new endpoint
-// admission) until some external timeout. Expiry fails closed to 503.
+// Response-latency bound for the admission lookup, so a stalled database
+// query cannot hold the relay's per-connection access check (and with it
+// every new endpoint admission) until some external timeout. Expiry fails
+// closed to 503. The real resource bound is server-side: the admission
+// transaction sets a shorter statement_timeout
+// (RELAY_ALLOW_STATEMENT_TIMEOUT_MS), so Postgres cancels a stalled query
+// and frees the pooled connection instead of leaving abandoned work in
+// flight behind this deadline.
 const ADMISSION_TIMEOUT_MS = 3_000;
 // iroh-relay 1.0.3 sends the hex EndpointId in this header (constant
 // X_IROH_ENDPOINT_ID = "X-Iroh-NodeId" in its src/main.rs).
@@ -75,9 +80,14 @@ async function admissionWithDeadline(
   endpointId: string,
 ): Promise<RelayAllowAdmission> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const admission = deps.admission(endpointId);
+  // A lookup that settles (typically rejecting on the database-side
+  // statement_timeout) after losing the race must not surface as an
+  // unhandled rejection.
+  admission.catch(() => undefined);
   try {
     return await Promise.race([
-      deps.admission(endpointId),
+      admission,
       new Promise<never>((_, reject) => {
         timer = setTimeout(
           () => reject(new Error("relay_allow_admission_timeout")),

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -23,11 +23,10 @@ import {
 } from "../../../../services/relay/allow";
 
 const MAX_BODY_BYTES = 4 * 1_024;
-// Suggested relay-side cache TTLs, surfaced as standard cache hints. Allow
-// decisions are safe to reuse for an hour; denials stay short so a fresh
-// registration or an un-wedged account is admitted quickly.
-const ALLOW_CACHE_SECONDS = 3_600;
-const DENY_CACHE_SECONDS = 60;
+// Bound the admission lookup so a stalled database query cannot hold the
+// relay's per-connection access check (and with it every new endpoint
+// admission) until some external timeout. Expiry fails closed to 503.
+const ADMISSION_TIMEOUT_MS = 3_000;
 // iroh-relay 1.0.3 sends the hex EndpointId in this header (constant
 // X_IROH_ENDPOINT_ID = "X-Iroh-NodeId" in its src/main.rs).
 const ENDPOINT_ID_HEADER = "x-iroh-nodeid";
@@ -36,6 +35,7 @@ const ENDPOINT_ID_RE = /^[0-9a-f]{64}$/;
 export interface RelayAllowDeps {
   readonly secretBase64: () => string | undefined;
   readonly admission: (endpointId: string) => Promise<RelayAllowAdmission>;
+  readonly admissionTimeoutMs?: number;
 }
 
 const productionDeps: RelayAllowDeps = {
@@ -62,11 +62,33 @@ export async function handleRelayAllowRequest(
   if (endpointId instanceof Response) return endpointId;
 
   try {
-    return admissionResponse(await deps.admission(endpointId));
+    return admissionResponse(await admissionWithDeadline(deps, endpointId));
   } catch {
     // Never log EndpointIDs; the route and failure class are enough.
     console.error("relay allow admission failed", { failure: "unexpected" });
     return jsonResponse({ error: "relay_allow_unavailable" }, 503);
+  }
+}
+
+async function admissionWithDeadline(
+  deps: RelayAllowDeps,
+  endpointId: string,
+): Promise<RelayAllowAdmission> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      deps.admission(endpointId),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("relay_allow_admission_timeout")),
+          deps.admissionTimeoutMs ?? ADMISSION_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    // Cancel the deadline as soon as the lookup settles so no timer outlives
+    // the request.
+    clearTimeout(timer);
   }
 }
 
@@ -112,12 +134,17 @@ function extractEndpointId(
 function admissionResponse(admission: RelayAllowAdmission): Response {
   const allow = admission === "allow";
   // The body MUST be exactly `true` to grant; JSON true serializes to that
-  // exact text. Cache hints let the relay honor server-suggested TTLs.
+  // exact text. Always no-store: the endpoint identity rides the
+  // X-Iroh-NodeId header of an otherwise identical POST, so any intermediary
+  // HTTP cache would serve one endpoint's decision to a different endpoint,
+  // and a cached allow would outlive revocation. Decision caching keyed by
+  // endpoint id belongs to the relay consumer (CMUX_RELAY_ALLOW_CACHE_SECS
+  // in manaflow-ai/cmux-relay).
   return new Response(allow ? "true" : "false", {
     status: 200,
     headers: {
       "content-type": "application/json",
-      "cache-control": `max-age=${allow ? ALLOW_CACHE_SECONDS : DENY_CACHE_SECONDS}`,
+      "cache-control": "no-store",
     },
   });
 }

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -23,14 +23,19 @@ import {
 } from "../../../../services/relay/allow";
 
 const MAX_BODY_BYTES = 4 * 1_024;
+// The byte limit alone does not stop a slowloris client that trickles (or
+// never finishes) an unauthenticated body to occupy the handler. The read
+// deadline cancels the request stream itself on expiry.
+const BODY_READ_TIMEOUT_MS = 5_000;
 // Response-latency bound for the admission lookup, so a stalled database
 // query cannot hold the relay's per-connection access check (and with it
 // every new endpoint admission) until some external timeout. Expiry fails
-// closed to 503. The real resource bound is server-side: the admission
-// transaction sets a shorter statement_timeout
-// (RELAY_ALLOW_STATEMENT_TIMEOUT_MS), so Postgres cancels a stalled query
-// and frees the pooled connection instead of leaving abandoned work in
-// flight behind this deadline.
+// closed to 503. The resource bounds live in services/relay/allow.ts: the
+// admission transaction sets a shorter statement_timeout
+// (RELAY_ALLOW_STATEMENT_TIMEOUT_MS) so Postgres cancels an executing query
+// and frees the pooled connection, and a hard concurrency cap
+// (RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS) bounds retained work even when a
+// stall happens before execution, where no cancellation handle exists.
 const ADMISSION_TIMEOUT_MS = 3_000;
 // iroh-relay 1.0.3 sends the hex EndpointId in this header (constant
 // X_IROH_ENDPOINT_ID = "X-Iroh-NodeId" in its src/main.rs).
@@ -41,6 +46,7 @@ export interface RelayAllowDeps {
   readonly secretBase64: () => string | undefined;
   readonly admission: (endpointId: string) => Promise<RelayAllowAdmission>;
   readonly admissionTimeoutMs?: number;
+  readonly bodyReadTimeoutMs?: number;
 }
 
 const productionDeps: RelayAllowDeps = {
@@ -55,7 +61,10 @@ export async function handleRelayAllowRequest(
   const secret = parseRelayAllowSecret(deps.secretBase64());
   if (!secret) return jsonResponse({ error: "relay_allow_not_configured" }, 503);
 
-  const body = await readBoundedBody(request);
+  const body = await readBoundedBody(
+    request,
+    deps.bodyReadTimeoutMs ?? BODY_READ_TIMEOUT_MS,
+  );
   if (!body.ok) return body.response;
 
   const provided = providedSignature(request);
@@ -159,7 +168,10 @@ function admissionResponse(admission: RelayAllowAdmission): Response {
   });
 }
 
-async function readBoundedBody(request: Request): Promise<
+async function readBoundedBody(
+  request: Request,
+  timeoutMs: number,
+): Promise<
   | { readonly ok: true; readonly bytes: Uint8Array }
   | { readonly ok: false; readonly response: Response }
 > {
@@ -175,6 +187,13 @@ async function readBoundedBody(request: Request): Promise<
   if (!reader) return { ok: true, bytes: new Uint8Array() };
   const chunks: Uint8Array[] = [];
   let total = 0;
+  let timedOut = false;
+  // Cancelling the reader on expiry resolves the pending read() and releases
+  // the underlying stream: real cancellation, not an abandoned promise.
+  const timer = setTimeout(() => {
+    timedOut = true;
+    void reader.cancel().catch(() => undefined);
+  }, timeoutMs);
   try {
     while (true) {
       const next = await reader.read();
@@ -187,7 +206,14 @@ async function readBoundedBody(request: Request): Promise<
       chunks.push(next.value);
     }
   } catch {
-    return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
+    if (!timedOut) {
+      return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+  if (timedOut) {
+    return { ok: false, response: jsonResponse({ error: "request_read_timeout" }, 408) };
   }
   return {
     ok: true,

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -324,6 +324,12 @@ export const env = createEnv({
     // Optional dedicated rule. Preferences deliberately fall back to the token
     // rule so existing deployments keep one shared account-scoped limiter.
     CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: z.string().min(1).optional(),
+    // Shared secret for the relay fleet's per-connection access-control hook
+    // (POST /api/relay/allow). Optional: when unset the route answers 503 and
+    // the fleet fails closed for new endpoint admissions. Same base64 shape as
+    // CMUX_IROH_MINT_HMAC_SECRET_B64.
+    CMUX_RELAY_ALLOW_HMAC_SECRET_B64:
+      z.string().max(512).regex(/^[A-Za-z0-9+/]{43,}={0,2}$/).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -420,6 +426,9 @@ export const env = createEnv({
     CMUX_RELAY_TOKEN_RATE_LIMIT_ID: trimEnv(process.env.CMUX_RELAY_TOKEN_RATE_LIMIT_ID),
     CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: trimEnv(
       process.env.CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID,
+    ),
+    CMUX_RELAY_ALLOW_HMAC_SECRET_B64: trimEnv(
+      process.env.CMUX_RELAY_ALLOW_HMAC_SECRET_B64,
     ),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,

--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -23,7 +23,10 @@ const globalForDb = globalThis as typeof globalThis & {
   __cmuxCloudDb?: CloudDbState;
 };
 
-export function createAwsRdsIamPool(config: CloudDbAwsRdsIamConfig): Pool {
+export function createAwsRdsIamPool(
+  config: CloudDbAwsRdsIamConfig,
+  overrides: Partial<ConstructorParameters<typeof Pool>[0] & object> = {},
+): Pool {
   const signer = new Signer({
     hostname: config.host,
     port: config.port,
@@ -46,6 +49,7 @@ export function createAwsRdsIamPool(config: CloudDbAwsRdsIamConfig): Pool {
       ...(config.sslCaPem ? { ca: config.sslCaPem } : {}),
     },
     max: config.poolMax,
+    ...overrides,
   });
 }
 

--- a/web/services/account/deletionLock.ts
+++ b/web/services/account/deletionLock.ts
@@ -75,7 +75,7 @@ export function isBlockingAccountDeletionTombstone(
 }
 
 export async function hasBlockingAccountDeletionIdentity(
-  db: ReturnType<typeof cloudDb>,
+  db: AccountDeletionQueryExecutor,
   userIds: readonly string[],
 ): Promise<boolean> {
   const userIdHashes = uniqueAccountDeletionIdentityHashes(userIds);

--- a/web/services/account/deletionLock.ts
+++ b/web/services/account/deletionLock.ts
@@ -75,7 +75,7 @@ export function isBlockingAccountDeletionTombstone(
 }
 
 export async function hasBlockingAccountDeletionIdentity(
-  db: AccountDeletionQueryExecutor,
+  db: ReturnType<typeof cloudDb>,
   userIds: readonly string[],
 ): Promise<boolean> {
   const userIdHashes = uniqueAccountDeletionIdentityHashes(userIds);

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -165,6 +165,17 @@ function admissionClient(): AdmissionClientState {
   const key = cloudDbConfigKey(config);
   const cached = globalForAdmission.__cmuxRelayAllowAdmission;
   if (cached?.key === key) return cached;
+  if (cached) {
+    // The database config rotated within this runtime: drop the stale client
+    // and close it so its pool is not retained alongside the replacement.
+    // In-flight lookups hold their own reference and settle under their phase
+    // deadlines; close() (pool.end / sql.end) waits for them, so this cannot
+    // interrupt an admission already running.
+    globalForAdmission.__cmuxRelayAllowAdmission = undefined;
+    void cached.close().catch(() => {
+      // Best-effort teardown; the replacement client is unaffected.
+    });
+  }
 
   let state: AdmissionClientState;
   if (config.driver === "aws-rds-iam") {

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -76,6 +76,18 @@ export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
  */
 export const RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS = 16;
 
+/**
+ * Upper bound on how long one admission holds its slot. A slot is released
+ * when its operation settles OR when this lease expires, whichever comes
+ * first, so operations that never settle cannot keep the instance saturated
+ * after the database recovers. The lease sits above every legitimate settle
+ * path (2.5 s statement_timeout, the drivers' ~30 s connect timeouts), so it
+ * only fires for operations that are already stuck; those keep at most one
+ * pooled connection each, which the pool's own max bounds, while admission
+ * capacity comes back within one lease.
+ */
+export const RELAY_ALLOW_ADMISSION_SLOT_TTL_MS = 45_000;
+
 export class RelayAllowAdmissionSaturatedError extends Error {
   constructor() {
     super("relay allow admission concurrency saturated");
@@ -85,18 +97,33 @@ export class RelayAllowAdmissionSaturatedError extends Error {
 
 let inFlightAdmissions = 0;
 
-/** Runs one admission under the concurrency cap; rejects when saturated. */
+/**
+ * Runs one admission under the concurrency cap; rejects when saturated. The
+ * slot lease is settle-or-expiry: release is idempotent, so an operation that
+ * settles after its lease expired does not double-free another slot.
+ */
 export async function withRelayAllowAdmissionSlot<T>(
   operation: () => Promise<T>,
+  slotTtlMs: number = RELAY_ALLOW_ADMISSION_SLOT_TTL_MS,
 ): Promise<T> {
   if (inFlightAdmissions >= RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS) {
     throw new RelayAllowAdmissionSaturatedError();
   }
   inFlightAdmissions += 1;
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    inFlightAdmissions -= 1;
+  };
+  const lease = setTimeout(release, slotTtlMs);
+  // Do not keep a long-lived process alive just for a lease backstop.
+  lease.unref?.();
   try {
     return await operation();
   } finally {
-    inFlightAdmissions -= 1;
+    clearTimeout(lease);
+    release();
   }
 }
 

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -65,12 +65,54 @@ export function verifyRelayAllowSignature(
 export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
 
 /**
+ * Hard cap on concurrently running admission lookups per runtime instance.
+ * statement_timeout bounds an executing query, but a stall BEFORE execution
+ * (pool checkout, connection establishment, a network black hole) can leave
+ * an admission promise pending after its request already answered 503, and
+ * the driver exposes no abort signal to cancel it. The cap makes retained
+ * work bounded by construction: at most this many admission operations exist
+ * at once, and a saturated instance rejects immediately (the route's 503,
+ * which the relay treats as deny and retries later) instead of queueing.
+ */
+export const RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS = 16;
+
+export class RelayAllowAdmissionSaturatedError extends Error {
+  constructor() {
+    super("relay allow admission concurrency saturated");
+    this.name = "RelayAllowAdmissionSaturatedError";
+  }
+}
+
+let inFlightAdmissions = 0;
+
+/** Runs one admission under the concurrency cap; rejects when saturated. */
+export async function withRelayAllowAdmissionSlot<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (inFlightAdmissions >= RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS) {
+    throw new RelayAllowAdmissionSaturatedError();
+  }
+  inFlightAdmissions += 1;
+  try {
+    return await operation();
+  } finally {
+    inFlightAdmissions -= 1;
+  }
+}
+
+/**
  * Admitted iff the endpoint has an active (non-revoked) binding whose account
  * has no blocking deletion tombstone. The partial unique index
  * `iroh_endpoint_bindings_active_endpoint_unique` guarantees at most one
  * active binding per EndpointId across all accounts.
  */
 export async function relayAllowAdmission(
+  endpointId: string,
+): Promise<RelayAllowAdmission> {
+  return await withRelayAllowAdmissionSlot(() => admissionLookup(endpointId));
+}
+
+async function admissionLookup(
   endpointId: string,
 ): Promise<RelayAllowAdmission> {
   const db = cloudDb();

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -1,0 +1,80 @@
+// Backend half of the relay fleet's per-connection access-control hook.
+// iroh-relay 1.0.3 (src/main.rs, `AccessConfig::Http`) POSTs once per
+// connecting endpoint with NO body, the hex EndpointId in the `X-Iroh-NodeId`
+// header, and an optional static `Authorization: Bearer <token>`. The relay
+// proves key ownership in its handshake before calling, so the EndpointId is
+// trustworthy; this side only decides whether that endpoint is admitted.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { irohEndpointBindings } from "../../db/schema";
+import { hasBlockingAccountDeletionIdentity } from "../account/deletionLock";
+
+export const RELAY_ALLOW_SIGNATURE_HEADER = "x-cmux-relay-allow-signature";
+
+export type RelayAllowAdmission = "allow" | "deny";
+
+/**
+ * Same canonical-base64 rules as the iroh minter secret, but a missing or
+ * malformed value returns null so the route can answer 503 (fail closed for
+ * admissions of new endpoints) instead of throwing.
+ */
+export function parseRelayAllowSecret(value: string | undefined): Buffer | null {
+  if (!value || value.length > 512) return null;
+  const decoded = Buffer.from(value, "base64");
+  const canonicalPadded = decoded.toString("base64");
+  const canonicalUnpadded = canonicalPadded.replace(/=+$/, "");
+  if (
+    decoded.byteLength < 32 ||
+    decoded.byteLength > 256 ||
+    (value !== canonicalPadded && value !== canonicalUnpadded)
+  ) {
+    return null;
+  }
+  return decoded;
+}
+
+/** base64url HMAC-SHA256 over the raw request body bytes (empty body included). */
+export function relayAllowSignature(secret: Buffer, body: Uint8Array): string {
+  return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
+export function verifyRelayAllowSignature(
+  secret: Buffer,
+  body: Uint8Array,
+  provided: string,
+): boolean {
+  // 32 HMAC-SHA256 bytes are exactly 43 unpadded base64url characters.
+  if (!/^[A-Za-z0-9_-]{43}$/.test(provided)) return false;
+  const expected = createHmac("sha256", secret).update(body).digest();
+  const candidate = Buffer.from(provided, "base64url");
+  return candidate.byteLength === expected.byteLength &&
+    timingSafeEqual(candidate, expected);
+}
+
+/**
+ * Admitted iff the endpoint has an active (non-revoked) binding whose account
+ * has no blocking deletion tombstone. The partial unique index
+ * `iroh_endpoint_bindings_active_endpoint_unique` guarantees at most one
+ * active binding per EndpointId across all accounts.
+ */
+export async function relayAllowAdmission(
+  endpointId: string,
+): Promise<RelayAllowAdmission> {
+  const db = cloudDb();
+  const [binding] = await db
+    .select({ userId: irohEndpointBindings.userId })
+    .from(irohEndpointBindings)
+    .where(and(
+      eq(irohEndpointBindings.endpointId, endpointId),
+      isNull(irohEndpointBindings.revokedAt),
+    ))
+    .limit(1);
+  if (!binding) return "deny";
+  if (await hasBlockingAccountDeletionIdentity(db, [binding.userId])) {
+    return "deny";
+  }
+  return "allow";
+}

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -6,7 +6,7 @@
 // trustworthy; this side only decides whether that endpoint is admitted.
 
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { irohEndpointBindings } from "../../db/schema";
@@ -55,6 +55,16 @@ export function verifyRelayAllowSignature(
 }
 
 /**
+ * Server-side execution bound for the admission queries. Postgres cancels a
+ * query that exceeds it and returns the pooled connection, so a stalled
+ * lookup cannot accumulate in-flight work while the route's own deadline
+ * (slightly longer, see the route) bounds the response. Kept below that
+ * deadline so the database usually cancels first and the route answers its
+ * clean fail-closed 503 through the ordinary error path.
+ */
+export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
+
+/**
  * Admitted iff the endpoint has an active (non-revoked) binding whose account
  * has no blocking deletion tombstone. The partial unique index
  * `iroh_endpoint_bindings_active_endpoint_unique` guarantees at most one
@@ -64,17 +74,30 @@ export async function relayAllowAdmission(
   endpointId: string,
 ): Promise<RelayAllowAdmission> {
   const db = cloudDb();
-  const [binding] = await db
-    .select({ userId: irohEndpointBindings.userId })
-    .from(irohEndpointBindings)
-    .where(and(
-      eq(irohEndpointBindings.endpointId, endpointId),
-      isNull(irohEndpointBindings.revokedAt),
-    ))
-    .limit(1);
-  if (!binding) return "deny";
-  if (await hasBlockingAccountDeletionIdentity(db, [binding.userId])) {
-    return "deny";
-  }
-  return "allow";
+  return await db.transaction(async (tx) => {
+    // SET LOCAL via set_config: scoped to this transaction, cancels the
+    // statement server-side on expiry (error 57014 -> the route's 503).
+    await tx.execute(sql`
+      select set_config(
+        'statement_timeout',
+        ${String(RELAY_ALLOW_STATEMENT_TIMEOUT_MS)},
+        true
+      )
+    `);
+    const [binding] = await tx
+      .select({ userId: irohEndpointBindings.userId })
+      .from(irohEndpointBindings)
+      .where(and(
+        eq(irohEndpointBindings.endpointId, endpointId),
+        isNull(irohEndpointBindings.revokedAt),
+      ))
+      .limit(1);
+    if (!binding) return "deny" as const;
+    // Reads through the same transaction so the tombstone check shares this
+    // transaction's statement_timeout.
+    if (await hasBlockingAccountDeletionIdentity(tx, [binding.userId])) {
+      return "deny" as const;
+    }
+    return "allow" as const;
+  });
 }

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -4,17 +4,87 @@
 // header, and an optional static `Authorization: Bearer <token>`. The relay
 // proves key ownership in its handshake before calling, so the EndpointId is
 // trustworthy; this side only decides whether that endpoint is admitted.
+//
+// The admission lookup deliberately does NOT borrow the shared cloudDb
+// client: its pool checkout and connection phases have no deadline there, so
+// a stalled operation could neither be cancelled nor be counted on to settle.
+// Instead the admission path owns a dedicated client sized to its concurrency
+// cap with a hard bound on every phase (connect, checkout, execution, plus a
+// client-side cancel), so every admission operation settles within a known
+// bound and the concurrency slots — released strictly at settlement — bound
+// retained work without ever staying saturated after an outage heals.
 
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { attachDatabasePool } from "@vercel/functions";
+import type { Pool } from "pg";
+import postgres, { type Sql } from "postgres";
 
-import { cloudDb } from "../../db/client";
-import { irohEndpointBindings } from "../../db/schema";
-import { hasBlockingAccountDeletionIdentity } from "../account/deletionLock";
+import { createAwsRdsIamPool } from "../../db/client";
+import { cloudDbConfig, cloudDbConfigKey } from "../../db/config";
+import { isBlockingAccountDeletionTombstone } from "../account/deletionLock";
 
 export const RELAY_ALLOW_SIGNATURE_HEADER = "x-cmux-relay-allow-signature";
 
 export type RelayAllowAdmission = "allow" | "deny";
+
+/**
+ * Hard cap on concurrently running admission lookups per runtime instance,
+ * and the size of the dedicated admission pool. Cap == pool max means no
+ * admission ever queues inside the driver; a saturated instance rejects
+ * immediately (the route's fail-closed 503, which the relay treats as deny
+ * and retries later). Slots release strictly when their operation settles,
+ * and settlement is guaranteed by the phase deadlines below, so the cap is a
+ * true bound on retained work AND the instance always recovers.
+ */
+export const RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS = 16;
+
+/**
+ * Server-side statement_timeout, set as a session parameter on every
+ * admission connection: Postgres cancels an executing statement and frees
+ * the connection.
+ */
+export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
+
+/**
+ * Client-side settle bound. postgres.js: a timer calls query.cancel(), which
+ * rejects the query whether it is still queued or already executing. pg: the
+ * pool's query_timeout enforces the same bound. Slightly above the statement
+ * timeout so the server usually cancels first.
+ */
+export const RELAY_ALLOW_LOOKUP_SETTLE_MS = 4_000;
+
+/** Connection-establishment (and, for pg, checkout-wait) deadline. */
+const CONNECT_TIMEOUT_MS = 5_000;
+const IDLE_TIMEOUT_SECONDS = 60;
+
+export class RelayAllowAdmissionSaturatedError extends Error {
+  constructor() {
+    super("relay allow admission concurrency saturated");
+    this.name = "RelayAllowAdmissionSaturatedError";
+  }
+}
+
+let inFlightAdmissions = 0;
+
+/**
+ * Runs one admission under the concurrency cap; rejects when saturated. The
+ * slot is held until the operation settles — never released early — which is
+ * safe because every admission operation is deadline-bounded at each phase
+ * and therefore always settles.
+ */
+export async function withRelayAllowAdmissionSlot<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (inFlightAdmissions >= RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS) {
+    throw new RelayAllowAdmissionSaturatedError();
+  }
+  inFlightAdmissions += 1;
+  try {
+    return await operation();
+  } finally {
+    inFlightAdmissions -= 1;
+  }
+}
 
 /**
  * Same canonical-base64 rules as the iroh minter secret, but a missing or
@@ -54,77 +124,106 @@ export function verifyRelayAllowSignature(
     timingSafeEqual(candidate, expected);
 }
 
-/**
- * Server-side execution bound for the admission queries. Postgres cancels a
- * query that exceeds it and returns the pooled connection, so a stalled
- * lookup cannot accumulate in-flight work while the route's own deadline
- * (slightly longer, see the route) bounds the response. Kept below that
- * deadline so the database usually cancels first and the route answers its
- * clean fail-closed 503 through the ordinary error path.
- */
-export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
+type AdmissionRow = {
+  readonly userId: string;
+  readonly tombstoneStatus: string | null;
+  readonly tombstoneUpdatedAt: Date | null;
+  readonly tombstoneAnalyticsDeletedAt: Date | null;
+};
 
-/**
- * Hard cap on concurrently running admission lookups per runtime instance.
- * statement_timeout bounds an executing query, but a stall BEFORE execution
- * (pool checkout, connection establishment, a network black hole) can leave
- * an admission promise pending after its request already answered 503, and
- * the driver exposes no abort signal to cancel it. The cap makes retained
- * work bounded by construction: at most this many admission operations exist
- * at once, and a saturated instance rejects immediately (the route's 503,
- * which the relay treats as deny and retries later) instead of queueing.
- */
-export const RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS = 16;
+// One round trip: the active binding plus its account's deletion tombstone.
+// encode(sha256(convert_to(user_id, 'UTF8')), 'hex') is byte-for-byte
+// accountDeletionUserHash from services/account/deletionLock.ts; the
+// deletion-blocked case in tests/relay-allow-db-behavior.test.ts pins the
+// equivalence against Postgres.
+const ADMISSION_SQL = `
+  select
+    binding.user_id as "userId",
+    tombstone.status as "tombstoneStatus",
+    tombstone.updated_at as "tombstoneUpdatedAt",
+    tombstone.analytics_deleted_at as "tombstoneAnalyticsDeletedAt"
+  from iroh_endpoint_bindings binding
+  left join account_deletion_tombstones tombstone
+    on tombstone.user_id_hash = encode(sha256(convert_to(binding.user_id, 'UTF8')), 'hex')
+  where binding.endpoint_id = $1
+    and binding.revoked_at is null
+  limit 1
+`;
 
-/**
- * Upper bound on how long one admission holds its slot. A slot is released
- * when its operation settles OR when this lease expires, whichever comes
- * first, so operations that never settle cannot keep the instance saturated
- * after the database recovers. The lease sits above every legitimate settle
- * path (2.5 s statement_timeout, the drivers' ~30 s connect timeouts), so it
- * only fires for operations that are already stuck; those keep at most one
- * pooled connection each, which the pool's own max bounds, while admission
- * capacity comes back within one lease.
- */
-export const RELAY_ALLOW_ADMISSION_SLOT_TTL_MS = 45_000;
+type AdmissionClientState = {
+  readonly key: string;
+  readonly lookup: (endpointId: string) => Promise<AdmissionRow | null>;
+  readonly close: () => Promise<void>;
+};
 
-export class RelayAllowAdmissionSaturatedError extends Error {
-  constructor() {
-    super("relay allow admission concurrency saturated");
-    this.name = "RelayAllowAdmissionSaturatedError";
+const globalForAdmission = globalThis as typeof globalThis & {
+  __cmuxRelayAllowAdmission?: AdmissionClientState;
+};
+
+function admissionClient(): AdmissionClientState {
+  const config = cloudDbConfig();
+  const key = cloudDbConfigKey(config);
+  const cached = globalForAdmission.__cmuxRelayAllowAdmission;
+  if (cached?.key === key) return cached;
+
+  let state: AdmissionClientState;
+  if (config.driver === "aws-rds-iam") {
+    const pool: Pool = createAwsRdsIamPool(config, {
+      max: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
+      // Bounds checkout waits as well as connection establishment.
+      connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+      idleTimeoutMillis: IDLE_TIMEOUT_SECONDS * 1_000,
+      statement_timeout: RELAY_ALLOW_STATEMENT_TIMEOUT_MS,
+      query_timeout: RELAY_ALLOW_LOOKUP_SETTLE_MS,
+    });
+    attachDatabasePool(pool);
+    state = {
+      key,
+      lookup: async (endpointId) => {
+        const result = await pool.query<AdmissionRow>(ADMISSION_SQL, [endpointId]);
+        return result.rows[0] ?? null;
+      },
+      close: () => pool.end(),
+    };
+  } else {
+    const sql: Sql = postgres(config.url, {
+      max: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
+      prepare: false,
+      connect_timeout: Math.ceil(CONNECT_TIMEOUT_MS / 1_000),
+      idle_timeout: IDLE_TIMEOUT_SECONDS,
+      connection: { statement_timeout: RELAY_ALLOW_STATEMENT_TIMEOUT_MS },
+    });
+    state = {
+      key,
+      lookup: async (endpointId) => {
+        const query = sql.unsafe<AdmissionRow[]>(ADMISSION_SQL, [endpointId]);
+        // cancel() rejects the query whether still queued or executing, so
+        // the operation settles even through a pool or network stall.
+        const settleBound = setTimeout(() => {
+          try {
+            query.cancel();
+          } catch {
+            // Cancellation is best-effort; the statement timeout remains.
+          }
+        }, RELAY_ALLOW_LOOKUP_SETTLE_MS);
+        try {
+          const rows = await query;
+          return rows[0] ?? null;
+        } finally {
+          clearTimeout(settleBound);
+        }
+      },
+      close: () => sql.end(),
+    };
   }
+  globalForAdmission.__cmuxRelayAllowAdmission = state;
+  return state;
 }
 
-let inFlightAdmissions = 0;
-
-/**
- * Runs one admission under the concurrency cap; rejects when saturated. The
- * slot lease is settle-or-expiry: release is idempotent, so an operation that
- * settles after its lease expired does not double-free another slot.
- */
-export async function withRelayAllowAdmissionSlot<T>(
-  operation: () => Promise<T>,
-  slotTtlMs: number = RELAY_ALLOW_ADMISSION_SLOT_TTL_MS,
-): Promise<T> {
-  if (inFlightAdmissions >= RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS) {
-    throw new RelayAllowAdmissionSaturatedError();
-  }
-  inFlightAdmissions += 1;
-  let released = false;
-  const release = () => {
-    if (released) return;
-    released = true;
-    inFlightAdmissions -= 1;
-  };
-  const lease = setTimeout(release, slotTtlMs);
-  // Do not keep a long-lived process alive just for a lease backstop.
-  lease.unref?.();
-  try {
-    return await operation();
-  } finally {
-    clearTimeout(lease);
-    release();
-  }
+export async function closeRelayAllowAdmissionClientForTests(): Promise<void> {
+  const state = globalForAdmission.__cmuxRelayAllowAdmission;
+  globalForAdmission.__cmuxRelayAllowAdmission = undefined;
+  await state?.close();
 }
 
 /**
@@ -136,37 +235,21 @@ export async function withRelayAllowAdmissionSlot<T>(
 export async function relayAllowAdmission(
   endpointId: string,
 ): Promise<RelayAllowAdmission> {
-  return await withRelayAllowAdmissionSlot(() => admissionLookup(endpointId));
+  return await withRelayAllowAdmissionSlot(async () => {
+    const row = await admissionClient().lookup(endpointId);
+    if (!row) return "deny" as const;
+    if (tombstoneBlocks(row)) return "deny" as const;
+    return "allow" as const;
+  });
 }
 
-async function admissionLookup(
-  endpointId: string,
-): Promise<RelayAllowAdmission> {
-  const db = cloudDb();
-  return await db.transaction(async (tx) => {
-    // SET LOCAL via set_config: scoped to this transaction, cancels the
-    // statement server-side on expiry (error 57014 -> the route's 503).
-    await tx.execute(sql`
-      select set_config(
-        'statement_timeout',
-        ${String(RELAY_ALLOW_STATEMENT_TIMEOUT_MS)},
-        true
-      )
-    `);
-    const [binding] = await tx
-      .select({ userId: irohEndpointBindings.userId })
-      .from(irohEndpointBindings)
-      .where(and(
-        eq(irohEndpointBindings.endpointId, endpointId),
-        isNull(irohEndpointBindings.revokedAt),
-      ))
-      .limit(1);
-    if (!binding) return "deny" as const;
-    // Reads through the same transaction so the tombstone check shares this
-    // transaction's statement_timeout.
-    if (await hasBlockingAccountDeletionIdentity(tx, [binding.userId])) {
-      return "deny" as const;
-    }
-    return "allow" as const;
+// Same blocking rule as hasBlockingAccountDeletionIdentity in
+// services/account/deletionLock.ts, applied to the joined tombstone columns.
+function tombstoneBlocks(row: AdmissionRow): boolean {
+  if (row.tombstoneStatus === null) return false;
+  if (row.tombstoneAnalyticsDeletedAt !== null) return true;
+  return isBlockingAccountDeletionTombstone({
+    status: row.tombstoneStatus,
+    updatedAt: row.tombstoneUpdatedAt,
   });
 }

--- a/web/tests/relay-allow-db-behavior.test.ts
+++ b/web/tests/relay-allow-db-behavior.test.ts
@@ -9,7 +9,10 @@ import postgres, { type Sql } from "postgres";
 
 import { closeCloudDbForTests } from "../db/client";
 import { accountDeletionUserHash } from "../services/account/deletionLock";
-import { relayAllowAdmission } from "../services/relay/allow";
+import {
+  closeRelayAllowAdmissionClientForTests,
+  relayAllowAdmission,
+} from "../services/relay/allow";
 
 const runDbTests = process.env.CMUX_DB_TEST === "1";
 const dbTest = runDbTests ? test : test.skip;
@@ -42,6 +45,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
+  await closeRelayAllowAdmissionClientForTests();
   await closeCloudDbForTests();
   await sql?.end();
 });

--- a/web/tests/relay-allow-db-behavior.test.ts
+++ b/web/tests/relay-allow-db-behavior.test.ts
@@ -1,0 +1,109 @@
+// Database-backed tests of the real relay admission policy behind
+// POST /api/relay/allow: the route tests fake the admission, so the
+// revokedAt filter and the account-deletion tombstone rule are proven here
+// against Postgres. Gated like tests/iroh-db-behavior.test.ts.
+
+import { afterAll, beforeAll, beforeEach, describe, test, expect } from "bun:test";
+import { randomUUID } from "node:crypto";
+import postgres, { type Sql } from "postgres";
+
+import { closeCloudDbForTests } from "../db/client";
+import { accountDeletionUserHash } from "../services/account/deletionLock";
+import { relayAllowAdmission } from "../services/relay/allow";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+let sql: Sql | null = null;
+
+function requiredSql(): Sql {
+  if (!sql) throw new Error("sql not initialized");
+  return sql;
+}
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  sql = postgres(databaseURL, { max: 4 });
+});
+
+beforeEach(async () => {
+  if (!sql) return;
+  await sql`
+    truncate
+      iroh_relay_token_issuances,
+      iroh_pair_grant_issuances,
+      iroh_registration_challenges,
+      iroh_endpoint_bindings,
+      account_deletion_tombstones
+    restart identity cascade
+  `;
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+async function insertBinding(input: {
+  readonly userId: string;
+  readonly endpointId: string;
+  readonly revokedAt?: Date;
+}): Promise<void> {
+  await requiredSql()`
+    insert into iroh_endpoint_bindings (
+      user_id, device_uuid, app_instance_id, tag, platform, endpoint_id,
+      identity_generation, revoked_at, revoked_reason
+    ) values (
+      ${input.userId}, ${randomUUID()}, ${randomUUID()}, 'stable', 'mac',
+      ${input.endpointId}, 1,
+      ${input.revokedAt ?? null},
+      ${input.revokedAt ? "user_requested" : null}
+    )
+  `;
+}
+
+describe("relay allow admission database policy", () => {
+  dbTest("allows an active binding", async () => {
+    const endpointId = "11".repeat(32);
+    await insertBinding({ userId: "user-allow-active", endpointId });
+    expect(await relayAllowAdmission(endpointId)).toBe("allow");
+  });
+
+  dbTest("denies an unknown endpoint", async () => {
+    expect(await relayAllowAdmission("22".repeat(32))).toBe("deny");
+  });
+
+  dbTest("denies a revoked binding", async () => {
+    const endpointId = "33".repeat(32);
+    await insertBinding({
+      userId: "user-allow-revoked",
+      endpointId,
+      revokedAt: new Date(),
+    });
+    expect(await relayAllowAdmission(endpointId)).toBe("deny");
+  });
+
+  dbTest("denies an active binding while account deletion is in progress", async () => {
+    const endpointId = "44".repeat(32);
+    const userId = "user-allow-deleting";
+    await insertBinding({ userId, endpointId });
+    await requiredSql()`
+      insert into account_deletion_tombstones (user_id_hash, user_id, status, updated_at)
+      values (${accountDeletionUserHash(userId)}, ${userId}, 'pending', now())
+    `;
+    expect(await relayAllowAdmission(endpointId)).toBe("deny");
+  });
+
+  dbTest("readmits after the tombstone records a terminal failed deletion", async () => {
+    const endpointId = "55".repeat(32);
+    const userId = "user-allow-deletion-failed";
+    await insertBinding({ userId, endpointId });
+    await requiredSql()`
+      insert into account_deletion_tombstones (user_id_hash, user_id, status, updated_at)
+      values (${accountDeletionUserHash(userId)}, ${userId}, 'failed', now())
+    `;
+    expect(await relayAllowAdmission(endpointId)).toBe("allow");
+  });
+});

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -6,10 +6,13 @@ import {
   type RelayAllowDeps,
 } from "../app/api/relay/allow/route";
 import {
+  RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
   RELAY_ALLOW_SIGNATURE_HEADER,
+  RelayAllowAdmissionSaturatedError,
   parseRelayAllowSecret,
   relayAllowSignature,
   verifyRelayAllowSignature,
+  withRelayAllowAdmissionSlot,
 } from "../services/relay/allow";
 
 // Pure route tests: deps injection only, nothing leaks into the shared
@@ -203,6 +206,29 @@ describe("POST /api/relay/allow", () => {
     expect(Date.now() - startedAt).toBeLessThan(1_000);
   });
 
+  test("408 within the bound when an unauthenticated body stalls (slowloris)", async () => {
+    const startedAt = Date.now();
+    const response = await handleRelayAllowRequest(
+      new Request("https://cmux.dev/api/relay/allow", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        // A stream that trickles one byte and never finishes.
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0x7b]));
+          },
+        }),
+        // @ts-expect-error duplex is required for stream bodies but absent
+        // from the lib.dom Request typings.
+        duplex: "half",
+      }),
+      deps({ bodyReadTimeoutMs: 25 }),
+    );
+    expect(response.status).toBe(408);
+    expect(await response.text()).not.toBe("true");
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   test("503 (deny at the relay) when the admission lookup throws", async () => {
     const response = await handleRelayAllowRequest(
       relayShapedRequest(ACTIVE_ID),
@@ -213,6 +239,31 @@ describe("POST /api/relay/allow", () => {
       }),
     );
     expect(response.status).toBe(503);
+  });
+});
+
+describe("relay allow admission concurrency cap", () => {
+  test("bounds retained work and rejects immediately when saturated", async () => {
+    const releases: (() => void)[] = [];
+    const held = Array.from(
+      { length: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS },
+      () =>
+        withRelayAllowAdmissionSlot(
+          () =>
+            new Promise<"allow">((resolve) => {
+              releases.push(() => resolve("allow"));
+            }),
+        ),
+    );
+    // Every slot is held by a pending lookup: the next admission must fail
+    // fast (the route's fail-closed 503) instead of queueing more work.
+    await expect(withRelayAllowAdmissionSlot(async () => "allow")).rejects.toThrow(
+      RelayAllowAdmissionSaturatedError,
+    );
+    for (const release of releases) release();
+    await Promise.all(held);
+    // Slots free once lookups settle.
+    expect(await withRelayAllowAdmissionSlot(async () => "allow")).toBe("allow");
   });
 });
 

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -72,17 +72,19 @@ describe("POST /api/relay/allow", () => {
     // iroh-relay compares res.text() == "true" byte-for-byte.
     expect(await response.text()).toBe("true");
     expect(response.headers.get("content-type")).toBe("application/json");
-    expect(response.headers.get("cache-control")).toBe("max-age=3600");
+    // Never cacheable: the endpoint identity rides a header, so a shared HTTP
+    // cache would cross decisions between endpoints and outlive revocation.
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
-  test("denies an unknown endpoint with `false` and a short cache hint", async () => {
+  test("denies an unknown endpoint with `false`, uncacheable", async () => {
     const response = await handleRelayAllowRequest(
       relayShapedRequest(UNKNOWN_ID),
       deps(),
     );
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("false");
-    expect(response.headers.get("cache-control")).toBe("max-age=60");
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
   test("denies a revoked binding", async () => {
@@ -183,6 +185,22 @@ describe("POST /api/relay/allow", () => {
     });
     const response = await handleRelayAllowRequest(request, deps());
     expect(response.status).toBe(400);
+  });
+
+  test("503 within the deadline when the admission lookup stalls", async () => {
+    const startedAt = Date.now();
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID),
+      deps({
+        // Never settles: a stalled database query must not hold the relay's
+        // access check open. The deadline fails closed.
+        admission: () => new Promise<never>(() => {}),
+        admissionTimeoutMs: 25,
+      }),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.text()).not.toBe("true");
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   });
 
   test("503 (deny at the relay) when the admission lookup throws", async () => {

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+
+import {
+  handleRelayAllowRequest,
+  type RelayAllowDeps,
+} from "../app/api/relay/allow/route";
+import {
+  RELAY_ALLOW_SIGNATURE_HEADER,
+  parseRelayAllowSecret,
+  relayAllowSignature,
+  verifyRelayAllowSignature,
+} from "../services/relay/allow";
+
+// Pure route tests: deps injection only, nothing leaks into the shared
+// bun-test module registry, no database.
+const SECRET = randomBytes(32);
+const SECRET_B64 = SECRET.toString("base64");
+const ACTIVE_ID = "0123456789abcdef".repeat(4);
+const REVOKED_ID = "f".repeat(64);
+const UNKNOWN_ID = "e".repeat(64);
+const EMPTY_BODY_SIGNATURE = relayAllowSignature(SECRET, new Uint8Array());
+
+function deps(overrides: Partial<RelayAllowDeps> = {}): RelayAllowDeps {
+  return {
+    secretBase64: () => SECRET_B64,
+    // The production impl treats revoked and unknown identically (deny); the
+    // fake keeps them distinct so both paths are pinned here.
+    admission: async (endpointId) => endpointId === ACTIVE_ID ? "allow" : "deny",
+    ...overrides,
+  };
+}
+
+/** The exact shape iroh-relay 1.0.3 sends: empty body, X-Iroh-NodeId header,
+ * static bearer token (configured as the HMAC of the empty body). */
+function relayShapedRequest(
+  endpointId: string,
+  bearer: string = EMPTY_BODY_SIGNATURE,
+): Request {
+  return new Request("https://cmux.dev/api/relay/allow", {
+    method: "POST",
+    headers: {
+      "X-Iroh-NodeId": endpointId,
+      authorization: `Bearer ${bearer}`,
+    },
+  });
+}
+
+function jsonShapedRequest(
+  body: unknown,
+  signature?: string,
+): Request {
+  const text = JSON.stringify(body);
+  return new Request("https://cmux.dev/api/relay/allow", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      [RELAY_ALLOW_SIGNATURE_HEADER]:
+        signature ?? relayAllowSignature(SECRET, Buffer.from(text, "utf8")),
+    },
+    body: text,
+  });
+}
+
+describe("POST /api/relay/allow", () => {
+  test("admits an active binding with the exact `true` text contract", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID),
+      deps(),
+    );
+    expect(response.status).toBe(200);
+    // iroh-relay compares res.text() == "true" byte-for-byte.
+    expect(await response.text()).toBe("true");
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("cache-control")).toBe("max-age=3600");
+  });
+
+  test("denies an unknown endpoint with `false` and a short cache hint", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(UNKNOWN_ID),
+      deps(),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("false");
+    expect(response.headers.get("cache-control")).toBe("max-age=60");
+  });
+
+  test("denies a revoked binding", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(REVOKED_ID),
+      deps(),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("false");
+  });
+
+  test("accepts the JSON body form signed over the body", async () => {
+    const response = await handleRelayAllowRequest(
+      jsonShapedRequest({ endpointId: ACTIVE_ID }),
+      deps(),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("true");
+  });
+
+  test("lowercases a mixed-case endpoint id before admission", async () => {
+    const observed: string[] = [];
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID.toUpperCase()),
+      deps({
+        admission: async (endpointId) => {
+          observed.push(endpointId);
+          return "allow";
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(observed).toEqual([ACTIVE_ID]);
+  });
+
+  test("401 when the signature is missing", async () => {
+    const request = new Request("https://cmux.dev/api/relay/allow", {
+      method: "POST",
+      headers: { "X-Iroh-NodeId": ACTIVE_ID },
+    });
+    const response = await handleRelayAllowRequest(request, deps());
+    expect(response.status).toBe(401);
+  });
+
+  test("401 when the bearer HMAC is wrong", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID, relayAllowSignature(randomBytes(32), new Uint8Array())),
+      deps(),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("401 when a body signature does not cover the actual body", async () => {
+    // Signature valid for a DIFFERENT endpoint's body: tampering must fail.
+    const response = await handleRelayAllowRequest(
+      jsonShapedRequest(
+        { endpointId: ACTIVE_ID },
+        relayAllowSignature(
+          SECRET,
+          Buffer.from(JSON.stringify({ endpointId: UNKNOWN_ID }), "utf8"),
+        ),
+      ),
+      deps(),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("503 when the shared secret is unset (fail closed)", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID),
+      deps({ secretBase64: () => undefined }),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.text()).not.toBe("true");
+  });
+
+  test("503 when the shared secret is malformed", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID),
+      deps({ secretBase64: () => "not-base64!!" }),
+    );
+    expect(response.status).toBe(503);
+  });
+
+  test("400 on a malformed endpoint id header", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest("zz".repeat(32)),
+      deps(),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.text()).not.toBe("true");
+  });
+
+  test("400 when no endpoint id is present anywhere", async () => {
+    const request = new Request("https://cmux.dev/api/relay/allow", {
+      method: "POST",
+      headers: { authorization: `Bearer ${EMPTY_BODY_SIGNATURE}` },
+    });
+    const response = await handleRelayAllowRequest(request, deps());
+    expect(response.status).toBe(400);
+  });
+
+  test("503 (deny at the relay) when the admission lookup throws", async () => {
+    const response = await handleRelayAllowRequest(
+      relayShapedRequest(ACTIVE_ID),
+      deps({
+        admission: async () => {
+          throw new Error("database unreachable");
+        },
+      }),
+    );
+    expect(response.status).toBe(503);
+  });
+});
+
+describe("relay allow HMAC helpers", () => {
+  test("parseRelayAllowSecret enforces canonical base64 and 32-256 bytes", () => {
+    expect(parseRelayAllowSecret(undefined)).toBeNull();
+    expect(parseRelayAllowSecret("")).toBeNull();
+    expect(parseRelayAllowSecret(randomBytes(16).toString("base64"))).toBeNull();
+    const canonical = parseRelayAllowSecret(SECRET_B64);
+    expect(canonical?.equals(SECRET)).toBe(true);
+    // Unpadded canonical form is accepted too.
+    expect(
+      parseRelayAllowSecret(SECRET_B64.replace(/=+$/, ""))?.equals(SECRET),
+    ).toBe(true);
+  });
+
+  test("verifyRelayAllowSignature rejects wrong length and wrong key", () => {
+    const body = Buffer.from("{}", "utf8");
+    const good = relayAllowSignature(SECRET, body);
+    expect(verifyRelayAllowSignature(SECRET, body, good)).toBe(true);
+    expect(verifyRelayAllowSignature(SECRET, body, good.slice(0, 42))).toBe(false);
+    expect(verifyRelayAllowSignature(SECRET, body, `${good}a`)).toBe(false);
+    expect(
+      verifyRelayAllowSignature(randomBytes(32), body, good),
+    ).toBe(false);
+  });
+});

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -266,21 +266,12 @@ describe("relay allow admission concurrency cap", () => {
     expect(await withRelayAllowAdmissionSlot(async () => "allow")).toBe("allow");
   });
 
-  test("slot leases expire so never-settling operations cannot brick admissions", async () => {
-    // Saturate every slot with operations that never settle, under a short
-    // lease. Recovery must not depend on the operations.
-    const stuck = Array.from(
-      { length: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS },
-      () =>
-        withRelayAllowAdmissionSlot(() => new Promise<never>(() => {}), 20),
-    );
-    for (const promise of stuck) promise.catch(() => undefined);
+  test("a slot held by a rejecting operation is released at settlement", async () => {
     await expect(
-      withRelayAllowAdmissionSlot(async () => "allow", 20),
-    ).rejects.toThrow(RelayAllowAdmissionSaturatedError);
-    // After the lease bound the instance admits again even though the stuck
-    // operations are still pending.
-    await new Promise((resolve) => setTimeout(resolve, 60));
+      withRelayAllowAdmissionSlot(async () => {
+        throw new Error("lookup failed");
+      }),
+    ).rejects.toThrow("lookup failed");
     expect(await withRelayAllowAdmissionSlot(async () => "allow")).toBe("allow");
   });
 });

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -265,6 +265,24 @@ describe("relay allow admission concurrency cap", () => {
     // Slots free once lookups settle.
     expect(await withRelayAllowAdmissionSlot(async () => "allow")).toBe("allow");
   });
+
+  test("slot leases expire so never-settling operations cannot brick admissions", async () => {
+    // Saturate every slot with operations that never settle, under a short
+    // lease. Recovery must not depend on the operations.
+    const stuck = Array.from(
+      { length: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS },
+      () =>
+        withRelayAllowAdmissionSlot(() => new Promise<never>(() => {}), 20),
+    );
+    for (const promise of stuck) promise.catch(() => undefined);
+    await expect(
+      withRelayAllowAdmissionSlot(async () => "allow", 20),
+    ).rejects.toThrow(RelayAllowAdmissionSaturatedError);
+    // After the lease bound the instance admits again even though the stuck
+    // operations are still pending.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(await withRelayAllowAdmissionSlot(async () => "allow")).toBe("allow");
+  });
 });
 
 describe("relay allow HMAC helpers", () => {

--- a/web/tests/relay-allow-route.test.ts
+++ b/web/tests/relay-allow-route.test.ts
@@ -155,6 +155,42 @@ describe("POST /api/relay/allow", () => {
     expect(response.status).toBe(401);
   });
 
+  test("400 when the unsigned header conflicts with the signed body", async () => {
+    // The HMAC covers only the body, so replaying a captured body-signed
+    // request with a different X-Iroh-NodeId must not redirect the decision.
+    const text = JSON.stringify({ endpointId: ACTIVE_ID });
+    const request = new Request("https://cmux.dev/api/relay/allow", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Iroh-NodeId": UNKNOWN_ID,
+        [RELAY_ALLOW_SIGNATURE_HEADER]:
+          relayAllowSignature(SECRET, Buffer.from(text, "utf8")),
+      },
+      body: text,
+    });
+    const response = await handleRelayAllowRequest(request, deps());
+    expect(response.status).toBe(400);
+    expect(await response.text()).not.toBe("true");
+  });
+
+  test("admits when the header and the signed body agree", async () => {
+    const text = JSON.stringify({ endpointId: ACTIVE_ID });
+    const request = new Request("https://cmux.dev/api/relay/allow", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Iroh-NodeId": ACTIVE_ID,
+        [RELAY_ALLOW_SIGNATURE_HEADER]:
+          relayAllowSignature(SECRET, Buffer.from(text, "utf8")),
+      },
+      body: text,
+    });
+    const response = await handleRelayAllowRequest(request, deps());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("true");
+  });
+
   test("503 when the shared secret is unset (fail closed)", async () => {
     const response = await handleRelayAllowRequest(
       relayShapedRequest(ACTIVE_ID),


### PR DESCRIPTION
Backend half of the relay fleet's per-connection authorization hook. Consumer: the manaflow-ai/cmux-relay allow-hook PR (manaflow-ai/cmux-relay#9), which configures iroh-relay 1.0.3 HTTP access mode to call this route. The route is additive and dark until the fleet is configured to call it; `git revert` is safe at any time. No existing token route changed.

## Contract

**Request** (primary shape = exactly what iroh-relay 1.0.3 `AccessConfig::Http` sends, verified against the published crate's `src/main.rs`):

```
POST /api/relay/allow
X-Iroh-NodeId: <64-char lowercase hex EndpointId>     (constant X_IROH_ENDPOINT_ID)
Authorization: Bearer <token>                          (static, see auth below)
<empty body>
```

Alternative shape for a relay-side caller that can sign per-request:

```
POST /api/relay/allow
Content-Type: application/json
x-cmux-relay-allow-signature: <base64url HMAC-SHA256 over the raw body>
{"endpointId": "<64-hex>"}
```

The `X-Iroh-NodeId` header wins when both are present. Mixed-case hex is lowercased. EndpointId Display in iroh-base 1.x is `HEXLOWER` of the 32-byte key, matching the DB check constraint `^[0-9a-f]{64}$`.

**Response** (the text body is the contract; iroh-relay compares `res.text() == "true"` byte-for-byte and treats everything else as deny):

| case | status | body |
| --- | --- | --- |
| active binding, account has no blocking deletion tombstone | 200 | `true` |
| unknown endpoint, or revoked binding, or account deletion in progress | 200 | `false` |
| missing/bad HMAC | 401 | JSON error |
| malformed/missing endpoint id | 400 | JSON error |
| `CMUX_RELAY_ALLOW_HMAC_SECRET_B64` unset, DB failure, or admission deadline (3 s) expired | 503 | JSON error |

Every response is `Cache-Control: no-store`. The endpoint identity rides the `X-Iroh-NodeId` header of an otherwise identical POST, so any intermediary HTTP cache would serve one endpoint's decision to a different endpoint, and a cached allow would outlive revocation. Decision caching is therefore keyed by endpoint id on the relay side only: the cache-TTL contract moved fully to the relay config (`CMUX_RELAY_ALLOW_CACHE_SECS` in manaflow-ai/cmux-relay#9); this route sends no cache hints.

`content-type: application/json` on the 200s: JSON `true`/`false` serializes to the exact required text, so the JSON alternative and the text contract are the same bytes.

The route defends its own resources on three layers, all failing closed:

- **Every phase deadlined**: the admission path owns a dedicated database client sized to its concurrency cap instead of borrowing the shared app client. postgres.js: 5 s connect_timeout, 2.5 s session statement_timeout, and a 4 s client-side `query.cancel()` (which rejects a query whether queued or executing). pg: `connectionTimeoutMillis` (bounds checkout waits too), `statement_timeout`, `query_timeout`. Every admission operation therefore settles within a known bound.
- **Retained-work bound**: at most 16 admission lookups run concurrently per instance (cap == dedicated pool max, so nothing queues in the driver). Slots release strictly at settlement — safe because settlement is guaranteed above — so the cap is a true bound on retained work and the instance always recovers after an outage. A saturated instance answers 503 immediately, which the relay treats as deny and retries.
- **Response bound**: a 3 s deadline on the admission answers 503 even when the database is still inside its own bounds.

The body read runs under a 5 s deadline on top of its 4 KB byte limit; expiry cancels the request stream itself and answers 408, so an unauthenticated slowloris client cannot hold the handler open.

## Authentication

New optional env var `CMUX_RELAY_ALLOW_HMAC_SECRET_B64` (same canonical-base64, 32-256 byte rules as `CMUX_IROH_MINT_HMAC_SECRET_B64`). Verification is HMAC-SHA256 over the raw request body, base64url, constant-time compare (`timingSafeEqual`).

Upstream iroh-relay cannot compute a per-request MAC; it only attaches a static bearer token (config `bearer_token`, env `IROH_RELAY_HTTP_BEARER_TOKEN`). Its access-mode POST has an empty body, and the MAC of the empty body under the shared secret is a constant, so the fleet sets `bearer_token = base64url(HMAC-SHA256(secret, ""))` and the route accepts that value from `Authorization: Bearer`. A caller sending the JSON body form signs that body and uses the `x-cmux-relay-allow-signature` header. When the secret is unset the route answers 503: admission of NEW endpoints fails closed; the relay side carries the availability story via its endpoint-keyed allow cache.

## What the relay-side implementer must match

- Send the EndpointId as lowercase hex in `X-Iroh-NodeId` (iroh-relay already does).
- Compute the bearer token as `base64url(HMAC-SHA256(secret, empty))`, 43 chars, no padding.
- Treat only `200` + exact `true` as allow (iroh-relay already does).
- Own decision caching, keyed by endpoint id, via `CMUX_RELAY_ALLOW_CACHE_SECS`; this route intentionally returns `no-store` and no TTL hint. Suggested defaults: cache allow for up to 1 hour (bounds how long a revoked endpoint keeps reconnecting through a warm relay), deny for about 60 s.
- Distribute the same base64 secret to the fleet as `CMUX_RELAY_ALLOW_HMAC_SECRET_B64` holds on Vercel.

## Admission semantics

`web/services/relay/allow.ts` reuses the existing iroh bindings table and the account-deletion tombstone helper: allow iff a non-revoked `iroh_endpoint_bindings` row exists for the EndpointId (the partial unique index `iroh_endpoint_bindings_active_endpoint_unique` guarantees at most one across all accounts) and `hasBlockingAccountDeletionIdentity` reports no blocking tombstone for that row's account. No new tables, no schema change.

## Tests

`web/tests/relay-allow-db-behavior.test.ts` (CMUX_DB_TEST-gated, runs in the CI database lane) proves the real policy against Postgres: allow for an active binding, deny for unknown, deny for revoked, deny while a deletion tombstone blocks the account, readmit after a terminal failed deletion. Verified green locally against a migrated throwaway Postgres 16.

`web/tests/relay-allow-route.test.ts` (deps-injected, no DB): allow for active binding with exact-text assertions, deny for unknown and for revoked, both request shapes, mixed-case normalization, `no-store` on the 200s, 401 for missing/wrong/tampered HMAC, 503 for unset and malformed secret, 400 for malformed/missing endpoint id, 503 when the lookup throws, 503 within the bound when the lookup stalls, plus unit tests of the secret parser and constant-time verifier. `bun test` on the touched files: 47 pass, 0 fail. `bun run typecheck` clean.

## Revert

The route is additive and dark: nothing calls it until the relay fleet is configured with the hook URL and secret. `git revert` of this commit is safe at any time; reverting after the fleet is configured makes relays deny-by-default once their caches expire (fail closed).

Dictionary:
- **access-control hook**: iroh-relay's per-connection callback that asks an external HTTP endpoint whether a connecting endpoint may use the relay.
- **EndpointId**: the hex-encoded public key an iroh endpoint proves ownership of during the relay handshake.
- **binding**: a row tying an EndpointId to a signed-in cmux account and device; revocation ends it.
- **tombstone**: the account-deletion marker row that blocks account activity while deletion runs.
- **fail closed**: when configuration, the database, or the deadline is unavailable, answer deny/503 rather than admit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated relay access control with endpoint eligibility checks.
  - Supports endpoint IDs from relay headers or request bodies.
  - Added configurable shared-secret authentication and secure allow/deny responses.
  - Added timeout handling, concurrency limits, and fail-closed behavior for admission checks.
  - Added configuration for the relay access-control authentication secret.

- **Tests**
  - Added coverage for authentication, validation, timeouts, concurrency, database states, signature handling, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



