### PR TITLE
relay(chatmux): emit terminal_gone for missing pinned terminals

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -33,6 +33,7 @@ use serde_json::{Value, json};
 
 use crate::actions::{expand_path, scrubbed_env, validate_request_path};
 use crate::control::ControlHandle;
+use crate::relay_wire::RelayPtyErrorCode;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
 
@@ -480,6 +481,22 @@ fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, message: &st
     }));
 }
 
+fn send_typed_pty_error(
+    context: &FrameContext,
+    pty_id: &str,
+    code: RelayPtyErrorCode,
+    message: &str,
+) {
+    let wire_code = match code {
+        RelayPtyErrorCode::BadRequest => "bad_request",
+        RelayPtyErrorCode::TrustRefused => "trust_refused",
+        RelayPtyErrorCode::SessionLimit => "session_limit",
+        RelayPtyErrorCode::TerminalGone => "terminal_gone",
+        RelayPtyErrorCode::Failed => "failed",
+    };
+    send_pty_error(context, pty_id, wire_code, message);
+}
+
 impl Inner {
     async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
@@ -604,7 +621,7 @@ impl Inner {
                 Ok(Some(opened)) => Some(opened),
                 Ok(None) => None, // degrade to whole-session
                 Err((code, message)) => {
-                    fail(code, &message);
+                    send_typed_pty_error(context, &pty_id, code, &message);
                     return;
                 }
             }
@@ -1547,13 +1564,13 @@ impl Inner {
         pty_id: &str,
         server_roots: Option<&[String]>,
         context: &FrameContext,
-    ) -> Result<Option<Opened>, (&'static str, String)> {
+    ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
         let ensured = self
             .deps
             .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env)
             .await
-            .map_err(|message| ("failed", message))?;
+            .map_err(|message| (RelayPtyErrorCode::Failed, message))?;
         let control = match self.deps.connect_control(&ensured.socket_path).await {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
@@ -1602,7 +1619,7 @@ impl Inner {
             // closed) — permanent, so clients render an ended state and
             // never offer a retry.
             return Err((
-                "terminal_gone",
+                RelayPtyErrorCode::TerminalGone,
                 format!(
                     "terminal \"{surface_ref}\" not found in session \"{session}\" (it may have been closed)"
                 ),
@@ -1622,14 +1639,14 @@ impl Inner {
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
                 control.end();
                 return Err((
-                    "failed",
+                    RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             }
             let Some(actual) = actual else {
                 control.end();
                 return Err((
-                    "failed",
+                    RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             };
@@ -1638,7 +1655,7 @@ impl Inner {
             {
                 control.end();
                 return Err((
-                    "failed",
+                    RelayPtyErrorCode::Failed,
                     "existing surface cwd is outside allowed roots".to_owned(),
                 ));
             }
@@ -1684,7 +1701,7 @@ impl Inner {
                 .and_then(Value::as_str)
                 .unwrap_or("no reply");
             return Err((
-                "failed",
+                RelayPtyErrorCode::Failed,
                 format!("attach-surface failed for terminal \"{surface_ref}\": {reason}"),
             ));
         }
@@ -2596,6 +2613,9 @@ mod tests {
         // The typed code is the contract (chatmux protocol RelayPtyErrorCode);
         // the message keeps the human wording the Node relay used.
         assert_eq!(error["code"], "terminal_gone");
+        let decoded: crate::relay_wire::RelayPtyError =
+            serde_json::from_value(error.clone()).expect("generated pty_error fixture");
+        assert_eq!(decoded.code, RelayPtyErrorCode::TerminalGone);
         assert!(
             error["message"].as_str().unwrap_or_default().contains("not found in session"),
         );

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -603,8 +603,8 @@ impl Inner {
             {
                 Ok(Some(opened)) => Some(opened),
                 Ok(None) => None, // degrade to whole-session
-                Err(message) => {
-                    fail("failed", &message);
+                Err((code, message)) => {
+                    fail(code, &message);
                     return;
                 }
             }
@@ -1547,9 +1547,13 @@ impl Inner {
         pty_id: &str,
         server_roots: Option<&[String]>,
         context: &FrameContext,
-    ) -> Result<Option<Opened>, String> {
+    ) -> Result<Option<Opened>, (&'static str, String)> {
         let socket_dir = self.deps.socket_dir();
-        let ensured = self.deps.ensure_daemon(cmux_tui, session, &socket_dir, cwd, env).await?;
+        let ensured = self
+            .deps
+            .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env)
+            .await
+            .map_err(|message| ("failed", message))?;
         let control = match self.deps.connect_control(&ensured.socket_path).await {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
@@ -1594,8 +1598,14 @@ impl Inner {
         }
         let Some(surface_id) = surface_id else {
             control.end();
-            return Err(format!(
-                "terminal \"{surface_ref}\" not found in session \"{session}\" (it may have been closed)"
+            // Typed refusal: the terminal died with its process (or its tab
+            // closed) — permanent, so clients render an ended state and
+            // never offer a retry.
+            return Err((
+                "terminal_gone",
+                format!(
+                    "terminal \"{surface_ref}\" not found in session \"{session}\" (it may have been closed)"
+                ),
             ));
         };
 
@@ -1611,17 +1621,26 @@ impl Inner {
                 .and_then(Value::as_str);
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
                 control.end();
-                return Err("cannot prove existing surface cwd is within allowed roots".to_owned());
+                return Err((
+                    "failed",
+                    "cannot prove existing surface cwd is within allowed roots".to_owned(),
+                ));
             }
             let Some(actual) = actual else {
                 control.end();
-                return Err("cannot prove existing surface cwd is within allowed roots".to_owned());
+                return Err((
+                    "failed",
+                    "cannot prove existing surface cwd is within allowed roots".to_owned(),
+                ));
             };
             if scoped_cwd(Some(actual), &self.home, context.local_roots.as_deref(), server_roots)
                 .is_err()
             {
                 control.end();
-                return Err("existing surface cwd is outside allowed roots".to_owned());
+                return Err((
+                    "failed",
+                    "existing surface cwd is outside allowed roots".to_owned(),
+                ));
             }
         }
 
@@ -1664,7 +1683,10 @@ impl Inner {
                 .and_then(|v| v.get("error"))
                 .and_then(Value::as_str)
                 .unwrap_or("no reply");
-            return Err(format!("attach-surface failed for terminal \"{surface_ref}\": {reason}"));
+            return Err((
+                "failed",
+                format!("attach-surface failed for terminal \"{surface_ref}\": {reason}"),
+            ));
         }
 
         let proxy = Arc::new(ControlTerminalControl { control, surface_id });
@@ -1858,6 +1880,8 @@ impl Inner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control::{CloseHandler, EventHandler};
+    use std::future::Future;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
@@ -1971,6 +1995,7 @@ mod tests {
         socket_dir: PathBuf,
         read_dir: Option<Vec<String>>,
         ensure_socket_path: Option<PathBuf>,
+        control: Option<Arc<dyn ControlHandle>>,
     }
 
     #[async_trait]
@@ -2014,7 +2039,10 @@ mod tests {
             socket_path: &Path,
         ) -> Result<Arc<dyn ControlHandle>, String> {
             self.recorded.lock().unwrap().connected.push(socket_path.to_path_buf());
-            Err("no control socket in tests unless injected".to_owned())
+            match &self.control {
+                Some(control) => Ok(Arc::clone(control)),
+                None => Err("no control socket in tests unless injected".to_owned()),
+            }
         }
         async fn read_dir(&self, _path: &Path) -> Result<Vec<String>, ()> {
             self.read_dir.clone().ok_or(())
@@ -2054,6 +2082,15 @@ mod tests {
         read_dir: Option<Vec<String>>,
         ensure_socket_path: Option<PathBuf>,
     ) -> Harness {
+        harness_with_control(resolve, read_dir, ensure_socket_path, None)
+    }
+
+    fn harness_with_control(
+        resolve: Option<CmuxTui>,
+        read_dir: Option<Vec<String>>,
+        ensure_socket_path: Option<PathBuf>,
+        control: Option<Arc<dyn ControlHandle>>,
+    ) -> Harness {
         let home = TestDirectory::new("harness");
         let home_path = home.path.clone();
         let env = env_map(&home_path);
@@ -2066,6 +2103,7 @@ mod tests {
             socket_dir,
             read_dir,
             ensure_socket_path,
+            control,
         });
         let manager = PtyManager::with_limits(
             deps,
@@ -2506,6 +2544,62 @@ mod tests {
         // a second path from socket_dir and session.
         assert_eq!(h.connected(), vec![daemon_socket]);
         assert_eq!(h.sent()[0]["type"], "pty_opened");
+    }
+
+    /// Scripted control plane: identifies at the protocol floor and lists a
+    /// workspace tree WITHOUT the requested terminal — the JS harness's
+    /// "closed tab" shape.
+    struct GoneControl;
+
+    impl ControlHandle for GoneControl {
+        fn request(
+            &self,
+            cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            let response = match cmd {
+                "identify" => Some(serde_json::json!({
+                    "ok": true,
+                    "data": { "protocol": CONTROL_MIN_PROTOCOL, "capabilities": [] },
+                })),
+                "list-workspaces" => Some(serde_json::json!({
+                    "ok": true,
+                    "data": { "workspaces": [] },
+                })),
+                _ => None,
+            };
+            Box::pin(async move { response })
+        }
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {}
+    }
+
+    #[tokio::test]
+    async fn missing_surface_refuses_with_typed_terminal_gone() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness_with_control(Some(cmux), None, None, Some(Arc::new(GoneControl)));
+        h.open(
+            "p1",
+            "job-x",
+            serde_json::json!({ "surface": "term_dead" }),
+            "supervised",
+            h.owner.clone(),
+        )
+        .await;
+        let sent = h.sent();
+        let error = sent.iter().find(|f| ty(f) == "pty_error").expect("pty_error frame");
+        // The typed code is the contract (chatmux protocol RelayPtyErrorCode);
+        // the message keeps the human wording the Node relay used.
+        assert_eq!(error["code"], "terminal_gone");
+        assert!(
+            error["message"].as_str().unwrap_or_default().contains("not found in session"),
+        );
+        // A gone terminal must NOT degrade to a whole-session attach.
+        assert!(!sent.iter().any(|f| ty(f) == "pty_opened"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2616,9 +2616,7 @@ mod tests {
         let decoded: crate::relay_wire::RelayPtyError =
             serde_json::from_value(error.clone()).expect("generated pty_error fixture");
         assert_eq!(decoded.code, RelayPtyErrorCode::TerminalGone);
-        assert!(
-            error["message"].as_str().unwrap_or_default().contains("not found in session"),
-        );
+        assert!(error["message"].as_str().unwrap_or_default().contains("not found in session"),);
         // A gone terminal must NOT degrade to a whole-session attach.
         assert!(!sent.iter().any(|f| ty(f) == "pty_opened"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2413,6 +2413,7 @@ mod tests {
             socket_dir: PathBuf::from("/run/cmux-tui-501"),
             read_dir: None,
             ensure_socket_path: None,
+            control: None,
         });
         let manager =
             PtyManager::with_limits(deps, home_path.clone(), env, MAX_PTYS, 32, OUTPUT_BUFFER_CAP);

--- a/cmux-tui/crates/chatmux-relay/src/relay_wire.rs
+++ b/cmux-tui/crates/chatmux-relay/src/relay_wire.rs
@@ -1098,6 +1098,8 @@ pub enum RelayPtyErrorCode {
     TrustRefused,
     #[serde(rename = "session_limit")]
     SessionLimit,
+    #[serde(rename = "terminal_gone")]
+    TerminalGone,
     #[serde(rename = "failed")]
     Failed,
 }


### PR DESCRIPTION
## Summary

- add the generated `RelayPtyErrorCode::TerminalGone` wire variant from chatmux protocol PR #504
- map a missing pinned cmux-tui surface to `pty_error.code = terminal_gone`
- keep the existing human-readable not-found message for transition compatibility
- add a scripted control-plane regression test and keep other failures as `failed`

This is separate from relay hashed-socket identity fix #10723 and clippy baseline #10729.

## Verification

The cmux maintainer checkout forbids local Cargo and Zig. I will run the hosted focused relay lane and the hosted full lane against the exact head.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790244771&installation_model_id=21920&pr_number=10732&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10732&signature=f6cf535d4a07052017639305f2efa589a1402d5cb4ac7ab618ad37b6df9e01f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits a typed pty error with code "terminal_gone" when a pinned terminal is missing. Previously this returned "failed" and some clients kept prompting to reconnect; now clients can render a final ended state and stop retries.

- Bug Fixes
  - Missing pinned terminals never fall back to a whole-session attach.
  - Keeps the existing not-found message for transition compatibility.
  - Adds `RelayPtyErrorCode::TerminalGone` to the vendored relay wire and uses it.
  - Changes the internal error path to `(code, message)` to carry typed refusals.
  - Adds a scripted control-plane test that asserts the new code and no attach fallback.

- Migration
  - If your client matched the error message to stop retries, switch to checking `pty_error.code === "terminal_gone"`.

<sup>Written for commit f489ef448e9d7e46236bf091bea67c984452a624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

