### PR TITLE
Desktop panes: cmux_token URLs, 7-day sessions, honest expiry

### DIFF
--- a/web/app/api/vm/[id]/open-port/route.ts
+++ b/web/app/api/vm/[id]/open-port/route.ts
@@ -8,6 +8,7 @@ import {
 import { setSpanAttributes } from "../../../../../services/telemetry";
 import { isVmNotFoundError } from "../../../../../services/vms/errors";
 import { openVmPort, runVmWorkflow } from "../../../../../services/vms/workflows";
+import { desktopWrapperUrl } from "../../../../../services/vms/desktopWrapper";
 
 
 export async function POST(
@@ -63,7 +64,17 @@ export async function POST(
           providerVmId: id,
           port,
         }));
-        return jsonResponse(endpoint);
+        // People see and keep openUrl, so it points at the cmux desktop
+        // wrapper (`cmux_token` on our origin, honest expiry screen); the raw
+        // gateway URL and token stay available for programmatic callers.
+        const wrapped = desktopWrapperUrl({
+          origin: new URL(request.url).origin,
+          vmId: id,
+          upstreamUrl: endpoint.url,
+          token: endpoint.token,
+          expiresAtMs: endpoint.expiresAtMs,
+        });
+        return jsonResponse(wrapped ? { ...endpoint, openUrl: wrapped } : endpoint);
       } catch (err) {
         if (isVmNotFoundError(err)) return notFoundVm(id);
         throw err;

--- a/web/app/vm/desktop/[id]/layout.tsx
+++ b/web/app/vm/desktop/[id]/layout.tsx
@@ -1,0 +1,14 @@
+// The desktop wrapper lives outside the [locale] tree (like /billing) so the
+// URL a person keeps in a pane never gets rewritten by next-intl; it carries
+// its own html/body per the out-of-locale layout requirement.
+export default function VmDesktopLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body style={{ margin: 0, background: "#101418" }}>{children}</body>
+    </html>
+  );
+}

--- a/web/app/vm/desktop/[id]/layout.tsx
+++ b/web/app/vm/desktop/[id]/layout.tsx
@@ -1,13 +1,19 @@
+import { headers } from "next/headers";
+import { preferredLocaleFromAcceptLanguage } from "../../../../i18n/accept-language";
+
 // The desktop wrapper lives outside the [locale] tree (like /billing) so the
 // URL a person keeps in a pane never gets rewritten by next-intl; it carries
-// its own html/body per the out-of-locale layout requirement.
-export default function VmDesktopLayout({
+// its own html/body per the out-of-locale layout requirement, negotiating the
+// document language from Accept-Language since no locale segment exists here.
+export default async function VmDesktopLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const acceptLanguage = (await headers()).get("accept-language") ?? "";
+  const locale = preferredLocaleFromAcceptLanguage(acceptLanguage);
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <body style={{ margin: 0, background: "#101418" }}>{children}</body>
     </html>
   );

--- a/web/app/vm/desktop/[id]/page.tsx
+++ b/web/app/vm/desktop/[id]/page.tsx
@@ -1,0 +1,85 @@
+import { desktopIframeUrl } from "../../../../services/vms/desktopWrapper";
+
+// The cmux-owned face of a machine's screen. The pane's address bar shows
+// this URL (`cmux_token` on our origin); the gateway's own token parameter
+// exists only inside the iframe src. When the token lapses, the overlay says
+// so and points at the fix instead of leaving a silent white canvas.
+export default async function VmDesktopPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { id } = await params;
+  const query = await searchParams;
+  const token = typeof query.cmux_token === "string" ? query.cmux_token : "";
+  const host = typeof query.host === "string" ? query.host : "";
+  const expiresAtMs = typeof query.exp === "string" ? Number.parseInt(query.exp, 10) : NaN;
+  const frameSrc = desktopIframeUrl({ host, token, params: query });
+  const machine = decodeURIComponent(id);
+
+  const shell: React.CSSProperties = {
+    margin: 0,
+    height: "100vh",
+    background: "#101418",
+    color: "#dbe5ea",
+    fontFamily: "-apple-system, 'Segoe UI', sans-serif",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+  };
+
+  if (!frameSrc) {
+    return (
+      <main style={shell}>
+        <div style={{ maxWidth: 440, padding: 24 }}>
+          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>This desktop link isn&apos;t valid</h1>
+          <p style={{ margin: 0, color: "#8fa2ac", fontSize: 14, lineHeight: 1.5 }}>
+            The link is missing its session or points somewhere cmux won&apos;t frame.
+            Reopen the desktop from cmux: right-click <code>{machine}</code> in the
+            Machines panel and choose Open Desktop.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const expired = Number.isFinite(expiresAtMs) && Date.now() > expiresAtMs;
+  if (expired) {
+    return (
+      <main style={shell}>
+        <div style={{ maxWidth: 440, padding: 24 }}>
+          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>This desktop session expired</h1>
+          <p style={{ margin: 0, color: "#8fa2ac", fontSize: 14, lineHeight: 1.5 }}>
+            <code>{machine}</code> and everything on it are fine — only this link&apos;s
+            session ended. Reopen the desktop from cmux (right-click the machine →
+            Open Desktop) to get a fresh one.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ margin: 0, height: "100vh", background: "#101418" }}>
+      <title>{`${machine} — desktop`}</title>
+      <iframe
+        src={frameSrc}
+        title={`${machine} desktop`}
+        allow="clipboard-read; clipboard-write; fullscreen"
+        style={{ border: 0, width: "100%", height: "100%", display: "block" }}
+      />
+      {Number.isFinite(expiresAtMs) ? (
+        <script
+          // Long-lived panes outlive the token: when the deadline passes,
+          // reload so the server renders the honest expiry screen above.
+          dangerouslySetInnerHTML={{
+            __html: `setTimeout(function(){location.reload()}, Math.min(${expiresAtMs} - Date.now() + 2000, 2147483647));`,
+          }}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/web/app/vm/desktop/[id]/page.tsx
+++ b/web/app/vm/desktop/[id]/page.tsx
@@ -1,4 +1,8 @@
+import { createTranslator } from "next-intl";
+import { headers } from "next/headers";
 import { desktopIframeUrl } from "../../../../services/vms/desktopWrapper";
+import { preferredLocaleFromAcceptLanguage } from "../../../../i18n/accept-language";
+import { loadMessages } from "../../../../i18n/messages";
 
 // The cmux-owned face of a machine's screen. The pane's address bar shows
 // this URL (`cmux_token` on our origin); the gateway's own token parameter
@@ -19,6 +23,16 @@ export default async function VmDesktopPage({
   const frameSrc = desktopIframeUrl({ host, token, params: query });
   const machine = decodeURIComponent(id);
 
+  const acceptLanguage = (await headers()).get("accept-language") ?? "";
+  const locale = preferredLocaleFromAcceptLanguage(acceptLanguage);
+  // Messages load at runtime, so createTranslator cannot type the ICU
+  // parameters; the narrow cast keeps the call sites honest.
+  const t = createTranslator({
+    locale,
+    messages: await loadMessages(locale),
+    namespace: "vmDesktop",
+  }) as unknown as (key: string, values?: Record<string, string | number>) => string;
+
   const shell: React.CSSProperties = {
     margin: 0,
     height: "100vh",
@@ -35,11 +49,9 @@ export default async function VmDesktopPage({
     return (
       <main style={shell}>
         <div style={{ maxWidth: 440, padding: 24 }}>
-          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>This desktop link isn&apos;t valid</h1>
+          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>{t("invalidTitle")}</h1>
           <p style={{ margin: 0, color: "#8fa2ac", fontSize: 14, lineHeight: 1.5 }}>
-            The link is missing its session or points somewhere cmux won&apos;t frame.
-            Reopen the desktop from cmux: right-click <code>{machine}</code> in the
-            Machines panel and choose Open Desktop.
+            {t("invalidBody", { machine })}
           </p>
         </div>
       </main>
@@ -51,11 +63,9 @@ export default async function VmDesktopPage({
     return (
       <main style={shell}>
         <div style={{ maxWidth: 440, padding: 24 }}>
-          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>This desktop session expired</h1>
+          <h1 style={{ fontSize: 18, margin: "0 0 8px" }}>{t("expiredTitle")}</h1>
           <p style={{ margin: 0, color: "#8fa2ac", fontSize: 14, lineHeight: 1.5 }}>
-            <code>{machine}</code> and everything on it are fine — only this link&apos;s
-            session ended. Reopen the desktop from cmux (right-click the machine →
-            Open Desktop) to get a fresh one.
+            {t("expiredBody", { machine })}
           </p>
         </div>
       </main>
@@ -73,10 +83,24 @@ export default async function VmDesktopPage({
       />
       {Number.isFinite(expiresAtMs) ? (
         <script
-          // Long-lived panes outlive the token: when the deadline passes,
-          // reload so the server renders the honest expiry screen above.
+          // Long-lived panes outlive the token, and browser timers stall while
+          // a pane is backgrounded or the machine sleeps — so the deadline is
+          // re-checked on wake/focus/visibility as well as a chained timer
+          // (re-armed, since a single stalled setTimeout can fire early
+          // relative to real elapsed time). Crossing it reloads so the server
+          // renders the honest expiry screen above.
           dangerouslySetInnerHTML={{
-            __html: `setTimeout(function(){location.reload()}, Math.min(${expiresAtMs} - Date.now() + 2000, 2147483647));`,
+            __html: `(function () {
+  var exp = ${expiresAtMs};
+  function check() { if (Date.now() > exp) location.reload(); }
+  document.addEventListener("visibilitychange", check);
+  window.addEventListener("focus", check);
+  window.addEventListener("pageshow", check);
+  (function arm() {
+    var delay = Math.min(Math.max(exp - Date.now() + 2000, 1000), 2147483647);
+    setTimeout(function () { check(); if (Date.now() <= exp) arm(); }, delay);
+  })();
+})();`,
           }}
         />
       ) : null}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,4 +1,10 @@
 {
+  "vmDesktop": {
+    "invalidTitle": "This desktop link isn't valid",
+    "invalidBody": "The link is missing its session or points somewhere cmux won't frame. Reopen the desktop from cmux: right-click {machine} in the Machines panel and choose Open Desktop.",
+    "expiredTitle": "This desktop session expired",
+    "expiredBody": "{machine} and everything on it are fine — only this link's session ended. Reopen the desktop from cmux (right-click the machine, then Open Desktop) to get a fresh one."
+  },
   "ios": {
     "metaTitle": "cmux iOS — your terminals on iPhone and iPad",
     "metaDescription": "The cmux iOS app mirrors your Mac terminals to iPhone and iPad in realtime, over your own Tailscale or local network. Drive your coding agents from anywhere.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1,4 +1,10 @@
 {
+  "vmDesktop": {
+    "invalidTitle": "このデスクトップリンクは無効です",
+    "invalidBody": "リンクにセッションがないか、cmux が表示できない場所を指しています。cmux のマシンパネルで {machine} を右クリックし、「デスクトップを開く」からもう一度開いてください。",
+    "expiredTitle": "このデスクトップセッションは期限切れです",
+    "expiredBody": "{machine} とその中身は無事です。このリンクのセッションだけが終了しました。cmux でマシンを右クリックし、「デスクトップを開く」から新しく開き直してください。"
+  },
   "ios": {
     "metaTitle": "cmux iOS — iPhone と iPad でターミナルを",
     "metaDescription": "cmux iOS アプリは、Mac のターミナルを自分の Tailscale やローカルネットワーク経由で iPhone・iPad にリアルタイムでミラーリング。どこからでもコーディングエージェントを操作できます。",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -147,6 +147,12 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Machine desktop wrapper panes: the URL lives inside long-lived app panes,
+  // so it must never be rewritten into the locale tree.
+  if (pathname.startsWith("/vm/desktop/")) {
+    return NextResponse.next();
+  }
+
   const isChangelogVersionPath =
     /^(?:\/[a-z]{2}(?:-[A-Z]{2})?)?\/docs\/changelog\/[^/]+\/?$/.test(
       pathname,

--- a/web/services/vms/desktopWrapper.ts
+++ b/web/services/vms/desktopWrapper.ts
@@ -1,0 +1,82 @@
+/**
+ * The cmux-owned desktop wrapper: the URL a person actually sees and keeps.
+ *
+ * Blaxel's gateway owns the `bl_preview_token` query parameter — it cannot be
+ * renamed at their edge — so instead the raw tokened preview URL stops being
+ * user-visible at all. `openUrl` for a port open points at
+ * `/vm/desktop/<machine>?cmux_token=…` on our origin; that page validates the
+ * upstream host and frames the noVNC page with the token internal to the
+ * iframe src. The wrapper also knows the token's expiry, so a lapsed pane
+ * shows an honest "reopen from cmux" screen instead of a silent white one.
+ */
+
+/** Hosts the wrapper will agree to frame: Blaxel previews, branded or not. */
+const ALLOWED_UPSTREAM_SUFFIXES = [".vm.cmux.sh", ".preview.bl.run"] as const;
+
+export function isAllowedDesktopUpstreamHost(host: string | null | undefined): boolean {
+  const normalized = host?.trim().toLowerCase();
+  if (!normalized) return false;
+  // Previews terminate on the gateway's 443 only; a port marks a forgery.
+  if (normalized.includes(":") || normalized.includes("/") || normalized.includes("@")) return false;
+  return ALLOWED_UPSTREAM_SUFFIXES.some(
+    (suffix) => normalized.endsWith(suffix) && normalized.length > suffix.length,
+  );
+}
+
+/** noVNC display options the wrapper forwards into the iframe, nothing else. */
+const FORWARDED_DISPLAY_PARAMS = [
+  "autoconnect",
+  "resize",
+  "reconnect",
+  "reconnect_delay",
+  "view_only",
+] as const;
+
+export function desktopWrapperUrl(input: {
+  readonly origin: string;
+  readonly vmId: string;
+  readonly upstreamUrl: string;
+  readonly token: string;
+  readonly expiresAtMs?: number;
+}): string | null {
+  let upstreamHost: string;
+  try {
+    const upstream = new URL(input.upstreamUrl);
+    if (upstream.protocol !== "https:") return null;
+    upstreamHost = upstream.host;
+  } catch {
+    return null;
+  }
+  if (!isAllowedDesktopUpstreamHost(upstreamHost)) return null;
+  const wrapper = new URL(`/vm/desktop/${encodeURIComponent(input.vmId)}`, input.origin);
+  wrapper.searchParams.set("cmux_token", input.token);
+  wrapper.searchParams.set("host", upstreamHost);
+  if (input.expiresAtMs && Number.isFinite(input.expiresAtMs)) {
+    wrapper.searchParams.set("exp", String(Math.floor(input.expiresAtMs)));
+  }
+  return wrapper.toString();
+}
+
+/**
+ * The iframe src the wrapper page renders: the upstream noVNC page with the
+ * gateway's own token parameter plus the forwarded display options.
+ */
+export function desktopIframeUrl(input: {
+  readonly host: string;
+  readonly token: string;
+  readonly params: Readonly<Record<string, string | string[] | undefined>>;
+}): string | null {
+  if (!isAllowedDesktopUpstreamHost(input.host)) return null;
+  const token = input.token.trim();
+  if (!token || !/^[A-Za-z0-9_-]{8,512}$/.test(token)) return null;
+  const url = new URL(`https://${input.host.trim().toLowerCase()}/`);
+  url.searchParams.set("bl_preview_token", token);
+  for (const key of FORWARDED_DISPLAY_PARAMS) {
+    const value = input.params[key];
+    const single = Array.isArray(value) ? value[0] : value;
+    if (typeof single === "string" && single.length > 0 && single.length <= 64) {
+      url.searchParams.set(key, single);
+    }
+  }
+  return url.toString();
+}

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -130,6 +130,10 @@ export const DESKTOP_VNC_HEAL_COMMAND = [
 
 const CMUXD_PREVIEW_NAME = "cmuxd";
 const PREVIEW_TOKEN_TTL_SECONDS = 12 * 60 * 60;
+// Desktop/port panes are long-lived surfaces a person leaves open for days; a
+// 12h token turned every long-lived pane into a silent white screen at hour
+// twelve. The wrapper page shows an honest expiry screen when this lapses.
+const PREVIEW_OPEN_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
 const EXEC_DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_EXEC_TIMEOUT_MS = 15 * 60 * 1000;
 const HEALTH_RETRY_ATTEMPTS = 12;
@@ -970,8 +974,12 @@ export class BlaxelProvider implements VMProvider {
     return url;
   }
 
-  private async mintPreviewToken(vmId: string, previewName = CMUXD_PREVIEW_NAME): Promise<string> {
-    const expiresAt = new Date(Date.now() + PREVIEW_TOKEN_TTL_SECONDS * 1000).toISOString();
+  private async mintPreviewToken(
+    vmId: string,
+    previewName = CMUXD_PREVIEW_NAME,
+    ttlSeconds = PREVIEW_TOKEN_TTL_SECONDS,
+  ): Promise<string> {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
     const created = await blaxelFetch<{ spec?: { token?: string } }>(
       "POST",
       `${CONTROL_PLANE_BASE}/sandboxes/${encodeURIComponent(vmId)}/previews/${previewName}/tokens`,
@@ -1018,9 +1026,10 @@ export class BlaxelProvider implements VMProvider {
         await this.getSandbox(vmId);
         const previewName = `port-${port}`;
         const url = await this.ensurePreview(vmId, previewName, port);
-        const token = await this.mintPreviewToken(vmId, previewName);
+        const expiresAtMs = Date.now() + PREVIEW_OPEN_TOKEN_TTL_SECONDS * 1000;
+        const token = await this.mintPreviewToken(vmId, previewName, PREVIEW_OPEN_TOKEN_TTL_SECONDS);
         const openUrl = `${url.replace(/\/+$/, "")}/?bl_preview_token=${encodeURIComponent(token)}`;
-        return { url, token, openUrl };
+        return { url, token, openUrl, expiresAtMs };
       },
     );
   }

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -144,7 +144,7 @@ export interface VMProvider {
   // Optional: mint a private, token-gated HTTPS preview URL for an arbitrary HTTP port on the
   // VM (the exe.dev "https://vmname.exe.xyz:3456" equivalent). openUrl embeds the token as a
   // query parameter for direct browser use.
-  openPort?(vmId: string, port: number): Promise<{ url: string; token: string; openUrl: string }>;
+  openPort?(vmId: string, port: number): Promise<{ url: string; token: string; openUrl: string; expiresAtMs?: number }>;
 
   snapshot(vmId: string, name?: string): Promise<SnapshotRef>;
   restore(snapshotId: string): Promise<VMHandle>;

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -39,7 +39,7 @@ export type VmProviderGatewayShape = {
     provider: ProviderId,
     vmId: string,
     port: number,
-  ) => Effect.Effect<{ url: string; token: string; openUrl: string }, VmProviderOperationError>;
+  ) => Effect.Effect<{ url: string; token: string; openUrl: string; expiresAtMs?: number }, VmProviderOperationError>;
   readonly getStats?: (
     provider: ProviderId,
     vmId: string,

--- a/web/tests/vm-desktop-wrapper.test.ts
+++ b/web/tests/vm-desktop-wrapper.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  desktopIframeUrl,
+  desktopWrapperUrl,
+  isAllowedDesktopUpstreamHost,
+} from "../services/vms/desktopWrapper";
+
+describe("desktop upstream host allowlist", () => {
+  test("branded and gateway preview hosts pass", () => {
+    expect(isAllowedDesktopUpstreamHost("tidy-heron-6901.vm.cmux.sh")).toBe(true);
+    expect(isAllowedDesktopUpstreamHost("noble-wren-cmux.preview.bl.run")).toBe(true);
+  });
+
+  test("anything else fails closed", () => {
+    expect(isAllowedDesktopUpstreamHost("evil.example.com")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost("vm.cmux.sh")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost("x.vm.cmux.sh.evil.com")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost("a.vm.cmux.sh:8443")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost("user@a.vm.cmux.sh")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost("")).toBe(false);
+    expect(isAllowedDesktopUpstreamHost(null)).toBe(false);
+  });
+});
+
+describe("wrapper URL (what people see and keep)", () => {
+  test("carries cmux_token on our origin, never the gateway parameter", () => {
+    const url = desktopWrapperUrl({
+      origin: "http://localhost:3777",
+      vmId: "tidy-heron",
+      upstreamUrl: "https://tidy-heron-6901.vm.cmux.sh",
+      token: "abc123def456",
+      expiresAtMs: 1_800_000_000_000,
+    });
+    expect(url).toBe(
+      "http://localhost:3777/vm/desktop/tidy-heron?cmux_token=abc123def456&host=tidy-heron-6901.vm.cmux.sh&exp=1800000000000",
+    );
+    expect(url).not.toContain("bl_preview_token");
+  });
+
+  test("refuses non-https or unallowed upstreams", () => {
+    expect(desktopWrapperUrl({
+      origin: "https://cmux.com",
+      vmId: "x",
+      upstreamUrl: "http://tidy-heron-6901.vm.cmux.sh",
+      token: "abc123def456",
+    })).toBeNull();
+    expect(desktopWrapperUrl({
+      origin: "https://cmux.com",
+      vmId: "x",
+      upstreamUrl: "https://evil.example.com",
+      token: "abc123def456",
+    })).toBeNull();
+  });
+});
+
+describe("iframe URL (internal to the wrapper)", () => {
+  test("uses the gateway parameter and forwards only display options", () => {
+    const url = desktopIframeUrl({
+      host: "tidy-heron-6901.vm.cmux.sh",
+      token: "abc123def456",
+      params: {
+        cmux_token: "abc123def456",
+        host: "tidy-heron-6901.vm.cmux.sh",
+        exp: "1800000000000",
+        autoconnect: "1",
+        resize: "remote",
+        reconnect: "1",
+        reconnect_delay: "2000",
+        evil: "1",
+      },
+    });
+    expect(url).toContain("bl_preview_token=abc123def456");
+    expect(url).toContain("autoconnect=1");
+    expect(url).toContain("resize=remote");
+    expect(url).toContain("reconnect=1");
+    expect(url).toContain("reconnect_delay=2000");
+    expect(url).not.toContain("evil");
+    expect(url).not.toContain("cmux_token");
+    expect(url).not.toContain("exp=");
+  });
+
+  test("rejects bad hosts and malformed tokens", () => {
+    expect(desktopIframeUrl({ host: "evil.example.com", token: "abc123def456", params: {} })).toBeNull();
+    expect(desktopIframeUrl({ host: "a-1.vm.cmux.sh", token: "", params: {} })).toBeNull();
+    expect(desktopIframeUrl({ host: "a-1.vm.cmux.sh", token: "bad token!", params: {} })).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes the two problems with long-lived desktop (VNC) panes.

## Why panes died "after a long time"

The pane's URL embedded a gateway preview token minted with a **12-hour TTL**. At hour twelve the token expired server-side, noVNC's `reconnect` retried forever against 401s, and the pane went silently white. (Verified live: page 200 + websocket 101 while the token is valid; nothing survives its expiry.)

## What changed

- **7-day tokens for port opens** (`PREVIEW_OPEN_TOKEN_TTL_SECONDS`) — a pane now outlives a work week. Attach/RPC tokens keep 12 h.
- **`openUrl` is now a cmux-served wrapper**: `/vm/desktop/<machine>?cmux_token=…` on our origin. Blaxel's edge owns the `bl_preview_token` parameter name — it can't be renamed there — so the raw tokened URL simply stops being user-visible: it exists only inside the wrapper's iframe src (the gateway sends no `X-Frame-Options`/CSP, verified).
- The wrapper **fails closed** on upstream hosts (allowlist: `.vm.cmux.sh`, `.preview.bl.run`; https only; no ports/userinfo), forwards only noVNC display options, and at the token's deadline reloads into an **honest expiry screen** ("machine is fine, reopen the desktop from cmux") instead of a silent white canvas.
- Lives outside the `[locale]` tree with its own layout + proxy bypass, like `/billing`.
- **No client changes**: app and CLI already open whatever `openUrl` the backend returns; `url`/`token` stay raw for programmatic callers.

## Tests

Host-allowlist matrix (subdomain forgeries, ports, userinfo), wrapper-URL shape (`cmux_token`, never `bl_preview_token`), iframe param forwarding allowlist, malformed-token rejection. `tsc` clean; VM suites green.

## Follow-up (infra, not this PR)

True renaming at the edge — accepting `cmux_token` on `*.vm.cmux.sh` itself — needs a proxy we own in front of Blaxel's gateway (e.g. a Worker translating to `X-Blaxel-Preview-Token`), with websocket passthrough. This PR removes the user-visible exposure without that hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790292488&installation_model_id=21920&pr_number=10766&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10766&signature=a1ae771319896d881f8d1490a9adf45288576171b9c10c1cbc7b8a7a670a996c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM port previews now open in a branded desktop view when supported.
  * Desktop sessions display full-screen remote desktops with approved display settings.
  * Preview links remain available for up to seven days where supported.
* **Bug Fixes**
  * Added clearer handling for invalid or expired desktop links.
  * Desktop sessions automatically refresh when their access period ends.
* **Security**
  * Restricted desktop connections to approved secure endpoints and validated preview links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->