### PR TITLE
Fix capture-pane positional argument fallback

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17900,6 +17900,7 @@ struct CMUXCLI {
               --window <id|ref|index>      Window context for workspace/surface refs and indexes
               --scrollback           Include scrollback
               --lines <n>            Return only the last N lines (implies --scrollback)
+              \(String(localized: "cli.tmuxCompat.capturePane.help.noPositional", defaultValue: "Positional arguments are not supported; use --surface <id|ref|index>."))
 
             Example:
               cmux capture-pane --workspace workspace:2 --surface surface:1 --scrollback --lines 200
@@ -25162,6 +25163,38 @@ struct CMUXCLI {
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let (linesArg, rem3) = parseOption(rem2, name: "--lines")
+            var includeScrollback = false
+            var pastTerminator = false
+            for argument in rem3 {
+                if !pastTerminator, argument == "--" {
+                    pastTerminator = true
+                    continue
+                }
+                if !pastTerminator, argument == "--scrollback" {
+                    includeScrollback = true
+                    continue
+                }
+                if !pastTerminator, Self.isFlagToken(argument) {
+                    throw CLIError(
+                        message: String(
+                            format: String(
+                                localized: "cli.tmuxCompat.capturePane.error.unknownFlag",
+                                defaultValue: "capture-pane: unknown flag '%@'"
+                            ),
+                            argument
+                        )
+                    )
+                }
+                throw CLIError(
+                    message: String(
+                        format: String(
+                            localized: "cli.tmuxCompat.capturePane.error.unknownPositional",
+                            defaultValue: "capture-pane: unknown positional arg '%@'; use --surface <id|ref|index>"
+                        ),
+                        argument
+                    )
+                )
+            }
             let windowRaw = windowOpt ?? windowOverride
             let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(sfArg, windowRaw: windowRaw)
             let surfaceArg = sfArg ?? (wsArg == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
@@ -25174,7 +25207,6 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId, windowHandle: winId)
             if let sfId { params["surface_id"] = sfId }
 
-            let includeScrollback = rem3.contains("--scrollback")
             if includeScrollback {
                 params["scrollback"] = true
             }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -56389,6 +56389,57 @@
         }
       }
     },
+    "cli.tmuxCompat.capturePane.error.unknownFlag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "capture-pane: unknown flag '%@'"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "capture-pane: 不明なフラグ '%@'"
+          }
+        }
+      }
+    },
+    "cli.tmuxCompat.capturePane.error.unknownPositional": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "capture-pane: unknown positional arg '%@'; use --surface <id|ref|index>"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "capture-pane: 不明な位置引数 '%@'。--surface <id|ref|index> を使用してください"
+          }
+        }
+      }
+    },
+    "cli.tmuxCompat.capturePane.help.noPositional": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Positional arguments are not supported; use --surface <id|ref|index>."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置引数はサポートされていません。--surface <id|ref|index> を使用してください。"
+          }
+        }
+      }
+    },
     "cli.tmuxCompat.respawnPane.requiresForce": {
       "extractionState": "manual",
       "localizations": {

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -39,6 +39,92 @@ struct CLIExplicitSurfaceRoutingTests {
         )
     }
 
+    @Test func capturePaneRejectsPositionalSurfaceWhenCallerSurfaceIsUnset() throws {
+        let (requests, result) = try runCapturePane(
+            arguments: ["capture-pane", Self.targetSurfaceRef],
+            callerSurfaceId: nil
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(
+            (result.stderr + result.stdout).contains("unknown positional arg '\(Self.targetSurfaceRef)'"),
+            Comment(rawValue: result.stderr + result.stdout)
+        )
+        #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
+    }
+
+    @Test func capturePaneRejectsPositionalSurfaceInsteadOfCallerEnvironmentSurface() throws {
+        let (requests, result) = try runCapturePane(
+            arguments: ["capture-pane", Self.targetSurfaceRef],
+            callerSurfaceId: "surface:294"
+        )
+
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(
+            (result.stderr + result.stdout).contains("unknown positional arg '\(Self.targetSurfaceRef)'"),
+            Comment(rawValue: result.stderr + result.stdout)
+        )
+        #expect(!(result.stdout + result.stderr).contains("caller screen"))
+        #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
+    }
+
+    @Test func capturePaneFlagsPreserveTargetAndScrollbackOptions() throws {
+        let (requests, result) = try runCapturePane(arguments: [
+            "capture-pane",
+            "--surface", Self.targetSurfaceRef,
+            "--scrollback",
+            "--lines", "7",
+        ])
+
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        let request = try #require(requests.first)
+        #expect(request["method"] as? String == "surface.read_text")
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["surface_id"] as? String == Self.targetSurfaceRef)
+        #expect(params["workspace_id"] == nil)
+        #expect(params["window_id"] == nil)
+        #expect(params["scrollback"] as? Bool == true)
+        #expect(params["lines"] as? Int == 7)
+    }
+
+    @Test(arguments: ["unexpected", "--bogus"])
+    func capturePaneRejectsUnknownExtraArguments(_ extraArgument: String) throws {
+        let (requests, result) = try runCapturePane(arguments: [
+            "capture-pane",
+            "--surface", Self.targetSurfaceRef,
+            extraArgument,
+        ])
+
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(
+            (result.stderr + result.stdout).contains(extraArgument),
+            Comment(rawValue: result.stderr + result.stdout)
+        )
+        #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
+    }
+
+    @Test func capturePaneHelpDocumentsFlagOnlyTargeting() throws {
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: ["capture-pane", "--help"],
+            environment: [
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+                "CMUX_SOCKET_PATH": Self.makeSocketPath("capture-help"),
+            ],
+            timeout: 5
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(
+            result.stdout.contains("Positional arguments are not supported"),
+            Comment(rawValue: result.stdout)
+        )
+        #expect(
+            result.stdout.contains("--surface <id|ref|index>"),
+            Comment(rawValue: result.stdout)
+        )
+    }
+
     @Test func numericSurfaceHandleStillInheritsCallerWorkspaceForIndexResolution() throws {
         let socketPath = Self.makeSocketPath("numeric")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -379,6 +465,52 @@ struct CLIExplicitSurfaceRoutingTests {
         if let expectedKey {
             #expect(params["key"] as? String == expectedKey)
         }
+    }
+
+    private func runCapturePane(
+        arguments: [String],
+        callerSurfaceId: String? = Self.callerSurfaceId
+    ) throws -> (requests: [[String: Any]], result: ProcessRunResult) {
+        let socketPath = Self.makeSocketPath("capture")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            guard method == "surface.read_text" else {
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+            return Self.v2Response(id: id, ok: true, result: ["text": "capture screen\n"])
+        }
+
+        var environment = cliEnvironment(socketPath: socketPath)
+        if let callerSurfaceId {
+            environment["CMUX_SURFACE_ID"] = callerSurfaceId
+        } else {
+            environment.removeValue(forKey: "CMUX_SURFACE_ID")
+        }
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: arguments,
+            environment: environment,
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        return (try state.requestObjects(), result)
     }
 
     private func cliEnvironment(socketPath: String) -> [String: String] {

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -300,7 +300,7 @@ tmux compatibility commands:
 
 | Command | Contract |
 | --- | --- |
-| `capture-pane` | Read pane text. |
+| `capture-pane` | Read pane text. Target with `--surface <id|ref|index>`; positional arguments are rejected. |
 | `resize-pane` | Resize a pane with direction flags. |
 | `pipe-pane` | Pipe pane text to a shell command. |
 | `wait-for` | Signal or wait on a named synchronization point. |

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -46,7 +46,7 @@ cmux list-pane-surfaces --pane <dock-pane-id>
 
 Text output marks them as `[dock:workspace]` or `[dock:global]`. JSON and socket rows carry the additive `dock_scope` field with the stable value `workspace` or `global`; existing non-Dock rows are unchanged. Pane and surface IDs remain stable for the lifetime of their Dock items.
 
-Existing surface-addressed terminal verbs accept these Dock surface IDs directly. In particular, `send`, `send-key`, `read-screen`, `capture-pane`, `focus`, and `close` can target a Dock terminal by its bare surface ID in either Dock scope. No Dock-specific addressing syntax is required.
+Existing surface-addressed terminal verbs accept these Dock surface IDs directly. In particular, `send`, `send-key`, `read-screen`, `focus`, and `close` can target a Dock terminal by its bare surface ID in either Dock scope. `capture-pane` targets a Dock terminal with `--surface <id|ref|index>`; positional arguments are rejected. No Dock-specific addressing syntax is required.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #4670.

`capture-pane` currently ignores residual positional arguments after option parsing, so a command such as `cmux capture-pane surface:298` silently reads the caller surface (or `CMUX_SURFACE_ID`). This PR adds behavioral coverage for both environment states, valid routing flags, scrollback/line options, unknown extra arguments, and the help contract. The first commit is intentionally test-only so CI records the regression before the parser fix; the follow-up commit will make the command fail closed.

Test-only commit: dfe8c2f64b

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296415&installation_model_id=21920&pr_number=10767&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10767&signature=887e2060409a949184b44255b87a5114e3de150da5003ff3a30df96e80c90159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation for `capture-pane` command targeting and scrollback options.
  * Added coverage ensuring invalid positional and unknown arguments are rejected.
  * Verified that explicit targets are honored without falling back to the caller’s surface context.
  * Confirmed help text clearly documents flag-only target selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->