### PR TITLE
Fix Quick Look retirement reentrancy for large text previews

### DIFF
--- a/Sources/Panels/FilePreviewQuickLookContainerView.swift
+++ b/Sources/Panels/FilePreviewQuickLookContainerView.swift
@@ -9,6 +9,7 @@ import Quartz
 /// representable teardown, so no closed preview is reused.
 final class FilePreviewQuickLookContainerView: NSView {
     private var previewView: QLPreviewView?
+    private var isRetiring = false
     private var isDismantled = false
 
     /// Creates an empty stable host for a replaceable inner preview.
@@ -26,10 +27,10 @@ final class FilePreviewQuickLookContainerView: NSView {
     /// Returns the preview owned by this mounted host, creating it when needed.
     /// A dismantled representable cannot create or re-adopt a preview.
     func livePreviewView() -> QLPreviewView? {
+        guard !isRetiring, !isDismantled else { return nil }
         if let previewView {
             return previewView
         }
-        guard !isDismantled else { return nil }
 
         guard let previewView = QLPreviewView(frame: bounds, style: .normal) else {
             return nil
@@ -37,8 +38,9 @@ final class FilePreviewQuickLookContainerView: NSView {
         previewView.autostarts = true
         previewView.shouldCloseWithWindow = false
         previewView.autoresizingMask = [.width, .height]
-        addSubview(previewView)
         self.previewView = previewView
+        // Register the child before AppKit can synchronously re-enter this host.
+        addSubview(previewView)
         return previewView
     }
 
@@ -56,7 +58,14 @@ final class FilePreviewQuickLookContainerView: NSView {
     }
 
     private func retireLivePreview(reason: String) {
-        guard let previewView else { return }
+        guard !isRetiring, let previewView else { return }
+        isRetiring = true
+        self.previewView = nil
+        defer { isRetiring = false }
+
+        // Invalidate the slot before any AppKit call. `close()` and
+        // `removeFromSuperview()` can synchronously trigger SwiftUI/responder
+        // updates while the old Quick Look view is already deactivated.
         sentryBreadcrumb(
             "quickLook.preview.retire",
             category: "filePreview",
@@ -67,6 +76,5 @@ final class FilePreviewQuickLookContainerView: NSView {
         // when the preview has never entered a window.
         previewView.close()
         previewView.removeFromSuperview()
-        self.previewView = nil
     }
 }

--- a/Sources/Panels/FilePreviewQuickLookSession.swift
+++ b/Sources/Panels/FilePreviewQuickLookSession.swift
@@ -62,20 +62,28 @@ final class FilePreviewQuickLookSession {
     func dismantle(_ view: NSView) {
         guard liveViews.contains(view) else { return }
         liveViews.remove(view)
-        Self.releaseView(view)
         if liveViews.allObjects.isEmpty {
             item = nil
             itemRevision = nil
         }
+        // Retire the root only after the session has forgotten it and any
+        // last shared item. AppKit teardown can synchronously re-enter a
+        // representable update while the old QLPreviewView is deactivated.
+        Self.releaseView(view)
     }
 
     func close() {
-        for view in liveViews.allObjects {
-            Self.releaseView(view)
-        }
+        let views = liveViews.allObjects
+        // A preview root can synchronously re-enter SwiftUI while AppKit
+        // detaches its inner QLPreviewView. Remove every root from the session
+        // before invoking teardown so that re-entrant updates cannot configure
+        // a retiring representable.
         liveViews.removeAllObjects()
         item = nil
         itemRevision = nil
+        for view in views {
+            Self.releaseView(view)
+        }
     }
 
     private static func makeView() -> NSView {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1155,6 +1155,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE86520000000000000007 /* FilePreviewPDFZoomChromeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000008 /* FilePreviewPDFZoomChromeView.swift */; };
 		C0DE8652000000000000010D /* FilePreviewQLItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE8652000000000000010E /* FilePreviewQLItem.swift */; };
 		C0DE64020000000000001002 /* FilePreviewQuickLookContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64020000000000001001 /* FilePreviewQuickLookContainerView.swift */; };
+		C0DE10728000000000000001 /* FilePreviewQuickLookRetirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10728000000000000002 /* FilePreviewQuickLookRetirementTests.swift */; };
 		DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */; };
 		C0DE8652000000000000010F /* FilePreviewQuickLookViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000110 /* FilePreviewQuickLookViewCoordinator.swift */; };
 		C0DE86520000000000000012 /* FilePreviewReloadCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000011 /* FilePreviewReloadCompletionTests.swift */; };
@@ -3984,6 +3985,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE86520000000000000008 /* FilePreviewPDFZoomChromeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewPDFZoomChromeView.swift; sourceTree = "<group>"; };
 		C0DE8652000000000000010E /* FilePreviewQLItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQLItem.swift; sourceTree = "<group>"; };
 		C0DE64020000000000001001 /* FilePreviewQuickLookContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookContainerView.swift; sourceTree = "<group>"; };
+		C0DE10728000000000000002 /* FilePreviewQuickLookRetirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewQuickLookRetirementTests.swift; sourceTree = "<group>"; };
 		0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookSession.swift; sourceTree = "<group>"; };
 		C0DE86520000000000000110 /* FilePreviewQuickLookViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookViewCoordinator.swift; sourceTree = "<group>"; };
 		C0DE86520000000000000011 /* FilePreviewReloadCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReloadCompletionTests.swift; sourceTree = "<group>"; };
@@ -8294,6 +8296,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C8349002C8349002C8349002 /* MainWindowCloseTerminationRoutingTests.swift */,
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 				C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
+				C0DE10728000000000000002 /* FilePreviewQuickLookRetirementTests.swift */,
 				C0DE86520000000000000118 /* FilePreviewNativeRefreshStateTests.swift */,
 				C0DE86520000000000000011 /* FilePreviewReloadCompletionTests.swift */,
 				C0DE86520000000000000002 /* FilePreviewReloadTests.swift */,
@@ -11437,6 +11440,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE49950000000000000001 /* FilePreviewKindResolverTests.swift in Sources */,
 				C0DE86520000000000000117 /* FilePreviewNativeRefreshStateTests.swift in Sources */,
 				A5001436A5001436A5001436 /* FilePreviewPDFThumbnailSidebarTests.swift in Sources */,
+				C0DE10728000000000000001 /* FilePreviewQuickLookRetirementTests.swift in Sources */,
 				C0DE86520000000000000012 /* FilePreviewReloadCompletionTests.swift in Sources */,
 				C0DE86520000000000000001 /* FilePreviewReloadTests.swift in Sources */,
 				C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */,

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -40,6 +40,24 @@ struct FilePreviewKindResolverTests {
         }
     }
 
+    @Test("Large single-line text routes through the bounded text path")
+    func largeSingleLineTextRoutesThroughTextPreview() throws {
+        let contents = String(repeating: "x", count: 1_048_576)
+        for fileExtension in [nil, "txt"] {
+            let baseURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)")
+            let url = fileExtension.map { baseURL.appendingPathExtension($0) } ?? baseURL
+            try Data(contents.utf8).write(to: url, options: .atomic)
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            #expect(
+                FilePreviewKindResolver.initialMode(for: url)
+                    == (fileExtension == nil ? .quickLook : .text)
+            )
+            #expect(FilePreviewKindResolver.mode(for: url) == .text)
+        }
+    }
+
     @Test("MTS binary transport streams keep media preview after sniffing")
     func mtsBinaryTransportStreamsKeepMediaPreviewAfterSniffing() throws {
         let url = try temporaryFile(

--- a/cmuxTests/FilePreviewQuickLookRetirementTests.swift
+++ b/cmuxTests/FilePreviewQuickLookRetirementTests.swift
@@ -1,0 +1,93 @@
+import AppKit
+import Quartz
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Quick Look retirement")
+struct FilePreviewQuickLookRetirementTests {
+    private final class ReentrantResponderView: NSView {
+        var onResign: (() -> Void)?
+
+        override var acceptsFirstResponder: Bool {
+            true
+        }
+
+        override func resignFirstResponder() -> Bool {
+            onResign?()
+            return super.resignFirstResponder()
+        }
+    }
+
+    @Test
+    func retirementInvalidatesCachedPreviewBeforeSynchronousResponderTeardown() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-10728-quicklook-\(UUID().uuidString)")
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: fileURL.path,
+            startFileWatcher: false,
+            modeResolver: { _ in .quickLook }
+        )
+        defer { panel.close() }
+
+        let session = FilePreviewQuickLookSession()
+        let container = try #require(session.view(
+            panel: panel,
+            revision: panel.previewRevision,
+            isVisibleInUI: true,
+            backgroundColor: .clear,
+            drawsBackground: false
+        ) as? FilePreviewQuickLookContainerView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            session.dismantle(container)
+            window.close()
+        }
+
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        let previewView = try #require(container.livePreviewView())
+        let responder = ReentrantResponderView(
+            frame: NSRect(x: 0, y: 0, width: 20, height: 20)
+        )
+        previewView.addSubview(responder)
+        #expect(window.makeFirstResponder(responder))
+        #expect(window.firstResponder === responder)
+
+        var resignCount = 0
+        var previewDuringRetirement: QLPreviewView?
+        responder.onResign = {
+            resignCount += 1
+            previewDuringRetirement = container.livePreviewView()
+        }
+
+        session.dismantle(container)
+        responder.onResign = nil
+
+        #expect(
+            resignCount > 0,
+            "The fixture must observe AppKit's synchronous responder teardown"
+        )
+        #expect(
+            previewDuringRetirement == nil,
+            "A retiring or dismantled container must not re-adopt its deactivated child"
+        )
+        #expect(container.livePreviewView() == nil)
+    }
+}


### PR DESCRIPTION
Fixes #10728

## What changed

- Invalidate the cached inner QLPreviewView and enter a retirement state before any close/remove AppKit call.
- Prevent a dismantled or synchronously retiring container from vending the deactivated child.
- Remove Quick Look representable roots from the session before teardown so re-entrant SwiftUI updates cannot configure a retiring root.
- Add a synchronous responder-teardown regression test and a synthetic 1 MiB single-line fixture covering extensionless sniff routing and known `.txt` routing.

The normal Quick Look session/item sharing and fresh-view behavior after a real window transition remain unchanged.

## Regression commits

1. `25a872d1ca` — test-only regression coverage (red before the fix).
2. `712b2d1651` — lifecycle fix (green with the fix).

## Validation

- `./scripts/lint-pbxproj-test-wiring.sh`
- Tagged app build and hosted cmux unit checks will be reported in the PR.
- The original crash was not intentionally reproduced locally; the public report does not retain the original file extension/size, and local macOS app/XCUITest execution is out of scope for this checkout.

Tagged dogfood should exercise Ctrl-click opening of a large one-line extensionless file and a known-text-extension file, then switch/close/reopen the tab while watching the tagged debug log for Quick Look retirement events.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296675&installation_model_id=21920&pr_number=10769&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10769&signature=27bf07a36bf836def8912cea6fd9c2a89058f204c353339bc70b48d2eae3a5b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->