### PR TITLE
iOS: show Rename Workspace in the detail header menu alongside Customize

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuContent.swift
@@ -27,7 +27,9 @@ struct WorkspaceTitleMenuContent: View {
                         )
                     }
                     .accessibilityIdentifier("MobileWorkspaceTitleCustomizeMenuItem")
-                } else if canRenameWorkspace {
+                }
+
+                if canRenameWorkspace {
                     Button(action: presentRename) {
                         Label(
                             L10n.string("mobile.workspace.rename.title", defaultValue: "Rename Workspace"),

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6690,6 +6690,28 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testWorkspaceTitleMenuShowsRenameAlongsideCustomize() async throws {
+        let server = try MobileSyncMockHostServer(advertisesWorkspaceMetadata: true)
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        try openSelectedWorkspaceIfNeeded(app)
+        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 4))
+
+        tapCompactToolbarTitleMenu(app.buttons["MobileWorkspaceTitleMenu"], in: app)
+        XCTAssertTrue(
+            app.buttons["MobileWorkspaceTitleCustomizeMenuItem"].waitForExistence(timeout: 4),
+            "A metadata-capable host must offer Customize Workspace in the title menu."
+        )
+        XCTAssertTrue(
+            app.buttons["MobileWorkspaceTitleRenameMenuItem"].exists,
+            "The title menu must offer Rename Workspace alongside Customize, matching the row context menu."
+        )
+        dismissOpenMenu(in: app)
+    }
+
+    @MainActor
     func testWorkspaceDetailToolbarSurvivesDelayedTerminalLifecycle() throws {
         let app = launchWorkspaceDetailDelayedTerminalPreviewApp()
         let backButton = app.buttons["MobileWorkspaceBackButton"]
@@ -9572,6 +9594,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
     private let holdsTerminalPasteResponse: Bool
     private let rejectsTerminalPaste: Bool
     private let advertisesTaskAttachments: Bool
+    private let advertisesWorkspaceMetadata: Bool
     private let advertisesCaffeineControl: Bool
     private let taskModelsByProvider: [String: [(id: String, displayName: String)]]
     private let holdsTaskModelResponse: Bool
@@ -9657,6 +9680,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         holdsTerminalPasteResponse: Bool = false,
         rejectsTerminalPaste: Bool = false,
         advertisesTaskAttachments: Bool = false,
+        advertisesWorkspaceMetadata: Bool = false,
         advertisesCaffeineControl: Bool = false,
         taskModelsByProvider: [String: [(id: String, displayName: String)]] = [:],
         holdsTaskModelResponse: Bool = false,
@@ -9669,6 +9693,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         self.holdsTerminalPasteResponse = holdsTerminalPasteResponse
         self.rejectsTerminalPaste = rejectsTerminalPaste
         self.advertisesTaskAttachments = advertisesTaskAttachments
+        self.advertisesWorkspaceMetadata = advertisesWorkspaceMetadata
         self.advertisesCaffeineControl = advertisesCaffeineControl
         self.taskModelsByProvider = taskModelsByProvider
         self.holdsTaskModelResponse = holdsTaskModelResponse
@@ -10221,6 +10246,9 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         ]
         if advertisesTaskAttachments {
             capabilities.append("task.attachments.v1")
+        }
+        if advertisesWorkspaceMetadata {
+            capabilities.append("workspace.metadata.v1")
         }
         if advertisesCaffeineControl {
             capabilities.append("caffeine.control.v1")


### PR DESCRIPTION
The workspace detail header (title) menu rendered Rename Workspace only as a fallback when Customize Workspace was unavailable. Real Macs advertise `workspace.metadata.v1`, so Customize was always present and the header menu never offered Rename, while the row context menu offered both. This makes Rename an independent item in `WorkspaceTitleMenuContent`, matching the row context menu.

Commit 1 adds the failing XCUITest only (the mock host can now advertise `workspace.metadata.v1` like a real Mac, and `testWorkspaceTitleMenuShowsRenameAlongsideCustomize` asserts Customize and Rename coexist), commit 2 adds the fix.

Red/green CI proof is currently blocked by a pre-existing `test-ios.yml` breakage on main: every `launchConnectedApp` mock-host test times out at `waitForWorkspaceShell` (cmuxUITests.swift:7222) before reaching its own assertions. Control run of the untouched sibling test `testWorkspaceToolbarCreatesWorkspaceAndTerminal` on this head fails identically: https://github.com/manaflow-ai/cmux/actions/runs/32930766414 (new test's runs: https://github.com/manaflow-ai/cmux/actions/runs/32929060189 red commit, https://github.com/manaflow-ai/cmux/actions/runs/32929064788 head). Re-dispatch once the lane is fixed; the filter form that selects the test is `cmuxUITests/cmuxUITests/testWorkspaceTitleMenuShowsRenameAlongsideCustomize` with a full-SHA `ref`.

Verified live instead on tag `rnhdr` (isolated simulator paired to the tagged Mac, same build installed on the physical iPhone): the header menu now shows Customize Workspace, Rename Workspace, Mark as Unread, Close Workspace; tapping Rename opens the prefilled dialog, and saving a new name round-trips to the Mac (`workspace list --json` reported `custom_title` = the typed name, header title updated live). Evidence screenshots in cmuxterm-hq `artifacts/feat-ios-detail-header-rename/`.

HIG check: [Menus](https://developer.apple.com/design/human-interface-guidelines/menus). Related items stay grouped in one section, the frequent action order (Customize, Rename, read state, destructive Close last) is preserved, and every item in the group keeps an icon for uniform visual treatment.

Localization audit: no new strings. The menu reuses `mobile.workspace.rename.title` ("Rename Workspace" / "ワークスペースの名前を変更"), already translated for en and ja in `Localizable.xcstrings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)