### PR TITLE
iOS: show first-run onboarding only after sign-in

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileOnboardingStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileOnboardingStore.swift
@@ -3,10 +3,10 @@ import Observation
 
 /// Persists the durable milestone reached in first-run onboarding.
 ///
-/// The flow presents a short product tour, then signs in if needed, and finally
-/// starts same-account computer discovery. Persisting the transition to
-/// ``MobileOnboardingProgress/connect`` means a person who leaves during sign-in
-/// or connection resumes at the remaining prerequisite instead of replaying the
+/// The flow presents only after sign-in: a short product tour, then
+/// same-account computer discovery. Persisting the transition to
+/// ``MobileOnboardingProgress/connect`` means a person who leaves during
+/// connection resumes at the remaining prerequisite instead of replaying the
 /// product tour. QR pairing remains an explicit fallback.
 ///
 /// The backing `UserDefaults` is injected so the store is testable without

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -29,6 +29,7 @@ struct CMUXMobileRootView: View {
     /// capability closures are rebuilt for the newly selected method.
     @State private var connectionMethodObservationToken: MobileConnectionMethod?
     @Environment(\.dogfoodAttachPreparation) private var dogfoodAttachPreparation
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let signOutHook: MobileSignOutHook
     private let startupConnectionCoordinator: MobileStartupConnectionCoordinator
     #if os(iOS)
@@ -255,7 +256,11 @@ struct CMUXMobileRootView: View {
             pairingSheet(initialPresentation: pairingPresentation)
         }
         #endif
-        .animation(.snappy(duration: 0.18), value: isAuthenticated)
+        // Full-screen surface swaps (sign-in <-> onboarding <-> shell) get a
+        // longer, softer curve than in-shell phase changes; 0.18s reads as a
+        // hard cut across two unrelated screens.
+        .animation(.smooth(duration: 0.35), value: isAuthenticated)
+        .animation(.smooth(duration: 0.35), value: shouldShowOnboarding)
         .animation(.snappy(duration: 0.18), value: store.phase)
         .onAppear {
             syncShellAuthentication(isAuthenticated)
@@ -470,9 +475,19 @@ struct CMUXMobileRootView: View {
         } else if shouldShowOnboardingPreview {
             onboardingPreview
         } else if shouldShowOnboarding {
+            // Sign-in hands directly into onboarding, so the swap reads as a
+            // forward push in the tour's paging direction rather than a cut.
             onboardingFlow
+                .transition(reduceMotion ? .opacity : .asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .opacity
+                ))
         } else if !isAuthenticated {
             SignInView()
+                .transition(reduceMotion ? .opacity : .asymmetric(
+                    insertion: .opacity,
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
         } else {
             switch MobileRootAuthGate.shellSurface(
                 connectionState: store.connectionState,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -797,10 +797,14 @@ struct CMUXMobileRootView: View {
         )
     }
 
-    /// Whether first-run onboarding has an unfinished durable milestone.
+    /// Whether first-run onboarding should present: only for a signed-in
+    /// account, and only while a durable milestone remains unfinished. Signed
+    /// out, `rootContent` falls through to the sign-in screen instead.
     private var shouldShowOnboarding: Bool {
         #if os(iOS)
-        return onboardingStore.progress.shouldShowOnboarding
+        return onboardingStore.progress.shouldShowOnboarding(
+            isAuthenticated: isAuthenticated
+        )
         #else
         return false
         #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -813,12 +813,16 @@ struct CMUXMobileRootView: View {
     }
 
     /// Whether first-run onboarding should present: only for a signed-in
-    /// account, and only while a durable milestone remains unfinished. Signed
-    /// out, `rootContent` falls through to the sign-in screen instead.
+    /// account session, and only while a durable milestone remains unfinished.
+    /// Signed out, `rootContent` falls through to the sign-in screen instead.
+    /// Deliberately narrower than the composite `isAuthenticated`: a temporary
+    /// attach-ticket authentication must reach the shell so the attach
+    /// completes, not detour into the tour (whose discovery keep-alive
+    /// requires an account session anyway).
     private var shouldShowOnboarding: Bool {
         #if os(iOS)
         return onboardingStore.progress.shouldShowOnboarding(
-            isAuthenticated: isAuthenticated
+            isAuthenticated: authManager.isAuthenticated
         )
         #else
         return false

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
@@ -4,8 +4,8 @@ import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
 
-/// A short product tour that routes into authentication after the tour, then
-/// same-account computer discovery, with pairing available for Tailscale.
+/// A short product tour presented after sign-in, ending in same-account
+/// computer discovery, with pairing available for Tailscale.
 struct OnboardingFlowView: View {
     let context: OnboardingContext
     let isAuthenticated: Bool

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
@@ -2,16 +2,20 @@ public import CmuxMobileShellModel
 
 /// Pure gating policy for the first-run onboarding screen in the mobile root scene.
 ///
-/// Onboarding demonstrates the product before authentication, then hands into
-/// sign-in and same-account computer discovery at the connection milestone. The
-/// single decision uses only durable onboarding progress. Live connection state
-/// never suppresses an unfinished flow, so cancelling QR fallback returns to the
-/// connection step.
+/// Onboarding presents only to a signed-in account: a signed-out launch goes
+/// straight to sign-in, and the flow presents (or resumes) once authentication
+/// succeeds, handing into same-account computer discovery at the connection
+/// milestone. Beyond authentication the decision uses only durable onboarding
+/// progress. Live connection state never suppresses an unfinished flow, so
+/// cancelling QR fallback returns to the connection step.
 public extension MobileOnboardingProgress {
     /// Whether the first-run onboarding should be presented.
     ///
-    /// - Returns: `true` until onboarding is explicitly completed.
-    var shouldShowOnboarding: Bool {
-        self != .complete
+    /// - Parameter isAuthenticated: Whether an account is signed in. Without
+    ///   one there is nothing to onboard into, so sign-in owns the screen.
+    /// - Returns: `true` for a signed-in account until onboarding is
+    ///   explicitly completed.
+    func shouldShowOnboarding(isAuthenticated: Bool) -> Bool {
+        isAuthenticated && self != .complete
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
@@ -8,12 +8,20 @@ import Testing
         MobileOnboardingProgress.welcome,
         MobileOnboardingProgress.connect,
     ])
-    func showsEveryIncompleteMilestone(_ progress: MobileOnboardingProgress) {
-        #expect(progress.shouldShowOnboarding)
+    func showsEveryIncompleteMilestoneWhenSignedIn(_ progress: MobileOnboardingProgress) {
+        #expect(progress.shouldShowOnboarding(isAuthenticated: true))
     }
 
     @Test func skipsCompletedOnboarding() {
-        #expect(!MobileOnboardingProgress.complete.shouldShowOnboarding)
+        #expect(!MobileOnboardingProgress.complete.shouldShowOnboarding(isAuthenticated: true))
     }
 
+    @Test(arguments: [
+        MobileOnboardingProgress.welcome,
+        MobileOnboardingProgress.connect,
+        MobileOnboardingProgress.complete,
+    ])
+    func neverShowsSignedOut(_ progress: MobileOnboardingProgress) {
+        #expect(!progress.shouldShowOnboarding(isAuthenticated: false))
+    }
 }

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -12,8 +12,8 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     let generatedArtifactContents: Data
     /// Filesystem identity captured immediately after `git worktree add`.
     /// Rollback refuses to touch a path whose checkout was replaced.
-    let worktreeDeviceID: UInt64? = nil
-    let worktreeFileID: UInt64? = nil
+    let worktreeDeviceID: UInt64?
+    let worktreeFileID: UInt64?
     /// A convenience command (e.g. a sample dev-server launcher) that should run
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.


### PR DESCRIPTION
Onboarding previously presented on every fresh install ahead of authentication, so signed-out users saw the product tour before they could sign in. There is no point onboarding someone who cannot use the app yet.

`MobileOnboardingProgress.shouldShowOnboarding` (the pure gate in `MobileOnboardingGate.swift`) now takes `isAuthenticated`. Signed out, the root scene falls through to `SignInView`; once sign-in succeeds, onboarding presents and resumes at its persisted milestone (`welcome` or `connect`). Signing out mid-onboarding returns to sign-in, and the flow resumes after re-authentication. The `rootContent` branch order is unchanged, and the debug preview harness (`CMUX_UITEST_ONBOARDING_PREVIEW`) is unaffected because it bypasses the real gate. The connect stage's signed-out affordances remain as defensive code but are unreachable in first-run.

Stale doc comments in `MobileOnboardingStore` and `OnboardingFlowView` describing the tour-then-sign-in order were updated. `MobileOnboardingGateTests` covers signed-in incomplete milestones (shows), signed-in complete (hidden), and signed-out at every milestone (hidden).

Includes a cherry-pick of #10787 (remove stored identity defaults from worktree result) because current `main` HEAD (12430deb9f) does not compile without it; it merges as a no-op once that PR lands.

HIG: reviewed https://developer.apple.com/design/human-interface-guidelines/onboarding — onboarding stays brief, skippable, and resumes at durable milestones; presenting it after authentication follows the guidance to postpone flows people cannot act on yet. No user-facing strings changed, so no localization updates were needed (audited: gate, root view branch, doc comments only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790310095&installation_model_id=21920&pr_number=10789&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10789&signature=17ab5b9aea489e82e6bd21ceed673fc88d7fb592877b8557b54de2864f2a1cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding now appears only after sign-in.
  - Signed-out users proceed directly to authentication.
  - Returning users resume onboarding from the next incomplete prerequisite.
  - The product tour concludes with discovery of a computer using the same account.

- **Bug Fixes**
  - Completed onboarding remains hidden for signed-in users.
  - Onboarding progress stays hidden while signed out.

- **Usability Improvements**
  - Sign-in and onboarding transitions are smoother and respect reduced-motion preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->