### PR TITLE
ci: fix main-CI red workflow-guard-tests (R2 uploader TypeError on Python 3.9)

### DIFF
--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import datetime as dt
 import hashlib


### PR DESCRIPTION
Fixes the pre-existing red `workflow-guard-tests` job on `main`. The step "Validate Python R2 appcast upload guard" fails with:

```
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'
```

Failing runs on main:
- https://github.com/manaflow-ai/cmux/actions/runs/32918349296 (post-merge)
- https://github.com/manaflow-ai/cmux/actions/runs/32906007066 (pre-merge baseline, so the failure predates that merge)

Root cause: commit abb6c79a7e added `extra_headers: dict[str, str] | None = None` to `scripts/ci/upload-r2-object.py`. In the `workflow-guard-tests` job, the earlier step "Set up Python 3.9 for nightly prune compatibility" (`actions/setup-python` with default `update-environment: true`) puts Python 3.9 first on `PATH` for every later step, so `tests/test_ci_r2_upload_python.sh` executes the uploader with Python 3.9. Without `from __future__ import annotations`, function signature annotations evaluate at import time, and the PEP 604 union `X | None` needs Python 3.10 (`types.GenericAlias.__or__` does not exist on 3.9). The `py_compile` step passes because compilation never evaluates annotations; the failure happens at module import.

Fix: add `from __future__ import annotations` to the uploader, matching the existing convention in this repo's Python scripts (`scripts/normalize-pbxproj.py`, `scripts/swift_warning_budget.py`, and others). Annotations become strings and are never evaluated, so the script stays 3.9-compatible, which the job's step ordering effectively requires (the same constraint `tests/test_ci_nightly_prune_python_compat.sh` enforces intentionally for the nightly prune script).

Verified locally with system Python 3.9.6: `tests/test_ci_r2_upload_python.sh` reproduces the exact TypeError before the change and prints `PASS` after it, and still passes under Python 3.14.

The existing guard test is the regression test and is already red on main (both run links above), so this PR is the single green-making commit rather than the usual red-then-green pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility for type annotations in the upload utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->