### PR TITLE
relay npm: rc-era launcher fallback (tolerate pre-R5 launcher publish failure on next only)

### DIFF
--- a/.github/workflows/relay-publish-npm.yml
+++ b/.github/workflows/relay-publish-npm.yml
@@ -204,24 +204,58 @@ jobs:
           done
 
       - name: Publish relay launcher package
+        id: launcher
         env:
           DIST_TAG: ${{ needs.version.outputs.dist_tag }}
-        run: npm publish --provenance --access public --tag "$DIST_TAG" dist/npm-packages/cmux-relay
+        run: |
+          set -euo pipefail
+          if npm publish --provenance --access public --tag "$DIST_TAG" dist/npm-packages/cmux-relay; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$DIST_TAG" == "next" ]]; then
+            # Pre-R5 rc era: npm allows one trusted publisher per package and
+            # the cmux-relay launcher's publisher stays with the chatmux Node
+            # lane until the R5 owner switch (chatmux docs/RELAY-RUST.md). rc
+            # launcher publishes fail here until then; the platform packages
+            # above are the rc gate, and the launcher is smoke-tested from the
+            # local tarball against the registry platform packages instead.
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::cmux-relay launcher publish failed on an rc tag; running the local-tarball smoke instead (expected until the R5 trusted-publisher switch)."
+          else
+            echo "stable cmux-relay publish failed: move the cmux-relay trusted publisher to this repository before the first stable cmux-relay-vX.Y.Z tag." >&2
+            exit 1
+          fi
 
       - name: Smoke install from the registry
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          LAUNCHER_PUBLISHED: ${{ steps.launcher.outputs.published }}
         run: |
           set -euo pipefail
-          # Registry propagation can lag the publish by a few seconds.
-          for attempt in $(seq 1 10); do
-            if npm install -g "cmux-relay@$VERSION"; then
-              break
-            fi
-            if [[ "$attempt" == "10" ]]; then
-              echo "npm install -g cmux-relay@$VERSION never resolved" >&2
-              exit 1
-            fi
-            sleep 15
-          done
+          if [[ "$LAUNCHER_PUBLISHED" == "true" ]]; then
+            # Registry propagation can lag the publish by a few seconds.
+            for attempt in $(seq 1 10); do
+              if npm install -g "cmux-relay@$VERSION"; then
+                break
+              fi
+              if [[ "$attempt" == "10" ]]; then
+                echo "npm install -g cmux-relay@$VERSION never resolved" >&2
+                exit 1
+              fi
+              sleep 15
+            done
+          else
+            # rc-era fallback: local launcher package, registry platform
+            # packages. npm still resolves the exact-version platform
+            # dependency from the registry, so this smokes the published rc.
+            for attempt in $(seq 1 10); do
+              if npm install -g ./dist/npm-packages/cmux-relay; then
+                break
+              fi
+              if [[ "$attempt" == "10" ]]; then
+                echo "local cmux-relay install never resolved its registry platform package" >&2
+                exit 1
+              fi
+              sleep 15
+            done
+          fi
           cmux-relay --version

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1539,6 +1539,24 @@ def test_relay_publisher_is_tag_bound_rc_aware_and_attested() -> None:
     assert "persist-credentials: false" in text
 
 
+def test_relay_launcher_rc_fallback_never_relaxes_stable() -> None:
+    text = workflow("relay-publish-npm.yml")
+
+    # Pre-R5 rc era: npm allows one trusted publisher per package and the
+    # cmux-relay launcher's publisher stays with the chatmux Node lane until
+    # the R5 owner switch. Only the next dist-tag tolerates a failed launcher
+    # publish; a stable (latest) publish must hard-fail.
+    assert 'elif [[ "$DIST_TAG" == "next" ]]' in text
+    assert "move the cmux-relay trusted publisher to this repository" in text
+    assert 'echo "published=false"' in text
+    # The rc fallback smoke installs the LOCAL launcher package so the
+    # registry platform packages are still exercised; the smoke itself is
+    # never skipped and always executes the installed binary.
+    assert "npm install -g ./dist/npm-packages/cmux-relay" in text
+    assert "LAUNCHER_PUBLISHED: ${{ steps.launcher.outputs.published }}" in text
+    assert text.count("cmux-relay --version") == 1
+
+
 def test_npm_builder_accepts_relay_release_candidate_versions() -> None:
     builder = ROOT / "cmux-tui" / "dist" / "scripts" / "package_npm.py"
     namespace = runpy.run_path(str(builder), run_name="cmux_tui_package_npm_test")


### PR DESCRIPTION
## Why

npm allows one trusted publisher per package. The `cmux-relay` launcher's publisher stays with the chatmux Node lane until the R5 owner switch (chatmux `docs/RELAY-RUST.md`), so every `cmux-relay-v*-rc.N` run fails at the launcher publish step and never reaches the install smoke. A gate that is red by design on every rc trains everyone to ignore red.

## What

- The launcher publish step tolerates a failure **only when the dist-tag is `next`** (rc): it emits a `::warning` and records `published=false`. On `latest` (stable) it stays a hard failure with an actionable message.
- The smoke step branches: registry install when the launcher published; otherwise it installs the **local** launcher package, which still resolves the exact-version platform packages from the registry — so the published rc platform packages are exercised either way. `cmux-relay --version` runs in both paths.
- New security test `test_relay_launcher_rc_fallback_never_relaxes_stable` pins the asymmetry (rc-only tolerance, stable hard-fail, local-tarball fallback, smoke never skipped).

## Gates

- `tests/test_tui_publish_workflow_security.py`: 54/54 locally.
- Workflow YAML parse-checked.

Part of the R3/R5 relay cutover program (see chatmux `docs/RELAY-RUST.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release-candidate publishing resilience with a local fallback when launcher publishing fails.
  * Smoke tests now verify installations using either the published package or a local package archive.

* **Bug Fixes**
  * Stable releases continue to fail when publishing is unsuccessful, preventing incomplete releases.
  * Added safeguards to ensure fallback behavior applies only to release candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->