### PR TITLE
Make transient control-socket rearm outages observable

### DIFF
--- a/Packages/macOS/CmuxControlSocket/README.md
+++ b/Packages/macOS/CmuxControlSocket/README.md
@@ -34,6 +34,16 @@ This package owns the listener server (`SocketControlServer`: reservation, bind/
 - `ControlClientRateLimiter` — per-connection token-bucket backpressure for
   high-frequency list/tree/top/read-text polling.
 
+Accept-source recovery is bounded by the policy's configured maximum backoff
+(5 seconds by default). A fatal descriptor error or a persistent accept-failure
+streak emits `socket.listener.rearm.started`, parks the listener for the
+reported `delayMs`, and then emits `socket.listener.rearm.ready` when the host
+claims the generation. A successful restart preserving the failure streak emits
+`socket.listener.rearm.completed`; `socket.listener.rearm.failed` marks a
+restart that could not bind. The interval is the recovery-clock delay supplied
+to the host, so a host that does not claim the generation must surface that
+failure rather than silently treating the listener as healthy.
+
 Stage failures carry stable `stage` strings (`SocketStageFailure`) that feed telemetry breadcrumbs and the fallback policy; do not rename existing stages.
 
 ## Testing

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
@@ -152,7 +152,10 @@ extension SocketControlServer {
     /// re-fire on a hot errno; those re-fires return here without counting
     /// or emitting, matching the legacy cadence where the source was already
     /// suspended by this point.
-    private nonisolated func handleAcceptFailure(
+    // Internal for the package's deterministic state-machine coverage. The
+    // test drives this same recovery decision after binding a real listener;
+    // it does not bypass path ownership or connection authentication.
+    nonisolated func handleAcceptFailure(
         listenerSocket: Int32,
         generation: UInt64,
         errnoCode: Int32

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
@@ -17,6 +17,16 @@ extension SocketControlServer {
         source.setCancelHandler { @Sendable [weak self] in
             close(listenerSocket)
             guard let self else { return }
+            let snapshot = self.listenerStateSnapshot()
+            if snapshot.pendingRearmGeneration == generation {
+                self.events.breadcrumb(
+                    "socket.listener.rearm.socket_closed",
+                    self.socketListenerEventData(
+                        stage: "accept_rearm_socket_closed",
+                        extra: ["generation": generation]
+                    )
+                )
+            }
             Task { @MainActor in
                 self.finishAcceptSourceCancel(listenerSocket: listenerSocket, generation: generation)
             }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
@@ -266,6 +266,20 @@ extension SocketControlServer {
             }
             cleanup.sourceToCancel?.cancel()
 
+            events.breadcrumb(
+                "socket.listener.rearm.started",
+                socketListenerEventData(
+                    stage: "accept_rearm",
+                    errnoCode: errnoCode,
+                    extra: [
+                        "generation": generation,
+                        "consecutiveFailures": consecutiveFailures,
+                        "rearmDelayMs": delayMs,
+                        "rearmBounded": 1,
+                    ]
+                )
+            )
+
             events.rearmRequested(generation, errnoCode, consecutiveFailures, delayMs)
         }
     }
@@ -372,6 +386,18 @@ extension SocketControlServer {
             "socket.listener.rearm.requested",
             socketListenerEventData(
                 stage: "accept_rearm",
+                errnoCode: errnoCode,
+                extra: [
+                    "generation": generation,
+                    "consecutiveFailures": consecutiveFailures,
+                    "rearmDelayMs": delayMs,
+                ]
+            )
+        )
+        events.breadcrumb(
+            "socket.listener.rearm.ready",
+            socketListenerEventData(
+                stage: "accept_rearm_ready",
                 errnoCode: errnoCode,
                 extra: [
                     "generation": generation,

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+AcceptSource.swift
@@ -152,10 +152,13 @@ extension SocketControlServer {
     /// re-fire on a hot errno; those re-fires return here without counting
     /// or emitting, matching the legacy cadence where the source was already
     /// suspended by this point.
-    // Internal for the package's deterministic state-machine coverage. The
-    // test drives this same recovery decision after binding a real listener;
-    // it does not bypass path ownership or connection authentication.
-    nonisolated func handleAcceptFailure(
+    // SPI for the package's deterministic state-machine coverage. The test
+    // drives this same recovery decision after binding a real listener; it
+    // does not bypass path ownership or connection authentication. Keeping
+    // this out of the ordinary public API prevents production clients from
+    // manufacturing an accept failure transition.
+    @_spi(CmuxControlSocketTesting)
+    public nonisolated func handleAcceptFailure(
         listenerSocket: Int32,
         generation: UInt64,
         errnoCode: Int32

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
@@ -159,6 +159,15 @@ extension SocketControlServer {
         var listenerActivated = false
         defer {
             if !listenerActivated {
+                if preserveAcceptFailureStreak {
+                    events.breadcrumb(
+                        "socket.listener.rearm.failed",
+                        socketListenerEventData(
+                            stage: "rearm_start",
+                            extra: ["preservedAcceptFailureStreak": 1]
+                        )
+                    )
+                }
                 if let activeBoundSocketPathIdentity,
                    listenerPolicy.shouldUnlinkSocketPathAfterListenerStop(
                        currentIdentity: transport.pathIdentity(at: activeSocketPath),
@@ -372,6 +381,18 @@ extension SocketControlServer {
                 "backlog": transport.listenBacklog,
             ]
         )
+        if preserveAcceptFailureStreak {
+            events.breadcrumb(
+                "socket.listener.rearm.completed",
+                socketListenerEventData(
+                    stage: "accept_rearm_complete",
+                    extra: [
+                        "generation": generation,
+                        "preservedAcceptFailureStreak": 1,
+                    ]
+                )
+            )
+        }
         events.listenerDidStart(activeSocketPath, generation)
 
         startSocketPathMonitor(path: activeSocketPath, generation: generation)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer.swift
@@ -86,6 +86,7 @@ public final class SocketControlServer {
         let acceptLoopAlive: Bool
         let activeGeneration: UInt64
         let pendingRearmGeneration: UInt64?
+        let listenerReadSourceSuspended: Bool
         let reservedStartupSocketPath: String?
         let listenerStartInProgress: Bool
         let socketPathLockHeld: Bool
@@ -278,6 +279,7 @@ public final class SocketControlServer {
             acceptLoopAlive: state.acceptLoopAlive,
             activeGeneration: state.activeAcceptLoopGeneration,
             pendingRearmGeneration: state.pendingAcceptLoopRearmGeneration,
+            listenerReadSourceSuspended: state.listenerReadSourceSuspended,
             reservedStartupSocketPath: state.reservedStartupSocketPath,
             listenerStartInProgress: state.listenerStartInProgress,
             socketPathLockHeld: state.socketPathLockFD >= 0,
@@ -437,6 +439,23 @@ public final class SocketControlServer {
         if let errnoCode {
             data["errno"] = Int(errnoCode)
             data["errnoDescription"] = String(cString: strerror(errnoCode))
+        }
+        let listenerState: String
+        if snapshot.pendingRearmGeneration != nil {
+            listenerState = "rearming"
+        } else if snapshot.listenerStartInProgress {
+            listenerState = "starting"
+        } else if snapshot.isRunning && snapshot.acceptLoopAlive {
+            listenerState = "running"
+        } else if snapshot.isRunning {
+            listenerState = "accept_source_starting"
+        } else {
+            listenerState = "stopped"
+        }
+        data["listenerState"] = listenerState
+        data["acceptSourceSuspended"] = snapshot.listenerReadSourceSuspended ? 1 : 0
+        if let pendingRearmGeneration = snapshot.pendingRearmGeneration {
+            data["pendingRearmGeneration"] = pendingRearmGeneration
         }
         for (key, value) in extra {
             data[key] = value

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
@@ -1,0 +1,300 @@
+import CmuxSettings
+import Darwin
+import Foundation
+import os
+import Testing
+
+@testable import CmuxControlSocket
+
+private struct RecordedRearm: Sendable {
+    let generation: UInt64
+    let errnoCode: Int32
+    let consecutiveFailures: Int
+    let delayMs: Int
+}
+
+private struct RecordedRearmBreadcrumb: Sendable {
+    let message: String
+    let listenerState: String?
+    let errnoCode: Int?
+    let pendingRearmGeneration: UInt64?
+    let delayMs: Int?
+}
+
+private final class AcceptRearmRecorder: Sendable {
+    private struct State {
+        var breadcrumbs: [RecordedRearmBreadcrumb] = []
+        var rearms: [RecordedRearm] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    let rearmRequests: AsyncStream<RecordedRearm>
+    private let rearmRequestsContinuation: AsyncStream<RecordedRearm>.Continuation
+
+    init() {
+        let stream = AsyncStream<RecordedRearm>.makeStream(bufferingPolicy: .unbounded)
+        rearmRequests = stream.stream
+        rearmRequestsContinuation = stream.continuation
+    }
+
+    var breadcrumbs: [RecordedRearmBreadcrumb] {
+        state.withLock { $0.breadcrumbs }
+    }
+
+    var rearms: [RecordedRearm] {
+        state.withLock { $0.rearms }
+    }
+
+    func makeEvents() -> SocketControlServerEvents {
+        SocketControlServerEvents(
+            breadcrumb: { message, data in
+                let breadcrumb = RecordedRearmBreadcrumb(
+                    message: message,
+                    listenerState: data["listenerState"] as? String,
+                    errnoCode: data["errno"] as? Int,
+                    pendingRearmGeneration: data["pendingRearmGeneration"] as? UInt64,
+                    delayMs: data["rearmDelayMs"] as? Int
+                )
+                self.state.withLock { $0.breadcrumbs.append(breadcrumb) }
+            },
+            failure: { _, _, _, _ in },
+            listenerDidStart: { _, _ in },
+            recordLastSocketPath: { _ in },
+            pathMissingDetected: { _, _ in },
+            rearmRequested: { generation, errnoCode, consecutiveFailures, delayMs in
+                let rearm = RecordedRearm(
+                    generation: generation,
+                    errnoCode: errnoCode,
+                    consecutiveFailures: consecutiveFailures,
+                    delayMs: delayMs
+                )
+                self.state.withLock { $0.rearms.append(rearm) }
+                self.rearmRequestsContinuation.yield(rearm)
+            }
+        )
+    }
+}
+
+@MainActor
+private struct AcceptRearmHarness: ~Copyable {
+    let directory: URL
+    let socketPath: String
+    let recorder: AcceptRearmRecorder
+    let server: SocketControlServer
+
+    init(clock: TestSocketRecoveryClock, policy: SocketListenerPolicy) throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("accept-rearm-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketPath = directory.appendingPathComponent("cmux.sock").path
+        recorder = AcceptRearmRecorder()
+        server = SocketControlServer(
+            initialSocketPath: socketPath,
+            listenerPolicy: policy,
+            recoveryClock: clock,
+            notificationCenter: NotificationCenter(),
+            events: recorder.makeEvents()
+        )
+    }
+
+    func shutdown() {
+        server.stop()
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+private struct UnixConnectAttempt: Sendable {
+    let connected: Bool
+    let errnoCode: Int32
+}
+
+private func connectAttempt(to path: String) -> UnixConnectAttempt {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+        return UnixConnectAttempt(connected: false, errnoCode: errno)
+    }
+    defer { close(fd) }
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let copied = path.withCString { source -> Bool in
+        let length = strlen(source)
+        guard length < MemoryLayout.size(ofValue: address.sun_path) else { return false }
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.baseAddress?.copyMemory(from: source, byteCount: length + 1)
+        }
+        return true
+    }
+    guard copied else {
+        return UnixConnectAttempt(connected: false, errnoCode: ENAMETOOLONG)
+    }
+
+    let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+            Darwin.connect(fd, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    let connectErrno = result == 0 ? 0 : errno
+    return UnixConnectAttempt(connected: result == 0, errnoCode: connectErrno)
+}
+
+private func concurrentConnectBurst(to path: String, count: Int) async -> [UnixConnectAttempt] {
+    await withTaskGroup(of: UnixConnectAttempt.self) { group in
+        for _ in 0..<count {
+            group.addTask {
+                connectAttempt(to: path)
+            }
+        }
+        var attempts: [UnixConnectAttempt] = []
+        attempts.reserveCapacity(count)
+        for await attempt in group {
+            attempts.append(attempt)
+        }
+        return attempts
+    }
+}
+
+@MainActor
+private func waitForRearmCondition(
+    attempts: Int = 1_000,
+    _ predicate: () -> Bool
+) async -> Bool {
+    for _ in 0..<attempts {
+        if predicate() { return true }
+        await Task.yield()
+    }
+    return predicate()
+}
+
+@MainActor
+private func driveBackoffFailure(
+    server: SocketControlServer,
+    listenerSocket: Int32,
+    generation: UInt64,
+    clock: TestSocketRecoveryClock
+) async {
+    server.handleAcceptFailure(
+        listenerSocket: listenerSocket,
+        generation: generation,
+        errnoCode: EMFILE
+    )
+    let didSchedule = await waitForRearmCondition { clock.pendingSleepCount == 1 }
+    #expect(didSchedule)
+    clock.advance()
+    let didResume = await waitForRearmCondition {
+        let sourceSuspended = server.withListenerState { $0.listenerReadSourceSuspended }
+        let recoveryHopInFlight = server.acceptRecovery.withLock {
+            $0.generation == generation && $0.recoveryHopInFlight
+        }
+        return clock.pendingSleepCount == 0
+            && !sourceSuspended
+            && !recoveryHopInFlight
+    }
+    #expect(didResume)
+}
+
+@MainActor
+@Suite("SocketControlServer accept rearm stress")
+struct SocketControlServerAcceptRearmStressTests {
+    @Test func exactPathReportsRefusedDuringBoundedRearmAndRecoversAfterConcurrentHookBurst() async throws {
+        let clock = TestSocketRecoveryClock()
+        let policy = SocketListenerPolicy(
+            acceptFailureBaseBackoffMs: 1,
+            acceptFailureMaxBackoffMs: 8,
+            acceptFailureMinimumRearmDelayMs: 8,
+            acceptFailureRearmThreshold: 3
+        )
+        let harness = try AcceptRearmHarness(clock: clock, policy: policy)
+        defer { harness.shutdown() }
+        let server = harness.server
+        #expect(server.start(socketPath: harness.socketPath, accessMode: .cmuxOnly))
+
+        let initial = server.listenerStateSnapshot()
+        #expect(initial.serverSocket >= 0)
+        #expect(initial.activeGeneration > 0)
+
+        let hostRecovery = Task { @MainActor in
+            var rearmIterator = harness.recorder.rearmRequests.makeAsyncIterator()
+            guard let rearm = await rearmIterator.next() else { return false }
+            do {
+                try await clock.sleep(forMilliseconds: rearm.delayMs)
+            } catch {
+                return false
+            }
+            guard let restartPath = server.claimPendingRearm(
+                generation: rearm.generation,
+                errnoCode: rearm.errnoCode,
+                consecutiveFailures: rearm.consecutiveFailures,
+                delayMs: rearm.delayMs
+            ) else { return false }
+
+            server.stop(cleanupDiscoveryState: false)
+            return server.start(
+                socketPath: restartPath,
+                accessMode: .cmuxOnly,
+                preserveAcceptFailureStreak: true
+            )
+        }
+
+        await driveBackoffFailure(
+            server: server,
+            listenerSocket: initial.serverSocket,
+            generation: initial.activeGeneration,
+            clock: clock
+        )
+        await driveBackoffFailure(
+            server: server,
+            listenerSocket: initial.serverSocket,
+            generation: initial.activeGeneration,
+            clock: clock
+        )
+        server.handleAcceptFailure(
+            listenerSocket: initial.serverSocket,
+            generation: initial.activeGeneration,
+            errnoCode: EMFILE
+        )
+
+        let didEnterRearm = await waitForRearmCondition {
+            server.hasPendingAcceptLoopRearm
+                && harness.recorder.rearms.count == 1
+                && clock.pendingSleepCount == 1
+        }
+        #expect(didEnterRearm)
+        let rearm = try #require(harness.recorder.rearms.first)
+        #expect(rearm.errnoCode == EMFILE)
+        #expect(rearm.consecutiveFailures == 3)
+        #expect(rearm.delayMs == 8)
+        #expect(FileManager.default.fileExists(atPath: harness.socketPath))
+
+        // Model the issue's 100 concurrent Codex hook connections against the
+        // exact pinned path while the listener is parked for rearm.
+        let burst = await concurrentConnectBurst(to: harness.socketPath, count: 100)
+        #expect(burst.count == 100)
+        #expect(burst.allSatisfy { !$0.connected && $0.errnoCode == ECONNREFUSED })
+
+        let exactProbe = connectAttempt(to: harness.socketPath)
+        #expect(!exactProbe.connected)
+        #expect(exactProbe.errnoCode == ECONNREFUSED)
+
+        let started = try #require(
+            harness.recorder.breadcrumbs.first { $0.message == "socket.listener.rearm.started" }
+        )
+        #expect(started.listenerState == "rearming")
+        #expect(started.errnoCode == Int(EMFILE))
+        #expect(started.pendingRearmGeneration == initial.activeGeneration)
+        #expect(started.delayMs == 8)
+
+        clock.advance()
+        #expect(await hostRecovery.value)
+        #expect(server.isRunning)
+        #expect(connectAttempt(to: harness.socketPath).connected)
+
+        let messages = harness.recorder.breadcrumbs.map(\.message)
+        let startedIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.started"))
+        let readyIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.ready"))
+        let completedIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.completed"))
+        #expect(startedIndex < readyIndex)
+        #expect(readyIndex < completedIndex)
+        #expect(!messages.contains("socket.listener.rearm.failed"))
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
@@ -207,6 +207,7 @@ struct SocketControlServerAcceptRearmStressTests {
         let harness = try AcceptRearmHarness(clock: clock, policy: policy)
         defer { harness.shutdown() }
         let server = harness.server
+        let recorder = harness.recorder
         #expect(server.start(socketPath: harness.socketPath, accessMode: .cmuxOnly))
 
         let initial = server.listenerStateSnapshot()
@@ -214,7 +215,7 @@ struct SocketControlServerAcceptRearmStressTests {
         #expect(initial.activeGeneration > 0)
 
         let hostRecovery = Task { @MainActor in
-            var rearmIterator = harness.recorder.rearmRequests.makeAsyncIterator()
+            var rearmIterator = recorder.rearmRequests.makeAsyncIterator()
             guard let rearm = await rearmIterator.next() else { return false }
             do {
                 try await clock.sleep(forMilliseconds: rearm.delayMs)
@@ -235,6 +236,7 @@ struct SocketControlServerAcceptRearmStressTests {
                 preserveAcceptFailureStreak: true
             )
         }
+        defer { hostRecovery.cancel() }
 
         await driveBackoffFailure(
             server: server,
@@ -256,11 +258,11 @@ struct SocketControlServerAcceptRearmStressTests {
 
         let didEnterRearm = await waitForRearmCondition {
             server.hasPendingAcceptLoopRearm
-                && harness.recorder.rearms.count == 1
+                && recorder.rearms.count == 1
                 && clock.pendingSleepCount == 1
         }
         #expect(didEnterRearm)
-        let rearm = try #require(harness.recorder.rearms.first)
+        let rearm = try #require(recorder.rearms.first)
         #expect(rearm.errnoCode == EMFILE)
         #expect(rearm.consecutiveFailures == 3)
         #expect(rearm.delayMs == 8)
@@ -277,7 +279,7 @@ struct SocketControlServerAcceptRearmStressTests {
         #expect(exactProbe.errnoCode == ECONNREFUSED)
 
         let started = try #require(
-            harness.recorder.breadcrumbs.first { $0.message == "socket.listener.rearm.started" }
+            recorder.breadcrumbs.first { $0.message == "socket.listener.rearm.started" }
         )
         #expect(started.listenerState == "rearming")
         #expect(started.errnoCode == Int(EMFILE))
@@ -289,7 +291,7 @@ struct SocketControlServerAcceptRearmStressTests {
         #expect(server.isRunning)
         #expect(connectAttempt(to: harness.socketPath).connected)
 
-        let messages = harness.recorder.breadcrumbs.map(\.message)
+        let messages = recorder.breadcrumbs.map(\.message)
         let startedIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.started"))
         let readyIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.ready"))
         let completedIndex = try #require(messages.firstIndex(of: "socket.listener.rearm.completed"))

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
@@ -268,6 +268,11 @@ struct SocketControlServerAcceptRearmStressTests {
         #expect(rearm.delayMs == 8)
         #expect(FileManager.default.fileExists(atPath: harness.socketPath))
 
+        let didCloseListener = await waitForRearmCondition {
+            recorder.breadcrumbs.contains { $0.message == "socket.listener.rearm.socket_closed" }
+        }
+        #expect(didCloseListener)
+
         // Model the issue's 100 concurrent Codex hook connections against the
         // exact pinned path while the listener is parked for rearm.
         let burst = await concurrentConnectBurst(to: harness.socketPath, count: 100)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerAcceptRearmStressTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import os
 import Testing
 
-@testable import CmuxControlSocket
+@_spi(CmuxControlSocketTesting) @testable import CmuxControlSocket
 
 private struct RecordedRearm: Sendable {
     let generation: UInt64

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/TestSocketRecoveryClock.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/TestSocketRecoveryClock.swift
@@ -1,0 +1,101 @@
+import CmuxControlSocket
+import Foundation
+import Testing
+
+final class TestSocketRecoveryClock: SocketRecoveryClock, @unchecked Sendable {
+    private typealias Waiter = CheckedContinuation<Void, any Error>
+
+    private let lock = NSLock()
+    private var state: (waiters: [UUID: Waiter], bufferedAdvanceCount: Int) = ([:], 0)
+
+    func sleep(forMilliseconds milliseconds: Int) async throws {
+        let id = UUID()
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let shouldResume: Bool? = withStateLock { state in
+                    guard !Task.isCancelled else { return false }
+                    if state.bufferedAdvanceCount > 0 {
+                        state.bufferedAdvanceCount -= 1
+                        return true
+                    }
+                    state.waiters[id] = continuation
+                    return nil
+                }
+                switch shouldResume {
+                case true:
+                    continuation.resume()
+                case false:
+                    continuation.resume(throwing: CancellationError())
+                case nil:
+                    break
+                }
+            }
+        } onCancel: { [weak self] in
+            self?.cancelWaiter(id)
+        }
+    }
+
+    func advance() {
+        let pending = withStateLock { state in
+            guard !state.waiters.isEmpty else {
+                state.bufferedAdvanceCount += 1
+                return [Waiter]()
+            }
+            let pending = Array(state.waiters.values)
+            state.waiters.removeAll(keepingCapacity: true)
+            return pending
+        }
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+
+    var pendingSleepCount: Int {
+        withStateLock { $0.waiters.count }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        let waiter = withStateLock { $0.waiters.removeValue(forKey: id) }
+        waiter?.resume(throwing: CancellationError())
+    }
+
+    private func withStateLock<T>(
+        _ body: (inout (waiters: [UUID: Waiter], bufferedAdvanceCount: Int)) -> T
+    ) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&state)
+    }
+}
+
+@Test func socketRecoveryClockBuffersAdvanceBeforeSleep() async throws {
+    let clock = TestSocketRecoveryClock()
+    clock.advance()
+
+    // Returning is the assertion: this fake clock never consults wall time, so
+    // the buffered advance must synchronously satisfy the next suspension.
+    try await clock.sleep(forMilliseconds: 1_000)
+}
+
+@Test func cancelledSocketRecoverySleepFinishesWithoutAdvance() async {
+    let clock = TestSocketRecoveryClock()
+    let sleeper = Task {
+        try await clock.sleep(forMilliseconds: 1_000)
+    }
+    for _ in 0..<100 where clock.pendingSleepCount == 0 {
+        await Task.yield()
+    }
+    #expect(clock.pendingSleepCount == 1)
+
+    sleeper.cancel()
+    do {
+        try await sleeper.value
+        Issue.record("Expected cancellation to terminate the virtual sleep")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Unexpected virtual-clock error: \(error)")
+    }
+    #expect(clock.pendingSleepCount == 0)
+}


### PR DESCRIPTION
## Summary

Investigates #10754 by pinning the exact listener state that produces a refused socket during accept-source rearm and making the transition visible in release breadcrumbs. The listener keeps its existing bounded recovery policy; this change adds no timing workaround.

## Eligibility / overlap

The current-main audit found this is distinct from existing coverage:

- #5757, #7357, #6878, #10558, and #2604 cover worker/thread pressure and main-actor serialization, not the accept-failure rearm contract.
- #6406 and #6887 cover activation-time ping/self-heal, not a concurrent burst while the listener is rearming.
- #9769/#9796 cover the PTY-spawn wedge, not listener state.
- #10058/#10059 cover startup stale-socket reclaim and ambient discovery/reroute; explicit --socket remains pinned and already reports the exact path/errno.
- Open #4306, #8799, #891, #9417, and #10554 overlap older watchdog/startup/telemetry concerns but do not contain this exact-path accept-rearm stress contract.

Issue #10754 remains open and owned by austinywang; no competing branch/agent/PR was found.

## What changed

- Added deterministic package coverage using a real Unix listener, an injected virtual recovery clock, three resource-pressure accept failures, 100 concurrent exact-path hook probes while rearming, and post-rearm recovery.
- Added release breadcrumbs for socket.listener.rearm.started, .socket_closed, .ready, .completed, and .failed, including errno, generation, listener state, and bounded delay. The stress test waits for the actual descriptor-close breadcrumb before probing, so the refused window is not a close-race artifact.
- Documented the default 5-second policy cap and host generation-claim requirement.
- Kept the direct accept-failure test driver behind @_spi(CmuxControlSocketTesting) so ordinary production clients cannot invoke it.

## Commits

1. 96c87c1fde - test: cover exact-path accept rearm outage (red proof)
2. c3f4565979 - fix: expose bounded socket rearm diagnostics
3. 3d4272023f - test: keep accept rearm hook in testing SPI
4. 46da3e0a96 - test: wait for rearmed listener descriptor close

## Verification

Passed locally without launching cmux:

- swift test --package-path Packages/macOS/CmuxControlSocket --disable-sandbox --filter SocketControlServerAcceptRearmStressTests (1 Swift Testing test passed)
- swift test --package-path Packages/macOS/CmuxControlSocket --disable-sandbox --list-tests (test target discovery/compile passed)
- swift build --package-path Packages/macOS/CmuxControlSocket --disable-sandbox
- swiftc -parse on all changed Swift files
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/check-package-resolved-policy.py
- git diff --check

Remote verification blockers:

- CI run 32907038013 (https://github.com/manaflow-ai/cmux/actions/runs/32907038013) failed its unrelated web-db-migrations job (tests/devices-route.test.ts), so swift-package-tests was skipped.
- Focused Tart app-host run 32907886368 (https://github.com/manaflow-ai/cmux/actions/runs/32907886368) failed before tests on pre-existing ExtensionWorktreePrototype.swift compile errors under Xcode 26.3.
- The requested AWS builder was unreachable (the default aws-m4pro-1 was offline; alternate Tailscale SSH attempts timed out).
- This clone does not contain the mandated Swift file-budget script/TSV (scripts/swift_file_length_budget.py and .github/swift-file-length-budget.tsv), so that check could not be run.

The original 2026-08-25 stable-app outage is not claimed fixed: the deterministic test establishes that the existing accept-rearm state produces exact-path ECONNREFUSED and recovers after the bounded host delay, but production telemetry is still needed to identify whether that incident was EMFILE/ENFILE, a fatal descriptor, or main-actor starvation.