### PR TITLE
Fix file drag hit-test amplification

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -635,6 +635,7 @@ private func attachFileDropOverlay(
     to referenceView: NSView,
     in containerView: NSView
 ) {
+    overlay.hitTestReferenceView = referenceView
     overlay.translatesAutoresizingMaskIntoConstraints = false
     containerView.addSubview(overlay, positioned: .above, relativeTo: referenceView)
     NSLayoutConstraint.activate([

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -61,6 +61,8 @@ final class FileDropOverlayView: NSView {
     let hintBadgeView = FileDropHintBadgeView(frame: .zero)
     var lastHitTestLogSignature: String?
     var lastDragRouteLogSignatureByPhase: [String: String] = [:]
+    weak var hitTestReferenceView: NSView?
+    var dragUpdateHitTest: (location: NSPoint, view: NSView?)?
 
     override var acceptsFirstResponder: Bool { false }
 

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -6,6 +6,9 @@ import WebKit
 extension FileDropOverlayView {
     func updateDragTarget(_ sender: any NSDraggingInfo, phase: String) -> NSDragOperation {
         let loc = sender.draggingLocation
+        let previousHitTest = dragUpdateHitTest
+        dragUpdateHitTest = (loc, uncachedViewUnderPoint(loc))
+        defer { dragUpdateHitTest = previousHitTest }
         let hasLocalDraggingSource = sender.draggingSource != nil
         let types = sender.draggingPasteboard.types
         let shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -196,11 +199,16 @@ extension FileDropOverlayView {
     }
 
     private func viewUnderPoint(_ windowPoint: NSPoint) -> NSView? {
-        guard let window, let contentView = window.contentView else { return nil }
-        isHidden = true
-        defer { isHidden = false }
-        let point = contentView.convert(windowPoint, from: nil)
-        return contentView.hitTest(point)
+        if let dragUpdateHitTest, dragUpdateHitTest.location == windowPoint {
+            return dragUpdateHitTest.view
+        }
+        return uncachedViewUnderPoint(windowPoint)
+    }
+
+    private func uncachedViewUnderPoint(_ windowPoint: NSPoint) -> NSView? {
+        guard let rootView = hitTestReferenceView ?? window?.contentView else { return nil }
+        let point = rootView.convert(windowPoint, from: nil)
+        return rootView.hitTest(point)
     }
 
     private func editableTextViewUnderPoint(_ windowPoint: NSPoint) -> NSTextView? {
@@ -241,13 +249,7 @@ extension FileDropOverlayView {
             return portalWebView
         }
 
-        guard let window, let contentView = window.contentView else { return nil }
-        isHidden = true
-        defer { isHidden = false }
-        let point = contentView.convert(windowPoint, from: nil)
-        let hitView = contentView.hitTest(point)
-
-        var current: NSView? = hitView
+        var current = viewUnderPoint(windowPoint)
         while let view = current {
             if let webView = view as? WKWebView { return webView }
             current = view.superview
@@ -390,13 +392,7 @@ extension FileDropOverlayView {
             return portalTerminal
         }
 
-        guard let window, let contentView = window.contentView else { return nil }
-        isHidden = true
-        defer { isHidden = false }
-        let point = contentView.convert(windowPoint, from: nil)
-        let hitView = contentView.hitTest(point)
-
-        var current: NSView? = hitView
+        var current = viewUnderPoint(windowPoint)
         while let view = current {
             if let terminal = view as? GhosttyNSView { return terminal }
             current = view.superview
@@ -431,16 +427,13 @@ extension FileDropOverlayView {
 
     private func inlinePaneDropTargetUnderPoint(_ windowPoint: NSPoint) -> PaneDropTargetView? {
         guard let window, let contentView = window.contentView else { return nil }
-        isHidden = true
-        defer { isHidden = false }
-
         let point = contentView.convert(windowPoint, from: nil)
         return paneDropTarget(in: contentView, at: point)
     }
 
     private func paneDropTarget(in view: NSView, at point: NSPoint) -> PaneDropTargetView? {
         for subview in view.subviews.reversed() {
-            guard !subview.isHidden, subview.alphaValue > 0 else { continue }
+            guard subview !== self, !subview.isHidden, subview.alphaValue > 0 else { continue }
             let pointInSubview = subview.convert(point, from: view)
             guard subview.bounds.contains(pointInSubview) else { continue }
             if let paneTarget = subview as? PaneDropTargetView {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1092,6 +1092,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
 		D0B1001AA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */; };
+		781100017811000178110001 /* FileDropOverlayHitTestPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781100027811000278110002 /* FileDropOverlayHitTestPerformanceTests.swift */; };
 		D0B10020A1B2C3D4E5F60001 /* FileDropOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */; };
 		D0B10022A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */; };
 		D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */; };
@@ -3921,6 +3922,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
 		D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropHintBadgeView.swift; sourceTree = "<group>"; };
+		781100027811000278110002 /* FileDropOverlayHitTestPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayHitTestPerformanceTests.swift; sourceTree = "<group>"; };
 		D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayView.swift; sourceTree = "<group>"; };
 		D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayViewHitTesting.swift; sourceTree = "<group>"; };
 		D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayViewTests.swift; sourceTree = "<group>"; };
@@ -8286,6 +8288,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */,
 				E30760060000000000000001 /* TmuxWorkspacePaneOverlayModelTests.swift */,
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
+				781100027811000278110002 /* FileDropOverlayHitTestPerformanceTests.swift */,
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
 				875900000000000000000002 /* Issue8759FreezeRegressionTests.swift */,
@@ -11425,6 +11428,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				FEED49850000000000000001 /* FeedEventClassificationTests.swift in Sources */,
 				FEEDC1A50000000000000003 /* FeedEventClassifier.swift in Sources */,
+				781100017811000178110001 /* FileDropOverlayHitTestPerformanceTests.swift in Sources */,
 				D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */,
 				FE002110 /* FileExplorerDoubleClickActionTests.swift in Sources */,
 				FE002112 /* FileExplorerGitStatusProviderTests.swift in Sources */,

--- a/cmuxTests/FileDropOverlayHitTestPerformanceTests.swift
+++ b/cmuxTests/FileDropOverlayHitTestPerformanceTests.swift
@@ -1,0 +1,125 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct FileDropOverlayHitTestPerformanceTests {
+    private final class CountingContentView: NSView {
+        var hitTestCallCount = 0
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            hitTestCallCount += 1
+            return super.hitTest(point)
+        }
+    }
+
+    private final class MockDraggingInfo: NSObject, NSDraggingInfo {
+        let draggingDestinationWindow: NSWindow?
+        let draggingSourceOperationMask: NSDragOperation = .copy
+        var draggingLocation: NSPoint
+        let draggedImageLocation: NSPoint
+        let draggedImage: NSImage? = nil
+        nonisolated(unsafe) let draggingPasteboard: NSPasteboard
+        nonisolated(unsafe) let draggingSource: Any? = nil
+        let draggingSequenceNumber = 7811
+        var draggingFormation: NSDraggingFormation = .default
+        var animatesToDestination = false
+        var numberOfValidItemsForDrop = 1
+        let springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+        init(window: NSWindow, location: NSPoint, pasteboard: NSPasteboard) {
+            draggingDestinationWindow = window
+            draggingLocation = location
+            draggedImageLocation = location
+            draggingPasteboard = pasteboard
+        }
+
+        func slideDraggedImage(to screenPoint: NSPoint) {}
+
+        override func namesOfPromisedFilesDropped(atDestination dropDestination: URL) -> [String]? {
+            nil
+        }
+
+        func enumerateDraggingItems(
+            options enumOpts: NSDraggingItemEnumerationOptions = [],
+            for view: NSView?,
+            classes classArray: [AnyClass],
+            searchOptions: [NSPasteboard.ReadingOptionKey: Any] = [:],
+            using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+        ) {}
+
+        func resetSpringLoading() {}
+    }
+
+    @Test("Each drag update reuses one underlying window hit test")
+    func eightyDragUpdatesPerformOneUnderlyingHitTestEach() throws {
+        _ = NSApplication.shared
+        let defaults = UserDefaults.standard
+        let savedBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defaults.set(FileDropDefaultBehavior.text.rawValue, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defer {
+            if let savedBehavior {
+                defaults.set(savedBehavior, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            } else {
+                defaults.removeObject(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            }
+        }
+
+        let contentView = CountingContentView(frame: NSRect(x: 0, y: 0, width: 520, height: 340))
+        let window = NSWindow(
+            contentRect: contentView.bounds,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = contentView
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let textView = NSTextView(frame: NSRect(x: 80, y: 70, width: 260, height: 170))
+        textView.isEditable = true
+        contentView.addSubview(textView)
+
+        let themeFrame = try #require(contentView.superview)
+        let overlay = FileDropOverlayView(frame: contentView.frame)
+        themeFrame.addSubview(overlay, positioned: .above, relativeTo: contentView)
+
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.drag.hit-test.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        #expect(
+            pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/issue-7811.txt") as NSURL]),
+            "Expected a file URL drag payload"
+        )
+        let dragInfo = MockDraggingInfo(
+            window: window,
+            location: textView.convert(NSPoint(x: 10, y: textView.bounds.midY), to: nil),
+            pasteboard: pasteboard
+        )
+
+        contentView.hitTestCallCount = 0
+        for index in 0..<80 {
+            let progress = CGFloat(index) / 79
+            dragInfo.draggingLocation = textView.convert(
+                NSPoint(x: 10 + progress * (textView.bounds.width - 20), y: textView.bounds.midY),
+                to: nil
+            )
+            let operation = index == 0
+                ? overlay.draggingEntered(dragInfo)
+                : overlay.draggingUpdated(dragInfo)
+            #expect(operation == .copy)
+        }
+
+        #expect(
+            contentView.hitTestCallCount == 80,
+            "The 80-event issue repro should walk the underlying AppKit hierarchy no more than once per event"
+        )
+    }
+}


### PR DESCRIPTION
Closes #7811.

## Profile evidence

Before editing, I reproduced the issue against the installed release app with 104 workspaces. The scripted drag used the issue's exact 80 mouse-moves over 4 seconds, from an `AGENTS.md` file-explorer row to the terminal center.

In the 4.41-second drag interval of the Time Profiler trace (`/tmp/cmux-7811-baseline-profile`):

- 77 main-thread samples were under `NSCoreDragReceiveMessageProc`, matching the 80-event driver.
- 313 ms were under transaction flushing (`stepTransactionFlush`).
- 211 ms were under AppKit/SwiftUI hit-testing.
- 76 ms were under `NSView._setHidden`.
- 55 ms were under layout, 8 ms under accessibility work, and 5 ms under pasteboard work.

The release build strips the cmux method names, but the system stacks align with the current `FileDropOverlayView` source: each routing query hid the overlay and independently called `contentView.hitTest`.

## Change

- Resolve the underlying content view once for each `draggingEntered` / `draggingUpdated` event and reuse that immutable result for text, web, and terminal routing during that event.
- Hit-test the overlay's known content sibling directly, so drag destination routing no longer toggles `isHidden` and triggers AppKit layout/display invalidation.
- Stop toggling visibility for pane-target geometry traversal and skip the overlay subtree itself.

The snapshot is scoped to one mouse event and restored with `defer`; it is not cached across cursor positions.

## Regression coverage

The commits intentionally preserve the required red/green order:

1. `90dd8b6bd0` adds the regression test only.
2. `6a29623c98` adds the fix.

`FileDropOverlayHitTestPerformanceTests` drives 80 distinct cursor positions through the real `draggingEntered` / `draggingUpdated` path and requires exactly 80 underlying AppKit hit-tests. Before the fix, the same event path performs several full hierarchy hit-tests per event; after the fix, it performs one current-position lookup per event.

## Verification

- PASS: the new Swift Testing file type-checks against the emitted app module with warnings treated as errors.
- PASS: Xcode frontend compilation of `ContentView.swift`, `FileDropOverlayView.swift`, and `FileDropOverlayViewHitTesting.swift`.
- PASS: `./scripts/lint-pbxproj-test-wiring.sh` (706 test files).
- PASS: `./scripts/check-pbxproj.sh`.
- PASS: `git diff --check origin/main...HEAD`.
- PASS: new Swift file is 125 lines; touched file counts are 17,575 / 491 / 448 / 125 lines respectively, and `FileDropOverlayViewHitTesting.swift` shrinks by seven lines.
- BLOCKED upstream: the compile-only `cmux-unit` scheme reaches this branch's files successfully, then current main fails in `ExtensionWorktreePrototype.swift:44-45` because #10781 assigns `let` properties that retain declaration defaults. This is unrelated to the PR.
- BLOCKED upstream: `python3 scripts/swift_file_length_budget.py` cannot run because main intentionally deleted that script and `.github/swift-file-length-budget.tsv` in #8125. The exact command was attempted and returned `Errno 2`; no removed budget infrastructure is reintroduced here.

Per the task constraint, I did not run a tagged reload or launch a development app, so no post-fix UI profile is claimed. The baseline trace is real; the regression cap is objective; CI can execute the app-hosted test. No user-facing strings changed, so localization catalogs were audited as unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790308045&installation_model_id=21920&pr_number=10783&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10783&signature=c0fdc05ce080154b9801ccab970110f4ddaeb25f8088cb3ceb3059949e03dbc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file drag-and-drop targeting across nested panes, web views, and terminal areas.
  * Dragged files now resolve the correct destination more reliably without overlay interference.
  * Preserved consistent copy behavior during repeated drag updates.

* **Performance**
  * Reduced repeated hit-testing work during file drags for smoother interactions.

* **Tests**
  * Added coverage to verify drag targets and hit-testing efficiency across repeated file-drop updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->