### PR TITLE
fix: preserve worktree identity initializer contract (follow-up to #10777)

### DIFF
--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -18,6 +18,33 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.
     let setupCommand: String
+
+    /// Keeps the optional filesystem identity labels available on every toolchain.
+    /// Swift omits stored properties with default values from a synthesized
+    /// memberwise initializer, which would otherwise drop the rollback identity.
+    init(
+        projectRootPath: String,
+        worktreePath: String,
+        branchName: String,
+        workspaceTitle: String,
+        createdHead: String,
+        generatedArtifactRelativePath: String,
+        generatedArtifactContents: Data,
+        worktreeDeviceID: UInt64? = nil,
+        worktreeFileID: UInt64? = nil,
+        setupCommand: String
+    ) {
+        self.projectRootPath = projectRootPath
+        self.worktreePath = worktreePath
+        self.branchName = branchName
+        self.workspaceTitle = workspaceTitle
+        self.createdHead = createdHead
+        self.generatedArtifactRelativePath = generatedArtifactRelativePath
+        self.generatedArtifactContents = generatedArtifactContents
+        self.worktreeDeviceID = worktreeDeviceID
+        self.worktreeFileID = worktreeFileID
+        self.setupCommand = setupCommand
+    }
 }
 
 /// Arguments for spawning a workspace in a freshly created worktree.
@@ -537,7 +564,9 @@ enum CmuxExtensionWorktreePrototype {
         expectedIdentity: (deviceID: UInt64, fileID: UInt64)?
     ) async {
         guard let expectedIdentity,
-              filesystemIdentity(at: worktree) == expectedIdentity else {
+              let currentIdentity = filesystemIdentity(at: worktree),
+              currentIdentity.deviceID == expectedIdentity.deviceID,
+              currentIdentity.fileID == expectedIdentity.fileID else {
             logPrivateDiagnostic("Skipped failed worktree cleanup after identity changed.")
             return
         }

--- a/cmuxTests/WorkspaceCreateReviewRegressionTests.swift
+++ b/cmuxTests/WorkspaceCreateReviewRegressionTests.swift
@@ -11,6 +11,25 @@ import Testing
 
 @MainActor
 @Suite(.serialized) struct WorkspaceCreateReviewRegressionTests {
+    @Test("worktree creation result preserves filesystem identity")
+    func worktreeCreationResultPreservesFilesystemIdentity() {
+        let result = CmuxExtensionWorktreeCreationResult(
+            projectRootPath: "/tmp/project",
+            worktreePath: "/tmp/project/.cmux/worktrees/created",
+            branchName: "cmux-sidebar-created",
+            workspaceTitle: "cmux-sidebar-created",
+            createdHead: String(repeating: "0", count: 40),
+            generatedArtifactRelativePath: "cmux-sample-dev/index.html",
+            generatedArtifactContents: Data(),
+            worktreeDeviceID: 17,
+            worktreeFileID: 29,
+            setupCommand: ""
+        )
+
+        #expect(result.worktreeDeviceID == 17)
+        #expect(result.worktreeFileID == 29)
+    }
+
     @Test func oversizedWorkingDirectoryIsRejectedBeforeClassification() async {
         let classifierCalls = LockedInvocationCount()
         let service = TerminalController.WorkspaceCreateWorkingDirectoryValidationService(


### PR DESCRIPTION
## Summary

This is a deliberately scoped follow-up/superseding alternative to active PR #10777 (`lawrencecchen`), which repairs the same nightly compiler regression with the minimum synthesized-initializer change. This branch does not amend, overwrite, or push to that owner’s branch.

The regression was introduced by #8567 (`6cf5630c14`): default-valued `worktreeDeviceID`/`worktreeFileID` properties were omitted from Swift’s synthesized memberwise initializer, while direct equality of the optional tuple was rejected by the nightly Swift toolchain.

This follow-up is materially different in two ways that should land together with the repair:

- `CmuxExtensionWorktreeCreationResult` keeps its intended optional/default source contract through an explicit initializer. Callers that do not have an identity (legacy/test fixtures) remain source-compatible, while the production creator can pass the captured identity; future stored-property defaults cannot silently remove these labels again.
- A behavior-level test asserts that both captured identity values survive initialization. #10777 updates a fixture to pass `nil`, but does not test value propagation.

The cleanup guard also compares the two unwrapped identity components explicitly, avoiding optional-tuple/operator inference differences across Swift toolchains.

No workflow or CI configuration is changed.

## Commits

1. `ee871d426b` — regression test (intentionally before the fix)
2. `978bfda4e2` — implementation

## Verification

- `git diff --check`
- `./scripts/check-pbxproj.sh` — passed
- `python3 scripts/check-package-resolved-policy.py` — passed
- `python3 scripts/check-workspace-package-groups.py --check` — passed
- Swift frontend parse checks for both changed Swift files — passed
- The focused local Swift package build was attempted but could not complete because this shared Mac volume had only ~164 MiB free (`No space left on device`); no app `xcodebuild`, XCUITest, or tagged reload was run.
- Nightly evidence: scheduled run [32915386334](https://github.com/manaflow-ai/cmux/actions/runs/32915386334) and push runs [32922800552](https://github.com/manaflow-ai/cmux/actions/runs/32921699450), [32921699450](https://github.com/manaflow-ai/cmux/actions/runs/32921699450), [32921683054](https://github.com/manaflow-ai/cmux/actions/runs/32921683054), and [32923689411](https://github.com/manaflow-ai/cmux/actions/runs/32923689411) all failed at the same `ExtensionWorktreePrototype.swift` initializer/identity diagnostics. The newer run 32923689411 is also failed, so `main` was not already repaired.

## Remote PTY scope

The tinybox reattach flood is issue #10173. Current `main` still starts the reconnect input pump before replay drains and prints each retry; open PR #10327 (owner `austinywang`) and #10350 (owner `smoreg`) already own the backoff/error-flood/input-replay changes. No remote-PTY change is included here; the nightly update did not expose an independent missing fix in that path.
