### PR TITLE
fix(tui): gate stale watch frames after reopen

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -40,8 +40,9 @@ use crate::trust::{
     has_yolo_confirmation, relay_trust,
 };
 use crate::wire::{
-    CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame, PTY_PROTOCOL_VERSION,
-    ServerFrame, advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
+    CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame,
+    PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION, PTY_PROTOCOL_VERSION, ServerFrame,
+    advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
 };
 
 const MAX_OUTBOUND_FRAMES: usize = 256;
@@ -66,11 +67,20 @@ struct AuthSnapshot {
     trust: String,
     roots: Option<Vec<String>>,
     owner: Option<String>,
+    negotiated_version: u64,
 }
 
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
+    pub(crate) live: Option<Arc<AtomicBool>>,
+    pub(crate) ack: Option<tokio::sync::oneshot::Sender<()>>,
     _bytes: OwnedSemaphorePermit,
+}
+
+impl OutboundFrame {
+    pub(crate) fn is_live(&self) -> bool {
+        self.live.as_ref().is_none_or(|live| live.load(Ordering::Acquire))
+    }
 }
 
 async fn send_socket_message<S>(
@@ -139,14 +149,36 @@ impl OutboundSink {
     }
 
     pub(crate) async fn critical_text(&self, text: String) -> Result<(), ()> {
+        self.critical_text_with_token(text, None).await
+    }
+
+    pub(crate) async fn critical_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        self.critical_text_with_token_ack(text, live, Some(ack_tx)).await?;
+        ack_rx.await.map_err(|_| ())
+    }
+
+    pub(crate) async fn critical_text_with_token_ack(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+        ack: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         if bytes as usize > MAX_OUTBOUND_BYTES {
             self.critical_overflow.store(true, Ordering::Release);
             return Err(());
         }
         let permit = Arc::clone(&self.bytes).acquire_many_owned(bytes).await.map_err(|_| ())?;
-        let result =
-            self.critical.send(OutboundFrame { text, _bytes: permit }).await.map_err(|_| ());
+        let result = self
+            .critical
+            .send(OutboundFrame { text, live, ack, _bytes: permit })
+            .await
+            .map_err(|_| ());
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
         }
@@ -166,7 +198,9 @@ impl OutboundSink {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+            self.critical
+                .try_send(OutboundFrame { text, live: None, ack: None, _bytes: permit })
+                .map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -175,13 +209,23 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_critical_text(&self, text: String) -> Result<(), ()> {
+        self.try_critical_text_with_token(text, None)
+    }
+
+    pub(crate) fn try_critical_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
         let result = (|| {
             let bytes = u32::try_from(text.len()).map_err(|_| ())?;
             if bytes as usize > MAX_OUTBOUND_BYTES {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+            self.critical
+                .try_send(OutboundFrame { text, live, ack: None, _bytes: permit })
+                .map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -194,9 +238,17 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_watch_text(&self, text: String) -> Result<(), ()> {
+        self.try_watch_text_with_token(text, None)
+    }
+
+    pub(crate) fn try_watch_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-        self.watch.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+        self.watch.try_send(OutboundFrame { text, live, ack: None, _bytes: permit }).map_err(|_| ())
     }
 }
 
@@ -376,6 +428,7 @@ fn make_context(out: &OutboundSink, pending: &Arc<AtomicU64>, auth: &AuthSnapsho
             }
         }),
         buffered_amount: Arc::new(move || pending_probe.load(Ordering::SeqCst)),
+        negotiated_version: auth.negotiated_version,
         trust: auth.trust.clone(),
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
@@ -550,6 +603,12 @@ async fn relay_session(
                 }
             }
             Wake::Outbound(is_critical, Some(frame)) => {
+                if !frame.is_live() {
+                    if let Some(ack) = frame.ack {
+                        let _ = ack.send(());
+                    }
+                    continue;
+                }
                 if is_critical {
                     critical_burst += 1;
                 } else {
@@ -561,6 +620,9 @@ async fn relay_session(
                 pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
                     break Ok(connected);
+                }
+                if let Some(ack) = frame.ack {
+                    let _ = ack.send(());
                 }
             }
             Wake::Outbound(_, None) => {
@@ -681,6 +743,7 @@ async fn relay_session(
                             snapshot.trust = effective_trust;
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
+                            snapshot.negotiated_version = negotiated_version;
                             workspace.set_local_observe(local_observe);
                         }
                         let mut interval = tokio::time::interval(Duration::from_millis(
@@ -769,7 +832,10 @@ async fn relay_session(
                                     "version": version,
                                     "actionId": action_id,
                                     "ok": false,
-                                    "code": "busy",
+                                    // `busy` is not a RelayActionErrorCode. Keep the
+                                    // retry guidance in the message and use the
+                                    // contract's generic retryable failure code.
+                                    "code": "failed",
                                     "message": "relay is busy; retry this action",
                                 });
                                 let size = serde_json::to_string(&result)
@@ -856,27 +922,21 @@ async fn relay_session(
                                 Ok(()) => {}
                                 Err(mpsc::error::TrySendError::Closed(_)) => break Ok(connected),
                                 Err(mpsc::error::TrySendError::Full(raw)) => {
-                                    // Never silently discard a server command. Slow opens/listing
-                                    // have an explicit busy response; control frames use the same
-                                    // typed refusal when the serialized ingress queue is saturated.
-                                    let reply = raw
-                                        .get("ptyId")
-                                        .and_then(Value::as_str)
-                                        .map(|id| serde_json::json!({
+                                    // Never silently discard a terminal command. A PTY
+                                    // refusal uses the v7 `busy` code only after the
+                                    // negotiated feature gate. Surface listing has no
+                                    // error response in the wire schema, so close the
+                                    // connection instead of fabricating an empty or
+                                    // invalid result.
+                                    let reply = raw.get("ptyId").and_then(Value::as_str).map(|id| {
+                                        serde_json::json!({
                                             "version": PTY_PROTOCOL_VERSION,
                                             "type": "pty_error",
                                             "ptyId": id,
-                                            "code": "busy",
+                                            "code": if negotiated_version >= PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION { "busy" } else { "failed" },
                                             "message": if is_slow { "relay is busy; retry this terminal request" } else { "relay is busy; retry this terminal command" },
-                                        }))
-                                        .or_else(|| raw.get("requestId").and_then(Value::as_str).map(|id| serde_json::json!({
-                                            "version": PTY_PROTOCOL_VERSION,
-                                            "type": "surface_list_result",
-                                            "requestId": id,
-                                            "surfaces": [],
-                                            "code": "busy",
-                                            "message": "relay is busy; retry this terminal request",
-                                        })));
+                                        })
+                                    });
                                     if let Some(reply) = reply {
                                         // This response is mandatory. Send it directly so a full
                                         // outbound queue cannot block this loop and stop socket
@@ -890,6 +950,11 @@ async fn relay_session(
                                         if sent.is_err() {
                                             break Ok(connected);
                                         }
+                                    } else if raw.get("requestId").is_some() {
+                                        eprintln!(
+                                            "Closing relay connection because surface_list was rejected by a full ingress queue"
+                                        );
+                                        break Ok(connected);
                                     }
                                 }
                             }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -40,9 +40,8 @@ use crate::trust::{
     has_yolo_confirmation, relay_trust,
 };
 use crate::wire::{
-    CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame,
-    PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION, PTY_PROTOCOL_VERSION, ServerFrame,
-    advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
+    CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame, PTY_PROTOCOL_VERSION,
+    ServerFrame, advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
 };
 
 const MAX_OUTBOUND_FRAMES: usize = 256;
@@ -67,7 +66,6 @@ struct AuthSnapshot {
     trust: String,
     roots: Option<Vec<String>>,
     owner: Option<String>,
-    negotiated_version: u64,
 }
 
 pub(crate) struct OutboundFrame {
@@ -151,17 +149,15 @@ impl OutboundSink {
     pub(crate) async fn critical_text(&self, text: String) -> Result<(), ()> {
         self.critical_text_with_token(text, None).await
     }
-
     pub(crate) async fn critical_text_with_token(
         &self,
         text: String,
         live: Option<Arc<AtomicBool>>,
     ) -> Result<(), ()> {
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        self.critical_text_with_token_ack(text, live, Some(ack_tx)).await?;
-        ack_rx.await.map_err(|_| ())
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.critical_text_with_token_ack(text, live, Some(tx)).await?;
+        rx.await.map_err(|_| ())
     }
-
     pub(crate) async fn critical_text_with_token_ack(
         &self,
         text: String,
@@ -209,14 +205,6 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_critical_text(&self, text: String) -> Result<(), ()> {
-        self.try_critical_text_with_token(text, None)
-    }
-
-    pub(crate) fn try_critical_text_with_token(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
         let result = (|| {
             let bytes = u32::try_from(text.len()).map_err(|_| ())?;
             if bytes as usize > MAX_OUTBOUND_BYTES {
@@ -224,7 +212,7 @@ impl OutboundSink {
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
             self.critical
-                .try_send(OutboundFrame { text, live, ack: None, _bytes: permit })
+                .try_send(OutboundFrame { text, live: None, ack: None, _bytes: permit })
                 .map_err(|_| ())
         })();
         if result.is_err() {
@@ -238,17 +226,11 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_watch_text(&self, text: String) -> Result<(), ()> {
-        self.try_watch_text_with_token(text, None)
-    }
-
-    pub(crate) fn try_watch_text_with_token(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-        self.watch.try_send(OutboundFrame { text, live, ack: None, _bytes: permit }).map_err(|_| ())
+        self.watch
+            .try_send(OutboundFrame { text, live: None, ack: None, _bytes: permit })
+            .map_err(|_| ())
     }
 }
 
@@ -428,7 +410,6 @@ fn make_context(out: &OutboundSink, pending: &Arc<AtomicU64>, auth: &AuthSnapsho
             }
         }),
         buffered_amount: Arc::new(move || pending_probe.load(Ordering::SeqCst)),
-        negotiated_version: auth.negotiated_version,
         trust: auth.trust.clone(),
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
@@ -619,6 +600,9 @@ async fn relay_session(
                 let sent = send_socket_text(&socket, text, cancellation).await;
                 pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
+                    if let Some(ack) = frame.ack {
+                        let _ = ack.send(());
+                    }
                     break Ok(connected);
                 }
                 if let Some(ack) = frame.ack {
@@ -743,7 +727,6 @@ async fn relay_session(
                             snapshot.trust = effective_trust;
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
-                            snapshot.negotiated_version = negotiated_version;
                             workspace.set_local_observe(local_observe);
                         }
                         let mut interval = tokio::time::interval(Duration::from_millis(
@@ -832,10 +815,7 @@ async fn relay_session(
                                     "version": version,
                                     "actionId": action_id,
                                     "ok": false,
-                                    // `busy` is not a RelayActionErrorCode. Keep the
-                                    // retry guidance in the message and use the
-                                    // contract's generic retryable failure code.
-                                    "code": "failed",
+                                    "code": "busy",
                                     "message": "relay is busy; retry this action",
                                 });
                                 let size = serde_json::to_string(&result)
@@ -922,21 +902,27 @@ async fn relay_session(
                                 Ok(()) => {}
                                 Err(mpsc::error::TrySendError::Closed(_)) => break Ok(connected),
                                 Err(mpsc::error::TrySendError::Full(raw)) => {
-                                    // Never silently discard a terminal command. A PTY
-                                    // refusal uses the v7 `busy` code only after the
-                                    // negotiated feature gate. Surface listing has no
-                                    // error response in the wire schema, so close the
-                                    // connection instead of fabricating an empty or
-                                    // invalid result.
-                                    let reply = raw.get("ptyId").and_then(Value::as_str).map(|id| {
-                                        serde_json::json!({
+                                    // Never silently discard a server command. Slow opens/listing
+                                    // have an explicit busy response; control frames use the same
+                                    // typed refusal when the serialized ingress queue is saturated.
+                                    let reply = raw
+                                        .get("ptyId")
+                                        .and_then(Value::as_str)
+                                        .map(|id| serde_json::json!({
                                             "version": PTY_PROTOCOL_VERSION,
                                             "type": "pty_error",
                                             "ptyId": id,
-                                            "code": if negotiated_version >= PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION { "busy" } else { "failed" },
+                                            "code": "busy",
                                             "message": if is_slow { "relay is busy; retry this terminal request" } else { "relay is busy; retry this terminal command" },
-                                        })
-                                    });
+                                        }))
+                                        .or_else(|| raw.get("requestId").and_then(Value::as_str).map(|id| serde_json::json!({
+                                            "version": PTY_PROTOCOL_VERSION,
+                                            "type": "surface_list_result",
+                                            "requestId": id,
+                                            "surfaces": [],
+                                            "code": "busy",
+                                            "message": "relay is busy; retry this terminal request",
+                                        })));
                                     if let Some(reply) = reply {
                                         // This response is mandatory. Send it directly so a full
                                         // outbound queue cannot block this loop and stop socket
@@ -950,11 +936,6 @@ async fn relay_session(
                                         if sent.is_err() {
                                             break Ok(connected);
                                         }
-                                    } else if raw.get("requestId").is_some() {
-                                        eprintln!(
-                                            "Closing relay connection because surface_list was rejected by a full ingress queue"
-                                        );
-                                        break Ok(connected);
                                     }
                                 }
                             }

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -31,7 +31,13 @@ const DEBOUNCE_QUIET: Duration = Duration::from_millis(150);
 const DEBOUNCE_MAX_LATENCY: Duration = Duration::from_millis(500);
 const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 
-type Sessions = Arc<Mutex<HashMap<String, (u64, Option<tokio::task::JoinHandle<()>>)>>>;
+struct WatchSession {
+    generation: u64,
+    live: Arc<AtomicBool>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+type Sessions = Arc<Mutex<HashMap<String, WatchSession>>>;
 
 pub struct WatchRegistry {
     outbound: OutboundSink,
@@ -44,8 +50,9 @@ impl Drop for WatchRegistry {
         // The socket died with this registry; the Worker re-opens watches
         // on the next connection.
         if let Ok(mut sessions) = self.sessions.lock() {
-            for (_, (_, task)) in sessions.drain() {
-                if let Some(task) = task {
+            for (_, session) in sessions.drain() {
+                session.live.store(false, Ordering::Release);
+                if let Some(task) = session.task {
                     task.abort();
                 }
             }
@@ -80,9 +87,12 @@ impl WatchRegistry {
 
     pub fn close(&self, watch_id: &str) {
         if let Ok(mut sessions) = self.sessions.lock()
-            && let Some((_, Some(task))) = sessions.remove(watch_id)
+            && let Some(session) = sessions.remove(watch_id)
         {
-            task.abort();
+            session.live.store(false, Ordering::Release);
+            if let Some(task) = session.task {
+                task.abort();
+            }
         }
     }
 
@@ -105,11 +115,19 @@ impl WatchRegistry {
         })
         .unwrap_or_else(|_| String::new());
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let live = Arc::new(AtomicBool::new(true));
         let previous = match self.sessions.lock() {
             Ok(mut sessions)
                 if sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS =>
             {
-                Ok(sessions.insert(watch_id.clone(), (generation, None)))
+                let previous = sessions.insert(
+                    watch_id.clone(),
+                    WatchSession { generation, live: Arc::clone(&live), task: None },
+                );
+                if let Some(previous) = previous.as_ref() {
+                    previous.live.store(false, Ordering::Release);
+                }
+                Ok(previous)
             }
             Ok(_) | Err(_) => Err(()),
         };
@@ -124,28 +142,26 @@ impl WatchRegistry {
                 return;
             }
         };
-        let _ = self.outbound.try_critical_text(opened);
+        let _ = self.outbound.try_critical_text_with_token(opened, Some(Arc::clone(&live)));
         let outbound = self.outbound.clone();
         let sessions = Arc::clone(&self.sessions);
         let task_id = watch_id.clone();
+        let task_live = Arc::clone(&live);
         let mut task = Some(tokio::spawn(async move {
-            run_watch(&task_id, &root, &outbound).await;
+            run_watch(&task_id, &root, &outbound, task_live).await;
             if let Ok(mut sessions) = sessions.lock() {
                 // `tokio::spawn` starts the task immediately, so a watcher
                 // that fails during startup can finish before its handle is
                 // installed in the registry. Remove our generation's
-                // placeholder regardless of whether the handle is present;
-                // a replacement watch has a different generation and is
-                // therefore preserved.
-                if sessions.get(&task_id).is_some_and(|entry| entry.0 == generation) {
+                if sessions.get(&task_id).is_some_and(|entry| entry.generation == generation) {
                     sessions.remove(&task_id);
                 }
             }
         }));
         let installed = if let Ok(mut sessions) = self.sessions.lock() {
             if let Some(entry) = sessions.get_mut(&watch_id) {
-                if entry.0 == generation {
-                    entry.1 = task.take();
+                if entry.generation == generation {
+                    entry.task = task.take();
                     true
                 } else {
                     false
@@ -157,9 +173,10 @@ impl WatchRegistry {
             false
         };
         if !installed && let Some(task) = task {
+            live.store(false, Ordering::Release);
             task.abort();
         }
-        if let Some((_, Some(previous))) = previous {
+        if let Some(previous) = previous.and_then(|session| session.task) {
             previous.abort();
         }
     }
@@ -199,7 +216,7 @@ fn watch_root_with_capabilities(
 // The watch task: notify events -> debounce -> gitignore filter -> frames
 // ---------------------------------------------------------------------------
 
-async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
+async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: Arc<AtomicBool>) {
     use notify::Watcher as _;
     let (event_tx, mut event_rx) =
         channel::<Result<notify::Event, notify::Error>>(MAX_PENDING_NOTIFY_EVENTS);
@@ -229,22 +246,28 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
             Ok(watcher) => watcher,
             Err(error) => {
                 let _ = outbound
-                    .critical_text(watch_error_frame(
-                        watch_id,
-                        wire::WorkspaceErrorCode::Failed,
-                        &format!("could not start the watcher: {error}"),
-                    ))
+                    .critical_text_with_token(
+                        watch_error_frame(
+                            watch_id,
+                            wire::WorkspaceErrorCode::Failed,
+                            &format!("could not start the watcher: {error}"),
+                        ),
+                        Some(Arc::clone(&live)),
+                    )
                     .await;
                 return;
             }
         };
     if let Err(error) = watcher.watch(root, notify::RecursiveMode::Recursive) {
         let _ = outbound
-            .critical_text(watch_error_frame(
-                watch_id,
-                wire::WorkspaceErrorCode::Failed,
-                &format!("could not watch {}: {error}", root.display()),
-            ))
+            .critical_text_with_token(
+                watch_error_frame(
+                    watch_id,
+                    wire::WorkspaceErrorCode::Failed,
+                    &format!("could not watch {}: {error}", root.display()),
+                ),
+                Some(Arc::clone(&live)),
+            )
             .await;
         return;
     }
@@ -293,11 +316,14 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
         }
         if overflow {
             let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    "watch event burst overflowed; refresh the tree",
-                ))
+                .critical_text_with_token(
+                    watch_error_frame(
+                        watch_id,
+                        wire::WorkspaceErrorCode::Failed,
+                        "watch event burst overflowed; refresh the tree",
+                    ),
+                    Some(Arc::clone(&live)),
+                )
                 .await;
         }
         let latched_error = latched_error.lock().ok().and_then(|mut error| error.take());
@@ -310,7 +336,7 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
                 overflow: overflow.then_some(true),
             })
             .unwrap_or_else(|_| String::new());
-            if outbound.try_watch_text(frame).is_err() {
+            if outbound.try_watch_text_with_token(frame, Some(Arc::clone(&live))).is_err() {
                 // The outbound sink is saturated or closed. Retrying by
                 // latching overflow would wake this loop immediately and
                 // spin forever while producing no observable frame. The
@@ -323,21 +349,27 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
         }
         if let Some(error) = fatal {
             let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    &format!("the watcher died: {error}"),
-                ))
+                .critical_text_with_token(
+                    watch_error_frame(
+                        watch_id,
+                        wire::WorkspaceErrorCode::Failed,
+                        &format!("the watcher died: {error}"),
+                    ),
+                    Some(Arc::clone(&live)),
+                )
                 .await;
             break;
         }
         if let Some(error) = latched_error {
             let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    &format!("the watcher reported an error: {error}"),
-                ))
+                .critical_text_with_token(
+                    watch_error_frame(
+                        watch_id,
+                        wire::WorkspaceErrorCode::Failed,
+                        &format!("the watcher reported an error: {error}"),
+                    ),
+                    Some(Arc::clone(&live)),
+                )
                 .await;
             break;
         }
@@ -554,6 +586,52 @@ mod tests {
             .unwrap_or_else(|_| panic!("no {what} frame within 10s"))
             .expect("channel open");
         serde_json::from_str(&frame.text).expect("valid frame json")
+    }
+
+    async fn next_raw_frame(
+        critical: &mut Receiver<OutboundFrame>,
+        watch: &mut Receiver<OutboundFrame>,
+        what: &str,
+    ) -> OutboundFrame {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::select! { biased; frame = critical.recv() => frame, frame = watch.recv() => frame }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("no {what} frame within 10s"))
+        .expect("channel open")
+    }
+
+    #[tokio::test]
+    async fn queued_watch_frame_becomes_stale_when_its_token_is_retired() {
+        let (sink, _critical, mut watch) = OutboundSink::channels();
+        let live = Arc::new(AtomicBool::new(true));
+        sink.try_watch_text_with_token("event".to_owned(), Some(Arc::clone(&live)))
+            .expect("queue event");
+
+        live.store(false, Ordering::Release);
+
+        let frame = watch.recv().await.expect("queued event");
+        assert!(!frame.is_live(), "the writer must drop a retired queued frame");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reopening_a_watch_retires_queued_frames_before_new_opened_frame() {
+        let root = scratch("reopen-token");
+        let (sink, mut critical, mut watch) = OutboundSink::channels();
+        let registry = WatchRegistry::new(sink);
+
+        registry.open(open_frame("same", &root), None);
+        let old_opened = next_raw_frame(&mut critical, &mut watch, "first opened").await;
+        assert!(old_opened.is_live());
+
+        registry.open(open_frame("same", &root), None);
+        let new_opened = next_raw_frame(&mut critical, &mut watch, "replacement opened").await;
+
+        assert!(!old_opened.is_live(), "replacement must retire the old generation first");
+        assert!(new_opened.is_live(), "replacement opened frame must remain live");
+        registry.close("same");
+        assert!(!new_opened.is_live(), "close must retire queued frames");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -154,7 +154,9 @@ impl WatchRegistry {
                 // that fails during startup can finish before its handle is
                 // installed in the registry. Remove our generation's
                 if sessions.get(&task_id).is_some_and(|entry| entry.generation == generation) {
-                    sessions.remove(&task_id);
+                    if let Some(session) = sessions.remove(&task_id) {
+                        session.live.store(false, Ordering::Release);
+                    }
                 }
             }
         }));


### PR DESCRIPTION
## Summary
- retire the previous filesystem-watch liveness token before a replacement opened frame is queued
- attach liveness to watch events and awaited critical errors, then drop stale frames at the writer boundary
- add deterministic queued-frame and reopen/close coverage

## Verification
- direct rustfmt passed
- git diff --check passed
- hosted cmux-tui verification required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale filesystem-watch frames after a reopen or when a watch task exits by gating frames with a per-session liveness token; the writer drops retired frames so dead watches stop emitting. Also limits PTY "busy" to protocol v7+ and closes the connection when a full ingress queue rejects `surface_list`.

**Bug Fixes**
- Retires the previous watch generation before enqueuing the replacement opened frame.
- Retires queued frames on close and on task exit, and removes finished sessions from the registry to avoid late events.

<sup>Written for commit 7df47c86d2c7b71d7b5791300687f5f4d553c51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

