### PR TITLE
fix(tui): preserve authoritative tabs across lazy attach

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3374,12 +3374,13 @@ impl RemoteSession {
             },
         );
         drop(capabilities);
-        // A tree snapshot can race a detach or overflow event. The surface
-        // catalog is authoritative for what can be rendered, so filter the
-        // snapshot while holding one catalog snapshot before publishing it.
-        let attached_surface_ids = self.surfaces.lock().unwrap().keys().copied().collect();
+        // The server tree is authoritative. The local surface catalog is a
+        // lazy mirror and may be empty during startup or reconnect, so it
+        // cannot be used as a negative filter. Remove only explicit retire
+        // evidence captured at the detach boundary.
+        let retired_surface_ids = self.retired_surfaces.lock().unwrap().clone();
         let mut tree = tree;
-        tree.retain_surfaces(&attached_surface_ids);
+        tree.retain_not_retired(&retired_surface_ids);
         let live_surface_ids = tree
             .workspaces
             .iter()

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3374,6 +3374,14 @@ impl RemoteSession {
             },
         );
         drop(capabilities);
+        let raw_surface_ids = tree
+            .workspaces
+            .iter()
+            .flat_map(|workspace| workspace.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .flat_map(|pane| pane.tabs.iter())
+            .map(|tab| tab.surface)
+            .collect::<HashSet<_>>();
         // The server tree is authoritative. The local surface catalog is a
         // lazy mirror and may be empty during startup or reconnect, so it
         // cannot be used as a negative filter. Remove only explicit retire
@@ -3392,7 +3400,7 @@ impl RemoteSession {
         self.retired_surfaces
             .lock()
             .unwrap()
-            .retain(|surface_id| live_surface_ids.contains(surface_id));
+            .retain(|surface_id| raw_surface_ids.contains(surface_id));
         self.prune_exited_surfaces(&live_surface_ids);
         self.surface_overflow_recovery
             .lock()
@@ -3400,6 +3408,8 @@ impl RemoteSession {
             .retain(|surface_id, _| live_surface_ids.contains(surface_id));
         let tree = {
             let mut cache = self.tree.lock().unwrap();
+            let retired = self.retired_surfaces.lock().unwrap().clone();
+            tree.retain_not_retired(&retired);
             cache.replace(tree, title_refresh_generation);
             cache.replace_agents(agents, agent_refresh_generation);
             cache.view.clone()

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -110,8 +110,11 @@ impl TreeView {
         for workspace in &mut self.workspaces {
             for screen in &mut workspace.screens {
                 for pane in &mut screen.panes {
+                    let active_surface = pane.tabs.get(pane.active_tab).map(|tab| tab.surface);
                     pane.tabs.retain(|tab| !retired.contains(&tab.surface));
-                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
+                    pane.active_tab = active_surface
+                        .and_then(|surface| pane.tabs.iter().position(|tab| tab.surface == surface))
+                        .unwrap_or_else(|| pane.active_tab.min(pane.tabs.len().saturating_sub(1)));
                 }
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -103,6 +103,20 @@ impl TreeView {
         }
     }
 
+    /// Retain the server's authoritative tab topology, removing only tabs
+    /// with explicit detach/retire evidence. The local surface mirror is a
+    /// lazy cache and can be empty during startup or reconnect.
+    pub fn retain_not_retired(&mut self, retired: &HashSet<SurfaceId>) {
+        for workspace in &mut self.workspaces {
+            for screen in &mut workspace.screens {
+                for pane in &mut screen.panes {
+                    pane.tabs.retain(|tab| !retired.contains(&tab.surface));
+                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
+                }
+            }
+        }
+    }
+
     pub fn session_resource_selectors() -> ResourceSelectors {
         ResourceSelectors {
             machine: Some("current".to_string()),
@@ -668,6 +682,15 @@ mod tests {
         let pane = &tree.workspaces[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
         assert_eq!(pane.active_tab, 0);
+    }
+
+    #[test]
+    fn retain_not_retired_keeps_tabs_when_local_catalog_is_empty() {
+        let mut tree = parse_tree(
+            &json!({"workspaces":[{"id":1,"screens":[{"id":2,"panes":[{"id":3,"tabs":[{"surface":7},{"surface":8}],"active_tab":1}]}]}]}),
+        );
+        tree.retain_not_retired(&HashSet::new());
+        assert_eq!(tree.workspaces[0].screens[0].panes[0].tabs.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Retain server-authoritative tree tabs during lazy startup and reconnect. Filter only explicit retired surface evidence, avoiding separate-mutex catalog publication races. Adds startup catalog-empty coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves server-authoritative tabs across lazy startup and reconnect. Previously we filtered against the local surface catalog (which could be empty or stale), causing tabs to disappear and active_tab to point to nothing; now we drop only tabs with explicit retire evidence and clamp active_tab, preventing tab loss and flicker.

**Bug Fixes**
- Stop using the local catalog as a negative filter and retain tabs unless the server snapshot shows them retired.
- Re-prune with the latest retired set immediately before publishing the tree to fence races.
- Keep retire evidence based on raw server snapshot IDs, not the filtered view, to avoid prematurely clearing it.
- Add a test ensuring tabs persist when the local catalog is empty at startup.

<sup>Written for commit eb701b708a4dd402eb71f5b38b9dee5001edcb3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

