### PR TITLE
cmux-tui: default new terminals to the daemon launch cwd

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub mod transport {
     use std::io::{self, Read, Write};
@@ -822,6 +823,34 @@ pub fn home_dir() -> Option<PathBuf> {
     })
 }
 
+static LAUNCH_CWD: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Pin the process working directory before anything can change it. Entry
+/// points call this at startup so `default_terminal_cwd` keeps answering with
+/// the directory the user launched from.
+pub fn capture_launch_cwd() {
+    let _ = LAUNCH_CWD.get_or_init(|| std::env::current_dir().ok());
+}
+
+/// Directory a new terminal starts in when its creator names none: where the
+/// user launched `cmux`, not $HOME. The value is pinned at daemon startup, so
+/// clients attaching to an existing session never move it. A filesystem root
+/// or a launch directory that no longer exists falls back to $HOME so a
+/// durable session that outlives its worktree still spawns terminals.
+pub fn default_terminal_cwd() -> Option<String> {
+    let launch = LAUNCH_CWD.get_or_init(|| std::env::current_dir().ok()).clone();
+    default_terminal_cwd_from(launch.as_deref())
+}
+
+fn default_terminal_cwd_from(launch: Option<&Path>) -> Option<String> {
+    if let Some(dir) = launch {
+        if dir.parent().is_some() && dir.is_dir() {
+            return Some(dir.to_string_lossy().into_owned());
+        }
+    }
+    home_dir().map(|path| path.to_string_lossy().into_owned())
+}
+
 /// Convert a terminal-reported OSC 7 working directory into a local path.
 ///
 /// Shells normally report `file://host/path`. A URI from another host cannot
@@ -962,6 +991,22 @@ fn restrict_permissions(_path: &Path, _mode: u32) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_terminal_cwd_prefers_a_live_launch_directory() {
+        let dir = std::env::temp_dir().canonicalize().unwrap();
+        assert_eq!(default_terminal_cwd_from(Some(&dir)), Some(dir.to_string_lossy().into_owned()));
+    }
+
+    #[test]
+    fn default_terminal_cwd_rejects_roots_and_vanished_directories() {
+        let root = if cfg!(windows) { PathBuf::from("C:\\") } else { PathBuf::from("/") };
+        let home = home_dir().map(|path| path.to_string_lossy().into_owned());
+        assert_eq!(default_terminal_cwd_from(Some(&root)), home);
+        let gone = std::env::temp_dir().join(format!("cmux-cwd-gone-{}", std::process::id()));
+        assert_eq!(default_terminal_cwd_from(Some(&gone)), home);
+        assert_eq!(default_terminal_cwd_from(None), home);
+    }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2284,10 +2284,7 @@ impl Surface {
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
         }
-        let cwd = opts
-            .cwd
-            .clone()
-            .or_else(|| platform::home_dir().map(|path| path.to_string_lossy().into_owned()));
+        let cwd = opts.cwd.clone().or_else(platform::default_terminal_cwd);
         if let Some(cwd) = cwd.as_deref() {
             cmd.cwd(cwd);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1795,9 +1795,7 @@ mod unix {
             rows: options.rows,
             cell_pixels,
             scrollback: options.scrollback,
-            cwd: options.cwd.clone().or_else(|| {
-                crate::platform::home_dir().map(|path| path.to_string_lossy().into_owned())
-            }),
+            cwd: options.cwd.clone().or_else(crate::platform::default_terminal_cwd),
             command,
             extra_env: options.extra_env.clone(),
             default_colors,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1375,6 +1375,9 @@ fn main() {
 }
 
 fn run_main() {
+    // Pin the launch directory before any subsystem can move the process:
+    // new terminals default to it (not $HOME) for the daemon's lifetime.
+    cmux_tui_core::platform::capture_launch_cwd();
     let mut raw_args = std::env::args().skip(1).collect::<Vec<_>>();
     #[cfg(unix)]
     if raw_args.first().map(String::as_str) == Some("__agent-browser-provider") {

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -33,6 +33,18 @@ impl HeadlessServer {
     }
 
     fn start_with_config(name: &str, config_contents: Option<&str>) -> Self {
+        Self::start_with_options(name, config_contents, None)
+    }
+
+    fn start_in(name: &str, launch_cwd: &std::path::Path) -> Self {
+        Self::start_with_options(name, None, Some(launch_cwd))
+    }
+
+    fn start_with_options(
+        name: &str,
+        config_contents: Option<&str>,
+        launch_cwd: Option<&std::path::Path>,
+    ) -> Self {
         let dir = unique_temp_dir(name);
         fs::create_dir_all(&dir).unwrap();
         let socket = dir.join("mux.sock");
@@ -44,16 +56,19 @@ impl HeadlessServer {
         if let Some(contents) = config_contents {
             fs::write(&config, contents).unwrap();
         }
-        let child = Command::new(bin())
+        let mut command = Command::new(bin());
+        command
             .args(["--headless", "--socket"])
             .arg(&socket)
             .arg("--state")
             .arg(&state)
             .env("CMUX_TUI_CONFIG", &config)
             .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+            .stderr(Stdio::piped());
+        if let Some(launch_cwd) = launch_cwd {
+            command.current_dir(launch_cwd);
+        }
+        let child = command.spawn().unwrap();
         let server = Self { child, socket, state, dir };
         server.wait_for_socket();
         server
@@ -3856,6 +3871,31 @@ fn plugin_cli(data_home: &PathBuf, config_path: &PathBuf, args: &[&str]) -> Outp
 fn git(dir: &PathBuf, args: &[&str]) {
     let output = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
     assert_success(&output);
+}
+
+#[test]
+fn new_terminals_default_to_the_daemon_launch_directory() {
+    // Regression for https://github.com/manaflow-ai/cmux/issues/10756: a
+    // terminal created without an explicit cwd must start where the daemon
+    // was launched, not in $HOME. $HOME-rooted agents recursively scan and
+    // watch the whole home directory.
+    let launch = unique_temp_dir("launch-cwd-dir");
+    fs::create_dir_all(&launch).unwrap();
+    // The daemon reports its physical working directory, so compare against
+    // the resolved path (macOS /tmp is a symlink to /private/tmp).
+    let launch = launch.canonicalize().unwrap();
+    let server = HeadlessServer::start_in("launch-cwd", &launch);
+
+    let created = json_cli(&server, &["tab", "create", "terminal"]);
+    assert_success(&created);
+    let listed = json_output(&json_cli(&server, &["terminal", "list"]));
+    let terminals = listed.as_array().expect("terminal list returns an array");
+    assert_eq!(terminals.len(), 1, "expected one terminal: {listed}");
+    assert_eq!(
+        terminals[0]["cwd"].as_str(),
+        launch.to_str(),
+        "terminal cwd must be the daemon launch directory"
+    );
 }
 
 fn cli(server: &HeadlessServer, args: &[&str]) -> Output {

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -1097,7 +1097,7 @@ Example:
 | status | implemented |
 | since | protocol 5 |
 
-Creates a new PTY tab in a pane and makes it the active tab. If `pane` is absent, the active pane of the active screen is used. If the selected workspace exists but has no screens, the command materializes its first screen, pane, and terminal and preserves `cwd`. If the session has no workspaces, the command creates a workspace containing the tab; that legacy fallback ignores `cwd`. The new tab inherits the active surface working directory of the target pane when `cwd` is absent. Initial dimensions follow [Sizing](#sizing).
+Creates a new PTY tab in a pane and makes it the active tab. If `pane` is absent, the active pane of the active screen is used. If the selected workspace exists but has no screens, the command materializes its first screen, pane, and terminal and preserves `cwd`. If the session has no workspaces, the command creates a workspace containing the tab; that legacy fallback ignores `cwd`. The new tab inherits the active surface working directory of the target pane when `cwd` is absent. When there is nothing to inherit, the terminal starts in the directory the session daemon was launched from, and falls back to the user home directory only when that directory no longer exists. Initial dimensions follow [Sizing](#sizing).
 
 Params:
 


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/10756.

A terminal created without an explicit `cwd` fell back straight to $HOME in both spawn paths (durable terminal-host launch in `terminal_host_runtime.rs` and embedded surface spawn in `surface.rs`). Every terminal of a headless session therefore opened in the home directory no matter where the user ran `cmux`. Agents launched through such sessions recursively scan and watch all of $HOME; last night this amplified the workload behind the kernel zone-map panics on Lawrence's Mac (an opencode instance booted with `directory=/Users/lawrence` and put an FSEvents watcher on the whole home directory).

Mechanism: `run_main` pins the process working directory once at startup (`capture_launch_cwd`), and both spawn sites now default through `platform::default_terminal_cwd()`: explicit `cwd` > pinned launch directory > $HOME. $HOME is used only when the launch directory is the filesystem root or no longer exists, so a durable session that outlives its worktree still spawns terminals. Attaching to an existing session never moves the pinned value, so the default stays where the session was created. Tab-level inheritance from the active surface (spec §new-tab) is unchanged; this only fixes the base case with nothing to inherit.

Commit 1 adds the failing regression test (headless daemon started in a temp dir; first terminal must report that dir as `cwd`), commit 2 the fix plus unit tests for the fallback chain and one spec sentence documenting the default.

Verification: `./scripts/verify-cmux-tui-hosted.sh --filter default_t` (running; covers the new unit tests and the integration test on hosted Linux and macOS).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790287586&installation_model_id=21920&pr_number=10757&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10757&signature=7adebb2f00373c20d8c3f2ed1e0b6eb267471bd7e426c80f8cd761735d813f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New terminals and tabs now start in the directory where the session was launched when no working directory is specified.
  - Added reliable fallback to the user’s home directory if the launch directory is unavailable or invalid.
  - Improved consistency across local terminals, terminal hosts, and `new-tab` commands.
- **Tests**
  - Added coverage for valid, missing, vanished, and root launch directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->