### PR TITLE
fix(tui): close filtered tree publication race

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3377,8 +3377,12 @@ impl RemoteSession {
         // A tree snapshot can race a detach or overflow event. The surface
         // catalog is authoritative for what can be rendered, so filter the
         // snapshot while holding one catalog snapshot before publishing it.
-        let attached_surface_ids = self.surfaces.lock().unwrap().keys().copied().collect();
         let mut tree = tree;
+        // Keep the catalog lock through filtering and cache publication. This
+        // makes the tree and attached-surface set one coherent revision from
+        // the renderer's point of view, so a detach cannot land between them.
+        let surfaces_guard = self.surfaces.lock().unwrap();
+        let attached_surface_ids = surfaces_guard.keys().copied().collect();
         tree.retain_surfaces(&attached_surface_ids);
         let live_surface_ids = tree
             .workspaces
@@ -3403,11 +3407,12 @@ impl RemoteSession {
             cache.replace_agents(agents, agent_refresh_generation);
             cache.view.clone()
         };
+        let surfaces = surfaces_guard.values().cloned().collect::<Vec<_>>();
+        drop(surfaces_guard);
         let browser_sources = browser_sources_from_tree(&tree);
         *self.browser_sources.lock().unwrap() = browser_sources.clone();
-        let surfaces = self.surfaces.lock().unwrap().clone();
-        for (id, surface) in surfaces {
-            surface.update_browser_source(browser_sources.get(&id).copied());
+        for surface in surfaces {
+            surface.update_browser_source(browser_sources.get(&surface.id).copied());
         }
         Ok(tree)
     }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -96,8 +96,15 @@ impl TreeView {
         for workspace in &mut self.workspaces {
             for screen in &mut workspace.screens {
                 for pane in &mut screen.panes {
+                    let active_surface = pane.tabs.get(pane.active_tab).map(|tab| tab.surface);
                     pane.tabs.retain(|tab| surfaces.contains(&tab.surface));
-                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
+                    if pane.tabs.is_empty() {
+                        pane.active_tab = 0;
+                    } else if let Some(active_surface) = active_surface.filter(|id| surfaces.contains(id)) {
+                        pane.active_tab = pane.tabs.iter().position(|tab| tab.surface == active_surface).unwrap_or(0);
+                    } else {
+                        pane.active_tab = pane.active_tab.min(pane.tabs.len() - 1);
+                    }
                 }
             }
         }
@@ -668,6 +675,29 @@ mod tests {
         let pane = &tree.workspaces[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
         assert_eq!(pane.active_tab, 0);
+    }
+
+    #[test]
+    fn retain_surfaces_preserves_active_surface_when_tabs_before_it_are_removed() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{"id": 1, "screens": [{"id": 2, "layout": {"type":"leaf", "pane":3}, "panes": [{"id":3, "active_tab":1, "tabs":[{"surface":7},{"surface":8},{"surface":9}]}]}]}]
+        }));
+        tree.retain_surfaces(&HashSet::from([8, 9]));
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8, 9]);
+        assert_eq!(pane.active_surface(), Some(8));
+    }
+
+    #[test]
+    fn retain_surfaces_handles_all_tabs_removed() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{"id": 1, "screens": [{"id": 2, "layout": {"type":"leaf", "pane":3}, "panes": [{"id":3, "active_tab":1, "tabs":[{"surface":7},{"surface":8}]}]}]}]
+        }));
+        tree.retain_surfaces(&HashSet::new());
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert!(pane.tabs.is_empty());
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), None);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to PR #10743.

Preserve the active SurfaceId while removing detached tabs, use a deterministic clamped fallback when it disappears, and keep empty panes valid. Hold the surface catalog lock through filtering and tree-cache publication so detach events cannot publish a mismatched tree/catalog pair.

Focused tests cover active-tab identity and all-tabs-removed panes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in TUI tree publication that could produce a tree/catalog mismatch and scramble the active tab when surfaces detached mid-update. The renderer now sees a coherent snapshot, and panes remain valid even when all tabs are removed.

- Bug Fixes
- Hold the surface catalog lock through tree filtering and cache publication to prevent mismatched revisions.
- Preserve the previously active surface when earlier tabs are removed; clamp to the last tab only if the active surface no longer exists.
- Keep empty panes valid with active_tab=0 and no active surface.
- Capture surfaces under the lock and drop it before updating browser sources to avoid lock-held iteration.
- Add focused tests for active-tab preservation and all-tabs-removed panes.

<sup>Written for commit 35ef21fa3b41f528709b2c932468737aa6475369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

