### PR TITLE
test: cover aged remote upload marker recovery

### DIFF
--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -387,7 +387,14 @@ extension RemoteSessionCoordinator {
           [ -r "$cmux_pid_file" ] || continue
           cmux_pid="$(cat "$cmux_pid_file" 2>/dev/null || true)"
           case "$cmux_pid" in
-            ''|0|1|*[!0-9]*) continue ;;
+            ''|0|1|*[!0-9]*)
+              # Malformed markers are treated as stale only after the same
+              # conservative age window used for dead owners.
+              if find "$cmux_pid_file" -mmin -30 2>/dev/null | grep . >/dev/null; then continue; fi
+              cmux_temp_path="${cmux_pid_file%.pid}"
+              rm -f -- "$cmux_temp_path" "$cmux_pid_file"
+              continue
+              ;;
             *)
               if kill -0 "$cmux_pid" 2>/dev/null; then continue; fi
               # Reclaim only markers that are older than the conservative

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -396,7 +396,11 @@ extension RemoteSessionCoordinator {
               continue
               ;;
             *)
-              if kill -0 "$cmux_pid" 2>/dev/null; then continue; fi
+              if kill -0 "$cmux_pid" 2>/dev/null; then
+                # A live PID can be reused after the original writer exits.
+                # Keep fresh markers, but reclaim aged ones without signaling.
+                if find "$cmux_pid_file" -mmin -30 2>/dev/null | grep . >/dev/null; then continue; fi
+              fi
               # Reclaim only markers that are older than the conservative
               # recovery window. This avoids PID-reuse races.
               if find "$cmux_pid_file" -mmin -30 2>/dev/null | grep . >/dev/null; then continue; fi

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -94,20 +94,33 @@ extension RemoteSessionCoordinator {
         watchdog_pid=
         temp_path=\(quotedRemoteTempPath)
         pid_path=\(quotedRemoteTempPIDPath)
-        printf '%s\\n' "$$" > "$pid_path"
         trap 'if [ -n "$cat_pid" ]; then kill "$cat_pid" 2>/dev/null || true; fi; if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; fi; rm -f -- "$temp_path" "$pid_path"; exit 1' HUP INT TERM
         # POSIX shells give an asynchronous command /dev/null for stdin unless
         # the parent explicitly preserves the descriptor first. Without this
         # dup, cat exits 0 after writing an empty payload even though ssh had
         # a file-backed stdin stream to forward.
         exec 3<&0
-        cat <&3 > "$temp_path" &
+        # Keep the shell PID marker for stale-file detection. Recovery never
+        # signals a marker PID because numeric PIDs can be reused.
+        set -C
+        # Create the owner marker atomically after noclobber is enabled.
+        if ! printf '%s\\n' "$$" > "$pid_path"; then
+          printf '%s\\n' 'cmux daemon upload could not create a unique owner marker' >&2
+          exit 76
+        fi
+        # Open the payload once with noclobber, then write through the
+        # descriptor. This refuses a pre-existing payload symlink or file.
+        if ! exec 4> "$temp_path"; then
+          printf '%s\\n' 'cmux daemon upload could not create a unique temporary file' >&2
+          exit 76
+        fi
+        cat <&3 >&4 &
         cat_pid=$!
-        printf '%s\\n' "$cat_pid" > "$pid_path"
         (
           stall_checks=0
           previous_size=0
           while kill -0 "$cat_pid" 2>/dev/null; do
+            touch "$pid_path" 2>/dev/null || true
             current_size="$(wc -c < "$temp_path" 2>/dev/null || printf '0')"
             set -- $current_size
             current_size="${1:-0}"
@@ -132,6 +145,7 @@ extension RemoteSessionCoordinator {
         cat_status=$?
         cat_pid=
         exec 3<&-
+        exec 4>&-
         if [ -n "$watchdog_pid" ]; then kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; fi
         watchdog_pid=
         rm -f -- "$pid_path"
@@ -367,27 +381,41 @@ extension RemoteSessionCoordinator {
     ) -> String {
         let quotedRemotePath = remotePath.shellSingleQuoted
         let processCleanup = """
+        # Reclaim only markers whose owner is gone. A live marker belongs to a
+        # concurrent upload and must not be signaled or glob-deleted.
         for cmux_pid_file in \(quotedRemotePath).tmp-*.pid; do
           [ -r "$cmux_pid_file" ] || continue
           cmux_pid="$(cat "$cmux_pid_file" 2>/dev/null || true)"
           case "$cmux_pid" in
-            ''|0|1|*[!0-9]*) ;;
-            *) [ "$cmux_pid" = "$$" ] || kill "$cmux_pid" 2>/dev/null || true ;;
+            ''|0|1|*[!0-9]*) continue ;;
+            *)
+              if kill -0 "$cmux_pid" 2>/dev/null; then continue; fi
+              # Reclaim only markers that are older than the conservative
+              # recovery window. This avoids PID-reuse races.
+              if find "$cmux_pid_file" -mmin -30 2>/dev/null | grep . >/dev/null; then continue; fi
+              cmux_temp_path="${cmux_pid_file%.pid}"
+              rm -f -- "$cmux_temp_path" "$cmux_pid_file"
+              ;;
           esac
         done
         """
-        let specificRemoveTargets: String
+        let currentCleanup: String
         if let currentTemporaryPath {
             let quotedCurrentTemporaryPath = currentTemporaryPath.shellSingleQuoted
             let quotedCurrentPIDPath = "\(currentTemporaryPath).pid".shellSingleQuoted
-            specificRemoveTargets =
-                " \(quotedCurrentTemporaryPath) \(quotedCurrentPIDPath)"
+            currentCleanup = """
+            # A numeric PID is not a process identity. It can be reused by an
+            # unrelated process between reading the marker and signaling it.
+            # Never signal from a marker; the upload owner's trap handles its
+            # own children, while recovery only removes its files.
+            rm -f -- \(quotedCurrentTemporaryPath) \(quotedCurrentPIDPath)
+            """
         } else {
-            specificRemoveTargets = ""
+            currentCleanup = ":"
         }
         return """
         \(processCleanup)
-        rm -f -- \(quotedRemotePath).tmp-* \(quotedRemotePath).tmp-*.pid\(specificRemoveTargets)
+        \(currentCleanup)
         """
     }
 

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -269,6 +269,20 @@ extension RemoteDaemonUploadTests {
         #expect(cleanup.terminationStatus == 0)
         #expect(fileManager.fileExists(atPath: temporaryPath))
         #expect(fileManager.fileExists(atPath: pidPath))
+        try Self.ageFile(atPath: pidPath)
+        try Self.ageFile(atPath: temporaryPath)
+        let agedLiveCleanup = Process()
+        agedLiveCleanup.executableURL = URL(fileURLWithPath: "/bin/sh")
+        agedLiveCleanup.arguments = ["-c", RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(remotePath: remotePath)]
+        agedLiveCleanup.standardInput = FileHandle.nullDevice
+        agedLiveCleanup.standardOutput = FileHandle.nullDevice
+        agedLiveCleanup.standardError = FileHandle.nullDevice
+        try agedLiveCleanup.run()
+        agedLiveCleanup.waitUntilExit()
+        #expect(agedLiveCleanup.terminationStatus == 0)
+        #expect(writer.isRunning)
+        #expect(!fileManager.fileExists(atPath: temporaryPath))
+        #expect(!fileManager.fileExists(atPath: pidPath))
         writer.terminate()
         writer.waitUntilExit()
         try Self.ageFile(atPath: pidPath)

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -184,6 +184,7 @@ extension RemoteDaemonUploadTests {
             relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
             absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
         )
+        let remotePath = location.absolutePath
 
         do {
             try coordinator.queue.sync {
@@ -209,13 +210,15 @@ extension RemoteDaemonUploadTests {
         #expect(uploadRequest.arguments.last?.contains("kill") == true)
         #expect(uploadRequest.arguments.last?.contains("stall_checks") == true)
         #expect(uploadRequest.arguments.last?.contains("without byte progress") == true)
-        #expect(cleanupRequest.arguments.last?.contains(".tmp-*") == true)
+        #expect(cleanupRequest.arguments.last?.contains("kill -0") == true)
+        #expect(cleanupRequest.arguments.last?.contains("kill \"$cmux_current_pid\"") == false)
+        #expect(cleanupRequest.arguments.last?.contains("rm -f -- \(remotePath).tmp-*") == false)
         #expect(Self.consecutive(cleanupRequest.arguments, "-o", "ControlPath=none"))
         #expect(!cleanupRequest.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
     }
 
-    @Test("Remote cleanup terminates recorded writers and removes every temporary upload")
-    func cleanupScriptKillsRecordedWriters() throws {
+    @Test("Remote cleanup preserves live writers and reclaims stale uploads")
+    func cleanupScriptPreservesLiveWriters() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory.appendingPathComponent(
             "cmux-remote-daemon-cleanup-\(UUID().uuidString)",
@@ -264,10 +267,139 @@ extension RemoteDaemonUploadTests {
         cleanup.waitUntilExit()
 
         #expect(cleanup.terminationStatus == 0)
+        #expect(fileManager.fileExists(atPath: temporaryPath))
+        #expect(fileManager.fileExists(atPath: pidPath))
+        writer.terminate()
+        writer.waitUntilExit()
+        try Self.ageFile(atPath: pidPath)
+        try Self.ageFile(atPath: temporaryPath)
+        #expect(!writer.isRunning)
+
+        let staleCleanup = Process()
+        staleCleanup.executableURL = URL(fileURLWithPath: "/bin/sh")
+        staleCleanup.arguments = ["-c", RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(remotePath: remotePath)]
+        staleCleanup.standardInput = FileHandle.nullDevice
+        staleCleanup.standardOutput = FileHandle.nullDevice
+        staleCleanup.standardError = FileHandle.nullDevice
+        try staleCleanup.run()
+        staleCleanup.waitUntilExit()
+        #expect(staleCleanup.terminationStatus == 0)
         #expect(!fileManager.fileExists(atPath: temporaryPath))
         #expect(!fileManager.fileExists(atPath: pidPath))
-        writer.waitUntilExit()
-        #expect(!writer.isRunning)
+    }
+
+    @Test("Remote cleanup keeps fresh dead and malformed markers until aged")
+    func cleanupScriptRequiresAgedMarkers() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-cleanup-age-\(UUID().uuidString)", isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+        let remotePath = root.appendingPathComponent("quoted path's/cmuxd-remote").path
+        try fileManager.createDirectory(
+            at: URL(fileURLWithPath: remotePath).deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let deadPath = "\(remotePath).tmp-dead"
+        let malformedPath = "\(remotePath).tmp-malformed"
+        try Data("dead".utf8).write(to: URL(fileURLWithPath: deadPath))
+        try Data("999999\n".utf8).write(to: URL(fileURLWithPath: "\(deadPath).pid"))
+        try Data("malformed".utf8).write(to: URL(fileURLWithPath: malformedPath))
+        try Data("not-a-pid\n".utf8).write(to: URL(fileURLWithPath: "\(malformedPath).pid"))
+
+        #expect(try Self.runShell(RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(remotePath: remotePath)) == 0)
+        #expect(fileManager.fileExists(atPath: deadPath))
+        #expect(fileManager.fileExists(atPath: malformedPath))
+
+        try Self.ageFile(atPath: deadPath)
+        try Self.ageFile(atPath: "\(deadPath).pid")
+        try Self.ageFile(atPath: malformedPath)
+        try Self.ageFile(atPath: "\(malformedPath).pid")
+        #expect(try Self.runShell(RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(remotePath: remotePath)) == 0)
+        #expect(!fileManager.fileExists(atPath: deadPath))
+        #expect(!fileManager.fileExists(atPath: malformedPath))
+    }
+
+    @Test("Remote cleanup kills only the explicitly failed writer")
+    func cleanupScriptScopesCurrentWriter() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-cleanup-scope-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let remotePath = root
+            .appendingPathComponent("remote path's", isDirectory: true)
+            .appendingPathComponent("cmuxd-remote", isDirectory: false)
+            .path
+        let remoteDirectory = URL(fileURLWithPath: remotePath).deletingLastPathComponent()
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+
+        let currentPath = "\(remotePath).tmp-current"
+        let otherPath = "\(remotePath).tmp-other"
+        let currentPIDPath = "\(currentPath).pid"
+        let otherPIDPath = "\(otherPath).pid"
+        try Data("current".utf8).write(to: URL(fileURLWithPath: currentPath))
+        try Data("other".utf8).write(to: URL(fileURLWithPath: otherPath))
+
+        let currentWriter = Process()
+        currentWriter.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        currentWriter.arguments = ["30"]
+        currentWriter.standardInput = FileHandle.nullDevice
+        currentWriter.standardOutput = FileHandle.nullDevice
+        currentWriter.standardError = FileHandle.nullDevice
+        try currentWriter.run()
+        defer {
+            if currentWriter.isRunning {
+                currentWriter.terminate()
+                currentWriter.waitUntilExit()
+            }
+        }
+
+        let otherWriter = Process()
+        otherWriter.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        otherWriter.arguments = ["30"]
+        otherWriter.standardInput = FileHandle.nullDevice
+        otherWriter.standardOutput = FileHandle.nullDevice
+        otherWriter.standardError = FileHandle.nullDevice
+        try otherWriter.run()
+        defer {
+            if otherWriter.isRunning {
+                otherWriter.terminate()
+                otherWriter.waitUntilExit()
+            }
+        }
+
+        try Data("\(currentWriter.processIdentifier)\n".utf8)
+            .write(to: URL(fileURLWithPath: currentPIDPath))
+        try Data("\(otherWriter.processIdentifier)\n".utf8)
+            .write(to: URL(fileURLWithPath: otherPIDPath))
+
+        let currentCleanup = RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(
+            remotePath: remotePath,
+            currentTemporaryPath: currentPath
+        )
+        #expect(try Self.runShell(currentCleanup) == 0)
+        #expect(currentWriter.isRunning)
+        #expect(!fileManager.fileExists(atPath: currentPath))
+        #expect(!fileManager.fileExists(atPath: currentPIDPath))
+        #expect(otherWriter.isRunning)
+        #expect(fileManager.fileExists(atPath: otherPath))
+        #expect(fileManager.fileExists(atPath: otherPIDPath))
+
+        otherWriter.terminate()
+        otherWriter.waitUntilExit()
+        try Self.ageFile(atPath: otherPath)
+        try Self.ageFile(atPath: otherPIDPath)
+        let staleCleanup = RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(
+            remotePath: remotePath
+        )
+        #expect(try Self.runShell(staleCleanup) == 0)
+        #expect(!fileManager.fileExists(atPath: otherPath))
+        #expect(!fileManager.fileExists(atPath: otherPIDPath))
     }
 
     private func uploadRequestForRecovery(
@@ -315,7 +447,7 @@ extension RemoteDaemonUploadTests {
         if command.contains("mkdir -p ") {
             return .createDirectory
         }
-        if command.contains("cat > ") || command.contains("cat <&3 > ") {
+        if command.contains("exec 4> ") || command.contains("cat <&3 >&4") {
             return .upload
         }
         if command.contains("chmod 755 "), command.contains("mv ") {
@@ -351,5 +483,13 @@ extension RemoteDaemonUploadTests {
         try process.run()
         process.waitUntilExit()
         return process.terminationStatus
+    }
+
+    private static func ageFile(atPath path: String) throws {
+        let oldDate = Date(timeIntervalSinceNow: -3600)
+        try FileManager.default.setAttributes(
+            [.modificationDate: oldDate],
+            ofItemAtPath: path
+        )
     }
 }


### PR DESCRIPTION
Add behavior coverage for remote upload marker retention and aged reclamation, including malformed markers, PID reuse safety, and quoted paths. Reclaim malformed markers only after the conservative age window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds remote daemon upload cleanup by a 30-minute heartbeat age and adds tests for recovery. Previously we killed recorded PIDs and glob-deleted temp files; now we atomically create a noclobber owner marker, never signal marker PIDs, and reclaim only markers older than the safety window—even if the PID currently exists—to avoid PID reuse races and preserve live writers.

- Uses set -C and exec 4> for noclobber temp creation; a watchdog touches the PID marker as a heartbeat.
- Reclaims only aged markers, including malformed ones; when scoped, removes only the current failed upload; no glob deletes.
- Adds tests for quoted paths, aged vs. fresh markers, preserving concurrent writers, and reclaiming aged markers with reused PIDs.

<sup>Written for commit 646f58844cdafda97627bf08fce41b30d6258900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer PTY relay error handling, compatibility behavior, buffering, ordering, and reconnect guidance.
  - Added support for normalizing additional terminal control sequences.
  - Improved command argument forwarding after entering a command scope.

- **Bug Fixes**
  - Prevented failed cancellation attempts from being retried.
  - Improved remote upload safety and recovery.
  - Preserved terminal admission when graphics quota operations time out.
  - Hardened Git output handling and transport fallback behavior.

- **Documentation**
  - Expanded session setup, attachment, protocol, and relay lifecycle guidance.

- **Reliability**
  - Added published-artifact verification and stronger release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->