### PR TITLE
fix: restore app target compilation broken by #8567 worktree identity fields

### DIFF
--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -12,8 +12,8 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     let generatedArtifactContents: Data
     /// Filesystem identity captured immediately after `git worktree add`.
     /// Rollback refuses to touch a path whose checkout was replaced.
-    let worktreeDeviceID: UInt64? = nil
-    let worktreeFileID: UInt64? = nil
+    let worktreeDeviceID: UInt64?
+    let worktreeFileID: UInt64?
     /// A convenience command (e.g. a sample dev-server launcher) that should run
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.
@@ -537,7 +537,8 @@ enum CmuxExtensionWorktreePrototype {
         expectedIdentity: (deviceID: UInt64, fileID: UInt64)?
     ) async {
         guard let expectedIdentity,
-              filesystemIdentity(at: worktree) == expectedIdentity else {
+              let currentIdentity = Self.filesystemIdentity(at: worktree),
+              currentIdentity == expectedIdentity else {
             logPrivateDiagnostic("Skipped failed worktree cleanup after identity changed.")
             return
         }

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -361,7 +361,7 @@ struct ExtensionWorktreeSpawnArgsTests {
         let mutationStatus = await withTaskGroup(of: Int32?.self, returning: Int32?.self) { group in
             group.addTask {
                 var mutationIterator = mutation.stream.makeAsyncIterator()
-                await mutationIterator.next()
+                return await mutationIterator.next()
             }
             group.addTask {
                 try? await Task.sleep(for: .seconds(5))

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -28,6 +28,8 @@ struct ExtensionWorktreeSpawnArgsTests {
             createdHead: "0000000000000000000000000000000000000000",
             generatedArtifactRelativePath: "cmux-sample-dev/index.html",
             generatedArtifactContents: Data(),
+            worktreeDeviceID: nil,
+            worktreeFileID: nil,
             setupCommand: setupCommand
         )
     }


### PR DESCRIPTION
main's app target does not compile since commit 6cf5630c14 (https://github.com/manaflow-ai/cmux/pull/8567). Evidence: speculative merge-gate run https://github.com/manaflow-ai/cmux/actions/runs/32919392868, job tests-build-and-lag, step "Build for runtime regressions", exit 65 with two errors in `Sources/ExtensionWorktreePrototype.swift`.

This is a forward-fix, not a revert: #8567's behavior (rollback refuses to touch a replaced checkout, PTY respawn fix) is worth keeping.

A `let` property with an initial value is excluded from Swift's synthesized memberwise initializer, so declaring `let worktreeDeviceID: UInt64? = nil` made the `createWorktree` call that passes `worktreeDeviceID:`/`worktreeFileID:` fail with "extra arguments at positions #8, #9 in call". Dropping the `= nil` defaults puts both fields back into the memberwise init, and the real captured identity keeps flowing into the result so rollback can still refuse a replaced checkout. The test-only call site in `cmuxTests/ExtensionWorktreeSpawnArgsTests.swift` now passes `nil` for both labels.

Second error, in `bestEffortCleanupFailedWorktree`: `filesystemIdentity(at:)` returns an optional tuple and `==` is not lifted over optional tuples, so the guard now binds `currentIdentity` first and compares the unwrapped values.

Third error, found while running the touched test class on a remote builder: the `group.addTask` closure in `rollbackRetainsEditsWrittenThroughOpenArtifactDescriptor` has more than one statement, so it gets no implicit return and failed with "missing return in closure expected to return 'Int32?'". An explicit `return` fixes it.

Verification: the app target builds clean from this branch on a fleet Mac (cloud reload run https://github.com/manaflow-ai/cmux/actions/runs/32921947474, blacksmith-6vcpu-macos-26), and `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/ExtensionWorktreeSpawnArgsTests test` runs on the AWS builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling failed worktree creation and cleanup.
  * Preserved existing cleanup behavior while ensuring filesystem identity checks are performed consistently.
  * Improved consistency when reporting worktree creation results.

* **Tests**
  * Updated worktree creation test coverage to reflect required result details.
  * Refined asynchronous test handling for more dependable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->