### PR TITLE
fix(tui): filter tree tabs against attached surfaces

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3374,6 +3374,12 @@ impl RemoteSession {
             },
         );
         drop(capabilities);
+        // A tree snapshot can race a detach or overflow event. The surface
+        // catalog is authoritative for what can be rendered, so filter the
+        // snapshot while holding one catalog snapshot before publishing it.
+        let attached_surface_ids = self.surfaces.lock().unwrap().keys().copied().collect();
+        let mut tree = tree;
+        tree.retain_surfaces(&attached_surface_ids);
         let live_surface_ids = tree
             .workspaces
             .iter()

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1,7 +1,7 @@
 //! Read-only tree snapshots shared by the renderer and input handling,
 //! plus the JSON parser for the remote `list-workspaces` shape.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use cmux_tui_core::resource::{
     BrowserPublicId, ContentPublicId, PanePublicId, ScreenPublicId, TabPublicId, TerminalPublicId,
@@ -87,6 +87,22 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
+    /// Remove pane tabs that cannot be backed by an attached surface.
+    ///
+    /// Remote tree snapshots and surface detach events travel on separate
+    /// streams. Applying this filter before publishing a snapshot keeps the
+    /// renderer from observing a tab whose surface has already been removed.
+    pub fn retain_surfaces(&mut self, surfaces: &HashSet<SurfaceId>) {
+        for workspace in &mut self.workspaces {
+            for screen in &mut workspace.screens {
+                for pane in &mut screen.panes {
+                    pane.tabs.retain(|tab| surfaces.contains(&tab.surface));
+                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
+                }
+            }
+        }
+    }
+
     pub fn session_resource_selectors() -> ResourceSelectors {
         ResourceSelectors {
             machine: Some("current".to_string()),
@@ -629,6 +645,29 @@ mod tests {
 
         assert_eq!(screen.display_name(0), "0");
         assert_eq!(screen.display_name(9), "9");
+    }
+
+    #[test]
+    fn retain_surfaces_drops_missing_tabs_and_clamps_active_index() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1, "active": true,
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "active_tab": 1, "tabs": [
+                        {"surface": 7, "title": "gone"},
+                        {"surface": 8, "title": "kept"}
+                    ]}]
+                }]
+            }]
+        }));
+
+        tree.retain_surfaces(&HashSet::from([8]));
+
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
+        assert_eq!(pane.active_tab, 0);
     }
 
     #[test]


### PR DESCRIPTION
Filter remote tree snapshots against the attached surface catalog before publishing them. This closes the detach/overflow race where a stale pane tab could create a TabView for a removed surface. Clamp active tab indexes after filtering.

Validation: cargo fmt --all -- --check; git diff --check. Rust tests/builds were not run locally per instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790259720&installation_model_id=21920&pr_number=10743&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10743&signature=77b1e9cdfd17a81ced02bfd5cded77a21e09e16fa8e567b7513b453a75604530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters remote tree snapshots to only include tabs backed by currently attached surfaces, closing the detach/overflow race that let a stale pane tab render a removed surface. After filtering, clamps each pane’s active tab index to the remaining tabs to avoid out-of-bounds; the active tab may shift when a surface detaches.

<sup>Written for commit 470252914f76bd3124d38a5e19c61c9716cd1fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue where detached or outdated surfaces could briefly remain visible in the session tree.
  * Session tabs now stay synchronized with the currently attached surfaces.
  * Active tab selection is automatically adjusted when tabs are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->