### PR TITLE
fix: route arrows to Edit Workspace Description editor

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -4,6 +4,9 @@ import CmuxCommandPalette
 import Foundation
 import CmuxTerminal
 
+let commandPaletteWorkspaceDescriptionInputMode = "workspace_description_input"
+let commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier = "CommandPaletteWorkspaceDescriptionEditor"
+
 func browserOmnibarSelectionDeltaForControlNavigation(
     hasFocusedAddressBar: Bool,
     flags: NSEvent.ModifierFlags,
@@ -283,6 +286,41 @@ func shouldDispatchEditableTextViewArrowViaFirstResponderKeyDown(
     )
 }
 
+/// Whether the command palette should keep keyboard navigation in its inline text editor.
+///
+/// The workspace-description mode snapshot is authoritative while SwiftUI is handing first
+/// responder ownership to the multiline editor. That mode fallback prevents the app-level
+/// shortcut monitor from moving the command list selection during the async focus handoff.
+func shouldUseCommandPaletteInlineTextHandling(
+    mode: String,
+    isInteractive: Bool,
+    firstResponderIsMultilineTextResponder: Bool
+) -> Bool {
+    guard isInteractive else { return false }
+    return firstResponderIsMultilineTextResponder
+        || mode == commandPaletteWorkspaceDescriptionInputMode
+}
+
+/// Whether an active workspace-description editor should receive an arrow through `keyDown`.
+///
+/// This is deliberately scoped to the marked editor instead of broadening field-editor
+/// forwarding. It shares the text-editor modifier policy with the existing standalone editor
+/// path, leaves Cmd+Option pane focus shortcuts alone, and lets marked text stay with the IME.
+func shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsWorkspaceDescriptionEditor: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsWorkspaceDescriptionEditor else { return false }
+    return shouldDispatchEditableTextViewArrowViaFirstResponderKeyDown(
+        keyCode: keyCode,
+        firstResponderIsEditableTextView: true,
+        firstResponderHasMarkedText: firstResponderHasMarkedText,
+        flags: flags
+    )
+}
+
 /// Ctrl-N / Ctrl-P navigate the mention-completion popover (and emacs-style line
 /// movement) inside the terminal textbox. Like plain arrows, the window's
 /// `performKeyEquivalent` claims these before they reach the textbox `keyDown`, so
@@ -344,7 +382,9 @@ func shouldConsumeShortcutWhileCommandPaletteVisible(
     isCommandPaletteVisible: Bool,
     normalizedFlags: NSEvent.ModifierFlags,
     chars: String,
-    keyCode: UInt16
+    keyCode: UInt16,
+    allowsInlineTextNavigation: Bool = false,
+    inlineTextHasMarkedText: Bool = false
 ) -> Bool {
     guard isCommandPaletteVisible else { return false }
 
@@ -352,6 +392,22 @@ func shouldConsumeShortcutWhileCommandPaletteVisible(
     // underlying terminal or browser content.
     if normalizedFlags.isEmpty, keyCode == 53 {
         return true
+    }
+
+    // Command-modified arrows are normally palette/app shortcuts. Once the
+    // workspace-description editor owns the inline text path, preserve the
+    // standard NSTextView boundary/selection variants so the event can reach
+    // the window-level first-responder forwarding hook. The caller must prove
+    // that the workspace-description editor is the actual first responder;
+    // mode snapshots alone only suppress palette selection during focus handoff.
+    if allowsInlineTextNavigation,
+       !inlineTextHasMarkedText,
+       shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+           keyCode: keyCode,
+           firstResponderIsWorkspaceDescriptionEditor: true,
+           flags: normalizedFlags
+       ) {
+        return false
     }
 
     guard normalizedFlags.contains(.command) else { return false }
@@ -396,7 +452,7 @@ func shouldSubmitCommandPaletteWithReturn(
         return true
     }
     if normalizedFlags == [.shift] {
-        return mode != "workspace_description_input"
+        return mode != commandPaletteWorkspaceDescriptionInputMode
     }
     return false
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6678,6 +6678,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return isCommandPaletteResponder(textView)
     }
 
+    private func isCommandPaletteWorkspaceDescriptionEditorActive(in window: NSWindow) -> Bool {
+        guard let textView = window.firstResponder as? NSTextView,
+              textView.isEditable,
+              textView.window === window,
+              textView.accessibilityIdentifier() == commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier,
+              isInsideCommandPaletteOverlay(textView) else {
+            return false
+        }
+        return isCommandPaletteOverlayPresented(in: window)
+    }
+
     private func commandPaletteMarkedTextInput(in window: NSWindow) -> NSTextView? {
         if let textView = window.firstResponder as? NSTextView,
            isCommandPaletteResponder(textView),
@@ -14052,7 +14063,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
         }
 
-        let paletteUsesInlineTextHandling = commandPaletteShortcutWindow.map { isCommandPaletteMultilineTextResponderActive(in: $0) } ?? false
+        let paletteSnapshot = commandPaletteShortcutWindow
+            .flatMap { mainWindowId(for: $0).map(commandPaletteSnapshot(windowId:)) }
+            ?? .empty
+        let paletteFirstResponderIsMultilineTextResponder = commandPaletteShortcutWindow.map {
+            isCommandPaletteMultilineTextResponderActive(in: $0)
+        } ?? false
+        let paletteFirstResponderOwnsWorkspaceDescriptionEditor =
+            (123...126).contains(event.keyCode)
+            && (commandPaletteShortcutWindow.map {
+                isCommandPaletteWorkspaceDescriptionEditorActive(in: $0)
+            } ?? false)
+        let paletteUsesInlineTextHandling = shouldUseCommandPaletteInlineTextHandling(
+            mode: paletteSnapshot.mode,
+            isInteractive: commandPaletteInteractiveInTargetWindow,
+            firstResponderIsMultilineTextResponder: paletteFirstResponderIsMultilineTextResponder
+        )
 
         let paletteSelectionDelta = contextAwareCommandPaletteSelectionDelta(for: event)
 
@@ -14080,7 +14106,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if commandPaletteInteractiveInTargetWindow,
            let paletteWindow = commandPaletteShortcutWindow {
             let paletteFieldEditorHasMarkedText = commandPaletteFieldEditorHasMarkedText(in: paletteWindow)
-            let paletteSnapshot = mainWindowId(for: paletteWindow).map(commandPaletteSnapshot(windowId:)) ?? .empty
             let paletteUsesInlineReturnHandling = paletteUsesInlineTextHandling
             if isPlainEscape {
                 if paletteFieldEditorHasMarkedText {
@@ -14195,7 +14220,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         let commandPaletteConsumesShortcut = shouldConsumeShortcutWhileCommandPaletteVisible(
             isCommandPaletteVisible: commandPaletteEffectiveInTargetWindow,
-            normalizedFlags: normalizedFlags, chars: chars, keyCode: event.keyCode
+            normalizedFlags: normalizedFlags,
+            chars: chars,
+            keyCode: event.keyCode,
+            allowsInlineTextNavigation: paletteFirstResponderOwnsWorkspaceDescriptionEditor,
+            inlineTextHasMarkedText: commandPaletteShortcutWindow.map {
+                shortcutResponderHasMarkedText($0.firstResponder)
+            } ?? false
         )
         let commandPaletteCanRouteUnarmedGlobalSearch = commandPaletteEffectiveInTargetWindow && commandPaletteConsumesShortcut
         let globalSearchUnarmedChordPrefixMatches = matchesUnarmedGlobalSearchChordPrefix(event, normalizedFlags: normalizedFlags)
@@ -18365,6 +18396,21 @@ extension AppDelegate {
 }
 
 private extension NSWindow {
+    static func cmuxCommandPaletteOwnsWorkspaceDescriptionEditor(
+        _ textView: NSTextView?,
+        in window: NSWindow
+    ) -> Bool {
+        guard let textView,
+              textView.isEditable,
+              textView.window === window,
+              textView.accessibilityIdentifier() == commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier,
+              let container = cmuxCommandPaletteOverlayAncestor(of: textView) else {
+            return false
+        }
+
+        return cmuxCommandPaletteOverlayIsPresented(container)
+    }
+
     static func cmuxCommandPaletteOwnsFieldEditor(_ textView: NSTextView?, in window: NSWindow) -> Bool {
         guard let textView,
               textView.isFieldEditor,
@@ -18727,6 +18773,12 @@ private extension NSWindow {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }
         let firstResponderHasMarkedText = shortcutResponderHasMarkedText(self.firstResponder)
+        let firstResponderIsCommandPaletteWorkspaceDescriptionEditor =
+            (123...126).contains(event.keyCode)
+            && Self.cmuxCommandPaletteOwnsWorkspaceDescriptionEditor(
+                self.firstResponder as? NSTextView,
+                in: self
+            )
         let firstResponderIsCommandPaletteFieldEditor = Self.cmuxCommandPaletteOwnsFieldEditor(
             self.firstResponder as? NSTextView,
             in: self
@@ -18879,6 +18931,27 @@ private extension NSWindow {
                           "panel=\(firstResponderOmnibarPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil")"
                   )
             else {
+                return false
+            }
+            return true
+        }
+
+        // The workspace-description editor is a multiline NSTextView mounted
+        // inside the command-palette overlay. Keep its arrows on the normal
+        // AppKit text-navigation path even when the responder is represented
+        // as a field editor during SwiftUI/AppKit focus handoff (#4916).
+        if shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+            keyCode: event.keyCode,
+            firstResponderIsWorkspaceDescriptionEditor: firstResponderIsCommandPaletteWorkspaceDescriptionEditor,
+            firstResponderHasMarkedText: firstResponderHasMarkedText,
+            flags: event.modifierFlags
+        ) {
+            guard let target = self.firstResponder,
+                  cmuxForceDispatchKeyDownOnce(
+                      event,
+                      to: target,
+                      reason: "command palette workspace description arrow"
+                  ) else {
                 return false
             }
             return true

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3944,7 +3944,7 @@ struct ContentView: View {
         VStack(spacing: 0) {
             commandPaletteEditorField(
                 style: .multiline(
-                    accessibilityIdentifier: "CommandPaletteWorkspaceDescriptionEditor",
+                    accessibilityIdentifier: commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier,
                     accessibilityLabel: String(
                         localized: "command.editWorkspaceDescription.title",
                         defaultValue: "Edit Workspace Description…"
@@ -9611,7 +9611,7 @@ struct ContentView: View {
         case .renameConfirm:
             mode = "rename_confirm"
         case .workspaceDescriptionInput:
-            mode = "workspace_description_input"
+            mode = commandPaletteWorkspaceDescriptionInputMode
         }
 
         let rows = Array(commandPaletteVisibleResults.prefix(20)).map { result in

--- a/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
+++ b/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
@@ -506,6 +506,63 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         }
     }
 
+    func testWorkspaceDescriptionModeSuppressesPaletteSelectionDuringFocusHandoff() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, overlayContainer in
+            let fieldEditor = CommandPaletteShortcutFieldEditor(
+                frame: NSRect(x: 0, y: 0, width: 240, height: 24)
+            )
+            fieldEditor.isFieldEditor = true
+            overlayContainer.addSubview(fieldEditor)
+            defer { fieldEditor.removeFromSuperview() }
+
+            appDelegate.setCommandPaletteSnapshot(
+                CommandPaletteDebugSnapshot(
+                    query: "",
+                    mode: commandPaletteWorkspaceDescriptionInputMode,
+                    results: []
+                ),
+                for: window
+            )
+            XCTAssertTrue(window.makeFirstResponder(fieldEditor))
+
+            let moveExpectation = expectation(
+                description: "Workspace-description focus handoff must not move palette selection"
+            )
+            moveExpectation.isInverted = true
+            let moveToken = NotificationCenter.default.addObserver(
+                forName: .commandPaletteMoveSelection,
+                object: nil,
+                queue: nil
+            ) { _ in
+                moveExpectation.fulfill()
+            }
+            defer { NotificationCenter.default.removeObserver(moveToken) }
+
+            guard let downArrowEvent = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 125,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct workspace-description Down Arrow event")
+                return
+            }
+
+#if DEBUG
+            XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: downArrowEvent))
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+            wait(for: [moveExpectation], timeout: 0.2)
+        }
+    }
+
     func testWindowPerformKeyEquivalentDoesNotRouteHorizontalArrowsWhenPaletteOverlayIsTransparent() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
+++ b/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
@@ -406,6 +406,106 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         }
     }
 
+    func testWindowPerformKeyEquivalentRoutesAllArrowsToWorkspaceDescriptionEditor() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, overlayContainer in
+            let editor = CommandPaletteWorkspaceDescriptionArrowProbe(
+                frame: NSRect(x: 0, y: 0, width: 240, height: 96)
+            )
+            editor.isEditable = true
+            editor.isFieldEditor = true
+            editor.setAccessibilityIdentifier(commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier)
+            overlayContainer.addSubview(editor)
+            defer { editor.removeFromSuperview() }
+
+            appDelegate.setCommandPaletteSnapshot(
+                CommandPaletteDebugSnapshot(
+                    query: "",
+                    mode: commandPaletteWorkspaceDescriptionInputMode,
+                    results: []
+                ),
+                for: window
+            )
+            XCTAssertTrue(window.makeFirstResponder(editor))
+
+            let arrows: [(UInt16, String)] = [
+                (123, String(UnicodeScalar(NSLeftArrowFunctionKey)!)),
+                (124, String(UnicodeScalar(NSRightArrowFunctionKey)!)),
+                (125, String(UnicodeScalar(NSDownArrowFunctionKey)!)),
+                (126, String(UnicodeScalar(NSUpArrowFunctionKey)!)),
+            ]
+            for (keyCode, characters) in arrows {
+                guard let event = makeKeyDownEvent(
+                    key: characters,
+                    modifiers: [],
+                    keyCode: keyCode,
+                    windowNumber: window.windowNumber
+                ) else {
+                    XCTFail("Failed to construct workspace-description arrow event \(keyCode)")
+                    return
+                }
+                XCTAssertTrue(window.performKeyEquivalent(with: event))
+            }
+
+            XCTAssertEqual(
+                editor.keyDownKeyCodes,
+                [123, 124, 125, 126],
+                "The window hook must forward every arrow to the active workspace-description editor"
+            )
+        }
+    }
+
+    func testWorkspaceDescriptionArrowForwardingUsesTheReplayGuard() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, overlayContainer in
+            let editor = CommandPaletteWorkspaceDescriptionArrowProbe(
+                frame: NSRect(x: 0, y: 0, width: 240, height: 96)
+            )
+            editor.isEditable = true
+            editor.isFieldEditor = true
+            editor.setAccessibilityIdentifier(commandPaletteWorkspaceDescriptionEditorAccessibilityIdentifier)
+            editor.replayWindow = window
+            editor.replayNextKeyDown = true
+            overlayContainer.addSubview(editor)
+            defer { editor.removeFromSuperview() }
+
+            appDelegate.setCommandPaletteSnapshot(
+                CommandPaletteDebugSnapshot(
+                    query: "",
+                    mode: commandPaletteWorkspaceDescriptionInputMode,
+                    results: []
+                ),
+                for: window
+            )
+            XCTAssertTrue(window.makeFirstResponder(editor))
+
+            guard let event = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSUpArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 126,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct workspace-description Up Arrow event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(
+                editor.keyDownKeyCodes,
+                [126],
+                "A re-entered event must not be dispatched into the editor twice"
+            )
+        }
+    }
+
     func testWindowPerformKeyEquivalentDoesNotRouteHorizontalArrowsWhenPaletteOverlayIsTransparent() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -584,5 +684,22 @@ private final class CommandPaletteShortcutFieldEditor: NSTextView {
 
     override func keyDown(with event: NSEvent) {
         keyDownKeyCodes.append(event.keyCode)
+    }
+}
+
+private final class CommandPaletteWorkspaceDescriptionArrowProbe: NSTextView {
+    var keyDownKeyCodes: [UInt16] = []
+    var replayWindow: NSWindow?
+    var replayNextKeyDown = false
+
+    override func hasMarkedText() -> Bool {
+        false
+    }
+
+    override func keyDown(with event: NSEvent) {
+        keyDownKeyCodes.append(event.keyCode)
+        guard replayNextKeyDown, let replayWindow else { return }
+        replayNextKeyDown = false
+        _ = replayWindow.performKeyEquivalent(with: event)
     }
 }

--- a/cmuxTests/EditableTextViewArrowKeyForwardingTests.swift
+++ b/cmuxTests/EditableTextViewArrowKeyForwardingTests.swift
@@ -214,7 +214,18 @@ struct EditableTextViewArrowKeyForwardingTests {
                 keyCode: 125,
                 allowsInlineTextNavigation: true
             ),
-            "Cmd+Option+Arrow remains a cmux pane shortcut"
+            "Cmd+Option+Arrow must remain on the existing command-palette/app shortcut path"
+        )
+        #expect(
+            shouldConsumeShortcutWhileCommandPaletteVisible(
+                isCommandPaletteVisible: true,
+                normalizedFlags: [.command],
+                chars: "",
+                keyCode: 126,
+                allowsInlineTextNavigation: true,
+                inlineTextHasMarkedText: true
+            ),
+            "Marked-text composition must not bypass the palette shortcut monitor"
         )
     }
 }

--- a/cmuxTests/EditableTextViewArrowKeyForwardingTests.swift
+++ b/cmuxTests/EditableTextViewArrowKeyForwardingTests.swift
@@ -97,4 +97,124 @@ struct EditableTextViewArrowKeyForwardingTests {
             )
         )
     }
+
+    @Test(arguments: [123, 124, 125, 126] as [UInt16])
+    func routesWorkspaceDescriptionArrowWhenEditorIsActive(keyCode: UInt16) {
+        #expect(
+            shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+                keyCode: keyCode,
+                firstResponderIsWorkspaceDescriptionEditor: true,
+                flags: []
+            ),
+            "The active workspace-description editor must own arrow keyCode \(keyCode)"
+        )
+    }
+
+    @Test
+    func routesWorkspaceDescriptionSelectionAndBoundaryModifiers() {
+        let flagSets: [NSEvent.ModifierFlags] = [
+            [.shift], [.option], [.option, .shift], [.command], [.command, .shift],
+        ]
+        for flags in flagSets {
+            for keyCode in [123, 124, 125, 126] as [UInt16] {
+                #expect(
+                    shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+                        keyCode: keyCode,
+                        firstResponderIsWorkspaceDescriptionEditor: true,
+                        flags: flags
+                    ),
+                    "Workspace-description editor must retain text navigation for keyCode \(keyCode) flags \(flags.rawValue)"
+                )
+            }
+        }
+    }
+
+    @Test
+    func workspaceDescriptionArrowRoutingPreservesImeAndPaneGuards() {
+        #expect(
+            !shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+                keyCode: 125,
+                firstResponderIsWorkspaceDescriptionEditor: true,
+                firstResponderHasMarkedText: true,
+                flags: []
+            ),
+            "Marked-text composition must remain owned by the input method"
+        )
+        #expect(
+            !shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+                keyCode: 125,
+                firstResponderIsWorkspaceDescriptionEditor: true,
+                flags: [.command, .option]
+            ),
+            "Cmd+Option+Arrow must remain available for pane focus"
+        )
+        #expect(
+            !shouldDispatchCommandPaletteWorkspaceDescriptionArrowViaFirstResponderKeyDown(
+                keyCode: 125,
+                firstResponderIsWorkspaceDescriptionEditor: false,
+                flags: []
+            )
+        )
+    }
+
+    @Test
+    func workspaceDescriptionModeKeepsPaletteSelectionOutOfInlineEditorDuringFocusReentry() {
+        #expect(
+            shouldUseCommandPaletteInlineTextHandling(
+                mode: "workspace_description_input",
+                isInteractive: true,
+                firstResponderIsMultilineTextResponder: false
+            ),
+            "The authoritative mode snapshot must cover the async first-responder handoff"
+        )
+        #expect(
+            !shouldUseCommandPaletteInlineTextHandling(
+                mode: "workspace_description_input",
+                isInteractive: false,
+                firstResponderIsMultilineTextResponder: false
+            )
+        )
+        #expect(
+            shouldUseCommandPaletteInlineTextHandling(
+                mode: "commands",
+                isInteractive: true,
+                firstResponderIsMultilineTextResponder: true
+            )
+        )
+        #expect(
+            !shouldUseCommandPaletteInlineTextHandling(
+                mode: "rename_input",
+                isInteractive: true,
+                firstResponderIsMultilineTextResponder: false
+            )
+        )
+    }
+
+    @Test
+    func inlineWorkspaceDescriptionEditorDoesNotLetPaletteConsumeBoundaryArrows() {
+        for keyCode in [123, 124, 125, 126] as [UInt16] {
+            for flags in [[.command], [.command, .shift]] as [NSEvent.ModifierFlags] {
+                #expect(
+                    !shouldConsumeShortcutWhileCommandPaletteVisible(
+                        isCommandPaletteVisible: true,
+                        normalizedFlags: flags,
+                        chars: "",
+                        keyCode: keyCode,
+                        allowsInlineTextNavigation: true
+                    ),
+                    "Inline workspace-description text must retain Cmd-arrow keyCode \(keyCode) flags \(flags.rawValue)"
+                )
+            }
+        }
+        #expect(
+            shouldConsumeShortcutWhileCommandPaletteVisible(
+                isCommandPaletteVisible: true,
+                normalizedFlags: [.command, .option],
+                chars: "",
+                keyCode: 125,
+                allowsInlineTextNavigation: true
+            ),
+            "Cmd+Option+Arrow remains a cmux pane shortcut"
+        )
+    }
 }

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -116,6 +116,62 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         assertSavedDescription(description, in: app)
     }
 
+    func testLeftAndRightMoveWorkspaceDescriptionCaret() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+        prepareTerminalFocusedWorkspace(app)
+
+        app.typeKey("e", modifierFlags: [.command, .shift])
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor before testing horizontal arrows"
+        )
+        clickDescriptionEditor(editor, in: app)
+
+        app.typeText("abc")
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: [])
+        app.typeText("L")
+        app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [])
+        app.typeText("R")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss after horizontal caret navigation"
+        )
+        assertSavedDescription("abLcR", in: app)
+    }
+
+    func testUpAndDownMoveWorkspaceDescriptionCaretAcrossLines() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+        prepareTerminalFocusedWorkspace(app)
+
+        app.typeKey("e", modifierFlags: [.command, .shift])
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor before testing vertical arrows"
+        )
+        clickDescriptionEditor(editor, in: app)
+
+        app.typeText("11111")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [.shift])
+        app.typeText("22222")
+        app.typeKey(XCUIKeyboardKey.upArrow.rawValue, modifierFlags: [])
+        app.typeText("U")
+        app.typeKey(XCUIKeyboardKey.downArrow.rawValue, modifierFlags: [])
+        app.typeText("D")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss after vertical caret navigation"
+        )
+        assertSavedDescription("11111U\n22222D", in: app)
+    }
+
     func testSidebarRendersSavedDescriptionWithLineBreaks() {
         let app = configuredSidebarApp()
         launchAndActivate(app)


### PR DESCRIPTION
## Summary
- route Left, Right, Up, and Down through the active workspace-description multiline editor before NSWindow key-equivalent handling can swallow them
- suppress command-palette selection navigation during the workspace_description_input focus handoff while preserving other palette modes
- retain text-editor modifier policy, IME marked-text bypass, and key-down replay protection

Fixes #4916

## Routing proof
- AppDelegate local shortcut monitor uses the authoritative workspace_description_input snapshot to suppress palette selection routing during async first-responder handoff.
- NSWindow.performKeyEquivalent forwards all four arrow key codes only when the first responder is the editable CommandPaletteWorkspaceDescriptionEditor inside the visible palette overlay.
- Plain, Shift, Option, Option+Shift, Command, and Command+Shift arrows use the shared editable-text policy; Cmd+Option arrows remain excluded from editor forwarding.
- Marked text stays on normal IME handling, and cmuxForceDispatchKeyDownOnce prevents same-event reentry.

## Tests
- Added deterministic predicate, notification-routing, window-level four-arrow, replay-guard, IME/modifier, and UI caret tests.
- Source parse and git diff checks pass.
- Local tagged reload/compile could not run: this Mac has no Zig and only CommandLineTools (no Xcode); GitHub checks provide the build validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrow-key navigation in the command palette’s workspace description editor.
  * Preserved caret movement, text selection, multiline editing, and IME input behavior.
  * Prevented duplicate key handling and maintained pane shortcuts while editing.
  * Enter continues to save and dismiss workspace descriptions reliably.

* **Tests**
  * Added coverage for keyboard navigation, focus changes, marked text, selection boundaries, and multiline content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->