### PR TITLE
iOS: reclaim dismantled Ghostty surfaces

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceBridge.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceBridge.swift
@@ -6,12 +6,12 @@ import UIKit
 
 /// Bridges libghostty C callbacks (which run on the IO read thread or
 /// other Ghostty-internal threads) onto the main actor where the
-/// `GhosttySurfaceView` lives. The single mutable property is the
-/// `weak var surfaceView`; we serialise reads/writes through the main
-/// actor, which lets us conform to `Sendable` for the `Task { @MainActor }`
-/// hops below.
+/// `GhosttySurfaceView` lives. The deliberate strong back-reference keeps the
+/// raw UIKit pointer valid until dismantle detaches it; we serialise
+/// reads/writes through a lock because callbacks arrive off-main, which lets
+/// us safely perform the `Task { @MainActor }` hops below.
 final class GhosttySurfaceBridge: @unchecked Sendable {
-    // lint:allow lock — sanctioned carve-out: serial low-level primitive hidden behind the type, guarding a single weak ref on the libghostty-callback / typing-latency path; actor rewrite tracked as the GhosttySurfaceView split follow-up.
+    // lint:allow lock — sanctioned carve-out: serial low-level primitive hidden behind the type, guarding a single strong ref on the libghostty-callback / typing-latency path; actor rewrite tracked as the GhosttySurfaceView split follow-up.
     private let lock = NSLock()
     // Deliberately STRONG: libghostty holds the raw view pointer
     // (`ghostty_platform_ios_s.uiview`, passUnretained in `makeSurface`), so

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceFreeRetention.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceFreeRetention.swift
@@ -14,18 +14,10 @@ import UIKit
 final class GhosttySurfaceFreeRetention: @unchecked Sendable {
     private var retainedObject: AnyObject?
     private var didRelease = false
-    private let onRelease: @MainActor @Sendable () -> Void
 
     /// Creates a token that retains `object` until ``releaseAfterSurfaceFree``.
-    ///
-    /// `onRelease` is an injectable callback used by deterministic tests to
-    /// observe the release boundary without creating a libghostty surface.
-    init(
-        object: AnyObject,
-        onRelease: @escaping @MainActor @Sendable () -> Void = {}
-    ) {
+    init(object: AnyObject) {
         retainedObject = object
-        self.onRelease = onRelease
     }
 
     /// Releases the retained object after `ghostty_surface_free` returns.
@@ -36,7 +28,6 @@ final class GhosttySurfaceFreeRetention: @unchecked Sendable {
     func releaseAfterSurfaceFree() -> Bool {
         guard !didRelease else { return false }
         didRelease = true
-        onRelease()
         retainedObject = nil
         return true
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceFreeRetention.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceFreeRetention.swift
@@ -1,0 +1,45 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Holds a surface's UIKit view until libghostty has finished freeing it.
+///
+/// `ghostty_surface_free` can run after the host view has been removed from
+/// SwiftUI. libghostty still owns the raw `UIView` pointer supplied at surface
+/// creation, so the view must remain alive until that call returns. This token
+/// makes that ownership explicit and releases it exactly once on the main
+/// actor, where UIKit objects are allowed to deinitialize.
+// Safety: the surface queue only retains this token. All mutable access and
+// the final UIKit release remain isolated to MainActor.
+@MainActor
+final class GhosttySurfaceFreeRetention: @unchecked Sendable {
+    private var retainedObject: AnyObject?
+    private var didRelease = false
+    private let onRelease: @MainActor @Sendable () -> Void
+
+    /// Creates a token that retains `object` until ``releaseAfterSurfaceFree``.
+    ///
+    /// `onRelease` is an injectable callback used by deterministic tests to
+    /// observe the release boundary without creating a libghostty surface.
+    init(
+        object: AnyObject,
+        onRelease: @escaping @MainActor @Sendable () -> Void = {}
+    ) {
+        retainedObject = object
+        self.onRelease = onRelease
+    }
+
+    /// Releases the retained object after `ghostty_surface_free` returns.
+    ///
+    /// - Returns: `true` only for the first release; repeated calls are safe
+    ///   and return `false`.
+    @discardableResult
+    func releaseAfterSurfaceFree() -> Bool {
+        guard !didRelease else { return false }
+        didRelease = true
+        onRelease()
+        retainedObject = nil
+        return true
+    }
+}
+
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3373,6 +3373,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         artifactChipAccessibilityObserverTokens.removeAll()
         prepareForReuseAfterDetach()
+        // SwiftUI's dismantle callback is the ownership boundary for this
+        // UIKit view. Retire the libghostty surface here rather than waiting
+        // for deinit: the strong bridge back-reference intentionally keeps
+        // deinit from being reached while a live surface still owns the raw
+        // UIView pointer.
+        disposeSurface()
     }
 
     /// Quiesces the surface on window detach: resigns input, stops the display
@@ -3598,7 +3604,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // the surface concurrently. `processOutput`'s main-actor guard stops new
         // work from being enqueued once `surface` is nil, so only the bounded
         // backlog drains before the free. The host-owned bridge retain stays
-        // alive until synchronous libghostty teardown has stopped callbacks.
+        // alive until synchronous libghostty teardown has stopped callbacks;
+        // `enqueueSurfaceFree` separately retains the raw UIKit view through
+        // that same boundary before the bridge cycle is broken.
         enqueueSurfaceFree(surface, generation: surfaceGeneration, on: currentQueue)
     }
 
@@ -3607,12 +3615,27 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         generation: UInt64, on queue: GhosttySurfaceWorkQueue,
         completion: (@MainActor @Sendable () -> Void)? = nil
     ) {
+        // `makeSurface` gives libghostty an unretained raw UIView pointer. The
+        // bridge back-reference is detached before this operation is queued so
+        // late callbacks cannot re-enter a dismantled view; retain the view
+        // independently until `ghostty_surface_free` has synchronously drained
+        // every queued operation and callback.
+        let viewRetention = GhosttySurfaceFreeRetention(object: self)
         surfaceFreeDrainWatchdog.start(generation: generation) { [weak self] in self?.pendingSurfaceFreeCount ?? 0 }
-        queue.async { [weak self] in
+        queue.async { [weak self, viewRetention] in
             let userdata = ghostty_surface_userdata(surface)
             ghostty_surface_free(surface)
             GhosttySurfaceBridge.releaseRetainedOpaque(userdata)
-            Task { @MainActor in self?.surfaceFreeDrainWatchdog.cancel(generation: generation); completion?() }
+            // The C free has returned, so the raw UIKit pointer is no longer
+            // reachable from libghostty. Run recovery bookkeeping and the
+            // caller's completion while the explicit view retain is still
+            // held, then release it on MainActor so UIKit deinitialization
+            // cannot happen on the surface queue.
+            Task { @MainActor [weak self, viewRetention] in
+                self?.surfaceFreeDrainWatchdog.cancel(generation: generation)
+                completion?()
+                _ = viewRetention.releaseAfterSurfaceFree()
+            }
         }
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3363,6 +3363,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     /// Stops user-visible and accessibility output from a surface SwiftUI has removed.
+    ///
+    /// This is also the terminal surface's ownership handoff: the libghostty
+    /// surface is retired before SwiftUI releases the hosting view.
     public func prepareForDismantle() {
         isDismantled = true
         // Block-based observers stay registered (and their closures retained
@@ -3585,6 +3588,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return ghostty_surface_process_exited(surface)
     }
 
+    /// Retires the current libghostty surface exactly once and queues its free
+    /// behind all operations already submitted for this surface generation.
     func disposeSurface() {
         stopDisplayLink()
         cancelRenderPipelineRecoveryResumeTimer()
@@ -3610,6 +3615,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         enqueueSurfaceFree(surface, generation: surfaceGeneration, on: currentQueue)
     }
 
+    /// Queues a synchronous libghostty free while retaining the UIKit view
+    /// until the C teardown and any recovery completion have finished.
     func enqueueSurfaceFree(
         _ surface: ghostty_surface_t,
         generation: UInt64, on queue: GhosttySurfaceWorkQueue,

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import CMUXMobileCore
 import Foundation
 import GhosttyKit
 import Testing

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
@@ -10,6 +10,7 @@ import UIKit
 @MainActor
 @Suite("Ghostty surface dismantle", .serialized)
 struct GhosttySurfaceDismantleTests {
+    /// Verifies that dismantling detaches callbacks and is idempotent.
     @Test("prepareForDismantle retires the surface and detaches callbacks")
     func prepareForDismantleRetiresSurface() throws {
         let runtime = try GhosttyRuntime.shared()
@@ -37,8 +38,10 @@ struct GhosttySurfaceDismantleTests {
 
 @MainActor
 private final class DismantleTestDelegate: GhosttySurfaceViewDelegate {
+    /// Accepts input produced by the surface during the test.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
 
+    /// Accepts viewport reports without affecting the lifetime assertions.
     func ghosttySurfaceView(
         _ surfaceView: GhosttySurfaceView,
         didResize size: TerminalGridSize,

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceDismantleTests.swift
@@ -1,0 +1,48 @@
+#if canImport(UIKit)
+import Foundation
+import GhosttyKit
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+@MainActor
+@Suite("Ghostty surface dismantle", .serialized)
+struct GhosttySurfaceDismantleTests {
+    @Test("prepareForDismantle retires the surface and detaches callbacks")
+    func prepareForDismantleRetiresSurface() throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = DismantleTestDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate)
+        defer { view.prepareForDismantle() }
+
+        let surface = try #require(view.surface)
+        let bridge = try #require(
+            GhosttySurfaceBridge.fromOpaque(ghostty_surface_userdata(surface))
+        )
+        #expect(bridge.surfaceView === view)
+
+        view.prepareForDismantle()
+
+        #expect(view.surface == nil)
+        #expect(bridge.surfaceView == nil)
+
+        // SwiftUI may call dismantle more than once while replacing a host;
+        // the second call must not enqueue another free.
+        view.prepareForDismantle()
+        #expect(view.surface == nil)
+    }
+}
+
+@MainActor
+private final class DismantleTestDelegate: GhosttySurfaceViewDelegate {
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+
+    func ghosttySurfaceView(
+        _ surfaceView: GhosttySurfaceView,
+        didResize size: TerminalGridSize,
+        reportID: UInt64
+    ) {}
+}
+
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceFreeRetentionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceFreeRetentionTests.swift
@@ -1,0 +1,64 @@
+#if canImport(UIKit)
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@MainActor
+@Suite("Ghostty surface free retention")
+struct GhosttySurfaceFreeRetentionTests {
+    @Test("retention keeps the view alive through a fake free and releases once")
+    func retentionKeepsViewAliveThroughFakeFree() {
+        var callbackCount = 0
+        var probe: LifetimeProbe? = LifetimeProbe()
+        weak var weakProbe = probe
+        let retention = GhosttySurfaceFreeRetention(
+            object: probe!,
+            onRelease: {
+                callbackCount += 1
+                // The callback is the post-free boundary; the UIKit object is
+                // still alive until the token drops its final strong retain.
+                #expect(weakProbe != nil)
+            }
+        )
+        probe = nil
+
+        #expect(weakProbe != nil)
+
+        // This closure stands in for the serial queue's
+        // `ghostty_surface_free` call. It must run while the raw view pointer
+        // is still backed by a live object.
+        var fakeFreeCount = 0
+        fakeFreeCount += 1
+        #expect(weakProbe != nil)
+        #expect(fakeFreeCount == 1)
+
+        #expect(retention.releaseAfterSurfaceFree())
+        #expect(!retention.releaseAfterSurfaceFree())
+        #expect(callbackCount == 1)
+        #expect(weakProbe == nil)
+    }
+
+    @Test("repeated free cycles do not accumulate retention or double release")
+    func repeatedFreeCyclesRemainBounded() {
+        for _ in 0..<128 {
+            var callbackCount = 0
+            var probe: LifetimeProbe? = LifetimeProbe()
+            weak var weakProbe = probe
+            let retention = GhosttySurfaceFreeRetention(
+                object: probe!,
+                onRelease: { callbackCount += 1 }
+            )
+            probe = nil
+
+            #expect(weakProbe != nil)
+            #expect(retention.releaseAfterSurfaceFree())
+            #expect(!retention.releaseAfterSurfaceFree())
+            #expect(callbackCount == 1)
+            #expect(weakProbe == nil)
+        }
+    }
+}
+
+private final class LifetimeProbe {}
+
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceFreeRetentionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceFreeRetentionTests.swift
@@ -6,59 +6,56 @@ import Testing
 @MainActor
 @Suite("Ghostty surface free retention")
 struct GhosttySurfaceFreeRetentionTests {
+    /// Exercises the post-free retention boundary with a non-UIKit probe.
     @Test("retention keeps the view alive through a fake free and releases once")
     func retentionKeepsViewAliveThroughFakeFree() {
-        var callbackCount = 0
         var probe: LifetimeProbe? = LifetimeProbe()
         weak var weakProbe = probe
-        let retention = GhosttySurfaceFreeRetention(
-            object: probe!,
-            onRelease: {
-                callbackCount += 1
-                // The callback is the post-free boundary; the UIKit object is
-                // still alive until the token drops its final strong retain.
-                #expect(weakProbe != nil)
-            }
-        )
+        let retention = GhosttySurfaceFreeRetention(object: probe!)
         probe = nil
 
         #expect(weakProbe != nil)
 
-        // This closure stands in for the serial queue's
+        // This test-only callback stands in for the serial queue's
         // `ghostty_surface_free` call. It must run while the raw view pointer
         // is still backed by a live object.
-        var fakeFreeCount = 0
-        fakeFreeCount += 1
+        var fakeFree = FakeSurfaceFree()
+        fakeFree.run { #expect(weakProbe != nil) }
+        #expect(fakeFree.callCount == 1)
         #expect(weakProbe != nil)
-        #expect(fakeFreeCount == 1)
 
         #expect(retention.releaseAfterSurfaceFree())
         #expect(!retention.releaseAfterSurfaceFree())
-        #expect(callbackCount == 1)
         #expect(weakProbe == nil)
     }
 
+    /// Repeats the fake free protocol to expose leaked or duplicate releases.
     @Test("repeated free cycles do not accumulate retention or double release")
     func repeatedFreeCyclesRemainBounded() {
         for _ in 0..<128 {
-            var callbackCount = 0
             var probe: LifetimeProbe? = LifetimeProbe()
             weak var weakProbe = probe
-            let retention = GhosttySurfaceFreeRetention(
-                object: probe!,
-                onRelease: { callbackCount += 1 }
-            )
+            let retention = GhosttySurfaceFreeRetention(object: probe!)
             probe = nil
 
             #expect(weakProbe != nil)
             #expect(retention.releaseAfterSurfaceFree())
             #expect(!retention.releaseAfterSurfaceFree())
-            #expect(callbackCount == 1)
             #expect(weakProbe == nil)
         }
     }
 }
 
 private final class LifetimeProbe {}
+
+private struct FakeSurfaceFree {
+    private(set) var callCount = 0
+
+    /// Invokes the fake free callback exactly once for this test operation.
+    mutating func run(_ callback: () -> Void) {
+        callCount += 1
+        callback()
+    }
+}
 
 #endif


### PR DESCRIPTION
Fixes #7199

GhosttySurfaceView now retires its libghostty surface from `prepareForDismantle`. The strong bridge back-reference remains intact for raw UIKit-pointer safety, while a main-actor retention token keeps the view alive through the FIFO surface queue and synchronous `ghostty_surface_free`. The token is released exactly once after free completion; recovery frees use the same path.

Regression coverage is split across two commits: a real surface dismantle test and deterministic repeated fake retention/free cycles.

Validation: Swift 6 parsing and git diff checks locally; full iOS package/simulator validation is delegated to the iOS workflow because this host has CommandLineTools but no Xcode.app. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS terminal surface cleanup when views are dismantled.
  * Ensured surfaces remain valid during teardown and are released safely exactly once.
  * Made repeated cleanup operations safe and prevented lingering callbacks or retained views.

* **Tests**
  * Added coverage for dismantling terminal views, callback detachment, repeated cleanup, and surface retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->