### PR TITLE
iroh host: cache-first activation and register-when-ready publication

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -306,6 +306,11 @@ public actor CmxConnectivityEngine {
         await supervisor.hasConfiguredRelay()
     }
 
+    /// Returns whether the active endpoint generation reports a usable home relay.
+    public func hasUsableHomeRelay() async -> Bool {
+        await supervisor.hasUsableHomeRelay()
+    }
+
     /// Waits for the active endpoint generation to report relay readiness.
     public func waitForUsableHomeRelay(
         timeout: Duration = .seconds(15)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -708,6 +708,43 @@ extension CmxIrohHostRuntime {
         guard let connectivityEngine else {
             throw CmxIrohHostRuntimeError.inactive
         }
+        // The startup ready gate retains the superseded cached binding and
+        // relay bootstrap it was armed with. Cancel and drain it before
+        // rebinding so it can never activate the replacement coordinator with
+        // the stale identity or install a stale relay credential; the deferred
+        // first publication is re-armed onto the adopted binding below.
+        if let staleReadyGate = initialPublicationTask {
+            staleReadyGate.cancel()
+            initialPublicationTask = nil
+            await staleReadyGate.value
+            try requireCurrent(revision)
+        }
+        try await rebindRelayCoordinator(
+            policy: policy,
+            engine: connectivityEngine,
+            revision: revision
+        )
+        if initialPublicationPending {
+            // The drained gate owned the relay-readiness wait for the deferred
+            // first publication. Re-arm it bound to the adopted identity so
+            // the endpoint still publishes once the relay becomes usable.
+            scheduleInitialPublication(
+                binding: policy.binding,
+                endpointID: policy.binding.endpointID,
+                bootstrap: policy.relayBootstrap,
+                revision: revision
+            )
+        }
+    }
+
+    /// Deactivates the coordinator pinned to the replaced binding and, for a
+    /// managed relay profile, activates a replacement pinned to the adopted
+    /// binding.
+    private func rebindRelayCoordinator(
+        policy: ResolvedPolicy,
+        engine: CmxConnectivityEngine,
+        revision: UInt64
+    ) async throws {
         guard let coordinator = relayCoordinator else { return }
         relayActivationTask?.cancel()
         relayActivationTask = nil
@@ -721,7 +758,7 @@ extension CmxIrohHostRuntime {
               profile.source == .managed,
               !profile.allowedRelayURLs.isEmpty else { return }
         let replacement = CmxIrohRelayCredentialCoordinator(
-            supervisor: connectivityEngine,
+            supervisor: engine,
             broker: broker,
             managedRelayURLs: managedRelayURLs,
             selectedRelayURLs: profile.allowedRelayURLs,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -272,6 +272,33 @@ extension CmxIrohHostRuntime {
         return discovery
     }
 
+    /// Returns a start policy from the persisted last-good broker policy when
+    /// it still cryptographically verifies for this exact account, identity,
+    /// endpoint, and host settings. Any mismatch is a silent cache miss so
+    /// activation falls back to the blocking authenticated resolve.
+    func validatedCachedStartPolicy(
+        expectedEndpointID: CmxIrohPeerIdentity
+    ) -> ResolvedPolicy? {
+        guard let cached = configuration.cachedHostPolicy else { return nil }
+        do {
+            try validateCachedPolicy(cached, endpointID: expectedEndpointID)
+        } catch {
+            return nil
+        }
+        return ResolvedPolicy(
+            registration: nil,
+            discovery: nil,
+            binding: cached.binding,
+            pairingEnabled: cached.pairingEnabled,
+            grantVerificationKeys: cached.grantVerificationKeys,
+            attestation: cached.endpointAttestation,
+            relayBootstrap: configuration.cachedRelayCredential,
+            lanRendezvous: cached.lanRendezvous,
+            routePathHints: [],
+            registrationRetryAfterSeconds: nil
+        )
+    }
+
     func cachedPolicy(
         after error: any Error,
         expectedEndpointID: CmxIrohPeerIdentity,
@@ -541,7 +568,7 @@ extension CmxIrohHostRuntime {
               let previousBinding = localBinding else { return }
         do {
             let endpointID = try await connectivityEngine.localEndpointIdentity()
-            if !forcePublication {
+            if !forcePublication, !initialPublicationPending {
                 let state = try await registrationPublicationState(
                     engine: connectivityEngine,
                     expectedEndpointID: endpointID
@@ -560,9 +587,16 @@ extension CmxIrohHostRuntime {
                 revision: revision,
                 allowCachedFallback: false
             )
-            guard policy.binding.bindingID == previousBinding.bindingID else {
-                throw CmxIrohHostRuntimeError.invalidLocalBinding
+            if policy.binding.bindingID != previousBinding.bindingID {
+                guard allowsReplacedBindingAdoption else {
+                    throw CmxIrohHostRuntimeError.invalidLocalBinding
+                }
+                // A cache-first activation discovered its persisted binding
+                // was replaced server-side. Adopt the authenticated result in
+                // place, exactly as the blocking activation path would have.
+                try await adoptReplacedBinding(policy: policy, revision: revision)
             }
+            allowsReplacedBindingAdoption = false
             await admissionController.update(
                 keys: policy.grantVerificationKeys,
                 acceptor: grantPeer(for: policy.binding),
@@ -570,6 +604,13 @@ extension CmxIrohHostRuntime {
             )
             try requireCurrent(revision)
             localBinding = policy.binding
+            if currentSnapshot.bindingID != policy.binding.bindingID {
+                currentSnapshot = CmxIrohHostRuntimeSnapshot(
+                    state: currentSnapshot.state,
+                    endpointID: currentSnapshot.endpointID,
+                    bindingID: policy.binding.bindingID
+                )
+            }
             endpointAttestation = policy.attestation ?? endpointAttestation
             lanRendezvous = policy.lanRendezvous
             guard let registration = policy.registration,
@@ -593,6 +634,7 @@ extension CmxIrohHostRuntime {
                 revision: revision
             )
             registrationRefreshFailureCount = 0
+            initialPublicationPending = false
             completedSuccessfully = true
             scheduleRegistrationRenewal(
                 binding: registration.binding,
@@ -632,6 +674,53 @@ extension CmxIrohHostRuntime {
                 )?.retryAfterSeconds
             )
         }
+    }
+
+    /// Rebinds binding-scoped components to an authenticated replacement
+    /// binding. `CmxIrohAdmissionController.update` already propagates the new
+    /// acceptor to online and offline admission; only the relay credential
+    /// coordinator pins a binding ID at activation and must be recreated.
+    private func adoptReplacedBinding(
+        policy: ResolvedPolicy,
+        revision: UInt64
+    ) async throws {
+        try requireCurrent(revision)
+        guard let connectivityEngine else {
+            throw CmxIrohHostRuntimeError.inactive
+        }
+        guard let coordinator = relayCoordinator else { return }
+        relayActivationTask?.cancel()
+        relayActivationTask = nil
+        await coordinator.deactivate()
+        if relayCoordinator === coordinator {
+            relayCoordinator = nil
+        }
+        try requireCurrent(revision)
+        let binding = policy.binding
+        guard let profile = currentEndpointRelayProfile,
+              profile.source == .managed,
+              !profile.allowedRelayURLs.isEmpty else { return }
+        let replacement = CmxIrohRelayCredentialCoordinator(
+            supervisor: connectivityEngine,
+            broker: broker,
+            managedRelayURLs: managedRelayURLs,
+            selectedRelayURLs: profile.allowedRelayURLs,
+            credentialDidInstall: { [handleRelayCredential] response in
+                await handleRelayCredential(response, binding)
+            }
+        )
+        relayCoordinator = replacement
+        do {
+            try await replacement.activate(
+                bindingID: binding.bindingID,
+                endpointIdentity: binding.endpointID,
+                bootstrap: policy.relayBootstrap
+            )
+        } catch {
+            // The replacement coordinator owns bounded retry. An unavailable
+            // relay credential must not fail the adopted live policy.
+        }
+        try requireCurrent(revision)
     }
 
     static func seconds(_ date: Date) -> Int64? {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -617,6 +617,26 @@ extension CmxIrohHostRuntime {
                   let discovery = policy.discovery else {
                 throw CmxIrohHostRuntimeError.invalidLocalBinding
             }
+            if initialPublicationPending {
+                let ready = await initialPublicationReady(
+                    engine: connectivityEngine
+                )
+                try requireCurrent(revision)
+                guard ready else {
+                    // The first publication of this lifecycle stays gated on
+                    // a verified usable relay path; the authenticated
+                    // reconcile above already applied admission policy,
+                    // binding adoption, and renewal scheduling. The ready
+                    // gate runs the publishing round once the relay works.
+                    registrationRefreshFailureCount = 0
+                    completedSuccessfully = true
+                    scheduleRegistrationRenewal(
+                        binding: registration.binding,
+                        revision: revision
+                    )
+                    return
+                }
+            }
             await handleBinding(registration, discovery, policy.attestation)
             try requireCurrent(revision)
             await handleRoute(policy.binding, policy.routePathHints)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
@@ -88,6 +88,10 @@ extension CmxIrohHostRuntime {
         registrationRefreshFailureCount = 0
         relayActivationTask?.cancel()
         relayActivationTask = nil
+        initialPublicationTask?.cancel()
+        initialPublicationTask = nil
+        initialPublicationPending = false
+        allowsReplacedBindingAdoption = false
         lanPublicationGeneration &+= 1
         lanPublicationTask?.cancel()
         lanPublicationTask = nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -93,6 +93,14 @@ public actor CmxIrohHostRuntime {
     var offlineSessions: CmxIrohOfflinePairingSessions?
     var connectivityEventTask: Task<Void, Never>?
     var relayActivationTask: Task<Void, Never>?
+    var initialPublicationTask: Task<Void, Never>?
+    /// True while activation still owes the first ready publication. It makes
+    /// the next refresh round publish even when reachability is unchanged.
+    var initialPublicationPending = false
+    /// True only between a cache-first activation and its first completed live
+    /// resolve, allowing that resolve to adopt a replaced broker binding in
+    /// place instead of failing closed.
+    var allowsReplacedBindingAdoption = false
     var lanPublicationTask: Task<Void, Never>?
     var lanPublicationGeneration: UInt64 = 0
     var registrationRefreshTask: Task<Void, Never>?
@@ -161,7 +169,11 @@ public actor CmxIrohHostRuntime {
     }
 
 
-    /// Activates connectivity and resolves authenticated broker policy before any cached fallback.
+    /// Activates connectivity, restoring a verified cached policy immediately
+    /// when one matches this binding, and reconciles authenticated broker
+    /// policy in the background. Publication of the binding and route hints
+    /// waits for a usable home relay so the Mac is never
+    /// discoverable-but-undialable.
     public func start() async throws {
         guard lifecyclePhase.allowsStart else {
             throw CmxIrohHostRuntimeError.alreadyActive
@@ -173,6 +185,8 @@ public actor CmxIrohHostRuntime {
         registrationRefreshPendingForcesPublication = false
         registrationRefreshEnabled = false
         registrationRefreshFailureCount = 0
+        initialPublicationPending = false
+        allowsReplacedBindingAdoption = false
         currentSnapshot = CmxIrohHostRuntimeSnapshot(
             state: .starting,
             endpointID: nil,
@@ -208,11 +222,26 @@ public actor CmxIrohHostRuntime {
                 throw CmxIrohHostRuntimeError.invalidLocalBinding
             }
 
-            let policy = try await resolveInitialPolicy(
-                engine: connectivityEngine,
-                expectedEndpointID: endpointID,
-                revision: revision
-            )
+            let requiresRelayReadiness = !protocolConfiguration
+                .allowsNATTraversalAfterAdmission
+            // A verified same-binding cached policy activates admission and
+            // the endpoint immediately; the authenticated broker round then
+            // runs in the background and reconciles. First launch (no cache),
+            // an invalid cache, and relay-required debug hosts keep the
+            // blocking resolve.
+            let cachedStartPolicy = requiresRelayReadiness
+                ? nil
+                : validatedCachedStartPolicy(expectedEndpointID: endpointID)
+            let policy: ResolvedPolicy
+            if let cachedStartPolicy {
+                policy = cachedStartPolicy
+            } else {
+                policy = try await resolveInitialPolicy(
+                    engine: connectivityEngine,
+                    expectedEndpointID: endpointID,
+                    revision: revision
+                )
+            }
             try requireCurrent(revision)
 
             let offlineSessions = CmxIrohOfflinePairingSessions(
@@ -278,8 +307,6 @@ public actor CmxIrohHostRuntime {
                 bindingID: policy.binding.bindingID
             )
             var publishedPolicy = policy
-            let requiresRelayReadiness = !protocolConfiguration
-                .allowsNATTraversalAfterAdmission
             if requiresRelayReadiness {
                 if let relayCoordinator {
                     try await relayCoordinator.activate(
@@ -318,9 +345,19 @@ public actor CmxIrohHostRuntime {
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
             }
+            let publishInline: Bool
+            if requiresRelayReadiness {
+                publishInline = true
+            } else {
+                publishInline = await initialPublicationReady(
+                    engine: connectivityEngine
+                )
+                try requireCurrent(revision)
+            }
             let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
-               let discovery = publishedPolicy.discovery {
+               let discovery = publishedPolicy.discovery,
+               publishInline {
                 await handleBinding(registration, discovery, publishedPolicy.attestation)
                 try requireCurrent(revision)
                 if let routeRevision = discovery.revision {
@@ -337,28 +374,48 @@ public actor CmxIrohHostRuntime {
             } else {
                 publishedFreshBinding = false
             }
-            await handleRoute(
-                publishedPolicy.binding,
-                publishedPolicy.routePathHints
-            )
-            try requireCurrent(revision)
+            if publishedFreshBinding || publishedPolicy.registration == nil {
+                // Fresh relay-ready hints, or a cached authority whose local
+                // route identity is refreshed rather than unpublished. A live
+                // policy without a usable home relay publishes nothing yet:
+                // the Mac must not be discoverable-but-undialable.
+                await handleRoute(
+                    publishedPolicy.binding,
+                    publishedPolicy.routePathHints
+                )
+                try requireCurrent(revision)
+            }
             registrationRefreshEnabled = true
             if !publishedFreshBinding {
-                // Cached authority keeps offline admission and LAN discovery
-                // available, but it cannot describe this endpoint generation's
-                // live direct port. Give the lifecycle-owned retry loop the
-                // incomplete activation so the broker is refreshed without
-                // creating a second endpoint or relying on another network event.
                 registrationRefreshPending = false
-                scheduleRegistrationRetry(
-                    revision: revision,
-                    retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
-                )
+                if requiresRelayReadiness {
+                    // Cached authority keeps offline admission and LAN
+                    // discovery available, but it cannot describe this endpoint
+                    // generation's live direct port. Give the lifecycle-owned
+                    // retry loop the incomplete activation.
+                    scheduleRegistrationRetry(
+                        revision: revision,
+                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
+                    )
+                } else {
+                    // The ready gate activates the relay, waits for a usable
+                    // home relay, and then runs the one live reconcile that
+                    // publishes fresh path hints.
+                    initialPublicationPending = true
+                    allowsReplacedBindingAdoption = cachedStartPolicy != nil
+                    scheduleInitialPublication(
+                        binding: publishedPolicy.binding,
+                        endpointID: endpointID,
+                        bootstrap: publishedPolicy.relayBootstrap,
+                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds,
+                        revision: revision
+                    )
+                }
             } else if registrationRefreshPending {
                 registrationRefreshPending = false
                 scheduleRegistrationRefresh(revision: revision)
             }
-            if let relayCoordinator, !requiresRelayReadiness {
+            if let relayCoordinator, !requiresRelayReadiness, publishedFreshBinding {
                 scheduleRelayActivation(
                     relayCoordinator,
                     binding: policy.binding,
@@ -555,6 +612,85 @@ public actor CmxIrohHostRuntime {
             (try? await engine.localDirectAddresses()) ?? []
         }
         await handleLANPolicy(context, directAddresses)
+    }
+
+    /// Returns whether the binding may be published immediately: the home
+    /// relay is already usable, or this endpoint will never own a relay.
+    private func initialPublicationReady(
+        engine: CmxConnectivityEngine
+    ) async -> Bool {
+        if await engine.hasUsableHomeRelay() { return true }
+        guard relayCoordinator == nil else { return false }
+        return !(await engine.hasConfiguredRelay())
+    }
+
+    func scheduleInitialPublication(
+        binding: CmxIrohBrokerBindingMetadata,
+        endpointID: CmxIrohPeerIdentity,
+        bootstrap: CmxIrohRelayTokenResponse?,
+        retryAfterSeconds: Int?,
+        revision: UInt64
+    ) {
+        initialPublicationTask?.cancel()
+        initialPublicationTask = Task { [weak self] in
+            await self?.runInitialPublication(
+                binding: binding,
+                endpointID: endpointID,
+                bootstrap: bootstrap,
+                retryAfterSeconds: retryAfterSeconds,
+                revision: revision
+            )
+        }
+    }
+
+    private func runInitialPublication(
+        binding: CmxIrohBrokerBindingMetadata,
+        endpointID: CmxIrohPeerIdentity,
+        bootstrap: CmxIrohRelayTokenResponse?,
+        retryAfterSeconds: Int?,
+        revision: UInt64
+    ) async {
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let coordinator = relayCoordinator {
+            // Credential installation happens before the readiness wait so a
+            // cached relay bootstrap makes the home relay usable without a
+            // broker round. The coordinator owns bounded retry on failure.
+            try? await coordinator.activate(
+                bindingID: binding.bindingID,
+                endpointIdentity: endpointID,
+                bootstrap: bootstrap
+            )
+        }
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let connectivityEngine, await connectivityEngine.hasConfiguredRelay() {
+            do {
+                try await connectivityEngine.waitForUsableHomeRelay()
+            } catch is CancellationError {
+                return
+            } catch {
+                // The bounded readiness window elapsed or the generation moved
+                // on. Publication proceeds so a relay outage cannot leave this
+                // Mac permanently unpublished on its LAN and direct paths.
+            }
+        }
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let retryAfterSeconds {
+            // A broker cooldown observed during activation keeps its validated
+            // floor; the lifecycle retry loop owns the next live round.
+            scheduleRegistrationRetry(
+                revision: revision,
+                retryAfterSeconds: retryAfterSeconds
+            )
+            return
+        }
+        guard initialPublicationPending else { return }
+        scheduleRegistrationRefresh(revision: revision)
     }
 
     func scheduleRelayActivation(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -74,6 +74,9 @@ public actor CmxIrohHostRuntime {
     let registrationClock: any CmxIrohRelayClock
     let registrationRetrySchedule: CmxIrohRetrySchedule
     let registrationRetryJitter: @Sendable () -> Double
+    /// One bounded signal-or-deadline window for the startup relay-readiness
+    /// wait. A timeout keeps the endpoint unpublished and retries the wait.
+    let relayReadinessTimeout: Duration
     let handleTransport: TransportHandler
     let handleBinding: BindingHandler
     let handleRoute: RouteHandler
@@ -139,6 +142,7 @@ public actor CmxIrohHostRuntime {
         registrationRetryJitter: @escaping @Sendable () -> Double = {
             Double.random(in: 0 ... 1)
         },
+        relayReadinessTimeout: Duration = .seconds(15),
         handleTransport: @escaping TransportHandler,
         handleBinding: @escaping BindingHandler = { _, _, _ in },
         handleRoute: @escaping RouteHandler = { _, _ in },
@@ -157,6 +161,7 @@ public actor CmxIrohHostRuntime {
         self.registrationClock = registrationClock
         self.registrationRetrySchedule = registrationRetrySchedule
         self.registrationRetryJitter = registrationRetryJitter
+        self.relayReadinessTimeout = relayReadinessTimeout
         self.handleTransport = handleTransport
         self.handleBinding = handleBinding
         self.handleRoute = handleRoute
@@ -666,15 +671,54 @@ public actor CmxIrohHostRuntime {
         guard lifecyclePhase == .active,
               lifecycleRevision == revision,
               !Task.isCancelled else { return }
-        if let connectivityEngine, await connectivityEngine.hasConfiguredRelay() {
-            do {
-                try await connectivityEngine.waitForUsableHomeRelay()
-            } catch is CancellationError {
-                return
-            } catch {
-                // The bounded readiness window elapsed or the generation moved
-                // on. Publication proceeds so a relay outage cannot leave this
-                // Mac permanently unpublished on its LAN and direct paths.
+        guard let connectivityEngine else { return }
+        let relayExpected: Bool
+        if relayCoordinator != nil {
+            relayExpected = true
+        } else {
+            relayExpected = await connectivityEngine.hasConfiguredRelay()
+        }
+        if relayExpected {
+            // The Mac must never be discoverable-but-undialable: a readiness
+            // timeout keeps the endpoint unpublished and retries the wait with
+            // bounded backoff on the injected clock until a verified usable
+            // relay path exists or this lifecycle revision is superseded.
+            var readinessFailureCount = 0
+            while true {
+                guard lifecyclePhase == .active,
+                      lifecycleRevision == revision,
+                      !Task.isCancelled else { return }
+                do {
+                    try await connectivityEngine.waitForUsableHomeRelay(
+                        timeout: relayReadinessTimeout
+                    )
+                    break
+                } catch is CancellationError {
+                    return
+                } catch CmxIrohEndpointSupervisorError.relayReadinessTimedOut {
+                    // Retry below after bounded backoff.
+                } catch {
+                    // The endpoint generation was replaced or deactivated. The
+                    // successor lifecycle owns publication; this one stays
+                    // unpublished and existing failure handling surfaces state.
+                    return
+                }
+                guard lifecyclePhase == .active,
+                      lifecycleRevision == revision,
+                      !Task.isCancelled else { return }
+                let delay = registrationRetrySchedule.delay(
+                    failureCount: readinessFailureCount,
+                    retryAfterSeconds: nil,
+                    jitterUnitInterval: registrationRetryJitter()
+                )
+                readinessFailureCount = min(readinessFailureCount + 1, 20)
+                do {
+                    try await registrationClock.sleep(
+                        until: registrationClock.now().addingTimeInterval(delay)
+                    )
+                } catch {
+                    return
+                }
             }
         }
         guard lifecyclePhase == .active,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -392,6 +392,10 @@ public actor CmxIrohHostRuntime {
             registrationRefreshEnabled = true
             if !publishedFreshBinding {
                 registrationRefreshPending = false
+                // Every deferred first publication carries the pending flag so
+                // any refresh round that ends up performing it re-checks
+                // verified relay readiness first.
+                initialPublicationPending = true
                 if requiresRelayReadiness {
                     // Cached authority keeps offline admission and LAN
                     // discovery available, but it cannot describe this endpoint
@@ -402,7 +406,6 @@ public actor CmxIrohHostRuntime {
                         retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
                     )
                 } else {
-                    initialPublicationPending = true
                     allowsReplacedBindingAdoption = cachedStartPolicy != nil
                     if let retryAfterSeconds = publishedPolicy
                         .registrationRetryAfterSeconds {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -402,16 +402,31 @@ public actor CmxIrohHostRuntime {
                         retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
                     )
                 } else {
-                    // The ready gate activates the relay, waits for a usable
-                    // home relay, and then runs the one live reconcile that
-                    // publishes fresh path hints.
                     initialPublicationPending = true
                     allowsReplacedBindingAdoption = cachedStartPolicy != nil
+                    if let retryAfterSeconds = publishedPolicy
+                        .registrationRetryAfterSeconds {
+                        // A broker cooldown observed during activation keeps
+                        // its validated floor for the next live round.
+                        scheduleRegistrationRetry(
+                            revision: revision,
+                            retryAfterSeconds: retryAfterSeconds
+                        )
+                    } else if cachedStartPolicy != nil {
+                        // Cached authority is verified against the live broker
+                        // immediately, independent of relay readiness, so a
+                        // server-side revocation or replacement cannot hide
+                        // behind a relay outage. Readiness gates only the
+                        // publication inside the refresh round.
+                        scheduleRegistrationRefresh(revision: revision)
+                    }
+                    // The ready gate activates the relay, waits for a usable
+                    // home relay, and then runs the round that performs the
+                    // deferred first publication with fresh path hints.
                     scheduleInitialPublication(
                         binding: publishedPolicy.binding,
                         endpointID: endpointID,
                         bootstrap: publishedPolicy.relayBootstrap,
-                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds,
                         revision: revision
                     )
                 }
@@ -620,7 +635,7 @@ public actor CmxIrohHostRuntime {
 
     /// Returns whether the binding may be published immediately: the home
     /// relay is already usable, or this endpoint will never own a relay.
-    private func initialPublicationReady(
+    func initialPublicationReady(
         engine: CmxConnectivityEngine
     ) async -> Bool {
         if await engine.hasUsableHomeRelay() { return true }
@@ -632,7 +647,6 @@ public actor CmxIrohHostRuntime {
         binding: CmxIrohBrokerBindingMetadata,
         endpointID: CmxIrohPeerIdentity,
         bootstrap: CmxIrohRelayTokenResponse?,
-        retryAfterSeconds: Int?,
         revision: UInt64
     ) {
         initialPublicationTask?.cancel()
@@ -641,7 +655,6 @@ public actor CmxIrohHostRuntime {
                 binding: binding,
                 endpointID: endpointID,
                 bootstrap: bootstrap,
-                retryAfterSeconds: retryAfterSeconds,
                 revision: revision
             )
         }
@@ -651,7 +664,6 @@ public actor CmxIrohHostRuntime {
         binding: CmxIrohBrokerBindingMetadata,
         endpointID: CmxIrohPeerIdentity,
         bootstrap: CmxIrohRelayTokenResponse?,
-        retryAfterSeconds: Int?,
         revision: UInt64
     ) async {
         guard lifecyclePhase == .active,
@@ -723,16 +735,13 @@ public actor CmxIrohHostRuntime {
         guard lifecyclePhase == .active,
               lifecycleRevision == revision,
               !Task.isCancelled else { return }
-        if let retryAfterSeconds {
-            // A broker cooldown observed during activation keeps its validated
-            // floor; the lifecycle retry loop owns the next live round.
-            scheduleRegistrationRetry(
-                revision: revision,
-                retryAfterSeconds: retryAfterSeconds
-            )
+        guard initialPublicationPending else { return }
+        guard registrationRefreshFailureCount == 0 else {
+            // A broker cooldown or failure retry is already armed. That
+            // lifecycle-owned round performs the deferred publication once it
+            // succeeds, and it honors the broker's validated retry floor.
             return
         }
-        guard initialPublicationPending else { return }
         scheduleRegistrationRefresh(revision: revision)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -350,15 +350,14 @@ public actor CmxIrohHostRuntime {
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
             }
-            let publishInline: Bool
-            if requiresRelayReadiness {
-                publishInline = true
-            } else {
-                publishInline = await initialPublicationReady(
-                    engine: connectivityEngine
-                )
-                try requireCurrent(revision)
-            }
+            // Every path re-checks verified readiness immediately before
+            // publication. Relay-required activations arrive here only after
+            // the blocking waitForUsableHomeRelay() above succeeded, so the
+            // check returns true for them without a second wait.
+            let publishInline = await initialPublicationReady(
+                engine: connectivityEngine
+            )
+            try requireCurrent(revision)
             let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
                let discovery = publishedPolicy.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
@@ -22,7 +22,10 @@ public struct CmxIrohHostRuntimeConfiguration: Equatable, Sendable {
     /// `nil` preserves automatic use of the complete managed fleet.
     public let endpointRelayProfile: CmxIrohEndpointRelayProfile?
     public let cachedRelayCredential: CmxIrohRelayTokenResponse?
-    /// A previously verified offline policy considered only after broker connectivity failure.
+    /// A previously verified last-good policy. When it still verifies for this
+    /// exact binding it activates the host immediately (cache-first) while the
+    /// live broker resolve reconciles in the background; it also remains the
+    /// verified fallback after broker connectivity failure.
     public let cachedHostPolicy: CmxIrohCachedHostPolicy?
 
     /// Creates stable inputs for one Mac host runtime lifecycle.

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
@@ -16,8 +16,8 @@ extension CmxIrohHostRuntimeTests {
     func nonTransientRefreshRejectionFailsClosedThenRestarts() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let firstEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
-        let restartEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let firstEndpoint = try fixture.relayReadyEndpoint()
+        let restartEndpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
@@ -46,10 +46,17 @@ extension CmxIrohHostRuntimeTests {
             }
         )
         try await runtime.start()
+        // Native iroh reports the home relay online once the installed
+        // credential connects; the readiness gate publishes only after this.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
 
         let republished = await broker.waitForRegistrationCount(
             2,
-            timeout: .seconds(1)
+            timeout: .seconds(5)
         )
         #expect(
             republished,
@@ -75,14 +82,16 @@ extension CmxIrohHostRuntimeTests {
         #expect(initialDirectPorts == expectedDirectPorts)
         #expect(refreshedDirectPorts == expectedDirectPorts)
 
+        // The pre-relay state is never published; exactly one publication
+        // carries the newly usable relay address.
+        await runtime.waitForInitialPublicationForTesting()
         let published = await publications.values()
-        #expect(published.count == 2)
-        #expect(published[0].registration.pathHints.isEmpty)
-        #expect(published[0].discovered.pathHints.isEmpty)
-        #expect(published[1].registration.pathHints == [relayHint])
-        #expect(published[1].discovered.pathHints == [relayHint])
-        #expect(published[1].registration.endpointID == fixture.endpointID)
-        #expect(published[1].registration.bindingID == fixture.binding.bindingID)
+        let publication = try #require(published.first)
+        #expect(published.count == 1)
+        #expect(publication.registration.pathHints == [relayHint])
+        #expect(publication.discovered.pathHints == [relayHint])
+        #expect(publication.registration.endpointID == fixture.endpointID)
+        #expect(publication.registration.bindingID == fixture.binding.bindingID)
 
         let snapshot = await runtime.snapshot()
         #expect(snapshot.state == .active)
@@ -95,7 +104,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func validatedBindingPublishesBeforeRelayCredentialInstallationCompletes() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeSuspensionGate()
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
@@ -123,7 +132,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func validatedBindingPublishesBeforeLANAdvertisementCompletes() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeSuspensionGate()
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -30,7 +30,7 @@ extension CmxIrohHostRuntimeTests {
             )
         )
 
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -91,7 +91,7 @@ extension CmxIrohHostRuntimeTests {
     func unchangedReachabilityRenewsRegistrationBeforeHintExpiry() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -125,7 +125,7 @@ extension CmxIrohHostRuntimeTests {
     func registrationRenewalHonorsBrokerRetryAfterFloor() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -160,7 +160,7 @@ extension CmxIrohHostRuntimeTests {
     func registrationRenewalBacksOffConsecutiveFailures() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -201,7 +201,7 @@ extension CmxIrohHostRuntimeTests {
     func successfulRegistrationRenewalResetsBackoff() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -403,7 +403,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func failedSignOutPersistenceClosesHostAndQuarantinesLocalState() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let store = TestControllableSecureCredentialStore()
         let pendingRevocations = CmxIrohPendingRevocationOutbox(secureStore: store)
         let deactivations = HostRuntimeDeactivationRecorder()
@@ -447,7 +447,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func successfulSignOutClearsRegistrationPublicationState() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let store = TestControllableSecureCredentialStore()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -474,7 +474,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func requiredBindPolicyIsForwardedToTheEndpointGeneration() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -504,12 +504,12 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
-    func connectivityFailureUsesVerifiedCacheOnlyAfterOnlineAttempt() async throws {
+    func cacheFirstActivationBecomesActiveDespiteBrokerConnectivityFailure() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
         let cachedPolicy = try cachedFixture.policy()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -527,11 +527,17 @@ extension CmxIrohHostRuntimeTests {
             handleBinding: { _, _, _ in await bindings.record() }
         )
 
+        // The verified cache activates admission immediately; the failed
+        // background reconcile keeps cached authority active without a fresh
+        // publication until a live round succeeds.
         try await runtime.start()
 
-        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
+        await runtime.waitForInitialPublicationForTesting()
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
         #expect(await bindings.count() == 0)
         await runtime.stop()
     }
@@ -573,7 +579,6 @@ extension CmxIrohHostRuntimeTests {
 
         try await runtime.start()
 
-        #expect(await broker.observedRegistrationCount() == 1)
         #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await routes.values() == [
@@ -588,8 +593,7 @@ extension CmxIrohHostRuntimeTests {
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
         let currentPort: UInt16 = 55_123
-        let endpoint = TestIrohEndpoint(
-            identity: fixture.endpointID,
+        let endpoint = try fixture.relayReadyEndpoint(
             directAddresses: ["0.0.0.0:\(currentPort)"]
         )
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
@@ -682,7 +686,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func endpointNetworkChangeRequestsImmediateLANRefresh() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let recorder = HostRuntimeLANRefreshRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -707,7 +711,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func repeatedUnchangedNetworkEventsDoNotContactBroker() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -742,7 +746,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func changedDirectPortPublishesImmediately() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -768,7 +772,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func endpointOnlineRequestsImmediateReachabilityRefresh() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let recorder = HostRuntimeLANRefreshRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -809,7 +813,7 @@ extension CmxIrohHostRuntimeTests {
         _ failure: CmxIrohTrustBrokerClientError
     ) async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -514,7 +514,10 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity,
+            subsequentRegistrationErrors: [
+                .connectivity, .connectivity, .connectivity,
+            ]
         )
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
@@ -536,7 +539,7 @@ extension CmxIrohHostRuntimeTests {
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
         await runtime.waitForInitialPublicationForTesting()
-        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
         #expect(await runtime.snapshot().state == .active)
         #expect(await bindings.count() == 0)
         await runtime.stop()
@@ -570,7 +573,7 @@ extension CmxIrohHostRuntimeTests {
             configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            registrationClock: ImmediateHostActivationClock(),
+            registrationClock: HostRegistrationRenewalClock(now: now),
             handleTransport: { session, _ in await session.close() },
             handleRoute: { binding, pathHints in
                 await routes.record(binding: binding, pathHints: pathHints)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -237,7 +237,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func networkChangeDuringActiveRefreshDoesNotRequestAnotherRegistration() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeRegistrationGate()
         let refreshes = HostRuntimeLANRefreshRecorder()
         let broker = TestIrohHostBroker(
@@ -278,8 +278,7 @@ extension CmxIrohHostRuntimeTests {
             relays: Array(fixture.managedRelays),
             lanGeneration: 2
         )
-        let endpoint = TestIrohEndpoint(
-            identity: fixture.endpointID,
+        let endpoint = try fixture.relayReadyEndpoint(
             directAddresses: ["192.168.1.10:50906"]
         )
         let policies = HostRuntimeLANPolicyRecorder()
@@ -503,7 +502,7 @@ extension CmxIrohHostRuntimeTests {
 
         #expect(await runtime.snapshot().state == .failed)
         #expect(await bindings.count() == 0)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -351,7 +351,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
         #expect(await bindings.count() == 0)
     }
 
@@ -537,7 +537,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 
     @Test
@@ -571,7 +571,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -32,7 +32,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,
@@ -118,7 +118,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,
@@ -179,7 +179,7 @@ extension CmxIrohHostRuntimeTests {
             lanGeneration: 1,
             revision: 1
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: revisionTwo,
@@ -318,19 +318,20 @@ extension CmxIrohHostRuntimeTests {
         .rejected(statusCode: 400, code: "invalid_request"),
         .invalidResponse,
     ])
-    func terminalBrokerFailureNeverUsesCachedPolicy(
+    func terminalBrokerFailureFailsClosedAfterCacheFirstActivation(
         _ failure: CmxIrohTrustBrokerClientError
     ) async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
             registrationError: failure
         )
+        let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: factory,
             broker: broker,
@@ -339,18 +340,19 @@ extension CmxIrohHostRuntimeTests {
             ),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            handleTransport: { session, _ in await session.close() }
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
         )
 
-        do {
-            try await runtime.start()
-            Issue.record("Expected terminal broker failure")
-        } catch let error as CmxIrohTrustBrokerClientError {
-            #expect(error == failure)
-        }
+        // Cache-first activation succeeds locally, but the background live
+        // reconcile discovers the terminal rejection and fails closed: a Mac
+        // the broker refuses must not keep serving on cached authority.
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
-        #expect(await endpoint.observedCloseCallCount() == 1)
         #expect(await runtime.snapshot().state == .failed)
+        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await bindings.count() == 0)
     }
 
     @Test
@@ -367,7 +369,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let cachedFixture = try fixture.cachedPolicyFixture(binding: cachedMetadata)
         let now = cachedFixture.now
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -386,8 +388,13 @@ extension CmxIrohHostRuntimeTests {
             handleBinding: { _, _, _ in await bindings.record() }
         )
 
+        // Cache-first activation starts on the persisted binding; the live
+        // reconcile discovers it was replaced server-side and adopts the
+        // authenticated binding in place, publishing it exactly once.
         try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == fixture.binding.bindingID)
         #expect(await bindings.count() == 1)
         await runtime.stop()
@@ -459,7 +466,7 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
-    func confirmedOnlineBindingChangePreventsDiscoveryConnectivityFallback() async throws {
+    func halfConfirmedBindingChangeIsNeverAdoptedNorPublished() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
@@ -467,13 +474,14 @@ extension CmxIrohHostRuntimeTests {
             endpointID: fixture.endpointID.endpointID,
             bindingID: "123e4567-e89b-42d3-a456-426614174099"
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: changedBinding,
             discovery: fixture.discovery,
             discoveryError: .connectivity
         )
+        let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: factory,
             broker: broker,
@@ -482,18 +490,24 @@ extension CmxIrohHostRuntimeTests {
             ),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            handleTransport: { session, _ in await session.close() }
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.invalidLocalBinding) {
-            try await runtime.start()
-        }
+        // The reconcile registers a replaced binding but its discovery round
+        // fails on connectivity. The half-confirmed binding is confirmed
+        // proof that cached authority is stale, so the runtime fails closed
+        // without adopting or publishing the incomplete policy.
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await bindings.count() == 0)
         #expect(await endpoint.observedCloseCallCount() == 1)
     }
 
     @Test
-    func routeContractMismatchNeverUsesCachedPolicy() async throws {
+    func routeContractMismatchFailsClosedAfterCacheFirstActivation() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
@@ -502,7 +516,7 @@ extension CmxIrohHostRuntimeTests {
             relays: Array(fixture.managedRelays),
             routeContractVersion: 2
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -519,17 +533,17 @@ extension CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.routeContractMismatch) {
-            try await runtime.start()
-        }
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .failed)
         #expect(await endpoint.observedCloseCallCount() == 1)
     }
 
     @Test
     func discoverySubstitutionFailsClosedAndClosesEndpoint() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let substituted = try HostRuntimeFixture.discovery(
             binding: fixture.binding,
@@ -553,12 +567,11 @@ extension CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.invalidLocalBinding) {
-            try await runtime.start()
-        }
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
-        #expect(await endpoint.observedCloseCallCount() == 1)
         #expect(await runtime.snapshot().state == .failed)
+        #expect(await endpoint.observedCloseCallCount() == 1)
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeRequestedRefreshTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeRequestedRefreshTests.swift
@@ -27,7 +27,7 @@ extension CmxIrohHostRuntimeTests {
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -87,8 +87,14 @@ extension CmxIrohHostRuntimeTests {
         #expect(await routes.values().isEmpty)
         #expect(await runtime.snapshot().state == .active)
 
-        // The relay comes up through the normal credential installation path.
-        // Publication must follow, exactly once, with the post-relay hints.
+        // The relay credential installs, then native iroh reports the home
+        // relay online. Publication must follow, exactly once, with the
+        // post-relay hints.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
         #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
         let republished = await routes.values()
         #expect(republished.map(\.binding.bindingID) == [fixture.binding.bindingID])
@@ -300,5 +306,79 @@ extension CmxIrohHostRuntimeTests {
         #expect(await broker.observedRegistrationCount() == 1)
         #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
+    }
+
+    /// A requested refresh must not perform the deferred first publication
+    /// while the home relay is still unusable, even though its authenticated
+    /// broker round runs and applies admission policy.
+    @Test("a requested refresh while the relay is unready does not publish")
+    func requestedRefreshWhileRelayUnreadyDoesNotPublish() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        await runtime.requestRegistrationRefresh()
+
+        #expect(await broker.observedRegistrationCount() == 2)
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// Cached authority must be verified against the live broker even when
+    /// the home relay never becomes usable: a server-side rejection fails
+    /// the runtime closed instead of hiding behind the relay outage.
+    @Test("stale cached authority fails closed without relay readiness")
+    func staleCachedAuthorityFailsClosedWithoutRelayReadiness() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .missingAuthentication
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(
+                cachedHostPolicy: try cachedFixture.policy()
+            ),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            relayReadinessTimeout: .milliseconds(50),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
+        )
+
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        #expect(await endpoint.waitForCloseCallCount(1))
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await bindings.count() == 0)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -4,6 +4,17 @@ import Testing
 
 @testable import CmuxIrohTransport
 
+extension CmxIrohHostRuntime {
+    /// Awaits the startup ready gate and every refresh round it scheduled, so
+    /// tests observe the settled post-reconcile state deterministically.
+    func waitForInitialPublicationForTesting() async {
+        await initialPublicationTask?.value
+        while let task = registrationRefreshTask {
+            await task.value
+        }
+    }
+}
+
 extension CmxIrohHostRuntimeTests {
     /// Regression for the advertise-before-ready warm-up race
     /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not
@@ -71,6 +82,111 @@ extension CmxIrohHostRuntimeTests {
         #expect(republished.map(\.pathHints) == [[relayHint]])
         #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
 
+        await runtime.stop()
+    }
+
+    /// Cache-first activation: a persisted verified policy for the same
+    /// binding makes the Mac dialable immediately. The live broker round is
+    /// only a background reconcile, so start() completes while the broker has
+    /// not yet answered at all.
+    @Test("cache-first start becomes ready without a live broker response")
+    func cacheFirstStartBecomesReadyWithoutALiveBrokerResponse() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let cachedPolicy = try cachedFixture.policy()
+        let registrationGate = HostRuntimeRegistrationGate()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationHook: {
+                await registrationGate.waitOnce()
+                return true
+            }
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                try fixture.relayReadyEndpoint(),
+            ]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
+        // The cached route identity is refreshed, never unpublished, but no
+        // fresh binding may be published while the live round is unanswered.
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+        ])
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await bindings.count() == 0)
+
+        await registrationGate.open()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await bindings.count() == 1)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// The late live policy reconciles onto a cache-first activation: the
+    /// same binding is re-verified and the fresh broker route hints replace
+    /// the empty cached ones.
+    @Test("late live policy reconciles a cache-first activation")
+    func lateLivePolicyReconcilesCacheFirstActivation() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
+        let discoveredHint = try #require(fixture.binding.pathHints.first)
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let cachedPolicy = try cachedFixture.policy()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                try fixture.relayReadyEndpoint(),
+            ]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await bindings.count() == 1)
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+            .init(
+                binding: CmxIrohBrokerBindingMetadata(binding: fixture.binding),
+                pathHints: [discoveredHint]
+            ),
+        ])
+        #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -345,6 +345,89 @@ extension CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    /// A cache-first activation whose live reconcile adopts a server-side
+    /// replacement binding while the home relay is still unusable must move
+    /// the ready gate onto the adopted identity: the stale gate armed with
+    /// the superseded cached binding is drained so it can never activate the
+    /// replacement relay coordinator with the old binding, nothing publishes
+    /// before the relay is usable, and afterwards exactly the adopted
+    /// binding publishes, once.
+    @Test("adoption while the relay is unready re-arms the gate on the adopted binding")
+    func adoptionWhileRelayUnreadyReArmsGateOnAdoptedBinding() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let cachedPolicy = try cachedFixture.policy()
+        let now = cachedFixture.now
+        let replacementBinding = try HostRuntimeFixture.binding(
+            endpointID: fixture.endpointID.endpointID,
+            bindingID: "123e4567-e89b-42d3-a456-426614174099"
+        )
+        let replacementDiscovery = try HostRuntimeFixture.discovery(
+            binding: replacementBinding,
+            relays: HostRuntimeFixture.relayURLs
+        )
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: replacementBinding,
+            discovery: replacementDiscovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        // Cache-first start on the persisted binding: the cached route
+        // identity is refreshed, nothing publishes while the relay warms up.
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+        ])
+        #expect(await bindings.count() == 0)
+
+        // The live reconcile adopts the server-side replacement binding. The
+        // relay is still unusable, so the adopted binding must stay
+        // unpublished.
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        var adopted = false
+        for _ in 0 ..< 50_000 {
+            if await runtime.snapshot().bindingID == replacementBinding.bindingID {
+                adopted = true
+                break
+            }
+            await Task.yield()
+        }
+        #expect(adopted)
+        #expect(await bindings.count() == 0)
+
+        // The relay credential installs for the adopted binding, then the
+        // home relay comes online. Publication must follow, exactly once,
+        // with the adopted identity.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+        let published = await routes.values()
+        #expect(published.first?.binding.bindingID == cachedPolicy.binding.bindingID)
+        #expect(published.last?.binding.bindingID == replacementBinding.bindingID)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
     /// Cached authority must be verified against the live broker even when
     /// the home relay never becomes usable: a server-side rejection fails
     /// the runtime closed instead of hiding behind the relay outage.

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -1,0 +1,76 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+
+@testable import CmuxIrohTransport
+
+extension CmxIrohHostRuntimeTests {
+    /// Regression for the advertise-before-ready warm-up race
+    /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not
+    /// publish its binding or route hints while its home relay is still
+    /// warming up, because clients immediately burn doomed dials against an
+    /// endpoint that cannot yet accept them. The binding and route may only
+    /// be published once the relay is usable, with the post-relay hints, and
+    /// exactly once.
+    @Test("binding publication waits for a usable home relay")
+    func bindingPublicationWaitsForUsableHomeRelay() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let readyBinding = try HostRuntimeFixture.binding(
+            endpointID: fixture.endpointID.endpointID,
+            bindingID: fixture.binding.bindingID,
+            publicHintObservedAt: now,
+            publicHintExpiresAt: now.addingTimeInterval(60 * 60)
+        )
+        let relayHint = try #require(readyBinding.pathHints.first)
+        let readyDiscovery = try HostRuntimeFixture.discovery(
+            binding: readyBinding,
+            relays: HostRuntimeFixture.relayURLs
+        )
+        // The endpoint gains its usable relay hint only after the relay
+        // credential coordinator installs the first credential, exactly like
+        // a cold production launch.
+        let endpoint = TestIrohEndpoint(
+            identity: fixture.endpointID,
+            pathHintsAfterRelayReplacement: [relayHint]
+        )
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            subsequentRegistrationBindings: [readyBinding],
+            subsequentDiscoveries: [readyDiscovery]
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        // No usable home relay exists yet: the Mac must not be
+        // discoverable-but-undialable.
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await runtime.snapshot().state == .active)
+
+        // The relay comes up through the normal credential installation path.
+        // Publication must follow, exactly once, with the post-relay hints.
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        let republished = await routes.values()
+        #expect(republished.map(\.binding.bindingID) == [fixture.binding.bindingID])
+        #expect(republished.map(\.pathHints) == [[relayHint]])
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+
+        await runtime.stop()
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -189,4 +189,103 @@ extension CmxIrohHostRuntimeTests {
         #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
     }
+
+    /// A relay-readiness timeout must never publish. The gate keeps retrying
+    /// the readiness wait on the injected clock; once the relay becomes
+    /// usable, exactly one publication follows.
+    @Test("readiness timeouts keep the binding unpublished until the relay succeeds")
+    func readinessTimeoutsKeepBindingUnpublishedUntilRelaySucceeds() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            relayReadinessTimeout: .milliseconds(20),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        #expect(await bindings.count() == 0)
+
+        // First readiness timeout: still unpublished, backoff armed.
+        await clock.waitUntilSleepCount(1)
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        clock.advance(to: try #require(clock.observedSleepDeadlines().last))
+
+        // Second readiness timeout: still unpublished.
+        await clock.waitUntilSleepCount(2)
+        #expect(await bindings.count() == 0)
+
+        // The home relay comes up. Publication must follow, exactly once.
+        await endpoint.emit(.online)
+
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// A relay that never becomes usable must leave the endpoint permanently
+    /// unpublished: no handleBinding, no handleRoute, no extra broker rounds.
+    @Test("readiness that never succeeds never publishes")
+    func readinessThatNeverSucceedsNeverPublishes() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            relayReadinessTimeout: .milliseconds(20),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        for cycle in 1 ... 3 {
+            await clock.waitUntilSleepCount(cycle)
+            #expect(await bindings.count() == 0)
+            #expect(await routes.values().isEmpty)
+            clock.advance(to: try #require(clock.observedSleepDeadlines().last))
+        }
+
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -15,6 +15,19 @@ extension CmxIrohHostRuntime {
     }
 }
 
+extension TestIrohEndpoint {
+    /// A network-change refresh can own the terminal round and still be
+    /// finishing its teardown when the publication pipeline await returns.
+    /// Bounded wait for the endpoint close that teardown must perform.
+    func waitForCloseCallCount(_ minimum: Int) async -> Bool {
+        for _ in 0 ..< 50_000 {
+            if observedCloseCallCount() >= minimum { return true }
+            await Task.yield()
+        }
+        return observedCloseCallCount() >= minimum
+    }
+}
+
 extension CmxIrohHostRuntimeTests {
     /// Regression for the advertise-before-ready warm-up race
     /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
@@ -97,6 +97,34 @@ struct HostRuntimeFixture {
         )
     }
 
+    /// A public relay hint usable on the supervisor's wall clock for one hour.
+    /// An endpoint born with it reports a usable home relay immediately, so
+    /// activation publishes the binding inline instead of waiting on the ready
+    /// gate. Fixtures that pin `now` far in the future exclude it from
+    /// registration payloads automatically, keeping those payloads unchanged.
+    static func usableRelayHint() throws -> CmxIrohPathHint {
+        let observed = Date()
+        return try CmxIrohPathHint(
+            kind: .relayURL,
+            value: relayURLs[2],
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: observed,
+            expiresAt: observed.addingTimeInterval(60 * 60)
+        )
+    }
+
+    /// An endpoint whose home relay is usable from birth.
+    func relayReadyEndpoint(
+        directAddresses: [String] = []
+    ) throws -> TestIrohEndpoint {
+        TestIrohEndpoint(
+            identity: endpointID,
+            directAddresses: directAddresses,
+            pathHints: [try Self.usableRelayHint()]
+        )
+    }
+
     static let relayURLs = [
         "https://aps1-1.relay.lawrence.cmux.iroh.link/",
         "https://euc1-1.relay.lawrence.cmux.iroh.link/",


### PR DESCRIPTION
Fixes the Mac host warm-up race in https://github.com/manaflow-ai/cmux/issues/9724: `CmxIrohHostRuntime.start()` serialized connectivity start, a live broker resolve, relay credential activation, a relay-readiness wait, and a second resolve, while the previous run's registration kept the Mac advertised. Phones burned 5-15 s of doomed dials on every launch (43 s in the issue's trace).

## Mechanism

**Cache-first activation.** When the persisted last-good policy (`CmxIrohCachedHostPolicy`) still cryptographically verifies for this exact account, device, endpoint, identity generation, and host settings (the existing `validateCachedPolicy`, signature and expiry included), `start()` uses it immediately for grant verification keys, attestation, LAN rendezvous, and the endpoint relay bootstrap, and returns active with no broker round. First launch (no cache), an invalid cache, and relay-only debug hosts keep today's blocking `resolveInitialPolicy`.

**Register-when-ready publication.** `handleBinding`/`handleRoute` (and through them the app's status-cache route publication) never carry pre-relay state. Publication happens only after `waitForUsableHomeRelay()` verifies a usable relay path, on every path: the inline start path checks readiness, the ready gate retries the bounded readiness wait with backoff on the injected clock when it times out (a timeout never publishes), and every refresh round that would perform the lifecycle's first publication re-checks readiness immediately before publishing, so a direct-port change or requested refresh during warm-up cannot leak the endpoint early. A cached local route identity is refreshed, never unpublished, so LAN dialability stays up from the first moment. A host whose relay never becomes usable stays unpublished.

**Reconcile decoupled from readiness.** A cache-first activation schedules its authenticated broker reconcile immediately, independent of relay readiness, so a server-side revocation or replacement cannot hide behind a relay outage; readiness gates only the publication inside the round. A broker cooldown observed during activation keeps its validated Retry-After floor, and the ready gate defers to an armed failure retry instead of preempting it. If the reconcile discovers the binding was replaced server-side, it adopts the authenticated result in place: `CmxIrohAdmissionController.update` already propagates the new acceptor to online and offline admission, and only the relay credential coordinator pins a binding id, so it is recreated (`adoptReplacedBinding`). A half-confirmed change (registration succeeded, discovery failed) keeps failing closed, and the macOS composition root's existing `.failed` recovery ladder rebuilds. Renewal and `requestRegistrationRefresh` rounds keep today's fail-closed rule for replaced bindings; adoption is allowed only between a cache-first start and its first completed live resolve.

This is principled rather than a workaround: no new lifecycle machinery, no sleeps outside the injected clocks (the readiness wait is the supervisor's existing cancellable signal-or-deadline mechanism, now with an injectable window), every step preserves the `lifecycleRevision`/teardown guards (`tearDownComponents` cancels the ready gate on stop, failure, and sign-out alike), and the background reconcile feeds the existing single coalescing refresh owner so rounds cannot race.

## Residual risk

- A stale cached relay bootstrap right after a relay-fleet change can make the first relay connection fail; the readiness retry loop keeps the endpoint unpublished while the relay coordinator's own retry installs fresh credentials.
- Terminal broker rejections now surface after `start()` returns instead of failing `start()`; the app's existing failure-recovery backoff owns that path (verified: it schedules a guarded rebuild on `.failed`).
- The broker-side registration performed by the reconcile still precedes local publication (unavoidable without broker support for hidden registration); its payload carries only the hints that actually exist at that moment.

## Revert

`git revert` of the branch commits is safe. No persistence format changed: `CmxIrohStoredHostPolicyRecord` stays at version 2 and the cache write path is untouched; cache-first only changes when the already-persisted record is read.

## Tests

Two-commit regression pattern at the base: commit 1 adds the failing advertise-before-ready test, commit 2 the fix; review-gate hardening commits follow the same pattern. Behavior tests in `CmxIrohHostRuntimeStartupPublicationTests`: publication waits for a usable home relay and happens exactly once with post-relay hints; readiness that times out repeatedly keeps the binding unpublished and publishes exactly once after success; readiness that never succeeds never publishes; a requested refresh while the relay is unready does not publish; cache-first start becomes ready while the broker's response is still suspended; a late live policy reconciles fresh hints onto a cache-first activation; stale cached authority fails closed without relay readiness. `swift test --package-path Packages/Shared/CmuxIrohTransport`: 636 tests in 67 suites pass; the only skipped tests are three pre-existing real-network release-gate tests that stall identically on a pristine `main` checkout in a headless shell.