### PR TITLE
Machines panel: free-window countdowns and locked rows

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -123399,6 +123399,23 @@
         }
       }
     },
+    "machines.menu.upgradeToReconnect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade to Reconnect\u2026"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレードして再接続\u2026"
+          }
+        }
+      }
+    },
     "machines.rename.confirm": {
       "extractionState": "manual",
       "localizations": {
@@ -123480,6 +123497,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "マシンを削除"
+          }
+        }
+      }
+    },
+    "machines.row.dayLeft": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 day left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残り1日"
+          }
+        }
+      }
+    },
+    "machines.row.daysLeft": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d days left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残り%d日"
+          }
+        }
+      }
+    },
+    "machines.row.locked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locked"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロック中"
           }
         }
       }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -499,6 +499,9 @@ struct MachineRowActions {
     let runCommand: @MainActor (String, [String]) -> Void
     let confirmDelete: @MainActor (String) -> Void
     let promptRename: @MainActor (String, String?) -> Void
+    /// A locked (free-window-expired) machine routes here instead of a doomed
+    /// connect; the backend enforces the same boundary with 402s.
+    let promptUpgrade: @MainActor () -> Void
 
     static func bound(
         onWillMutate: @escaping @MainActor (String) -> Void = { _ in },
@@ -534,6 +537,9 @@ struct MachineRowActions {
             },
             promptRename: { id, currentLabel in
                 presentRenamePrompt(id: id, currentLabel: currentLabel, onWillMutate: onWillMutate, onDidMutate: onDidMutate)
+            },
+            promptUpgrade: {
+                ProUpgradePresenter.present()
             }
         )
     }
@@ -762,17 +768,31 @@ private struct MachineRow: View, Equatable {
         .contentShape(Rectangle())
         .background(rowBackground)
         .onHover { isHovered = $0 }
-        .onTapGesture(count: 2) { actions.openShell(machine.id) }
+        .onTapGesture(count: 2) {
+            if machine.freeAccess == .expired {
+                actions.promptUpgrade()
+            } else {
+                actions.openShell(machine.id)
+            }
+        }
         .help(helpText)
         .contextMenu { menuItems }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(machine.displayName), \(machine.activityLabel)")
     }
 
+    @ViewBuilder
     private var activityDot: some View {
-        Circle()
-            .fill(dotColor)
-            .frame(width: 7, height: 7)
+        if machine.freeAccess == .expired {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundColor(.secondary.opacity(0.8))
+                .frame(width: 7)
+        } else {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 7, height: 7)
+        }
     }
 
     private var rowBackground: some View {
@@ -800,6 +820,18 @@ private struct MachineRow: View, Equatable {
         if let createdAt = machine.createdAt {
             parts.append(Self.relativeFormatter.localizedString(for: createdAt, relativeTo: Date()))
         }
+        switch machine.freeAccess {
+        case .unrestricted:
+            break
+        case .expired:
+            parts.append(String(localized: "machines.row.locked", defaultValue: "Locked"))
+        case .active(let daysLeft):
+            parts.append(
+                daysLeft == 1
+                    ? String(localized: "machines.row.dayLeft", defaultValue: "1 day left")
+                    : String(format: String(localized: "machines.row.daysLeft", defaultValue: "%d days left"), daysLeft)
+            )
+        }
         return parts.joined(separator: " · ")
     }
 
@@ -809,12 +841,18 @@ private struct MachineRow: View, Equatable {
 
     @ViewBuilder
     private var menuItems: some View {
-        Button(String(localized: "machines.menu.openShell", defaultValue: "Open Shell")) {
-            actions.openShell(machine.id)
-        }
-        if machine.isDesktop {
-            Button(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) {
-                actions.openDesktop(machine.id)
+        if machine.freeAccess == .expired {
+            Button(String(localized: "machines.menu.upgradeToReconnect", defaultValue: "Upgrade to Reconnect\u{2026}")) {
+                actions.promptUpgrade()
+            }
+        } else {
+            Button(String(localized: "machines.menu.openShell", defaultValue: "Open Shell")) {
+                actions.openShell(machine.id)
+            }
+            if machine.isDesktop {
+                Button(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) {
+                    actions.openDesktop(machine.id)
+                }
             }
         }
         Divider()

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -18,6 +18,19 @@ struct MachineSnapshot: Equatable, Identifiable {
         case attention(String)
     }
 
+    /// Where a machine stands in the free plan's access window. The backend is
+    /// the enforcement point (402 on access verbs); this mirrors it so the row
+    /// can show the countdown and route a locked machine to the upgrade flow
+    /// instead of a doomed connect.
+    enum FreeAccessState: Equatable {
+        /// Paid plan, or the window is disabled server-side.
+        case unrestricted
+        /// Reachable, with this many whole-or-partial days remaining.
+        case active(daysLeft: Int)
+        /// Past the window: preserved but locked until the plan is upgraded.
+        case expired
+    }
+
     let id: String
     let provider: String
     let image: String
@@ -26,6 +39,8 @@ struct MachineSnapshot: Equatable, Identifiable {
     let createdAt: Date?
     /// User-chosen label; nil when the machine has no label.
     let label: String?
+    /// Free-plan access window position; `.unrestricted` on paid plans.
+    var freeAccess: FreeAccessState = .unrestricted
     /// Latest activity reading; nil until the first sample lands.
     var stats: VMStats?
 
@@ -60,19 +75,38 @@ struct MachinePlanSnapshot: Equatable {
 }
 
 enum MachineSnapshotBuilder {
-    static func snapshot(from summary: VMSummary) -> MachineSnapshot {
-        MachineSnapshot(
+    static func snapshot(
+        from summary: VMSummary,
+        freeAccessWindowDays: Int = 0,
+        now: Date = Date()
+    ) -> MachineSnapshot {
+        let createdAt = summary.createdAt > 0
+            ? Date(timeIntervalSince1970: TimeInterval(summary.createdAt) / 1000)
+            : nil
+        return MachineSnapshot(
             id: summary.id,
             provider: summary.provider,
             image: summary.image,
             isDesktop: summary.image.contains("xfce-vnc"),
             activity: activity(fromStatus: summary.status),
-            createdAt: summary.createdAt > 0
-                ? Date(timeIntervalSince1970: TimeInterval(summary.createdAt) / 1000)
-                : nil,
+            createdAt: createdAt,
             label: summary.displayName,
+            freeAccess: freeAccessState(createdAt: createdAt, windowDays: freeAccessWindowDays, now: now),
             stats: nil
         )
+    }
+
+    /// Mirrors the backend's window math (created + windowDays vs now); the
+    /// backend stays the enforcement point, this only drives the row UI.
+    static func freeAccessState(
+        createdAt: Date?,
+        windowDays: Int,
+        now: Date = Date()
+    ) -> MachineSnapshot.FreeAccessState {
+        guard windowDays > 0, let createdAt else { return .unrestricted }
+        let remaining = createdAt.addingTimeInterval(TimeInterval(windowDays) * 86_400).timeIntervalSince(now)
+        if remaining <= 0 { return .expired }
+        return .active(daysLeft: Int((remaining / 86_400).rounded(.up)))
     }
 
     static func activity(fromStatus status: String) -> MachineSnapshot.Activity {
@@ -224,7 +258,10 @@ final class MachinesPanelViewModel: ObservableObject {
         do {
             let page = try await client.listPage()
             let previous = Dictionary(uniqueKeysWithValues: machines.map { ($0.id, $0.stats) })
-            var snapshots = page.vms.map(MachineSnapshotBuilder.snapshot(from:))
+            let freeAccessWindowDays = page.limits?.freeAccessWindowDays ?? 0
+            var snapshots = page.vms.map {
+                MachineSnapshotBuilder.snapshot(from: $0, freeAccessWindowDays: freeAccessWindowDays)
+            }
             for index in snapshots.indices {
                 snapshots[index].stats = previous[snapshots[index].id] ?? nil
             }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -109,6 +109,41 @@ enum MachineSnapshotBuilder {
         return .active(daysLeft: Int((remaining / 86_400).rounded(.up)))
     }
 
+    /// The next instant at which a machine's free-access presentation changes:
+    /// each day-boundary where the "N days left" label decrements, and finally
+    /// the expiry itself. Nil once expired (or when no window applies) — there
+    /// is nothing left to wait for. Expiry is a *known future timestamp*, so
+    /// the panel arms a one-shot timer at exactly this instant instead of
+    /// discovering the transition on a poll sweep.
+    static func nextFreeAccessTransition(
+        createdAt: Date?,
+        windowDays: Int,
+        now: Date = Date()
+    ) -> Date? {
+        guard windowDays > 0, let createdAt else { return nil }
+        let expiry = createdAt.addingTimeInterval(TimeInterval(windowDays) * 86_400)
+        let remaining = expiry.timeIntervalSince(now)
+        guard remaining > 0 else { return nil }
+        let daysLeft = Int((remaining / 86_400).rounded(.up))
+        // The label decrements when remaining crosses (daysLeft - 1) whole days;
+        // for the final day that crossing IS the expiry.
+        return expiry.addingTimeInterval(-TimeInterval(daysLeft - 1) * 86_400)
+    }
+
+    /// Recomputes only the free-access facet of existing snapshots against a
+    /// fresh clock — no network, stats and identity preserved.
+    static func applyingFreeAccess(
+        to snapshots: [MachineSnapshot],
+        windowDays: Int,
+        now: Date = Date()
+    ) -> [MachineSnapshot] {
+        snapshots.map { snapshot in
+            var next = snapshot
+            next.freeAccess = freeAccessState(createdAt: snapshot.createdAt, windowDays: windowDays, now: now)
+            return next
+        }
+    }
+
     static func activity(fromStatus status: String) -> MachineSnapshot.Activity {
         switch status.lowercased() {
         case "running", "ready", "standby", "paused":
@@ -158,6 +193,12 @@ final class MachinesPanelViewModel: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
     private var statsTask: Task<Void, Never>?
+    /// One-shot timer armed at the exact next free-access transition (a
+    /// countdown day-boundary or an expiry). Expiry is client-computable from
+    /// createdAt + window, so rows flip at the boundary itself — scheduling,
+    /// not polling; the slow poll only covers changes made elsewhere.
+    private var freeAccessTransitionTask: Task<Void, Never>?
+    private var freeAccessWindowDays = 0
     private var authSignOutObserver: NSObjectProtocol?
     private static let statsInterval: Duration = .seconds(20)
 
@@ -231,6 +272,30 @@ final class MachinesPanelViewModel: ObservableObject {
         pollTask = nil
         statsTask?.cancel()
         statsTask = nil
+        freeAccessTransitionTask?.cancel()
+        freeAccessTransitionTask = nil
+    }
+
+    /// Sleeps until the earliest upcoming transition across the fleet, then
+    /// recomputes the free-access facet locally and re-arms for the next one.
+    private func scheduleFreeAccessTransition(now: Date = Date()) {
+        freeAccessTransitionTask?.cancel()
+        freeAccessTransitionTask = nil
+        guard freeAccessWindowDays > 0 else { return }
+        let windowDays = freeAccessWindowDays
+        let next = machines
+            .compactMap { MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: $0.createdAt, windowDays: windowDays, now: now) }
+            .min()
+        guard let next else { return }
+        // A hair past the boundary so the recompute lands on the new side.
+        let delay = max(next.timeIntervalSince(now), 0) + 0.5
+        freeAccessTransitionTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled, let self else { return }
+            let now = Date()
+            self.machines = MachineSnapshotBuilder.applyingFreeAccess(to: self.machines, windowDays: windowDays, now: now)
+            self.scheduleFreeAccessTransition(now: now)
+        }
     }
 
     /// Drop every locally cached machine and in-flight sample when auth ends.
@@ -242,6 +307,9 @@ final class MachinesPanelViewModel: ObservableObject {
         refreshTask = nil
         statsTask?.cancel()
         statsTask = nil
+        freeAccessTransitionTask?.cancel()
+        freeAccessTransitionTask = nil
+        freeAccessWindowDays = 0
         machines = []
         plan = nil
         activeOperation = nil
@@ -259,6 +327,7 @@ final class MachinesPanelViewModel: ObservableObject {
             let page = try await client.listPage()
             let previous = Dictionary(uniqueKeysWithValues: machines.map { ($0.id, $0.stats) })
             let freeAccessWindowDays = page.limits?.freeAccessWindowDays ?? 0
+            self.freeAccessWindowDays = freeAccessWindowDays
             var snapshots = page.vms.map {
                 MachineSnapshotBuilder.snapshot(from: $0, freeAccessWindowDays: freeAccessWindowDays)
             }
@@ -266,6 +335,7 @@ final class MachinesPanelViewModel: ObservableObject {
                 snapshots[index].stats = previous[snapshots[index].id] ?? nil
             }
             machines = snapshots
+            scheduleFreeAccessTransition()
             refreshStats()
             plan = MachineSnapshotBuilder.planSnapshot(activeCount: snapshots.count, limits: page.limits)
             lastErrorDescription = nil

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -269,6 +269,8 @@ struct VMSummary {
 struct VMPlanLimits {
     let maxActiveVms: Int
     let planId: String
+    /// Days a free-plan machine stays reachable after creation; 0 = no window.
+    let freeAccessWindowDays: Int
 }
 
 struct VMListPage {
@@ -445,7 +447,10 @@ actor VMClient {
         if let rawLimits = obj["limits"] as? [String: Any],
            let maxActiveVms = (rawLimits["maxActiveVms"] as? Int) ?? (rawLimits["maxActiveVms"] as? NSNumber)?.intValue,
            let planId = rawLimits["planId"] as? String {
-            limits = VMPlanLimits(maxActiveVms: maxActiveVms, planId: planId)
+            let freeAccessWindowDays = (rawLimits["freeAccessWindowDays"] as? Int)
+                ?? (rawLimits["freeAccessWindowDays"] as? NSNumber)?.intValue
+                ?? 0
+            limits = VMPlanLimits(maxActiveVms: maxActiveVms, planId: planId, freeAccessWindowDays: freeAccessWindowDays)
         }
         let vms = try items.enumerated().map { index, dict -> VMSummary in
             guard let id = dict["id"] as? String, !id.isEmpty else {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -75,20 +75,20 @@ final class MachinesPanelModelTests: XCTestCase {
 
         let underLimit = MachineSnapshotBuilder.planSnapshot(
             activeCount: 2,
-            limits: VMPlanLimits(maxActiveVms: 3, planId: "free")
+            limits: VMPlanLimits(maxActiveVms: 3, planId: "free", freeAccessWindowDays: 5)
         )
         XCTAssertEqual(underLimit?.isAtLimit, false)
         XCTAssertEqual(underLimit?.isPaidPlan, false)
 
         let atLimit = MachineSnapshotBuilder.planSnapshot(
             activeCount: 3,
-            limits: VMPlanLimits(maxActiveVms: 3, planId: "free")
+            limits: VMPlanLimits(maxActiveVms: 3, planId: "free", freeAccessWindowDays: 5)
         )
         XCTAssertEqual(atLimit?.isAtLimit, true)
 
         let paid = MachineSnapshotBuilder.planSnapshot(
             activeCount: 4,
-            limits: VMPlanLimits(maxActiveVms: 10, planId: "pro")
+            limits: VMPlanLimits(maxActiveVms: 10, planId: "pro", freeAccessWindowDays: 0)
         )
         XCTAssertEqual(paid?.isAtLimit, false)
         XCTAssertEqual(paid?.isPaidPlan, true)
@@ -136,5 +136,52 @@ final class MachinesPanelModelTests: XCTestCase {
         XCTAssertTrue(
             CloudVMPanelAuthState.signedIn.allowsAuthenticatedOperation
         )
+    }
+
+    func testFreeAccessStateMirrorsTheBackendWindow() {
+        let created = Date(timeIntervalSince1970: 1_787_400_000)
+        let day: TimeInterval = 86_400
+
+        // Paid plan / disabled window (0 days) never restricts.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.freeAccessState(createdAt: created, windowDays: 0, now: created.addingTimeInterval(400 * day)),
+            .unrestricted
+        )
+        // Unknown createdAt fails open, matching the backend.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.freeAccessState(createdAt: nil, windowDays: 5, now: Date()),
+            .unrestricted
+        )
+        // Inside the window: partial days round up so day one reads "5 days left".
+        XCTAssertEqual(
+            MachineSnapshotBuilder.freeAccessState(createdAt: created, windowDays: 5, now: created.addingTimeInterval(1)),
+            .active(daysLeft: 5)
+        )
+        XCTAssertEqual(
+            MachineSnapshotBuilder.freeAccessState(createdAt: created, windowDays: 5, now: created.addingTimeInterval(4.5 * day)),
+            .active(daysLeft: 1)
+        )
+        // Past the window: locked.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.freeAccessState(createdAt: created, windowDays: 5, now: created.addingTimeInterval(5 * day + 1)),
+            .expired
+        )
+    }
+
+    func testSnapshotCarriesFreeAccessState() {
+        let created = 1_787_400_000_000
+        let summary = VMSummary(
+            id: "noble-wren",
+            provider: "blaxel",
+            status: "running",
+            image: "blaxel/xfce-vnc:latest",
+            createdAt: created,
+            base: nil
+        )
+        let now = Date(timeIntervalSince1970: TimeInterval(created) / 1000 + 6 * 86_400)
+        let snapshot = MachineSnapshotBuilder.snapshot(from: summary, freeAccessWindowDays: 5, now: now)
+        XCTAssertEqual(snapshot.freeAccess, .expired)
+        let unrestricted = MachineSnapshotBuilder.snapshot(from: summary, freeAccessWindowDays: 0, now: now)
+        XCTAssertEqual(unrestricted.freeAccess, .unrestricted)
     }
 }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -168,6 +168,66 @@ final class MachinesPanelModelTests: XCTestCase {
         )
     }
 
+    func testNextFreeAccessTransitionIsTheExactBoundary() {
+        let created = Date(timeIntervalSince1970: 1_787_400_000)
+        let day: TimeInterval = 86_400
+
+        // Fresh machine: the first label decrement is one day in.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: created, windowDays: 5, now: created.addingTimeInterval(1)),
+            created.addingTimeInterval(day)
+        )
+        // Mid-window: next transition is the next whole-day crossing.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: created, windowDays: 5, now: created.addingTimeInterval(3.5 * day)),
+            created.addingTimeInterval(4 * day)
+        )
+        // Final day: the next transition IS the expiry.
+        XCTAssertEqual(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: created, windowDays: 5, now: created.addingTimeInterval(4.5 * day)),
+            created.addingTimeInterval(5 * day)
+        )
+        // Expired or unwindowed: nothing left to wait for.
+        XCTAssertNil(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: created, windowDays: 5, now: created.addingTimeInterval(6 * day))
+        )
+        XCTAssertNil(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: created, windowDays: 0, now: created)
+        )
+        XCTAssertNil(
+            MachineSnapshotBuilder.nextFreeAccessTransition(createdAt: nil, windowDays: 5, now: created)
+        )
+    }
+
+    func testApplyingFreeAccessRecomputesOnlyThatFacet() {
+        let created = 1_787_400_000_000
+        let summary = VMSummary(
+            id: "noble-wren",
+            provider: "blaxel",
+            status: "running",
+            image: "blaxel/xfce-vnc:latest",
+            createdAt: created,
+            base: nil
+        )
+        let createdDate = Date(timeIntervalSince1970: TimeInterval(created) / 1000)
+        let before = MachineSnapshotBuilder.snapshot(
+            from: summary,
+            freeAccessWindowDays: 5,
+            now: createdDate.addingTimeInterval(4.9 * 86_400)
+        )
+        XCTAssertEqual(before.freeAccess, .active(daysLeft: 1))
+
+        let after = MachineSnapshotBuilder.applyingFreeAccess(
+            to: [before],
+            windowDays: 5,
+            now: createdDate.addingTimeInterval(5 * 86_400 + 1)
+        )
+        XCTAssertEqual(after.count, 1)
+        XCTAssertEqual(after[0].freeAccess, .expired)
+        XCTAssertEqual(after[0].id, before.id)
+        XCTAssertEqual(after[0].stats, before.stats)
+    }
+
     func testSnapshotCarriesFreeAccessState() {
         let created = 1_787_400_000_000
         let summary = VMSummary(

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -21,10 +21,12 @@ import {
 } from "../../../services/vms/errors";
 import {
   defaultMemoryMbForPlan,
+  isPaidVmPlan,
   isVmBillingTeamResolutionError,
   isVmProGateBlocked,
   maxMemoryMbForPlan,
   resolveVmEntitlements,
+  vmFreeAccessWindowDays,
 } from "../../../services/vms/entitlements";
 import {
   imageUsesBakedFreestyleSignedAdmin,
@@ -109,8 +111,14 @@ export async function GET(request: Request): Promise<Response> {
           listEntitlements = null;
         }
       }
+      // freeAccessWindowDays is 0 for paid plans (no window) so clients can
+      // render countdowns/locks from the payload without hardcoding policy.
       const limits = listEntitlements
-        ? { maxActiveVms: listEntitlements.maxActiveVms, planId: listEntitlements.planId }
+        ? {
+          maxActiveVms: listEntitlements.maxActiveVms,
+          planId: listEntitlements.planId,
+          freeAccessWindowDays: isPaidVmPlan(listEntitlements.planId) ? 0 : vmFreeAccessWindowDays(),
+        }
         : undefined;
       return jsonResponse({ vms, limits });
     },


### PR DESCRIPTION
Stacked on #10758 (base: `austin/cmux-cloud-plans`) — the UI surfacing of the 5-day free access window.

## What it does

- `GET /api/vm` `limits` now includes **`freeAccessWindowDays`** (0 for paid plans), so clients render policy from the wire instead of hardcoding the 5.
- **Countdown rows**: a free-plan machine's subtitle appends `· 3 days left` (rounded up, so day one reads "5 days left").
- **Locked rows**: past the window, the row swaps the activity dot for a lock glyph, shows `· Locked`, and double-click / context menu route to the shared Pro upgrade presenter instead of a doomed connect — the backend still enforces the boundary with 402s, the UI just stops walking into them. Rename / Status / Delete stay available so the machine remains manageable and disposable while locked.
- Paid plans and a disabled window (`freeAccessWindowDays: 0`) render exactly as today.

## Tests

- `MachinesPanelModelTests`: window math mirrors the backend (rounding boundary, expiry boundary, fail-open on unknown createdAt, disabled window), and snapshots carry the state end to end.
- Web: `tsc` clean; route + paywall suites green.

## Trying it

The lock only applies to **free-plan** accounts — on a Pro dev account, `web/scripts/stripe/dev-reset.sh <email>` un-Pros it; `CMUX_VM_FREE_ACCESS_WINDOW_DAYS` shrinks the window for fast repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790289470&installation_model_id=21920&pr_number=10760&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10760&signature=6eb7297d4125d05ab7acbc10d5f492bb55fe06b33b71add1dfdbefeb3bc506d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->