### PR TITLE
Fix active pane border after full-screen transitions

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1224,9 +1224,18 @@ struct ContentView: View {
                   createIfNeeded: true
               ) else { return }
         controller.scheduleGeometryRefresh { [weak window] in
-            guard let window else { return nil }
+            guard let window,
+                  observedWindow === window else { return nil }
             return tmuxWorkspacePaneWindowOverlayState(for: window)
         }
+    }
+
+    private func cancelTmuxWorkspacePaneWindowOverlayGeometryRefresh() {
+        guard let window = observedWindow else { return }
+        WindowTmuxWorkspacePaneOverlayController.controller(
+            for: window,
+            createIfNeeded: false
+        )?.cancelPendingGeometryRefresh()
     }
 
     private struct CommandPaletteSwitcherWindowContext {
@@ -3247,6 +3256,7 @@ struct ContentView: View {
             )
             AppDelegate.shared?.fullscreenControlsViewModel = fullscreenControlsViewModel
             syncTrafficLightInset()
+            scheduleTmuxWorkspacePaneWindowOverlayGeometryRefresh(in: window)
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { notification in
@@ -3260,6 +3270,7 @@ struct ContentView: View {
             )
             AppDelegate.shared?.fullscreenControlsViewModel = nil
             syncTrafficLightInset()
+            scheduleTmuxWorkspacePaneWindowOverlayGeometryRefresh(in: window)
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: NSWindow.didResizeNotification)) { notification in
@@ -3269,6 +3280,13 @@ struct ContentView: View {
             clampSidebarWidthIfNeeded(availableWidth: availableWidth)
             clampRightSidebarWidthIfNeeded(availableWidth: availableWidth)
             updateSidebarResizerBandState()
+            scheduleTmuxWorkspacePaneWindowOverlayGeometryRefresh(in: window)
+        })
+
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: NSWindow.didEndLiveResizeNotification)) { notification in
+            guard let window = notification.object as? NSWindow,
+                  window === observedWindow else { return }
+            scheduleTmuxWorkspacePaneWindowOverlayGeometryRefresh(in: window)
         })
 
         view = AnyView(view.onChange(of: rightSidebarMaxWidthSetting) { _, _ in
@@ -3384,6 +3402,7 @@ struct ContentView: View {
 
         view = AnyView(view.onDisappear {
             sidebarState.removeVisibilityWillChangeHandler(ownerId: windowId)
+            cancelTmuxWorkspacePaneWindowOverlayGeometryRefresh()
             if isResizerDragging {
                 TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: tabManager)
                 isResizerDragging = false
@@ -3434,6 +3453,7 @@ struct ContentView: View {
 
         // Track this window for fullscreen notifications
         if observedWindow !== window {
+            cancelTmuxWorkspacePaneWindowOverlayGeometryRefresh()
             DispatchQueue.main.async {
                 observedWindowReference = WeakWindowReference(window)
                 isFullScreen = window.styleMask.contains(.fullScreen)

--- a/Sources/WindowTmuxWorkspacePaneOverlayController.swift
+++ b/Sources/WindowTmuxWorkspacePaneOverlayController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxFoundation
 import ObjectiveC
 import SwiftUI
 
@@ -15,7 +16,8 @@ final class WindowTmuxWorkspacePaneOverlayController: NSObject {
     private var installConstraints: [NSLayoutConstraint] = []
     private weak var installedReferenceView: NSView?
     private var lastRenderState: TmuxWorkspacePaneOverlayRenderState?
-    private var pendingGeometryRefresh = false
+    private let geometryRefreshScheduler = MainActorDeferredActionScheduler()
+    private var pendingGeometryStateProvider: (@MainActor () -> TmuxWorkspacePaneOverlayRenderState?)?
 
     var hasRenderedState: Bool {
         lastRenderState != nil || !containerView.isHidden
@@ -136,14 +138,30 @@ final class WindowTmuxWorkspacePaneOverlayController: NSObject {
     }
 
     func scheduleGeometryRefresh(stateProvider: @MainActor @escaping () -> TmuxWorkspacePaneOverlayRenderState?) {
-        guard !pendingGeometryRefresh else { return }
-        pendingGeometryRefresh = true
-        // Divider drags can emit many geometry snapshots; one overlay update per
-        // main-actor turn is enough to keep the active border aligned.
-        Task { @MainActor [weak self] in
+        // Keep the newest provider while a pass is queued. During a full-screen
+        // transition, bonsplit can publish an intermediate frame immediately
+        // before AppKit sends didEnter/didExit; retaining the first provider
+        // would make that stale frame win the coalesced pass.
+        pendingGeometryStateProvider = stateProvider
+        guard !geometryRefreshScheduler.isScheduled else { return }
+
+        // Yield once so the provider observes the layout committed by the
+        // notification that requested the refresh. The scheduler is owned by
+        // this window controller, and cancellation below prevents a detached
+        // ContentView's provider from running after its lifecycle ends.
+        geometryRefreshScheduler.schedule(zeroDelayPolicy: .yieldOnce) { [weak self] in
             guard let self else { return }
-            pendingGeometryRefresh = false
-            update(state: stateProvider())
+            let provider = self.pendingGeometryStateProvider
+            self.pendingGeometryStateProvider = nil
+            guard let provider, self.window != nil else { return }
+            self.update(state: provider())
         }
+    }
+
+    /// Cancels a queued geometry refresh when the owning window content leaves
+    /// the hierarchy, releasing its state provider before the next actor turn.
+    func cancelPendingGeometryRefresh() {
+        pendingGeometryStateProvider = nil
+        geometryRefreshScheduler.cancel()
     }
 }

--- a/cmuxTests/TmuxWorkspacePaneOverlayModelTests.swift
+++ b/cmuxTests/TmuxWorkspacePaneOverlayModelTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import Testing
 
 #if canImport(cmux_DEV)
@@ -60,5 +61,39 @@ struct TmuxWorkspacePaneOverlayModelTests {
         #expect(model.activePaneBorderRect == nil)
         #expect(model.activePaneBorderColorHex == nil)
         #expect(model.workspaceAttentionColor == WorkspaceAttentionColor(configuredHex: nil))
+    }
+
+    @Test
+    @MainActor
+    func geometryRefreshBurstUsesNewestStateProvider() async {
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 640, height: 400),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+
+        let controller = WindowTmuxWorkspacePaneOverlayController(window: window)
+        var deliveredProviders: [Int] = []
+
+        // A full-screen transition can enqueue an intermediate geometry update
+        // immediately before didEnter/didExit delivers the settled update. The
+        // pending refresh must evaluate the newest provider, not the one that
+        // happened to arrive first.
+        controller.scheduleGeometryRefresh {
+            deliveredProviders.append(1)
+            return nil
+        }
+        controller.scheduleGeometryRefresh {
+            deliveredProviders.append(2)
+            return nil
+        }
+
+        for _ in 0..<4 {
+            await Task.yield()
+        }
+
+        #expect(deliveredProviders == [2])
     }
 }

--- a/cmuxTests/TmuxWorkspacePaneOverlayModelTests.swift
+++ b/cmuxTests/TmuxWorkspacePaneOverlayModelTests.swift
@@ -75,25 +75,24 @@ struct TmuxWorkspacePaneOverlayModelTests {
         defer { window.close() }
 
         let controller = WindowTmuxWorkspacePaneOverlayController(window: window)
-        var deliveredProviders: [Int] = []
+        let deliveredProviders = AsyncStream<Int>.makeStream()
+        var deliveredProviderIterator = deliveredProviders.stream.makeAsyncIterator()
 
         // A full-screen transition can enqueue an intermediate geometry update
         // immediately before didEnter/didExit delivers the settled update. The
         // pending refresh must evaluate the newest provider, not the one that
         // happened to arrive first.
         controller.scheduleGeometryRefresh {
-            deliveredProviders.append(1)
+            deliveredProviders.continuation.yield(1)
             return nil
         }
         controller.scheduleGeometryRefresh {
-            deliveredProviders.append(2)
+            deliveredProviders.continuation.yield(2)
             return nil
         }
 
-        for _ in 0..<4 {
-            await Task.yield()
-        }
-
-        #expect(deliveredProviders == [2])
+        let deliveredProvider = await deliveredProviderIterator.next()
+        #expect(deliveredProvider == 2)
+        deliveredProviders.continuation.finish()
     }
 }


### PR DESCRIPTION
## Summary

- Refresh the window-level active-pane overlay after full-screen enter/exit and resize completion notifications.
- Make the overlay geometry scheduler latest-wins, lifecycle-cancelable, and layout-turn aware so the final portal geometry is used instead of an intermediate transition frame.
- Fixes #10751.

## Testing

- Added `geometryRefreshBurstUsesNewestStateProvider`, a behavior-level scheduler regression test.
- `swiftc -parse` passes for the changed Swift files.
- `./scripts/lint-pbxproj-test-wiring.sh` passes.
- Local Xcode/reload verification is unavailable in this checkout (CommandLineTools only; Zig is not installed); GitHub checks should provide the macOS build/test proof.

## Demo Video

- Not captured: local GUI verification is intentionally not run in this environment.

## Checklist

- [x] I added or updated tests for behavior changes
- [ ] I tested the change locally
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296901&installation_model_id=21920&pr_number=10771&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10771&signature=d360a35740ef64ea7b5c575efec1d09377a317242671d0409672a0c95d7f2979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->