### PR TITLE
fix: remove stored identity defaults from worktree result

### DIFF
--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -12,8 +12,8 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     let generatedArtifactContents: Data
     /// Filesystem identity captured immediately after `git worktree add`.
     /// Rollback refuses to touch a path whose checkout was replaced.
-    let worktreeDeviceID: UInt64? = nil
-    let worktreeFileID: UInt64? = nil
+    let worktreeDeviceID: UInt64?
+    let worktreeFileID: UInt64?
     /// A convenience command (e.g. a sample dev-server launcher) that should run
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #10781. Its explicit initializer assigns the two
filesystem identity `let` properties, but the stored declarations still had
`= nil` defaults. Xcode 26.5's nightly compiler therefore reports that each
immutable property may only be initialized once in `Sources/ExtensionWorktreePrototype.swift`.

This fix removes those stored-value defaults while keeping `= nil` on the
explicit initializer parameters, so callers that omit identity values remain
source-compatible. The component-wise optional identity comparison from #10781
and its existing behavior test asserting that captured identity values survive
initialization are unchanged.

This is a focused post-merge repair, not a duplicate of open PR #10777. The
remote PTY overlap is limited to the stale bridge lease and reattach work owned
by #10367/#10368, #10173/#10327/#10350; no remote PTY code is changed here.

## Verification

- `git diff --check`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- Swift 6.3.3 type-check of legacy (omitted identity) and captured-identity
  initializer call forms
- GitHub Actions nightly run 32927112366 reproduced the Xcode 26.5 diagnostics;
  the PR's CI run will provide the real Xcode compiler proof for this repair.

The repository has no `.github/swift-file-length-budget.tsv`,
`swift-warning-budget.tsv`, or `scripts/swift_file_length_budget.py` on this
base, so no budget files were created or modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309361&installation_model_id=21920&pr_number=10787&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10787&signature=80f62d7d21e57688ab9b5935ef35c35443d6fab1964ac2a3933a993f27ee98c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal initialization behavior for optional worktree identifiers without changing the user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->