### PR TITLE
iOS Iroh: bounded dials, hint-refresh fallback, fail-open credential refresh

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -26,6 +26,9 @@ public actor CmxConnectivityEngine {
     private let installRouteSnapshot: RouteSnapshotInstaller?
     private let diagnosticLog: DiagnosticLog?
     private let clock: any CmxIrohRelayClock
+    /// Deadline for each dial phase (public paths, private fallback, and the
+    /// admission barrier) of every peer session this engine creates.
+    private let dialPhaseTimeout: Duration
     private var desiredActive = false
     private var lifecycleRevision: UInt64 = 0
     private var endpointGeneration: UInt64?
@@ -59,7 +62,8 @@ public actor CmxConnectivityEngine {
         authority: (any CmxConnectivityAuthorityServing)? = nil,
         installRouteSnapshot: RouteSnapshotInstaller? = nil,
         diagnosticLog: DiagnosticLog? = nil,
-        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock(),
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         precondition((authority == nil) == (installRouteSnapshot == nil))
         supervisor = CmxIrohEndpointSupervisor(
@@ -72,6 +76,7 @@ public actor CmxConnectivityEngine {
         self.installRouteSnapshot = installRouteSnapshot
         self.diagnosticLog = diagnosticLog
         self.clock = clock
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 
     /// Creates a stopped endpoint-only engine for a host acceptor.
@@ -90,6 +95,7 @@ public actor CmxConnectivityEngine {
         installRouteSnapshot = nil
         diagnosticLog = nil
         clock = CmxIrohSystemRelayClock()
+        dialPhaseTimeout = .seconds(5)
     }
 
     init(
@@ -99,7 +105,8 @@ public actor CmxConnectivityEngine {
         authority: (any CmxConnectivityAuthorityServing)? = nil,
         installRouteSnapshot: RouteSnapshotInstaller? = nil,
         diagnosticLog: DiagnosticLog? = nil,
-        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock(),
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         precondition((authority == nil) == (installRouteSnapshot == nil))
         self.supervisor = supervisor
@@ -109,6 +116,7 @@ public actor CmxConnectivityEngine {
         self.installRouteSnapshot = installRouteSnapshot
         self.diagnosticLog = diagnosticLog
         self.clock = clock
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 
     /// Returns the current immutable UI-safe state.
@@ -533,6 +541,7 @@ public actor CmxConnectivityEngine {
         let protocolConfiguration = protocolConfiguration
         let diagnosticLog = diagnosticLog
         let clock = clock
+        let dialPhaseTimeout = dialPhaseTimeout
         let peer = CmxConnectivityPeerSession(
             peerID: peerID,
             buildSession: { request in
@@ -551,6 +560,7 @@ public actor CmxConnectivityEngine {
                             basedOn: context
                         )
                     },
+                    dialPhaseTimeout: dialPhaseTimeout,
                     protocolConfiguration: protocolConfiguration,
                     diagnostics: diagnosticLog
                 )

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -172,7 +172,8 @@ public actor CmxIrohClientRuntime {
             supervisor: supervisor,
             contextProvider: contextRouter,
             protocolConfiguration: protocolConfiguration,
-            diagnosticLog: diagnosticLog
+            diagnosticLog: diagnosticLog,
+            dialPhaseTimeout: configuration.dialPhaseTimeout
         )
         self.supervisor = supervisor
         self.connectivityEngine = connectivityEngine

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
@@ -44,6 +44,12 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
     /// flight. A signed registration refresh follows after activation.
     public let cachedBinding: CmxIrohBrokerBindingMetadata?
 
+    /// Deadline for each dial phase (public paths, private fallback, and the
+    /// admission barrier) of every peer dial this runtime performs. A phase
+    /// that never answers fails typed at this bound and hands control back to
+    /// recovery instead of holding the reconnect owner (cmux#9724).
+    public let dialPhaseTimeout: Duration
+
     /// Creates an immutable iOS client lifecycle configuration.
     ///
     /// Broker-facing validation occurs when ``CmxIrohClientRuntime/start()``
@@ -60,6 +66,8 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
     ///   - endpointRelayProfile: An optional local selection or custom override.
     ///   - cachedRelayCredential: A validated cached relay capability.
     ///   - cachedBinding: A previously verified exact local binding tuple.
+    ///   - dialPhaseTimeout: The per-phase dial deadline, injectable so tests
+    ///     can shrink it.
     public init(
         accountID: String,
         deviceID: String,
@@ -72,7 +80,8 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
         managedRelayURLs: Set<String>,
         endpointRelayProfile: CmxIrohEndpointRelayProfile? = nil,
         cachedRelayCredential: CmxIrohRelayTokenResponse? = nil,
-        cachedBinding: CmxIrohBrokerBindingMetadata? = nil
+        cachedBinding: CmxIrohBrokerBindingMetadata? = nil,
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         self.accountID = accountID
         self.deviceID = cmxCanonicalDeviceID(deviceID)
@@ -86,5 +95,6 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
         self.endpointRelayProfile = endpointRelayProfile
         self.cachedRelayCredential = cachedRelayCredential
         self.cachedBinding = cachedBinding
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
@@ -431,56 +431,71 @@ public actor CmxIrohClientSession {
 
         do {
             try Task.checkCancellation()
-            guard await establishedConnection.remoteIdentity() == targetIdentity else {
-                throw CmxIrohClientSessionError.remoteIdentityMismatch
-            }
-            try await establishedConnection.setIncomingStreamLimits(
-                maximumBidirectionalStreamCount: 0,
-                maximumUnidirectionalStreamCount: 0
-            )
-            let stream = try await establishedConnection.openBidirectionalStream()
-            let header = try CmxIrohStreamHeader(
-                lane: .control,
-                credential: credential
-            )
-            try await stream.sendStream.send(headerCodec.encode(header))
-            let admission = try await readAdmissionFrame(from: stream.receiveStream)
-            switch admission.frame {
-            case .acceptedPendingNatTraversal, .acceptedRelayOnly:
-                if admission.frame == .acceptedPendingNatTraversal {
-                    try Task.checkCancellation()
-                    try await establishedConnection.authorizeNatTraversal()
-                }
-                try Task.checkCancellation()
-                try await stream.sendStream.send(
-                    admissionCodec.encodeFrame(.clientReady)
+            // A half-ready peer can accept the QUIC connection and then never
+            // serve the admission frames. Bound the whole barrier like a dial
+            // phase so a silent peer hands control back to recovery instead
+            // of holding the redial owner open-endedly (cmux#9724).
+            return try await boundedByDialPhase { [weak self] in
+                guard let self else { throw CancellationError() }
+                return try await self.performAdmissionBarrier(
+                    on: establishedConnection
                 )
-                let confirmation = try await readAdmissionFrame(
-                    from: stream.receiveStream,
-                    initialBuffer: admission.trailingBytes
-                )
-                switch confirmation.frame {
-                case .serverReady:
-                    break
-                case let .denied(code):
-                    throw CmxIrohClientSessionError.admissionDenied(code: code)
-                case .acceptedPendingNatTraversal, .acceptedRelayOnly, .clientReady:
-                    throw CmxIrohClientSessionError.invalidAdmissionFrame
-                }
-                try Task.checkCancellation()
-                return CmxIrohConnectedControl(
-                    connection: establishedConnection,
-                    stream: stream,
-                    initialReceiveBuffer: confirmation.trailingBytes
-                )
-            case let .denied(code):
-                throw CmxIrohClientSessionError.admissionDenied(code: code)
-            case .clientReady, .serverReady:
-                throw CmxIrohClientSessionError.invalidAdmissionFrame
             }
         } catch {
             await establishedConnection.close(errorCode: 1, reason: "admission_failed")
             throw error
+        }
+    }
+
+    private func performAdmissionBarrier(
+        on establishedConnection: any CmxIrohConnection
+    ) async throws -> CmxIrohConnectedControl {
+        guard await establishedConnection.remoteIdentity() == targetIdentity else {
+            throw CmxIrohClientSessionError.remoteIdentityMismatch
+        }
+        try await establishedConnection.setIncomingStreamLimits(
+            maximumBidirectionalStreamCount: 0,
+            maximumUnidirectionalStreamCount: 0
+        )
+        let stream = try await establishedConnection.openBidirectionalStream()
+        let header = try CmxIrohStreamHeader(
+            lane: .control,
+            credential: credential
+        )
+        try await stream.sendStream.send(headerCodec.encode(header))
+        let admission = try await readAdmissionFrame(from: stream.receiveStream)
+        switch admission.frame {
+        case .acceptedPendingNatTraversal, .acceptedRelayOnly:
+            if admission.frame == .acceptedPendingNatTraversal {
+                try Task.checkCancellation()
+                try await establishedConnection.authorizeNatTraversal()
+            }
+            try Task.checkCancellation()
+            try await stream.sendStream.send(
+                admissionCodec.encodeFrame(.clientReady)
+            )
+            let confirmation = try await readAdmissionFrame(
+                from: stream.receiveStream,
+                initialBuffer: admission.trailingBytes
+            )
+            switch confirmation.frame {
+            case .serverReady:
+                break
+            case let .denied(code):
+                throw CmxIrohClientSessionError.admissionDenied(code: code)
+            case .acceptedPendingNatTraversal, .acceptedRelayOnly, .clientReady:
+                throw CmxIrohClientSessionError.invalidAdmissionFrame
+            }
+            try Task.checkCancellation()
+            return CmxIrohConnectedControl(
+                connection: establishedConnection,
+                stream: stream,
+                initialReceiveBuffer: confirmation.trailingBytes
+            )
+        case let .denied(code):
+            throw CmxIrohClientSessionError.admissionDenied(code: code)
+        case .clientReady, .serverReady:
+            throw CmxIrohClientSessionError.invalidAdmissionFrame
         }
     }
 
@@ -498,22 +513,32 @@ public actor CmxIrohClientSession {
     ) async throws -> any CmxIrohConnection {
         let endpoint = endpoint
         let alpn = protocolConfiguration.alpn
+        return try await boundedByDialPhase {
+            try await endpoint.connect(to: address, alpn: alpn)
+        }
+    }
+
+    /// Races one dial-phase operation against the injected phase bound. The
+    /// operation must cancel cooperatively; on timeout the loser is cancelled
+    /// and the phase fails typed so the redial machinery supersedes it
+    /// instead of wedging behind it (cmux#8531).
+    private func boundedByDialPhase<Value: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
         let bound = dialPhaseTimeout
-        return try await withThrowingTaskGroup(
-            of: (any CmxIrohConnection)?.self
-        ) { group in
+        return try await withThrowingTaskGroup(of: Value?.self) { group in
             group.addTask {
-                try await endpoint.connect(to: address, alpn: alpn)
+                try await operation()
             }
             group.addTask {
                 try await ContinuousClock().sleep(for: bound)
                 return nil
             }
             defer { group.cancelAll() }
-            guard let first = try await group.next(), let connection = first else {
+            guard let first = try await group.next(), let value = first else {
                 throw CmxIrohClientSessionError.dialTimedOut
             }
-            return connection
+            return value
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -193,6 +193,28 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
                 )
                 usedFreshDiscovery = true
             } catch {
+                try Task.checkCancellation()
+                // The refresh failed. Dialing with the last verified snapshot
+                // beats not dialing at all (cmux#9724): the staleness mark
+                // survives, so the next attempt still refetches once the
+                // broker recovers. Verification is not weakened; this
+                // snapshot passed the same checks when it was fetched.
+                if let lastGood = authoritativeDiscovery {
+                    do {
+                        return try await resolveContext(
+                            for: request,
+                            targetIdentity: targetIdentity,
+                            routeHints: routeHints,
+                            discovery: lastGood,
+                            at: clock
+                        )
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        // The last-good snapshot no longer authorizes this
+                        // peer; fall through to the offline cache.
+                    }
+                }
                 guard Self.isConnectivity(error),
                       let cached = try await cachedPolicy(
                           for: request,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
@@ -374,6 +374,14 @@ public actor CmxIrohRelayCredentialCoordinator {
                 ),
                 initialFailureCount: 1
             )
+            // Fail open while a last-good credential is installed on the
+            // endpoint: a failed mint must not fail the caller's foreground
+            // path into zero-route dial churn (cmux#10375). The bounded retry
+            // loop above keeps refreshing in the background, and the relay is
+            // the authority that rejects a credential that truly went bad.
+            if installedCredential != nil, !(error is CancellationError) {
+                return
+            }
             throw error
         }
     }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
@@ -97,16 +97,47 @@ public actor CmxIrohRelayPolicyCache {
     /// - Parameters:
     ///   - trustRoot: App-pinned public verification keys.
     ///   - now: Verification time.
+    ///   - expiredPolicyReuseGrace: Bounded fail-open window after the signed
+    ///     expiry in which the last-good policy still loads. The policy is
+    ///     re-verified at its final valid instant, so signature, rollback,
+    ///     and claim checks run unweakened; only the expiry gate is graced
+    ///     (cmux#10375). Zero preserves strict expiry.
     /// - Returns: The verified policy, or `nil` when no policy is cached.
     /// - Throws: ``CmxIrohRelayPolicyError`` or a secure-storage error.
     public func load(
         trustRoot: CmxIrohRelayPolicyTrustRoot,
-        now: Date
+        now: Date,
+        expiredPolicyReuseGrace: TimeInterval = 0
     ) async throws -> CmxIrohManagedRelayPolicy? {
         await acquire()
         defer { release() }
         guard let record = try await storedRecord() else { return nil }
-        let policy = try verifier.verify(record.signedPolicy, trustRoot: trustRoot, now: now)
+        let policy: CmxIrohManagedRelayPolicy
+        do {
+            policy = try verifier.verify(
+                record.signedPolicy,
+                trustRoot: trustRoot,
+                now: now
+            )
+        } catch CmxIrohRelayPolicyError.expired {
+            // The recorded expiry is cross-checked against the signed claims
+            // below; a record that overstates it re-fails as expired here or
+            // as rollback below.
+            guard expiredPolicyReuseGrace > 0,
+                  let recordedExpiry = record.expiresAt,
+                  now.timeIntervalSince1970
+                    <= TimeInterval(recordedExpiry) + expiredPolicyReuseGrace else {
+                throw CmxIrohRelayPolicyError.expired
+            }
+            let lastValidInstant = Date(
+                timeIntervalSince1970: TimeInterval(recordedExpiry) - 1
+            )
+            policy = try verifier.verify(
+                record.signedPolicy,
+                trustRoot: trustRoot,
+                now: min(now, lastValidInstant)
+            )
+        }
         guard policy.sequence == record.highestSequence,
               Self.metadataMatches(policy, record: record) else {
             throw CmxIrohRelayPolicyError.rollback

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -6,10 +6,18 @@ public actor CmxIrohRelayPolicyService {
     private typealias Resolution = CmxIrohRelayPolicyResolutionResult
     private typealias Resolver = CmxIrohRelayPolicyResolution
 
+    /// Bounded fail-open window in which ``restore`` keeps a recently-expired
+    /// last-good managed policy dialable after a failed refresh (cmux#10375).
+    /// A failed policy refresh must degrade to the last verified catalog, not
+    /// to a zero-route profile; the relay itself remains the authority on
+    /// credential validity and rejects a truly stale token.
+    public static let defaultExpiredPolicyReuseGrace: TimeInterval = 6 * 60 * 60
+
     private let policyCache: CmxIrohRelayPolicyCache
     private let preferenceStore: CmxIrohRelayPreferenceStore
     private let credentialStore: CmxIrohCustomRelayCredentialStore
     private let broker: (any CmxIrohRelayPolicyServing)?
+    private let expiredPolicyReuseGrace: TimeInterval
     private var currentEffective: CmxIrohEffectiveRelayPolicy?
     private var currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot.inactive
     private var continuations: [UUID: AsyncStream<CmxIrohRelayDiagnosticsSnapshot>.Continuation] = [:]
@@ -20,12 +28,15 @@ public actor CmxIrohRelayPolicyService {
         policyCache: CmxIrohRelayPolicyCache = CmxIrohRelayPolicyCache(),
         preferenceStore: CmxIrohRelayPreferenceStore = CmxIrohRelayPreferenceStore(),
         credentialStore: CmxIrohCustomRelayCredentialStore = CmxIrohCustomRelayCredentialStore(),
-        broker: (any CmxIrohRelayPolicyServing)? = nil
+        broker: (any CmxIrohRelayPolicyServing)? = nil,
+        expiredPolicyReuseGrace: TimeInterval = CmxIrohRelayPolicyService
+            .defaultExpiredPolicyReuseGrace
     ) {
         self.policyCache = policyCache
         self.preferenceStore = preferenceStore
         self.credentialStore = credentialStore
         self.broker = broker
+        self.expiredPolicyReuseGrace = max(0, expiredPolicyReuseGrace)
     }
 
     /// Fetches and installs the broker's current relay bootstrap response.
@@ -196,7 +207,15 @@ public actor CmxIrohRelayPolicyService {
         }
 
         do {
-            guard let policy = try await policyCache.load(trustRoot: trustRoot, now: now) else {
+            // Restore is the failed-refresh fallback path, so it alone grants
+            // the bounded expired-policy grace: a recently-expired last-good
+            // catalog must stay dialable instead of zeroing every relay route
+            // (cmux#10375). The graced state is visible as `.policyExpired`.
+            guard let policy = try await policyCache.load(
+                trustRoot: trustRoot,
+                now: now,
+                expiredPolicyReuseGrace: expiredPolicyReuseGrace
+            ) else {
                 return publishUnavailable(
                     configuration: persisted.requested,
                     revision: persisted.revision,
@@ -205,6 +224,8 @@ public actor CmxIrohRelayPolicyService {
                     failure: .policyUnavailable
                 )
             }
+            let policyIsExpired = TimeInterval(policy.expiresAt)
+                <= now.timeIntervalSince1970
             let resolution = await Resolver.resolve(
                 configuration: persisted.requested,
                 revision: persisted.revision,
@@ -218,7 +239,9 @@ public actor CmxIrohRelayPolicyService {
             return commit(
                 Resolution(
                     effective: resolution.effective,
-                    failure: cleanupFailure ?? resolution.failure
+                    failure: policyIsExpired
+                        ? .policyExpired
+                        : cleanupFailure ?? resolution.failure
                 ),
                 operation: operation
             )

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
@@ -1,0 +1,157 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Bounded-dial behavior (cmux#9724, cmux#8531): a dial attempt whose
+/// admission barrier never answers must fail at the configured dial bound and
+/// leave the session redialable, instead of holding the reconnect owner for
+/// an unbounded time. A half-ready Mac accepts the QUIC connection but never
+/// serves the admission frames; that exact shape produced the unbounded
+/// 16.2-second dial in the cmux#9724 trace.
+@Suite
+struct CmxIrohClientSessionDialBoundTests {
+    let localIdentity: CmxIrohPeerIdentity
+    let remoteIdentity: CmxIrohPeerIdentity
+    let credential: CmxIrohAdmissionCredential
+
+    init() throws {
+        localIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "ab", count: 32)
+        )
+        remoteIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "cd", count: 32)
+        )
+        credential = try .pairGrant("e30.e30.AA")
+    }
+
+    @Test("an admission barrier that never answers fails at the dial bound")
+    func admissionBarrierThatNeverAnswersFailsAtTheDialBound() async throws {
+        let control = CmxIrohBidirectionalStream(
+            receiveStream: TestHangingIrohReceiveStream(),
+            sendStream: TestIrohSendStream()
+        )
+        let connection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [control]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40)
+        )
+
+        let failure = await boundedConnectFailure(session, within: .seconds(2))
+        #expect(failure as? CmxIrohClientSessionError == .dialTimedOut)
+        #expect(await connection.observedCloseCallCount() >= 1)
+        await session.close()
+    }
+
+    @Test("a timed-out admission is superseded by the next connect attempt")
+    func timedOutAdmissionIsSupersededByTheNextConnectAttempt() async throws {
+        let hangingControl = CmxIrohBidirectionalStream(
+            receiveStream: TestHangingIrohReceiveStream(),
+            sendStream: TestIrohSendStream()
+        )
+        let hangingConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [hangingControl]
+        )
+        let goodConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [answeringControlStream()]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [
+                .connection(hangingConnection),
+                .connection(goodConnection),
+            ]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40)
+        )
+
+        let failure = await boundedConnectFailure(session, within: .seconds(2))
+        #expect(failure as? CmxIrohClientSessionError == .dialTimedOut)
+
+        // The timed-out attempt must have been retired cleanly: the very next
+        // attempt on the same session dials again and admits.
+        try await session.connect()
+
+        #expect(await endpoint.observedDialedAddresses().count == 2)
+        #expect(await hangingConnection.observedCloseCallCount() >= 1)
+        await session.close()
+    }
+
+    // MARK: - Support
+
+    /// Runs `connect()` under a test watchdog so the red state (an unbounded
+    /// admission hang) fails this test quickly instead of hanging the suite.
+    private func boundedConnectFailure(
+        _ session: CmxIrohClientSession,
+        within limit: Duration
+    ) async -> (any Error)? {
+        let connectTask = Task { try await session.connect() }
+        let watchdog = Task {
+            try? await ContinuousClock().sleep(for: limit)
+            connectTask.cancel()
+        }
+        defer { watchdog.cancel() }
+        do {
+            _ = try await connectTask.value
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func answeringControlStream() -> CmxIrohBidirectionalStream {
+        let codec = CmxIrohAdmissionAckCodec()
+        let accepted = codec.encodeFrame(.acceptedPendingNatTraversal)
+        let serverReady = codec.encodeFrame(.serverReady)
+        return CmxIrohBidirectionalStream(
+            receiveStream: TestIrohReceiveStream(buffer: accepted + serverReady),
+            sendStream: TestIrohSendStream()
+        )
+    }
+
+    private func publicRelayHint() throws -> CmxIrohPathHint {
+        try CmxIrohPathHint(
+            kind: .relayURL,
+            value: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+            source: .native,
+            privacyScope: .publicInternet
+        )
+    }
+}
+
+/// A control stream that never yields admission bytes. The hang is
+/// cancellable, mirroring the production stream contract the phase bound
+/// relies on (`TestIrohDialResult.hang` models the same shape for dials).
+actor TestHangingIrohReceiveStream: CmxIrohReceiveStream {
+    private var stoppedCodes: [UInt64] = []
+
+    func receive(maximumByteCount _: Int) async throws -> Data? {
+        try await Task.sleep(for: .seconds(3_600))
+        return nil
+    }
+
+    func stop(errorCode: UInt64) {
+        stoppedCodes.append(errorCode)
+    }
+
+    func observedStoppedCodes() -> [UInt64] {
+        stoppedCodes
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
@@ -155,3 +155,139 @@ actor TestHangingIrohReceiveStream: CmxIrohReceiveStream {
         stoppedCodes
     }
 }
+
+/// Field regression coverage (ibdl device dogfood): sessions established just
+/// inside the dial bound were observed closing ~250-300 ms after
+/// establishment with a local cancelled attribution. The deadline must be
+/// disarmed the moment its phase completes, and no remnant of a superseded
+/// earlier attempt may cancel a later established session.
+extension CmxIrohClientSessionDialBoundTests {
+    @Test("establishment just inside the deadline survives past the deadline")
+    func establishmentJustInsideTheDeadlineSurvivesPastTheDeadline() async throws {
+        let codec = CmxIrohAdmissionAckCodec()
+        let control = CmxIrohBidirectionalStream(
+            receiveStream: SlowIrohReceiveStream(
+                buffer: codec.encodeFrame(.acceptedPendingNatTraversal)
+                    + codec.encodeFrame(.serverReady),
+                delay: .milliseconds(180)
+            ),
+            sendStream: TestIrohSendStream()
+        )
+        let connection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [control]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(250)
+        )
+
+        // Admission completes at ~180ms, inside the 250ms bound.
+        try await session.connect()
+        #expect(await connection.observedCloseCallCount() == 0)
+
+        // Cross the original deadline (and a margin) while established. A
+        // deadline that was not disarmed on success fires in this window and
+        // closes the admitted connection.
+        try await ContinuousClock().sleep(for: .milliseconds(400))
+
+        #expect(await connection.isClosed() == false)
+        #expect(await connection.observedCloseCallCount() == 0)
+        await session.close()
+    }
+
+    @Test("a superseded timed-out attempt cannot kill the next established session")
+    func supersededTimedOutAttemptCannotKillTheNextEstablishedSession() async throws {
+        let codec = CmxIrohAdmissionAckCodec()
+        let hangingControl = CmxIrohBidirectionalStream(
+            receiveStream: TestHangingIrohReceiveStream(),
+            sendStream: TestIrohSendStream()
+        )
+        let hangingConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [hangingControl]
+        )
+        let goodControl = CmxIrohBidirectionalStream(
+            receiveStream: SlowIrohReceiveStream(
+                buffer: codec.encodeFrame(.acceptedPendingNatTraversal)
+                    + codec.encodeFrame(.serverReady),
+                delay: .milliseconds(60)
+            ),
+            sendStream: TestIrohSendStream()
+        )
+        let goodConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [goodControl]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [
+                .connection(hangingConnection),
+                .connection(goodConnection),
+            ]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(100)
+        )
+
+        let failure = await boundedConnectFailure(session, within: .seconds(2))
+        #expect(failure as? CmxIrohClientSessionError == .dialTimedOut)
+
+        // The superseding retry establishes inside its own bound.
+        try await session.connect()
+        #expect(await goodConnection.observedCloseCallCount() == 0)
+
+        // No remnant of the superseded attempt (its deadline, its cancelled
+        // children, or its close path) may touch the established session.
+        try await ContinuousClock().sleep(for: .milliseconds(300))
+
+        #expect(await goodConnection.isClosed() == false)
+        #expect(await goodConnection.observedCloseCallCount() == 0)
+        #expect(await hangingConnection.observedCloseCallCount() >= 1)
+        await session.close()
+    }
+}
+
+/// Delivers its admission bytes only after a fixed delay, modeling a peer
+/// that answers admission just inside the dial bound. The delay is
+/// cancellable like every production stream await.
+actor SlowIrohReceiveStream: CmxIrohReceiveStream {
+    private var buffer: Data
+    private var delay: Duration?
+    private var stoppedCodes: [UInt64] = []
+
+    init(buffer: Data, delay: Duration) {
+        self.buffer = buffer
+        self.delay = delay
+    }
+
+    func receive(maximumByteCount: Int) async throws -> Data? {
+        guard maximumByteCount > 0 else {
+            throw CmxIrohClientSessionError.invalidMaximumByteCount(maximumByteCount)
+        }
+        if let pending = delay {
+            delay = nil
+            try await Task.sleep(for: pending)
+        }
+        guard !buffer.isEmpty else { return nil }
+        let count = min(maximumByteCount, buffer.count)
+        let value = Data(buffer.prefix(count))
+        buffer.removeFirst(count)
+        return value
+    }
+
+    func stop(errorCode: UInt64) {
+        stoppedCodes.append(errorCode)
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
@@ -384,6 +384,40 @@ struct CmxIrohRegistryContextProviderStalenessTests {
     }
 
     @Test
+    func refreshFailureAfterStalenessFallsBackToLastVerifiedSnapshot() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [relay])
+        )
+        // A timed-out dial marked the peer stale, so the next attempt must
+        // try one fresh fetch first.
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [relay]),
+            failure: .timedOut
+        )
+        await broker.setDiscoverError(CmxIrohTrustBrokerClientError.connectivity)
+
+        // The forced refresh failed. Dialing with the last verified snapshot
+        // beats not dialing at all (cmux#9724): the staleness mark survives,
+        // so a later attempt still refetches once the broker recovers.
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
     func cooldownDuringEmptyPlanRefetchKeepsResolvedContextInsteadOfSpinning() async throws {
         let fixture = try RegistryFixture()
         let broker = ConfigurableRegistryBroker(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -344,6 +344,41 @@ struct CmxIrohRelayCredentialCoordinatorTests {
     }
 
     @Test
+    func refreshFailureKeepsLastGoodCredentialWithoutThrowing() async throws {
+        let fixture = try RelayCoordinatorFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.identity)
+        let supervisor = try await fixture.activeSupervisor(endpoint: endpoint)
+        let broker = TestRelayTokenBroker(steps: [.failure])
+        let clock = TestRelayClock(now: fixture.now)
+        let coordinator = CmxIrohRelayCredentialCoordinator(
+            supervisor: supervisor,
+            broker: broker,
+            managedRelayURLs: Set(fixture.relayURLs),
+            clock: clock,
+            jitter: { _, refreshAfter in refreshAfter },
+            retryJitter: { 0 }
+        )
+        try await coordinator.activate(
+            bindingID: fixture.bindingID,
+            endpointIdentity: fixture.identity,
+            bootstrap: try fixture.response()
+        )
+        // The installed credential is due for refresh but far from expiry.
+        clock.setNowWithoutResuming(fixture.refreshAfter.addingTimeInterval(1))
+
+        // A transient mint failure must not fail the caller while the
+        // last-good credential is installed (cmux#10375). The bounded retry
+        // loop keeps refreshing in the background; only the relay itself can
+        // reject the installed credential.
+        try await coordinator.refreshIfNeeded()
+
+        #expect(await coordinator.credentialExpiresAt() == fixture.expiresAt)
+        #expect(await endpoint.observedRelayUpdates().count == 1)
+        #expect(await broker.observedEndpointIDs() == [fixture.identity])
+        await coordinator.deactivate()
+    }
+
+    @Test
     func rateLimitRetryNeverPrecedesValidatedServerFloor() async throws {
         let fixture = try RelayCoordinatorFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.identity)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -289,6 +289,66 @@ struct CmxIrohRelayPolicyServiceTests {
     }
 
     @Test
+    func restoreFailsClosedBeyondTheExpiredPolicyReuseGrace() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        let expired = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(
+                3_600 + CmxIrohRelayPolicyService.defaultExpiredPolicyReuseGrace + 1
+            )
+        )
+
+        #expect(expired.source == .managedUnavailable)
+        #expect(expired.endpointRelayProfile.allowedRelayURLs.isEmpty)
+        #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
+    }
+
+    @Test
+    func expiredPolicyGraceNeverBypassesSignatureVerification() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        // A trust root that rejects the cached policy's signing key must
+        // fail closed even inside the expiry grace window: the grace covers
+        // only time, never a rejected credential.
+        let rejected = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.secondTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(3_600 + 300)
+        )
+
+        #expect(rejected.source == .managedUnavailable)
+        #expect(rejected.endpointRelayProfile.allowedRelayURLs.isEmpty)
+    }
+
+    @Test
     func cacheRestoresUntilSignedExpiryAndSupportsStagedKeyRotation() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let stores = makeStores()
@@ -324,14 +384,18 @@ struct CmxIrohRelayPolicyServiceTests {
         #expect(restored.usedCachedPolicy)
         #expect(restored.managedSnapshot?.policy.sequence == 2)
 
-        let expired = await stores.service.restore(
+        // Immediately past the signed expiry the last-good policy stays
+        // dialable inside the bounded reuse grace (cmux#10375); the graced
+        // state is reported as `.policyExpired` without zeroing routes.
+        let graced = await stores.service.restore(
             accountID: "account-a",
             trustRoot: try fixture.secondTrustRoot,
             relayCredential: fixture.relayCredential(),
             now: fixture.now.addingTimeInterval(3_600)
         )
-        #expect(expired.source == .managedUnavailable)
-        #expect(expired.endpointRelayProfile.allowedRelayURLs.isEmpty)
+        #expect(graced.source == .managed)
+        #expect(graced.usedCachedPolicy)
+        #expect(!graced.endpointRelayProfile.allowedRelayURLs.isEmpty)
         #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -336,6 +336,39 @@ struct CmxIrohRelayPolicyServiceTests {
     }
 
     @Test
+    func restoreKeepsRecentlyExpiredLastGoodPolicyRoutesForDialing() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        // The one-hour policy expired five minutes ago and the broker refresh
+        // failed (cmux#10375). Restoring must keep the last-good catalog
+        // dialable instead of publishing a zero-route managed profile; the
+        // relay itself remains the authority on credential validity.
+        let restored = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(3_600 + 300)
+        )
+
+        #expect(restored.source == .managed)
+        #expect(restored.usedCachedPolicy)
+        #expect(restored.endpointRelayProfile.allowedRelayURLs == Set(fixture.relayURLs))
+        #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
+    }
+
+    @Test
     func implicitRevisionZeroStillRejectsEquivocation() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let stores = makeStores()


### PR DESCRIPTION
Makes iOS Iroh dialing bounded and resilient (W2-A of the control-plane redesign). Evidence: the 43 s trace in #9724 (a dial hung 16.2 s with no bound), the 15+ min silent redial hang in #8531, and the zero-route dial-plan churn in #10375.

## Mechanisms

**1. Bounded dials.** `CmxIrohClientSession` already bounded the public and private connect phases at 5 s, but the admission barrier after QUIC connect (open control stream, admission frames, NAT-traversal authorize, server-ready) was unbounded. A half-ready Mac that accepts the connection and never answers admission is exactly the #9724 hang. The barrier now runs under the same generalized `boundedByDialPhase` race (injected `ContinuousClock` deadline, task-group cancellation, typed `dialTimedOut`), so one dial attempt is bounded by at most three phases. A timed-out attempt closes its connection (`admission_failed`), clears the session's coalesced connect task, and the next attempt redials; the peer-session redial machinery already retires wedged dials at a 10 s settle bound, giving defense in depth against a non-cooperative loser. The timeout is injected end to end: `CmxIrohClientRuntimeConfiguration.dialPhaseTimeout` (default 5 s) -> `CmxConnectivityEngine` -> every `CmxIrohClientSession`, so tests shrink it through the configuration object.

**2. Hint refresh between attempts.** A failed or timed-out dial already marks the peer's discovery stale, and the next attempt refetches the address-hint catalog from the broker. What was missing: when that forced refetch itself failed (broker outage, cooldown), the dial threw and nothing was dialed at all. `CmxIrohRegistryContextProvider.context(for:)` now falls back to the last verified in-memory snapshot (`authoritativeDiscovery`) and dials its hints; the staleness mark survives, so a later attempt still refetches once the broker recovers. The offline signed-policy cache remains the second fallback, and the broker cooldown still propagates unchanged when no last-good snapshot exists (the existing no-fetch-storm test is preserved).

Path preference is left alone: the public dial leg already hands relay and direct hints together to one native `endpoint.connect`, where iroh races them internally, so relay+direct racing exists today and a reordering would change native behavior for no measured gain.

**3. Fail-open credential refresh (#10375).** Two seams:
- `CmxIrohRelayPolicyService.restore` (the failed-refresh fallback path used by the iOS composition) previously published a zero-route `managedUnavailable` profile the moment the cached signed policy was past `exp`, which with 300 s policy TTLs was almost always. It now grants a bounded expired-policy reuse grace (`defaultExpiredPolicyReuseGrace = 6 h`, injectable): `CmxIrohRelayPolicyCache.load` re-verifies the record at its final valid instant, so signature, rollback, and claim checks run unweakened and only the expiry gate is graced. The graced state keeps the catalog and routes and is reported as `.policyExpired` in diagnostics. Beyond the grace, or on any signature/rollback rejection, restore still fails closed. #10731 (token+policy TTL 300 s -> 3600 s) makes this reuse window rarely needed but the grace fixes the zero-route failure mode independently.
- `CmxIrohRelayCredentialCoordinator.refreshIfNeeded` (the foreground pre-dial catch-up) no longer throws on a failed mint while a last-good credential is installed on the endpoint; it schedules the existing bounded-backoff retry loop and returns. The relay stays the authority on token validity: nothing here ever un-installs a credential, and a relay rejection surfaces as a connection failure that drives redial plus background refresh.

**Known-red CI gate on main.** `swift-package-tests` has been red on `main` since at least Aug 19 ([run 32212616081](https://github.com/manaflow-ai/cmux/actions/runs/32212616081)): `CmxConnectivityPeerSessionTests.onePeerTraceUsesOneAliasAndOneEstablishedSessionEvent` awaits a `GatedConnectivitySessionBuilder` dial that no line ever releases, so the suite deadlocks into the 300 s per-suite timeout twice per run. The fix is split into [#10741](https://github.com/manaflow-ai/cmux/pull/10741) so a revert of this feature PR cannot un-fix the gate; this PR's `swift-package-tests` job stays red on that inherited hang until #10741 merges. Locally, the full package (68 suites, 639 tests) passes with that fix applied on top of this branch.

## Principled or hacky

Changes 1 and 2 are principled: they extend existing bounded-race and staleness seams without new state machines. Change 3 is principled in mechanism (grace is time-bounded, verification is not weakened, diagnostics stay truthful) but the 6 h default is a judgment call; it trades bounded catalog staleness (worst case: dialing a decommissioned relay URL, which fails fast and falls to other paths) against launch-to-ready minutes lost to zero-route churn.

## Residual risks

- The bounded races rely on cooperative cancellation of the FFI dial and stream reads (same contract the existing connect bound relies on); a non-cooperative loser is contained by the peer session's 10 s retired-dial settle bound rather than fixed here.
- The service-level grace also applies to the Mac host's restore path (shared service); that is consistent with keeping last-good relays during broker outages but widens the change beyond iOS.
- The engine `dialPhaseTimeout` plumb is compile-verified and behavior-tested at the session level; there is no engine-level timeout test (pass-through only).

## Tests

Two-commit regression pattern: commit 1 adds the failing tests, commit 2 the fixes.

- `CmxIrohClientSessionDialBoundTests`: admission barrier that never answers fails at the dial bound; a timed-out admission is superseded by the next connect attempt.
- `CmxIrohRegistryContextProviderStalenessTests.refreshFailureAfterStalenessFallsBackToLastVerifiedSnapshot`.
- `CmxIrohRelayPolicyServiceTests`: `restoreKeepsRecentlyExpiredLastGoodPolicyRoutesForDialing`, `restoreFailsClosedBeyondTheExpiredPolicyReuseGrace`, `expiredPolicyGraceNeverBypassesSignatureVerification`; `cacheRestoresUntilSignedExpiryAndSupportsStagedKeyRotation` updated to the graced expectation.
- `CmxIrohRelayCredentialCoordinatorTests.refreshFailureKeepsLastGoodCredentialWithoutThrowing`.

## Revert

`git revert <fix-sha> <test-sha>` (no migrations, no persisted-format changes). Config-default changes to note: `CmxIrohClientRuntimeConfiguration.dialPhaseTimeout` (new, default 5 s, previously an unwired per-session default) and `CmxIrohRelayPolicyService.expiredPolicyReuseGrace` (new, default 6 h, previously effectively 0). Reverting restores strict-expiry restore behavior and the unbounded admission barrier.

Dictionary: admission barrier = the authenticated frame exchange after the QUIC connection that both peers must finish before application streams open; dial phase = one bounded leg of a dial attempt (public paths, private fallback, or admission); relay policy = the broker-signed catalog of managed relay URLs a build may use; relay token = the short-lived credential that authenticates this endpoint to those relays; grace = a bounded window after signed expiry in which the last verified value is still used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for peer connection and admission phases, defaulting to five seconds.
  * Added limited reuse of recently expired relay policies, while retaining signature and validation checks.
* **Bug Fixes**
  * Improved connection recovery after timed-out or failed admission attempts.
  * Preserved working credentials during transient refresh failures.
  * Used the last verified discovery data when fresh broker discovery is temporarily unavailable.
* **Tests**
  * Added coverage for connection timeouts, recovery, stale discovery fallback, credential retention, and policy expiry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->