### PR TITLE
fix(web): restore device-registry ownership guard

### DIFF
--- a/web/tests/devices-route.test.ts
+++ b/web/tests/devices-route.test.ts
@@ -29,6 +29,7 @@ const { DELETE, GET, POST } = await import("../app/api/devices/route");
 const { hostIsLoopback, hostIsTailscaleAttachable, manualRoutesAreValid } = await import(
   "../app/api/devices/route-classification"
 );
+const { clearNativeAuthCacheForTests } = await import("../services/vms/auth");
 
 let sql: Sql | null = null;
 
@@ -68,10 +69,15 @@ const publicIrohRoute = {
   },
 };
 
+// Tokens are per simulated user. `verifyRequest` caches successful native
+// verifications keyed by the exact access/refresh pair, and in production two
+// users can never present the same Stack token pair, so impersonating user 2
+// under user 1's literal tokens is unrealizable and would replay user 1's
+// cached identity, silently bypassing the ownership guards under test.
 function authHeaders(teamId?: string): Record<string, string> {
   const base: Record<string, string> = {
-    authorization: "Bearer access-token",
-    "x-stack-refresh-token": "refresh-token",
+    authorization: `Bearer access-token-${currentUserId}`,
+    "x-stack-refresh-token": `refresh-token-${currentUserId}`,
     "content-type": "application/json",
   };
   if (teamId) base["x-cmux-team-id"] = teamId;
@@ -101,10 +107,11 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  clearNativeAuthCacheForTests();
+  currentUserId = "registry-user-1";
+  getUser.mockClear();
   if (!sql) return;
   await sql`truncate devices, device_app_instances, account_deletion_tombstones restart identity cascade`;
-  getUser.mockClear();
-  currentUserId = "registry-user-1";
 });
 
 describe("device registry route", () => {


### PR DESCRIPTION
## Symptom

On current main, the `CMUX_DB_TEST=1` lane fails 3 ownership-guard expectations in `web/tests/devices-route.test.ts`: [only the registering user may overwrite a device's routes](https://github.com/manaflow-ai/cmux/blob/main/web/tests/devices-route.test.ts#L402) and [a non-owner cannot overwrite or delete a manual remote](https://github.com/manaflow-ai/cmux/blob/main/web/tests/devices-route.test.ts#L834) get 200 where 403 is expected, and [a non-owner cannot delete another user's device](https://github.com/manaflow-ai/cmux/blob/main/web/tests/devices-route.test.ts#L882) reports `deleted: 1` where 0 is expected. Baseline: [main ci.yml run 32906007066, web-db-migrations job](https://github.com/manaflow-ai/cmux/actions/runs/32906007066). Also reproduced locally at 7fdcfa583a against a migrated throwaway Postgres 16.

## Root cause

Commit 033d98e727f0 ([#10478](https://github.com/manaflow-ai/cmux/pull/10478), "cmux Cloud: your computer") added a 30-second native-bearer verification cache to `web/services/vms/auth.ts`, keyed by a hash of the exact access+refresh token pair plus result-affecting options. The devices test impersonates a second team member by flipping the mocked Stack user's id while sending the SAME literal token pair (`Bearer access-token` / `refresh-token`) for both users. The "attacker" request therefore hits the cache and replays user 1's `AuthedUser`, so the route sees the owner and correctly allows the write. Proof of mechanism: on unmodified main, `CMUX_VM_AUTH_CACHE_TTL_MS=0` makes all 26 tests pass.

The route's ownership guard itself never regressed: `POST /api/devices` still returns `device_not_owned` 403 when `devices.userId` differs from the caller ([route.ts guard](https://github.com/manaflow-ai/cmux/blob/main/web/app/api/devices/route.ts#L239)), and `DELETE` still scopes the delete to `devices.userId`.

## Exploitability

Not exploitable in production. The cache key contains the exact Stack access and refresh tokens; two different users can never present an identical pair (access tokens are per-session signed JWTs, refresh tokens are per-session secrets), so a cache hit always maps to the same session and the same user. An attacker who possesses a victim's token pair already has the victim's full API access; the cache adds no cross-account path. A real authenticated user CANNOT overwrite or delete another account's device routes on deployed main.

Blast radius of the actual regression: coverage loss (the DB lane could no longer verify the ownership guard) and a red main baseline. Residual, pre-existing tradeoff of #10478 worth knowing: a revoked token pair can keep verifying for up to 30s (the sign-out route invalidates its own entries explicitly), and team-membership revocation can take up to 30s to be observed on cached routes.

## Fix

Test-side, because the production check is intact and this is the narrowest correct fix: derive each simulated user's bearer/refresh tokens from `currentUserId` so the impersonation models production identity semantics, and clear the native auth cache in `beforeEach` (the same hygiene #10478 added to `vm-route-auth.test.ts` but not here). No two-commit red/green split: main itself is the red state, with the failures in the baseline run above.

## Verification

Against a migrated throwaway Postgres 16 (`postgres:16-alpine`, non-default port, removed after):
- main at d7b59bab2b: 23 pass / 3 fail (the three above)
- with this change, default cache TTL: 26 pass / 0 fail
- full `bun run test:db:behavior` lane: 13 files, all green (206 tests total, 0 fail)
- `bun run typecheck` (tsgo) clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790291148&installation_model_id=21920&pr_number=10763&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10763&signature=c2b1843ebd1b1b942f31262f05e5a8f5b79c53bbf276a8a96104e2b18d6db315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved device route test isolation by clearing authentication state and resetting simulated users between tests.
  * Updated authentication test scenarios to use user-specific tokens for more reliable coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->