### PR TITLE
fix(tui): accept relay release-candidate npm versions

### DIFF
--- a/cmux-tui/dist/scripts/package_npm.py
+++ b/cmux-tui/dist/scripts/package_npm.py
@@ -51,7 +51,7 @@ RELAY_TARGETS = [
 ]
 
 VERSION_RE = re.compile(
-    r"^(?:[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}\.[0-9]+)$"
+    r"^(?:[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}\.[0-9]+)$"
 )
 
 
@@ -68,7 +68,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--version",
         required=True,
-        help="Package version in X.Y.Z or X.Y.Z-nightly.YYYYMMDD.N form.",
+        help=(
+            "Package version in X.Y.Z, X.Y.Z-rc.N, or "
+            "X.Y.Z-nightly.YYYYMMDD.N form."
+        ),
     )
     parser.add_argument(
         "--out",
@@ -212,7 +215,10 @@ def package_launcher(version: str, out_dir: Path, include_windows: bool) -> None
 def main() -> None:
     args = parse_args()
     if not VERSION_RE.fullmatch(args.version):
-        raise SystemExit("--version must match X.Y.Z or X.Y.Z-nightly.YYYYMMDD.N")
+        raise SystemExit(
+            "--version must match X.Y.Z, X.Y.Z-rc.N, or "
+            "X.Y.Z-nightly.YYYYMMDD.N"
+        )
 
     binaries_dir = args.binaries_dir.resolve()
     out_dir = args.out.resolve()

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 import re
+import runpy
 import subprocess
 import tempfile
 import time
@@ -1536,6 +1537,19 @@ def test_relay_publisher_is_tag_bound_rc_aware_and_attested() -> None:
     assert '--source-digest "$GITHUB_SHA"' in text
     assert '--source-ref "$GITHUB_REF"' in text
     assert "persist-credentials: false" in text
+
+
+def test_npm_builder_accepts_relay_release_candidate_versions() -> None:
+    builder = ROOT / "cmux-tui" / "dist" / "scripts" / "package_npm.py"
+    namespace = runpy.run_path(str(builder), run_name="cmux_tui_package_npm_test")
+    version_re = namespace["VERSION_RE"]
+    assert isinstance(version_re, re.Pattern)
+
+    assert version_re.fullmatch("0.12.1")
+    assert version_re.fullmatch("0.12.1-rc.1")
+    assert version_re.fullmatch("0.12.1-nightly.20260825.7")
+    assert not version_re.fullmatch("0.12.1-rc")
+    assert not version_re.fullmatch("0.12.1-rc.0.extra")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`relay-publish-npm.yml` accepts `cmux-relay-vX.Y.Z-rc.N` tags and maps them to the npm `next` dist-tag, but the reusable `package_npm.py` builder rejected the same version. Every relay release candidate therefore failed before package publication.

This change accepts `X.Y.Z-rc.N` in the shared npm package builder, updates its CLI diagnostics, and adds a regression test for stable, RC, nightly, and malformed versions.

## Verification

- Hosted CI only; no local Cargo or Zig commands.
- The merged `#10727` workflow fix supplies `--access public` for first-time provenance publishes.
- Account-side npm Trusted Publisher setup remains required for the five new relay platform packages.

This PR does not publish packages, change permissions, or alter the stable cutover.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts relay RC npm versions in the reusable package builder so RC tags no longer fail before publication. Previously the builder rejected X.Y.Z-rc.N while the workflow accepted them and mapped to npm `next`; it now validates RCs, updates CLI help/error text, and adds tests for stable, RC, nightly, and malformed versions.

<sup>Written for commit 18565df9554ac442d3c77ae8daafad2572e90cff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that package versions correctly accept stable, release-candidate, and nightly formats.
  * Added validation ensuring malformed release-candidate versions are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->