### PR TITLE
iOS: reserve title space for the badged back button

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -19,6 +19,13 @@ import CoreGraphics
 struct MobileLeadingToolbarTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    /// Other-workspace unread count folded into the back button. A badged
+    /// back button renders chevron + spacing + a mono badge circle, up to
+    /// ~32pt wider than the bare chevron; reserving only the bare width let
+    /// the title over-claim exactly when another workspace held unread, and
+    /// the resulting first-pass collapse is invisible to the recovery
+    /// ratchet, so it stuck until remount.
+    let backButtonUnreadCount: Int
     let hasTrailingCluster: Bool
     /// Sum of the measured content widths of the structurally visible trailing
     /// toolbar items, 0 until the first layout pass reports them.
@@ -37,6 +44,10 @@ struct MobileLeadingToolbarTitleWidth {
     let hadTrailingCollapse: Bool
 
     static let backButtonReserve: CGFloat = 44
+    /// Chevron-to-badge spacing plus the badge circle (18pt minimum, wider
+    /// for "99+"), matching WorkspaceBackButton's layout with slack.
+    static let backButtonBadgeReserve: CGFloat = 24
+    static let backButtonWideBadgeReserve: CGFloat = 32
     static let trailingReserveBase: CGFloat = 64
     /// Dogfood on a 402pt iPhone 17 measured ~22pt of dead gap between the
     /// title pill and the trailing capsule under the original 84pt margin +
@@ -61,6 +72,7 @@ struct MobileLeadingToolbarTitleWidth {
     init(
         contentWidth: CGFloat,
         hasBackButton: Bool,
+        backButtonUnreadCount: Int = 0,
         hasTrailingCluster: Bool,
         measuredTrailingItemsWidth: CGFloat = 0,
         measuredTrailingItemCount: Int = 0,
@@ -69,6 +81,7 @@ struct MobileLeadingToolbarTitleWidth {
     ) {
         self.contentWidth = contentWidth
         self.hasBackButton = hasBackButton
+        self.backButtonUnreadCount = backButtonUnreadCount
         self.hasTrailingCluster = hasTrailingCluster
         self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
         self.measuredTrailingItemCount = measuredTrailingItemCount
@@ -78,9 +91,18 @@ struct MobileLeadingToolbarTitleWidth {
 
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
-        let leading = hasBackButton ? Self.backButtonReserve : 0
         let recovery = hadTrailingCollapse ? Self.collapseRecoveryReserve : 0
-        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing - recovery)
+        return max(0, contentWidth - leadingReserve - trailingReserve - Self.barMarginsAndSpacing - recovery)
+    }
+
+    private var leadingReserve: CGFloat {
+        guard hasBackButton else { return 0 }
+        guard backButtonUnreadCount > 0 else { return Self.backButtonReserve }
+        // WorkspaceBackButton caps the visible badge text at "99+".
+        let badge = backButtonUnreadCount > 99
+            ? Self.backButtonWideBadgeReserve
+            : Self.backButtonBadgeReserve
+        return Self.backButtonReserve + badge
     }
 
     private var trailingReserve: CGFloat {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -412,6 +412,7 @@ struct WorkspaceDetailView: View {
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
+            backButtonUnreadCount: backButtonConfiguration?.unreadCount ?? 0,
             hasTrailingCluster: true,
             measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
             measuredTrailingItemCount: measuredWidths.count,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -32,6 +32,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
         let cap = MobileLeadingToolbarTitleWidth(
             contentWidth: value.contentWidth,
             hasBackButton: value.hasBackButton,
+            backButtonUnreadCount: value.backButtonUnreadCount,
             hasTrailingCluster: value.hasTrailingCluster,
             measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
             measuredTrailingItemCount: value.measuredTrailingItemCount,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -4,6 +4,8 @@ import CoreGraphics
 struct WorkspaceTitleMenuValue: Equatable {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    /// Badge-aware back reserve; see `MobileLeadingToolbarTitleWidth`.
+    let backButtonUnreadCount: Int
     let hasTrailingCluster: Bool
     let measuredTrailingItemsWidth: CGFloat
     let measuredTrailingItemCount: Int

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -177,3 +177,61 @@ import Testing
             >= MobileLeadingToolbarTitleWidth.unmeasuredTrailingItemReserve)
     }
 }
+
+extension MobileLeadingToolbarTitleWidthTests {
+    @Test func badgedBackButtonShrinksTheTitle() {
+        // iOS 27 sim dogfood: opening a workspace while another held unread
+        // rendered the chevron + badge back button ~24pt wider than the bare
+        // chevron the reserve assumed, folding the picker into the More menu
+        // from the first pass, invisibly to the recovery ratchet.
+        let bare = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let badged = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            backButtonUnreadCount: 3,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let wideBadge = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            backButtonUnreadCount: 250,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+
+        #expect(bare.cap - badged.cap
+            == MobileLeadingToolbarTitleWidth.backButtonBadgeReserve)
+        #expect(bare.cap - wideBadge.cap
+            == MobileLeadingToolbarTitleWidth.backButtonWideBadgeReserve)
+    }
+
+    @Test func badgeWithoutBackButtonReservesNothing() {
+        let value = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: false,
+            backButtonUnreadCount: 5,
+            hasTrailingCluster: true,
+            trailingItemCount: 1
+        )
+        let bare = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: false,
+            hasTrailingCluster: true,
+            trailingItemCount: 1
+        )
+
+        #expect(value.cap == bare.cap)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -34,6 +34,7 @@ import Testing
         WorkspaceTitleMenuValue(
             contentWidth: 390,
             hasBackButton: true,
+            backButtonUnreadCount: 0,
             hasTrailingCluster: true,
             measuredTrailingItemsWidth: 0,
             measuredTrailingItemCount: 0,


### PR DESCRIPTION
Dogfood on an iOS 27.0 simulator (build containing https://github.com/manaflow-ai/cmux/pull/10646, verified by ancestry of its CMUX_GIT_SHA): opening a workspace occasionally showed the terminal picker inside the More "…" from the first frame, and reopening the same workspace cleared it. The screenshots carried the tell: every broken shot had an unread badge on the back button, and the healthy after-reopen shot did not (reopening cleared the unread).

Mechanism: `MobileLeadingToolbarTitleWidth` reserves a flat `backButtonReserve = 44` for the back control, but `WorkspaceBackButton` folds the other-workspace unread count into the button (chevron + 5pt spacing + an 18pt-minimum mono badge circle, wider for "99+"), rendering ~24-32pt wider than the bare chevron. With a badge present the title over-claimed by exactly that amount, the bar over-committed on the first pass, and the picker folded into More. A collapse born on the first pass never emits the attach-then-detach signature that the #10620 recovery ratchet watches, so it stuck until remount, which is why it read as rare and self-healing.

Fix: the leading reserve now scales with the same `unreadCount` the button renders: +24pt for a badge, +32pt for the "99+" cap. Deterministic, no measurement or timing involved. Regression tests pin both deltas and the no-back-button case.

Verified on an isolated iOS 27.0 simulator with a staged unread badge (second workspace receiving output): badged mount keeps back, title, Changes, and picker all in the bar.

No user-facing strings changed (localization audit: none needed). HIG reference: Navigation bars (https://developer.apple.com/design/human-interface-guidelines/navigation-bars), controls remain visible rather than overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790311028&installation_model_id=21920&pr_number=10790&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10790&signature=06dd528942e578d2a1d590a625d0e6c6d19c51ddccdaa0bde2f9df9ac11e02ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS workspace title layout when the back button displays unread-count badges.
  * Added wider spacing for badges showing counts above 99, preventing title overlap.

* **Tests**
  * Added coverage for regular and wide unread badges.
  * Verified no extra space is reserved when a back button is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->