### PR TITLE
Un-deadlock CmxConnectivityPeerSessionTests (red swift-package-tests gate on main)

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
@@ -44,7 +44,13 @@ struct CmxConnectivityPeerSessionTests {
             diagnosticLog: log
         )
 
-        _ = try await peer.connectedSession(for: request)
+        // The gated builder parks every dial until released. Awaiting the
+        // dial before releasing the gate deadlocked this test (and the
+        // package CI job) permanently.
+        let dial = Task { try await peer.connectedSession(for: request) }
+        try await Self.waitUntil { await builder.callCount() == 1 }
+        await builder.release()
+        _ = try await dial.value
         await peer.releaseControl(ownerID: UUID())
         await peer.invalidate()
         #expect(await waitForDiagnosticProcessedCount(log, atLeast: 3))


### PR DESCRIPTION
Un-deadlocks the `swift-package-tests` CI job, red on `main` since at least Aug 19 ([run 32212616081](https://github.com/manaflow-ai/cmux/actions/runs/32212616081)).

`CmxConnectivityPeerSessionTests.onePeerTraceUsesOneAliasAndOneEstablishedSessionEvent` awaits `peer.connectedSession(for:)` built on a `GatedConnectivitySessionBuilder`, and no line ever releases the gate, so the dial parks forever. The per-suite CI runner then hits its 300 s timeout, retries once, times out again, and fails the job on every run of every PR. The fix releases the gate the way the neighboring `concurrentCallersShareOneDialAndOneAdmittedSession` test does: start the dial in a task, wait until the builder records the call, release, then await the dial. The suite goes from a deterministic 600 s double-timeout to completing in milliseconds (17 tests).

Test-only change; no runtime code is touched. Split out of [#10739](https://github.com/manaflow-ai/cmux/pull/10739) so a revert of that feature PR cannot un-fix this CI gate.

Revert: `git revert <sha>` restores the deadlock and the red gate; nothing else depends on this commit.

Dictionary: per-suite runner = `scripts/ci/run-swift-testing-suites.sh`, which runs each test suite in its own process with a 300 s timeout and one retry; gate = a test helper continuation that parks a fake dial until the test resumes it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock in CmxConnectivityPeerSessionTests.onePeerTraceUsesOneAliasAndOneEstablishedSessionEvent that was timing out the `swift-package-tests` job on `main`. Previously the test awaited a gated dial without releasing the gate; it now runs the dial in a task, waits for the builder to record the call, releases the gate, then awaits the result, eliminating the hang.

Test-only change; no runtime code is modified. Reverting this will reintroduce the red CI gate.

<sup>Written for commit 1f0560895ef4996d60a93ca30ce3624d269249c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved connectivity test synchronization to reliably validate asynchronous connection establishment.
  * Ensured connection progress is observed before allowing setup to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->