### PR TITLE
relay: revert the crate to its last gated-green state (unbreak main + the cmux-relay release lane)

### DIFF
--- a/cmux-tui/crates/chatmux-relay/README.md
+++ b/cmux-tui/crates/chatmux-relay/README.md
@@ -72,7 +72,7 @@ release have completed.
    env, hard process-group timeouts, the v5 process-credential runtime,
    and the reconciled-trust gate (observe = read-only verbs only).
    Slices 2 and 3, plus the v6 pane verbs, are included; the advertised
-   dialect is **7**. Version 7 gates the additive PTY operational error codes.
+   dialect is **6**.
 4. **Wire-v6 pane verbs + preview proxy (DONE)** — fs/git/watch verbs and
    the chobitsu-injecting preview proxy. These verbs have no JS
    implementation; they are Rust-first by decision.
@@ -84,9 +84,8 @@ release have completed.
 
 ### Intentional divergences from the JS relay (still open)
 
-- The advertised relay protocol is **v7**. PTY and exec remain capability
-  gated at v4 and v3; workspace/watch/preview use v6. PTY operational errors
-  use the v7 outer feature gate and downgrade to `failed` for older Workers.
+- The advertised relay protocol is **v6**. PTY and exec remain capability
+  gated at v4 and v3; workspace/watch/preview use v6.
 - `--code` prints the `chatmux://pair` link without the terminal QR
   graphic (QR rendering comes with a later slice; the link carries the
   same payload).

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -853,44 +853,6 @@ pub struct RuntimeFile {
     pub path_hint: String,
 }
 
-/// Return unique runtime values in longest-first order. The values are
-/// credentials supplied for one process and must never cross the relay wire.
-fn runtime_redactions(runtime: &ProcessRuntime) -> Vec<String> {
-    let mut values: Vec<String> =
-        runtime.environment.values().filter(|value| !value.is_empty()).cloned().collect();
-    values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-    values.dedup();
-    values
-}
-
-fn redact_runtime_text(text: &str, redactions: &[String], capture_truncated: bool) -> String {
-    if redactions.is_empty() {
-        return text.to_owned();
-    }
-    let mut partial_length = 0;
-    if capture_truncated {
-        for secret in redactions {
-            let limit = secret.len().saturating_sub(1).min(text.len());
-            for length in (1..=limit).rev() {
-                if secret.is_char_boundary(length)
-                    && text.is_char_boundary(text.len() - length)
-                    && text.ends_with(&secret[..length])
-                {
-                    partial_length = partial_length.max(length);
-                    break;
-                }
-            }
-        }
-    }
-    let captured = if partial_length == 0 {
-        text.to_owned()
-    } else {
-        let split = text.len() - partial_length;
-        format!("{}[REDACTED_SECRET]", &text[..split])
-    };
-    redactions.iter().fold(captured, |current, secret| current.replace(secret, "[REDACTED_SECRET]"))
-}
-
 /// Validate the secret-bearing frame field without returning secret text in
 /// errors (v5 one-call process credentials).
 pub fn process_runtime(frame_runtime: Option<&Value>) -> Result<ProcessRuntime, String> {
@@ -938,9 +900,7 @@ pub fn process_runtime(frame_runtime: Option<&Value>) -> Result<ProcessRuntime, 
         let path_hint = file.get("pathHint").and_then(Value::as_str);
         if !valid_environment_name(&content)
             || !valid_environment_name(&path_var)
-            || content == path_var
             || path_hint.is_none()
-            || path_hint.is_some_and(|hint| hint.len() > 128 || hint.chars().any(char::is_control))
             || !environment.contains_key(&content)
         {
             return Err("process runtime file is invalid".to_owned());
@@ -1005,7 +965,7 @@ enum RunSpec<'a> {
 
 enum RunOutcome {
     Done { exit_code: i64, output: String },
-    TimedOut { output: String },
+    TimedOut,
     Failed { message: String },
 }
 
@@ -1038,7 +998,6 @@ async fn run_spec(
     cwd_fd: Option<ScopedCwdFd>,
     timeout_ms: u64,
     env: &HashMap<String, String>,
-    redactions: &[String],
 ) -> RunOutcome {
     use tokio::io::AsyncReadExt as _;
     let mut command = match &spec {
@@ -1106,8 +1065,7 @@ async fn run_spec(
     #[cfg(unix)]
     let mut process_group_guard = ProcessGroupGuard { pid, armed: true };
     // Collect a little past the char cap (bytes over-approximate chars).
-    let redaction_room = redactions.iter().map(String::len).sum::<usize>();
-    let byte_cap = MAX_OUTPUT_CHARS.saturating_add(redaction_room.max(10_000)).saturating_mul(4);
+    let byte_cap = (MAX_OUTPUT_CHARS + 10_000) * 4;
     let mut stdout = child.stdout.take();
     let mut stderr = child.stderr.take();
     let mut output: Vec<u8> = Vec::new();
@@ -1280,7 +1238,7 @@ async fn run_spec(
         process_group_guard.armed = false;
     }
     if timed_out {
-        return RunOutcome::TimedOut { output: String::from_utf8_lossy(&output).into_owned() };
+        return RunOutcome::TimedOut;
     }
     let text = String::from_utf8_lossy(&output);
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
@@ -1441,32 +1399,22 @@ fn run_reply(
     limit: Option<&Value>,
     default_limit: Option<i64>,
     timeout_ms: u64,
-    redactions: &[String],
 ) -> Value {
     let default_value = default_limit.map(Value::from);
     let limit = limit.or(default_value.as_ref());
     match outcome {
-        RunOutcome::Failed { message } => fail_result(
-            version,
-            action_id,
-            "failed",
-            &redact_runtime_text(&message, redactions, false),
-        ),
-        RunOutcome::TimedOut { output } => {
+        RunOutcome::Failed { message } => fail_result(version, action_id, "failed", &message),
+        RunOutcome::TimedOut => {
             let seconds = (timeout_ms as f64 / 1000.0).round() as u64;
-            let safe_output = redact_runtime_text(&output, redactions, true);
-            let tail: String =
-                safe_output.chars().rev().take(2_000).collect::<String>().chars().rev().collect();
-            let message = if tail.trim().is_empty() {
-                format!("command timed out after {seconds}s")
-            } else {
-                format!("command timed out after {seconds}s; output tail:\n{tail}")
-            };
-            fail_result(version, action_id, "timeout", &message)
+            fail_result(
+                version,
+                action_id,
+                "timeout",
+                &format!("command timed out after {seconds}s"),
+            )
         }
         RunOutcome::Done { exit_code, output } => {
-            let safe_output = redact_runtime_text(&output, redactions, true);
-            let bounded = truncate_output(&safe_output, MAX_OUTPUT_CHARS);
+            let bounded = truncate_output(&output, MAX_OUTPUT_CHARS);
             let (capped, truncated) = cap_lines(&bounded.output, bounded.truncated, limit);
             let mut result = Map::new();
             result.insert("exitCode".to_owned(), Value::from(exit_code));
@@ -1529,10 +1477,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
     let home = context.home.clone();
     let server_roots = match frame_roots(frame) {
         Ok(roots) => roots,
-        // RelayActionErrorCode deliberately has no request-shape variant;
-        // malformed roots are a value-free failed action, not a new wire
-        // code that older Workers would reject.
-        Err(message) => return fail("failed", message),
+        Err(message) => return fail("bad_request", message),
     };
     let root_lists: RootLists<'_> = [context.local_roots.as_deref(), server_roots.as_deref()];
     if let Err(message) = ensure_scoped_file_roots_available(cfg!(unix), &root_lists) {
@@ -1553,7 +1498,6 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
     }
     let mut env = context.env.clone();
     env.extend(runtime.environment.clone());
-    let redactions = runtime_redactions(&runtime);
     let first_roots = root_lists.iter().flatten().find(|roots| !roots.is_empty());
     let workdir = match first_roots {
         Some(roots) => expand_path(&roots[0], &home, &home).display().to_string(),
@@ -1698,18 +1642,9 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 command_cwd_fd,
                 timeout_ms,
                 &env,
-                &redactions,
             )
             .await;
-            run_reply(
-                version,
-                &action_id,
-                outcome,
-                args.get("limit"),
-                Some(200),
-                timeout_ms,
-                &redactions,
-            )
+            run_reply(version, &action_id, outcome, args.get("limit"), Some(200), timeout_ms)
         }
         "find" => {
             let raw =
@@ -1741,7 +1676,6 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                     args.get("limit"),
                     Some(500),
                     timeout_ms,
-                    &redactions,
                 );
             }
             #[cfg(not(unix))]
@@ -1779,18 +1713,9 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 command_cwd_fd,
                 timeout_ms,
                 &env,
-                &redactions,
             )
             .await;
-            run_reply(
-                version,
-                &action_id,
-                outcome,
-                args.get("limit"),
-                Some(500),
-                timeout_ms,
-                &redactions,
-            )
+            run_reply(version, &action_id, outcome, args.get("limit"), Some(500), timeout_ms)
         }
         "exec" => {
             let command = args.get("command").and_then(Value::as_str).unwrap_or_default();
@@ -1829,10 +1754,9 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 scoped_cwd_fd,
                 timeout_ms,
                 &env,
-                &redactions,
             )
             .await;
-            run_reply(version, &action_id, outcome, None, None, timeout_ms, &redactions)
+            run_reply(version, &action_id, outcome, None, None, timeout_ms)
         }
         _ => fail("unsupported_verb", &format!("verb \"{verb}\" fell through")),
     }
@@ -2231,11 +2155,11 @@ mod tests {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
         let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env, &[]),
+            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env),
         )
         .await
         .expect("timeout cleanup must not wait for a descendant pipe");
-        assert!(matches!(outcome, RunOutcome::TimedOut { .. }));
+        assert!(matches!(outcome, RunOutcome::TimedOut));
     }
     #[tokio::test]
     async fn exec_receives_scoped_process_environment_values() {
@@ -2251,34 +2175,7 @@ mod tests {
             &context,
         )
         .await;
-        assert_eq!(exec["result"]["output"], "[REDACTED_SECRET]");
-        assert!(!exec.to_string().contains("abc123"));
-        std::fs::remove_dir_all(&root).ok();
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn timeout_result_never_reflects_runtime_secret() {
-        let root = scratch("procenv-timeout");
-        let roots = vec![root.display().to_string()];
-        let mut context = ctx("supervised", Some(roots.clone()), root.clone());
-        context.env =
-            scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
-        let result = perform_action(
-            &json!({
-                "verb": "exec",
-                "actionId": "timeout-secret",
-                "allowedRoots": roots,
-                "args": { "command": "printf '%s' \"$TIMEOUT_SECRET\"; sleep 5" },
-                "timeoutMs": 1000,
-                "runtime": { "environment": { "TIMEOUT_SECRET": "timeout-private-value" }, "files": [] }
-            }),
-            &context,
-        )
-        .await;
-        assert_eq!(result["ok"], false);
-        assert_eq!(result["code"], "timeout");
-        assert!(!result.to_string().contains("timeout-private-value"));
+        assert_eq!(exec["result"]["output"], "abc123");
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/autostart.rs
+++ b/cmux-tui/crates/chatmux-relay/src/autostart.rs
@@ -221,22 +221,22 @@ mod tests {
     #[test]
     fn rejects_npx_cache_paths_but_allows_persistent_installs() {
         assert!(is_ephemeral_npx_path(Path::new(
-            "/Users/example/.npm/_npx/4f3/node_modules/cmux-relay-darwin-arm64/bin/chatmux-relay",
+            "/Users/example/.npm/_npx/4f3/node_modules/cmux-relay-darwin-arm64/bin/cmux-relay",
         )));
         assert!(is_ephemeral_npx_path(Path::new(
-            r"C:\\Users\\example\\AppData\\Local\\npm-cache\\_npx\\4f3\\node_modules\\cmux-relay-win32-x64\\bin\\chatmux-relay.exe",
+            r"C:\\Users\\example\\AppData\\Local\\npm-cache\\_npx\\4f3\\node_modules\\cmux-relay-win32-x64\\bin\\cmux-relay.exe",
         )));
         assert!(!is_ephemeral_npx_path(Path::new(
-            "/usr/local/lib/node_modules/cmux-relay-linux-x64/bin/chatmux-relay",
+            "/usr/local/lib/node_modules/cmux-relay-linux-x64/bin/cmux-relay",
         )));
         assert!(!is_ephemeral_npx_path(Path::new(
-            "/work/project/node_modules/cmux-relay-linux-x64/bin/chatmux-relay",
+            "/work/project/node_modules/cmux-relay-linux-x64/bin/cmux-relay",
         )));
     }
 
     #[test]
     fn npx_autostart_refusal_explains_the_durable_install_requirement() {
-        let error = validate_autostart_executable(Path::new("/tmp/_npx/abc/bin/chatmux-relay"))
+        let error = validate_autostart_executable(Path::new("/tmp/_npx/abc/bin/cmux-relay"))
             .expect_err("ephemeral npx path must be refused");
         assert!(error.contains("durable relay executable"));
         assert!(error.contains("npm install --global cmux-relay"));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -28,31 +28,12 @@ pub trait ControlHandle: Send + Sync {
     ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>>;
     /// Fire-and-forget (input/resize hot paths); the response line drops.
     fn send(&self, cmd: &str, params: Value);
-    /// Send one mutating command and wait for an ordered daemon barrier before
-    /// allowing the next session command. The default is for deterministic
-    /// test controls; UnixControl overrides it with a FIFO `identify` reply.
-    fn ordered_send(
-        &self,
-        cmd: &str,
-        params: Value,
-    ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-        self.send(cmd, params);
-        Box::pin(std::future::ready(true))
-    }
     fn on_event(&self, handler: EventHandler);
     /// Fires on unexpected close only (not after `end()`).
     fn on_close(&self, handler: CloseHandler);
     fn pause(&self);
     fn resume(&self);
     fn end(&self);
-    /// Close this transport only after the daemon has observed all commands
-    /// already queued on it. Test controls and older transports that have no
-    /// acknowledgement primitive may return `true` immediately; the Unix
-    /// implementation overrides this with an ordered `identify` barrier.
-    fn end_and_wait(&self) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-        self.end();
-        Box::pin(std::future::ready(true))
-    }
 }
 
 #[cfg(unix)]
@@ -113,8 +94,6 @@ mod unix {
         raw_fd: std::os::fd::RawFd,
         next_id: AtomicU64,
         timeout_ms: u64,
-        ended: AtomicBool,
-        barrier_completed: AtomicBool,
     }
 
     /// Connect a JSON-lines control client to a cmux-tui session socket.
@@ -156,8 +135,6 @@ mod unix {
             raw_fd,
             next_id: AtomicU64::new(1),
             timeout_ms,
-            ended: AtomicBool::new(false),
-            barrier_completed: AtomicBool::new(false),
         }))
     }
 
@@ -178,20 +155,15 @@ mod unix {
             let Some(line) = next_line else {
                 break;
             };
+            if shared.closed.load(Ordering::SeqCst) {
+                if let Some(written) = line.written {
+                    let _ = written.send(false);
+                }
+                continue;
+            }
             let result = {
                 let mut writer = writer.lock().await;
-                // Re-check only after acquiring the writer lock. `end()` can
-                // close the shared state while this task is waiting for a
-                // previous write; checking before the lock allowed a stale
-                // line to pass that check and be written after teardown.
-                if shared.closed.load(Ordering::SeqCst) {
-                    Err(std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "control writer closed",
-                    ))
-                } else {
-                    writer.write_all(&line.bytes).await
-                }
+                writer.write_all(&line.bytes).await
             };
             let succeeded = result.is_ok();
             if let Some(written) = line.written {
@@ -339,34 +311,6 @@ mod unix {
             let _ = self.enqueue_line(id, cmd, params, None);
         }
 
-        fn ordered_send(
-            &self,
-            cmd: &str,
-            params: Value,
-        ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            let cmd = cmd.to_owned();
-            Box::pin(async move {
-                if self.shared.closed.load(Ordering::Acquire) {
-                    return false;
-                }
-                let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-                if !self.enqueue_line(id, &cmd, params, None) {
-                    return false;
-                }
-                // JSON-lines requests are processed in read order by the
-                // daemon. The identify reply therefore acknowledges this
-                // command and every earlier command on this socket.
-                tokio::time::timeout(
-                    Duration::from_millis(self.timeout_ms),
-                    self.request("identify", serde_json::json!({})),
-                )
-                .await
-                .ok()
-                .flatten()
-                .is_some_and(|response| response.get("ok").and_then(Value::as_bool) == Some(true))
-            })
-        }
-
         fn on_event(&self, handler: EventHandler) {
             *self.shared.event_handler.lock().expect("control event lock") = Some(handler);
         }
@@ -385,9 +329,6 @@ mod unix {
         }
 
         fn end(&self) {
-            if self.ended.swap(true, Ordering::SeqCst) {
-                return;
-            }
             self.shared.deliberate.store(true, Ordering::SeqCst);
             self.shared.settle_closed();
             // Shut both directions so the read loop sees EOF and any blocked
@@ -397,40 +338,6 @@ mod unix {
             unsafe {
                 libc::shutdown(self.raw_fd, libc::SHUT_RDWR);
             }
-        }
-
-        fn end_and_wait(&self) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            Box::pin(async move {
-                if self.barrier_completed.load(Ordering::Acquire) {
-                    return true;
-                }
-                if self.shared.closed.load(Ordering::Acquire) {
-                    return false;
-                }
-                // `identify` is side-effect free and is ordered behind all
-                // earlier control commands on this JSON-lines connection.
-                // Its response is the daemon-observed close barrier. If the
-                // transport is already closed, no new claim may be admitted.
-                let barrier = tokio::time::timeout(
-                    Duration::from_millis(self.timeout_ms),
-                    self.request("identify", serde_json::json!({})),
-                )
-                .await
-                .ok()
-                .flatten()
-                .is_some_and(|response| response.get("ok").and_then(Value::as_bool) == Some(true));
-                if !barrier {
-                    self.end();
-                    return false;
-                }
-                self.barrier_completed.store(true, Ordering::Release);
-                self.end();
-                // The identify response is the daemon-observed barrier. Do
-                // not wait for peer EOF after local shutdown: EOF ordering is
-                // transport-dependent and cannot strengthen the protocol
-                // guarantee.
-                true
-            })
         }
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/main.rs
+++ b/cmux-tui/crates/chatmux-relay/src/main.rs
@@ -580,17 +580,7 @@ async fn main() {
     let parsed = match parse_cli_args(std::env::args().skip(1)) {
         Ok(parsed) => parsed,
         Err(error) => {
-            // Keep user-facing diagnostics independent from internal parser
-            // implementation names. Do not echo raw argv values here:
-            // positional arguments may contain copied credentials.
-            let (public_code, public_message) = match error.code {
-                "coderouter_unavailable" => (
-                    "unsupported_command",
-                    "cmux-relay: that command is not supported in this version.",
-                ),
-                _ => (error.code, error.message.as_str()),
-            };
-            eprintln!("cmux-relay error [{public_code}]: {public_message}");
+            eprintln!("{}", error.message);
             eprintln!("Run `cmux-relay --help` for usage.");
             std::process::exit(2);
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2803,11 +2803,11 @@ impl TerminalSizing {
             && !target.queue.closing_running.load(Ordering::Acquire)
             && !target.queue.wire_running.load(Ordering::Acquire)
             && wire_pending_empty
-            && state.closing.is_empty()
-            && state.closing_waiters.is_empty()
-            && state.closing_inflight.is_empty()
-            && state.abort_pending.is_empty()
-            && state.dispatching.is_none()
+            && queue_state.closing.is_empty()
+            && queue_state.closing_waiters.is_empty()
+            && queue_state.closing_inflight.is_empty()
+            && queue_state.abort_pending.is_empty()
+            && queue_state.dispatching.is_none()
         {
             target.queue.close_locked(&mut queue_state);
             targets.remove(&target.key);
@@ -8775,8 +8775,8 @@ mod tests {
                 && fence.endpoint_ptr == endpoint_ptr(&endpoint)
         }));
         drop(state);
-        let commands: Vec<&str> =
-            control.sends().iter().map(|(command, _)| command.as_str()).collect();
+        let sends = control.sends();
+        let commands: Vec<&str> = sends.iter().map(|(command, _)| command.as_str()).collect();
         assert_eq!(commands, vec!["resize-surface", "set-client-sizing", "send"]);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -20,12 +20,10 @@
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
 use std::collections::{HashMap, VecDeque};
-use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, Weak};
-use std::time::Duration;
-use tokio::sync::{Notify, oneshot};
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -36,7 +34,6 @@ use serde_json::{Value, json};
 use crate::actions::{expand_path, scrubbed_env, validate_request_path};
 use crate::control::ControlHandle;
 use crate::relay_wire::RelayPtyErrorCode;
-use crate::wire::PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
 
@@ -50,25 +47,13 @@ pub const SCROLLBACK_LIMIT: usize = 256 * 1024;
 pub const OUTPUT_BUFFER_CAP: u64 = 1024 * 1024;
 /// cmux-tui control protocol floor for attach-surface/send.
 const CONTROL_MIN_PROTOCOL: i64 = 5;
-/// cmux-tui protocol floor for per-surface geometry ownership. Older daemons
-/// still apply a direct `resize-surface`; newer daemons require a verified
-/// `set-client-sizing` claim before a resize changes the PTY grid.
-const CLIENT_SIZING_MIN_PROTOCOL: i64 = 10;
-/// Inner terminals listed per session (surface_list stays bounded). This is a
-/// deliberate capacity/security limit, not a pagination hint: callers must
-/// fail closed when the daemon reports more live PTYs than this cap.
+/// Inner terminals listed per session (surface_list stays bounded).
 const MAX_ENUM_TERMINALS: usize = 8;
 const MAX_ALLOWED_ROOTS: usize = 32;
 const MAX_ALLOWED_ROOT_BYTES: usize = 16 * 1024;
 const MAX_ENUM_SURFACES: usize = 8;
 const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
-/// A shell viewer must not retain unbounded output while its callback is
-/// blocked. The byte cap matches the per-attachment socket budget, and one
-/// event slot is reserved for the terminal control transition.
-const VIEWER_DELIVERY_MAX_BYTES: usize = OUTPUT_BUFFER_CAP as usize;
-const VIEWER_DELIVERY_MAX_EVENTS: usize = 4096;
-const MAX_ORDERED_CONTROL_COMMANDS: usize = 256;
 
 pub fn session_name_ok(name: &str) -> bool {
     let invalid = name.is_empty()
@@ -205,12 +190,6 @@ pub trait PtyControl: Send + Sync {
     fn resize(&self, cols: u16, rows: u16);
     fn pause(&self);
     fn resume(&self);
-    /// Release relay-local attachment state after the PTY has already exited.
-    /// Implementations must not terminate a still-running process here.
-    fn release(&self) {}
-    /// Transfer a just-spawned process from its cancellation guard to the
-    /// manager. Ordinary controls do not need a separate transfer step.
-    fn claim(&self) {}
     fn kill(&self);
 }
 
@@ -228,12 +207,6 @@ pub struct PtyHandle {
     pub control: Arc<dyn PtyControl>,
     pub output: Arc<dyn PtyOutput>,
     pub banner: Option<Vec<u8>>,
-}
-
-impl PtyHandle {
-    pub(crate) fn disarm_cleanup(&self) {
-        self.control.claim();
-    }
 }
 
 pub struct SpawnSpec {
@@ -283,9 +256,6 @@ pub trait PtyDeps: Send + Sync {
 pub struct FrameContext {
     pub send: Arc<dyn Fn(Value) + Send + Sync>,
     pub buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
-    /// Outer relay version negotiated during hello. PTY frames stay v4, but
-    /// operational PTY error codes require the v7 feature gate.
-    pub negotiated_version: u64,
     pub trust: String,
     pub local_roots: Option<Vec<String>>,
     pub owner_user_id: Option<String>,
@@ -310,213 +280,11 @@ pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
 // Shared session/attachment state
 // ---------------------------------------------------------------------------
 
-/// Events queued for one shell viewer while its initial replay is handed off.
-/// Keeping the queue separate from `ShellInner` lets the shell state lock stay
-/// short while callbacks run, without allowing live output to overtake replay.
-enum ViewerEvent {
-    Data(Bytes),
-    Exit(i64),
-}
-
-enum ViewerDeliveryAction {
-    None,
-    Drain,
-    Overflow,
-}
-
-struct ViewerDeliveryState {
-    active: bool,
-    finished: bool,
-    released: bool,
-    overflowed: bool,
-    overflow_notified: bool,
-    draining: bool,
-    queued_bytes: usize,
-    queue: VecDeque<ViewerEvent>,
-}
-
-/// Serializes one viewer's banner/replay/live/exit callbacks.
-///
-/// The delivery starts inactive. Producers can enqueue live output while the
-/// initial replay is being assembled; `activate` starts one drainer after the
-/// replay has been queued. Every subsequent producer either owns the drainer
-/// or appends to its FIFO queue, so callbacks cannot overtake one another.
-struct ViewerDelivery {
-    state: Mutex<ViewerDeliveryState>,
-    on_data: DataSink,
-    on_exit: ExitSink,
-    on_overflow: Arc<dyn Fn() + Send + Sync>,
-}
-
-impl ViewerDelivery {
-    fn with_overflow(
-        on_data: DataSink,
-        on_exit: ExitSink,
-        on_overflow: Arc<dyn Fn() + Send + Sync>,
-    ) -> Arc<ViewerDelivery> {
-        Arc::new(ViewerDelivery {
-            state: Mutex::new(ViewerDeliveryState {
-                active: false,
-                finished: false,
-                released: false,
-                overflowed: false,
-                overflow_notified: false,
-                draining: false,
-                queued_bytes: 0,
-                queue: VecDeque::new(),
-            }),
-            on_data,
-            on_exit,
-            on_overflow,
-        })
-    }
-
-    fn mark_overflow(state: &mut ViewerDeliveryState) {
-        state.finished = true;
-        state.overflowed = true;
-        state.queued_bytes = 0;
-        state.queue.clear();
-    }
-
-    fn enqueue_data(state: &mut ViewerDeliveryState, chunk: Bytes) -> bool {
-        let data_slots = VIEWER_DELIVERY_MAX_EVENTS.saturating_sub(1);
-        let Some(total) = state.queued_bytes.checked_add(chunk.len()) else {
-            Self::mark_overflow(state);
-            return false;
-        };
-        if state.queue.len() >= data_slots || total > VIEWER_DELIVERY_MAX_BYTES {
-            Self::mark_overflow(state);
-            return false;
-        }
-        state.queued_bytes = total;
-        state.queue.push_back(ViewerEvent::Data(chunk));
-        true
-    }
-
-    /// Queue an initial banner or replay while callbacks remain paused.
-    fn seed(&self, banner: Option<Bytes>, replay: Option<Bytes>) -> bool {
-        let mut state = self.state.lock().expect("viewer delivery lock");
-        if state.released {
-            return false;
-        }
-        // A shell can exit before the deferred viewer start finishes building
-        // its initial replay. Keep the terminal event last so the viewer still
-        // receives banner, replay, then exit.
-        let exit = state.finished.then(|| state.queue.pop_back()).flatten();
-        let mut overflowed = false;
-        if let Some(banner) = banner {
-            overflowed |= !Self::enqueue_data(&mut state, banner);
-        }
-        if !overflowed && let Some(replay) = replay {
-            overflowed |= !Self::enqueue_data(&mut state, replay);
-        }
-        if let Some(exit) = exit
-            && !overflowed
-        {
-            state.queue.push_back(exit);
-        }
-        overflowed
-    }
-
-    /// Queue live output and report whether this caller should drain it.
-    fn push_data(&self, chunk: Bytes) -> ViewerDeliveryAction {
-        let mut state = self.state.lock().expect("viewer delivery lock");
-        if state.finished || state.released {
-            return ViewerDeliveryAction::None;
-        }
-        if !Self::enqueue_data(&mut state, chunk) {
-            return ViewerDeliveryAction::Overflow;
-        }
-        if state.active && !state.draining {
-            state.draining = true;
-            ViewerDeliveryAction::Drain
-        } else {
-            ViewerDeliveryAction::None
-        }
-    }
-
-    /// Mark the viewer active and report whether this caller should drain it.
-    fn activate(&self) -> bool {
-        let mut state = self.state.lock().expect("viewer delivery lock");
-        if state.released || state.overflowed {
-            return false;
-        }
-        state.active = true;
-        if !state.queue.is_empty() && !state.draining {
-            state.draining = true;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Queue terminal exit and report whether this caller should drain it.
-    fn finish(&self, code: i64) -> ViewerDeliveryAction {
-        let mut state = self.state.lock().expect("viewer delivery lock");
-        if state.finished || state.released {
-            return ViewerDeliveryAction::None;
-        }
-        state.finished = true;
-        state.queue.push_back(ViewerEvent::Exit(code));
-        if state.active && !state.draining {
-            state.draining = true;
-            ViewerDeliveryAction::Drain
-        } else {
-            ViewerDeliveryAction::None
-        }
-    }
-
-    /// Invoke the overflow callback once, outside the delivery mutex.
-    fn notify_overflow(&self) {
-        let callback = {
-            let mut state = self.state.lock().expect("viewer delivery lock");
-            if !state.overflowed || state.overflow_notified || state.released {
-                None
-            } else {
-                state.overflow_notified = true;
-                Some(Arc::clone(&self.on_overflow))
-            }
-        };
-        if let Some(callback) = callback {
-            callback();
-        }
-    }
-
-    /// Stop future callbacks for a detached viewer and discard queued output.
-    fn release(&self) {
-        let mut state = self.state.lock().expect("viewer delivery lock");
-        state.finished = true;
-        state.released = true;
-        state.queued_bytes = 0;
-        state.queue.clear();
-    }
-
-    /// Drain callbacks without holding either the delivery or shell lock.
-    fn drain(&self) {
-        loop {
-            let event = {
-                let mut state = self.state.lock().expect("viewer delivery lock");
-                let Some(event) = state.queue.pop_front() else {
-                    state.draining = false;
-                    return;
-                };
-                if let ViewerEvent::Data(chunk) = &event {
-                    state.queued_bytes = state.queued_bytes.saturating_sub(chunk.len());
-                }
-                event
-            };
-            match event {
-                ViewerEvent::Data(chunk) => (self.on_data)(chunk),
-                ViewerEvent::Exit(code) => (self.on_exit)(code),
-            }
-        }
-    }
-}
-
 /// A per-attachment output sink into the framing path.
 struct ViewerSink {
     id: u64,
-    delivery: Arc<ViewerDelivery>,
+    on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
+    on_exit: Arc<dyn Fn(i64) + Send + Sync>,
 }
 
 /// A fallback $SHELL session: one PTY, a bounded ring, and a viewer set that
@@ -524,7 +292,6 @@ struct ViewerSink {
 struct ShellSession {
     control: Arc<dyn PtyControl>,
     inner: Mutex<ShellInner>,
-    resize_lock: Mutex<()>,
     banner: Option<Vec<u8>>,
 }
 
@@ -532,3374 +299,16 @@ struct ShellInner {
     ring: VecDeque<Bytes>,
     ring_size: usize,
     alive: bool,
-    exit_code: Option<i64>,
     viewers: Vec<ViewerSink>,
-    viewer_grids: HashMap<u64, SizingGrid>,
-    applied_grid: Option<SizingGrid>,
 }
 
 #[derive(Clone)]
 struct Attachment {
-    generation: u64,
-    gate: Arc<Mutex<()>>,
     closing: Arc<AtomicBool>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
     actor_id: String,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct SizingKey {
-    socket_path: PathBuf,
-    surface_id: i64,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct SizingGrid {
-    cols: u16,
-    rows: u16,
-}
-
-#[derive(Clone)]
-struct SizingViewer {
-    control: Arc<dyn ControlHandle>,
-    endpoint: Arc<OrderedControlEndpoint>,
-    grid: SizingGrid,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ClaimFence {
-    /// The target-state generation that reserved this fence. A late worker
-    /// from an older generation must not clear a newer fence with the same
-    /// viewer and grid.
-    generation: u64,
-    viewer_id: u64,
-    grid: SizingGrid,
-    /// Monotonic queue reservation token. A stale worker must not clear a
-    /// newer fence even when the viewer id and grid are unchanged.
-    token: u64,
-    /// Endpoint identity prevents a late worker from touching a replacement
-    /// attachment that reused the same viewer id.
-    endpoint_ptr: usize,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ClaimRequest {
-    /// Generation and token identify the exact explicit claim attempt. A
-    /// stale worker must not clear a newer request from the same endpoint.
-    generation: u64,
-    viewer_id: u64,
-    token: Option<u64>,
-    endpoint_ptr: usize,
-}
-
-struct OwnerResizeFence {
-    generation: u64,
-    owner_id: u64,
-    grid: SizingGrid,
-    endpoint_ptr: usize,
-    /// The response for the verification request already queued after the
-    /// resize report. `None` means the bounded queue could not accept the
-    /// complete pair; input must fail closed until a new generation.
-    response: Option<oneshot::Receiver<Option<Value>>>,
-}
-
-struct OrderedControlQueue {
-    surface_id: i64,
-    self_ref: OnceLock<Weak<OrderedControlQueue>>,
-    target: OnceLock<Weak<SizingTarget>>,
-    coordinator: OnceLock<Weak<TerminalSizing>>,
-    generation: AtomicU64,
-    state: Mutex<OrderedControlQueueState>,
-    wire_pending: Mutex<VecDeque<OrderedControlCommand>>,
-    wire_running: AtomicBool,
-    closing_running: AtomicBool,
-    closing_notify: Notify,
-    /// One daemon-acknowledged mutation at a time across every attachment
-    /// socket for this terminal. This is the only ordering primitive that can
-    /// establish cross-socket resize/claim/input order without a daemon
-    /// generation token.
-    wire_gate: tokio::sync::Mutex<()>,
-}
-
-struct OrderedControlCommand {
-    endpoint: Arc<OrderedControlEndpoint>,
-    generation: Option<u64>,
-    expected_owner: Option<u64>,
-    requires_unowned: bool,
-    kind: OrderedControlCommandKind,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct DispatchReservation {
-    id: u64,
-    generation: u64,
-    endpoint_ptr: usize,
-}
-
-enum OrderedControlCommandKind {
-    Send {
-        command: String,
-        params: Value,
-    },
-    Request {
-        command: String,
-        params: Value,
-        reply: oneshot::Sender<Option<Value>>,
-    },
-    Close {
-        reply: oneshot::Sender<bool>,
-    },
-    /// Local teardown after a target-wide close failure. This is dispatched
-    /// by the same wire actor but does not attempt another daemon barrier.
-    /// `ControlHandle::end` only closes this local transport; it does not
-    /// mutate daemon state. All daemon-state mutations still use the actor.
-    Abort,
-}
-
-struct OrderedControlQueueState {
-    /// Pending resize metadata carries the generation that created it. A
-    /// worker may run after a newer viewer mutation, so it must never retag an
-    /// old grid with the current generation while flushing the wire command.
-    pending_resize: Option<(u64, Arc<OrderedControlEndpoint>, SizingGrid, bool)>,
-    /// The last flushed resize is keyed by generation and endpoint identity
-    /// as well as viewer id. A stale worker or reconnect that reuses an id
-    /// must receive its own fence.
-    last_resize: Option<(u64, u64, usize, SizingGrid, bool)>,
-    /// A report/claim pair already reserved on the wire for a candidate.
-    /// `apply_target` consumes this marker instead of queueing a duplicate
-    /// pair. A failed verified claim clears the marker before a real retry.
-    claim_fence: Option<ClaimFence>,
-    /// A non-claim owner resize and its verification request were reserved as
-    /// one adjacent wire batch. Input may append after this pair, but never
-    /// between the report and request. A missing response marks QueueFull.
-    owner_resize_fence: Option<OwnerResizeFence>,
-    /// Endpoints removed from the target but not yet acknowledged by the
-    /// daemon. A new explicit claim must wait for every old transport's
-    /// ordered close barrier before it can write authority commands.
-    closing: Vec<Arc<OrderedControlEndpoint>>,
-    /// Close commands are inserted at detach time, before later input or
-    /// sizing commands. Keep their replies here so the close worker can clear
-    /// the barrier after the daemon acknowledges each FIFO close.
-    closing_waiters: Vec<(usize, oneshot::Receiver<bool>)>,
-    /// A failed close barrier permanently freezes this target generation.
-    /// The daemon gave no proof that old-socket writes are ordered before a
-    /// later command, so new input/claims must fail until the target is
-    /// retired and recreated.
-    closing_failed: bool,
-    /// Close replies removed by the barrier worker but not yet completed.
-    /// Input may be queued behind these already-enqueued FIFO closes.
-    closing_inflight: Vec<usize>,
-    /// Local aborts that could not fit behind retained close commands after a
-    /// failed barrier. Keep the endpoint until the wire worker can enqueue its
-    /// bounded local teardown; never drop an admitted control silently.
-    abort_pending: VecDeque<Arc<OrderedControlEndpoint>>,
-    /// The command currently reserved by the wire actor. The reservation is
-    /// the linearization point for a daemon mutation: a leave/update that
-    /// acquires the queue state lock after this point is ordered after the
-    /// reserved command, even if the control call itself awaits a reply.
-    dispatching: Option<DispatchReservation>,
-    next_dispatch_id: u64,
-    next_claim_token: u64,
-    worker_running: bool,
-    closed: bool,
-}
-
-impl OrderedControlQueue {
-    fn new(surface_id: i64) -> Arc<Self> {
-        let queue = Arc::new(Self {
-            surface_id,
-            self_ref: OnceLock::new(),
-            target: OnceLock::new(),
-            coordinator: OnceLock::new(),
-            generation: AtomicU64::new(1),
-            state: Mutex::new(OrderedControlQueueState {
-                pending_resize: None,
-                last_resize: None,
-                claim_fence: None,
-                owner_resize_fence: None,
-                closing: Vec::new(),
-                closing_waiters: Vec::new(),
-                closing_failed: false,
-                closing_inflight: Vec::new(),
-                abort_pending: VecDeque::new(),
-                dispatching: None,
-                next_dispatch_id: 0,
-                next_claim_token: 0,
-                worker_running: false,
-                closed: false,
-            }),
-            wire_pending: Mutex::new(VecDeque::new()),
-            wire_running: AtomicBool::new(false),
-            closing_running: AtomicBool::new(false),
-            closing_notify: Notify::new(),
-            wire_gate: tokio::sync::Mutex::new(()),
-        });
-        let _ = queue.self_ref.set(Arc::downgrade(&queue));
-        queue
-    }
-
-    fn bind_target(&self, target: &Arc<SizingTarget>, coordinator: &Arc<TerminalSizing>) {
-        let _ = self.target.set(Arc::downgrade(target));
-        let _ = self.coordinator.set(Arc::downgrade(coordinator));
-    }
-
-    fn current_generation(&self) -> u64 {
-        self.generation.load(Ordering::Acquire)
-    }
-
-    /// Return whether every detached endpoint already has a FIFO close
-    /// command registered with the wire actor. A queued or in-flight close is
-    /// enough: later commands are appended after that command, while a close
-    /// that could not fit in the bounded queue must block new mutations until
-    /// it can be retried.
-    fn close_barrier_ready_locked(&self, state: &OrderedControlQueueState) -> bool {
-        state.closing.iter().all(|endpoint| {
-            let pointer = endpoint_ptr(endpoint);
-            state.closing_waiters.iter().any(|(current, _)| *current == pointer)
-                || state.closing_inflight.contains(&pointer)
-        })
-    }
-
-    fn endpoint(
-        self: &Arc<Self>,
-        viewer_id: u64,
-        control: Arc<dyn ControlHandle>,
-    ) -> Arc<OrderedControlEndpoint> {
-        Arc::new(OrderedControlEndpoint {
-            queue: Arc::downgrade(self),
-            viewer_id,
-            control,
-            active: AtomicBool::new(true),
-            failure_handler: Mutex::new(None),
-        })
-    }
-
-    /// Queue a resize while the caller already owns the queue lock. This is
-    /// used by owner-loss transitions: the caller can hold this lock across
-    /// the ownership update, so input cannot pass between the loss decision
-    /// and the survivor's report/claim fence.
-    fn enqueue_resize_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        claim: bool,
-    ) -> bool {
-        if state.closed
-            || state.closing_failed
-            || !self.close_barrier_ready_locked(state)
-            || !endpoint.is_active()
-        {
-            return false;
-        }
-        // A survivor claim is an ownership reservation, not a best-effort
-        // resize. Do not let an older owner update replace its report/claim
-        // while the candidate worker is verifying authority.
-        if !claim && state.claim_fence.is_some() {
-            return false;
-        }
-        // A failed claim must be retried even when the viewer reports the
-        // same grid again. Non-claim owner updates can safely deduplicate
-        // an already-enqueued grid.
-        if !claim
-            && state.pending_resize.is_none()
-            && state.last_resize
-                == Some((
-                    self.current_generation(),
-                    endpoint.viewer_id,
-                    endpoint_ptr(endpoint),
-                    grid,
-                    false,
-                ))
-        {
-            return false;
-        }
-        state.pending_resize = Some((self.current_generation(), Arc::clone(endpoint), grid, claim));
-        if state.worker_running {
-            return false;
-        }
-        state.worker_running = true;
-        // Establish the first report/claim in the control writer before the
-        // caller can admit input. The whole pair is accepted under one
-        // pending-queue lock; a full queue leaves state.pending_resize intact
-        // and does not advance last_resize or claim_fence.
-        if self.flush_resize_locked(state) {
-            true
-        } else {
-            state.worker_running = false;
-            // A full bounded wire queue is a deterministic transition
-            // failure. Drop the unsent batch and leave ownership frozen; the
-            // next explicit viewer event may establish a fresh generation.
-            if state.pending_resize.as_ref().is_some_and(|(_, _, _, pending_claim)| *pending_claim)
-            {
-                state.claim_fence = None;
-            }
-            state.pending_resize = None;
-            false
-        }
-    }
-
-    /// Reserve a non-claim owner resize and its verification request as one
-    /// adjacent wire batch. The queue lock remains held while both commands
-    /// are appended, so input cannot enter between the report and request.
-    /// `response == None` is a visible QueueFull fence: the caller has no
-    /// request id to report and must fail this generation closed.
-    fn enqueue_owner_resize_batch_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        owner_id: u64,
-        grid: SizingGrid,
-        generation: u64,
-    ) -> (bool, bool) {
-        if state.closed
-            || state.closing_failed
-            || !self.close_barrier_ready_locked(state)
-            || self.current_generation() != generation
-            || !endpoint.is_active()
-        {
-            return (false, false);
-        }
-        if state.claim_fence.is_some() {
-            return (false, false);
-        }
-        if let Some(fence) = state.owner_resize_fence.take() {
-            if fence.generation == generation
-                && fence.owner_id == owner_id
-                && fence.grid == grid
-                && fence.endpoint_ptr == endpoint_ptr(endpoint)
-            {
-                state.owner_resize_fence = Some(fence);
-                return (true, false);
-            }
-            // A newer generation supersedes the old verification response.
-            // Its queued command carries the old generation and will be
-            // rejected by the wire actor; dropping this receiver prevents a
-            // stale worker from committing authority.
-        }
-        if state
-            .pending_resize
-            .as_ref()
-            .is_some_and(|(_, pending, _, claim)| *claim || !Arc::ptr_eq(pending, endpoint))
-        {
-            return (false, false);
-        }
-
-        let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-        if pending.len().saturating_add(2) > MAX_ORDERED_CONTROL_COMMANDS {
-            state.pending_resize = None;
-            state.owner_resize_fence = Some(OwnerResizeFence {
-                generation,
-                owner_id,
-                grid,
-                endpoint_ptr: endpoint_ptr(endpoint),
-                response: None,
-            });
-            return (true, false);
-        }
-
-        // The pending metadata has not reached the wire yet. Replace it with
-        // this latest report and append the verification request immediately
-        // after it. Both commands are accepted under the same queue lock.
-        state.pending_resize = None;
-        let (reply, response) = oneshot::channel();
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(endpoint),
-            generation: Some(generation),
-            expected_owner: Some(owner_id),
-            requires_unowned: false,
-            kind: OrderedControlCommandKind::Send {
-                command: "resize-surface".to_owned(),
-                params: json!({
-                    "surface": self.surface_id,
-                    "cols": grid.cols,
-                    "rows": grid.rows,
-                }),
-            },
-        });
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(endpoint),
-            generation: Some(generation),
-            expected_owner: Some(owner_id),
-            requires_unowned: false,
-            kind: OrderedControlCommandKind::Request {
-                command: "resize-surface".to_owned(),
-                params: json!({
-                    "surface": self.surface_id,
-                    "cols": grid.cols,
-                    "rows": grid.rows,
-                }),
-                reply,
-            },
-        });
-        drop(pending);
-        state.last_resize = Some((generation, owner_id, endpoint_ptr(endpoint), grid, false));
-        state.owner_resize_fence = Some(OwnerResizeFence {
-            generation,
-            owner_id,
-            grid,
-            endpoint_ptr: endpoint_ptr(endpoint),
-            response: Some(response),
-        });
-        (true, true)
-    }
-
-    /// Add one command to the session mutation queue. Callers hold the queue
-    /// state lock while deciding which command is canonical; the wire worker
-    /// takes ownership of the command before it awaits any daemon response.
-    fn enqueue_ordered_locked(
-        &self,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        command: &str,
-        params: Value,
-    ) -> bool {
-        if !endpoint.is_active() {
-            return false;
-        }
-        let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-        if pending.len() >= MAX_ORDERED_CONTROL_COMMANDS {
-            return false;
-        }
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(endpoint),
-            generation: Some(self.current_generation()),
-            expected_owner: None,
-            requires_unowned: false,
-            kind: OrderedControlCommandKind::Send { command: command.to_owned(), params },
-        });
-        drop(pending);
-        true
-    }
-
-    fn start_wire_drain(&self) {
-        if self.wire_running.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let Some(queue) = self.self_ref.get().and_then(Weak::upgrade) else {
-            self.wire_running.store(false, Ordering::Release);
-            return;
-        };
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            // Synchronous test controls have no daemon to acknowledge a
-            // barrier. Preserve their observable command log without trying
-            // to block on an async response outside Tokio.
-            queue.drain_wire_sync();
-            return;
-        };
-        handle.spawn(async move { queue.drain_wire().await });
-    }
-
-    /// Retry retired-target removal after the wire actor reaches a true idle
-    /// point. A close acknowledgement can wake the close worker before the
-    /// wire worker has popped its final command; the later idle callback is
-    /// the only safe point at which no post-close command can outlive the
-    /// target.
-    fn remove_retired_if_idle(&self) {
-        if let (Some(coordinator), Some(target)) = (
-            self.coordinator.get().and_then(Weak::upgrade),
-            self.target.get().and_then(Weak::upgrade),
-        ) {
-            coordinator.remove_retired_target(&target);
-        }
-    }
-
-    fn drain_wire_sync(&self) {
-        loop {
-            let Some(command) =
-                self.wire_pending.lock().expect("ordered control pending lock").pop_front()
-            else {
-                let abort_enqueued = {
-                    let mut state = self.state.lock().expect("ordered control queue lock");
-                    let mut pending =
-                        self.wire_pending.lock().expect("ordered control pending lock");
-                    self.enqueue_abort_pending_locked(&mut state, &mut pending)
-                };
-                if abort_enqueued {
-                    continue;
-                }
-                self.wire_running.store(false, Ordering::Release);
-                self.remove_retired_if_idle();
-                return;
-            };
-            let endpoint = Arc::clone(&command.endpoint);
-            if matches!(&command.kind, OrderedControlCommandKind::Close { .. }) {
-                // A close is still dispatched after detach. The endpoint is
-                // marked inactive before it enters the closing list so no
-                // later input can use it, but the close itself must reach the
-                // control even in the synchronous test fallback.
-                let OrderedControlCommandKind::Close { reply } = command.kind else {
-                    unreachable!("close command kind changed")
-                };
-                self.deactivate_endpoint(&endpoint);
-                end_local_transport(&endpoint);
-                let _ = reply.send(true);
-                continue;
-            }
-            let reservation = self.reserve_command(&command);
-            match command.kind {
-                OrderedControlCommandKind::Send { command, params } => {
-                    // `reservation` is the actor linearization point. The
-                    // endpoint may be marked inactive by a later leave while
-                    // this command is in flight, but that leave is ordered
-                    // after this already-reserved mutation.
-                    if reservation.is_some() {
-                        endpoint.control.send(&command, params);
-                    }
-                }
-                OrderedControlCommandKind::Request { command, params, reply } => {
-                    if reservation.is_some() {
-                        endpoint.control.send(&command, params);
-                    } else {
-                        let _ = reply.send(None);
-                    }
-                }
-                OrderedControlCommandKind::Close { .. } => unreachable!("close handled above"),
-                OrderedControlCommandKind::Abort => end_local_transport(&endpoint),
-            }
-            self.clear_dispatch_reservation(reservation);
-        }
-    }
-
-    /// Reserve a queued mutation at the last possible point before it is
-    /// written. The queue-state lock is the actor gate: every coordinator
-    /// mutation takes it before target state, so the final generation/owner/
-    /// endpoint check and this reservation are one linearized transition.
-    /// Once reserved, a later leave/update is ordered after this command; the
-    /// worker must therefore dispatch the reserved command before clearing the
-    /// reservation, even if the endpoint has since been marked inactive.
-    fn reserve_command(&self, command: &OrderedControlCommand) -> Option<DispatchReservation> {
-        let Some(generation) = command.generation else {
-            return None;
-        };
-        let mut queue_state = self.state.lock().expect("ordered control queue lock");
-        if queue_state.closed
-            || queue_state.closing_failed
-            || queue_state.dispatching.is_some()
-            || self.current_generation() != generation
-            || !command.endpoint.is_active()
-        {
-            return None;
-        }
-        let reservation = DispatchReservation {
-            id: queue_state.next_dispatch_id,
-            generation,
-            endpoint_ptr: endpoint_ptr(&command.endpoint),
-        };
-        let Some(target_slot) = self.target.get() else {
-            // Unbound queues are used only by synchronous test controls.
-            queue_state.next_dispatch_id = queue_state.next_dispatch_id.wrapping_add(1);
-            queue_state.dispatching = Some(reservation);
-            return Some(reservation);
-        };
-        let Some(target) = target_slot.upgrade() else {
-            // A bound queue whose target was retired cannot write a late
-            // mutation. Reject it instead of treating a dropped target as a
-            // valid test queue.
-            return None;
-        };
-        let state = target.state.lock().expect("terminal sizing state lock");
-        let current = self.current_generation() == generation
-            && target.generation.load(Ordering::Acquire) == generation
-            && !state.retired
-            && command.expected_owner.is_none_or(|owner| state.owner == Some(owner))
-            && (!command.requires_unowned || state.owner.is_none())
-            && state.viewers.get(&command.endpoint.viewer_id).is_some_and(|viewer| {
-                Arc::ptr_eq(&viewer.endpoint, &command.endpoint) && viewer.endpoint.is_active()
-            });
-        if current {
-            queue_state.next_dispatch_id = queue_state.next_dispatch_id.wrapping_add(1);
-            queue_state.dispatching = Some(reservation);
-            Some(reservation)
-        } else {
-            None
-        }
-    }
-
-    fn clear_dispatch_reservation(&self, reservation: Option<DispatchReservation>) {
-        let Some(reservation) = reservation else { return };
-        let mut state = self.state.lock().expect("ordered control queue lock");
-        if state.dispatching == Some(reservation) {
-            state.dispatching = None;
-        }
-    }
-
-    async fn drain_wire(self: Arc<Self>) {
-        loop {
-            let Some(command) =
-                self.wire_pending.lock().expect("ordered control pending lock").pop_front()
-            else {
-                let abort_enqueued = {
-                    let mut state = self.state.lock().expect("ordered control queue lock");
-                    let mut pending =
-                        self.wire_pending.lock().expect("ordered control pending lock");
-                    self.enqueue_abort_pending_locked(&mut state, &mut pending)
-                };
-                if abort_enqueued {
-                    continue;
-                }
-                self.wire_running.store(false, Ordering::Release);
-                // A producer can enqueue after the empty check but before the
-                // flag reset. Re-check once and keep one worker alive.
-                let pending_after_reset =
-                    !self.wire_pending.lock().expect("ordered control pending lock").is_empty();
-                if pending_after_reset && !self.wire_running.swap(true, Ordering::AcqRel) {
-                    continue;
-                }
-                self.remove_retired_if_idle();
-                // A close that could not fit in the bounded wire queue is
-                // retryable, not a successful barrier. Once the queue drains,
-                // start the close worker again so a retired target does not
-                // depend on a future viewer event to make progress.
-                if !pending_after_reset {
-                    let retry_close = {
-                        let state = self.state.lock().expect("ordered control queue lock");
-                        !state.closing.is_empty()
-                            && state.closing_waiters.is_empty()
-                            && state.closing_inflight.is_empty()
-                            && !state.closing_failed
-                    };
-                    if retry_close {
-                        self.schedule_closing();
-                    }
-                }
-                return;
-            };
-            let endpoint = Arc::clone(&command.endpoint);
-            let is_close = matches!(&command.kind, OrderedControlCommandKind::Close { .. });
-            let is_abort = matches!(&command.kind, OrderedControlCommandKind::Abort);
-            let (failed, reservation) = {
-                let _gate = self.wire_gate.lock().await;
-                let reservation =
-                    if is_close || is_abort { None } else { self.reserve_command(&command) };
-                let current = is_close || is_abort || reservation.is_some();
-                let kind = command.kind;
-                if !current {
-                    match kind {
-                        OrderedControlCommandKind::Request { reply, .. } => {
-                            let _ = reply.send(None);
-                        }
-                        OrderedControlCommandKind::Send { .. }
-                        | OrderedControlCommandKind::Close { .. }
-                        | OrderedControlCommandKind::Abort => {}
-                    }
-                    (false, reservation)
-                } else {
-                    let failed = match kind {
-                        OrderedControlCommandKind::Send { command, params } => {
-                            !endpoint.control.ordered_send(&command, params).await
-                        }
-                        OrderedControlCommandKind::Request { command, params, reply } => {
-                            let result = endpoint.control.request(&command, params).await;
-                            let failed = result.is_none();
-                            let _ = reply.send(result);
-                            failed
-                        }
-                        OrderedControlCommandKind::Close { reply } => {
-                            self.deactivate_endpoint(&endpoint);
-                            let result = endpoint.control.end_and_wait().await;
-                            if !result {
-                                // Set the fail-closed bit before the worker
-                                // can pop any later command. The close reply
-                                // and this state transition are one actor
-                                // step; a missing daemon barrier must reject
-                                // every following mutation.
-                                self.state
-                                    .lock()
-                                    .expect("ordered control queue lock")
-                                    .closing_failed = true;
-                            }
-                            let _ = reply.send(result);
-                            !result
-                        }
-                        OrderedControlCommandKind::Abort => {
-                            end_local_transport(&endpoint);
-                            false
-                        }
-                    };
-                    (failed, reservation)
-                }
-            };
-            self.clear_dispatch_reservation(reservation);
-            if failed {
-                if is_close {
-                    // A failed close is a target-wide ordering failure. Any
-                    // replacement admitted behind that close must be
-                    // detached before it can become a stuck live viewer.
-                    self.fail_target_after_close();
-                } else {
-                    self.fail_endpoint(&endpoint);
-                }
-            }
-        }
-    }
-
-    fn fail_target_after_close(&self) {
-        let (Some(coordinator), Some(target)) = (
-            self.coordinator.get().and_then(Weak::upgrade),
-            self.target.get().and_then(Weak::upgrade),
-        ) else {
-            return;
-        };
-        coordinator.fail_target_after_close(&target);
-    }
-
-    async fn ordered_request_at(
-        &self,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        command: &str,
-        params: Value,
-        generation: u64,
-        expected_owner: Option<u64>,
-        requires_unowned: bool,
-    ) -> Option<Value> {
-        if !endpoint.is_active() {
-            return None;
-        }
-        let (reply, response) = oneshot::channel();
-        // Revalidate and register the request while the coordinator queue
-        // state is locked. An update or leave cannot advance the generation
-        // between this check and the wire enqueue; the worker repeats the
-        // check immediately before dispatch as a second fence. The guards
-        // live in an inner block: the spawned future must stay `Send`, and
-        // the async lowering keeps lexically live guards in the future state
-        // even past an explicit `drop`.
-        {
-            let queue_state = self.state.lock().expect("ordered control queue lock");
-            if self.current_generation() != generation
-                || !queue_state.closing.is_empty()
-                || queue_state.closing_failed
-            {
-                return None;
-            }
-            if let Some(target) = self.target.get().and_then(Weak::upgrade) {
-                if target.generation.load(Ordering::Acquire) != generation {
-                    return None;
-                }
-                let state = target.state.lock().expect("terminal sizing state lock");
-                if state.retired
-                    || !state.viewers.get(&endpoint.viewer_id).is_some_and(|viewer| {
-                        Arc::ptr_eq(&viewer.endpoint, endpoint) && viewer.endpoint.is_active()
-                    })
-                {
-                    return None;
-                }
-            }
-            let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-            if pending.len() >= MAX_ORDERED_CONTROL_COMMANDS {
-                return None;
-            }
-            pending.push_back(OrderedControlCommand {
-                endpoint: Arc::clone(endpoint),
-                generation: Some(generation),
-                expected_owner,
-                requires_unowned,
-                kind: OrderedControlCommandKind::Request {
-                    command: command.to_owned(),
-                    params,
-                    reply,
-                },
-            });
-        }
-        self.start_wire_drain();
-        response.await.ok().flatten()
-    }
-
-    /// Reserve a report/claim pair for a candidate before its verified worker
-    /// round-trip. The marker is separate from ordinary claim enqueues so a
-    /// worker-created retry cannot leave stale reservation state behind.
-    fn reserve_resize_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-    ) -> bool {
-        if state.closed
-            || state.closing_failed
-            || !self.close_barrier_ready_locked(state)
-            || !endpoint.is_active()
-        {
-            return false;
-        }
-        {
-            let pending = self.wire_pending.lock().expect("ordered control pending lock");
-            if pending.len().saturating_add(2) > MAX_ORDERED_CONTROL_COMMANDS {
-                // Never reserve a claim that cannot be represented as one
-                // complete report+claim batch on the bounded wire queue.
-                return false;
-            }
-        }
-        if let Some(fence) = state.claim_fence {
-            if fence.viewer_id != endpoint.viewer_id {
-                return false;
-            }
-            if fence.generation != generation
-                || fence.grid != grid
-                || fence.endpoint_ptr != endpoint_ptr(endpoint)
-            {
-                // The same viewer advanced the state generation. Replace its
-                // old unverified fence with the newer canonical grid rather
-                // than leaving the worker stuck behind stale geometry.
-                state.claim_fence = None;
-                if state
-                    .pending_resize
-                    .as_ref()
-                    .is_some_and(|(_, pending, _, _)| Arc::ptr_eq(pending, endpoint))
-                {
-                    state.pending_resize = None;
-                }
-            }
-        }
-        if state.claim_fence.is_some_and(|fence| {
-            fence.generation == generation
-                && fence.viewer_id == endpoint.viewer_id
-                && fence.grid == grid
-                && fence.endpoint_ptr == endpoint_ptr(endpoint)
-        }) && state.pending_resize.is_none()
-            && state.last_resize
-                == Some((
-                    self.current_generation(),
-                    endpoint.viewer_id,
-                    endpoint_ptr(endpoint),
-                    grid,
-                    true,
-                ))
-        {
-            return false;
-        }
-        let token = state
-            .claim_fence
-            .filter(|fence| {
-                fence.generation == generation
-                    && fence.viewer_id == endpoint.viewer_id
-                    && fence.grid == grid
-                    && fence.endpoint_ptr == endpoint_ptr(endpoint)
-            })
-            .map_or_else(
-                || {
-                    let token = state.next_claim_token;
-                    state.next_claim_token = state.next_claim_token.wrapping_add(1);
-                    token
-                },
-                |fence| fence.token,
-            );
-        state.claim_fence = Some(ClaimFence {
-            generation,
-            viewer_id: endpoint.viewer_id,
-            grid,
-            token,
-            endpoint_ptr: endpoint_ptr(endpoint),
-        });
-        self.enqueue_resize_locked(state, endpoint, grid, true)
-    }
-
-    /// Drop a claim reservation that no longer names the canonical candidate.
-    ///
-    /// A failed claim keeps a fence in place so input cannot overtake its
-    /// bounded retry. A later join, update, or leave can change either the
-    /// candidate viewer or the smallest grid, however. In that case the old
-    /// reservation is stale and must not block the new candidate forever.
-    /// Callers hold the queue and target-state locks while invoking this
-    /// helper, so replacing the reservation is one ordered transition.
-    fn clear_stale_claim_fence_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        candidate: Option<(u64, u64, SizingGrid, usize)>,
-    ) {
-        let Some(fence) = state.claim_fence else { return };
-        if candidate.is_some_and(|(generation, viewer_id, grid, endpoint_ptr)| {
-            generation == fence.generation
-                && viewer_id == fence.viewer_id
-                && grid == fence.grid
-                && endpoint_ptr == fence.endpoint_ptr
-        }) {
-            return;
-        }
-        state.claim_fence = None;
-        if state.pending_resize.as_ref().is_some_and(|(_, endpoint, _, claim)| {
-            *claim
-                && endpoint.viewer_id == fence.viewer_id
-                && endpoint_ptr(endpoint) == fence.endpoint_ptr
-        }) {
-            state.pending_resize = None;
-        }
-    }
-
-    fn start_drain(self: &Arc<Self>, should_start: bool) {
-        if !should_start {
-            return;
-        }
-        let queue = Arc::clone(self);
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            queue.drain_sync();
-            return;
-        };
-        handle.spawn(async move { queue.drain_async().await });
-    }
-
-    /// Input is emitted only after any pending resize has been flushed under
-    /// the same mutex. This is the ordering fence for resize-before-input;
-    /// ingress itself never awaits the control reply.
-    fn enqueue_input(&self, endpoint: &Arc<OrderedControlEndpoint>, data: &[u8]) {
-        let (flushed, accepted) = {
-            let mut state = self.state.lock().expect("ordered control queue lock");
-            if state.closed || !endpoint.is_active() {
-                return;
-            }
-            // A worker may have retained a resize from an older generation
-            // while the viewer updated back to the already-applied grid.
-            // Drop that stale metadata before deciding whether input failed;
-            // a superseded resize is not a transport failure.
-            let stale_pending = self.discard_stale_pending_locked(&mut state);
-            self.discard_stale_owner_resize_fence_locked(&mut state);
-            let close_ready = state.closing.iter().all(|closing| {
-                state.closing_waiters.iter().any(|(pointer, _)| *pointer == endpoint_ptr(closing))
-                    || state.closing_inflight.contains(&endpoint_ptr(closing))
-            });
-            // An explicit replacement claim must have a durable queue fence
-            // before input is admitted. If the bounded queue rejected the
-            // report/claim pair, fail this attachment instead of letting
-            // bytes overtake an authority transition that can never run.
-            let claim_requested = self.target.get().and_then(Weak::upgrade).is_some_and(|target| {
-                let generation = target.generation.load(Ordering::Acquire);
-                target
-                    .state
-                    .lock()
-                    .expect("terminal sizing state lock")
-                    .claim_requested
-                    .is_some_and(|request| request.generation == generation)
-            });
-            let claim_without_fence = claim_requested
-                && state.claim_fence.is_none()
-                && !state.pending_resize.as_ref().is_some_and(|(_, _, _, claim)| *claim);
-            let owner_batch_failed = state.owner_resize_fence.as_ref().is_some_and(|fence| {
-                fence.generation == self.current_generation() && fence.response.is_none()
-            });
-            if state.closing_failed || !close_ready || claim_without_fence || owner_batch_failed {
-                (false, false)
-            } else {
-                let flushed = stale_pending || self.flush_resize_locked(&mut state);
-                let accepted = flushed
-                    && self.enqueue_ordered_locked(
-                        endpoint,
-                        "send",
-                        json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }),
-                    );
-                (flushed, accepted)
-            }
-        };
-        // The queue lock is not held while starting a synchronous fallback or
-        // spawning the async wire worker. This keeps the actor lock order
-        // queue -> target-state and prevents re-entrant control callbacks.
-        if flushed {
-            self.start_wire_drain();
-        }
-        if !flushed || !accepted {
-            // A saturated mutation queue must not silently discard input.
-            // Fence and detach this generation; a later authenticated
-            // attachment can retry on a fresh transport.
-            self.fail_endpoint(endpoint);
-        }
-    }
-
-    fn fail_endpoint(&self, endpoint: &Arc<OrderedControlEndpoint>) {
-        let became_inactive = {
-            // Endpoint invalidation is part of the same actor transition as
-            // reserve_command. A failure cannot flip `active` between the
-            // worker's final validation and its reserved dispatch.
-            let _state = self.state.lock().expect("ordered control queue lock");
-            endpoint.active.swap(false, Ordering::AcqRel)
-        };
-        if !became_inactive {
-            return;
-        }
-        if let Some(handler) = endpoint.failure_handler() {
-            handler();
-        }
-    }
-
-    /// Mark an endpoint inactive under the queue actor lock. Close commands
-    /// are already ordered after all preceding mutations; this helper keeps
-    /// their invalidation visible to the same reservation gate.
-    fn deactivate_endpoint(&self, endpoint: &Arc<OrderedControlEndpoint>) {
-        let _state = self.state.lock().expect("ordered control queue lock");
-        endpoint.active.store(false, Ordering::Release);
-    }
-
-    /// Insert one FIFO close command while the queue actor lock is held. A
-    /// full wire queue leaves the endpoint in `closing` without a waiter; the
-    /// close worker retries it later, and input remains ordered behind the
-    /// barrier rather than overtaking it.
-    fn enqueue_close_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        endpoint: &Arc<OrderedControlEndpoint>,
-    ) -> bool {
-        let pointer = endpoint_ptr(endpoint);
-        if state.closing_waiters.iter().any(|(current, _)| *current == pointer) {
-            return true;
-        }
-        let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-        if pending.len() >= MAX_ORDERED_CONTROL_COMMANDS {
-            return false;
-        }
-        let (reply, response) = oneshot::channel();
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(endpoint),
-            generation: None,
-            expected_owner: None,
-            requires_unowned: false,
-            kind: OrderedControlCommandKind::Close { reply },
-        });
-        state.closing_waiters.push((pointer, response));
-        true
-    }
-
-    /// Retry a close that could not fit in the bounded wire queue at detach.
-    fn enqueue_close_for_retry(&self, endpoint: &Arc<OrderedControlEndpoint>) -> bool {
-        let mut state = self.state.lock().expect("ordered control queue lock");
-        if state.closed || !state.closing.iter().any(|current| Arc::ptr_eq(current, endpoint)) {
-            return false;
-        }
-        self.enqueue_close_locked(&mut state, endpoint)
-    }
-
-    /// Move as many retained local aborts as fit into the bounded wire queue.
-    /// The caller holds the queue-state lock and the pending-queue lock. Any
-    /// remainder stays owned by the target and is retried when the worker
-    /// reaches the next empty-queue point.
-    fn enqueue_abort_pending_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        pending: &mut VecDeque<OrderedControlCommand>,
-    ) -> bool {
-        let mut enqueued = false;
-        while pending.len() < MAX_ORDERED_CONTROL_COMMANDS {
-            let Some(endpoint) = state.abort_pending.pop_front() else { break };
-            pending.push_back(OrderedControlCommand {
-                endpoint,
-                generation: None,
-                expected_owner: None,
-                requires_unowned: false,
-                kind: OrderedControlCommandKind::Abort,
-            });
-            enqueued = true;
-        }
-        enqueued
-    }
-
-    /// Remove one endpoint while the caller already owns the queue lock. The
-    /// pointer check prevents a late leave from clearing a replacement that
-    /// reused the same viewer ID.
-    fn detach_locked(
-        &self,
-        state: &mut OrderedControlQueueState,
-        endpoint: &Arc<OrderedControlEndpoint>,
-    ) {
-        // Invalidate the transport before removing its viewer state. This
-        // closes the ingress race where a caller passes the active check just
-        // as leave commits; the close command is inserted in FIFO before any
-        // later input, and drain_closing waits for its acknowledgement.
-        endpoint.active.store(false, Ordering::Release);
-        if state
-            .pending_resize
-            .as_ref()
-            .is_some_and(|(_, current, _, _)| Arc::ptr_eq(current, endpoint))
-        {
-            state.pending_resize = None;
-        }
-        if state.claim_fence.is_some_and(|fence| {
-            fence.viewer_id == endpoint.viewer_id && fence.endpoint_ptr == endpoint_ptr(endpoint)
-        }) {
-            state.claim_fence = None;
-        }
-        if state.owner_resize_fence.as_ref().is_some_and(|fence| {
-            fence.owner_id == endpoint.viewer_id && fence.endpoint_ptr == endpoint_ptr(endpoint)
-        }) {
-            // The queued request belongs to the detached generation. Drop its
-            // waiter before the FIFO close is appended so a late response
-            // cannot commit authority after detach.
-            state.owner_resize_fence = None;
-        }
-        if !state.closing.iter().any(|current| Arc::ptr_eq(current, endpoint)) {
-            state.closing.push(Arc::clone(endpoint));
-        }
-        let _ = self.enqueue_close_locked(state, endpoint);
-    }
-
-    fn close_locked(&self, state: &mut OrderedControlQueueState) {
-        state.closed = true;
-        state.pending_resize = None;
-        state.claim_fence = None;
-        state.owner_resize_fence = None;
-        state.closing.clear();
-        state.closing_waiters.clear();
-        state.closing_inflight.clear();
-        state.abort_pending.clear();
-        state.closing_failed = false;
-    }
-
-    /// Wait for the daemon-acknowledged close barrier of every endpoint that
-    /// was removed from this target. The queue lock is never held while an
-    /// endpoint sends its identify barrier or waits for the response.
-    async fn wait_for_closing(self: &Arc<Self>) -> bool {
-        if self.state.lock().expect("ordered control queue lock").closing_failed {
-            return false;
-        }
-        let notified = self.closing_notify.notified();
-        if self
-            .closing_running
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            notified.await;
-            let state = self.state.lock().expect("ordered control queue lock");
-            return state.closing.is_empty() && !state.closing_failed;
-        }
-        let completed = self.drain_closing().await;
-        self.closing_running.store(false, Ordering::Release);
-        self.closing_notify.notify_waiters();
-        if !completed {
-            let closing_failed =
-                { self.state.lock().expect("ordered control queue lock").closing_failed };
-            if closing_failed {
-                // The close worker may observe a dropped reply independently
-                // of the wire worker. Apply the same target-wide detach in
-                // that path so replacements cannot remain stuck.
-                self.fail_target_after_close();
-            } else {
-                // If the bounded wire queue was full, retry once the current
-                // worker has drained it. The wire worker also performs this
-                // check when it reaches an empty queue; this call closes the
-                // race where it finished while this waiter still owned
-                // `closing_running`.
-                self.schedule_closing();
-            }
-        }
-        completed
-    }
-
-    fn schedule_closing(self: &Arc<Self>) {
-        if self
-            .closing_running
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return;
-        }
-        let queue = Arc::clone(self);
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            queue.closing_running.store(false, Ordering::Release);
-            return;
-        };
-        handle.spawn(async move {
-            let completed = queue.drain_closing().await;
-            queue.closing_running.store(false, Ordering::Release);
-            queue.closing_notify.notify_waiters();
-            queue.retry_closing_after_worker(completed);
-            if let (Some(coordinator), Some(target)) = (
-                queue.coordinator.get().and_then(Weak::upgrade),
-                queue.target.get().and_then(Weak::upgrade),
-            ) {
-                if completed {
-                    // A pending survivor resize may have been held while the
-                    // detached endpoint's close queue was full. Reconcile
-                    // it only after the daemon-acknowledged close barrier.
-                    coordinator.request_reconcile(Arc::clone(&target));
-                } else if { queue.state.lock().expect("ordered control queue lock").closing_failed }
-                {
-                    // `drain_closing` can fail after its reply is dropped,
-                    // without the wire worker seeing the close command.
-                    coordinator.fail_target_after_close(&target);
-                }
-                coordinator.remove_retired_target(&target);
-            }
-        });
-    }
-
-    /// Transfer a failed full-queue retry to a fresh close worker after the
-    /// previous worker clears `closing_running`. The wire worker can observe
-    /// the old flag and decline to schedule; this hand-off closes that race.
-    fn retry_closing_after_worker(self: &Arc<Self>, completed: bool) {
-        if completed {
-            return;
-        }
-        let (closing_retry, wire_pending, wire_running) = {
-            let state = self.state.lock().expect("ordered control queue lock");
-            let wire_pending =
-                !self.wire_pending.lock().expect("ordered control pending lock").is_empty();
-            (
-                !state.closing.is_empty()
-                    && state.closing_waiters.is_empty()
-                    && state.closing_inflight.is_empty()
-                    && !state.closing_failed,
-                wire_pending,
-                self.wire_running.load(Ordering::Acquire),
-            )
-        };
-        if closing_retry {
-            if wire_pending && !wire_running {
-                self.start_wire_drain();
-            } else if !wire_pending && !wire_running {
-                self.schedule_closing();
-            }
-        }
-    }
-
-    async fn drain_closing(&self) -> bool {
-        loop {
-            let next_waiter = {
-                let mut state = self.state.lock().expect("ordered control queue lock");
-                if state.closing.is_empty() {
-                    return true;
-                }
-                if let Some(waiter) = state.closing_waiters.pop() {
-                    state.closing_inflight.push(waiter.0);
-                    Some(waiter)
-                } else {
-                    let endpoint = state.closing.first().cloned();
-                    drop(state);
-                    let Some(endpoint) = endpoint else { return true };
-                    if !self.enqueue_close_for_retry(&endpoint) {
-                        // The bounded wire queue is full or the target was
-                        // retired. Keep `closing` non-empty so authority
-                        // remains frozen. A later explicit event retries the
-                        // close once the bounded queue has drained.
-                        return false;
-                    }
-                    self.start_wire_drain();
-                    continue;
-                }
-            };
-            let Some((pointer, response)) = next_waiter else { continue };
-            self.start_wire_drain();
-            if !response.await.unwrap_or(false) {
-                // No daemon-observed barrier means no later authority command
-                // is safe. Leave this endpoint in `closing` and freeze.
-                {
-                    let mut state = self.state.lock().expect("ordered control queue lock");
-                    state.closing_inflight.retain(|current| *current != pointer);
-                    state.closing_failed = true;
-                }
-                self.fail_target_after_close();
-                return false;
-            }
-            let mut state = self.state.lock().expect("ordered control queue lock");
-            state.closing_inflight.retain(|current| *current != pointer);
-            state.closing.retain(|endpoint| endpoint_ptr(endpoint) != pointer);
-        }
-    }
-
-    fn drain_sync(&self) {
-        let flushed = {
-            let mut state = self.state.lock().expect("ordered control queue lock");
-            let flushed = if state.closing_failed || !self.close_barrier_ready_locked(&state) {
-                false
-            } else {
-                self.flush_resize_locked(&mut state)
-            };
-            state.worker_running = false;
-            flushed
-        };
-        if flushed {
-            self.start_wire_drain();
-        }
-    }
-
-    async fn drain_async(self: Arc<Self>) {
-        loop {
-            let (again, flushed) = {
-                let mut state = self.state.lock().expect("ordered control queue lock");
-                if state.closed {
-                    state.worker_running = false;
-                    (false, false)
-                } else if state.closing_failed || !self.close_barrier_ready_locked(&state) {
-                    // Keep the pending resize and claim fence intact while a
-                    // detached endpoint's FIFO close is queued or retrying.
-                    // The close worker requests a fresh reconcile after its
-                    // daemon acknowledgement.
-                    state.worker_running = false;
-                    (false, false)
-                } else if state.pending_resize.is_some() {
-                    if self.flush_resize_locked(&mut state) {
-                        (true, true)
-                    } else {
-                        if state.pending_resize.as_ref().is_some_and(|(_, _, _, claim)| *claim) {
-                            state.claim_fence = None;
-                        }
-                        state.pending_resize = None;
-                        state.worker_running = false;
-                        (false, false)
-                    }
-                } else {
-                    state.worker_running = false;
-                    (false, false)
-                }
-            };
-            if flushed {
-                self.start_wire_drain();
-            }
-            if !again {
-                return;
-            }
-            tokio::task::yield_now().await;
-        }
-    }
-
-    fn flush_resize_locked(&self, state: &mut OrderedControlQueueState) -> bool {
-        let Some((generation, endpoint, grid, claim)) = state.pending_resize.clone() else {
-            return true;
-        };
-        if generation != self.current_generation() {
-            // A newer state transition superseded this worker's grid. Do not
-            // retag the old command with the current generation.
-            state.pending_resize = None;
-            if claim {
-                state.claim_fence = None;
-            }
-            return false;
-        }
-        if !endpoint.is_active() {
-            state.pending_resize = None;
-            return false;
-        }
-        let count = if claim { 2 } else { 1 };
-        let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-        if pending.len().saturating_add(count) > MAX_ORDERED_CONTROL_COMMANDS {
-            // Do not consume the pending state or advance last_resize when a
-            // complete command set cannot fit. The caller freezes/retries on
-            // the next viewer event; partial report/claim pairs are invalid.
-            return false;
-        }
-        let (generation, endpoint, grid, claim) =
-            state.pending_resize.take().expect("pending resize");
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(&endpoint),
-            generation: Some(generation),
-            expected_owner: (!claim).then_some(endpoint.viewer_id),
-            requires_unowned: claim,
-            kind: OrderedControlCommandKind::Send {
-                command: "resize-surface".to_owned(),
-                params: json!({
-                    "surface": self.surface_id,
-                    "cols": grid.cols,
-                    "rows": grid.rows,
-                }),
-            },
-        });
-        if claim {
-            pending.push_back(OrderedControlCommand {
-                endpoint: Arc::clone(&endpoint),
-                generation: Some(generation),
-                expected_owner: (!claim).then_some(endpoint.viewer_id),
-                requires_unowned: claim,
-                kind: OrderedControlCommandKind::Send {
-                    command: "set-client-sizing".to_owned(),
-                    params: json!({
-                        "surface": self.surface_id,
-                        "enabled": true,
-                        "exclusive": true,
-                    }),
-                },
-            });
-        }
-        drop(pending);
-        state.last_resize =
-            Some((generation, endpoint.viewer_id, endpoint_ptr(&endpoint), grid, claim));
-        // The caller starts the wire worker after releasing `state`; starting
-        // a synchronous fallback while this lock is held would self-deadlock.
-        true
-    }
-
-    /// Remove pending resize metadata that belongs to an older state
-    /// generation. The caller holds the queue actor lock. Return `true` when
-    /// a stale entry was removed so ingress can continue without treating it
-    /// as a queue-capacity or transport failure.
-    fn discard_stale_pending_locked(&self, state: &mut OrderedControlQueueState) -> bool {
-        let Some((generation, endpoint, _, claim)) = state.pending_resize.as_ref() else {
-            return false;
-        };
-        if *generation == self.current_generation() {
-            return false;
-        }
-        let pending_generation = *generation;
-        let pending_endpoint = endpoint_ptr(endpoint);
-        let pending_claim = *claim;
-        state.pending_resize = None;
-        if pending_claim
-            && state.claim_fence.is_some_and(|fence| {
-                fence.generation == pending_generation && fence.endpoint_ptr == pending_endpoint
-            })
-        {
-            state.claim_fence = None;
-        }
-        true
-    }
-
-    fn discard_stale_owner_resize_fence_locked(&self, state: &mut OrderedControlQueueState) {
-        if state
-            .owner_resize_fence
-            .as_ref()
-            .is_some_and(|fence| fence.generation != self.current_generation())
-        {
-            state.owner_resize_fence = None;
-        }
-    }
-}
-
-struct OrderedControlEndpoint {
-    queue: Weak<OrderedControlQueue>,
-    viewer_id: u64,
-    control: Arc<dyn ControlHandle>,
-    active: AtomicBool,
-    failure_handler: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
-}
-
-fn endpoint_ptr(endpoint: &Arc<OrderedControlEndpoint>) -> usize {
-    Arc::as_ptr(endpoint) as usize
-}
-
-/// Close only the local control transport. This is the explicit exception to
-/// the daemon-mutation actor rule: `end` does not send a daemon command or
-/// claim geometry. Shared-sizing teardown calls this helper only from the
-/// ordered wire worker after it has fenced daemon requests.
-fn end_local_transport(endpoint: &OrderedControlEndpoint) {
-    endpoint.control.end();
-}
-
-impl OrderedControlEndpoint {
-    fn is_active(&self) -> bool {
-        self.active.load(Ordering::Acquire)
-    }
-
-    fn set_failure_handler(&self, handler: Arc<dyn Fn() + Send + Sync>) {
-        *self.failure_handler.lock().expect("ordered control failure lock") = Some(handler);
-    }
-
-    fn failure_handler(&self) -> Option<Arc<dyn Fn() + Send + Sync>> {
-        self.failure_handler.lock().expect("ordered control failure lock").clone()
-    }
-
-    fn enqueue_input(self: &Arc<Self>, data: &[u8]) {
-        if let Some(queue) = self.queue.upgrade() {
-            queue.enqueue_input(self, data);
-        }
-    }
-
-    #[cfg(test)]
-    fn flush_before_request(self: &Arc<Self>) {
-        if let Some(queue) = self.queue.upgrade() {
-            let flushed = {
-                let mut state = queue.state.lock().expect("ordered control queue lock");
-                queue.flush_resize_locked(&mut state)
-            };
-            if flushed {
-                queue.start_wire_drain();
-            }
-        }
-    }
-}
-
-struct SizingTargetState {
-    surface_id: i64,
-    viewers: HashMap<u64, SizingViewer>,
-    owner: Option<u64>,
-    /// One newly attached viewer may make an explicit first claim. After an
-    /// owner leaves, disconnects, or loses a claim, this remains `None` until
-    /// another attachment joins. The relay never elects an existing survivor
-    /// by itself because the core daemon has no generation token for that
-    /// cross-socket hand-off.
-    claim_requested: Option<ClaimRequest>,
-    applied: Option<SizingGrid>,
-    retired: bool,
-}
-
-enum CandidateRequestOutcome {
-    Stale,
-    Reply(Option<Value>),
-}
-
-enum CandidatePrepareOutcome {
-    Stale,
-    QueueFull,
-    Ready(u64),
-}
-
-enum OwnerResizeRequestOutcome {
-    Stale,
-    QueueFull,
-    Reply(Option<Value>),
-}
-
-struct SizingTarget {
-    key: SizingKey,
-    queue: Arc<OrderedControlQueue>,
-    state: Mutex<SizingTargetState>,
-    /// Lock-free generation snapshot used while the queue and target-state
-    /// locks are held. This avoids taking the retry mutex during a stale
-    /// worker commit and keeps lock ordering consistent.
-    generation: AtomicU64,
-    requested: AtomicBool,
-    worker_running: AtomicBool,
-    /// Serializes the worker hand-off with request registration. Without
-    /// this lock a new resize can start a second worker after the old worker
-    /// clears `worker_running` but before it drains waiters.
-    transition: Mutex<()>,
-    waiters: Mutex<Vec<oneshot::Sender<()>>>,
-}
-
-/// Return the viewer that has made an explicit relay-side claim request.
-/// Existing survivors are never selected implicitly: the core daemon does not
-/// provide a generation token that could order a cross-socket hand-off.
-fn candidate_viewer_id(state: &SizingTargetState) -> Option<u64> {
-    let request = state.claim_requested?;
-    state.viewers.get(&request.viewer_id).and_then(|viewer| {
-        (endpoint_ptr(&viewer.endpoint) == request.endpoint_ptr).then_some(request.viewer_id)
-    })
-}
-
-fn candidate_viewer_id_at_generation(state: &SizingTargetState, generation: u64) -> Option<u64> {
-    state
-        .claim_requested
-        .filter(|request| request.generation == generation)
-        .and_then(|_| candidate_viewer_id(state))
-}
-
-fn sync_claim_request_locked(
-    state: &mut SizingTargetState,
-    queue_state: &OrderedControlQueueState,
-    generation: u64,
-    viewer_id: u64,
-    endpoint: &Arc<OrderedControlEndpoint>,
-) {
-    let Some(fence) = queue_state.claim_fence else { return };
-    if fence.generation == generation
-        && fence.viewer_id == viewer_id
-        && fence.endpoint_ptr == endpoint_ptr(endpoint)
-    {
-        state.claim_requested = Some(ClaimRequest {
-            generation,
-            viewer_id,
-            token: Some(fence.token),
-            endpoint_ptr: fence.endpoint_ptr,
-        });
-    }
-}
-
-/// Coordinates geometry ownership for all raw terminal viewers on this relay.
-///
-/// Protocol 10 daemons accept a terminal resize only from the connection that
-/// successfully claimed `set-client-sizing`. Requests are asynchronous, so a
-/// single bounded worker per surface serializes report, claim, and resize
-/// round-trips while coalescing bursts of viewer updates.
-struct TerminalSizing {
-    targets: Mutex<HashMap<SizingKey, Arc<SizingTarget>>>,
-}
-
-impl TerminalSizing {
-    fn new() -> Arc<Self> {
-        Arc::new(Self { targets: Mutex::new(HashMap::new()) })
-    }
-
-    /// Advance the viewer state generation after an external join/update/
-    /// leave. The generation rejects late explicit-claim replies; it never
-    /// elects a replacement viewer.
-    fn advance_generation(&self, target: &Arc<SizingTarget>) -> u64 {
-        let generation = target.generation.load(Ordering::Relaxed).saturating_add(1);
-        target.generation.store(generation, Ordering::Release);
-        target.queue.generation.store(generation, Ordering::Release);
-        generation
-    }
-
-    fn current_generation(target: &Arc<SizingTarget>) -> u64 {
-        target.generation.load(Ordering::Acquire)
-    }
-
-    /// Abandon a failed or stale explicit claim. The relay leaves the core
-    /// geometry frozen and waits for a new attachment to claim it. In
-    /// particular, this method never schedules a survivor or a delayed retry.
-    fn abandon_candidate_request(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-        token: u64,
-    ) {
-        let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-        let mut state = target.state.lock().expect("terminal sizing state lock");
-        if queue_state.claim_fence
-            == Some(ClaimFence {
-                generation,
-                viewer_id,
-                grid,
-                token,
-                endpoint_ptr: endpoint_ptr(endpoint),
-            })
-        {
-            queue_state.claim_fence = None;
-        }
-        if state.claim_requested.is_some_and(|request| {
-            request.generation == generation
-                && request.viewer_id == viewer_id
-                && request.endpoint_ptr == endpoint_ptr(endpoint)
-                && request.token == Some(token)
-        }) {
-            state.claim_requested = None;
-        }
-    }
-
-    /// Check the endpoint and viewer generation immediately before a
-    /// candidate request is started. The endpoint is closed by leave and by
-    /// timeout handling, so a stale worker cannot start a new request after a
-    /// replacement has been reserved.
-    fn candidate_is_current(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-    ) -> bool {
-        // Do not hold the retry lock while taking target state. Generation
-        // transitions may run inside the queue/state critical section; the
-        // final endpoint and fence identity checks below handle a concurrent
-        // transition without creating a lock inversion.
-        if Self::current_generation(target) != generation {
-            return false;
-        }
-        let state = target.state.lock().expect("terminal sizing state lock");
-        Self::current_generation(target) == generation
-            && !state.retired
-            && state.owner.is_none()
-            && candidate_viewer_id_at_generation(&state, generation) == Some(viewer_id)
-            && smallest_sizing_grid(&state.viewers) == Some(grid)
-            && state.viewers.get(&viewer_id).is_some_and(|viewer| {
-                viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
-            })
-    }
-
-    async fn candidate_request(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-        command: &str,
-        params: Value,
-    ) -> CandidateRequestOutcome {
-        if !self.candidate_is_current(target, viewer_id, endpoint, grid, generation) {
-            return CandidateRequestOutcome::Stale;
-        }
-        let response = target
-            .queue
-            .ordered_request_at(endpoint, command, params, generation, None, true)
-            .await;
-        // `None` is used both for a transport failure and for a command that
-        // the ordered actor rejected as stale.  Do not turn the latter into
-        // `leave_endpoint`: a newer generation may already own this viewer
-        // identity and must not be detached by an old candidate worker.
-        if response.is_none()
-            && !self.candidate_is_current(target, viewer_id, endpoint, grid, generation)
-        {
-            CandidateRequestOutcome::Stale
-        } else {
-            CandidateRequestOutcome::Reply(response)
-        }
-    }
-
-    fn join(
-        self: &Arc<Self>,
-        key: SizingKey,
-        viewer_id: u64,
-        surface_id: i64,
-        control: Arc<dyn ControlHandle>,
-        grid: SizingGrid,
-    ) -> Option<oneshot::Receiver<()>> {
-        self.join_with_endpoint(key, viewer_id, surface_id, control, grid)
-            .map(|(waiter, _endpoint)| waiter)
-    }
-
-    /// Join and return the exact endpoint registered for this attachment.
-    /// Callers that own a lease must retain this identity: a later reconnect
-    /// may reuse the viewer id, and an old lease must not update or remove the
-    /// replacement endpoint.
-    fn join_with_endpoint(
-        self: &Arc<Self>,
-        key: SizingKey,
-        viewer_id: u64,
-        surface_id: i64,
-        control: Arc<dyn ControlHandle>,
-        grid: SizingGrid,
-    ) -> Option<(oneshot::Receiver<()>, Arc<OrderedControlEndpoint>)> {
-        let (target, joined_endpoint, should_start) = {
-            let mut targets = self.targets.lock().expect("terminal sizing targets lock");
-            let target_key = key.clone();
-            let target = targets.entry(key).or_insert_with(|| {
-                let queue = OrderedControlQueue::new(surface_id);
-                Arc::new(SizingTarget {
-                    key: target_key,
-                    queue,
-                    state: Mutex::new(SizingTargetState {
-                        surface_id,
-                        viewers: HashMap::new(),
-                        owner: None,
-                        claim_requested: None,
-                        applied: None,
-                        retired: false,
-                    }),
-                    generation: AtomicU64::new(1),
-                    requested: AtomicBool::new(false),
-                    worker_running: AtomicBool::new(false),
-                    transition: Mutex::new(()),
-                    waiters: Mutex::new(Vec::new()),
-                })
-            });
-            let target = Arc::clone(target);
-            target.queue.bind_target(&target, self);
-            // Keep the map lock while changing the target state. This makes a
-            // final leave and a concurrent join observe one linear order and
-            // prevents a newly joined viewer from being removed with a
-            // retired target.
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            if queue_state.closing_failed
-                || (state.retired && !target.queue.close_barrier_ready_locked(&queue_state))
-            {
-                // The old daemon transport did not acknowledge its close.
-                // Do not resurrect this target or attach a new socket to an
-                // authority whose cross-socket order is unknown. A queued or
-                // in-flight close is safe to join behind; a close that could
-                // not fit in the bounded queue must be retried before any
-                // replacement can enter the target.
-                return None;
-            }
-            state.retired = false;
-            if let Some(previous) = state.viewers.remove(&viewer_id) {
-                target.queue.detach_locked(&mut queue_state, &previous.endpoint);
-                if state.owner == Some(viewer_id) {
-                    state.owner = None;
-                }
-            }
-            let endpoint = target.queue.endpoint(viewer_id, Arc::clone(&control));
-            let endpoint_weak = Arc::downgrade(&endpoint);
-            let coordinator_weak = Arc::downgrade(self);
-            let callback_key = target.key.clone();
-            endpoint.set_failure_handler(Arc::new(move || {
-                if let (Some(coordinator), Some(endpoint)) =
-                    (coordinator_weak.upgrade(), endpoint_weak.upgrade())
-                {
-                    coordinator.leave_endpoint(&callback_key, viewer_id, &endpoint);
-                }
-            }));
-            state
-                .viewers
-                .insert(viewer_id, SizingViewer { control, endpoint: Arc::clone(&endpoint), grid });
-            let generation = self.advance_generation(&target);
-            // A new attachment is the only relay-local event that may make an
-            // explicit claim. Existing survivors are not selected after an
-            // owner loss or refusal.
-            let immediate_claim = state.owner.is_none();
-            state.claim_requested = immediate_claim.then_some(ClaimRequest {
-                generation,
-                viewer_id,
-                token: None,
-                endpoint_ptr: endpoint_ptr(&endpoint),
-            });
-            let owner_grid = smallest_sizing_grid(&state.viewers);
-            let owner_id =
-                if !immediate_claim && state.applied != owner_grid { state.owner } else { None };
-            let owner_endpoint = owner_id
-                .and_then(|id| state.viewers.get(&id).map(|viewer| Arc::clone(&viewer.endpoint)));
-            let mut should_start = false;
-            // Reserve the canonical command while the join mutation still
-            // holds queue -> target-state. A later input cannot enter the
-            // queue between the generation bump and this enqueue. If an old
-            // endpoint is closing, the FIFO close is already in the wire
-            // queue; append the new report/claim after it, so replacement
-            // input cannot overtake the authority command.
-            if let (Some(endpoint), Some(owner_id), Some(grid)) =
-                (owner_endpoint.as_ref(), owner_id, owner_grid)
-            {
-                let (_, start) = self.enqueue_update_locked(
-                    &target,
-                    &mut queue_state,
-                    &state,
-                    owner_id,
-                    Some(owner_id),
-                    endpoint,
-                    grid,
-                    false,
-                    generation,
-                );
-                should_start |= start;
-            }
-            if immediate_claim {
-                if let Some(grid) = owner_grid {
-                    let (valid, start) = self.enqueue_update_locked(
-                        &target,
-                        &mut queue_state,
-                        &state,
-                        viewer_id,
-                        None,
-                        &endpoint,
-                        grid,
-                        true,
-                        generation,
-                    );
-                    if valid {
-                        sync_claim_request_locked(
-                            &mut state,
-                            &queue_state,
-                            generation,
-                            viewer_id,
-                            &endpoint,
-                        );
-                    }
-                    should_start |= start;
-                }
-            }
-            drop(state);
-            drop(queue_state);
-            (target, Arc::clone(&endpoint), should_start)
-        };
-        if should_start {
-            target.queue.start_wire_drain();
-            target.queue.start_drain(true);
-        }
-        target.queue.schedule_closing();
-        Some((self.request_reconcile_wait(target), joined_endpoint))
-    }
-
-    fn queue_for(&self, key: &SizingKey, viewer_id: u64) -> Option<Arc<OrderedControlEndpoint>> {
-        let target =
-            self.targets.lock().expect("terminal sizing targets lock").get(key).cloned()?;
-        let state = target.state.lock().expect("terminal sizing state lock");
-        state.viewers.get(&viewer_id).map(|viewer| Arc::clone(&viewer.endpoint))
-    }
-
-    fn update(self: &Arc<Self>, key: &SizingKey, viewer_id: u64, grid: SizingGrid) {
-        self.update_inner(key, viewer_id, None, grid);
-    }
-
-    /// Update only the endpoint that owns a lease. A stale lease may retain
-    /// the same viewer id after reconnect; pointer identity prevents it from
-    /// mutating the replacement viewer's grid.
-    fn update_endpoint(
-        self: &Arc<Self>,
-        key: &SizingKey,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-    ) {
-        self.update_inner(key, viewer_id, Some(endpoint), grid);
-    }
-
-    fn update_inner(
-        self: &Arc<Self>,
-        key: &SizingKey,
-        viewer_id: u64,
-        expected_endpoint: Option<&Arc<OrderedControlEndpoint>>,
-        grid: SizingGrid,
-    ) {
-        let target = self.targets.lock().expect("terminal sizing targets lock").get(key).cloned();
-        let Some(target) = target else { return };
-        let (target, should_start) = {
-            // Serialize the state mutation and generation bump with the
-            // shared queue fence. The worker snapshots target state under the
-            // state lock, so advancing while that lock is held prevents it
-            // from observing a new grid under the previous generation.
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            if queue_state.closing_failed {
-                return;
-            }
-            let owner = state.owner;
-            let current_generation = Self::current_generation(&target);
-            // Preserve an explicit claim while any viewer updates. A passive
-            // viewer can change the smallest grid while another viewer's
-            // claim is in flight. Advancing the generation without carrying
-            // that claim would make the old request stale and leave the
-            // target frozen, even though the claimant is still attached.
-            let explicit_candidate = if owner.is_none() {
-                state
-                    .claim_requested
-                    .filter(|request| request.generation == current_generation)
-                    .and_then(|request| {
-                        state.viewers.get(&request.viewer_id).and_then(|viewer| {
-                            (viewer.endpoint.is_active()
-                                && endpoint_ptr(&viewer.endpoint) == request.endpoint_ptr)
-                                .then(|| (request.viewer_id, Arc::clone(&viewer.endpoint)))
-                        })
-                    })
-            } else {
-                None
-            };
-            let endpoint_matches = state.viewers.get(&viewer_id).is_some_and(|viewer| {
-                expected_endpoint.is_none_or(|expected| Arc::ptr_eq(&viewer.endpoint, expected))
-            });
-            if !endpoint_matches {
-                return;
-            }
-            let Some(viewer) = state.viewers.get_mut(&viewer_id) else { return };
-            viewer.grid = grid;
-            let Some(effective_grid) = smallest_sizing_grid(&state.viewers) else { return };
-            let claim = owner.is_none() && explicit_candidate.is_some();
-            let should_enqueue = claim || state.applied != Some(effective_grid);
-            let endpoint = if should_enqueue {
-                if let Some(owner_id) = owner {
-                    state.viewers.get(&owner_id).map(|viewer| Arc::clone(&viewer.endpoint))
-                } else if let Some((_, candidate_endpoint)) = explicit_candidate.as_ref() {
-                    Some(Arc::clone(candidate_endpoint))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            let endpoint_viewer_id = owner
-                .or_else(|| explicit_candidate.as_ref().map(|(candidate_id, _)| *candidate_id))
-                .unwrap_or(viewer_id);
-            let claim_endpoint_ptr = endpoint.as_ref().map(|endpoint| endpoint_ptr(endpoint));
-            let generation = self.advance_generation(&target);
-            if claim {
-                // An update while an explicit claim is in flight is a new
-                // generation of the same claim attempt. Carry the identity
-                // forward before the queue validates the new generation;
-                // otherwise a passive viewer update would erase the only
-                // candidate marker and leave the unowned target frozen.
-                if let Some(endpoint_ptr) = claim_endpoint_ptr {
-                    let same_claim = state.claim_requested.is_some_and(|request| {
-                        request.viewer_id == endpoint_viewer_id
-                            && request.endpoint_ptr == endpoint_ptr
-                    });
-                    if same_claim {
-                        state.claim_requested = Some(ClaimRequest {
-                            generation,
-                            viewer_id: endpoint_viewer_id,
-                            token: None,
-                            endpoint_ptr,
-                        });
-                    }
-                }
-            }
-            let should_start = endpoint.map_or(false, |endpoint| {
-                let (valid, should_start) = self.enqueue_update_locked(
-                    &target,
-                    &mut queue_state,
-                    &state,
-                    endpoint_viewer_id,
-                    owner,
-                    &endpoint,
-                    effective_grid,
-                    claim,
-                    generation,
-                );
-                if claim && valid {
-                    sync_claim_request_locked(
-                        &mut state,
-                        &queue_state,
-                        generation,
-                        endpoint_viewer_id,
-                        &endpoint,
-                    );
-                }
-                should_start
-            });
-            drop(state);
-            drop(queue_state);
-            (target, should_start)
-        };
-        if should_start {
-            target.queue.start_wire_drain();
-            target.queue.start_drain(true);
-        }
-        self.request_reconcile(target);
-    }
-
-    fn leave(self: &Arc<Self>, key: &SizingKey, viewer_id: u64) {
-        self.leave_inner(key, viewer_id, None, None);
-    }
-
-    /// Remove a viewer only when the endpoint that was used for the failed
-    /// sizing round is still attached. A viewer id can be reused after a
-    /// reconnect; pointer identity prevents a late timeout from removing the
-    /// healthy replacement.
-    fn leave_endpoint(
-        self: &Arc<Self>,
-        key: &SizingKey,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-    ) {
-        self.leave_inner(key, viewer_id, Some(endpoint), None);
-    }
-
-    /// Remove an endpoint only if the worker's generation is still current.
-    /// Timeout/error responses otherwise can detach a healthy same-pointer
-    /// endpoint after an update advanced its generation.
-    fn leave_endpoint_at_generation(
-        self: &Arc<Self>,
-        key: &SizingKey,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        generation: u64,
-    ) {
-        self.leave_inner(key, viewer_id, Some(endpoint), Some(generation));
-    }
-
-    fn leave_inner(
-        self: &Arc<Self>,
-        key: &SizingKey,
-        viewer_id: u64,
-        expected_endpoint: Option<&Arc<OrderedControlEndpoint>>,
-        expected_generation: Option<u64>,
-    ) {
-        let (target, should_start) = {
-            let mut targets = self.targets.lock().expect("terminal sizing targets lock");
-            let Some(target) = targets.get(key).cloned() else { return };
-            // Keep the queue before state lock order used by input and owner
-            // loss. This makes leave a linear transition: after the endpoint
-            // is removed, a survivor input cannot pass before its replacement
-            // report/claim or owner resize is enqueued.
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            if expected_generation
-                .is_some_and(|expected| Self::current_generation(&target) != expected)
-            {
-                return;
-            }
-            let Some(current) = state.viewers.get(&viewer_id) else {
-                return;
-            };
-            if expected_endpoint.is_some_and(|expected| !Arc::ptr_eq(&current.endpoint, expected)) {
-                return;
-            }
-            let Some(removed) = state.viewers.remove(&viewer_id) else { return };
-            target.queue.detach_locked(&mut queue_state, &removed.endpoint);
-            // Close only this attachment. A claim from another surviving
-            // endpoint is still explicit, so preserve it across this
-            // generation transition; only owner loss or candidate removal
-            // freezes authority.
-            let removed_owner = state.owner == Some(viewer_id);
-            let removed_candidate = state.claim_requested.is_some_and(|request| {
-                request.viewer_id == viewer_id
-                    && request.endpoint_ptr == endpoint_ptr(&removed.endpoint)
-            });
-            if removed_candidate {
-                state.claim_requested = None;
-            }
-            if removed_owner {
-                state.owner = None;
-                // Preserve `applied`: this is the frozen core geometry. A
-                // later attachment must explicitly claim before changing it.
-                state.claim_requested = None;
-            }
-            let generation = self.advance_generation(&target);
-            if state.viewers.is_empty() {
-                state.retired = true;
-                // Keep the retired target until the ordered close command has
-                // completed. Removing it here would drop the only coordinator
-                // that can fence a late writer.
-                drop(state);
-                drop(queue_state);
-                (target, false)
-            } else {
-                let grid = smallest_sizing_grid(&state.viewers);
-                let surviving_claim = if !removed_owner && !removed_candidate {
-                    state.claim_requested.and_then(|request| {
-                        state.viewers.get(&request.viewer_id).and_then(|viewer| {
-                            (viewer.endpoint.is_active()
-                                && endpoint_ptr(&viewer.endpoint) == request.endpoint_ptr)
-                                .then_some((request.viewer_id, Arc::clone(&viewer.endpoint)))
-                        })
-                    })
-                } else {
-                    None
-                };
-                if let Some((candidate_id, endpoint)) = surviving_claim.as_ref() {
-                    state.claim_requested = Some(ClaimRequest {
-                        generation,
-                        viewer_id: *candidate_id,
-                        token: None,
-                        endpoint_ptr: endpoint_ptr(endpoint),
-                    });
-                } else if !removed_owner {
-                    // A marker that no longer names a live viewer is stale;
-                    // do not let it block input after this leave.
-                    state.claim_requested = None;
-                }
-                target.queue.clear_stale_claim_fence_locked(&mut queue_state, None);
-                let should_start = if !target.queue.close_barrier_ready_locked(&queue_state)
-                    || queue_state.closing_failed
-                {
-                    false
-                } else if let (Some((candidate_id, endpoint)), Some(grid)) =
-                    (surviving_claim.as_ref(), grid)
-                {
-                    let (valid, should_start) = self.enqueue_update_locked(
-                        &target,
-                        &mut queue_state,
-                        &state,
-                        *candidate_id,
-                        None,
-                        endpoint,
-                        grid,
-                        true,
-                        generation,
-                    );
-                    if valid {
-                        sync_claim_request_locked(
-                            &mut state,
-                            &queue_state,
-                            generation,
-                            *candidate_id,
-                            endpoint,
-                        );
-                    }
-                    should_start
-                } else if let (Some(owner_id), Some(grid)) = (state.owner, grid) {
-                    if let Some(owner) = state.viewers.get(&owner_id)
-                        && owner.endpoint.is_active()
-                        && state.applied != Some(grid)
-                    {
-                        target
-                            .queue
-                            .enqueue_owner_resize_batch_locked(
-                                &mut queue_state,
-                                &owner.endpoint,
-                                owner_id,
-                                grid,
-                                generation,
-                            )
-                            .1
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                };
-                drop(state);
-                drop(queue_state);
-                (target, should_start)
-            }
-        };
-        if should_start {
-            target.queue.start_wire_drain();
-        }
-        target.queue.start_drain(should_start);
-        target.queue.schedule_closing();
-        self.request_reconcile(target);
-    }
-
-    fn request_reconcile(self: &Arc<Self>, target: Arc<SizingTarget>) {
-        self.request_reconcile_with_waiter(target, None);
-    }
-
-    fn request_reconcile_wait(
-        self: &Arc<Self>,
-        target: Arc<SizingTarget>,
-    ) -> oneshot::Receiver<()> {
-        let (sender, receiver) = oneshot::channel();
-        self.request_reconcile_with_waiter(target, Some(sender));
-        receiver
-    }
-
-    fn request_reconcile_with_waiter(
-        self: &Arc<Self>,
-        target: Arc<SizingTarget>,
-        waiter: Option<oneshot::Sender<()>>,
-    ) {
-        let should_start = {
-            let _transition = target.transition.lock().expect("terminal sizing transition lock");
-            if let Some(waiter) = waiter {
-                target.waiters.lock().expect("terminal sizing waiters lock").push(waiter);
-            }
-            target.requested.store(true, Ordering::Release);
-            target
-                .worker_running
-                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-        };
-        if !should_start {
-            return;
-        }
-        let coordinator = Arc::clone(self);
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            // All production callers are on the relay runtime. Leave the
-            // request and its waiters latched so the next viewer event can
-            // retry if a test or embedding caller invokes this method outside
-            // Tokio. The waiter is an enqueue/worker-turn notification, not a
-            // claim-success acknowledgement; callers that need authority
-            // must inspect the subsequent wire response.
-            let _transition = target.transition.lock().expect("terminal sizing transition lock");
-            target.worker_running.store(false, Ordering::Release);
-            return;
-        };
-        handle.spawn(async move {
-            coordinator.run_target(target).await;
-        });
-    }
-
-    async fn run_target(self: Arc<Self>, target: Arc<SizingTarget>) {
-        loop {
-            let should_apply = {
-                let _transition =
-                    target.transition.lock().expect("terminal sizing transition lock");
-                if target.requested.swap(false, Ordering::AcqRel) {
-                    true
-                } else {
-                    target.worker_running.store(false, Ordering::Release);
-                    // Request registration and waiter completion are serialized
-                    // by `transition`, so no new request can pass between this
-                    // check and the drain. Completion means the worker turn
-                    // drained/enqueued; a daemon refusal is retried on the
-                    // next viewer event.
-                    self.complete_waiters(&target);
-                    false
-                }
-            };
-            if !should_apply {
-                self.remove_retired_target(&target);
-                return;
-            }
-            self.apply_target(&target).await;
-        }
-    }
-
-    fn complete_waiters(&self, target: &Arc<SizingTarget>) {
-        let waiters =
-            std::mem::take(&mut *target.waiters.lock().expect("terminal sizing waiters lock"));
-        for waiter in waiters {
-            let _ = waiter.send(());
-        }
-    }
-
-    fn remove_retired_target(&self, target: &Arc<SizingTarget>) {
-        // A failed close is permanent for this target. Keep the retired entry
-        // in the map so a later join cannot create a new socket generation
-        // beside an old transport whose daemon ordering is unknown. The
-        // entry is removed only after a successful close and after every wire
-        // command/worker has quiesced; process restart is the recovery path
-        // for a permanently failed transport.
-        let mut targets = self.targets.lock().expect("terminal sizing targets lock");
-        let Some(current) = targets.get(&target.key) else { return };
-        if !Arc::ptr_eq(current, target) {
-            return;
-        }
-        // Keep the queue -> target-state order used by sizing transitions.
-        // Do not hold target state while closing the queue: that would let a
-        // concurrent input path deadlock against a concurrent close.
-        let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-        let state = target.state.lock().expect("terminal sizing state lock");
-        let wire_pending_empty =
-            target.queue.wire_pending.lock().expect("ordered control pending lock").is_empty();
-        if state.retired
-            && state.viewers.is_empty()
-            && !target.worker_running.load(Ordering::Acquire)
-            && !target.queue.closing_running.load(Ordering::Acquire)
-            && !target.queue.wire_running.load(Ordering::Acquire)
-            && wire_pending_empty
-            && queue_state.closing.is_empty()
-            && queue_state.closing_waiters.is_empty()
-            && queue_state.closing_inflight.is_empty()
-            && queue_state.abort_pending.is_empty()
-            && queue_state.dispatching.is_none()
-        {
-            target.queue.close_locked(&mut queue_state);
-            targets.remove(&target.key);
-        }
-    }
-
-    /// A failed close proves that no later command can be ordered against the
-    /// old daemon socket. Detach every viewer that was admitted behind that
-    /// close, including a replacement that joined while the close was in
-    /// flight. Mark the target retired and retain local abort commands under
-    /// the queue actor until the wire worker can dispatch them; no replacement
-    /// may remain active but permanently unable to send input.
-    fn fail_target_after_close(&self, target: &Arc<SizingTarget>) {
-        let should_start = {
-            let targets = self.targets.lock().expect("terminal sizing targets lock");
-            let Some(current) = targets.get(&target.key) else { return };
-            if !Arc::ptr_eq(current, target) {
-                return;
-            }
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            if !queue_state.closing_failed {
-                return;
-            }
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            let endpoints = if state.retired && state.viewers.is_empty() {
-                // A previous invocation may have filled the bounded queue
-                // before all local aborts were enqueued. Keep draining the
-                // retained list; never drop an admitted control on a repeat
-                // callback.
-                Vec::new()
-            } else {
-                let viewers = std::mem::take(&mut state.viewers);
-                for viewer in viewers.values() {
-                    viewer.endpoint.active.store(false, Ordering::Release);
-                }
-                state.owner = None;
-                state.claim_requested = None;
-                state.retired = true;
-                // Invalidate every queued mutation generation. The wire actor
-                // will reject already-enqueued commands while the failed close
-                // remains the permanent ordering barrier.
-                self.advance_generation(target);
-                queue_state.pending_resize = None;
-                queue_state.last_resize = None;
-                queue_state.claim_fence = None;
-                queue_state.owner_resize_fence = None;
-                viewers.into_values().map(|viewer| viewer.endpoint).collect::<Vec<_>>()
-            };
-            queue_state.abort_pending.extend(endpoints);
-            let mut pending =
-                target.queue.wire_pending.lock().expect("ordered control pending lock");
-            let mut retained = VecDeque::with_capacity(
-                pending.len().saturating_add(queue_state.abort_pending.len()),
-            );
-            for command in pending.drain(..) {
-                let OrderedControlCommand {
-                    endpoint,
-                    generation,
-                    expected_owner,
-                    requires_unowned,
-                    kind,
-                } = command;
-                match kind {
-                    OrderedControlCommandKind::Close { reply } => {
-                        // The target-wide barrier has already failed. Do not
-                        // leave another pending close ahead of local cleanup;
-                        // wake its waiter as failed and convert the endpoint
-                        // to the actor-owned local abort path.
-                        let _ = reply.send(false);
-                        queue_state.abort_pending.push_back(endpoint);
-                    }
-                    OrderedControlCommandKind::Abort => {
-                        retained.push_back(OrderedControlCommand {
-                            endpoint,
-                            generation,
-                            expected_owner,
-                            requires_unowned,
-                            kind: OrderedControlCommandKind::Abort,
-                        });
-                    }
-                    OrderedControlCommandKind::Request { reply, .. } => {
-                        let _ = reply.send(None);
-                    }
-                    OrderedControlCommandKind::Send { .. } => {}
-                }
-            }
-            target.queue.enqueue_abort_pending_locked(&mut queue_state, &mut retained);
-            let should_start = !retained.is_empty();
-            *pending = retained;
-            should_start
-        };
-        if should_start {
-            // The abort commands use the same actor as normal close commands;
-            // they do not attempt another daemon barrier.
-            target.queue.start_wire_drain();
-        }
-        self.complete_waiters(target);
-    }
-
-    /// Enqueue a viewer update only if the owner/endpoint snapshot is still
-    /// current. The queue lock is taken before target state, so an authority
-    /// transition cannot let a stale update replace a pending claim.
-    fn enqueue_update_if_current(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        expected_owner: Option<u64>,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        claim: bool,
-        generation: u64,
-    ) -> bool {
-        if Self::current_generation(target) != generation {
-            return false;
-        }
-        let (current, should_start) = {
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let state = target.state.lock().expect("terminal sizing state lock");
-            self.enqueue_update_locked(
-                target,
-                &mut queue_state,
-                &state,
-                viewer_id,
-                expected_owner,
-                endpoint,
-                grid,
-                claim,
-                generation,
-            )
-        };
-        if current && should_start {
-            // `flush_resize_locked` only appends while the coordinator locks
-            // are held. Start the wire worker after those locks are released.
-            target.queue.start_wire_drain();
-        }
-        target.queue.start_drain(should_start);
-        current
-    }
-
-    /// Validate and reserve a canonical resize while the caller already holds
-    /// the queue-state then target-state locks. Keeping the state mutation and
-    /// this enqueue in one actor transition prevents input from entering the
-    /// wire queue in the generation gap between them.
-    fn enqueue_update_locked(
-        &self,
-        target: &Arc<SizingTarget>,
-        queue_state: &mut OrderedControlQueueState,
-        state: &SizingTargetState,
-        viewer_id: u64,
-        expected_owner: Option<u64>,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        claim: bool,
-        generation: u64,
-    ) -> (bool, bool) {
-        if Self::current_generation(target) != generation
-            || state.retired
-            || state.owner != expected_owner
-            || !target.queue.close_barrier_ready_locked(queue_state)
-            || queue_state.closing_failed
-        {
-            // A closing transport is a daemon-order barrier. The caller
-            // leaves the state changed but lets the reconcile worker retry
-            // after `wait_for_closing` completes; no command may overtake it.
-            return (false, false);
-        }
-        let candidate = if state.owner.is_none() {
-            smallest_sizing_grid(&state.viewers).and_then(|current_grid| {
-                candidate_viewer_id_at_generation(state, generation).map(|id| (id, current_grid))
-            })
-        } else {
-            None
-        };
-        target.queue.discard_stale_owner_resize_fence_locked(queue_state);
-        target.queue.clear_stale_claim_fence_locked(
-            queue_state,
-            candidate.and_then(|(candidate_id, candidate_grid)| {
-                state.viewers.get(&candidate_id).map(|viewer| {
-                    (generation, candidate_id, candidate_grid, endpoint_ptr(&viewer.endpoint))
-                })
-            }),
-        );
-        let endpoint_current = state.viewers.get(&viewer_id).is_some_and(|viewer| {
-            viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
-        });
-        let grid_current = smallest_sizing_grid(&state.viewers) == Some(grid);
-        let candidate_current = expected_owner.is_none()
-            && candidate_viewer_id_at_generation(state, generation) == Some(viewer_id);
-        let queue_reserved_for_candidate = !claim && queue_state.claim_fence.is_some();
-        let valid = endpoint_current
-            && grid_current
-            && (claim == candidate_current)
-            && !queue_reserved_for_candidate;
-        if !valid {
-            return (false, false);
-        }
-        let should_start = if claim {
-            target.queue.reserve_resize_locked(queue_state, endpoint, grid, generation)
-        } else if let Some(owner_id) = expected_owner {
-            // Owner reports must reserve their verification request beside the
-            // resize. This prevents input from entering after an eager report
-            // flush but before `apply_target` can enqueue the request.
-            target
-                .queue
-                .enqueue_owner_resize_batch_locked(
-                    queue_state,
-                    endpoint,
-                    owner_id,
-                    grid,
-                    generation,
-                )
-                .1
-        } else {
-            target.queue.enqueue_resize_locked(queue_state, endpoint, grid, false)
-        };
-        (true, should_start)
-    }
-
-    /// Enqueue the canonical owner resize and its verified request as one
-    /// adjacent batch. A queue worker may already own a pending resize; this
-    /// method consumes that pending state while the queue and target state
-    /// locks are held, then appends the request immediately after it. This is
-    /// the owner-side ordering fence: a later input command cannot overtake
-    /// the report, even when a worker is between polls.
-    async fn owner_resize_request(
-        &self,
-        target: &Arc<SizingTarget>,
-        owner_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-        surface_id: i64,
-    ) -> OwnerResizeRequestOutcome {
-        if Self::current_generation(target) != generation {
-            return OwnerResizeRequestOutcome::Stale;
-        }
-        let (reply, response) = oneshot::channel();
-        let mut prequeued_response: Option<oneshot::Receiver<Option<Value>>> = None;
-        let batch: Result<(), OwnerResizeRequestOutcome> = {
-            // All coordinator mutations use queue -> target-state order. Do
-            // not await while either lock is held; the wire worker performs
-            // the daemon call after this atomic enqueue.
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            let endpoint_current = state.viewers.get(&owner_id).is_some_and(|viewer| {
-                viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
-            });
-            if Self::current_generation(target) != generation
-                || queue_state.closed
-                || queue_state.closing_failed
-                || state.retired
-                || state.owner != Some(owner_id)
-                || !endpoint_current
-                || smallest_sizing_grid(&state.viewers) != Some(grid)
-                || !queue_state.closing.is_empty()
-                || queue_state.claim_fence.is_some()
-            {
-                Err(OwnerResizeRequestOutcome::Stale)
-            } else if let Some(mut fence) = queue_state.owner_resize_fence.take() {
-                if fence.generation != generation
-                    || fence.owner_id != owner_id
-                    || fence.grid != grid
-                    || fence.endpoint_ptr != endpoint_ptr(endpoint)
-                {
-                    // A newer generation must not consume an older response
-                    // fence. Its queued command carries the old generation
-                    // and will be rejected by the wire actor.
-                    queue_state.owner_resize_fence = Some(fence);
-                    Err(OwnerResizeRequestOutcome::Stale)
-                } else if let Some(response) = fence.response.take() {
-                    // The update path already appended resize+request as one
-                    // adjacent batch. Consume only the response receiver;
-                    // input may safely append after the queued request.
-                    prequeued_response = Some(response);
-                    Ok(())
-                } else {
-                    // QueueFull is represented by a fence without a reply
-                    // receiver. Keep the generation fail-closed.
-                    Err(OwnerResizeRequestOutcome::QueueFull)
-                }
-            } else {
-                // A pending resize belongs to this owner queue. It may be
-                // stale after a coalesced update, so replace it with the
-                // latest grid; the replacement and the verified request are
-                // admitted together.
-                let pending_resize = queue_state.pending_resize.as_ref();
-                let needs_resize = pending_resize.is_some()
-                    || queue_state.last_resize
-                        != Some((generation, owner_id, endpoint_ptr(endpoint), grid, false));
-                let command_count = usize::from(needs_resize) + 1;
-                let mut pending =
-                    target.queue.wire_pending.lock().expect("ordered control pending lock");
-                if pending.len().saturating_add(command_count) > MAX_ORDERED_CONTROL_COMMANDS {
-                    // Leave the pending resize and last_resize untouched. The
-                    // caller detaches this endpoint, which freezes authority and
-                    // clears the unsent batch without allowing partial enqueue.
-                    Err(OwnerResizeRequestOutcome::QueueFull)
-                } else {
-                    if needs_resize {
-                        queue_state.pending_resize = None;
-                        pending.push_back(OrderedControlCommand {
-                            endpoint: Arc::clone(endpoint),
-                            generation: Some(generation),
-                            expected_owner: Some(owner_id),
-                            requires_unowned: false,
-                            kind: OrderedControlCommandKind::Send {
-                                command: "resize-surface".to_owned(),
-                                params: json!({
-                                    "surface": surface_id,
-                                    "cols": grid.cols,
-                                    "rows": grid.rows,
-                                }),
-                            },
-                        });
-                        queue_state.last_resize =
-                            Some((generation, owner_id, endpoint_ptr(endpoint), grid, false));
-                    }
-                    pending.push_back(OrderedControlCommand {
-                        endpoint: Arc::clone(endpoint),
-                        generation: Some(generation),
-                        expected_owner: Some(owner_id),
-                        requires_unowned: false,
-                        kind: OrderedControlCommandKind::Request {
-                            command: "resize-surface".to_owned(),
-                            params: json!({
-                                "surface": surface_id,
-                                "cols": grid.cols,
-                                "rows": grid.rows,
-                            }),
-                            reply,
-                        },
-                    });
-                    Ok(())
-                }
-            }
-        };
-        if let Err(outcome) = batch {
-            return outcome;
-        }
-        target.queue.start_wire_drain();
-        if let Some(response) = prequeued_response {
-            let result = response.await.ok().flatten();
-            return if result.is_none() && Self::current_generation(target) != generation {
-                OwnerResizeRequestOutcome::Stale
-            } else {
-                OwnerResizeRequestOutcome::Reply(result)
-            };
-        }
-        let result = response.await.ok().flatten();
-        if result.is_none() && Self::current_generation(target) != generation {
-            OwnerResizeRequestOutcome::Stale
-        } else {
-            OwnerResizeRequestOutcome::Reply(result)
-        }
-    }
-
-    /// Prepare a candidate's verified report/claim request atomically with
-    /// the shared queue. A stale owner update cannot replace the survivor
-    /// claim between marker consumption and the flush. The queue sends the
-    /// claim pair before this method returns, so later input cannot overtake
-    /// it. `set-client-sizing` is the authority command; its response is an
-    /// acknowledgement, so input is fenced by the command, not by waiting for
-    /// the duplicate verification response.
-    fn prepare_candidate_request(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-    ) -> CandidatePrepareOutcome {
-        let (should_start, token, wire_ready) = {
-            let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-            let mut state = target.state.lock().expect("terminal sizing state lock");
-            let generation_current = Self::current_generation(target) == generation;
-            let endpoint_current = state.owner.is_none()
-                && candidate_viewer_id_at_generation(&state, generation) == Some(viewer_id)
-                && state.viewers.get(&viewer_id).is_some_and(|viewer| {
-                    viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
-                })
-                && smallest_sizing_grid(&state.viewers) == Some(grid)
-                && !state.retired;
-            if !generation_current
-                || !endpoint_current
-                || queue_state.closed
-                || queue_state.closing_failed
-                || !queue_state.closing.is_empty()
-            {
-                (false, CandidatePrepareOutcome::Stale, false)
-            } else {
-                target.queue.clear_stale_claim_fence_locked(
-                    &mut queue_state,
-                    Some((generation, viewer_id, grid, endpoint_ptr(endpoint))),
-                );
-                // A fence for another endpoint or grid is stale. Clear it
-                // while the queue and target-state locks are held; a stale
-                // worker cannot replace the new candidate after this point.
-                if queue_state.claim_fence.is_some_and(|fence| {
-                    fence.generation != generation
-                        || fence.viewer_id != viewer_id
-                        || fence.grid != grid
-                        || fence.endpoint_ptr != endpoint_ptr(endpoint)
-                }) {
-                    queue_state.claim_fence = None;
-                    if queue_state.pending_resize.as_ref().is_some_and(|(_, pending, _, claim)| {
-                        *claim && pending.viewer_id == viewer_id
-                    }) {
-                        queue_state.pending_resize = None;
-                    }
-                }
-                // A pending pair from an older generation cannot satisfy the
-                // current candidate fence. Drop it before selecting whether
-                // to reuse or reserve a claim token.
-                target.queue.discard_stale_pending_locked(&mut queue_state);
-                let (should_start, token) = if let Some(fence) = queue_state.claim_fence {
-                    (false, Some(fence.token))
-                } else {
-                    let should_start = target.queue.reserve_resize_locked(
-                        &mut queue_state,
-                        endpoint,
-                        grid,
-                        generation,
-                    );
-                    let token = queue_state.claim_fence.and_then(|fence| {
-                        (fence.generation == generation
-                            && fence.viewer_id == viewer_id
-                            && fence.grid == grid
-                            && fence.endpoint_ptr == endpoint_ptr(endpoint))
-                        .then_some(fence.token)
-                    });
-                    (should_start, token)
-                };
-                if let Some(token) = token {
-                    // `reserve_resize_locked` may have left the pair pending
-                    // behind a running worker. Flush it under the same queue
-                    // lock before the direct verification request is started.
-                    if target.queue.flush_resize_locked(&mut queue_state) {
-                        queue_state.claim_fence = Some(ClaimFence {
-                            generation,
-                            viewer_id,
-                            grid,
-                            token,
-                            endpoint_ptr: endpoint_ptr(endpoint),
-                        });
-                        sync_claim_request_locked(
-                            &mut state,
-                            &queue_state,
-                            generation,
-                            viewer_id,
-                            endpoint,
-                        );
-                        (should_start, CandidatePrepareOutcome::Ready(token), true)
-                    } else {
-                        // A bounded queue cannot represent a partial claim
-                        // pair. Drop the reservation and freeze until a new
-                        // explicit attachment event can retry.
-                        queue_state.claim_fence = None;
-                        queue_state.pending_resize = None;
-                        (false, CandidatePrepareOutcome::QueueFull, false)
-                    }
-                } else {
-                    (false, CandidatePrepareOutcome::QueueFull, false)
-                }
-            }
-        };
-        if wire_ready {
-            target.queue.start_wire_drain();
-        }
-        target.queue.start_drain(should_start);
-        token
-    }
-
-    /// Finish the candidate round-trip while preserving queue/state lock
-    /// order. A successful claim clears the fence and records ownership in
-    /// one transition; a failed or stale round clears only its own fence so a
-    /// later candidate reservation can retry without reviving a stale owner.
-    fn finish_candidate_request(
-        &self,
-        target: &Arc<SizingTarget>,
-        viewer_id: u64,
-        endpoint: &Arc<OrderedControlEndpoint>,
-        grid: SizingGrid,
-        generation: u64,
-        token: u64,
-        success: bool,
-    ) -> bool {
-        let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-        let mut state = target.state.lock().expect("terminal sizing state lock");
-        let generation_current = Self::current_generation(target) == generation;
-        let current = !queue_state.closing_failed
-            && !state.retired
-            && state.owner.is_none()
-            && candidate_viewer_id_at_generation(&state, generation) == Some(viewer_id)
-            && smallest_sizing_grid(&state.viewers) == Some(grid)
-            && generation_current
-            && state.viewers.get(&viewer_id).is_some_and(|viewer| {
-                viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
-            });
-        // The queue token is part of the same claim identity as generation,
-        // viewer, grid, and endpoint. A retry can reuse all other fields in
-        // one generation; an old response must not finish that newer retry.
-        let fence_current = queue_state.claim_fence
-            == Some(ClaimFence {
-                generation,
-                viewer_id,
-                grid,
-                token,
-                endpoint_ptr: endpoint_ptr(endpoint),
-            });
-        if fence_current {
-            queue_state.claim_fence = None;
-        }
-        if success && current && fence_current {
-            state.owner = Some(viewer_id);
-            state.claim_requested = None;
-            state.applied = Some(grid);
-            true
-        } else {
-            // A refused explicit claim freezes the current core geometry. Do
-            // not schedule a replacement or retry from an existing viewer.
-            if state.claim_requested.is_some_and(|request| {
-                request.generation == generation
-                    && request.viewer_id == viewer_id
-                    && request.endpoint_ptr == endpoint_ptr(endpoint)
-                    && request.token == Some(token)
-            }) {
-                state.claim_requested = None;
-            }
-            false
-        }
-    }
-
-    /// Freeze geometry after the current owner loses authority. The core
-    /// daemon has no generation token for ordering a claim from another
-    /// socket, so the relay must not select an existing survivor. A later new
-    /// attachment sets `claim_requested` and performs an explicit claim.
-    fn freeze_after_owner_loss(
-        &self,
-        target: &Arc<SizingTarget>,
-        lost_owner: u64,
-        expected_generation: u64,
-    ) -> bool {
-        let mut queue_state = target.queue.state.lock().expect("ordered control queue lock");
-        let mut state = target.state.lock().expect("terminal sizing state lock");
-        if Self::current_generation(target) != expected_generation
-            || state.retired
-            || state.owner != Some(lost_owner)
-        {
-            return false;
-        }
-        state.owner = None;
-        state.claim_requested = None;
-        target.queue.clear_stale_claim_fence_locked(&mut queue_state, None);
-        target.queue.discard_stale_owner_resize_fence_locked(&mut queue_state);
-        queue_state.owner_resize_fence = None;
-        self.advance_generation(target);
-        false
-    }
-
-    async fn apply_target(self: &Arc<Self>, target: &Arc<SizingTarget>) {
-        // A detached socket is a daemon-order barrier for every later
-        // mutation, not only for a replacement claim. Join/update paths may
-        // have changed the state while the close worker was still draining;
-        // wait before snapshotting the command owner or canonical grid.
-        if !target.queue.wait_for_closing().await {
-            let failed =
-                target.queue.state.lock().expect("ordered control queue lock").closing_failed;
-            if failed {
-                let mut state = target.state.lock().expect("terminal sizing state lock");
-                // A failed daemon barrier cannot be retried from the same
-                // attachment. Clear its explicit claim marker and keep
-                // geometry frozen until a new authenticated attachment.
-                state.claim_requested = None;
-            }
-            return;
-        }
-        let (surface_id, grid, owner, owner_queue, candidate) = {
-            let state = target.state.lock().expect("terminal sizing state lock");
-            if state.retired || state.viewers.is_empty() {
-                return;
-            }
-            let Some(grid) = smallest_sizing_grid(&state.viewers) else { return };
-            let owner = state.owner.filter(|id| state.viewers.contains_key(id));
-            if let Some(owner_id) = owner {
-                let Some(viewer) = state.viewers.get(&owner_id) else { return };
-                if state.applied == Some(grid) {
-                    return;
-                }
-                (state.surface_id, grid, Some(owner_id), Some(Arc::clone(&viewer.endpoint)), None)
-            } else {
-                let generation = Self::current_generation(target);
-                let Some(viewer_id) = candidate_viewer_id_at_generation(&state, generation) else {
-                    return;
-                };
-                let Some(viewer) = state.viewers.get(&viewer_id) else { return };
-                (
-                    state.surface_id,
-                    grid,
-                    None,
-                    None,
-                    Some((viewer_id, Arc::clone(&viewer.control), Arc::clone(&viewer.endpoint))),
-                )
-            }
-        };
-
-        if let Some((viewer_id, _control, endpoint)) = candidate {
-            let generation = Self::current_generation(target);
-            // Only a newly attached viewer reaches this path. Existing
-            // survivors are intentionally not elected after owner loss.
-            if !self.candidate_is_current(target, viewer_id, &endpoint, grid, generation) {
-                return;
-            }
-            let token = match self
-                .prepare_candidate_request(target, viewer_id, &endpoint, grid, generation)
-            {
-                CandidatePrepareOutcome::Stale => return,
-                CandidatePrepareOutcome::QueueFull => {
-                    // This worker has no request id to report. Detach the
-                    // candidate and freeze authority rather than leaving a
-                    // claim fence that can never drain.
-                    self.leave_endpoint_at_generation(
-                        &target.key,
-                        viewer_id,
-                        &endpoint,
-                        generation,
-                    );
-                    return;
-                }
-                CandidatePrepareOutcome::Ready(token) => token,
-            };
-            // Leave/update can race the preparation above. Re-check the
-            // generation and endpoint immediately before starting the
-            // round-trip; an invalidated control is closed by leave and must
-            // not issue a late authority command.
-            if !self.candidate_is_current(target, viewer_id, &endpoint, grid, generation) {
-                self.abandon_candidate_request(
-                    target, viewer_id, &endpoint, grid, generation, token,
-                );
-                return;
-            }
-            let reported = match self
-                .candidate_request(
-                    target,
-                    viewer_id,
-                    &endpoint,
-                    grid,
-                    generation,
-                    "resize-surface",
-                    json!({ "surface": surface_id, "cols": grid.cols, "rows": grid.rows }),
-                )
-                .await
-            {
-                CandidateRequestOutcome::Stale => {
-                    if endpoint.is_active() {
-                        self.abandon_candidate_request(
-                            target, viewer_id, &endpoint, grid, generation, token,
-                        );
-                    }
-                    return;
-                }
-                CandidateRequestOutcome::Reply(response) => response,
-            };
-            // A reply can be valid JSON even after a leave/update advanced
-            // the candidate generation.  Check the fence before interpreting
-            // `ok` or `accepted`; an old refusal must not clear or freeze a
-            // newer explicit claim.
-            if !self.candidate_is_current(target, viewer_id, &endpoint, grid, generation) {
-                if endpoint.is_active() {
-                    self.abandon_candidate_request(
-                        target, viewer_id, &endpoint, grid, generation, token,
-                    );
-                } else {
-                    self.leave_endpoint_at_generation(
-                        &target.key,
-                        viewer_id,
-                        &endpoint,
-                        generation,
-                    );
-                }
-                return;
-            }
-            if reported.is_none() {
-                // A timeout or transport failure leaves a request that may
-                // still be queued in the control writer. Close this endpoint
-                // before reserving a replacement so the late request cannot
-                // steal authority after the survivor fence.
-                self.leave_endpoint_at_generation(&target.key, viewer_id, &endpoint, generation);
-                return;
-            }
-            if !control_response_ok(reported.as_ref()) {
-                self.abandon_candidate_request(
-                    target, viewer_id, &endpoint, grid, generation, token,
-                );
-                return;
-            }
-            let claimed = match self
-                .candidate_request(
-                    target,
-                    viewer_id,
-                    &endpoint,
-                    grid,
-                    generation,
-                    "set-client-sizing",
-                    json!({ "surface": surface_id, "enabled": true, "exclusive": true }),
-                )
-                .await
-            {
-                CandidateRequestOutcome::Stale => {
-                    if endpoint.is_active() {
-                        self.abandon_candidate_request(
-                            target, viewer_id, &endpoint, grid, generation, token,
-                        );
-                    }
-                    return;
-                }
-                CandidateRequestOutcome::Reply(response) => response,
-            };
-            // Apply the same generation fence to the claim response.  In
-            // particular, an old `ok:false` must not clear a newer claim
-            // reservation or detach its endpoint.
-            if !self.candidate_is_current(target, viewer_id, &endpoint, grid, generation) {
-                if endpoint.is_active() {
-                    self.abandon_candidate_request(
-                        target, viewer_id, &endpoint, grid, generation, token,
-                    );
-                } else {
-                    self.leave_endpoint_at_generation(
-                        &target.key,
-                        viewer_id,
-                        &endpoint,
-                        generation,
-                    );
-                }
-                return;
-            }
-            if claimed.is_none() {
-                self.leave_endpoint_at_generation(&target.key, viewer_id, &endpoint, generation);
-                return;
-            }
-            if !control_response_ok(claimed.as_ref()) {
-                self.abandon_candidate_request(
-                    target, viewer_id, &endpoint, grid, generation, token,
-                );
-                return;
-            }
-            if !self.candidate_is_current(target, viewer_id, &endpoint, grid, generation) {
-                if endpoint.is_active() {
-                    self.abandon_candidate_request(
-                        target, viewer_id, &endpoint, grid, generation, token,
-                    );
-                } else {
-                    self.leave_endpoint_at_generation(
-                        &target.key,
-                        viewer_id,
-                        &endpoint,
-                        generation,
-                    );
-                }
-                return;
-            }
-            if !self.finish_candidate_request(
-                target, viewer_id, &endpoint, grid, generation, token, true,
-            ) {
-                self.abandon_candidate_request(
-                    target, viewer_id, &endpoint, grid, generation, token,
-                );
-            }
-            return;
-        }
-
-        let Some(owner_id) = owner else { return };
-        // A non-owner viewer can change the canonical smallest grid. The owner
-        // resize and its verified request are admitted as one ordered batch,
-        // so input written on any connection cannot overtake this update.
-        let generation = Self::current_generation(target);
-        let Some(endpoint) = owner_queue.as_ref() else { return };
-        let resized = match self
-            .owner_resize_request(target, owner_id, endpoint, grid, generation, surface_id)
-            .await
-        {
-            OwnerResizeRequestOutcome::Stale => return,
-            OwnerResizeRequestOutcome::QueueFull => {
-                // A complete resize+request batch cannot fit. Detach and
-                // freeze this generation; never send only one half of the
-                // authority transition. `apply_target` is an internal
-                // observation with no request ID; its fixed failure is the
-                // frozen state and a new explicit attachment event.
-                self.leave_endpoint_at_generation(&target.key, owner_id, endpoint, generation);
-                return;
-            }
-            OwnerResizeRequestOutcome::Reply(response) => response,
-        };
-        // A response from an older generation cannot change authority or
-        // freeze the current owner. Check before every refusal path; the
-        // freeze helper repeats the check while holding the actor locks.
-        if Self::current_generation(target) != generation {
-            return;
-        }
-        if resized.is_none() {
-            // A timed-out owner request may still be queued in the control
-            // writer. Close that endpoint before reserving a survivor so a
-            // late command cannot regain authority.
-            if let Some(endpoint) = owner_queue.as_ref() {
-                self.leave_endpoint_at_generation(&target.key, owner_id, endpoint, generation);
-            } else {
-                self.freeze_after_owner_loss(target, owner_id, generation);
-            }
-            return;
-        }
-        if !control_response_ok(resized.as_ref()) {
-            self.freeze_after_owner_loss(target, owner_id, generation);
-            return;
-        }
-        if resized
-            .as_ref()
-            .and_then(|response| response.get("data"))
-            .and_then(|data| data.get("accepted"))
-            .and_then(Value::as_bool)
-            == Some(false)
-        {
-            self.freeze_after_owner_loss(target, owner_id, generation);
-            return;
-        }
-        // Recheck and commit under the same queue -> state fence used by
-        // updates. A worker may have passed its earlier generation check
-        // while an update advanced the target; it must not publish its old
-        // grid after that transition.
-        let _queue_state = target.queue.state.lock().expect("ordered control queue lock");
-        let mut state = target.state.lock().expect("terminal sizing state lock");
-        if Self::current_generation(target) == generation
-            && state.owner == Some(owner_id)
-            && !state.retired
-        {
-            state.applied = Some(grid);
-        }
-    }
-}
-
-fn smallest_sizing_grid(viewers: &HashMap<u64, SizingViewer>) -> Option<SizingGrid> {
-    viewers.values().map(|viewer| viewer.grid).reduce(|left, right| SizingGrid {
-        cols: left.cols.min(right.cols),
-        rows: left.rows.min(right.rows),
-    })
-}
-
-fn smallest_shell_grid(viewers: &HashMap<u64, SizingGrid>) -> Option<SizingGrid> {
-    viewers.values().copied().reduce(|left, right| SizingGrid {
-        cols: left.cols.min(right.cols),
-        rows: left.rows.min(right.rows),
-    })
-}
-
-fn control_response_ok(response: Option<&Value>) -> bool {
-    response.and_then(|value| value.get("ok")).and_then(Value::as_bool) == Some(true)
-}
-
-struct TerminalSizingLease {
-    // The manager owns the coordinator. A lease must not keep that manager
-    // alive through a control callback cycle after cancellation.
-    coordinator: std::sync::Weak<TerminalSizing>,
-    key: SizingKey,
-    viewer_id: u64,
-    surface_id: i64,
-    state: Mutex<SizingLeaseState>,
-}
-
-struct SizingLeaseState {
-    joining: bool,
-    joined: bool,
-    released: bool,
-    /// Once setup may have installed a coordinator endpoint, teardown stays
-    /// queue-owned for the rest of the lease lifetime. This survives the
-    /// joining-cancel rollback, which can enqueue a FIFO close after `joining`
-    /// becomes false but before the cleanup guard is dropped.
-    queue_owned: bool,
-    // Keep only a non-owning identity. The endpoint owns the control handle,
-    // whose callbacks retain the lease; an owning Arc here would form a
-    // lease -> endpoint -> control -> callback -> lease cycle.
-    endpoint: Option<Weak<OrderedControlEndpoint>>,
-}
-
-impl TerminalSizingLease {
-    fn new(
-        coordinator: &Arc<TerminalSizing>,
-        key: SizingKey,
-        viewer_id: u64,
-        surface_id: i64,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            coordinator: Arc::downgrade(coordinator),
-            key,
-            viewer_id,
-            surface_id,
-            state: Mutex::new(SizingLeaseState {
-                joining: false,
-                joined: false,
-                released: false,
-                queue_owned: false,
-                endpoint: None,
-            }),
-        })
-    }
-
-    fn join(
-        &self,
-        control: Arc<dyn ControlHandle>,
-        grid: SizingGrid,
-    ) -> Option<oneshot::Receiver<()>> {
-        let should_start = {
-            let mut state = self.state.lock().expect("terminal sizing lease lock");
-            if state.released || state.joined || state.joining {
-                false
-            } else {
-                state.joining = true;
-                true
-            }
-        };
-        if !should_start {
-            return None;
-        }
-        let mut waiter = None;
-        let mut endpoint = None;
-        {
-            let Some(coordinator) = self.coordinator.upgrade() else {
-                let mut state = self.state.lock().expect("terminal sizing lease lock");
-                state.joining = false;
-                state.released = true;
-                return None;
-            };
-            if let Some((joined_waiter, joined_endpoint)) = coordinator.join_with_endpoint(
-                self.key.clone(),
-                self.viewer_id,
-                self.surface_id,
-                control,
-                grid,
-            ) {
-                waiter = Some(joined_waiter);
-                endpoint = Some(joined_endpoint);
-            }
-            let rollback = self.finish_join(endpoint.as_ref());
-            if rollback {
-                if let Some(endpoint) = endpoint.as_ref() {
-                    coordinator.leave_endpoint(&self.key, self.viewer_id, endpoint);
-                }
-                waiter = None;
-            }
-        }
-        waiter
-    }
-
-    /// Complete the synchronous coordinator registration. Keeping this state
-    /// transition in one helper makes the cancellation/failed-registration
-    /// branch explicit: queue ownership survives only when an endpoint exists
-    /// and a rollback close can be enqueued.
-    fn finish_join(&self, endpoint: Option<&Arc<OrderedControlEndpoint>>) -> bool {
-        let mut state = self.state.lock().expect("terminal sizing lease lock");
-        state.joining = false;
-        if state.released || endpoint.is_none() {
-            // Do not retain the endpoint after a cancelled or failed join.
-            // The endpoint owns the control callbacks, and those callbacks
-            // can retain this lease. Keeping the reference here would create
-            // a lease -> endpoint -> control -> callback -> lease cycle.
-            state.endpoint = None;
-            // A cancellation may have marked teardown as queue-owned while
-            // join was in flight. If no endpoint was installed, no FIFO close
-            // can be pending for this lease; permit direct standalone cleanup.
-            if endpoint.is_none() {
-                state.queue_owned = false;
-            }
-            true
-        } else {
-            state.joined = true;
-            state.queue_owned = true;
-            state.endpoint = endpoint.map(Arc::downgrade);
-            false
-        }
-    }
-
-    fn update(&self, grid: SizingGrid) {
-        let endpoint = {
-            let state = self.state.lock().expect("terminal sizing lease lock");
-            if state.joined && !state.released {
-                state.endpoint.as_ref().and_then(Weak::upgrade)
-            } else {
-                None
-            }
-        };
-        if let Some(endpoint) = endpoint {
-            if let Some(coordinator) = self.coordinator.upgrade() {
-                coordinator.update_endpoint(&self.key, self.viewer_id, &endpoint, grid);
-            }
-        }
-    }
-
-    fn queue(&self) -> Option<Arc<OrderedControlEndpoint>> {
-        let endpoint = {
-            let state = self.state.lock().expect("terminal sizing lease lock");
-            if state.joined && !state.released {
-                state.endpoint.as_ref().and_then(Weak::upgrade)
-            } else {
-                None
-            }
-        };
-        self.coordinator.upgrade()?;
-        endpoint
-    }
-
-    /// Release the relay sizing attachment. Returns true when the sizing
-    /// coordinator owns transport teardown, including repeated calls after a
-    /// callback already released the lease. Callers must not close the
-    /// control directly in that case because the queue must first establish
-    /// the daemon-observed ordering barrier.
-    fn leave(&self) -> bool {
-        let (queue_owned, endpoint) = {
-            let mut state = self.state.lock().expect("terminal sizing lease lock");
-            if state.released {
-                // A close/event callback can release the lease before the
-                // proxy's Drop path runs. Preserve the queue-owned marker so
-                // the second path cannot bypass the FIFO close with a direct
-                // `control.end()`.
-                let queue_owned = state.queue_owned || state.joined || state.joining;
-                state.queue_owned = queue_owned;
-                (queue_owned, None)
-            } else {
-                state.released = true;
-                // Clone only the endpoint needed for the immediate ordered
-                // removal, then drop the owning reference from the lease.
-                // Control callbacks may retain the lease, so retaining this
-                // Arc after release would keep the whole control cycle alive.
-                let queue_owned = state.queue_owned || state.joined || state.joining;
-                state.queue_owned = queue_owned;
-                (queue_owned, state.endpoint.take().and_then(|endpoint| endpoint.upgrade()))
-            }
-        };
-        if queue_owned && let Some(endpoint) = endpoint {
-            if let Some(coordinator) = self.coordinator.upgrade() {
-                coordinator.leave_endpoint(&self.key, self.viewer_id, &endpoint);
-            }
-        }
-        queue_owned
-    }
-}
-
-impl Drop for TerminalSizingLease {
-    fn drop(&mut self) {
-        // A cancelled open can drop the lease before the control proxy exists.
-        // Keep the target map bounded even when no close callback is installed.
-        let _ = self.leave();
-    }
-}
-
-/// Owns a connected cmux-tui control until raw attachment setup completes.
-/// Every fallible request in `open_cmux_terminal` is therefore cancellation
-/// safe; successful setup transfers ownership to `ControlTerminalControl`.
-struct ControlCleanupGuard {
-    control: Option<Arc<dyn ControlHandle>>,
-    /// Shared-sizing setup can enqueue a FIFO close before open returns. Keep
-    /// the lease in this guard until setup transfers ownership to the proxy so
-    /// cancellation never calls `control.end()` ahead of that queue barrier.
-    sizing: Option<Arc<TerminalSizingLease>>,
-}
-
-impl ControlCleanupGuard {
-    fn new(control: Arc<dyn ControlHandle>) -> Self {
-        Self { control: Some(control), sizing: None }
-    }
-
-    fn set_sizing(&mut self, sizing: Arc<TerminalSizingLease>) {
-        self.sizing = Some(sizing);
-    }
-
-    fn disarm(&mut self) {
-        self.control = None;
-        self.sizing = None;
-    }
-}
-
-impl Drop for ControlCleanupGuard {
-    fn drop(&mut self) {
-        // If the sizing lease ever joined (or is in the middle of joining),
-        // its coordinator owns teardown. This remains true when an event
-        // callback already released it, so a cancelled open cannot race a
-        // queued FIFO close with a direct control end.
-        let sizing_owned = self.sizing.take().is_some_and(|sizing| sizing.leave());
-        if sizing_owned {
-            self.control.take();
-            return;
-        }
-        if let Some(control) = self.control.take() {
-            control.end();
-        }
-    }
 }
 
 struct Inner {
@@ -3914,10 +323,7 @@ struct Inner {
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
-    sizing: Arc<TerminalSizing>,
     auth: Mutex<Option<AuthSnapshot>>,
-    next_generation: AtomicU64,
-    next_sizing_id: AtomicU64,
 }
 
 struct ShellStartReservation {
@@ -3949,7 +355,6 @@ impl Drop for OpeningReservation {
     }
 }
 
-#[derive(Clone)]
 pub struct PtyManager {
     inner: Arc<Inner>,
 }
@@ -3969,10 +374,7 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                sizing: TerminalSizing::new(),
                 auth: Mutex::new(None),
-                next_generation: AtomicU64::new(1),
-                next_sizing_id: AtomicU64::new(1),
             }),
         }
     }
@@ -3998,10 +400,7 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                sizing: TerminalSizing::new(),
                 auth: Mutex::new(None),
-                next_generation: AtomicU64::new(1),
-                next_sizing_id: AtomicU64::new(1),
             }),
         }
     }
@@ -4039,12 +438,6 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    // Resize is a hot-path, fire-and-forget operation.  The
-                    // sizing coordinator coalesces updates and performs its
-                    // control-plane replies in a separate worker.  Waiting
-                    // here can hold the serialized relay ingress for the
-                    // full three-second control timeout and block input,
-                    // close, or trust updates behind a slow daemon.
                     attachment.control.resize(cols, rows);
                 }
             }
@@ -4076,84 +469,51 @@ impl PtyManager {
             self.inner.close(&id);
         }
     }
-
-    /// Close one attachment after outbound output saturation. This is kept
-    /// separate from `detach_all` so one slow viewer cannot terminate other
-    /// sessions on the same relay connection.
-    pub fn detach_on_output_overflow(&self, pty_id: &str) {
-        self.inner.close(pty_id);
-    }
 }
 
-fn send_pty_error(context: &FrameContext, pty_id: &str, code: RelayPtyErrorCode, message: &str) {
-    // Keep the hand-written frame path aligned with the generated serde
-    // contract. A second string mapping can silently drift when a variant is
-    // added to RelayPtyErrorCode.
-    let encoded =
-        serde_json::to_value(code).expect("RelayPtyErrorCode serialization is infallible");
-    let wire_code = encoded.as_str().expect("RelayPtyErrorCode serializes as a string");
+fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, message: &str) {
     (context.send)(json!({
         "version": PTY_PROTOCOL_VERSION,
         "type": "pty_error",
         "ptyId": pty_id,
-        "code": wire_code,
+        "code": code,
         "message": message,
     }));
 }
 
-fn operational_pty_error_code(
-    context: &FrameContext,
-    operational: RelayPtyErrorCode,
-) -> RelayPtyErrorCode {
-    crate::wire::pty_operational_error_code(context.negotiated_version, operational)
-}
-
-fn send_operational_pty_error(
+fn send_typed_pty_error(
     context: &FrameContext,
     pty_id: &str,
     code: RelayPtyErrorCode,
-    typed_message: &str,
-    legacy_message: &str,
+    message: &str,
 ) {
-    let code = operational_pty_error_code(context, code);
-    let message = if context.negotiated_version >= PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION {
-        typed_message
-    } else {
-        legacy_message
+    let wire_code = match code {
+        RelayPtyErrorCode::BadRequest => "bad_request",
+        RelayPtyErrorCode::TrustRefused => "trust_refused",
+        RelayPtyErrorCode::SessionLimit => "session_limit",
+        RelayPtyErrorCode::TerminalGone => "terminal_gone",
+        RelayPtyErrorCode::Failed => "failed",
     };
-    send_pty_error(context, pty_id, code, message);
+    send_pty_error(context, pty_id, wire_code, message);
 }
 
 impl Inner {
-    /// Remove a shell map entry only when it still points at the session that
-    /// exited. A replacement can be installed before a late exit callback
-    /// runs; pointer identity prevents that callback from deleting the live
-    /// replacement.
-    fn remove_shell_session_if_current(&self, session: &str, expected: &Arc<ShellSession>) {
-        let mut sessions = self.shell_sessions.lock().expect("shell lock");
-        if sessions.get(session).is_some_and(|current| Arc::ptr_eq(current, expected)) {
-            sessions.remove(session);
-        }
-    }
-
     async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
             return;
         }
-        let fail = |code: RelayPtyErrorCode, message: &str| {
-            send_pty_error(context, &pty_id, code, message)
-        };
+        let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
         let reservation_result = {
             let mut opening = self.opening_ids.lock().expect("opening lock");
             let attached = self.attachments.lock().expect("attach lock").contains_key(&pty_id);
             if attached || opening.contains(&pty_id) {
-                Err((RelayPtyErrorCode::BadRequest, "ptyId is already attached".to_owned()))
+                Err(("bad_request", "ptyId is already attached".to_owned()))
             } else if self.attachments.lock().expect("attach lock").len() + opening.len()
                 >= self.max_ptys
             {
                 Err((
-                    RelayPtyErrorCode::SessionLimit,
+                    "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
@@ -4171,11 +531,11 @@ impl Inner {
         let session = frame.get("session").and_then(Value::as_str).unwrap_or_default().to_owned();
         let (Some(cols), Some(rows)) = (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
         else {
-            fail(RelayPtyErrorCode::BadRequest, "invalid session name or dimensions");
+            fail("bad_request", "invalid session name or dimensions");
             return;
         };
         if !session_name_ok(&session) {
-            fail(RelayPtyErrorCode::BadRequest, "invalid session name or dimensions");
+            fail("bad_request", "invalid session name or dimensions");
             return;
         }
         let mut surface_ref: Option<String> = None;
@@ -4183,7 +543,7 @@ impl Inner {
             match surface.as_str() {
                 Some(value) if surface_ref_ok(value) => surface_ref = Some(value.to_owned()),
                 _ => {
-                    fail(RelayPtyErrorCode::BadRequest, "invalid surface ref");
+                    fail("bad_request", "invalid surface ref");
                     return;
                 }
             }
@@ -4195,14 +555,14 @@ impl Inner {
         // state fails closed; the untrusted frame cannot elevate access.
         let trust = context.trust.clone();
         if trust.is_empty() {
-            fail(RelayPtyErrorCode::TrustRefused, "terminal trust is not established");
+            fail("trust_refused", "terminal trust is not established");
             return;
         }
         let owner = context.owner_user_id.as_deref();
         let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
         if trust == "observe" && (owner.is_none() || Some(actor) != owner) {
             fail(
-                RelayPtyErrorCode::TrustRefused,
+                "trust_refused",
                 "this machine is paired at observe trust; terminals are owner-only",
             );
             return;
@@ -4213,7 +573,7 @@ impl Inner {
         let server_roots = match parse_allowed_roots(frame) {
             Ok(roots) => roots,
             Err(message) => {
-                fail(RelayPtyErrorCode::BadRequest, message);
+                fail("bad_request", message);
                 return;
             }
         };
@@ -4221,7 +581,7 @@ impl Inner {
             && !value.is_null()
             && !value.is_string()
         {
-            fail(RelayPtyErrorCode::BadRequest, "cwd must be a string");
+            fail("bad_request", "cwd must be a string");
             return;
         }
         let cwd = match scoped_cwd(
@@ -4232,7 +592,7 @@ impl Inner {
         ) {
             Ok(cwd) => cwd,
             Err(message) => {
-                fail(RelayPtyErrorCode::BadRequest, &message);
+                fail("bad_request", &message);
                 return;
             }
         };
@@ -4261,14 +621,14 @@ impl Inner {
                 Ok(Some(opened)) => Some(opened),
                 Ok(None) => None, // degrade to whole-session
                 Err((code, message)) => {
-                    send_pty_error(context, &pty_id, code, &message);
+                    send_typed_pty_error(context, &pty_id, code, &message);
                     return;
                 }
             }
         } else {
             None
         };
-        let mut opened = match opened {
+        let opened = match opened {
             Some(opened) => opened,
             None => {
                 let result = if let Some(cmux_tui) = cmux_tui.as_ref() {
@@ -4302,176 +662,105 @@ impl Inner {
                 match result {
                     Ok(opened) => opened,
                     Err(message) => {
-                        fail(RelayPtyErrorCode::Failed, &message);
+                        fail("failed", &message);
                         return;
                     }
                 }
             }
         };
 
-        // Keep the opening marker until the attachment is installed. Release
-        // its mutex while waiting for an older delivery gate, so a callback
-        // cannot deadlock by asking `close` to cancel this opening.
-        let cancelled = {
-            let _opening = self.opening_ids.lock().expect("opening lock");
-            self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id)
-        };
-        if cancelled {
-            self.opening_ids.lock().expect("opening lock").remove(&pty_id);
-            reservation.active = false;
-            return;
-        }
-        let previous_gate = self
-            .attachments
-            .lock()
-            .expect("attach lock")
-            .get(&pty_id)
-            .map(|attachment| Arc::clone(&attachment.gate));
-        let previous_gate_guard =
-            previous_gate.as_ref().map(|gate| gate.lock().expect("attachment gate"));
+        // Keep the opening reservation held until the attachment is installed.
+        // `close` takes this lock first, so it cannot observe a gap between
+        // removing the opening marker and inserting the attachment.
         let mut opening = self.opening_ids.lock().expect("opening lock");
         let cancelled =
             self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
         if cancelled {
             opening.remove(&pty_id);
             drop(opening);
-            drop(previous_gate_guard);
             reservation.active = false;
+            opened.closing.store(true, Ordering::SeqCst);
+            opened.control.kill();
             return;
         }
         let previous = self.attachments.lock().expect("attach lock").insert(
             pty_id.clone(),
             Attachment {
-                generation: opened.generation,
-                gate: Arc::clone(&opened.gate),
-                closing: Arc::clone(&opened.closing),
-                control: Arc::clone(&opened.control),
+                closing: opened.closing,
+                control: opened.control,
                 actor_id: actor.to_owned(),
             },
         );
-        opening.remove(&pty_id);
-        drop(opening);
-        drop(previous_gate_guard);
         if let Some(previous) = previous {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
-        // The attachment table now owns the control. Dropping `opened` after
-        // this point must not run its cancellation cleanup.
-        opened.disarm_cleanup();
+        opening.remove(&pty_id);
+        drop(opening);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
         opened_frame.insert("type".to_owned(), Value::from("pty_opened"));
         opened_frame.insert("ptyId".to_owned(), Value::from(pty_id.clone()));
         opened_frame.insert("session".to_owned(), Value::from(session));
-        if let Some(surface) = opened.surface.as_ref() {
-            opened_frame.insert("surface".to_owned(), Value::from(surface.as_str()));
+        if let Some(surface) = opened.surface {
+            opened_frame.insert("surface".to_owned(), Value::from(surface));
         }
         opened_frame.insert("created".to_owned(), Value::from(opened.created));
         opened_frame.insert("cols".to_owned(), Value::from(cols));
         opened_frame.insert("rows".to_owned(), Value::from(rows));
         (context.send)(Value::Object(opened_frame));
 
-        if opened.post_open_resize {
-            // Legacy protocol-5..9 daemons have no shared sizing lease. Send
-            // exactly one canonical resize after `pty_opened`, before output
-            // or input can reach the control writer.
-            opened.control.resize(cols, rows);
-        }
-
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
-        (opened.start.take().expect("opened start callback"))();
+        (opened.start)();
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
-    fn sinks(
-        self: &Arc<Self>,
-        pty_id: &str,
-        context: &FrameContext,
-        control: Weak<dyn PtyControl>,
-    ) -> (u64, Arc<Mutex<()>>, DataSink, ExitSink) {
-        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let gate = Arc::new(Mutex::new(()));
+    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink) {
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let control = control.clone();
-            let gate = Arc::clone(&gate);
-            Arc::new(move |chunk: Bytes| {
-                let kill = {
-                    let _guard = gate.lock().expect("attachment gate");
-                    inner.emit_output(&pty_id, generation, &chunk, &context, &control)
-                };
-                if let Some(control) = kill {
-                    control.kill();
-                }
-            }) as Arc<dyn Fn(Bytes) + Send + Sync>
+            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context))
+                as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let control = control.clone();
-            let gate = Arc::clone(&gate);
-            Arc::new(move |code: i64| {
-                let kill = {
-                    let _guard = gate.lock().expect("attachment gate");
-                    inner.emit_raw_exit(&pty_id, generation, None, code, &context, &control)
-                };
-                if let Some(control) = kill {
-                    control.kill();
-                }
-            }) as Arc<dyn Fn(i64) + Send + Sync>
+            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context))
+                as Arc<dyn Fn(i64) + Send + Sync>
         };
-        (generation, gate, on_data, on_exit)
+        (on_data, on_exit)
     }
 
-    fn emit_output(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        chunk: &Bytes,
-        context: &FrameContext,
-        control: &Weak<dyn PtyControl>,
-    ) -> Option<Arc<dyn PtyControl>> {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return None };
-        let Some(control) = control.upgrade() else { return None };
-        if !self.attachment_is_current(pty_id, generation, &control) {
-            return None;
-        }
+    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
+        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
         if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
-            // The caller already owns the attachment gate. Remove and detach
-            // directly instead of calling `close`, which would try to lock
-            // the same gate again during a trust downgrade.
-            if self.remove_attachment_if_current(pty_id, generation, &control) {
-                return Some(control);
-            }
-            return None;
+            return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
-            return None;
+            return;
         }
         let buffered = (auth.buffered_amount)();
         // Admit the complete frame before sending it. The socket may accept a
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            if self.remove_attachment_if_current(pty_id, generation, &control) {
-                send_operational_pty_error(
-                    context,
-                    pty_id,
-                    RelayPtyErrorCode::Overflow,
-                    "terminal output overflowed; reattach to continue receiving output",
-                    "PTY output buffer is full. Reattach to continue.",
-                );
-                return Some(control);
-            }
-            return None;
+            self.close(pty_id);
+            send_pty_error(
+                context,
+                pty_id,
+                "failed",
+                &format!(
+                    "dropped: {buffered} bytes buffered toward the server (cap {})",
+                    self.output_cap
+                ),
+            );
+            return;
         }
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
@@ -4479,106 +768,26 @@ impl Inner {
             "ptyId": pty_id,
             "dataB64": BASE64.encode(chunk),
         }));
-        None
     }
 
-    fn emit_raw_exit(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        stream: Option<&TerminalStream>,
-        code: i64,
-        context: &FrameContext,
-        control: &Weak<dyn PtyControl>,
-    ) -> Option<Arc<dyn PtyControl>> {
-        if stream.is_none_or(|stream| !stream.overflowed()) {
-            self.emit_exit(pty_id, generation, code, context, control);
-            return None;
-        }
-        let Some(control) = control.upgrade() else { return None };
-        // A stale overflow callback must not send an error after a replacement
-        // attachment has taken the same pty ID. The generation check and
-        // removal are one operation; only the owner of the current entry may
-        // kill it or report overflow.
-        if self.remove_attachment_if_current(pty_id, generation, &control) {
-            send_pty_error(
-                context,
-                pty_id,
-                operational_pty_error_code(context, RelayPtyErrorCode::Overflow),
-                "pty output backlog overflowed; reattach to continue receiving output",
-            );
-            return Some(control);
-        }
-        None
-    }
-
-    fn emit_exit(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        code: i64,
-        context: &FrameContext,
-        control: &Weak<dyn PtyControl>,
-    ) {
+    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
         let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
-        let Some(control) = control.upgrade() else { return };
-        if !self.attachment_is_current(pty_id, generation, &control) {
-            return;
-        }
         if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
-            if self.remove_attachment_if_current(pty_id, generation, &control) {
-                control.kill();
-            }
             return;
         }
-        if !self.remove_attachment_if_current(pty_id, generation, &control) {
-            return;
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        match attachments.get(pty_id) {
+            Some(attachment) if !attachment.closing.load(Ordering::SeqCst) => {}
+            _ => return,
         }
-        // Release relay-local state after the PTY has exited. Do not call
-        // `kill`: whole-session controls may still own a process handle and
-        // an exit callback must never send a late SIGKILL to a reused PID.
-        control.release();
+        attachments.remove(pty_id);
+        drop(attachments);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
             "code": code,
         }));
-    }
-
-    fn handle_viewer_overflow(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        gate: &Arc<Mutex<()>>,
-        control: &Weak<dyn PtyControl>,
-        context: &FrameContext,
-    ) {
-        // Serialize overflow teardown with output and exit callbacks. This
-        // keeps a callback that already passed its identity check from
-        // sending after the overflow error removes the attachment.
-        let kill = {
-            let _guard = gate.lock().expect("attachment gate");
-            let Some(control) = control.upgrade() else { return };
-            if self.remove_attachment_if_current(pty_id, generation, &control) {
-                // Overflow is a terminal viewer failure. `pty_error` is the
-                // protocol's close signal and tells the client to reattach;
-                // do not emit a second `pty_exit` for the removed attachment.
-                // The operational code is downgraded for pre-v7 Workers.
-                send_pty_error(
-                    context,
-                    pty_id,
-                    operational_pty_error_code(context, RelayPtyErrorCode::Overflow),
-                    "pty viewer delivery queue overflowed; reattach to continue receiving output",
-                );
-                Some(control)
-            } else {
-                None
-            }
-        };
-        if let Some(control) = kill {
-            control.kill();
-        }
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -4594,70 +803,16 @@ impl Inner {
             return;
         }
         drop(opening);
-        // Capture the identity together with the gate. A replacement can be
-        // installed while we wait for the old gate, so removal must prove
-        // that the observed generation and control are still current.
-        let observed =
-            self.attachments.lock().expect("attach lock").get(pty_id).map(|attachment| {
-                (
-                    Arc::clone(&attachment.gate),
-                    attachment.generation,
-                    Arc::clone(&attachment.closing),
-                    Arc::clone(&attachment.control),
-                )
-            });
-        let removed = observed.and_then(|(gate, generation, closing, control)| {
-            let _guard = gate.lock().expect("attachment gate");
-            self.remove_attachment_if_current(pty_id, generation, &control)
-                .then_some((closing, control))
-        });
-        if let Some((closing, control)) = removed {
-            closing.store(true, Ordering::SeqCst);
-            control.kill();
+        let attachment = self.attachments.lock().expect("attach lock").remove(pty_id);
+        if let Some(attachment) = attachment {
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment.control.kill();
         }
-    }
-
-    fn attachment_is_current(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        control: &Arc<dyn PtyControl>,
-    ) -> bool {
-        self.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|attachment| {
-            attachment.generation == generation
-                && !attachment.closing.load(Ordering::SeqCst)
-                && Arc::ptr_eq(&attachment.control, control)
-        })
-    }
-
-    /// Remove an attachment only if the callback still belongs to the current
-    /// generation. The identity check and removal share one lock, so
-    /// replacement cannot slip between them.
-    fn remove_attachment_if_current(
-        &self,
-        pty_id: &str,
-        generation: u64,
-        control: &Arc<dyn PtyControl>,
-    ) -> bool {
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let matches = attachments.get(pty_id).is_some_and(|attachment| {
-            attachment.generation == generation
-                && !attachment.closing.load(Ordering::SeqCst)
-                && Arc::ptr_eq(&attachment.control, control)
-        });
-        if matches {
-            attachments.remove(pty_id);
-        }
-        matches
     }
 
     fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
         let auth = self.auth.lock().expect("auth lock").clone()?;
-        let attachment = self.authorize_snapshot(pty_id, &auth, context, action);
-        if attachment.is_none() {
-            self.close(pty_id);
-        }
-        attachment
+        self.authorize_snapshot(pty_id, &auth, context, action)
     }
 
     fn authorize_snapshot(
@@ -4665,7 +820,7 @@ impl Inner {
         pty_id: &str,
         auth: &AuthSnapshot,
         context: &FrameContext,
-        _action: &str,
+        action: &str,
     ) -> Option<Attachment> {
         let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
         let owner = auth.owner_user_id.as_deref();
@@ -4675,12 +830,12 @@ impl Inner {
         if allowed {
             Some(attachment)
         } else {
-            send_operational_pty_error(
+            self.close(pty_id);
+            send_pty_error(
                 context,
                 pty_id,
-                RelayPtyErrorCode::TrustRevoked,
-                "PTY trust changed. Restore trust, then reattach.",
-                "PTY trust changed. Restore trust, then reattach.",
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
             );
             None
         }
@@ -4694,38 +849,11 @@ impl Inner {
 
 /// A resolved open: what to echo, plus a deferred `start` that begins output.
 struct Opened {
-    generation: u64,
-    gate: Arc<Mutex<()>>,
     created: bool,
     surface: Option<String>,
     control: Arc<dyn PtyControl>,
-    /// Legacy protocol-5..9 raw daemons need one canonical resize after the
-    /// `pty_opened` frame. Protocol-10 sizing queues perform that fence during
-    /// join and must not receive a duplicate direct resize here.
-    post_open_resize: bool,
     closing: Arc<AtomicBool>,
-    start: Option<Box<dyn FnOnce() + Send>>,
-    cleanup_armed: AtomicBool,
-}
-
-impl Opened {
-    /// Transfer control ownership to the attachment table. Until this call,
-    /// dropping the value is the cancellation/error cleanup path.
-    fn disarm_cleanup(&self) {
-        self.cleanup_armed.store(false, Ordering::Release);
-    }
-}
-
-impl Drop for Opened {
-    fn drop(&mut self) {
-        if self.cleanup_armed.swap(false, Ordering::AcqRel) {
-            self.closing.store(true, Ordering::Release);
-            // The guard owns a just-opened control until attachment insertion;
-            // cancellation must release sizing ownership and close the local
-            // control socket rather than leaking a daemon attachment.
-            self.control.kill();
-        }
-    }
+    start: Box<dyn FnOnce() + Send>,
 }
 
 // ---------------------------------------------------------------------------
@@ -4771,46 +899,58 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
-            let mut control_cleanup = ControlCleanupGuard::new(Arc::clone(&control));
             let Some(listed) = control.request("list-workspaces", json!({})).await else {
+                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if listed.get("ok").and_then(Value::as_bool) != Some(true) {
+                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let Some(data) = listed.get("data").and_then(Value::as_object) else {
+                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if !data.get("workspaces").is_some_and(Value::is_array) {
+                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             if !workspace_shape_valid(listed.get("data")) {
+                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let tabs = match collect_pty_tabs_strict(listed.get("data")) {
                 Ok(tabs) => tabs,
-                Err(_) => return Err("cannot inspect existing daemon surfaces".to_owned()),
+                Err(_) => {
+                    control.end();
+                    return Err("cannot inspect existing daemon surfaces".to_owned());
+                }
             };
             if tabs.len() > MAX_ENUM_TERMINALS || (tabs.is_empty() && !ensured.created) {
+                control.end();
                 return Err("cannot prove existing daemon cwd is within allowed roots".to_owned());
             }
             for tab in tabs {
                 let Some(info) =
                     control.request("process-info", json!({ "surface": tab.surface_id })).await
                 else {
+                    control.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 };
                 if info.get("ok").and_then(Value::as_bool) != Some(true) {
+                    control.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 }
                 let Some(actual) =
                     info.get("data").and_then(|v| v.get("cwd")).and_then(Value::as_str)
                 else {
+                    control.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
                 };
                 if actual.is_empty() || !Path::new(actual).is_absolute() {
+                    control.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
@@ -4823,10 +963,11 @@ impl Inner {
                 )
                 .is_err()
                 {
+                    control.end();
                     return Err("existing surface cwd is outside allowed roots".to_owned());
                 }
             }
-            drop(control_cleanup);
+            control.end();
         }
         let mut args = cmux_tui.prefix.clone();
         args.extend([
@@ -4836,7 +977,7 @@ impl Inner {
             "--socket".to_owned(),
             ensured.socket_path.to_string_lossy().into_owned(),
         ]);
-        let mut handle = self
+        let handle = self
             .deps
             .spawn_pty(SpawnSpec {
                 file: cmux_tui.file.clone(),
@@ -4847,24 +988,16 @@ impl Inner {
                 env: env.clone(),
             })
             .await;
-        // The PTY handle owns a cancellation guard until this synchronous
-        // setup transfers its control surface into the attachment guard.
-        handle.disarm_cleanup();
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let control_identity = Arc::downgrade(&control);
-        let (generation, gate, on_data, on_exit) = self.sinks(pty_id, context, control_identity);
+        let (on_data, on_exit) = self.sinks(pty_id, context);
         Ok(Opened {
-            generation,
-            gate,
             created: ensured.created,
             surface: None,
             control,
-            post_open_resize: false,
             closing: Arc::new(AtomicBool::new(false)),
-            start: Some(Box::new(move || drive_handle(output, banner, on_data, on_exit))),
-            cleanup_armed: AtomicBool::new(true),
+            start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
 
@@ -4883,186 +1016,126 @@ impl Inner {
         context: &FrameContext,
     ) -> Result<Opened, String> {
         let mut created = false;
-        let (shell_session, viewer_id, released) = loop {
-            // A failed liveness check may retry after the just-created shell
-            // exits. Do not carry that attempt's `created` bit to a different
-            // session map entry.
-            created = false;
-            let shell_session = loop {
-                if let Some(existing) =
-                    self.shell_sessions.lock().expect("shell lock").get(session).cloned()
+        let shell_session = loop {
+            if let Some(existing) =
+                self.shell_sessions.lock().expect("shell lock").get(session).cloned()
+            {
+                if context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
+                    || server_roots.is_some_and(|r| !r.is_empty())
                 {
-                    break existing;
+                    return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
-                let (notify, owner, waiter) = {
-                    let mut starting = self.shell_starting.lock().expect("shell starting lock");
-                    if let Some(notify) = starting.get(session) {
-                        let notify = Arc::clone(notify);
-                        // Register before releasing the map lock. The owner may
-                        // finish immediately; creating this future later could
-                        // miss `notify_waiters`.
-                        let waiter = Arc::clone(&notify).notified_owned();
-                        (notify, false, Some(waiter))
-                    } else {
-                        let notify = Arc::new(Notify::new());
-                        starting.insert(session.to_owned(), Arc::clone(&notify));
-                        (notify, true, None)
-                    }
-                };
-                if !owner {
-                    waiter.expect("shell waiter").await;
-                    continue;
-                }
-                if self.shell_sessions.lock().expect("shell lock").len() >= self.max_ptys {
-                    self.shell_starting.lock().expect("shell starting lock").remove(session);
-                    notify.notify_waiters();
-                    return Err(format!("this relay caps persistent shells at {}", self.max_ptys));
-                }
-                let mut reservation = ShellStartReservation {
-                    inner: Arc::clone(&self),
-                    session: session.to_owned(),
-                    notify,
-                    active: true,
-                };
-                {
-                    let shell = self.deps.shell();
-                    let mut handle = self
-                        .deps
-                        .spawn_pty(SpawnSpec {
-                            file: shell,
-                            args: Vec::new(),
-                            cols,
-                            rows,
-                            cwd: cwd.to_path_buf(),
-                            env: env.clone(),
-                        })
-                        .await;
-                    let control = Arc::clone(&handle.control);
-                    let output = Arc::clone(&handle.output);
-                    let banner = handle.banner.clone();
-                    handle.disarm_cleanup();
-                    let shell_session = Arc::new(ShellSession {
-                        control,
-                        resize_lock: Mutex::new(()),
-                        banner,
-                        inner: Mutex::new(ShellInner {
-                            ring: VecDeque::new(),
-                            ring_size: 0,
-                            alive: true,
-                            exit_code: None,
-                            viewers: Vec::new(),
-                            viewer_grids: HashMap::new(),
-                            applied_grid: Some(SizingGrid { cols, rows }),
-                        }),
-                    });
-                    // Session-level plumbing runs for the session's whole life:
-                    // the ring fills even while detached, and exit ends the
-                    // session for every attached viewer. One fanout sink is
-                    // subscribed to the session PTY; per-viewer sinks live in the
-                    // viewer set.
-                    let session_name = session.to_owned();
-                    let scrollback_limit = self.scrollback_limit;
-                    let data_session = Arc::clone(&shell_session);
-                    let exit_session = Arc::clone(&shell_session);
-                    let manager = Arc::clone(&self);
-                    let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
-                        let (viewers_to_drain, viewers_overflowed) = {
-                            let mut inner = data_session.inner.lock().expect("shell inner lock");
-                            inner.ring_size += chunk.len();
-                            inner.ring.push_back(chunk.clone());
-                            while inner.ring_size > scrollback_limit && inner.ring.len() > 1 {
-                                let Some(dropped) = inner.ring.pop_front() else { break };
-                                inner.ring_size -= dropped.len();
-                            }
-                            let mut viewers_to_drain = Vec::new();
-                            let mut viewers_overflowed = Vec::new();
-                            for viewer in &inner.viewers {
-                                match viewer.delivery.push_data(chunk.clone()) {
-                                    ViewerDeliveryAction::Drain => {
-                                        viewers_to_drain.push(Arc::clone(&viewer.delivery));
-                                    }
-                                    ViewerDeliveryAction::Overflow => {
-                                        viewers_overflowed.push(Arc::clone(&viewer.delivery));
-                                    }
-                                    ViewerDeliveryAction::None => {}
-                                }
-                            }
-                            (viewers_to_drain, viewers_overflowed)
-                        };
-                        for delivery in viewers_overflowed {
-                            delivery.notify_overflow();
-                        }
-                        for delivery in viewers_to_drain {
-                            delivery.drain();
-                        }
-                    });
-                    let on_session_exit: ExitSink = Arc::new(move |code: i64| {
-                        let (viewers_to_drain, viewers_overflowed) = {
-                            let mut inner = exit_session.inner.lock().expect("shell inner lock");
-                            if !inner.alive {
-                                return;
-                            }
-                            inner.alive = false;
-                            inner.exit_code = Some(code);
-                            inner.viewer_grids.clear();
-                            let mut viewers_to_drain = Vec::new();
-                            let mut viewers_overflowed = Vec::new();
-                            for viewer in std::mem::take(&mut inner.viewers) {
-                                match viewer.delivery.finish(code) {
-                                    ViewerDeliveryAction::Drain => {
-                                        viewers_to_drain.push(viewer.delivery);
-                                    }
-                                    ViewerDeliveryAction::Overflow => {
-                                        viewers_overflowed.push(viewer.delivery);
-                                    }
-                                    ViewerDeliveryAction::None => {}
-                                }
-                            }
-                            (viewers_to_drain, viewers_overflowed)
-                        };
-                        manager.remove_shell_session_if_current(&session_name, &exit_session);
-                        for delivery in viewers_overflowed {
-                            delivery.notify_overflow();
-                        }
-                        for delivery in viewers_to_drain {
-                            delivery.drain();
-                        }
-                    });
-                    self.shell_sessions
-                        .lock()
-                        .expect("shell lock")
-                        .insert(session.to_owned(), Arc::clone(&shell_session));
-                    // Register before subscribing so a synchronous buffered exit
-                    // can remove this session instead of being overwritten by a
-                    // later insertion.
-                    output.subscribe(on_session_data, on_session_exit);
-                    self.shell_starting.lock().expect("shell starting lock").remove(session);
-                    reservation.active = false;
-                    reservation.notify.notify_waiters();
-                    created = true;
-                    break shell_session;
+                existing.control.resize(cols, rows);
+                break existing;
+            }
+            let (notify, owner, waiter) = {
+                let mut starting = self.shell_starting.lock().expect("shell starting lock");
+                if let Some(notify) = starting.get(session) {
+                    let notify = Arc::clone(notify);
+                    // Register before releasing the map lock. The owner may
+                    // finish immediately; creating this future later could
+                    // miss `notify_waiters`.
+                    let waiter = Arc::clone(&notify).notified_owned();
+                    (notify, false, Some(waiter))
+                } else {
+                    let notify = Arc::new(Notify::new());
+                    starting.insert(session.to_owned(), Arc::clone(&notify));
+                    (notify, true, None)
                 }
             };
-
-            // A stable viewer id lets release remove exactly this sink. The
-            // liveness check and grid insertion share the resize lock and the
-            // session lock, so an already-exited session cannot be returned.
-            let viewer_id = next_viewer_id();
-            let released = Arc::new(AtomicBool::new(false));
-            if !shell_session.set_viewer_grid(viewer_id, SizingGrid { cols, rows }, &released) {
-                self.remove_shell_session_if_current(session, &shell_session);
+            if !owner {
+                waiter.expect("shell waiter").await;
                 continue;
             }
-            if !created
-                && (context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
-                    || server_roots.is_some_and(|r| !r.is_empty()))
-            {
-                shell_session.release_viewer(viewer_id);
-                return Err("cannot reattach existing shell under scoped roots".to_owned());
+            if self.shell_sessions.lock().expect("shell lock").len() >= self.max_ptys {
+                self.shell_starting.lock().expect("shell starting lock").remove(session);
+                notify.notify_waiters();
+                return Err(format!("this relay caps persistent shells at {}", self.max_ptys));
             }
-            break (shell_session, viewer_id, released);
+            let mut reservation = ShellStartReservation {
+                inner: Arc::clone(&self),
+                session: session.to_owned(),
+                notify,
+                active: true,
+            };
+            {
+                let shell = self.deps.shell();
+                let handle = self
+                    .deps
+                    .spawn_pty(SpawnSpec {
+                        file: shell,
+                        args: Vec::new(),
+                        cols,
+                        rows,
+                        cwd: cwd.to_path_buf(),
+                        env: env.clone(),
+                    })
+                    .await;
+                let PtyHandle { control, output, banner } = handle;
+                let shell_session = Arc::new(ShellSession {
+                    control,
+                    banner,
+                    inner: Mutex::new(ShellInner {
+                        ring: VecDeque::new(),
+                        ring_size: 0,
+                        alive: true,
+                        viewers: Vec::new(),
+                    }),
+                });
+                // Session-level plumbing runs for the session's whole life:
+                // the ring fills even while detached, and exit ends the
+                // session for every attached viewer. One fanout sink is
+                // subscribed to the session PTY; per-viewer sinks live in the
+                // viewer set.
+                let session_name = session.to_owned();
+                let scrollback_limit = self.scrollback_limit;
+                let data_session = Arc::clone(&shell_session);
+                let exit_session = Arc::clone(&shell_session);
+                let manager = Arc::clone(&self);
+                let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
+                    let viewers_to_notify: Vec<Arc<dyn Fn(Bytes) + Send + Sync>> = {
+                        let mut inner = data_session.inner.lock().expect("shell inner lock");
+                        inner.ring_size += chunk.len();
+                        inner.ring.push_back(chunk.clone());
+                        while inner.ring_size > scrollback_limit && inner.ring.len() > 1 {
+                            let Some(dropped) = inner.ring.pop_front() else { break };
+                            inner.ring_size -= dropped.len();
+                        }
+                        inner.viewers.iter().map(|viewer| Arc::clone(&viewer.on_data)).collect()
+                    };
+                    for on_data in viewers_to_notify {
+                        on_data(chunk.clone());
+                    }
+                });
+                let on_session_exit: ExitSink = Arc::new(move |code: i64| {
+                    let viewers = {
+                        let mut inner = exit_session.inner.lock().expect("shell inner lock");
+                        inner.alive = false;
+                        std::mem::take(&mut inner.viewers)
+                    };
+                    manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
+                    for viewer in viewers {
+                        (viewer.on_exit)(code);
+                    }
+                });
+                output.subscribe(on_session_data, on_session_exit);
+                self.shell_sessions
+                    .lock()
+                    .expect("shell lock")
+                    .insert(session.to_owned(), Arc::clone(&shell_session));
+                self.shell_starting.lock().expect("shell starting lock").remove(session);
+                reservation.active = false;
+                reservation.notify.notify_waiters();
+                created = true;
+                break shell_session;
+            }
         };
+
+        // A stable viewer id lets release remove exactly this sink.
+        let viewer_id = next_viewer_id();
+        let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
+        let (on_data, on_exit) = self.sinks(pty_id, context);
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -5070,84 +1143,38 @@ impl Inner {
             session: Arc::clone(&shell_session),
             viewer_id,
             released: Arc::clone(&released),
-            delivery: OnceLock::new(),
         });
-        let proxy_control: Arc<dyn PtyControl> = proxy.clone();
-        let control_identity = Arc::downgrade(&proxy_control);
-        let (generation, gate, on_data, on_exit) = self.sinks(pty_id, context, control_identity);
-        let overflow_inner = Arc::clone(&self);
-        let overflow_context = context.clone();
-        let overflow_pty_id = pty_id.to_owned();
-        let overflow_gate = Arc::clone(&gate);
-        let overflow_control = Arc::downgrade(&proxy_control);
-        let on_overflow: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
-            overflow_inner.handle_viewer_overflow(
-                &overflow_pty_id,
-                generation,
-                &overflow_gate,
-                &overflow_control,
-                &overflow_context,
-            );
-        });
-        let delivery = ViewerDelivery::with_overflow(on_data, on_exit, on_overflow);
-        assert!(
-            proxy.delivery.set(Arc::clone(&delivery)).is_ok(),
-            "shell viewer delivery initialized"
-        );
 
         let start_session = Arc::clone(&shell_session);
-        let start_delivery = Arc::clone(&delivery);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+            let (banner, replay, alive) = {
+                let inner = start_session.inner.lock().expect("shell inner lock");
+                let banner = created.then(|| start_session.banner.clone()).flatten();
+                let replay = (!created && inner.ring_size > 0).then(|| {
+                    inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
+                });
+                (banner, replay, inner.alive)
+            };
+            if let Some(banner) = banner {
+                on_data(Bytes::from(banner));
+            }
+            if let Some(replay) = replay {
+                on_data(Bytes::from(replay));
+            }
             if released.load(Ordering::SeqCst) {
                 return;
             }
-            // Register an inactive delivery and seed its replay while holding
-            // the shell lock. Live bytes arriving after this point queue behind
-            // the replay instead of racing past it.
-            let (should_activate, seed_overflowed) = {
-                let mut inner = start_session.inner.lock().expect("shell inner lock");
-                if released.load(Ordering::SeqCst) {
-                    (false, false)
-                } else {
-                    let banner = created.then(|| start_session.banner.clone()).flatten();
-                    let replay = (inner.ring_size > 0).then(|| {
-                        inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
-                    });
-                    let seed_overflowed =
-                        start_delivery.seed(banner.map(Bytes::from), replay.map(Bytes::from));
-                    if inner.alive && !seed_overflowed {
-                        inner.viewers.push(ViewerSink {
-                            id: viewer_id,
-                            delivery: Arc::clone(&start_delivery),
-                        });
-                    }
-                    if !inner.alive
-                        && !seed_overflowed
-                        && let Some(code) = inner.exit_code
-                    {
-                        let _ = start_delivery.finish(code);
-                    }
-                    (true, seed_overflowed)
-                }
-            };
-            if seed_overflowed {
-                start_delivery.notify_overflow();
-            } else if should_activate && start_delivery.activate() {
-                start_delivery.drain();
+            if !alive {
+                on_exit(0);
+                return;
+            }
+            let mut inner = start_session.inner.lock().expect("shell inner lock");
+            if !released.load(Ordering::SeqCst) && inner.alive {
+                inner.viewers.push(ViewerSink { id: viewer_id, on_data, on_exit });
             }
         });
 
-        Ok(Opened {
-            generation,
-            gate,
-            created,
-            surface: None,
-            control: proxy,
-            post_open_resize: false,
-            closing,
-            start: Some(start),
-            cleanup_armed: AtomicBool::new(true),
-        })
+        Ok(Opened { created, surface: None, control: proxy, closing, start })
     }
 }
 
@@ -5155,77 +1182,13 @@ struct ShellViewerControl {
     session: Arc<ShellSession>,
     viewer_id: u64,
     released: Arc<AtomicBool>,
-    delivery: OnceLock<Arc<ViewerDelivery>>,
-}
-
-impl ShellSession {
-    /// Register or update one viewer only while the session is alive.
-    /// Returns false when the process has already exited, so callers can
-    /// discard the stale map entry and acquire a replacement.
-    fn set_viewer_grid(&self, viewer_id: u64, grid: SizingGrid, released: &AtomicBool) -> bool {
-        // Serialize the state calculation with the actual PTY ioctl. Without
-        // this guard, concurrent callbacks can calculate 100x30 and 90x20,
-        // then deliver the older 100x30 resize last.
-        let _resize_guard = self.resize_lock.lock().expect("shell resize lock");
-        if released.load(Ordering::Acquire) {
-            return false;
-        }
-        let resize = {
-            let mut inner = self.inner.lock().expect("shell inner lock");
-            if !inner.alive {
-                return false;
-            }
-            inner.viewer_grids.insert(viewer_id, grid);
-            let next = smallest_shell_grid(&inner.viewer_grids);
-            if inner.applied_grid == next {
-                None
-            } else {
-                inner.applied_grid = next;
-                next
-            }
-        };
-        if let Some(grid) = resize {
-            self.control.resize(grid.cols, grid.rows);
-        }
-        true
-    }
-
-    fn release_viewer(&self, viewer_id: u64) {
-        let _resize_guard = self.resize_lock.lock().expect("shell resize lock");
-        let resize = {
-            let mut inner = self.inner.lock().expect("shell inner lock");
-            inner.viewers.retain(|viewer| viewer.id != viewer_id);
-            inner.viewer_grids.remove(&viewer_id);
-            if !inner.alive || inner.viewer_grids.is_empty() {
-                None
-            } else {
-                let next = smallest_shell_grid(&inner.viewer_grids);
-                if inner.applied_grid == next {
-                    None
-                } else {
-                    inner.applied_grid = next;
-                    next
-                }
-            }
-        };
-        if let Some(grid) = resize {
-            self.control.resize(grid.cols, grid.rows);
-        }
-    }
 }
 
 impl ShellViewerControl {
     fn release(&self) {
-        if self.released.swap(true, Ordering::SeqCst) {
-            return;
-        }
-        self.session.release_viewer(self.viewer_id);
-        // The viewer may already have exited and been removed from the shell
-        // set. Release the delivery in either case so a queued handoff cannot
-        // emit after the attachment has been closed.
-        if let Some(delivery) = self.delivery.get() {
-            delivery.release();
-        }
+        self.released.store(true, Ordering::SeqCst);
+        let mut inner = self.session.inner.lock().expect("shell inner lock");
+        inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
     }
 }
 
@@ -5234,7 +1197,7 @@ impl PtyControl for ShellViewerControl {
         self.session.control.write(data);
     }
     fn resize(&self, cols: u16, rows: u16) {
-        self.session.set_viewer_grid(self.viewer_id, SizingGrid { cols, rows }, &self.released);
+        self.session.control.resize(cols, rows);
     }
     fn pause(&self) {
         self.session.control.pause();
@@ -5300,6 +1263,7 @@ impl TerminalStream {
             overflowed: AtomicBool::new(false),
         }
     }
+
     /// Mark the queue as owned by a drainer, if the live sinks are installed.
     fn start_delivery(state: &mut TerminalStreamState) -> bool {
         if state.delivering
@@ -5411,46 +1375,18 @@ impl TerminalStream {
 struct ControlTerminalControl {
     control: Arc<dyn ControlHandle>,
     surface_id: i64,
-    sizing: Option<Arc<TerminalSizingLease>>,
-    queue: Option<Arc<OrderedControlEndpoint>>,
-    ended: AtomicBool,
 }
 
 impl PtyControl for ControlTerminalControl {
     fn write(&self, data: &[u8]) {
-        if self.sizing.is_some() {
-            let Some(queue) = &self.queue else {
-                // A protocol-10+ control must never bypass the sizing actor.
-                // The open path rejects this state; keep the proxy fail
-                // closed if a later lifecycle race drops its endpoint.
-                self.release();
-                return;
-            };
-            queue.enqueue_input(data);
-        } else {
-            // Protocols without shared sizing use the legacy whole-session
-            // path. Protocol-10+ raw attachments always install `queue` and
-            // take the fail-closed branch above if that invariant is broken.
-            self.control
-                .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }));
-        }
+        self.control
+            .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }));
     }
     fn resize(&self, cols: u16, rows: u16) {
-        if let Some(sizing) = &self.sizing {
-            if self.queue.is_none() {
-                // Do not send a direct resize after shared sizing setup has
-                // failed. Such a frame could race a retired transport.
-                self.release();
-                return;
-            }
-            sizing.update(SizingGrid { cols, rows });
-        } else {
-            // Legacy protocol path: no relay sizing coordinator exists.
-            self.control.send(
-                "resize-surface",
-                json!({ "surface": self.surface_id, "cols": cols, "rows": rows }),
-            );
-        }
+        self.control.send(
+            "resize-surface",
+            json!({ "surface": self.surface_id, "cols": cols, "rows": rows }),
+        );
     }
     fn pause(&self) {
         self.control.pause();
@@ -5458,25 +1394,8 @@ impl PtyControl for ControlTerminalControl {
     fn resume(&self) {
         self.control.resume();
     }
-    fn release(&self) {
-        if self.ended.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let sizing_handoff = self.sizing.as_ref().is_some_and(|sizing| sizing.leave());
-        if !sizing_handoff {
-            // Legacy or setup path: protocol-10+ raw attachments close through
-            // the shared sizing queue. End only this control socket here.
-            self.control.end();
-        }
-    }
     fn kill(&self) {
-        self.release();
-    }
-}
-
-impl Drop for ControlTerminalControl {
-    fn drop(&mut self) {
-        self.release();
+        self.control.end(); // detach only; the daemon keeps the terminal
     }
 }
 
@@ -5651,20 +1570,11 @@ impl Inner {
             .deps
             .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env)
             .await
-            // Daemon setup errors can contain paths, command output, or other
-            // control-plane details. Keep those details on the machine side;
-            // the PTY wire only exposes a stable product-level failure.
-            .map_err(|_| {
-                (
-                    RelayPtyErrorCode::Failed,
-                    "terminal service could not prepare the session".to_owned(),
-                )
-            })?;
+            .map_err(|message| (RelayPtyErrorCode::Failed, message))?;
         let control = match self.deps.connect_control(&ensured.socket_path).await {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
         };
-        let mut control_cleanup = ControlCleanupGuard::new(Arc::clone(&control));
 
         let identify = control.request("identify", json!({})).await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
@@ -5674,6 +1584,7 @@ impl Inner {
             .and_then(Value::as_i64)
             .unwrap_or(0);
         if protocol < CONTROL_MIN_PROTOCOL {
+            control.end();
             return Ok(None);
         }
         let capabilities: Vec<String> = info
@@ -5691,39 +1602,27 @@ impl Inner {
             None
         };
         if surface_id.is_none() {
-            let Some(listed) = control.request("list-workspaces", json!({})).await else {
-                return Err((
-                    RelayPtyErrorCode::Failed,
-                    "terminal could not be resolved".to_owned(),
-                ));
-            };
-            if listed.get("ok").and_then(Value::as_bool) != Some(true) {
-                return Err((
-                    RelayPtyErrorCode::Failed,
-                    "terminal could not be resolved".to_owned(),
-                ));
-            }
-            let tabs = match collect_pty_tabs_strict(listed.get("data")) {
-                Ok(tabs) => tabs,
-                Err(()) => {
-                    return Err((
-                        RelayPtyErrorCode::Failed,
-                        "terminal could not be resolved".to_owned(),
-                    ));
-                }
-            };
+            let listed = control.request("list-workspaces", json!({})).await;
+            let tabs = listed
+                .as_ref()
+                .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+                .map(|v| collect_pty_tabs(v.get("data")))
+                .unwrap_or_default();
             surface_id = tabs
                 .iter()
                 .find(|tab| tab.resource_id.as_deref() == Some(surface_ref))
                 .map(|tab| tab.surface_id);
         }
         let Some(surface_id) = surface_id else {
+            control.end();
             // Typed refusal: the terminal died with its process (or its tab
             // closed) — permanent, so clients render an ended state and
             // never offer a retry.
             return Err((
                 RelayPtyErrorCode::TerminalGone,
-                "requested terminal is no longer available".to_owned(),
+                format!(
+                    "terminal \"{surface_ref}\" not found in session \"{session}\" (it may have been closed)"
+                ),
             ));
         };
 
@@ -5738,12 +1637,14 @@ impl Inner {
                 .and_then(|v| v.get("cwd"))
                 .and_then(Value::as_str);
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
+                control.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             }
             let Some(actual) = actual else {
+                control.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
@@ -5752,6 +1653,7 @@ impl Inner {
             if scoped_cwd(Some(actual), &self.home, context.local_roots.as_deref(), server_roots)
                 .is_err()
             {
+                control.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "existing surface cwd is outside allowed roots".to_owned(),
@@ -5759,23 +1661,8 @@ impl Inner {
             }
         }
 
-        let shared_sizing = protocol >= CLIENT_SIZING_MIN_PROTOCOL;
-        let sizing = shared_sizing.then(|| {
-            let viewer_id = self.next_sizing_id.fetch_add(1, Ordering::Relaxed);
-            TerminalSizingLease::new(
-                &self.sizing,
-                SizingKey { socket_path: ensured.socket_path.clone(), surface_id },
-                viewer_id,
-                surface_id,
-            )
-        });
-        if let Some(sizing) = &sizing {
-            control_cleanup.set_sizing(Arc::clone(sizing));
-        }
         let stream = Arc::new(TerminalStream::new());
         let event_stream = Arc::clone(&stream);
-        let event_sizing = sizing.clone();
-        let event_control = Arc::downgrade(&control);
         control.on_event(Box::new(move |event| {
             if event.get("surface").and_then(Value::as_i64) != Some(surface_id) {
                 return;
@@ -5793,123 +1680,58 @@ impl Inner {
                         event_stream.push_output(Bytes::from(reset));
                     }
                 }
-                "detached" => {
-                    let sizing_handoff = event_sizing.as_ref().is_some_and(|sizing| sizing.leave());
-                    // A detached raw view no longer needs the control socket.
-                    // End it before handing the terminal exit to the relay so
-                    // a stale sizing request cannot race a surviving viewer.
-                    if !sizing_handoff && let Some(control) = event_control.upgrade() {
-                        control.end();
-                    }
-                    event_stream.finish_exit(0);
-                }
+                "detached" => event_stream.finish_exit(0),
                 _ => {}
             }
         }));
         let close_stream = Arc::clone(&stream);
-        let close_sizing = sizing.clone();
-        control.on_close(Box::new(move || {
-            if let Some(sizing) = &close_sizing {
-                let _ = sizing.leave();
-            }
-            close_stream.finish_exit(0);
-        }));
+        control.on_close(Box::new(move || close_stream.finish_exit(0)));
 
-        let attach_initial_size = capabilities.iter().any(|c| c == "attach-initial-size");
-        let attach_params = if attach_initial_size {
+        let attach_params = if capabilities.iter().any(|c| c == "attach-initial-size") {
             json!({ "surface": surface_id, "cols": cols, "rows": rows })
         } else {
             json!({ "surface": surface_id })
         };
         let attached = control.request("attach-surface", attach_params).await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
-            return Err((RelayPtyErrorCode::Failed, "terminal attachment failed".to_owned()));
-        }
-        if let Some(sizing) = &sizing {
-            // A protocol-10+ attach size is only a retained report. Report
-            // once more through a verified request, then claim geometry
-            // authority before later resize frames can change the PTY grid.
-            // The worker is deliberately detached from open: a slow or
-            // unavailable control reply must not hold `pty_opened` for the
-            // full three-second request budget. Subsequent resize requests
-            // are coalesced by the same worker and converge the grid.
-            if sizing.join(Arc::clone(&control), SizingGrid { cols, rows }).is_none() {
-                // Protocol-10+ attachments require the shared sizing queue.
-                // Do not emit `pty_opened` and fall back to direct control
-                // writes when the target is retired or its close barrier has
-                // failed: that would bypass the fail-closed generation fence.
-                return Err((
-                    RelayPtyErrorCode::Failed,
-                    "terminal sizing coordination is unavailable; reconnect and retry".to_owned(),
-                ));
-            }
-        } else {
-            // The client sends one canonical resize after `pty_opened` for
-            // protocol 5-9. Do not send a second pre-open resize here: the
-            // post-open command is the ordering fence before pending input.
+            control.end();
+            let reason = attached
+                .as_ref()
+                .and_then(|v| v.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("no reply");
+            return Err((
+                RelayPtyErrorCode::Failed,
+                format!("attach-surface failed for terminal \"{surface_ref}\": {reason}"),
+            ));
         }
 
-        // The lease installs the queue before `pty_opened` is emitted. The
-        // proxy uses that exact queue for every later input so a resize that
-        // was accepted before open cannot be overtaken on the control FIFO.
-        let sizing_queue = if let Some(sizing) = &sizing {
-            let Some(queue) = sizing.queue() else {
-                // The lease was reported as joined, but its endpoint was
-                // retired before the proxy was created. Keep the same
-                // fail-closed rule as the join check above.
-                return Err((
-                    RelayPtyErrorCode::Failed,
-                    "terminal sizing coordination is unavailable; reconnect and retry".to_owned(),
-                ));
-            };
-            Some(queue)
-        } else {
-            None
-        };
-
-        let proxy = Arc::new(ControlTerminalControl {
-            control,
-            surface_id,
-            sizing,
-            queue: sizing_queue,
-            ended: AtomicBool::new(false),
-        });
-        let proxy_control: Arc<dyn PtyControl> = proxy.clone();
-        let control_identity = Arc::downgrade(&proxy_control);
-        let (generation, gate, on_data, _) = self.sinks(pty_id, context, control_identity.clone());
+        let proxy = Arc::new(ControlTerminalControl { control, surface_id });
+        let (on_data, _) = self.sinks(pty_id, context);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
-        let gate_for_exit = Arc::clone(&gate);
         let on_exit: ExitSink = Arc::new(move |code| {
-            let kill = {
-                let _guard = gate_for_exit.lock().expect("attachment gate");
-                relay.emit_raw_exit(
-                    &pty_id_for_exit,
-                    generation,
-                    Some(&stream_for_exit),
-                    code,
+            if stream_for_exit.overflowed() {
+                relay.close(&pty_id_for_exit);
+                send_pty_error(
                     &context_for_exit,
-                    &control_identity,
-                )
-            };
-            if let Some(control) = kill {
-                control.kill();
+                    &pty_id_for_exit,
+                    "overflow",
+                    "pty output backlog overflowed; reattach to continue receiving output",
+                );
+            } else {
+                relay.emit_exit(&pty_id_for_exit, code, &context_for_exit);
             }
         });
         let start_stream = Arc::clone(&stream);
-        control_cleanup.disarm();
         Ok(Some(Opened {
-            generation,
-            gate,
             created: ensured.created,
             surface: Some(surface_ref.to_owned()),
             control: proxy,
-            post_open_resize: !shared_sizing && !attach_initial_size,
             closing: Arc::new(AtomicBool::new(false)),
-            start: Some(Box::new(move || start_stream.go_live(on_data, on_exit))),
-            cleanup_armed: AtomicBool::new(true),
+            start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }
 
@@ -6080,8 +1902,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
-    use std::time::Duration;
-    use tokio::sync::Notify as TestNotify;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
@@ -6115,7 +1935,7 @@ mod tests {
     }
 
     /// A fake PTY: emit() calls the subscribed sink synchronously, like the
-    /// JS fakePty. Records writes/resizes/pause/release/kill for assertions.
+    /// JS fakePty. Records writes/resizes/pause/kill for assertions.
     #[derive(Default)]
     struct FakeState {
         on_data: Option<DataSink>,
@@ -6124,7 +1944,6 @@ mod tests {
         resized: Vec<(u16, u16)>,
         paused: bool,
         killed: bool,
-        released: bool,
     }
 
     #[derive(Clone)]
@@ -6133,45 +1952,6 @@ mod tests {
         spawn_file: String,
         spawn_cwd: PathBuf,
         spawn_term: String,
-    }
-
-    #[test]
-    fn strict_terminal_enumeration_rejects_more_than_the_cap() {
-        let tabs = (0..=MAX_ENUM_TERMINALS)
-            .map(|surface| {
-                serde_json::json!({
-                    "kind": "pty",
-                    "surface": surface,
-                    "dead": false,
-                    "name": format!("terminal-{surface}"),
-                })
-            })
-            .collect::<Vec<_>>();
-        let data = serde_json::json!({
-            "workspaces": [{
-                "name": "workspace",
-                "screens": [{
-                    "panes": [{"tabs": tabs}]
-                }]
-            }]
-        });
-        assert!(collect_pty_tabs_strict(Some(&data)).is_err());
-
-        let bounded = serde_json::json!({
-            "workspaces": [{
-                "name": "workspace",
-                "screens": [{
-                    "panes": [{"tabs": (0..MAX_ENUM_TERMINALS)
-                        .map(|surface| serde_json::json!({
-                            "kind": "pty",
-                            "surface": surface,
-                            "dead": false,
-                        }))
-                        .collect::<Vec<_>>() }]
-                }]
-            }]
-        });
-        assert_eq!(collect_pty_tabs_strict(Some(&bounded)).unwrap().len(), MAX_ENUM_TERMINALS);
     }
 
     impl FakePty {
@@ -6205,9 +1985,6 @@ mod tests {
         fn resume(&self) {
             self.state.lock().unwrap().paused = false;
         }
-        fn release(&self) {
-            self.state.lock().unwrap().released = true;
-        }
         fn kill(&self) {
             self.state.lock().unwrap().killed = true;
         }
@@ -6219,112 +1996,6 @@ mod tests {
             state.on_data = Some(on_data);
             state.on_exit = Some(on_exit);
         }
-    }
-
-    #[test]
-    fn viewer_delivery_keeps_banner_replay_live_and_exit_ordered() {
-        let seen = TestArc::new(StdMutex::new(Vec::<String>::new()));
-        let entered = TestArc::new(Barrier::new(2));
-        let release = TestArc::new(Barrier::new(2));
-        let invocations = TestArc::new(AtomicUsize::new(0));
-
-        let callback_seen = TestArc::clone(&seen);
-        let callback_entered = TestArc::clone(&entered);
-        let callback_release = TestArc::clone(&release);
-        let callback_invocations = TestArc::clone(&invocations);
-        let on_data: DataSink = TestArc::new(move |chunk| {
-            let invocation = callback_invocations.fetch_add(1, AtomicOrdering::Relaxed);
-            if invocation == 0 {
-                callback_entered.wait();
-                callback_release.wait();
-            }
-            callback_seen
-                .lock()
-                .expect("viewer callback lock")
-                .push(String::from_utf8_lossy(&chunk).into_owned());
-        });
-        let callback_seen = TestArc::clone(&seen);
-        let on_exit: ExitSink = TestArc::new(move |code| {
-            callback_seen.lock().expect("viewer callback lock").push(format!("exit:{code}"));
-        });
-
-        let delivery = ViewerDelivery::with_overflow(on_data, on_exit, TestArc::new(|| {}));
-        delivery.seed(Some(Bytes::from_static(b"banner")), Some(Bytes::from_static(b"buffered")));
-
-        let worker_delivery = TestArc::clone(&delivery);
-        let worker = thread::spawn(move || {
-            assert!(worker_delivery.activate());
-            worker_delivery.drain();
-        });
-
-        entered.wait();
-        assert!(matches!(
-            delivery.push_data(Bytes::from_static(b"live")),
-            ViewerDeliveryAction::None
-        ));
-        assert!(matches!(delivery.finish(7), ViewerDeliveryAction::None));
-        release.wait();
-        worker.join().expect("viewer delivery worker");
-
-        assert_eq!(
-            *seen.lock().expect("viewer callback lock"),
-            vec![
-                "banner".to_owned(),
-                "buffered".to_owned(),
-                "live".to_owned(),
-                "exit:7".to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn viewer_delivery_overflow_is_bounded_and_notified_once() {
-        let notifications = TestArc::new(AtomicUsize::new(0));
-        let callback_notifications = TestArc::clone(&notifications);
-        let delivery = ViewerDelivery::with_overflow(
-            TestArc::new(|_| {}),
-            TestArc::new(|_| {}),
-            TestArc::new(move || {
-                callback_notifications.fetch_add(1, AtomicOrdering::Relaxed);
-            }),
-        );
-
-        assert!(matches!(
-            delivery.push_data(Bytes::from(vec![0_u8; VIEWER_DELIVERY_MAX_BYTES])),
-            ViewerDeliveryAction::None
-        ));
-        assert!(matches!(
-            delivery.push_data(Bytes::from_static(b"overflow")),
-            ViewerDeliveryAction::Overflow
-        ));
-        delivery.notify_overflow();
-        delivery.notify_overflow();
-
-        let state = delivery.state.lock().expect("viewer delivery lock");
-        assert!(state.overflowed);
-        assert_eq!(state.queued_bytes, 0);
-        assert!(state.queue.is_empty());
-        drop(state);
-        assert_eq!(notifications.load(AtomicOrdering::Relaxed), 1);
-    }
-
-    #[test]
-    fn viewer_delivery_finish_before_start_preserves_replay_before_exit() {
-        let seen = TestArc::new(StdMutex::new(Vec::<String>::new()));
-        let data_seen = TestArc::clone(&seen);
-        let on_data: DataSink = TestArc::new(move |chunk| {
-            data_seen.lock().unwrap().push(String::from_utf8_lossy(&chunk).into_owned());
-        });
-        let exit_seen = TestArc::clone(&seen);
-        let on_exit: ExitSink = TestArc::new(move |code| {
-            exit_seen.lock().unwrap().push(format!("exit:{code}"));
-        });
-        let delivery = ViewerDelivery::with_overflow(on_data, on_exit, TestArc::new(|| {}));
-        assert!(matches!(delivery.finish(9), ViewerDeliveryAction::None));
-        delivery.seed(Some(Bytes::from_static(b"banner")), Some(Bytes::from_static(b"replay")));
-        assert!(delivery.activate());
-        delivery.drain();
-        assert_eq!(*seen.lock().unwrap(), vec!["banner", "replay", "exit:9"]);
     }
 
     #[derive(Default)]
@@ -6472,58 +2143,19 @@ mod tests {
 
     impl Harness {
         fn context(&self, trust: &str, owner: Option<String>) -> FrameContext {
-            self.context_at_version(PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION, trust, owner)
-        }
-
-        fn context_at_version(
-            &self,
-            negotiated_version: u64,
-            trust: &str,
-            owner: Option<String>,
-        ) -> FrameContext {
             let sent = Arc::clone(&self.sent);
             let buffered = Arc::clone(&self.buffered);
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
-                negotiated_version,
                 trust: trust.to_owned(),
                 local_roots: None,
                 owner_user_id: owner,
             }
         }
 
-        fn context_with_version(
-            &self,
-            trust: &str,
-            owner: Option<String>,
-            negotiated_version: u64,
-        ) -> FrameContext {
-            self.context_at_version(negotiated_version, trust, owner)
-        }
-
         async fn open(
             &self,
-            pty_id: &str,
-            session: &str,
-            extra: Value,
-            trust: &str,
-            owner: Option<String>,
-        ) {
-            self.open_at_version(
-                PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION,
-                pty_id,
-                session,
-                extra,
-                trust,
-                owner,
-            )
-            .await;
-        }
-
-        async fn open_at_version(
-            &self,
-            negotiated_version: u64,
             pty_id: &str,
             session: &str,
             extra: Value,
@@ -6546,9 +2178,7 @@ mod tests {
                     frame[k] = v;
                 }
             }
-            self.manager
-                .handle_frame(&frame, &self.context_at_version(negotiated_version, trust, owner))
-                .await;
+            self.manager.handle_frame(&frame, &self.context(trust, owner)).await;
         }
 
         async fn frame(&self, frame: Value) {
@@ -6558,20 +2188,7 @@ mod tests {
         }
 
         async fn frame_as(&self, frame: Value, trust: &str, owner: Option<String>) {
-            self.frame_as_at_version(PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION, frame, trust, owner)
-                .await;
-        }
-
-        async fn frame_as_at_version(
-            &self,
-            negotiated_version: u64,
-            frame: Value,
-            trust: &str,
-            owner: Option<String>,
-        ) {
-            self.manager
-                .handle_frame(&frame, &self.context_at_version(negotiated_version, trust, owner))
-                .await;
+            self.manager.handle_frame(&frame, &self.context(trust, owner)).await;
         }
 
         fn sent(&self) -> Vec<Value> {
@@ -6709,34 +2326,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trust_downgrade_downgrades_for_v6_workers() {
-        let h = harness(None, None);
-        h.open_at_version(
-            6,
-            "p1",
-            "main",
-            serde_json::json!({"actorId": "user_other"}),
-            "supervised",
-            h.owner.clone(),
-        )
-        .await;
-        h.frame_as_at_version(
-            6,
-            serde_json::json!({"type":"pty_input","ptyId":"p1","dataB64":b64("x")}),
-            "observe",
-            h.owner.clone(),
-        )
-        .await;
-        let error = h
-            .sent()
-            .into_iter()
-            .find(|frame| ty(frame) == "pty_error")
-            .expect("trust downgrade error");
-        assert_eq!(error["code"], "failed");
-        assert!(error["message"].as_str().unwrap_or_default().contains("restore trust"));
-    }
-
-    #[tokio::test]
     async fn output_after_trust_downgrade_is_not_forwarded() {
         let h = harness(None, None);
         h.open(
@@ -6789,73 +2378,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_callbacks_after_reopen_cannot_affect_replacement() {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let h = harness(Some(cmux), None);
-        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let old = h.spawned()[0].clone();
-        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
-        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let replacement = h.spawned()[1].clone();
-
-        let before_stale = h.sent().len();
-        old.emit("stale output");
-        old.exit(7);
-        let stale_frames = h.sent();
-        assert!(!stale_frames[before_stale..].iter().any(|frame| matches!(
-            frame.get("type").and_then(Value::as_str),
-            Some("pty_output" | "pty_exit")
-        )));
-
-        replacement.emit("replacement output");
-        replacement.exit(0);
-        let frames = h.sent();
-        assert_eq!(
-            frames.last().and_then(|frame| frame.get("type")).and_then(Value::as_str),
-            Some("pty_exit")
-        );
-        assert_eq!(
-            frames.last().and_then(|frame| frame.get("code")).and_then(Value::as_i64),
-            Some(0)
-        );
-    }
-
-    #[tokio::test]
-    async fn stale_overflow_after_reopen_cannot_error_replacement() {
-        let h = harness(None, None);
-        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let old = h.manager.inner.attachments.lock().unwrap().get("p1").unwrap().clone();
-        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
-        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let replacement_generation =
-            h.manager.inner.attachments.lock().unwrap().get("p1").unwrap().generation;
-
-        let stale_stream = TerminalStream::new();
-        stale_stream.push_output(Bytes::from(vec![b'x'; RAW_ATTACH_BACKLOG_CAP]));
-        stale_stream.push_output(Bytes::from_static(b"late"));
-        assert!(stale_stream.overflowed());
-
-        let old_control = Arc::clone(&old.control);
-        let old_identity = Arc::downgrade(&old_control);
-        let before = h.sent().len();
-        let _ = h.manager.inner.emit_raw_exit(
-            "p1",
-            old.generation,
-            Some(&stale_stream),
-            1,
-            &h.context("supervised", h.owner.clone()),
-            &old_identity,
-        );
-
-        let after = h.sent();
-        assert!(!after[before..].iter().any(|frame| ty(frame) == "pty_error"));
-        assert_eq!(
-            h.manager.inner.attachments.lock().unwrap().get("p1").unwrap().generation,
-            replacement_generation
-        );
-    }
-
-    #[tokio::test]
     async fn zero_byte_chunks_never_become_output_frames() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
@@ -6886,14 +2408,10 @@ mod tests {
     async fn session_exit_sends_exit_once_and_next_open_creates() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let pty = h.spawned()[0].clone();
-        pty.exit(3);
+        h.spawned()[0].exit(3);
         let exit = &h.sent()[1];
         assert_eq!(exit["type"], "pty_exit");
         assert_eq!(exit["code"], 3);
-        let state = pty.state.lock().unwrap();
-        assert!(state.released, "PTY exit must release relay state");
-        assert!(!state.killed, "PTY exit must not kill a whole-session process");
         h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
         assert_eq!(h.sent()[2]["created"], true);
         assert_eq!(h.spawned().len(), 2);
@@ -6958,49 +2476,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shell_viewers_use_smallest_grid_and_relax_after_release() {
-        let h = harness(None, None);
-        h.open(
-            "p1",
-            "main",
-            serde_json::json!({ "cols": 120, "rows": 40 }),
-            "supervised",
-            h.owner.clone(),
-        )
-        .await;
-        h.open(
-            "p2",
-            "main",
-            serde_json::json!({ "cols": 80, "rows": 24 }),
-            "supervised",
-            h.owner.clone(),
-        )
-        .await;
-        let pty = h.spawned()[0].clone();
-        assert_eq!(pty.state.lock().unwrap().resized, vec![(80, 24)]);
-
-        h.frame(serde_json::json!({
-            "type": "pty_resize",
-            "ptyId": "p2",
-            "cols": 100,
-            "rows": 30
-        }))
-        .await;
-        h.frame(serde_json::json!({
-            "type": "pty_resize",
-            "ptyId": "p1",
-            "cols": 90,
-            "rows": 20
-        }))
-        .await;
-        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
-        assert_eq!(
-            pty.state.lock().unwrap().resized,
-            vec![(80, 24), (100, 30), (90, 20), (100, 30)]
-        );
-    }
-
-    #[tokio::test]
     async fn detaching_one_viewer_leaves_the_other_live_exit_reaches_every_viewer() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
@@ -7044,27 +2519,13 @@ mod tests {
         let last = h.sent();
         let last = last.last().unwrap();
         assert_eq!(last["type"], "pty_error");
-        assert_eq!(last["code"], "overflow");
-        assert!(last["message"].as_str().unwrap_or_default().contains("reattach"));
+        assert_eq!(last["code"], "failed");
         assert!(!pty.state.lock().unwrap().killed);
         h.buffered.store(0, Ordering::SeqCst);
         h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
         let reopened =
             h.sent().into_iter().find(|f| ty(f) == "pty_opened" && f["ptyId"] == "p2").unwrap();
         assert_eq!(reopened["created"], false);
-    }
-
-    #[tokio::test]
-    async fn output_backlog_overflow_downgrades_for_v6_workers() {
-        let h = harness(None, None);
-        h.open_at_version(6, "p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        let pty = h.spawned()[0].clone();
-        h.buffered.store(OUTPUT_BUFFER_CAP + 1, Ordering::SeqCst);
-        pty.emit("flood");
-        let last = h.sent().last().cloned().expect("overflow error");
-        assert_eq!(last["type"], "pty_error");
-        assert_eq!(last["code"], "failed");
-        assert!(last["message"].as_str().unwrap_or_default().contains("reattach"));
     }
 
     #[tokio::test]
@@ -7079,72 +2540,6 @@ mod tests {
         let viewer = h.spawned()[0].clone();
         h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
         assert!(viewer.state.lock().unwrap().killed);
-    }
-
-    #[tokio::test]
-    async fn cmux_protocol_ten_refuses_open_when_sizing_target_is_frozen() {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let control = SizingControl::new(10, &[]);
-        let h = harness_with_control(Some(cmux), None, None, Some(Arc::new(control.clone())));
-
-        // Retire the same daemon surface with a failed close barrier. A
-        // protocol-10+ raw attach must report a fixed failure, not degrade to
-        // a whole-session shell that bypasses the sizing generation fence.
-        let old_control = SizingControl::new(10, &[]);
-        old_control.set_end_ok(false);
-        let key =
-            SizingKey { socket_path: PathBuf::from("/run/cmux-tui-501/main.sock"), surface_id: 40 };
-        h.manager
-            .inner
-            .sizing
-            .join(
-                key.clone(),
-                1,
-                40,
-                Arc::new(old_control.clone()),
-                SizingGrid { cols: 80, rows: 24 },
-            )
-            .expect("initial sizing join")
-            .await
-            .expect("initial sizing worker");
-        h.manager.inner.sizing.leave(&key, 1);
-        old_control.wait_for_end().await;
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                let frozen = h
-                    .manager
-                    .inner
-                    .sizing
-                    .targets
-                    .lock()
-                    .unwrap()
-                    .get(&key)
-                    .is_some_and(|target| target.queue.state.lock().unwrap().closing_failed);
-                if frozen {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("sizing target did not become frozen");
-
-        h.open_at_version(
-            10,
-            "p1",
-            "main",
-            serde_json::json!({ "surface": "40" }),
-            "supervised",
-            h.owner.clone(),
-        )
-        .await;
-        let sent = h.sent();
-        assert_eq!(sent.len(), 1);
-        assert_eq!(sent[0]["type"], "pty_error");
-        assert_eq!(sent[0]["code"], "failed");
-        assert!(sent[0]["message"].as_str().unwrap_or_default().contains("sizing"));
-        assert!(!sent.iter().any(|frame| ty(frame) == "pty_opened"));
-        assert!(control.ended(), "failed open must close the raw control");
     }
 
     #[tokio::test]
@@ -7201,2281 +2596,6 @@ mod tests {
         fn end(&self) {}
     }
 
-    #[derive(Clone)]
-    struct SizingControl {
-        state: TestArc<StdMutex<SizingControlState>>,
-        notify: TestArc<TestNotify>,
-        sizing_release: TestArc<TestNotify>,
-        ordered_send_started: TestArc<TestNotify>,
-        ordered_send_release: TestArc<TestNotify>,
-        end_started: TestArc<TestNotify>,
-        end_release: TestArc<TestNotify>,
-        claim_dispatch_started: TestArc<TestNotify>,
-        claim_dispatch_release: TestArc<TestNotify>,
-        ended_notify: TestArc<TestNotify>,
-        settled: TestArc<TestNotify>,
-    }
-
-    struct SizingControlState {
-        protocol: i64,
-        capabilities: Vec<String>,
-        claim_ok: bool,
-        reject_next_resize: bool,
-        block_sizing: bool,
-        block_ordered_send: bool,
-        ordered_send_started: bool,
-        block_end: bool,
-        end_started: bool,
-        end_ok: bool,
-        block_claim_dispatch: bool,
-        ended: bool,
-        requests: Vec<(String, Value)>,
-        sends: Vec<(String, Value)>,
-        events: Vec<String>,
-    }
-
-    impl SizingControl {
-        fn new(protocol: i64, capabilities: &[&str]) -> Self {
-            Self {
-                state: TestArc::new(StdMutex::new(SizingControlState {
-                    protocol,
-                    capabilities: capabilities.iter().map(|value| (*value).to_owned()).collect(),
-                    claim_ok: true,
-                    reject_next_resize: false,
-                    block_sizing: false,
-                    block_ordered_send: false,
-                    ordered_send_started: false,
-                    block_end: false,
-                    end_started: false,
-                    end_ok: true,
-                    block_claim_dispatch: false,
-                    ended: false,
-                    requests: Vec::new(),
-                    sends: Vec::new(),
-                    events: Vec::new(),
-                })),
-                notify: TestArc::new(TestNotify::new()),
-                sizing_release: TestArc::new(TestNotify::new()),
-                ordered_send_started: TestArc::new(TestNotify::new()),
-                ordered_send_release: TestArc::new(TestNotify::new()),
-                end_started: TestArc::new(TestNotify::new()),
-                end_release: TestArc::new(TestNotify::new()),
-                claim_dispatch_started: TestArc::new(TestNotify::new()),
-                claim_dispatch_release: TestArc::new(TestNotify::new()),
-                ended_notify: TestArc::new(TestNotify::new()),
-                settled: TestArc::new(TestNotify::new()),
-            }
-        }
-
-        fn set_claim_ok(&self, value: bool) {
-            self.state.lock().unwrap().claim_ok = value;
-        }
-
-        fn reject_next_resize(&self) {
-            self.state.lock().unwrap().reject_next_resize = true;
-        }
-
-        fn block_sizing(&self) {
-            self.state.lock().unwrap().block_sizing = true;
-        }
-
-        fn release_sizing(&self) {
-            self.state.lock().unwrap().block_sizing = false;
-            self.sizing_release.notify_waiters();
-        }
-
-        fn block_ordered_send(&self) {
-            self.state.lock().unwrap().block_ordered_send = true;
-        }
-
-        fn release_ordered_send(&self) {
-            self.state.lock().unwrap().block_ordered_send = false;
-            self.ordered_send_release.notify_waiters();
-        }
-
-        fn block_end(&self) {
-            self.state.lock().unwrap().block_end = true;
-        }
-
-        fn release_end(&self) {
-            self.state.lock().unwrap().block_end = false;
-            self.end_release.notify_waiters();
-        }
-
-        fn set_end_ok(&self, value: bool) {
-            self.state.lock().unwrap().end_ok = value;
-        }
-
-        fn block_claim_dispatch(&self) {
-            self.state.lock().unwrap().block_claim_dispatch = true;
-        }
-
-        fn release_claim_dispatch(&self) {
-            self.state.lock().unwrap().block_claim_dispatch = false;
-            self.claim_dispatch_release.notify_waiters();
-        }
-
-        fn requests(&self) -> Vec<(String, Value)> {
-            self.state.lock().unwrap().requests.clone()
-        }
-
-        fn sends(&self) -> Vec<(String, Value)> {
-            self.state.lock().unwrap().sends.clone()
-        }
-
-        fn events(&self) -> Vec<String> {
-            self.state.lock().unwrap().events.clone()
-        }
-
-        fn ended(&self) -> bool {
-            self.state.lock().unwrap().ended
-        }
-
-        async fn wait_for_requests(&self, count: usize) {
-            let wait = async {
-                loop {
-                    let notified = self.notify.notified();
-                    if self.requests().len() >= count {
-                        return;
-                    }
-                    notified.await;
-                }
-            };
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing request worker did not settle");
-        }
-
-        async fn wait_for_sends(&self, count: usize) {
-            let wait = async {
-                loop {
-                    let notified = self.notify.notified();
-                    if self.sends().len() >= count {
-                        return;
-                    }
-                    notified.await;
-                }
-            };
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing send queue did not settle");
-        }
-
-        async fn wait_for_settled(&self) {
-            let wait = self.settled.notified();
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing request did not settle");
-        }
-
-        async fn wait_for_claim_dispatch(&self) {
-            let wait = self.claim_dispatch_started.notified();
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing claim did not reach dispatch gate");
-        }
-
-        async fn wait_for_ordered_send(&self) {
-            let wait = async {
-                loop {
-                    let notified = self.ordered_send_started.notified();
-                    if self.state.lock().unwrap().ordered_send_started {
-                        return;
-                    }
-                    notified.await;
-                }
-            };
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing ordered send did not reach dispatch gate");
-        }
-
-        async fn wait_for_end(&self) {
-            let wait = async {
-                loop {
-                    let notified = self.ended_notify.notified();
-                    if self.ended() {
-                        return;
-                    }
-                    notified.await;
-                }
-            };
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing close did not settle");
-        }
-
-        async fn wait_for_end_started(&self) {
-            let wait = async {
-                loop {
-                    let notified = self.end_started.notified();
-                    if self.state.lock().unwrap().end_started {
-                        return;
-                    }
-                    notified.await;
-                }
-            };
-            tokio::time::timeout(Duration::from_secs(2), wait)
-                .await
-                .expect("terminal sizing close did not reach dispatch gate");
-        }
-    }
-
-    impl ControlHandle for SizingControl {
-        fn request(
-            &self,
-            cmd: &str,
-            params: Value,
-        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
-            let dispatch_blocked = {
-                let state = self.state.lock().unwrap();
-                state.block_claim_dispatch && cmd == "set-client-sizing"
-            };
-            let dispatch_release = TestArc::clone(&self.claim_dispatch_release);
-            let claim_dispatch_started = TestArc::clone(&self.claim_dispatch_started);
-            let settled = TestArc::clone(&self.settled);
-            let cmd = cmd.to_owned();
-            Box::pin(async move {
-                if dispatch_blocked {
-                    claim_dispatch_started.notify_waiters();
-                    dispatch_release.notified().await;
-                    if self.ended() {
-                        settled.notify_waiters();
-                        return None;
-                    }
-                }
-                let (response, blocked) = {
-                    let mut state = self.state.lock().unwrap();
-                    if state.ended {
-                        return None;
-                    }
-                    state.requests.push((cmd.clone(), params));
-                    state.events.push(format!("request:{cmd}"));
-                    let response = match cmd.as_str() {
-                        "identify" => Some(json!({
-                            "ok": true,
-                            "data": {
-                                "protocol": state.protocol,
-                                "capabilities": state.capabilities.clone(),
-                            },
-                        })),
-                        "attach-surface" => Some(json!({ "ok": true, "data": {} })),
-                        "resize-surface" => {
-                            let accepted = !state.reject_next_resize;
-                            state.reject_next_resize = false;
-                            Some(json!({
-                                "ok": true,
-                                "data": { "accepted": accepted, "reservation_id": Value::Null },
-                            }))
-                        }
-                        "set-client-sizing" if state.claim_ok => {
-                            Some(json!({ "ok": true, "data": {} }))
-                        }
-                        "set-client-sizing" => Some(json!({ "ok": false, "error": "refused" })),
-                        _ => Some(json!({ "ok": true, "data": {} })),
-                    };
-                    let blocked = state.block_sizing
-                        && matches!(cmd.as_str(), "resize-surface" | "set-client-sizing");
-                    (response, blocked)
-                };
-                self.notify.notify_waiters();
-                let release = TestArc::clone(&self.sizing_release);
-                if blocked {
-                    release.notified().await;
-                }
-                settled.notify_waiters();
-                response
-            })
-        }
-
-        fn send(&self, cmd: &str, params: Value) {
-            let mut state = self.state.lock().unwrap();
-            state.sends.push((cmd.to_owned(), params));
-            state.events.push(format!("send:{cmd}"));
-            self.notify.notify_waiters();
-        }
-
-        fn ordered_send(
-            &self,
-            cmd: &str,
-            params: Value,
-        ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            let blocked = {
-                let state = self.state.lock().unwrap();
-                state.block_ordered_send && cmd == "resize-surface"
-            };
-            let started = TestArc::clone(&self.ordered_send_started);
-            let release = TestArc::clone(&self.ordered_send_release);
-            let cmd = cmd.to_owned();
-            Box::pin(async move {
-                if blocked {
-                    self.state.lock().unwrap().ordered_send_started = true;
-                    started.notify_waiters();
-                    release.notified().await;
-                }
-                self.send(&cmd, params);
-                true
-            })
-        }
-
-        fn on_event(&self, _handler: EventHandler) {}
-        fn on_close(&self, _handler: CloseHandler) {}
-        fn pause(&self) {}
-        fn resume(&self) {}
-        fn end(&self) {
-            let mut state = self.state.lock().unwrap();
-            state.ended = true;
-            state.events.push("end".to_owned());
-            self.ended_notify.notify_waiters();
-        }
-
-        fn end_and_wait(&self) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            let blocked = self.state.lock().unwrap().block_end;
-            let end_ok = self.state.lock().unwrap().end_ok;
-            let started = TestArc::clone(&self.end_started);
-            let release = TestArc::clone(&self.end_release);
-            Box::pin(async move {
-                if blocked {
-                    self.state.lock().unwrap().end_started = true;
-                    started.notify_waiters();
-                    release.notified().await;
-                }
-                self.end();
-                end_ok
-            })
-        }
-    }
-
-    /// Control test double that retains the close callback. Raw attach uses
-    /// callbacks that retain its sizing lease, so this models the ownership
-    /// edge that must not keep an endpoint alive after release.
-    #[derive(Clone)]
-    struct CallbackSizingControl {
-        inner: SizingControl,
-        close_handler: TestArc<StdMutex<Option<CloseHandler>>>,
-    }
-
-    impl CallbackSizingControl {
-        fn new(protocol: i64) -> Self {
-            Self {
-                inner: SizingControl::new(protocol, &[]),
-                close_handler: TestArc::new(StdMutex::new(None)),
-            }
-        }
-    }
-
-    impl ControlHandle for CallbackSizingControl {
-        fn request(
-            &self,
-            cmd: &str,
-            params: Value,
-        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
-            self.inner.request(cmd, params)
-        }
-
-        fn send(&self, cmd: &str, params: Value) {
-            self.inner.send(cmd, params);
-        }
-
-        fn on_event(&self, _handler: EventHandler) {}
-
-        fn on_close(&self, handler: CloseHandler) {
-            *self.close_handler.lock().unwrap() = Some(handler);
-        }
-
-        fn pause(&self) {}
-
-        fn resume(&self) {}
-
-        fn end(&self) {
-            self.inner.end();
-        }
-    }
-
-    #[tokio::test]
-    async fn terminal_sizing_refused_claim_freezes_until_new_attachment() {
-        let control = SizingControl::new(12, &[]);
-        control.set_claim_ok(false);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey { socket_path: PathBuf::from("/tmp/cmux-sizing.sock"), surface_id: 7 };
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        coordinator.join(key.clone(), 1, 7, control_handle, SizingGrid { cols: 80, rows: 24 });
-        control.wait_for_requests(2).await;
-        let initial = control.requests();
-        assert_eq!(initial[0].0, "resize-surface");
-        assert_eq!(initial[1].0, "set-client-sizing");
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert_eq!(control.requests().len(), 2, "a refused claim must not auto-retry");
-
-        let replacement = SizingControl::new(12, &[]);
-        coordinator.join(
-            key.clone(),
-            2,
-            7,
-            Arc::new(replacement.clone()),
-            SizingGrid { cols: 81, rows: 25 },
-        );
-        replacement.wait_for_requests(2).await;
-        assert_eq!(replacement.requests()[1].0, "set-client-sizing");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            Some(2)
-        );
-        coordinator.leave(&key, 1);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn stale_candidate_reply_does_not_clear_same_endpoint_update_claim() {
-        let control = SizingControl::new(12, &[]);
-        control.block_claim_dispatch();
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-candidate-reply.sock"),
-            surface_id: 41,
-        };
-        coordinator
-            .join(key.clone(), 1, 41, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier");
-        control.wait_for_claim_dispatch().await;
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("candidate endpoint");
-        let old_generation = TerminalSizing::current_generation(&target);
-        let old_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("initial claim fence").token;
-
-        // Update the same endpoint while the old claim request is waiting
-        // for its daemon response. The update must renew the explicit claim
-        // marker and queue fence under the new generation before the old
-        // worker can return.
-        coordinator.update_endpoint(&key, 1, &endpoint, SizingGrid { cols: 81, rows: 25 });
-        let new_generation = TerminalSizing::current_generation(&target);
-        assert!(new_generation > old_generation);
-        let new_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("updated claim fence").token;
-        assert_ne!(new_token, old_token, "the updated generation must reserve a new token");
-        assert!(target.state.lock().unwrap().claim_requested.is_some_and(|request| {
-            request.generation == new_generation
-                && request.viewer_id == 1
-                && request.token == Some(new_token)
-                && request.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-        assert!(
-            !coordinator.finish_candidate_request(
-                &target,
-                1,
-                &endpoint,
-                SizingGrid { cols: 81, rows: 25 },
-                new_generation,
-                old_token,
-                true,
-            ),
-            "an old retry token must not finish the newer same-endpoint claim"
-        );
-        assert!(target.state.lock().unwrap().claim_requested.is_some_and(|request| {
-            request.generation == new_generation
-                && request.token == Some(new_token)
-                && request.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-        control.release_claim_dispatch();
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.state.lock().unwrap().owner == Some(1) {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("stale candidate worker did not clear its old fence");
-
-        let current = coordinator.queue_for(&key, 1).expect("current endpoint");
-        assert!(Arc::ptr_eq(&current, &endpoint), "stale reply detached the live endpoint");
-        assert!(current.is_active(), "stale reply deactivated the live endpoint");
-        assert_eq!(
-            target.state.lock().unwrap().claim_requested,
-            None,
-            "the renewed claim should be consumed only by its own worker"
-        );
-        assert_eq!(
-            target.state.lock().unwrap().owner,
-            Some(1),
-            "the renewed claim must be completed by its own generation"
-        );
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn stale_candidate_reply_survives_passive_viewer_leave() {
-        let owner = SizingControl::new(12, &[]);
-        let passive = SizingControl::new(12, &[]);
-        let candidate = SizingControl::new(12, &[]);
-        candidate.block_claim_dispatch();
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-passive-leave-claim.sock"),
-            surface_id: 42,
-        };
-        coordinator
-            .join(key.clone(), 1, 42, Arc::new(owner.clone()), SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier")
-            .await
-            .expect("owner sizing worker");
-        coordinator
-            .join(key.clone(), 2, 42, Arc::new(passive.clone()), SizingGrid { cols: 100, rows: 30 })
-            .expect("passive sizing barrier")
-            .await
-            .expect("passive sizing worker");
-        coordinator.leave(&key, 1);
-
-        coordinator
-            .join(
-                key.clone(),
-                3,
-                42,
-                Arc::new(candidate.clone()),
-                SizingGrid { cols: 90, rows: 28 },
-            )
-            .expect("candidate sizing barrier");
-        candidate.wait_for_claim_dispatch().await;
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 3).expect("candidate endpoint");
-        let old_generation = TerminalSizing::current_generation(&target);
-        let old_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("candidate fence").token;
-
-        // Removing an unrelated passive viewer must renew the in-flight
-        // explicit candidate claim. Its old response is stale after the
-        // generation change, but the surviving candidate remains eligible.
-        coordinator.leave(&key, 2);
-        let new_generation = TerminalSizing::current_generation(&target);
-        assert!(new_generation > old_generation);
-        let new_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("renewed fence").token;
-        assert_ne!(new_token, old_token);
-        assert!(target.state.lock().unwrap().claim_requested.is_some_and(|request| {
-            request.generation == new_generation
-                && request.viewer_id == 3
-                && request.token == Some(new_token)
-                && request.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-
-        candidate.release_claim_dispatch();
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.state.lock().unwrap().owner == Some(3) {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("renewed candidate did not complete after passive leave");
-        assert!(endpoint.is_active(), "passive leave detached the candidate endpoint");
-        coordinator.leave(&key, 3);
-    }
-
-    #[tokio::test]
-    async fn stale_candidate_reply_survives_passive_viewer_update() {
-        let owner = SizingControl::new(12, &[]);
-        let passive = SizingControl::new(12, &[]);
-        let candidate = SizingControl::new(12, &[]);
-        candidate.block_claim_dispatch();
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-passive-update-claim.sock"),
-            surface_id: 43,
-        };
-        coordinator
-            .join(key.clone(), 1, 43, Arc::new(owner.clone()), SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier")
-            .await
-            .expect("owner sizing worker");
-        coordinator
-            .join(key.clone(), 2, 43, Arc::new(passive.clone()), SizingGrid { cols: 100, rows: 30 })
-            .expect("passive sizing barrier")
-            .await
-            .expect("passive sizing worker");
-        coordinator.leave(&key, 1);
-
-        coordinator
-            .join(
-                key.clone(),
-                3,
-                43,
-                Arc::new(candidate.clone()),
-                SizingGrid { cols: 90, rows: 28 },
-            )
-            .expect("candidate sizing barrier");
-        candidate.wait_for_claim_dispatch().await;
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 3).expect("candidate endpoint");
-        let old_generation = TerminalSizing::current_generation(&target);
-        let old_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("candidate fence").token;
-
-        // A passive viewer can change the smallest grid while the candidate's
-        // claim request is waiting for a daemon response. The candidate is an
-        // explicit relay request, so renew it at the new generation instead
-        // of invalidating it and freezing the target.
-        coordinator.update(&key, 2, SizingGrid { cols: 80, rows: 24 });
-        let new_generation = TerminalSizing::current_generation(&target);
-        assert!(new_generation > old_generation);
-        let new_token =
-            target.queue.state.lock().unwrap().claim_fence.expect("renewed fence").token;
-        assert_ne!(new_token, old_token);
-        assert!(target.state.lock().unwrap().claim_requested.is_some_and(|request| {
-            request.generation == new_generation
-                && request.viewer_id == 3
-                && request.token == Some(new_token)
-                && request.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-
-        candidate.release_claim_dispatch();
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.state.lock().unwrap().owner == Some(3) {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("renewed candidate did not complete after passive update");
-        assert!(endpoint.is_active(), "passive update detached the candidate endpoint");
-        coordinator.leave(&key, 3);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn failed_close_permanently_freezes_retired_target_without_revival() {
-        let control = SizingControl::new(12, &[]);
-        control.set_end_ok(false);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-close-failure.sock"),
-            surface_id: 40,
-        };
-
-        coordinator
-            .join(key.clone(), 1, 40, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-
-        // The close response is false: the daemon did not prove that all
-        // old-socket writes were processed. The target must remain retained
-        // and fail closed, because recreating it would allow a new socket to
-        // race an unknown old transport generation.
-        coordinator.leave(&key, 1);
-        control.wait_for_end().await;
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.queue.state.lock().unwrap().closing_failed {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("failed close did not freeze the target");
-        coordinator.remove_retired_target(&target);
-
-        {
-            let queue_state = target.queue.state.lock().unwrap();
-            assert!(queue_state.closing_failed);
-            assert!(!queue_state.closing.is_empty());
-            assert!(target.queue.wire_pending.lock().unwrap().is_empty());
-            assert!(!target.queue.wire_running.load(Ordering::Acquire));
-        }
-        assert!(target.state.lock().unwrap().retired);
-        assert!(coordinator.targets.lock().unwrap().contains_key(&key));
-
-        // A failed close is permanent for this target. A join must not clear
-        // `retired` or attach a replacement to the un-ordered transport.
-        assert!(
-            coordinator
-                .join(
-                    key.clone(),
-                    2,
-                    40,
-                    Arc::new(SizingControl::new(12, &[])),
-                    SizingGrid { cols: 80, rows: 24 },
-                )
-                .is_none(),
-            "failed close must not revive a retired target"
-        );
-        assert!(target.state.lock().unwrap().viewers.is_empty());
-    }
-
-    #[tokio::test]
-    async fn failed_close_detaches_replacement_admitted_behind_barrier() {
-        let owner = SizingControl::new(12, &[]);
-        owner.block_end();
-        owner.set_end_ok(false);
-        let replacement = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-close-replacement-failure.sock"),
-            surface_id: 43,
-        };
-        coordinator
-            .join(key.clone(), 1, 43, Arc::new(owner.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-
-        coordinator.leave(&key, 1);
-        owner.wait_for_end_started().await;
-        let (joined, replacement_endpoint) = coordinator
-            .join_with_endpoint(
-                key.clone(),
-                2,
-                43,
-                Arc::new(replacement.clone()),
-                SizingGrid { cols: 80, rows: 24 },
-            )
-            .expect("replacement is admitted behind the in-flight close");
-        drop(joined);
-        assert!(replacement_endpoint.is_active());
-
-        owner.release_end();
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.state.lock().unwrap().retired
-                    && target.state.lock().unwrap().viewers.is_empty()
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("failed close did not detach the replacement");
-        assert!(!replacement_endpoint.is_active());
-        assert!(replacement.ended(), "replacement control was left live after close failure");
-        assert!(target.queue.state.lock().unwrap().closing_failed);
-        assert!(coordinator.queue_for(&key, 2).is_none());
-    }
-
-    #[tokio::test]
-    async fn terminal_sizing_claims_after_a_passive_report_is_not_accepted() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key =
-            SizingKey { socket_path: PathBuf::from("/tmp/cmux-sizing-report.sock"), surface_id: 8 };
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        // `accepted:false` on the passive report means that another client
-        // currently owns the geometry. It is not a claim failure; the next
-        // command must still be the exclusive claim request.
-        control.reject_next_resize();
-        coordinator.join(key.clone(), 1, 8, control_handle, SizingGrid { cols: 80, rows: 24 });
-        control.wait_for_requests(2).await;
-        let requests = control.requests();
-        assert_eq!(requests[0].0, "resize-surface");
-        assert_eq!(requests[1].0, "set-client-sizing");
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn terminal_sizing_refused_owner_resize_freezes_until_new_attachment() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-reclaim.sock"),
-            surface_id: 9,
-        };
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        coordinator.join(key.clone(), 1, 9, control_handle, SizingGrid { cols: 80, rows: 24 });
-        control.wait_for_requests(2).await;
-
-        control.reject_next_resize();
-        coordinator.update(&key, 1, SizingGrid { cols: 100, rows: 40 });
-        control.wait_for_requests(3).await;
-        let requests = control.requests();
-        assert_eq!(requests[2].0, "resize-surface");
-        assert_eq!(requests[2].1["cols"], 100);
-        assert_eq!(requests[2].1["rows"], 40);
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert_eq!(control.requests().len(), 3, "refusal must not auto-retry");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            None
-        );
-
-        let replacement = SizingControl::new(12, &[]);
-        coordinator.join(
-            key.clone(),
-            2,
-            9,
-            Arc::new(replacement.clone()),
-            SizingGrid { cols: 100, rows: 40 },
-        );
-        replacement.wait_for_requests(2).await;
-        assert_eq!(replacement.requests()[1].0, "set-client-sizing");
-        coordinator.leave(&key, 1);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn terminal_sizing_uses_smallest_viewer_and_freezes_after_owner_leaves() {
-        let first = SizingControl::new(12, &[]);
-        let second = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-multi-viewer.sock"),
-            surface_id: 10,
-        };
-        let first_handle: Arc<dyn ControlHandle> = Arc::new(first.clone());
-        let second_handle: Arc<dyn ControlHandle> = Arc::new(second.clone());
-
-        coordinator.join(key.clone(), 1, 10, first_handle, SizingGrid { cols: 120, rows: 40 });
-        first.wait_for_requests(2).await;
-
-        coordinator.join(key.clone(), 2, 10, second_handle, SizingGrid { cols: 80, rows: 24 });
-        first.wait_for_requests(3).await;
-        let first_requests = first.requests();
-        assert_eq!(first_requests[2].0, "resize-surface");
-        assert_eq!(first_requests[2].1["cols"], 80);
-        assert_eq!(first_requests[2].1["rows"], 24);
-        assert!(second.requests().is_empty(), "non-owner must not resize the surface");
-
-        // Removing the owner freezes the core grid. The existing survivor is
-        // not elected from another socket.
-        coordinator.leave(&key, 1);
-        assert!(second.requests().is_empty(), "owner loss must not issue a replacement claim");
-        let second_endpoint = coordinator.queue_for(&key, 2).expect("survivor endpoint");
-        second_endpoint.enqueue_input(b"after-owner-leave");
-        assert_eq!(
-            second.sends().iter().map(|(command, _)| command.as_str()).collect::<Vec<_>>(),
-            vec!["send"]
-        );
-
-        // A newly attached viewer makes the explicit replacement claim.
-        let replacement = SizingControl::new(12, &[]);
-        coordinator.join(
-            key.clone(),
-            3,
-            10,
-            Arc::new(replacement.clone()),
-            SizingGrid { cols: 100, rows: 30 },
-        );
-        replacement.wait_for_requests(2).await;
-        assert_eq!(replacement.requests()[1].0, "set-client-sizing");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            Some(3)
-        );
-
-        // A resize from the explicit owner is sent through its connection.
-        coordinator.update(&key, 2, SizingGrid { cols: 100, rows: 30 });
-        replacement.wait_for_requests(3).await;
-        assert_eq!(replacement.requests()[2].0, "resize-surface");
-        coordinator.leave(&key, 2);
-        coordinator.leave(&key, 3);
-    }
-
-    #[tokio::test]
-    async fn non_owner_resize_is_fenced_before_owner_input_and_freezes_after_disconnect() {
-        let owner = SizingControl::new(12, &[]);
-        let viewer = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-cross-viewer-order.sock"),
-            surface_id: 15,
-        };
-        let owner_handle: Arc<dyn ControlHandle> = Arc::new(owner.clone());
-        let viewer_handle: Arc<dyn ControlHandle> = Arc::new(viewer.clone());
-
-        let owner_joined = coordinator
-            .join(key.clone(), 1, 15, owner_handle.clone(), SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier");
-        owner.wait_for_requests(2).await;
-        owner_joined.await.expect("owner sizing worker");
-        let viewer_joined = coordinator
-            .join(key.clone(), 2, 15, viewer_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("viewer sizing barrier");
-        viewer_joined.await.expect("viewer sizing worker");
-        let owner_claims_before =
-            owner.requests().iter().filter(|(command, _)| command == "set-client-sizing").count();
-
-        // Hold the owner's request reply. The synchronous queue fence must
-        // still reach the wire before input from the owner can be accepted.
-        owner.block_sizing();
-        coordinator.update(&key, 2, SizingGrid { cols: 80, rows: 24 });
-        owner.wait_for_requests(3).await;
-        let owner_queue = coordinator.queue_for(&key, 1).expect("owner sizing queue");
-        let owner_proxy = ControlTerminalControl {
-            control: owner_handle,
-            surface_id: 15,
-            sizing: None,
-            queue: Some(owner_queue),
-            ended: AtomicBool::new(false),
-        };
-        owner_proxy.write(b"input-after-viewer-resize");
-        let sends = owner.sends();
-        let tail =
-            sends.iter().map(|(command, _)| command.as_str()).rev().take(2).collect::<Vec<_>>();
-        assert_eq!(tail, vec!["send", "resize-surface"]);
-
-        // Disconnect the owner while its direct resize request is blocked.
-        // The stale owner must not claim again, and the remaining viewer is
-        // left attached with the core grid frozen.
-        coordinator.leave(&key, 1);
-        owner.end();
-        owner.release_sizing();
-        let viewer_endpoint = coordinator.queue_for(&key, 2).expect("survivor endpoint");
-        viewer_endpoint.enqueue_input(b"input-after-owner-loss");
-        assert_eq!(
-            viewer.sends(),
-            vec![(
-                "send".to_owned(),
-                json!({
-                    "surface": 15,
-                    "bytes": BASE64.encode(b"input-after-owner-loss"),
-                })
-            )]
-        );
-        assert_eq!(
-            owner.requests().iter().filter(|(command, _)| command == "set-client-sizing").count(),
-            owner_claims_before,
-            "a disconnected owner must not emit a stale claim"
-        );
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn shared_sizing_queue_orders_shrink_and_all_viewer_input() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-shared-input-order.sock"),
-            surface_id: 16,
-        };
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let owner_joined = coordinator
-            .join(
-                key.clone(),
-                1,
-                16,
-                Arc::clone(&control_handle),
-                SizingGrid { cols: 120, rows: 40 },
-            )
-            .expect("owner sizing barrier");
-        owner_joined.await.expect("owner sizing worker");
-        let viewer_joined = coordinator
-            .join(key.clone(), 2, 16, control_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("viewer sizing barrier");
-        viewer_joined.await.expect("viewer sizing worker");
-
-        let owner_endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let viewer_endpoint = coordinator.queue_for(&key, 2).expect("viewer endpoint");
-        let owner_proxy = Arc::new(ControlTerminalControl {
-            control: Arc::new(control.clone()),
-            surface_id: 16,
-            sizing: None,
-            queue: Some(owner_endpoint),
-            ended: AtomicBool::new(false),
-        });
-        let viewer_proxy = Arc::new(ControlTerminalControl {
-            control: Arc::new(control.clone()),
-            surface_id: 16,
-            sizing: None,
-            queue: Some(viewer_endpoint),
-            ended: AtomicBool::new(false),
-        });
-
-        // The non-owner shrink is canonicalized on the shared session queue;
-        // input from that same viewer cannot appear before its resize fence.
-        coordinator.update(&key, 2, SizingGrid { cols: 80, rows: 24 });
-        viewer_proxy.write(b"viewer-after-shrink");
-
-        // Concurrent input from both viewers uses the same queue. The order of
-        // the two input frames may vary, but neither can overtake the resize.
-        let owner_thread = {
-            let owner_proxy = Arc::clone(&owner_proxy);
-            std::thread::spawn(move || owner_proxy.write(b"owner-concurrent"))
-        };
-        let viewer_thread = {
-            let viewer_proxy = Arc::clone(&viewer_proxy);
-            std::thread::spawn(move || viewer_proxy.write(b"viewer-concurrent"))
-        };
-        owner_thread.join().expect("owner input thread");
-        viewer_thread.join().expect("viewer input thread");
-
-        let sends = control.sends();
-        let commands: Vec<&str> = sends.iter().map(|(command, _)| command.as_str()).collect();
-        let resize_index = commands
-            .iter()
-            .rposition(|command| *command == "resize-surface")
-            .expect("canonical shrink resize");
-        assert!(
-            commands[resize_index..]
-                .iter()
-                .all(|command| *command == "resize-surface" || *command == "send")
-        );
-        assert_eq!(commands.len() - resize_index, 4);
-        let payloads: Vec<String> = sends[resize_index + 1..]
-            .iter()
-            .filter_map(|(command, params)| {
-                (command == "send").then(|| params["bytes"].as_str().unwrap_or_default().to_owned())
-            })
-            .map(|encoded| {
-                String::from_utf8(BASE64.decode(encoded).expect("base64 input"))
-                    .expect("utf8 input")
-            })
-            .collect();
-        assert_eq!(payloads.len(), 3);
-        assert!(payloads.iter().any(|payload| payload == "viewer-after-shrink"));
-        assert!(payloads.iter().any(|payload| payload == "owner-concurrent"));
-        assert!(payloads.iter().any(|payload| payload == "viewer-concurrent"));
-        coordinator.leave(&key, 1);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn refused_owner_resize_freezes_survivor_until_explicit_claim() {
-        let owner = SizingControl::new(12, &[]);
-        let survivor = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-refused-owner-order.sock"),
-            surface_id: 17,
-        };
-        let owner_handle: Arc<dyn ControlHandle> = Arc::new(owner.clone());
-        let survivor_handle: Arc<dyn ControlHandle> = Arc::new(survivor.clone());
-        let owner_joined = coordinator
-            .join(key.clone(), 1, 17, owner_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier");
-        owner_joined.await.expect("owner sizing worker");
-        let survivor_joined = coordinator
-            .join(key.clone(), 2, 17, survivor_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("survivor sizing barrier");
-        survivor_joined.await.expect("survivor sizing worker");
-
-        owner.reject_next_resize();
-        owner.block_sizing();
-        coordinator.update(&key, 2, SizingGrid { cols: 80, rows: 24 });
-        owner.wait_for_requests(3).await;
-        owner.release_sizing();
-
-        // The accepted:false response clears ownership and leaves the core
-        // geometry frozen. The existing survivor does not receive a claim.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            None,
-            "accepted:false must freeze authority, not elect the survivor"
-        );
-        assert_eq!(
-            owner.requests().iter().filter(|(command, _)| command == "set-client-sizing").count(),
-            1,
-            "the refused owner must not claim again"
-        );
-        let survivor_endpoint = coordinator.queue_for(&key, 2).expect("survivor endpoint");
-        let survivor_proxy = ControlTerminalControl {
-            control: Arc::new(survivor.clone()),
-            surface_id: 17,
-            sizing: None,
-            queue: Some(survivor_endpoint),
-            ended: AtomicBool::new(false),
-        };
-        survivor_proxy.write(b"input-after-refused-owner");
-        assert_eq!(
-            survivor.sends().iter().map(|(command, _)| command.as_str()).collect::<Vec<_>>(),
-            vec!["send"]
-        );
-        coordinator.leave(&key, 1);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn single_viewer_refused_resize_freezes_without_a_new_claim() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-single-refusal.sock"),
-            surface_id: 25,
-        };
-        let handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let joined = coordinator
-            .join(key.clone(), 1, 25, handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("initial sizing barrier");
-        control.wait_for_requests(2).await;
-        joined.await.expect("initial sizing worker");
-
-        // The owner reports a new grid, but the daemon refuses that resize.
-        // With no explicit new claim, authority remains frozen.
-        control.reject_next_resize();
-        control.block_sizing();
-        coordinator.update(&key, 1, SizingGrid { cols: 100, rows: 30 });
-        control.wait_for_requests(3).await;
-        control.release_sizing();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let requests = control.requests();
-        assert_eq!(requests[2].0, "resize-surface");
-        assert_eq!(requests.len(), 3);
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            None
-        );
-
-        let endpoint = coordinator.queue_for(&key, 1).expect("frozen endpoint");
-        endpoint.enqueue_input(b"after-single-viewer-refusal");
-        let sends = control.sends();
-        assert_eq!(sends.last().map(|(command, _)| command.as_str()), Some("send"));
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn owner_loss_does_not_auto_claim_from_an_old_or_surviving_socket() {
-        let owner = SizingControl::new(12, &[]);
-        let survivor = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-frozen-owner-loss.sock"),
-            surface_id: 26,
-        };
-        let owner_handle: Arc<dyn ControlHandle> = Arc::new(owner.clone());
-        let survivor_handle: Arc<dyn ControlHandle> = Arc::new(survivor.clone());
-        coordinator
-            .join(key.clone(), 1, 26, owner_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier")
-            .await
-            .expect("owner sizing worker");
-        coordinator
-            .join(key.clone(), 2, 26, survivor_handle, SizingGrid { cols: 80, rows: 24 })
-            .expect("survivor sizing barrier")
-            .await
-            .expect("survivor sizing worker");
-
-        let old_generation = {
-            let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-            TerminalSizing::current_generation(&target)
-        };
-        coordinator.leave(&key, 1);
-        coordinator.update(&key, 2, SizingGrid { cols: 80, rows: 24 });
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert!(survivor.requests().is_empty(), "survivor update must not auto-claim");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            None
-        );
-        assert!(
-            TerminalSizing::current_generation(
-                &coordinator.targets.lock().unwrap().get(&key).cloned().unwrap()
-            ) > old_generation
-        );
-
-        // A new attachment is the only event that may issue a replacement
-        // report/claim.
-        let replacement = SizingControl::new(12, &[]);
-        coordinator.join(
-            key.clone(),
-            3,
-            26,
-            Arc::new(replacement.clone()),
-            SizingGrid { cols: 80, rows: 24 },
-        );
-        replacement.wait_for_requests(2).await;
-        assert_eq!(replacement.requests()[1].0, "set-client-sizing");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            Some(3)
-        );
-        coordinator.leave(&key, 2);
-        coordinator.leave(&key, 3);
-    }
-
-    #[tokio::test]
-    async fn owner_leave_freezes_survivor_input_until_explicit_claim() {
-        let owner = SizingControl::new(12, &[]);
-        let survivor = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-owner-leave-order.sock"),
-            surface_id: 18,
-        };
-        let owner_handle: Arc<dyn ControlHandle> = Arc::new(owner.clone());
-        let survivor_handle: Arc<dyn ControlHandle> = Arc::new(survivor.clone());
-        coordinator
-            .join(key.clone(), 1, 18, owner_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier")
-            .await
-            .expect("owner sizing worker");
-        coordinator
-            .join(key.clone(), 2, 18, survivor_handle, SizingGrid { cols: 100, rows: 30 })
-            .expect("survivor sizing barrier")
-            .await
-            .expect("survivor sizing worker");
-        assert_eq!(
-            coordinator.targets.lock().unwrap().get(&key).unwrap().state.lock().unwrap().owner,
-            Some(1)
-        );
-
-        let before = survivor.sends().len();
-        coordinator.leave(&key, 1);
-        let survivor_endpoint = coordinator.queue_for(&key, 2).expect("survivor endpoint");
-        survivor_endpoint.enqueue_input(b"after-owner-leave");
-        let suffix: Vec<String> =
-            survivor.sends()[before..].iter().map(|(command, _)| command.clone()).collect();
-        assert_eq!(suffix, vec!["send"]);
-        coordinator.leave(&key, 2);
-    }
-
-    #[tokio::test]
-    async fn non_owner_leave_fences_owner_grid_growth_before_input() {
-        let owner = SizingControl::new(12, &[]);
-        let viewer = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-viewer-leave-order.sock"),
-            surface_id: 21,
-        };
-        let owner_handle: Arc<dyn ControlHandle> = Arc::new(owner.clone());
-        let viewer_handle: Arc<dyn ControlHandle> = Arc::new(viewer.clone());
-        coordinator
-            .join(key.clone(), 1, 21, owner_handle, SizingGrid { cols: 120, rows: 40 })
-            .expect("owner sizing barrier")
-            .await
-            .expect("owner sizing worker");
-        coordinator
-            .join(key.clone(), 2, 21, viewer_handle, SizingGrid { cols: 80, rows: 24 })
-            .expect("viewer sizing barrier")
-            .await
-            .expect("viewer sizing worker");
-
-        let before = owner.sends().len();
-        coordinator.leave(&key, 2);
-        let owner_endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        owner_endpoint.enqueue_input(b"after-viewer-leave");
-        let suffix: Vec<String> =
-            owner.sends()[before..].iter().map(|(command, _)| command.clone()).collect();
-        assert_eq!(suffix, vec!["resize-surface", "send"]);
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn stale_update_for_missing_viewer_keeps_claim_generation() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-update-generation.sock"),
-            surface_id: 29,
-        };
-        coordinator
-            .join(key.clone(), 1, 29, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("active endpoint");
-        let generation = TerminalSizing::current_generation(&target);
-        {
-            let mut state = target.queue.state.lock().unwrap();
-            state.claim_fence = Some(ClaimFence {
-                generation,
-                viewer_id: 1,
-                grid: SizingGrid { cols: 80, rows: 24 },
-                token: 41,
-                endpoint_ptr: endpoint_ptr(&endpoint),
-            });
-        }
-
-        // This update names no attached viewer. It must not advance the
-        // active generation or clear the current candidate fence.
-        coordinator.update(&key, 99, SizingGrid { cols: 100, rows: 30 });
-        assert_eq!(TerminalSizing::current_generation(&target), generation);
-        assert!(target.queue.state.lock().unwrap().claim_fence.is_some_and(|fence| {
-            fence.generation == generation
-                && fence.viewer_id == 1
-                && fence.token == 41
-                && fence.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn stale_leave_cannot_remove_a_reconnected_endpoint_or_advance_generation() {
-        let old_control = SizingControl::new(12, &[]);
-        let new_control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-leave-generation.sock"),
-            surface_id: 30,
-        };
-        coordinator
-            .join(
-                key.clone(),
-                1,
-                30,
-                Arc::new(old_control.clone()),
-                SizingGrid { cols: 80, rows: 24 },
-            )
-            .expect("old sizing barrier")
-            .await
-            .expect("old sizing worker");
-        let old_endpoint = coordinator.queue_for(&key, 1).expect("old endpoint");
-        coordinator
-            .join(
-                key.clone(),
-                1,
-                30,
-                Arc::new(new_control.clone()),
-                SizingGrid { cols: 80, rows: 24 },
-            )
-            .expect("replacement sizing barrier")
-            .await
-            .expect("replacement sizing worker");
-        let new_endpoint = coordinator.queue_for(&key, 1).expect("replacement endpoint");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let generation = TerminalSizing::current_generation(&target);
-
-        coordinator.leave_endpoint(&key, 1, &old_endpoint);
-        assert_eq!(TerminalSizing::current_generation(&target), generation);
-        let current = coordinator.queue_for(&key, 1).expect("replacement remains attached");
-        assert!(Arc::ptr_eq(&current, &new_endpoint));
-        assert!(new_endpoint.is_active());
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn stale_sizing_lease_cannot_update_or_remove_replacement() {
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-lease.sock"),
-            surface_id: 31,
-        };
-        let old_control = SizingControl::new(12, &[]);
-        let new_control = SizingControl::new(12, &[]);
-        let old_lease = TerminalSizingLease::new(&coordinator, key.clone(), 1, 31);
-        let new_lease = TerminalSizingLease::new(&coordinator, key.clone(), 1, 31);
-
-        old_lease
-            .join(Arc::new(old_control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("old lease join")
-            .await
-            .expect("old sizing worker");
-        let old_endpoint = old_lease.queue().expect("old lease endpoint");
-        new_lease
-            .join(Arc::new(new_control.clone()), SizingGrid { cols: 100, rows: 30 })
-            .expect("replacement lease join")
-            .await
-            .expect("replacement sizing worker");
-        let new_endpoint = new_lease.queue().expect("replacement lease endpoint");
-        assert!(!Arc::ptr_eq(&old_endpoint, &new_endpoint));
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let generation = TerminalSizing::current_generation(&target);
-        old_lease.update(SizingGrid { cols: 40, rows: 20 });
-        assert_eq!(TerminalSizing::current_generation(&target), generation);
-        assert_eq!(
-            target.state.lock().unwrap().viewers.get(&1).map(|viewer| viewer.grid),
-            Some(SizingGrid { cols: 100, rows: 30 })
-        );
-
-        old_lease.leave();
-        let current = coordinator.queue_for(&key, 1).expect("replacement remains attached");
-        assert!(Arc::ptr_eq(&current, &new_endpoint));
-        assert!(new_endpoint.is_active());
-        new_lease.leave();
-    }
-
-    #[tokio::test]
-    async fn released_sizing_lease_drops_endpoint_callback_cycle() {
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-lease-cycle.sock"),
-            surface_id: 32,
-        };
-        let control = CallbackSizingControl::new(12);
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let lease = TerminalSizingLease::new(&coordinator, key, 1, 32);
-        let lease_for_callback = Arc::clone(&lease);
-        control_handle.on_close(Box::new(move || {
-            let _ = lease_for_callback.leave();
-        }));
-
-        let waiter = lease
-            .join(control_handle.clone(), SizingGrid { cols: 80, rows: 24 })
-            .expect("sizing lease join");
-        waiter.await.expect("sizing worker");
-        let endpoint = lease.queue().expect("sizing endpoint");
-        let endpoint_weak = Arc::downgrade(&endpoint);
-        let lease_weak = Arc::downgrade(&lease);
-
-        assert!(lease.leave(), "joined lease must own queue teardown");
-        // The close callback and the proxy drop can both release the same
-        // lease. A repeated call must retain the queue-owned marker; otherwise
-        // the second path can call control.end() directly while the FIFO close
-        // is still pending.
-        assert!(lease.leave(), "repeated joined-lease release must stay queue-owned");
-        assert!(lease.state.lock().unwrap().endpoint.is_none());
-        drop(endpoint);
-        drop(lease);
-        drop(control_handle);
-        drop(control);
-
-        assert!(endpoint_weak.upgrade().is_none(), "released lease retained endpoint");
-        assert!(lease_weak.upgrade().is_none(), "control callback retained released lease");
-    }
-
-    #[tokio::test]
-    async fn setup_cleanup_guard_waits_for_queued_sizing_close() {
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-guard-close.sock"),
-            surface_id: 42,
-        };
-        let control = SizingControl::new(12, &[]);
-        control.block_end();
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let lease = TerminalSizingLease::new(&coordinator, key.clone(), 1, 42);
-        lease
-            .join(control_handle.clone(), SizingGrid { cols: 80, rows: 24 })
-            .expect("sizing join")
-            .await
-            .expect("sizing worker");
-
-        let mut guard = ControlCleanupGuard::new(control_handle);
-        guard.set_sizing(Arc::clone(&lease));
-        assert!(lease.leave(), "joined lease must queue its close");
-        control.wait_for_end_started().await;
-
-        // The setup guard is released while the coordinator's end barrier is
-        // still waiting. It must not call control.end() directly.
-        drop(guard);
-        assert!(!control.ended(), "cleanup bypassed the queued sizing close");
-        control.release_end();
-        control.wait_for_end().await;
-    }
-
-    #[tokio::test]
-    async fn joining_cancel_persists_queue_owned_cleanup_through_rollback() {
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-joining-cancel.sock"),
-            surface_id: 43,
-        };
-        let control = SizingControl::new(12, &[]);
-        control.block_end();
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let lease = TerminalSizingLease::new(&coordinator, key.clone(), 1, 43);
-        let mut guard = ControlCleanupGuard::new(Arc::clone(&control_handle));
-        guard.set_sizing(Arc::clone(&lease));
-
-        // Model the cancellation point inside TerminalSizingLease::join:
-        // the coordinator endpoint has been created, but the lease has not
-        // yet transferred to `joined`.
-        let (waiter, endpoint) = coordinator
-            .join_with_endpoint(
-                key.clone(),
-                1,
-                43,
-                control_handle,
-                SizingGrid { cols: 80, rows: 24 },
-            )
-            .expect("coordinator endpoint");
-        waiter.await.expect("initial sizing worker");
-        {
-            let mut state = lease.state.lock().unwrap();
-            state.joining = true;
-        }
-        assert!(lease.leave(), "cancellation during join must reserve queue teardown");
-        {
-            let mut state = lease.state.lock().unwrap();
-            // This is the rollback transition after join observes released.
-            state.joining = false;
-            state.joined = false;
-        }
-        coordinator.leave_endpoint(&key, 1, &endpoint);
-        control.wait_for_end_started().await;
-
-        // The rollback close is now in flight, but the lease no longer says
-        // `joining` or `joined`. The persistent queue-owned marker must still
-        // prevent the cleanup guard from directly ending the socket.
-        drop(guard);
-        assert!(!control.ended(), "joining-cancel cleanup bypassed FIFO close");
-        control.release_end();
-        control.wait_for_end().await;
-    }
-
-    #[test]
-    fn failed_join_without_endpoint_releases_queue_owned_marker() {
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-failed-join-marker.sock"),
-            surface_id: 44,
-        };
-        let control = SizingControl::new(12, &[]);
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        let lease = TerminalSizingLease::new(&coordinator, key, 1, 44);
-        {
-            let mut state = lease.state.lock().unwrap();
-            state.joining = true;
-            state.released = true;
-            state.queue_owned = true;
-        }
-
-        // A failed coordinator registration returns no endpoint, so no FIFO
-        // close can exist. The rollback must clear the provisional marker and
-        // let the setup guard close this standalone control.
-        assert!(lease.finish_join(None));
-        assert!(!lease.state.lock().unwrap().queue_owned);
-        let mut guard = ControlCleanupGuard::new(control_handle);
-        guard.set_sizing(lease);
-        drop(guard);
-        assert!(control.ended(), "failed join did not close its standalone control");
-    }
-
-    #[test]
-    fn delayed_claim_fence_is_preserved_before_survivor_input() {
-        let control = SizingControl::new(12, &[]);
-        let queue = OrderedControlQueue::new(18);
-        let endpoint = queue.endpoint(2, Arc::new(control.clone()));
-
-        // Model an owner-loss transition while the sizing worker is between
-        // polls. The candidate pair is reserved but not yet drained.
-        {
-            let mut state = queue.state.lock().unwrap();
-            state.worker_running = true;
-            assert!(!queue.reserve_resize_locked(
-                &mut state,
-                &endpoint,
-                SizingGrid { cols: 80, rows: 24 },
-                1,
-            ));
-        }
-
-        // An intervening same-grid candidate update must not consume the
-        // private marker. Input still flushes the reserved report/claim
-        // first; when the delayed worker reaches the candidate it consumes
-        // the marker instead of emitting a duplicate pair after this input.
-        {
-            let mut state = queue.state.lock().unwrap();
-            assert!(!queue.enqueue_resize_locked(
-                &mut state,
-                &endpoint,
-                SizingGrid { cols: 80, rows: 24 },
-                true,
-            ));
-        }
-        endpoint.enqueue_input(b"survivor-input");
-        let state = queue.state.lock().unwrap();
-        assert!(state.claim_fence.is_some_and(|fence| {
-            fence.viewer_id == endpoint.viewer_id
-                && fence.grid == SizingGrid { cols: 80, rows: 24 }
-                && fence.endpoint_ptr == endpoint_ptr(&endpoint)
-        }));
-        drop(state);
-        let sends = control.sends();
-        let commands: Vec<&str> = sends.iter().map(|(command, _)| command.as_str()).collect();
-        assert_eq!(commands, vec!["resize-surface", "set-client-sizing", "send"]);
-    }
-
-    #[tokio::test]
-    async fn reserved_resize_precedes_generation_update_and_leave() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-dispatch-reservation.sock"),
-            surface_id: 35,
-        };
-        coordinator
-            .join(key.clone(), 1, 35, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let before = control.events().len();
-        let before_sends = control.sends().len();
-        control.block_ordered_send();
-
-        // The worker reserves the resize while the old generation is still
-        // current, then pauses immediately before the control write.
-        coordinator.update(&key, 1, SizingGrid { cols: 100, rows: 30 });
-        control.wait_for_ordered_send().await;
-
-        // Both mutations acquire the queue actor lock after the reservation.
-        // They must advance/freeze the state, but they cannot retract the
-        // already-reserved resize or let a later close overtake it.
-        coordinator.update(&key, 1, SizingGrid { cols: 120, rows: 40 });
-        coordinator.leave_endpoint(&key, 1, &endpoint);
-        assert!(!endpoint.is_active());
-
-        control.release_ordered_send();
-        control.wait_for_sends(before_sends + 1).await;
-        control.wait_for_end().await;
-        let events = control.events();
-        assert_eq!(events[before], "send:resize-surface");
-        assert!(control.ended());
-    }
-
-    #[tokio::test]
-    async fn reserved_resize_precedes_failure_invalidation_and_close() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-dispatch-failure.sock"),
-            surface_id: 36,
-        };
-        coordinator
-            .join(key.clone(), 1, 36, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let queue = endpoint.queue.upgrade().expect("sizing queue");
-        let before = control.events().len();
-        let before_sends = control.sends().len();
-        control.block_ordered_send();
-
-        coordinator.update(&key, 1, SizingGrid { cols: 100, rows: 30 });
-        control.wait_for_ordered_send().await;
-
-        // A transport failure uses the same actor lock as reserve_command.
-        // It invalidates the endpoint and queues its close, but cannot cancel
-        // the resize that was already reserved before the failure.
-        queue.fail_endpoint(&endpoint);
-        assert!(!endpoint.is_active());
-        control.release_ordered_send();
-        control.wait_for_sends(before_sends + 1).await;
-        control.wait_for_end().await;
-
-        let events = control.events();
-        assert_eq!(events[before], "send:resize-surface");
-        assert!(control.ended());
-    }
-
-    #[tokio::test]
-    async fn busy_queue_flushes_resize_before_verified_request() {
-        let control = SizingControl::new(12, &[]);
-        let queue = OrderedControlQueue::new(19);
-        let endpoint = queue.endpoint(1, Arc::new(control.clone()));
-        {
-            let mut state = queue.state.lock().unwrap();
-            state.worker_running = true;
-            assert!(!queue.enqueue_resize_locked(
-                &mut state,
-                &endpoint,
-                SizingGrid { cols: 100, rows: 30 },
-                false,
-            ));
-        }
-
-        // A worker may be between drain polls. The verified request must not
-        // enter the control writer before the pending report.
-        endpoint.flush_before_request();
-        let _ = control
-            .request("resize-surface", json!({ "surface": 19, "cols": 100, "rows": 30 }))
-            .await;
-        assert_eq!(control.sends()[0].0, "resize-surface");
-        assert_eq!(control.requests()[0].0, "resize-surface");
-    }
-
-    #[tokio::test]
-    async fn owner_resize_batch_keeps_pending_report_before_request_when_worker_running() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-owner-batch.sock"),
-            surface_id: 33,
-        };
-        let joined = coordinator
-            .join(key.clone(), 1, 33, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial owner sizing barrier");
-        joined.await.expect("initial owner sizing worker");
-        control.wait_for_sends(2).await;
-        control.wait_for_requests(2).await;
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let before = control.events().len();
-        let before_sends = control.sends().len();
-        let grid = SizingGrid { cols: 100, rows: 30 };
-        let generation = {
-            // Leave a pending resize behind a worker that is already marked
-            // running. The owner batch must consume it and append its
-            // verified request before any later input command.
-            let mut queue_state = target.queue.state.lock().unwrap();
-            let mut state = target.state.lock().unwrap();
-            state.viewers.get_mut(&1).unwrap().grid = grid;
-            state.applied = Some(SizingGrid { cols: 80, rows: 24 });
-            let generation = coordinator.advance_generation(&target);
-            queue_state.worker_running = true;
-            queue_state.pending_resize = Some((generation, Arc::clone(&endpoint), grid, false));
-            generation
-        };
-
-        let result =
-            coordinator.owner_resize_request(&target, 1, &endpoint, grid, generation, 33).await;
-        assert!(matches!(result, OwnerResizeRequestOutcome::Reply(Some(_))));
-
-        endpoint.enqueue_input(b"after-owner-resize");
-        control.wait_for_sends(before_sends + 2).await;
-        let events = control.events();
-        let suffix: Vec<&str> = events[before..].iter().map(String::as_str).collect();
-        assert_eq!(suffix, vec!["send:resize-surface", "request:resize-surface", "send:send"]);
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn update_enqueues_resize_before_owner_input() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-update-input-order.sock"),
-            surface_id: 37,
-        };
-        coordinator
-            .join(key.clone(), 1, 37, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let before = control.events().len();
-        let before_sends = control.sends().len();
-        let before_requests = control.requests().len();
-        control.block_sizing();
-        coordinator.update(&key, 1, SizingGrid { cols: 100, rows: 30 });
-        endpoint.enqueue_input(b"ordered-update-input");
-        control.wait_for_requests(before_requests + 1).await;
-        let blocked_events = control.events();
-        assert_eq!(
-            blocked_events[before..].iter().map(String::as_str).collect::<Vec<_>>(),
-            vec!["send:resize-surface", "request:resize-surface"]
-        );
-        control.release_sizing();
-        control.wait_for_sends(before_sends + 2).await;
-        let events = control.events();
-        let suffix: Vec<&str> = events[before..before + 3].iter().map(String::as_str).collect();
-        assert_eq!(suffix, vec!["send:resize-surface", "request:resize-surface", "send:send"]);
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn join_enqueues_owner_resize_before_owner_input() {
-        let owner = SizingControl::new(12, &[]);
-        let viewer = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-join-input-order.sock"),
-            surface_id: 38,
-        };
-        coordinator
-            .join(key.clone(), 1, 38, Arc::new(owner.clone()), SizingGrid { cols: 120, rows: 40 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let before = owner.events().len();
-        let before_sends = owner.sends().len();
-        let before_requests = owner.requests().len();
-        coordinator
-            .join(key.clone(), 2, 38, Arc::new(viewer.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("viewer sizing barrier")
-            .await
-            .expect("viewer sizing worker");
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        endpoint.enqueue_input(b"ordered-join-input");
-        owner.wait_for_requests(before_requests + 1).await;
-        owner.wait_for_sends(before_sends + 2).await;
-        let events = owner.events();
-        let suffix: Vec<&str> = events[before..before + 3].iter().map(String::as_str).collect();
-        assert_eq!(suffix, vec!["send:resize-surface", "request:resize-surface", "send:send"]);
-        coordinator.leave(&key, 2);
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn reconnect_input_waits_behind_fifo_close_barrier() {
-        let old = SizingControl::new(12, &[]);
-        let new = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-close-fifo.sock"),
-            surface_id: 39,
-        };
-        coordinator
-            .join(key.clone(), 1, 39, Arc::new(old.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let old_endpoint = coordinator.queue_for(&key, 1).expect("old endpoint");
-        old.block_end();
-        let replacement_waiter = coordinator
-            .join(key.clone(), 1, 39, Arc::new(new.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("replacement sizing barrier");
-        let replacement = coordinator.queue_for(&key, 1).expect("replacement endpoint");
-        old.wait_for_end_started().await;
-
-        // The replacement can enqueue input while the old close is waiting,
-        // but the close command was inserted first under the queue actor. No
-        // replacement frame may reach its control before the old barrier.
-        replacement.enqueue_input(b"after-reconnect");
-        assert!(new.sends().is_empty());
-
-        old.release_end();
-        old.wait_for_end().await;
-        replacement_waiter.await.expect("replacement sizing worker");
-        new.wait_for_sends(3).await;
-        let events = new.events();
-        let input_index = events.iter().position(|event| event == "send:send");
-        let claim_index = events.iter().position(|event| event == "send:set-client-sizing");
-        assert!(input_index > claim_index, "input overtook replacement claim: {events:?}");
-        assert!(!old_endpoint.is_active());
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn failed_close_retry_handoff_restarts_an_idle_worker() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-close-retry-handoff.sock"),
-            surface_id: 44,
-        };
-        coordinator
-            .join(key.clone(), 1, 44, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("endpoint");
-
-        // Model the previous close worker returning after a full-queue retry:
-        // the endpoint remains in `closing`, but no close waiter or wire
-        // command is present. The worker hand-off must start a fresh close
-        // without waiting for a later viewer event.
-        {
-            let mut state = target.queue.state.lock().unwrap();
-            endpoint.active.store(false, Ordering::Release);
-            state.closing.push(Arc::clone(&endpoint));
-        }
-        target.queue.retry_closing_after_worker(false);
-        control.wait_for_end().await;
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if target.queue.state.lock().unwrap().closing.is_empty() {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("close retry handoff left a stale closing endpoint");
-        assert!(!target.queue.closing_running.load(Ordering::Acquire));
-        coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn owner_resize_batch_queue_full_freezes_without_partial_commands() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-owner-batch-full.sock"),
-            surface_id: 34,
-        };
-        coordinator
-            .join(key.clone(), 1, 34, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial owner sizing barrier")
-            .await
-            .expect("initial owner sizing worker");
-        control.wait_for_sends(2).await;
-        control.wait_for_requests(2).await;
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let generation = TerminalSizing::current_generation(&target);
-        {
-            let mut queue_state = target.queue.state.lock().unwrap();
-            let mut state = target.state.lock().unwrap();
-            state.viewers.get_mut(&1).unwrap().grid = SizingGrid { cols: 100, rows: 30 };
-            state.applied = Some(SizingGrid { cols: 80, rows: 24 });
-            // Keep the bounded wire queue full and do not start a worker. The
-            // owner batch must reject both commands together, not append only
-            // its request and leave a report behind.
-            queue_state.worker_running = true;
-            let mut pending = target.queue.wire_pending.lock().unwrap();
-            for _ in 0..MAX_ORDERED_CONTROL_COMMANDS {
-                pending.push_back(OrderedControlCommand {
-                    endpoint: Arc::clone(&endpoint),
-                    generation: None,
-                    expected_owner: None,
-                    requires_unowned: false,
-                    kind: OrderedControlCommandKind::Send {
-                        command: "capacity-probe".to_owned(),
-                        params: Value::Null,
-                    },
-                });
-            }
-        }
-
-        let before_sends = control.sends().len();
-        let before_requests = control.requests().len();
-        let result = coordinator
-            .owner_resize_request(
-                &target,
-                1,
-                &endpoint,
-                SizingGrid { cols: 100, rows: 30 },
-                generation,
-                34,
-            )
-            .await;
-        assert!(matches!(result, OwnerResizeRequestOutcome::QueueFull));
-        assert_eq!(control.sends().len(), before_sends);
-        assert_eq!(control.requests().len(), before_requests);
-        assert_eq!(target.queue.wire_pending.lock().unwrap().len(), MAX_ORDERED_CONTROL_COMMANDS);
-
-        // `apply_target` has no request id to fail. Its documented QueueFull
-        // response is to detach this owner and leave the core geometry frozen.
-        coordinator.leave(&key, 1);
-        let state = target.state.lock().unwrap();
-        assert_eq!(state.owner, None);
-        assert_eq!(state.applied, Some(SizingGrid { cols: 80, rows: 24 }));
-        assert!(state.viewers.is_empty());
-        drop(state);
-        assert!(
-            coordinator
-                .join(
-                    key,
-                    2,
-                    34,
-                    Arc::new(SizingControl::new(12, &[])),
-                    SizingGrid { cols: 80, rows: 24 },
-                )
-                .is_none(),
-            "a retired target with an unqueued close must not be revived"
-        );
-    }
-
-    #[tokio::test]
-    async fn stale_pending_resize_is_dropped_after_generation_advance() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-pending.sock"),
-            surface_id: 41,
-        };
-        let joined = coordinator
-            .join(key.clone(), 1, 41, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier");
-        joined.await.expect("initial sizing worker");
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("owner endpoint");
-        let old_generation = TerminalSizing::current_generation(&target);
-        {
-            let mut queue_state = target.queue.state.lock().unwrap();
-            let mut state = target.state.lock().unwrap();
-            state.viewers.get_mut(&1).unwrap().grid = SizingGrid { cols: 100, rows: 30 };
-            queue_state.pending_resize = Some((
-                old_generation,
-                Arc::clone(&endpoint),
-                SizingGrid { cols: 100, rows: 30 },
-                false,
-            ));
-            queue_state.worker_running = true;
-            let first_new_generation = coordinator.advance_generation(&target);
-            state.viewers.get_mut(&1).unwrap().grid = SizingGrid { cols: 80, rows: 24 };
-            let second_new_generation = coordinator.advance_generation(&target);
-            assert!(first_new_generation > old_generation);
-            assert!(second_new_generation > first_new_generation);
-        }
-
-        let sends_before = control.sends().len();
-        target.queue.clone().drain_async().await;
-        assert!(target.queue.state.lock().unwrap().pending_resize.is_none());
-        endpoint.enqueue_input(b"after-stale-resize");
-        control.wait_for_sends(sends_before + 1).await;
-        assert_eq!(control.sends()[sends_before].0, "send");
-        assert!(endpoint.is_active(), "stale resize must not detach a healthy endpoint");
-    }
-
-    #[test]
-    fn stale_nonclaim_pending_does_not_clear_current_claim_fence() {
-        let queue = OrderedControlQueue::new(41);
-        let old_control: Arc<dyn ControlHandle> = Arc::new(SizingControl::new(12, &[]));
-        let new_control: Arc<dyn ControlHandle> = Arc::new(SizingControl::new(12, &[]));
-        let old_endpoint = queue.endpoint(1, old_control);
-        let new_endpoint = queue.endpoint(2, new_control);
-        let current_generation = queue.current_generation();
-        let expected_fence = ClaimFence {
-            generation: current_generation,
-            viewer_id: new_endpoint.viewer_id,
-            grid: SizingGrid { cols: 80, rows: 24 },
-            token: 7,
-            endpoint_ptr: endpoint_ptr(&new_endpoint),
-        };
-        let mut state = queue.state.lock().unwrap();
-        state.claim_fence = Some(expected_fence);
-        state.pending_resize = Some((
-            current_generation.saturating_sub(1),
-            old_endpoint,
-            SizingGrid { cols: 100, rows: 30 },
-            false,
-        ));
-        assert!(queue.discard_stale_pending_locked(&mut state));
-        assert_eq!(state.claim_fence, Some(expected_fence));
-        assert!(state.pending_resize.is_none());
-    }
-
-    #[test]
-    fn terminal_resize_does_not_wait_for_control_plane_barrier() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-fire-and-forget.sock"),
-            surface_id: 14,
-        };
-        let lease = TerminalSizingLease::new(&coordinator, key, 1, 14);
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        lease.join(Arc::clone(&control_handle), SizingGrid { cols: 80, rows: 24 });
-        let queue = lease.queue();
-        // This is the same operation used by the pty_resize ingress branch;
-        // it must only enqueue a coalesced worker request and return.
-        let proxy = ControlTerminalControl {
-            control: control_handle,
-            surface_id: 14,
-            sizing: Some(lease),
-            queue,
-            ended: AtomicBool::new(false),
-        };
-        proxy.resize(140, 50);
-        assert!(control.requests().is_empty());
-        proxy.write(b"input");
-        let sends = control.sends();
-        assert_eq!(
-            sends.iter().map(|(command, _)| command.as_str()).collect::<Vec<_>>(),
-            vec![
-                "resize-surface",
-                "set-client-sizing",
-                "resize-surface",
-                "set-client-sizing",
-                "send"
-            ]
-        );
-    }
-
-    #[test]
-    fn protocol_ten_proxy_fails_closed_without_sizing_queue() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let lease = TerminalSizingLease::new(
-            &coordinator,
-            SizingKey {
-                socket_path: PathBuf::from("/tmp/cmux-sizing-missing-queue.sock"),
-                surface_id: 26,
-            },
-            1,
-            26,
-        );
-        let proxy = ControlTerminalControl {
-            control: Arc::new(control.clone()),
-            surface_id: 26,
-            sizing: Some(lease),
-            queue: None,
-            ended: AtomicBool::new(false),
-        };
-
-        // A protocol-10+ proxy without its ordered queue must never fall
-        // back to direct daemon writes. The defensive path closes the
-        // transport instead.
-        proxy.write(b"must-not-bypass-sizing");
-        proxy.resize(120, 40);
-        assert!(control.sends().is_empty());
-        assert!(control.requests().is_empty());
-        assert!(control.ended());
-    }
-
-    #[tokio::test]
-    async fn raw_release_ends_only_control_socket_and_releases_sizing_lease() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-release.sock"),
-            surface_id: 11,
-        };
-        let lease = TerminalSizingLease::new(&coordinator, key, 1, 11);
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        lease.join(Arc::clone(&control_handle), SizingGrid { cols: 80, rows: 24 });
-        control.wait_for_requests(2).await;
-        let queue = lease.queue();
-
-        let proxy = ControlTerminalControl {
-            control: control_handle,
-            surface_id: 11,
-            sizing: Some(lease),
-            queue,
-            ended: AtomicBool::new(false),
-        };
-        proxy.release();
-        assert!(control.ended(), "release must close only the relay control socket");
-        assert!(coordinator.targets.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn cancelled_open_guard_releases_raw_control_before_attachment_insert() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-cancel.sock"),
-            surface_id: 12,
-        };
-        let lease = TerminalSizingLease::new(&coordinator, key, 1, 12);
-        let control_handle: Arc<dyn ControlHandle> = Arc::new(control.clone());
-        lease.join(Arc::clone(&control_handle), SizingGrid { cols: 80, rows: 24 });
-        control.wait_for_requests(1).await;
-        let queue = lease.queue();
-        let proxy: Arc<dyn PtyControl> = Arc::new(ControlTerminalControl {
-            control: control_handle,
-            surface_id: 12,
-            sizing: Some(lease),
-            queue,
-            ended: AtomicBool::new(false),
-        });
-        let opened = Opened {
-            generation: 1,
-            gate: Arc::new(Mutex::new(())),
-            created: false,
-            surface: Some("12".to_owned()),
-            control: proxy,
-            post_open_resize: false,
-            closing: Arc::new(AtomicBool::new(false)),
-            start: None,
-            cleanup_armed: AtomicBool::new(true),
-        };
-        drop(opened);
-        assert!(control.ended(), "cancellation must close the raw control socket");
-        assert!(coordinator.targets.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn protocol_five_to_nine_without_initial_size_sends_one_post_open_resize() {
-        for protocol in 5..=9 {
-            let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-            let control = SizingControl::new(protocol, &[]);
-            let h = harness_with_control(
-                Some(cmux),
-                None,
-                Some(PathBuf::from(format!("/tmp/cmux-sizing-v{protocol}.sock"))),
-                Some(Arc::new(control.clone())),
-            );
-            h.open_at_version(
-                PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION,
-                "p1",
-                "work",
-                serde_json::json!({ "surface": "7" }),
-                "supervised",
-                h.owner.clone(),
-            )
-            .await;
-            h.frame_as_at_version(
-                PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION,
-                serde_json::json!({
-                    "version": 4,
-                    "type": "pty_resize",
-                    "ptyId": "p1",
-                    "cols": 80,
-                    "rows": 24,
-                }),
-                "supervised",
-                h.owner.clone(),
-            )
-            .await;
-            let requests = control.requests();
-            let attach =
-                requests.iter().find(|(cmd, _)| cmd == "attach-surface").expect("attach request");
-            assert_eq!(attach.1["surface"], 7);
-            assert!(attach.1.get("cols").is_none());
-            assert_eq!(control.sends().len(), 1);
-            assert_eq!(control.sends()[0].0, "resize-surface");
-            assert_eq!(control.sends()[0].1["cols"], 80);
-            assert_eq!(control.sends()[0].1["rows"], 24);
-        }
-    }
-
-    #[tokio::test]
-    async fn protocol_nine_with_initial_size_capability_uses_attach_dimensions_once() {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let control = SizingControl::new(9, &["attach-initial-size"]);
-        let h = harness_with_control(
-            Some(cmux),
-            None,
-            Some(PathBuf::from("/tmp/cmux-sizing-v9-cap.sock")),
-            Some(Arc::new(control.clone())),
-        );
-        h.open("p1", "work", serde_json::json!({ "surface": "7" }), "supervised", h.owner.clone())
-            .await;
-        let requests = control.requests();
-        let attach =
-            requests.iter().find(|(cmd, _)| cmd == "attach-surface").expect("attach request");
-        assert_eq!(attach.1["surface"], 7);
-        assert_eq!(attach.1["cols"], 80);
-        assert_eq!(attach.1["rows"], 24);
-        assert!(control.sends().is_empty());
-    }
-
-    #[tokio::test]
-    async fn raw_open_emits_before_a_slow_sizing_reply_and_converges_after_release() {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let control = SizingControl::new(12, &[]);
-        control.block_sizing();
-        let h = harness_with_control(
-            Some(cmux),
-            None,
-            Some(PathBuf::from("/tmp/cmux-sizing-open-order.sock")),
-            Some(Arc::new(control.clone())),
-        );
-
-        // A hung set-client-sizing/resize reply must not delay pty_opened.
-        h.open("p1", "work", serde_json::json!({ "surface": "7" }), "supervised", h.owner.clone())
-            .await;
-        assert!(h.sent().iter().any(|frame| ty(frame) == "pty_opened"));
-        control.wait_for_requests(3).await;
-
-        control.release_sizing();
-        control.wait_for_requests(4).await;
-        let requests = control.requests();
-        assert_eq!(requests[2].0, "resize-surface");
-        assert_eq!(requests[3].0, "set-client-sizing");
-    }
-
-    #[tokio::test]
-    async fn raw_detach_cancels_pending_sizing_without_a_stale_claim() {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let control = SizingControl::new(12, &[]);
-        control.block_sizing();
-        let h = harness_with_control(
-            Some(cmux),
-            None,
-            Some(PathBuf::from("/tmp/cmux-sizing-detach-order.sock")),
-            Some(Arc::new(control.clone())),
-        );
-        h.open("p1", "work", serde_json::json!({ "surface": "7" }), "supervised", h.owner.clone())
-            .await;
-        control.wait_for_requests(3).await;
-        let sends_before_close = control.sends().len();
-        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
-
-        control.release_sizing();
-        tokio::task::yield_now().await;
-        let requests = control.requests();
-        assert_eq!(
-            requests.iter().filter(|(command, _)| command == "resize-surface").count(),
-            1,
-            "the blocked report may complete, but no new resize is allowed after leave"
-        );
-        assert!(!requests.iter().any(|(command, _)| command == "set-client-sizing"));
-        assert_eq!(control.sends().len(), sends_before_close, "leave cancels pending wire work");
-        assert!(control.ended(), "detaching the raw viewer must close its control socket");
-    }
-
     #[tokio::test]
     async fn missing_surface_refuses_with_typed_terminal_gone() {
         let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
@@ -9496,135 +2616,9 @@ mod tests {
         let decoded: crate::relay_wire::RelayPtyError =
             serde_json::from_value(error.clone()).expect("generated pty_error fixture");
         assert_eq!(decoded.code, RelayPtyErrorCode::TerminalGone);
-        assert_eq!(error["message"], "requested terminal is no longer available");
+        assert!(error["message"].as_str().unwrap_or_default().contains("not found in session"),);
         // A gone terminal must NOT degrade to a whole-session attach.
         assert!(!sent.iter().any(|f| ty(f) == "pty_opened"));
-    }
-
-    #[test]
-    fn typed_pty_error_codes_use_the_generated_wire_names() {
-        let harness = harness(None, None);
-        let context = harness.context("supervised", harness.owner.clone());
-        let cases = [
-            (RelayPtyErrorCode::BadRequest, "bad_request"),
-            (RelayPtyErrorCode::TrustRefused, "trust_refused"),
-            (RelayPtyErrorCode::SessionLimit, "session_limit"),
-            (RelayPtyErrorCode::TerminalGone, "terminal_gone"),
-            (RelayPtyErrorCode::Failed, "failed"),
-            (RelayPtyErrorCode::Overflow, "overflow"),
-            (RelayPtyErrorCode::TrustRevoked, "trust_revoked"),
-            (RelayPtyErrorCode::Busy, "busy"),
-        ];
-        for (code, expected) in cases {
-            send_pty_error(&context, "p1", code, "test");
-            assert_eq!(harness.sent().pop().expect("error frame")["code"], expected);
-        }
-    }
-
-    #[test]
-    fn pty_operational_errors_use_v7_codes_and_v6_safe_fallbacks() {
-        let harness = harness(None, None);
-        let old_context = harness.context_with_version(
-            "supervised",
-            harness.owner.clone(),
-            crate::wire::RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION - 1,
-        );
-        send_operational_pty_error(
-            &old_context,
-            "p1",
-            RelayPtyErrorCode::Overflow,
-            "typed overflow detail",
-            "PTY output overflowed. Reattach to continue.",
-        );
-        let old_frame = harness.sent().pop().expect("legacy error frame");
-        assert_eq!(old_frame["code"], "failed");
-        assert_eq!(old_frame["message"], "PTY output overflowed. Reattach to continue.");
-
-        let new_context = harness.context_with_version(
-            "supervised",
-            harness.owner.clone(),
-            crate::wire::RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION,
-        );
-        send_operational_pty_error(
-            &new_context,
-            "p1",
-            RelayPtyErrorCode::Overflow,
-            "typed overflow detail",
-            "PTY output overflowed. Reattach to continue.",
-        );
-        let new_frame = harness.sent().pop().expect("typed error frame");
-        assert_eq!(new_frame["code"], "overflow");
-        assert_eq!(new_frame["message"], "typed overflow detail");
-    }
-
-    struct InvalidListControl {
-        response: Option<Value>,
-    }
-
-    impl ControlHandle for InvalidListControl {
-        fn request(
-            &self,
-            cmd: &str,
-            _params: Value,
-        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
-            let response = match cmd {
-                "identify" => Some(serde_json::json!({
-                    "ok": true,
-                    "data": { "protocol": CONTROL_MIN_PROTOCOL, "capabilities": [] },
-                })),
-                "list-workspaces" => self.response.clone(),
-                _ => None,
-            };
-            Box::pin(async move { response })
-        }
-        fn send(&self, _cmd: &str, _params: Value) {}
-        fn on_event(&self, _handler: EventHandler) {}
-        fn on_close(&self, _handler: CloseHandler) {}
-        fn pause(&self) {}
-        fn resume(&self) {}
-        fn end(&self) {}
-    }
-
-    async fn assert_invalid_list_is_failed(response: Option<Value>) {
-        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
-        let h = harness_with_control(
-            Some(cmux),
-            None,
-            None,
-            Some(Arc::new(InvalidListControl { response })),
-        );
-        h.open(
-            "p1",
-            "job-x",
-            serde_json::json!({ "surface": "term_dead" }),
-            "supervised",
-            h.owner.clone(),
-        )
-        .await;
-        let error = h.sent().into_iter().find(|f| ty(f) == "pty_error").unwrap();
-        assert_eq!(error["code"], "failed");
-        let message = error["message"].as_str().unwrap_or_default();
-        assert!(!message.contains("list-workspaces"));
-        assert!(!message.contains("response"));
-    }
-
-    #[tokio::test]
-    async fn failed_list_workspaces_is_not_terminal_gone() {
-        assert_invalid_list_is_failed(Some(serde_json::json!({ "ok": false }))).await;
-    }
-
-    #[tokio::test]
-    async fn missing_list_workspaces_is_not_terminal_gone() {
-        assert_invalid_list_is_failed(None).await;
-    }
-
-    #[tokio::test]
-    async fn malformed_list_workspaces_is_not_terminal_gone() {
-        assert_invalid_list_is_failed(Some(serde_json::json!({
-            "ok": true,
-            "data": { "workspaces": {} }
-        })))
-        .await;
     }
 
     #[tokio::test]
@@ -9775,37 +2769,17 @@ mod tests {
     }
 
     #[test]
-    fn backlog_overflow_uses_contract_pty_error_code() {
+    fn backlog_overflow_uses_explicit_pty_error_code() {
         let harness = harness(None, None);
         let context = harness.context("supervised", harness.owner.clone());
         send_pty_error(
             &context,
             "p1",
-            operational_pty_error_code(&context, RelayPtyErrorCode::Overflow),
-            "terminal output overflowed; reattach to continue receiving output",
+            "overflow",
+            "pty output backlog overflowed; reattach to continue receiving output",
         );
         let frame = harness.sent().pop().unwrap();
         assert_eq!(frame["type"], "pty_error");
         assert_eq!(frame["code"], "overflow");
-        let decoded: crate::relay_wire::RelayPtyError =
-            serde_json::from_value(frame).expect("contract-valid pty_error frame");
-        assert_eq!(decoded.code, RelayPtyErrorCode::Overflow);
-    }
-
-    #[test]
-    fn operational_pty_error_downgrades_for_older_workers() {
-        let harness = harness(None, None);
-        let context = harness.context_at_version(6, "supervised", harness.owner.clone());
-        send_pty_error(
-            &context,
-            "p1",
-            operational_pty_error_code(&context, RelayPtyErrorCode::Overflow),
-            "pty output backlog overflowed; reattach to continue receiving output",
-        );
-        let frame = harness.sent().pop().unwrap();
-        assert_eq!(frame["code"], "failed");
-        let decoded: crate::relay_wire::RelayPtyError =
-            serde_json::from_value(frame).expect("contract-valid downgraded pty_error frame");
-        assert_eq!(decoded.code, RelayPtyErrorCode::Failed);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1261,40 +1261,47 @@ impl OrderedControlQueue {
         // Revalidate and register the request while the coordinator queue
         // state is locked. An update or leave cannot advance the generation
         // between this check and the wire enqueue; the worker repeats the
-        // check immediately before dispatch as a second fence.
-        let _queue_state = self.state.lock().expect("ordered control queue lock");
-        if self.current_generation() != generation
-            || !_queue_state.closing.is_empty()
-            || _queue_state.closing_failed
+        // check immediately before dispatch as a second fence. The guards
+        // live in an inner block: the spawned future must stay `Send`, and
+        // the async lowering keeps lexically live guards in the future state
+        // even past an explicit `drop`.
         {
-            return None;
-        }
-        if let Some(target) = self.target.get().and_then(Weak::upgrade) {
-            if target.generation.load(Ordering::Acquire) != generation {
-                return None;
-            }
-            let state = target.state.lock().expect("terminal sizing state lock");
-            if state.retired
-                || !state.viewers.get(&endpoint.viewer_id).is_some_and(|viewer| {
-                    Arc::ptr_eq(&viewer.endpoint, endpoint) && viewer.endpoint.is_active()
-                })
+            let queue_state = self.state.lock().expect("ordered control queue lock");
+            if self.current_generation() != generation
+                || !queue_state.closing.is_empty()
+                || queue_state.closing_failed
             {
                 return None;
             }
+            if let Some(target) = self.target.get().and_then(Weak::upgrade) {
+                if target.generation.load(Ordering::Acquire) != generation {
+                    return None;
+                }
+                let state = target.state.lock().expect("terminal sizing state lock");
+                if state.retired
+                    || !state.viewers.get(&endpoint.viewer_id).is_some_and(|viewer| {
+                        Arc::ptr_eq(&viewer.endpoint, endpoint) && viewer.endpoint.is_active()
+                    })
+                {
+                    return None;
+                }
+            }
+            let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
+            if pending.len() >= MAX_ORDERED_CONTROL_COMMANDS {
+                return None;
+            }
+            pending.push_back(OrderedControlCommand {
+                endpoint: Arc::clone(endpoint),
+                generation: Some(generation),
+                expected_owner,
+                requires_unowned,
+                kind: OrderedControlCommandKind::Request {
+                    command: command.to_owned(),
+                    params,
+                    reply,
+                },
+            });
         }
-        let mut pending = self.wire_pending.lock().expect("ordered control pending lock");
-        if pending.len() >= MAX_ORDERED_CONTROL_COMMANDS {
-            return None;
-        }
-        pending.push_back(OrderedControlCommand {
-            endpoint: Arc::clone(endpoint),
-            generation: Some(generation),
-            expected_owner,
-            requires_unowned,
-            kind: OrderedControlCommandKind::Request { command: command.to_owned(), params, reply },
-        });
-        drop(pending);
-        drop(_queue_state);
         self.start_wire_drain();
         response.await.ok().flatten()
     }
@@ -1455,36 +1462,18 @@ impl OrderedControlQueue {
             // before input is admitted. If the bounded queue rejected the
             // report/claim pair, fail this attachment instead of letting
             // bytes overtake an authority transition that can never run.
-            let claim_context = self.target.get().and_then(Weak::upgrade).and_then(|target| {
+            let claim_requested = self.target.get().and_then(Weak::upgrade).is_some_and(|target| {
                 let generation = target.generation.load(Ordering::Acquire);
-                let target_state = target.state.lock().expect("terminal sizing state lock");
-                target_state
+                target
+                    .state
+                    .lock()
+                    .expect("terminal sizing state lock")
                     .claim_requested
-                    .filter(|request| request.generation == generation)
-                    .map(|request| (request, smallest_sizing_grid(&target_state.viewers)))
+                    .is_some_and(|request| request.generation == generation)
             });
-            let claim_fence_matches = claim_context.is_some_and(|(request, current_grid)| {
-                state.claim_fence.is_some_and(|fence| {
-                    fence.generation == request.generation
-                        && fence.viewer_id == request.viewer_id
-                        && fence.endpoint_ptr == request.endpoint_ptr
-                        && current_grid == Some(fence.grid)
-                        && request.token.is_none_or(|token| token == fence.token)
-                })
-            });
-            let pending_claim_matches = claim_context.is_some_and(|(request, current_grid)| {
-                state.pending_resize.as_ref().is_some_and(
-                    |(generation, pending_endpoint, pending_grid, claim)| {
-                        *claim
-                            && *generation == request.generation
-                            && pending_endpoint.viewer_id == request.viewer_id
-                            && endpoint_ptr(pending_endpoint) == request.endpoint_ptr
-                            && current_grid == Some(*pending_grid)
-                    },
-                )
-            });
-            let claim_without_fence =
-                claim_context.is_some() && !claim_fence_matches && !pending_claim_matches;
+            let claim_without_fence = claim_requested
+                && state.claim_fence.is_none()
+                && !state.pending_resize.as_ref().is_some_and(|(_, _, _, claim)| *claim);
             let owner_batch_failed = state.owner_resize_fence.as_ref().is_some_and(|fence| {
                 fence.generation == self.current_generation() && fence.response.is_none()
             });
@@ -1655,7 +1644,7 @@ impl OrderedControlQueue {
     /// Wait for the daemon-acknowledged close barrier of every endpoint that
     /// was removed from this target. The queue lock is never held while an
     /// endpoint sends its identify barrier or waits for the response.
-    async fn wait_for_closing(&self) -> bool {
+    async fn wait_for_closing(self: &Arc<Self>) -> bool {
         if self.state.lock().expect("ordered control queue lock").closing_failed {
             return false;
         }
@@ -2374,6 +2363,8 @@ impl TerminalSizing {
                     should_start |= start;
                 }
             }
+            drop(state);
+            drop(queue_state);
             (target, Arc::clone(&endpoint), should_start)
         };
         if should_start {
@@ -2519,6 +2510,8 @@ impl TerminalSizing {
                 }
                 should_start
             });
+            drop(state);
+            drop(queue_state);
             (target, should_start)
         };
         if should_start {
@@ -2611,6 +2604,8 @@ impl TerminalSizing {
                 // Keep the retired target until the ordered close command has
                 // completed. Removing it here would drop the only coordinator
                 // that can fence a late writer.
+                drop(state);
+                drop(queue_state);
                 (target, false)
             } else {
                 let grid = smallest_sizing_grid(&state.viewers);
@@ -2687,6 +2682,8 @@ impl TerminalSizing {
                 } else {
                     false
                 };
+                drop(state);
+                drop(queue_state);
                 (target, should_start)
             }
         };
@@ -2897,7 +2894,7 @@ impl TerminalSizing {
                     OrderedControlCommandKind::Send { .. } => {}
                 }
             }
-            self.enqueue_abort_pending_locked(&mut queue_state, &mut retained);
+            target.queue.enqueue_abort_pending_locked(&mut queue_state, &mut retained);
             let should_start = !retained.is_empty();
             *pending = retained;
             should_start
@@ -2966,24 +2963,7 @@ impl TerminalSizing {
         claim: bool,
         generation: u64,
     ) -> (bool, bool) {
-        let generation_current = Self::current_generation(target) == generation;
-        let candidate = if generation_current && state.owner.is_none() {
-            smallest_sizing_grid(&state.viewers).and_then(|current_grid| {
-                candidate_viewer_id_at_generation(state, generation).and_then(|id| {
-                    state.viewers.get(&id).map(|viewer| {
-                        (generation, id, current_grid, endpoint_ptr(&viewer.endpoint))
-                    })
-                })
-            })
-        } else {
-            None
-        };
-        // Clear a fence for an old candidate before any close-barrier early
-        // return. A replacement join can install a new ClaimRequest while
-        // its close is still queued; retaining the old fence would make input
-        // look authorized even though the replacement claim is not on wire.
-        target.queue.clear_stale_claim_fence_locked(queue_state, candidate);
-        if !generation_current
+        if Self::current_generation(target) != generation
             || state.retired
             || state.owner != expected_owner
             || !target.queue.close_barrier_ready_locked(queue_state)
@@ -2994,7 +2974,22 @@ impl TerminalSizing {
             // after `wait_for_closing` completes; no command may overtake it.
             return (false, false);
         }
+        let candidate = if state.owner.is_none() {
+            smallest_sizing_grid(&state.viewers).and_then(|current_grid| {
+                candidate_viewer_id_at_generation(state, generation).map(|id| (id, current_grid))
+            })
+        } else {
+            None
+        };
         target.queue.discard_stale_owner_resize_fence_locked(queue_state);
+        target.queue.clear_stale_claim_fence_locked(
+            queue_state,
+            candidate.and_then(|(candidate_id, candidate_grid)| {
+                state.viewers.get(&candidate_id).map(|viewer| {
+                    (generation, candidate_id, candidate_grid, endpoint_ptr(&viewer.endpoint))
+                })
+            }),
+        );
         let endpoint_current = state.viewers.get(&viewer_id).is_some_and(|viewer| {
             viewer.endpoint.is_active() && Arc::ptr_eq(&viewer.endpoint, endpoint)
         });
@@ -4371,7 +4366,7 @@ impl Inner {
         opened_frame.insert("ptyId".to_owned(), Value::from(pty_id.clone()));
         opened_frame.insert("session".to_owned(), Value::from(session));
         if let Some(surface) = opened.surface.as_ref() {
-            opened_frame.insert("surface".to_owned(), Value::from(surface));
+            opened_frame.insert("surface".to_owned(), Value::from(surface.as_str()));
         }
         opened_frame.insert("created".to_owned(), Value::from(opened.created));
         opened_frame.insert("cols".to_owned(), Value::from(cols));
@@ -7710,61 +7705,6 @@ mod tests {
             "the renewed claim must be completed by its own generation"
         );
         coordinator.leave(&key, 1);
-    }
-
-    #[tokio::test]
-    async fn stale_claim_fence_cannot_admit_input_for_current_claim() {
-        let control = SizingControl::new(12, &[]);
-        let coordinator = TerminalSizing::new();
-        let key = SizingKey {
-            socket_path: PathBuf::from("/tmp/cmux-sizing-stale-fence-input.sock"),
-            surface_id: 43,
-        };
-        coordinator
-            .join(key.clone(), 1, 43, Arc::new(control.clone()), SizingGrid { cols: 80, rows: 24 })
-            .expect("initial sizing barrier")
-            .await
-            .expect("initial sizing worker");
-
-        let target = coordinator.targets.lock().unwrap().get(&key).cloned().unwrap();
-        let endpoint = coordinator.queue_for(&key, 1).expect("current endpoint");
-        let generation = TerminalSizing::current_generation(&target);
-        let grid = SizingGrid { cols: 80, rows: 24 };
-
-        // Model a replacement claim after the old candidate fence was left
-        // behind by a full close queue. The request names the current
-        // endpoint and generation, but the fence has an old token. Input
-        // must fail closed instead of passing the stale authority boundary.
-        {
-            let mut queue_state = target.queue.state.lock().unwrap();
-            let mut state = target.state.lock().unwrap();
-            state.owner = None;
-            state.claim_requested = Some(ClaimRequest {
-                generation,
-                viewer_id: 1,
-                token: Some(11),
-                endpoint_ptr: endpoint_ptr(&endpoint),
-            });
-            queue_state.claim_fence = Some(ClaimFence {
-                generation,
-                viewer_id: 1,
-                grid,
-                token: 10,
-                endpoint_ptr: endpoint_ptr(&endpoint),
-            });
-        }
-
-        let sends_before = control.sends().len();
-        endpoint.enqueue_input(b"stale-fence-input");
-        tokio::task::yield_now().await;
-
-        assert!(!endpoint.is_active(), "stale claim input must close the attachment");
-        assert_eq!(
-            control.sends().len(),
-            sends_before,
-            "input must not be sent while the current claim lacks its exact fence"
-        );
-        coordinator.leave_endpoint(&key, 1, &endpoint);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -769,7 +769,7 @@ impl PtyDeps for RealPtyDeps {
             if dir.as_os_str().is_empty() {
                 continue;
             }
-            let candidate = Path::new(dir).join("cmux-tui");
+            let candidate = dir.join("cmux-tui");
             if is_executable(&candidate).await {
                 return Some(CmuxTui {
                     file: candidate.to_string_lossy().into_owned(),

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -9,11 +9,9 @@
 #![cfg(unix)]
 
 use std::collections::{HashMap, VecDeque};
-use std::ffi::OsString;
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -210,154 +208,6 @@ pub struct RealPtyDeps {
     shell: String,
 }
 
-/// A child spawned while an async open is still in progress. `spawn_blocking`
-/// does not stop its closure when the awaiting future is cancelled, so the
-/// closure and the async owner share this hand-off state. The child killer is
-/// installed before any fallible setup and is removed only after the returned
-/// `PtyHandle` owns the child.
-trait SpawnKiller: Send + Sync {
-    fn kill(&self);
-}
-
-struct PortableSpawnKiller(Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>);
-
-impl SpawnKiller for PortableSpawnKiller {
-    fn kill(&self) {
-        if let Ok(mut killer) = self.0.lock() {
-            let _ = killer.kill();
-        }
-    }
-}
-
-struct SpawnState {
-    cancelled: bool,
-    killer: Option<Arc<dyn SpawnKiller>>,
-}
-
-struct SpawnLifecycle {
-    state: Mutex<SpawnState>,
-}
-
-impl SpawnLifecycle {
-    fn new() -> Arc<Self> {
-        Arc::new(Self { state: Mutex::new(SpawnState { cancelled: false, killer: None }) })
-    }
-
-    fn is_cancelled(&self) -> bool {
-        self.state.lock().map(|state| state.cancelled).unwrap_or(true)
-    }
-
-    /// Install a kill handle unless cancellation won the race. The caller
-    /// must not publish a child before this succeeds.
-    fn install_killer(&self, killer: Arc<dyn SpawnKiller>) -> bool {
-        let mut state = self.state.lock().expect("spawn lifecycle lock");
-        if state.cancelled {
-            drop(state);
-            killer.kill();
-            return false;
-        }
-        state.killer = Some(killer);
-        true
-    }
-
-    fn cancel(&self) {
-        let killer = {
-            let mut state = self.state.lock().expect("spawn lifecycle lock");
-            state.cancelled = true;
-            state.killer.take()
-        };
-        if let Some(killer) = killer {
-            killer.kill();
-        }
-    }
-
-    /// Dispose the current failed child without marking the caller as
-    /// cancelled. A real PTY setup error may still degrade to a pipe shell;
-    /// cancellation remains a separate, sticky state checked before the
-    /// fallback child is spawned and again when its killer is installed.
-    fn kill_current(&self) {
-        let killer = self.state.lock().expect("spawn lifecycle lock").killer.take();
-        if let Some(killer) = killer {
-            killer.kill();
-        }
-    }
-
-    fn claim(&self) {
-        self.state.lock().expect("spawn lifecycle lock").killer = None;
-    }
-}
-
-/// Keeps the spawn killer armed until the manager has synchronously moved the
-/// returned control into an attachment or persistent shell session.
-struct SpawnGuardControl {
-    inner: Arc<dyn PtyControl>,
-    lifecycle: Arc<SpawnLifecycle>,
-    claimed: AtomicBool,
-}
-
-impl PtyControl for SpawnGuardControl {
-    fn write(&self, data: &[u8]) {
-        self.inner.write(data);
-    }
-
-    fn resize(&self, cols: u16, rows: u16) {
-        self.inner.resize(cols, rows);
-    }
-
-    fn pause(&self) {
-        self.inner.pause();
-    }
-
-    fn resume(&self) {
-        self.inner.resume();
-    }
-
-    fn release(&self) {
-        self.inner.release();
-    }
-
-    fn claim(&self) {
-        if !self.claimed.swap(true, Ordering::AcqRel) {
-            self.lifecycle.claim();
-        }
-    }
-
-    fn kill(&self) {
-        self.inner.kill();
-    }
-}
-
-impl Drop for SpawnGuardControl {
-    fn drop(&mut self) {
-        if !self.claimed.swap(true, Ordering::AcqRel) {
-            self.lifecycle.cancel();
-        }
-    }
-}
-
-struct SpawnCancellationGuard {
-    lifecycle: Arc<SpawnLifecycle>,
-    armed: bool,
-}
-
-impl SpawnCancellationGuard {
-    fn new(lifecycle: Arc<SpawnLifecycle>) -> Self {
-        Self { lifecycle, armed: true }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for SpawnCancellationGuard {
-    fn drop(&mut self) {
-        if self.armed {
-            self.lifecycle.cancel();
-        }
-    }
-}
-
 impl RealPtyDeps {
     pub fn new(env: HashMap<String, String>) -> RealPtyDeps {
         // SAFETY: getuid is always safe.
@@ -395,62 +245,11 @@ impl PtyControl for MasterControl {
     }
 }
 
-/// A degraded pipe-mode shell (no TTY) used when PTY allocation fails. Keep
-/// the child handle behind one lock so `try_wait` can retire it atomically;
-/// no cancellation path ever signals a raw PID after it may be reused.
-struct PipeChild {
-    child: Mutex<Option<std::process::Child>>,
-}
-
-impl PipeChild {
-    fn new(child: std::process::Child) -> Arc<Self> {
-        Arc::new(Self { child: Mutex::new(Some(child)) })
-    }
-
-    fn kill(&self) {
-        if let Ok(mut child) = self.child.lock()
-            && let Some(child) = child.as_mut()
-        {
-            let _ = child.kill();
-        }
-    }
-
-    fn wait(&self) -> i64 {
-        loop {
-            let result = {
-                let mut slot = self.child.lock().expect("pipe child lock");
-                let Some(child) = slot.as_mut() else { return 0 };
-                match child.try_wait() {
-                    Ok(Some(status)) => {
-                        // Retire the handle while the identity lock is still
-                        // held. A later kill cannot target the reused PID.
-                        *slot = None;
-                        Some(status.code().unwrap_or(0) as i64)
-                    }
-                    Ok(None) => None,
-                    Err(_) => {
-                        *slot = None;
-                        Some(1)
-                    }
-                }
-            };
-            if let Some(code) = result {
-                return code;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-    }
-}
-
-impl SpawnKiller for PipeChild {
-    fn kill(&self) {
-        PipeChild::kill(self);
-    }
-}
-
+/// A degraded pipe-mode shell (no TTY) used when PTY allocation fails. The
+/// child is owned by its wait thread; kill signals it by pid.
 struct PipeControl {
     stdin: Mutex<Option<std::process::ChildStdin>>,
-    child: Arc<PipeChild>,
+    pid: i32,
 }
 
 impl PtyControl for PipeControl {
@@ -466,17 +265,14 @@ impl PtyControl for PipeControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        self.child.kill();
+        // SAFETY: signalling a child pid this handle spawned; harmless if gone.
+        unsafe {
+            libc::kill(self.pid, libc::SIGKILL);
+        }
     }
 }
 
-fn spawn_real_pty(
-    spec: &SpawnSpec,
-    lifecycle: &Arc<SpawnLifecycle>,
-) -> anyhow::Result<Option<PtyHandle>> {
-    if lifecycle.is_cancelled() {
-        return Ok(None);
-    }
+fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let pair = cmux_pty::open(PtySize {
         rows: spec.rows,
         cols: spec.cols,
@@ -491,25 +287,8 @@ fn spawn_real_pty(
         command.env(key, value);
     }
     let spawned = pair.spawn(command)?;
-    let abort_killer: Arc<dyn SpawnKiller> =
-        Arc::new(PortableSpawnKiller(Mutex::new(spawned.child.clone_killer())));
-    if !lifecycle.install_killer(Arc::clone(&abort_killer)) {
-        return Ok(None);
-    }
-    let reader = match spawned.master.try_clone_reader() {
-        Ok(reader) => reader,
-        Err(error) => {
-            lifecycle.kill_current();
-            return Err(error.into());
-        }
-    };
-    let writer = match spawned.master.take_writer() {
-        Ok(writer) => writer,
-        Err(error) => {
-            lifecycle.kill_current();
-            return Err(error.into());
-        }
-    };
+    let reader = spawned.master.try_clone_reader()?;
+    let writer = spawned.master.take_writer()?;
     let killer = spawned.child.clone_killer();
     let output = ThreadOutput::new();
 
@@ -533,35 +312,18 @@ fn spawn_real_pty(
         exit_output.push_exit(code);
     });
 
-    let inner_control: Arc<dyn PtyControl> = Arc::new(MasterControl {
-        master: Mutex::new(spawned.master),
-        writer: Mutex::new(writer),
-        killer: Mutex::new(killer),
-    });
-    let handle = PtyHandle {
-        control: Arc::new(SpawnGuardControl {
-            inner: inner_control,
-            lifecycle: Arc::clone(lifecycle),
-            claimed: AtomicBool::new(false),
+    Ok(PtyHandle {
+        control: Arc::new(MasterControl {
+            master: Mutex::new(spawned.master),
+            writer: Mutex::new(writer),
+            killer: Mutex::new(killer),
         }),
         output,
         banner: None,
-    };
-    if lifecycle.is_cancelled() {
-        handle.control.kill();
-        return Ok(None);
-    }
-    Ok(Some(handle))
+    })
 }
 
-fn spawn_pipe_mode(
-    spec: &SpawnSpec,
-    reason: &str,
-    lifecycle: &Arc<SpawnLifecycle>,
-) -> Option<PtyHandle> {
-    if lifecycle.is_cancelled() {
-        return None;
-    }
+fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     let output = ThreadOutput::new();
     let mut command = std::process::Command::new(&spec.file);
     command.args(&spec.args).current_dir(&spec.cwd).env_clear();
@@ -582,57 +344,34 @@ fn spawn_pipe_mode(
     match command.spawn() {
         Ok(mut child) => {
             let stdin = child.stdin.take();
-            let child = PipeChild::new(child);
-            let abort_killer: Arc<dyn SpawnKiller> = child.clone();
-            if !lifecycle.install_killer(Arc::clone(&abort_killer)) {
-                child.kill();
-                let _ = child.wait();
-                return None;
-            }
-            let (stdout, stderr) = {
-                let mut slot = child.child.lock().expect("pipe child lock");
-                let child_handle = slot.as_mut().expect("pipe child installed");
-                (child_handle.stdout.take(), child_handle.stderr.take())
-            };
-            if let Some(stdout) = stdout {
+            let pid = child.id() as i32;
+            if let Some(stdout) = child.stdout.take() {
                 let out = Arc::clone(&output);
                 std::thread::spawn(move || pump_pipe(stdout, out));
             }
-            if let Some(stderr) = stderr {
+            if let Some(stderr) = child.stderr.take() {
                 let out = Arc::clone(&output);
                 std::thread::spawn(move || pump_pipe(stderr, out));
             }
+            // The wait would need its own thread; the shell exits when its
+            // pipes close, and the manager treats a data EOF plus process
+            // teardown as the end. Report exit when both pipes close.
             let wait_output = Arc::clone(&output);
-            let wait_child = Arc::clone(&child);
             std::thread::spawn(move || {
-                let code = wait_child.wait();
+                let code =
+                    child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
                 wait_output.push_exit(code);
             });
-            let inner_control: Arc<dyn PtyControl> =
-                Arc::new(PipeControl { stdin: Mutex::new(stdin), child });
-            let handle = PtyHandle {
-                control: Arc::new(SpawnGuardControl {
-                    inner: inner_control,
-                    lifecycle: Arc::clone(lifecycle),
-                    claimed: AtomicBool::new(false),
-                }),
+            PtyHandle {
+                control: Arc::new(PipeControl { stdin: Mutex::new(stdin), pid }),
                 output,
                 banner: Some(banner.into_bytes()),
-            };
-            if lifecycle.is_cancelled() {
-                handle.control.kill();
-                return None;
             }
-            Some(handle)
         }
         Err(error) => {
             let _ = error;
             output.push_exit(1);
-            Some(PtyHandle {
-                control: Arc::new(DeadControl),
-                output,
-                banner: Some(banner.into_bytes()),
-            })
+            PtyHandle { control: Arc::new(DeadControl), output, banner: Some(banner.into_bytes()) }
         }
     }
 }
@@ -660,67 +399,25 @@ async fn socket_exists(path: &Path) -> bool {
     tokio::fs::metadata(path).await.is_ok()
 }
 
-/// Owns a newly started cmux-tui daemon until readiness is proven. Dropping
-/// an async future does not drop a process group, so cancellation must start
-/// cleanup from `Drop` as well as from ordinary timeout/error paths.
-struct DaemonChildGuard {
-    child: Option<tokio::process::Child>,
-}
-
-impl DaemonChildGuard {
-    fn new(child: tokio::process::Child) -> Self {
-        Self { child: Some(child) }
-    }
-
-    async fn cleanup(&mut self) {
-        let Some(child) = self.child.as_mut() else { return };
-        if let Some(pid) = child.id() {
-            unsafe {
-                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-            }
-        }
-        if matches!(tokio::time::timeout(Duration::from_millis(250), child.wait()).await, Ok(Ok(_)))
-        {
-            self.child = None;
-            return;
-        }
-        if let Some(pid) = child.id() {
-            unsafe {
-                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-            }
-        }
-        let _ = child.kill().await;
-        let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
-        self.child = None;
-    }
-
-    fn disarm(&mut self) {
-        self.child = None;
-    }
-}
-
-impl Drop for DaemonChildGuard {
-    fn drop(&mut self) {
-        let Some(mut child) = self.child.take() else { return };
-        // Kill synchronously before scheduling the reaper. This closes the
-        // cancellation window even if the runtime is already shutting down.
-        let exited = child.try_wait().ok().flatten().is_some();
-        if !exited {
-            if let Some(pid) = child.id() {
-                unsafe {
-                    let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-                }
-            }
-            let _ = child.start_kill();
-        }
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move {
-                let _ = child.wait().await;
-            });
-        } else {
-            let _ = child.try_wait();
+/// Stop a daemon that was started by `ensure_daemon` but never became ready.
+/// The daemon is placed in its own process group, so cleanup also covers
+/// children it may have spawned before readiness failed.
+async fn cleanup_daemon(mut child: tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        unsafe {
+            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
         }
     }
+    if tokio::time::timeout(Duration::from_millis(250), child.wait()).await.is_ok() {
+        return;
+    }
+    if let Some(pid) = child.id() {
+        unsafe {
+            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+        }
+    }
+    let _ = child.kill().await;
+    let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
 }
 
 #[async_trait]
@@ -730,27 +427,15 @@ impl PtyDeps for RealPtyDeps {
         // On PTY allocation failure (ptmx exhaustion et al) degrade to a
         // pipe-mode shell so the terminal still functions, with a banner.
         let output = ThreadOutput::new();
-        let lifecycle = SpawnLifecycle::new();
-        let mut cancellation = SpawnCancellationGuard::new(Arc::clone(&lifecycle));
-        let result = tokio::task::spawn_blocking(move || match spawn_real_pty(&spec, &lifecycle) {
-            Ok(Some(handle)) => Some(handle),
-            Ok(None) => None,
-            Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &lifecycle),
+        tokio::task::spawn_blocking(move || match spawn_real_pty(&spec) {
+            Ok(handle) => handle,
+            Err(error) => spawn_pipe_mode(&spec, &error.to_string()),
         })
-        .await;
-        // The returned PtyHandle keeps the child-kill guard armed. Disarm the
-        // await guard in this poll; the caller must explicitly transfer the
-        // handle before its own guard is removed.
-        if result.is_ok() {
-            cancellation.disarm();
-        }
-        match result {
-            Ok(Some(handle)) => handle,
-            Ok(None) | Err(_) => {
-                output.push_exit(1);
-                PtyHandle { control: Arc::new(DeadControl), output, banner: None }
-            }
-        }
+        .await
+        .unwrap_or_else(|_| {
+            output.push_exit(1);
+            PtyHandle { control: Arc::new(DeadControl), output, banner: None }
+        })
     }
 
     async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
@@ -765,11 +450,11 @@ impl PtyDeps for RealPtyDeps {
             };
         }
         // Never a bare `cmux` on PATH — that name is ambiguous; only cmux-tui.
-        for dir in path_entries(self.env.get("PATH").map(String::as_str).unwrap_or("")) {
-            if dir.as_os_str().is_empty() {
+        for dir in self.env.get("PATH").map(String::as_str).unwrap_or("").split(':') {
+            if dir.is_empty() {
                 continue;
             }
-            let candidate = dir.join("cmux-tui");
+            let candidate = Path::new(dir).join("cmux-tui");
             if is_executable(&candidate).await {
                 return Some(CmuxTui {
                     file: candidate.to_string_lossy().into_owned(),
@@ -806,11 +491,7 @@ impl PtyDeps for RealPtyDeps {
         let socket_path = session_socket_path(socket_dir, self.uid, session)?;
         if socket_exists(&socket_path).await {
             let ready = match connect_control(&socket_path, CONTROL_TIMEOUT_MS).await {
-                Ok(control) => {
-                    let ready = control_ready(&control, session).await;
-                    control.end();
-                    ready
-                }
+                Ok(control) => control_ready(&control, session).await,
                 Err(_) => false,
             };
             if ready {
@@ -840,7 +521,6 @@ impl PtyDeps for RealPtyDeps {
         command.process_group(0);
         let child =
             command.spawn().map_err(|error| format!("cmux-tui daemon spawn failed: {error}"))?;
-        let mut child = DaemonChildGuard::new(child);
 
         let deadline = Instant::now() + Duration::from_millis(DAEMON_SOCKET_WAIT_MS);
         while Instant::now() < deadline {
@@ -848,14 +528,8 @@ impl PtyDeps for RealPtyDeps {
                 // Probe a control round-trip before declaring readiness.
                 while Instant::now() < deadline {
                     match connect_control(&socket_path, CONTROL_TIMEOUT_MS).await {
-                        Ok(control) => {
-                            let ready = control_ready(&control, session).await;
-                            control.end();
-                            if ready {
-                                child.disarm();
-                                return Ok(EnsureDaemon { created: true, socket_path });
-                            }
-                            tokio::time::sleep(Duration::from_millis(50)).await;
+                        Ok(control) if control_ready(&control, session).await => {
+                            return Ok(EnsureDaemon { created: true, socket_path });
                         }
                         _ => tokio::time::sleep(Duration::from_millis(50)).await,
                     }
@@ -863,14 +537,14 @@ impl PtyDeps for RealPtyDeps {
                 // Do not unlink the path here. Another daemon may have won
                 // the socket race after our initial absence check; ownership
                 // of a pathname cannot be proven after the fact.
-                child.cleanup().await;
+                cleanup_daemon(child).await;
                 return Err(format!(
                     "cmux-tui daemon for \"{session}\" did not become control-ready"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-        child.cleanup().await;
+        cleanup_daemon(child).await;
         Err(format!("cmux-tui daemon for \"{session}\" never created {}", socket_path.display()))
     }
 
@@ -911,10 +585,6 @@ async fn is_executable(path: &Path) -> bool {
     }
 }
 
-fn path_entries(value: &str) -> Vec<PathBuf> {
-    std::env::split_paths(&OsString::from(value)).collect()
-}
-
 /// Session-name validity is re-exported so the daemon path can reject early.
 pub fn valid_session(name: &str) -> bool {
     session_name_ok(name)
@@ -926,31 +596,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex};
     use std::thread;
-
-    struct CountingSpawnKiller(TestArc<AtomicUsize>);
-
-    impl SpawnKiller for CountingSpawnKiller {
-        fn kill(&self) {
-            self.0.fetch_add(1, AtomicOrdering::SeqCst);
-        }
-    }
-
-    #[test]
-    fn failed_spawn_cleanup_keeps_pipe_fallback_eligible() {
-        let lifecycle = SpawnLifecycle::new();
-        let kills = TestArc::new(AtomicUsize::new(0));
-        let first: Arc<dyn SpawnKiller> = Arc::new(CountingSpawnKiller(TestArc::clone(&kills)));
-        assert!(lifecycle.install_killer(first));
-        lifecycle.kill_current();
-        assert_eq!(kills.load(AtomicOrdering::SeqCst), 1);
-        assert!(!lifecycle.is_cancelled());
-
-        let fallback: Arc<dyn SpawnKiller> = Arc::new(CountingSpawnKiller(TestArc::clone(&kills)));
-        assert!(lifecycle.install_killer(fallback));
-        lifecycle.cancel();
-        assert_eq!(kills.load(AtomicOrdering::SeqCst), 2);
-        assert!(lifecycle.is_cancelled());
-    }
 
     #[test]
     fn session_socket_path_matches_core_fallback_order() {
@@ -974,17 +619,6 @@ mod tests {
         let error = session_socket_path(Path::new("/run/cmux-tui-501"), 501, "bad/name")
             .expect_err("path separator must be rejected");
         assert!(error.contains("invalid session"));
-    }
-
-    #[test]
-    fn path_entries_uses_platform_path_separator() {
-        let value = if cfg!(windows) { r"C:\\tools;D:\\bin" } else { "/opt/tools:/usr/local/bin" };
-        let entries = path_entries(value);
-        if cfg!(windows) {
-            assert_eq!(entries, vec![PathBuf::from(r"C:\tools"), PathBuf::from(r"D:\bin")]);
-        } else {
-            assert_eq!(entries, vec![PathBuf::from("/opt/tools"), PathBuf::from("/usr/local/bin")]);
-        }
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/relay_wire.rs
+++ b/cmux-tui/crates/chatmux-relay/src/relay_wire.rs
@@ -13,8 +13,7 @@
 //
 // Dialect constants (src/relay.ts):
 //   v2 hello negotiation, v3 exec verbs, v4 PTY, v5 process credentials,
-//   v6 workspace verbs + fs_watch, v7 PTY operational-error feature gate
-//   (RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION).
+//   v6 workspace verbs + fs_watch (RELAY_PROTOCOL_WORKSPACE_VERSION).
 // Requires serde + serde_json (derive feature); no other crates.
 
 #![allow(clippy::all)]
@@ -1103,12 +1102,6 @@ pub enum RelayPtyErrorCode {
     TerminalGone,
     #[serde(rename = "failed")]
     Failed,
-    #[serde(rename = "overflow")]
-    Overflow,
-    #[serde(rename = "trust_revoked")]
-    TrustRevoked,
-    #[serde(rename = "busy")]
-    Busy,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -14,9 +14,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-#[cfg(unix)]
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt as _, StreamExt as _};
@@ -37,8 +35,6 @@ use crate::pairing::websocket_url;
 use crate::pty::FrameContext;
 #[cfg(unix)]
 use crate::pty::PtyManager;
-#[cfg(unix)]
-use crate::relay_wire::RelayPtyErrorCode;
 use crate::trust::{
     DEFAULT_RELAY_TRUST, Trust, clear_invalid_yolo_confirmation, effective_local_trust,
     has_yolo_confirmation, relay_trust,
@@ -47,8 +43,6 @@ use crate::wire::{
     CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame, PTY_PROTOCOL_VERSION,
     ServerFrame, advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
 };
-#[cfg(unix)]
-use crate::wire::{PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION, pty_operational_error_code};
 
 const MAX_OUTBOUND_FRAMES: usize = 256;
 const MAX_WATCH_OUTBOUND_FRAMES: usize = 64;
@@ -74,65 +68,9 @@ struct AuthSnapshot {
     owner: Option<String>,
 }
 
-/// Own one producer's contribution to the socket backlog gauge. The token is
-/// created before queue admission so cancellation while waiting for capacity
-/// also releases the contribution.
-pub(crate) struct PendingBytes {
-    counter: Option<Arc<AtomicU64>>,
-    bytes: u64,
-}
-
-impl PendingBytes {
-    pub(crate) fn none() -> PendingBytes {
-        PendingBytes { counter: None, bytes: 0 }
-    }
-
-    pub(crate) fn new(counter: Arc<AtomicU64>, bytes: u64) -> PendingBytes {
-        counter.fetch_add(bytes, Ordering::SeqCst);
-        PendingBytes { counter: Some(counter), bytes }
-    }
-}
-
-impl Drop for PendingBytes {
-    fn drop(&mut self) {
-        if let Some(counter) = self.counter.take() {
-            release_pending_bytes(&counter, self.bytes);
-        }
-    }
-}
-
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
-    pub(crate) live: Option<Arc<AtomicBool>>,
-    pub(crate) ack: Option<tokio::sync::oneshot::Sender<()>>,
-    pending: Option<PendingBytes>,
     _bytes: OwnedSemaphorePermit,
-}
-
-impl OutboundFrame {
-    pub(crate) fn is_live(&self) -> bool {
-        self.live.as_ref().is_none_or(|live| live.load(Ordering::Acquire))
-    }
-
-    /// Complete a producer waiting for this frame to leave the writer. The
-    /// sender is optional for lossy frames, and sending is best effort because
-    /// the producer may have been cancelled already.
-    pub(crate) fn acknowledge(&mut self) {
-        // Release accounting before waking a producer waiting for this ack.
-        drop(self.pending.take());
-        if let Some(ack) = self.ack.take() {
-            let _ = ack.send(());
-        }
-    }
-}
-
-impl Drop for OutboundFrame {
-    fn drop(&mut self) {
-        // Covers queue teardown and producer send errors. The writer calls
-        // `acknowledge` explicitly for stale, sent, and failed frames; Drop
-        // makes the shutdown/EOF path safe even if a receiver is discarded.
-        self.acknowledge();
-    }
 }
 
 async fn send_socket_message<S>(
@@ -196,59 +134,19 @@ impl OutboundSink {
     }
 
     pub(crate) async fn critical_value(&self, frame: Value) -> Result<(), ()> {
-        self.critical_value_with_pending(frame, PendingBytes::none()).await
-    }
-
-    pub(crate) async fn critical_value_with_pending(
-        &self,
-        frame: Value,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let Some(text) = Self::encode(frame) else { return Err(()) };
-        self.critical_text_with_token_ack_pending(text, None, None, pending).await
+        self.critical_text(text).await
     }
 
     pub(crate) async fn critical_text(&self, text: String) -> Result<(), ()> {
-        self.critical_text_with_token_ack_pending(text, None, None, PendingBytes::none()).await
-    }
-
-    pub(crate) async fn critical_text_with_token(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.critical_text_with_token_ack(text, live, Some(tx)).await?;
-        rx.await.map_err(|_| ())
-    }
-
-    pub(crate) async fn critical_text_with_token_ack(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-        ack: Option<tokio::sync::oneshot::Sender<()>>,
-    ) -> Result<(), ()> {
-        self.critical_text_with_token_ack_pending(text, live, ack, PendingBytes::none()).await
-    }
-
-    pub(crate) async fn critical_text_with_token_ack_pending(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-        ack: Option<tokio::sync::oneshot::Sender<()>>,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         if bytes as usize > MAX_OUTBOUND_BYTES {
             self.critical_overflow.store(true, Ordering::Release);
             return Err(());
         }
         let permit = Arc::clone(&self.bytes).acquire_many_owned(bytes).await.map_err(|_| ())?;
-        let result = self
-            .critical
-            .send(OutboundFrame { text, live, ack, pending: Some(pending), _bytes: permit })
-            .await
-            .map_err(|_| ());
+        let result =
+            self.critical.send(OutboundFrame { text, _bytes: permit }).await.map_err(|_| ());
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
         }
@@ -256,61 +154,11 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_watch_value(&self, frame: Value) -> Result<(), ()> {
-        self.try_watch_value_with_pending(frame, PendingBytes::none())
-    }
-
-    pub(crate) fn try_watch_value_with_pending(
-        &self,
-        frame: Value,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
-        self.try_watch_value_with_token_pending(frame, None, pending)
-    }
-
-    pub(crate) fn try_watch_value_with_token(
-        &self,
-        frame: Value,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
-        self.try_watch_value_with_token_pending(frame, live, PendingBytes::none())
-    }
-
-    pub(crate) fn try_watch_value_with_token_pending(
-        &self,
-        frame: Value,
-        live: Option<Arc<AtomicBool>>,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let Some(text) = Self::encode(frame) else { return Err(()) };
-        self.try_watch_text_with_token_pending(text, live, pending)
+        self.try_watch_text(text)
     }
 
     pub(crate) fn try_critical_value(&self, frame: Value) -> Result<(), ()> {
-        self.try_critical_value_with_token_pending(frame, None, PendingBytes::none())
-    }
-
-    pub(crate) fn try_critical_value_with_pending(
-        &self,
-        frame: Value,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
-        self.try_critical_value_with_token_pending(frame, None, pending)
-    }
-
-    pub(crate) fn try_critical_value_with_token(
-        &self,
-        frame: Value,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
-        self.try_critical_value_with_token_pending(frame, live, PendingBytes::none())
-    }
-
-    pub(crate) fn try_critical_value_with_token_pending(
-        &self,
-        frame: Value,
-        live: Option<Arc<AtomicBool>>,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let result = (|| {
             let text = Self::encode(frame).ok_or(())?;
             let bytes = u32::try_from(text.len()).map_err(|_| ())?;
@@ -318,15 +166,7 @@ impl OutboundSink {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical
-                .try_send(OutboundFrame {
-                    text,
-                    live,
-                    ack: None,
-                    pending: Some(pending),
-                    _bytes: permit,
-                })
-                .map_err(|_| ())
+            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -335,38 +175,13 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_critical_text(&self, text: String) -> Result<(), ()> {
-        self.try_critical_text_with_token_pending(text, None, PendingBytes::none())
-    }
-
-    pub(crate) fn try_critical_text_with_token(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
-        self.try_critical_text_with_token_pending(text, live, PendingBytes::none())
-    }
-
-    pub(crate) fn try_critical_text_with_token_pending(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let result = (|| {
             let bytes = u32::try_from(text.len()).map_err(|_| ())?;
             if bytes as usize > MAX_OUTBOUND_BYTES {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical
-                .try_send(OutboundFrame {
-                    text,
-                    live,
-                    ack: None,
-                    pending: Some(pending),
-                    _bytes: permit,
-                })
-                .map_err(|_| ())
+            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -379,34 +194,9 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_watch_text(&self, text: String) -> Result<(), ()> {
-        self.try_watch_text_with_token(text, None)
-    }
-
-    pub(crate) fn try_watch_text_with_token(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-    ) -> Result<(), ()> {
-        self.try_watch_text_with_token_pending(text, live, PendingBytes::none())
-    }
-
-    pub(crate) fn try_watch_text_with_token_pending(
-        &self,
-        text: String,
-        live: Option<Arc<AtomicBool>>,
-        pending: PendingBytes,
-    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-        self.watch
-            .try_send(OutboundFrame {
-                text,
-                live,
-                ack: None,
-                pending: Some(pending),
-                _bytes: permit,
-            })
-            .map_err(|_| ())
+        self.watch.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
     }
 }
 
@@ -484,36 +274,6 @@ async fn shutdown_connection_tasks(
     timeout(CONNECTION_TASK_SHUTDOWN_TIMEOUT, connection_tasks.shutdown()).await.is_ok()
 }
 
-/// Resolve acknowledgements for frames that were accepted by a producer but
-/// never reached the socket because the writer stopped at EOF or shutdown.
-fn acknowledge_pending_frames(
-    critical_rx: &mut mpsc::Receiver<OutboundFrame>,
-    watch_rx: &mut mpsc::Receiver<OutboundFrame>,
-) {
-    while let Ok(mut frame) = critical_rx.try_recv() {
-        frame.acknowledge();
-    }
-    while let Ok(mut frame) = watch_rx.try_recv() {
-        frame.acknowledge();
-    }
-}
-
-/// Release bytes from the approximate socket backlog without allowing
-/// concurrent producers to subtract the same bytes twice.
-fn release_pending_bytes(pending: &AtomicU64, bytes: u64) {
-    if bytes == 0 {
-        return;
-    }
-    let mut current = pending.load(Ordering::SeqCst);
-    loop {
-        let next = current.saturating_sub(bytes);
-        match pending.compare_exchange_weak(current, next, Ordering::SeqCst, Ordering::SeqCst) {
-            Ok(_) => return,
-            Err(actual) => current = actual,
-        }
-    }
-}
-
 /// Keep the machine online until the process cancellation token is raised.
 /// Fatal errors are returned to the CLI; transient errors ride a jittered
 /// exponential backoff with a 30s ceiling.
@@ -588,82 +348,34 @@ fn unsupported_platform_pty_reply(frame_type: &str, raw: &Value) -> Option<Value
 }
 
 /// Build a per-frame FrameContext reading the current reconciled auth.
-#[cfg(unix)]
-fn make_context(
-    out: &OutboundSink,
-    pending: &Arc<AtomicU64>,
-    auth: &AuthSnapshot,
-    negotiated_relay_version: u64,
-    manager: &PtyManager,
-) -> FrameContext {
+fn make_context(out: &OutboundSink, pending: &Arc<AtomicU64>, auth: &AuthSnapshot) -> FrameContext {
     let sender = out.clone();
     let pending_send = Arc::clone(pending);
     let pending_probe = Arc::clone(pending);
-    let reported_output_overflow = Arc::new(Mutex::new(HashSet::<String>::new()));
-    let overflow_reported = Arc::clone(&reported_output_overflow);
-    let overflow_manager = manager.clone();
     FrameContext {
         send: Arc::new(move |frame: Value| {
-            // Own the type tag: the frame moves into the sink below while the
-            // tag is still needed for the overflow report.
-            let frame_type =
-                frame.get("type").and_then(Value::as_str).unwrap_or_default().to_owned();
-            let pty_id = frame.get("ptyId").and_then(Value::as_str).map(str::to_owned);
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
-            let pending_frame = PendingBytes::new(Arc::clone(&pending_send), size);
+            pending_send.fetch_add(size, Ordering::SeqCst);
             let critical = matches!(
-                frame_type.as_str(),
-                "pty_opened" | "pty_error" | "pty_exit" | "pty_closed" | "surface_list_result"
+                frame.get("type").and_then(Value::as_str),
+                Some(
+                    "pty_opened" | "pty_error" | "pty_exit" | "pty_closed" | "surface_list_result"
+                )
             );
             let result = if critical {
-                sender.try_critical_value_with_token_pending(frame, None, pending_frame)
+                sender.try_critical_value(frame)
             } else {
-                sender.try_watch_value_with_token_pending(frame, None, pending_frame)
+                sender.try_watch_value(frame)
             };
             if result.is_err() {
-                if frame_type == "pty_output" {
-                    if let Some(pty_id) = pty_id {
-                        let first = overflow_reported
-                            .lock()
-                            .expect("PTY overflow report lock")
-                            .insert(pty_id.clone());
-                        if first {
-                            let code = pty_operational_error_code(
-                                negotiated_relay_version,
-                                RelayPtyErrorCode::Overflow,
-                            );
-                            let message = if negotiated_relay_version
-                                >= crate::wire::RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION
-                            {
-                                "terminal output overflowed; reattach to continue receiving output"
-                            } else {
-                                "terminal output buffer is full; reattach to continue receiving output"
-                            };
-                            let overflow = serde_json::json!({
-                                "version": PTY_PROTOCOL_VERSION,
-                                "type": "pty_error",
-                                "ptyId": pty_id,
-                                "code": code,
-                                "message": message,
-                            });
-                            let overflow_size = serde_json::to_string(&overflow)
-                                .map(|text| text.len() as u64)
-                                .unwrap_or(0);
-                            let overflow_pending =
-                                PendingBytes::new(Arc::clone(&pending_send), overflow_size);
-                            let _ =
-                                sender.try_critical_value_with_pending(overflow, overflow_pending);
-                            overflow_manager.detach_on_output_overflow(&pty_id);
-                        }
-                    }
-                }
                 eprintln!(
-                    "Dropping relay outbound frame because its bounded queue is full; mandatory={critical} type={frame_type}"
+                    "Dropping relay outbound frame because its bounded queue is full; mandatory={critical}"
                 );
+                pending_send
+                    .fetch_sub(size.min(pending_send.load(Ordering::SeqCst)), Ordering::SeqCst);
             }
         }),
         buffered_amount: Arc::new(move || pending_probe.load(Ordering::SeqCst)),
-        negotiated_version: negotiated_relay_version,
         trust: auth.trust.clone(),
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
@@ -717,11 +429,7 @@ async fn relay_session(
     let (out_tx, mut critical_rx, mut watch_rx) = OutboundSink::channels();
     let pending = Arc::new(AtomicU64::new(0));
     let action_slots = Arc::new(Semaphore::new(8));
-    let auth = Arc::new(std::sync::Mutex::new(AuthSnapshot {
-        trust: String::new(),
-        roots: None,
-        owner: None,
-    }));
+    let auth = Arc::new(std::sync::Mutex::new(AuthSnapshot::default()));
     let workspace_runtime = Arc::clone(&runtime.workspace);
     let workspace = crate::workspace::Connection::new(workspace_runtime, out_tx.clone());
     // A child token ends every task admitted by this physical connection on
@@ -729,9 +437,6 @@ async fn relay_session(
     // this child is also raised for ordinary reconnects.
     let connection_cancellation = cancellation.child_token();
     let mut connection_tasks = JoinSet::new();
-    // Shared with the ordered PTY worker so every frame gets the exact outer
-    // hello version negotiated on this connection.
-    let negotiated_version_shared = Arc::new(AtomicU64::new(0));
 
     // Ordered PTY frame dispatch on its own task so a slow open (daemon
     // spawn) never stalls heartbeats or other frames.
@@ -747,7 +452,6 @@ async fn relay_session(
         let pending = Arc::clone(&pending);
         let auth = Arc::clone(&auth);
         let cancellation = connection_cancellation.clone();
-        let negotiated_version = Arc::clone(&negotiated_version_shared);
         connection_tasks.spawn(async move {
             loop {
                 let frame = tokio::select! {
@@ -759,13 +463,7 @@ async fn relay_session(
                     }
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
-                let context = make_context(
-                    &out,
-                    &pending,
-                    &snapshot,
-                    negotiated_version.load(Ordering::Acquire),
-                    &manager,
-                );
+                let context = make_context(&out, &pending, &snapshot);
                 tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => break,
@@ -852,23 +550,18 @@ async fn relay_session(
                 }
             }
             Wake::Outbound(is_critical, Some(frame)) => {
-                let mut frame = frame;
-                if !frame.is_live() {
-                    frame.acknowledge();
-                    continue;
-                }
                 if is_critical {
                     critical_burst += 1;
                 } else {
                     critical_burst = 0;
                 }
-                let text = std::mem::take(&mut frame.text);
+                let text = frame.text;
+                let size = text.len() as u64;
                 let sent = send_socket_text(&socket, text, cancellation).await;
+                pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
-                    frame.acknowledge();
                     break Ok(connected);
                 }
-                frame.acknowledge();
             }
             Wake::Outbound(_, None) => {
                 critical_burst = 0;
@@ -900,7 +593,6 @@ async fn relay_session(
                     ServerFrame::HelloAccepted(hello) => {
                         connected = true;
                         negotiated_version = hello.relay_protocol_version;
-                        negotiated_version_shared.store(negotiated_version, Ordering::Release);
                         clear_invalid_yolo_confirmation(config);
                         let configured = relay_trust(
                             config.pending_trust.as_deref().or(config.trust.as_deref()),
@@ -1077,21 +769,24 @@ async fn relay_session(
                                     "version": version,
                                     "actionId": action_id,
                                     "ok": false,
-                                    // `busy` is not a RelayActionErrorCode. Keep the
-                                    // retry guidance in the message and use the
-                                    // contract's generic retryable failure code.
-                                    "code": "failed",
+                                    "code": "busy",
                                     "message": "relay is busy; retry this action",
                                 });
                                 let size = serde_json::to_string(&result)
                                     .map(|text| text.len() as u64)
                                     .unwrap_or(0);
-                                let pending_frame = PendingBytes::new(Arc::clone(&pending), size);
-                                let _ = tokio::select! {
+                                pending.fetch_add(size, Ordering::SeqCst);
+                                let sent = tokio::select! {
                                     biased;
                                     _ = connection_cancellation.cancelled() => Err(()),
-                                    result = out.critical_value_with_pending(result, pending_frame) => result,
+                                    result = out.critical_value(result) => result,
                                 };
+                                if sent.is_err() {
+                                    pending.fetch_sub(
+                                        size.min(pending.load(Ordering::SeqCst)),
+                                        Ordering::SeqCst,
+                                    );
+                                }
                                 continue;
                             }
                         };
@@ -1116,12 +811,18 @@ async fn relay_session(
                             let size = serde_json::to_string(&result)
                                 .map(|text| text.len() as u64)
                                 .unwrap_or(0);
-                            let pending_frame = PendingBytes::new(Arc::clone(&pending), size);
-                            let _ = tokio::select! {
+                            pending.fetch_add(size, Ordering::SeqCst);
+                            let sent = tokio::select! {
                                 biased;
                                 _ = task_cancellation.cancelled() => Err(()),
-                                result = out.critical_value_with_pending(result, pending_frame) => result,
+                                result = out.critical_value(result) => result,
                             };
+                            if sent.is_err() {
+                                pending.fetch_sub(
+                                    size.min(pending.load(Ordering::SeqCst)),
+                                    Ordering::SeqCst,
+                                );
+                            }
                         });
                     }
                     ServerFrame::Pty { frame_type, raw } => {
@@ -1143,13 +844,7 @@ async fn relay_session(
                                 // bounded work queue is saturated. The manager close path is
                                 // synchronous and short, so this cannot create an unbounded wait.
                                 let snapshot = auth_direct.lock().expect("auth lock").clone();
-                                let context = make_context(
-                                    &out_tx,
-                                    &pending,
-                                    &snapshot,
-                                    negotiated_version,
-                                    &manager_direct,
-                                );
+                                let context = make_context(&out_tx, &pending, &snapshot);
                                 tokio::select! {
                                     biased;
                                     _ = cancellation.cancelled() => break Ok(connected),
@@ -1161,21 +856,27 @@ async fn relay_session(
                                 Ok(()) => {}
                                 Err(mpsc::error::TrySendError::Closed(_)) => break Ok(connected),
                                 Err(mpsc::error::TrySendError::Full(raw)) => {
-                                    // Never silently discard a terminal command. A PTY
-                                    // refusal uses the v7 `busy` code only after the
-                                    // negotiated feature gate. Surface listing has no
-                                    // error response in the wire schema, so close the
-                                    // connection instead of fabricating an empty or
-                                    // invalid result.
-                                    let reply = raw.get("ptyId").and_then(Value::as_str).map(|id| {
-                                        serde_json::json!({
+                                    // Never silently discard a server command. Slow opens/listing
+                                    // have an explicit busy response; control frames use the same
+                                    // typed refusal when the serialized ingress queue is saturated.
+                                    let reply = raw
+                                        .get("ptyId")
+                                        .and_then(Value::as_str)
+                                        .map(|id| serde_json::json!({
                                             "version": PTY_PROTOCOL_VERSION,
                                             "type": "pty_error",
                                             "ptyId": id,
-                                            "code": if negotiated_version >= PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION { "busy" } else { "failed" },
+                                            "code": "busy",
                                             "message": if is_slow { "relay is busy; retry this terminal request" } else { "relay is busy; retry this terminal command" },
-                                        })
-                                    });
+                                        }))
+                                        .or_else(|| raw.get("requestId").and_then(Value::as_str).map(|id| serde_json::json!({
+                                            "version": PTY_PROTOCOL_VERSION,
+                                            "type": "surface_list_result",
+                                            "requestId": id,
+                                            "surfaces": [],
+                                            "code": "busy",
+                                            "message": "relay is busy; retry this terminal request",
+                                        })));
                                     if let Some(reply) = reply {
                                         // This response is mandatory. Send it directly so a full
                                         // outbound queue cannot block this loop and stop socket
@@ -1189,11 +890,6 @@ async fn relay_session(
                                         if sent.is_err() {
                                             break Ok(connected);
                                         }
-                                    } else if raw.get("requestId").is_some() {
-                                        eprintln!(
-                                            "Closing relay connection because surface_list was rejected by a full ingress queue"
-                                        );
-                                        break Ok(connected);
                                     }
                                 }
                             }
@@ -1250,18 +946,6 @@ async fn relay_session(
         }
     };
 
-    // Cancel and await workspace-owned request tasks before draining the
-    // outbound queues. Git tasks must reap their child before the connection
-    // releases its runtime resources; a synchronous `Drop` abort is not a
-    // sufficient child-reaping boundary.
-    if !workspace.shutdown().await {
-        eprintln!(
-            "Workspace request shutdown exceeded {:?}; remaining handlers were aborted.",
-            CONNECTION_TASK_SHUTDOWN_TIMEOUT
-        );
-    }
-    drop(workspace);
-
     // Handlers are owned by this socket. Cancel them before returning so a
     // dropped connection cannot leave work sending into a dead session. A
     // handler may be inside a non-cooperative provider call, so retain a hard
@@ -1272,8 +956,6 @@ async fn relay_session(
             "Relay connection task shutdown exceeded {CONNECTION_TASK_SHUTDOWN_TIMEOUT:?}; abandoning remaining handlers."
         );
     }
-
-    acknowledge_pending_frames(&mut critical_rx, &mut watch_rx);
 
     // Attachments die with the socket; sessions persist (docs/TERMINAL.md).
     #[cfg(unix)]
@@ -1338,88 +1020,5 @@ mod cancellation_tests {
         assert!(shutdown_connection_tasks(&mut tasks, &cancellation).await);
         assert!(cancellation.is_cancelled());
         assert!(tasks.is_empty());
-    }
-}
-
-#[cfg(test)]
-mod outbound_tests {
-    use super::{OutboundSink, PendingBytes, acknowledge_pending_frames};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-
-    #[tokio::test]
-    async fn accounted_stale_frame_releases_only_its_owned_bytes() {
-        let (sink, mut critical, mut watch) = OutboundSink::channels();
-        let live = Arc::new(AtomicBool::new(true));
-        let pending = Arc::new(AtomicU64::new(11));
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        sink.critical_text_with_token_ack_pending(
-            "stale".to_owned(),
-            Some(Arc::clone(&live)),
-            Some(ack_tx),
-            PendingBytes::new(Arc::clone(&pending), 5),
-        )
-        .await
-        .expect("queue stale frame");
-        assert_eq!(pending.load(Ordering::SeqCst), 16);
-        live.store(false, Ordering::Release);
-        let mut frame = critical.try_recv().expect("queued critical frame");
-        assert!(!frame.is_live());
-        frame.acknowledge();
-        assert_eq!(pending.load(Ordering::SeqCst), 11);
-        assert!(ack_rx.await.is_ok());
-        acknowledge_pending_frames(&mut critical, &mut watch);
-    }
-
-    #[tokio::test]
-    async fn unaccounted_stale_watch_frame_preserves_pending_bytes() {
-        let (sink, _critical, mut watch) = OutboundSink::channels();
-        let live = Arc::new(AtomicBool::new(true));
-        let pending = AtomicU64::new(11);
-        sink.try_watch_text_with_token("event".to_owned(), Some(Arc::clone(&live)))
-            .expect("queue watch frame");
-        live.store(false, Ordering::Release);
-        let mut frame = watch.try_recv().expect("queued watch frame");
-        assert!(!frame.is_live());
-        frame.acknowledge();
-        assert_eq!(pending.load(Ordering::SeqCst), 11);
-    }
-
-    #[tokio::test]
-    async fn shutdown_drain_releases_accounted_frames_before_acknowledging() {
-        let (sink, mut critical, mut watch) = OutboundSink::channels();
-        let pending = Arc::new(AtomicU64::new(0));
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        sink.critical_text_with_token_ack_pending(
-            "eof".to_owned(),
-            None,
-            Some(ack_tx),
-            PendingBytes::new(Arc::clone(&pending), 3),
-        )
-        .await
-        .expect("queue frame");
-        acknowledge_pending_frames(&mut critical, &mut watch);
-        assert_eq!(pending.load(Ordering::SeqCst), 0);
-        assert!(ack_rx.await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn closed_writer_releases_accounting_on_send_failure() {
-        let (sink, critical, _watch) = OutboundSink::channels();
-        drop(critical);
-        let pending = Arc::new(AtomicU64::new(0));
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        assert!(
-            sink.critical_text_with_token_ack_pending(
-                "closed".to_owned(),
-                None,
-                Some(ack_tx),
-                PendingBytes::new(Arc::clone(&pending), 6),
-            )
-            .await
-            .is_err()
-        );
-        assert_eq!(pending.load(Ordering::SeqCst), 0);
-        assert!(ack_rx.await.is_ok());
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -289,6 +289,14 @@ impl OutboundSink {
         self.try_critical_value_with_token_pending(frame, None, PendingBytes::none())
     }
 
+    pub(crate) fn try_critical_value_with_pending(
+        &self,
+        frame: Value,
+        pending: PendingBytes,
+    ) -> Result<(), ()> {
+        self.try_critical_value_with_token_pending(frame, None, pending)
+    }
+
     pub(crate) fn try_critical_value_with_token(
         &self,
         frame: Value,

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -604,15 +604,16 @@ fn make_context(
     let overflow_manager = manager.clone();
     FrameContext {
         send: Arc::new(move |frame: Value| {
-            let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
+            // Own the type tag: the frame moves into the sink below while the
+            // tag is still needed for the overflow report.
+            let frame_type =
+                frame.get("type").and_then(Value::as_str).unwrap_or_default().to_owned();
             let pty_id = frame.get("ptyId").and_then(Value::as_str).map(str::to_owned);
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
             let pending_frame = PendingBytes::new(Arc::clone(&pending_send), size);
             let critical = matches!(
-                Some(frame_type),
-                Some(
-                    "pty_opened" | "pty_error" | "pty_exit" | "pty_closed" | "surface_list_result"
-                )
+                frame_type.as_str(),
+                "pty_opened" | "pty_error" | "pty_exit" | "pty_closed" | "surface_list_result"
             );
             let result = if critical {
                 sender.try_critical_value_with_token_pending(frame, None, pending_frame)

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -31,13 +31,7 @@ const DEBOUNCE_QUIET: Duration = Duration::from_millis(150);
 const DEBOUNCE_MAX_LATENCY: Duration = Duration::from_millis(500);
 const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 
-struct WatchSession {
-    generation: u64,
-    live: Arc<AtomicBool>,
-    task: Option<tokio::task::JoinHandle<()>>,
-}
-
-type Sessions = Arc<Mutex<HashMap<String, WatchSession>>>;
+type Sessions = Arc<Mutex<HashMap<String, (u64, Option<tokio::task::JoinHandle<()>>)>>>;
 
 pub struct WatchRegistry {
     outbound: OutboundSink,
@@ -50,9 +44,8 @@ impl Drop for WatchRegistry {
         // The socket died with this registry; the Worker re-opens watches
         // on the next connection.
         if let Ok(mut sessions) = self.sessions.lock() {
-            for (_, session) in sessions.drain() {
-                session.live.store(false, Ordering::Release);
-                if let Some(task) = session.task {
+            for (_, (_, task)) in sessions.drain() {
+                if let Some(task) = task {
                     task.abort();
                 }
             }
@@ -87,12 +80,9 @@ impl WatchRegistry {
 
     pub fn close(&self, watch_id: &str) {
         if let Ok(mut sessions) = self.sessions.lock()
-            && let Some(session) = sessions.remove(watch_id)
+            && let Some((_, Some(task))) = sessions.remove(watch_id)
         {
-            session.live.store(false, Ordering::Release);
-            if let Some(task) = session.task {
-                task.abort();
-            }
+            task.abort();
         }
     }
 
@@ -115,19 +105,11 @@ impl WatchRegistry {
         })
         .unwrap_or_else(|_| String::new());
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let live = Arc::new(AtomicBool::new(true));
         let previous = match self.sessions.lock() {
             Ok(mut sessions)
                 if sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS =>
             {
-                let previous = sessions.insert(
-                    watch_id.clone(),
-                    WatchSession { generation, live: Arc::clone(&live), task: None },
-                );
-                if let Some(previous) = previous.as_ref() {
-                    previous.live.store(false, Ordering::Release);
-                }
-                Ok(previous)
+                Ok(sessions.insert(watch_id.clone(), (generation, None)))
             }
             Ok(_) | Err(_) => Err(()),
         };
@@ -142,28 +124,28 @@ impl WatchRegistry {
                 return;
             }
         };
-        let _ = self.outbound.try_critical_text_with_token(opened, Some(Arc::clone(&live)));
+        let _ = self.outbound.try_critical_text(opened);
         let outbound = self.outbound.clone();
         let sessions = Arc::clone(&self.sessions);
         let task_id = watch_id.clone();
-        let task_live = Arc::clone(&live);
         let mut task = Some(tokio::spawn(async move {
-            run_watch(&task_id, &root, &outbound, task_live).await;
+            run_watch(&task_id, &root, &outbound).await;
             if let Ok(mut sessions) = sessions.lock() {
                 // `tokio::spawn` starts the task immediately, so a watcher
                 // that fails during startup can finish before its handle is
                 // installed in the registry. Remove our generation's
-                if sessions.get(&task_id).is_some_and(|entry| entry.generation == generation) {
-                    if let Some(session) = sessions.remove(&task_id) {
-                        session.live.store(false, Ordering::Release);
-                    }
+                // placeholder regardless of whether the handle is present;
+                // a replacement watch has a different generation and is
+                // therefore preserved.
+                if sessions.get(&task_id).is_some_and(|entry| entry.0 == generation) {
+                    sessions.remove(&task_id);
                 }
             }
         }));
         let installed = if let Ok(mut sessions) = self.sessions.lock() {
             if let Some(entry) = sessions.get_mut(&watch_id) {
-                if entry.generation == generation {
-                    entry.task = task.take();
+                if entry.0 == generation {
+                    entry.1 = task.take();
                     true
                 } else {
                     false
@@ -175,10 +157,9 @@ impl WatchRegistry {
             false
         };
         if !installed && let Some(task) = task {
-            live.store(false, Ordering::Release);
             task.abort();
         }
-        if let Some(previous) = previous.and_then(|session| session.task) {
+        if let Some((_, Some(previous))) = previous {
             previous.abort();
         }
     }
@@ -218,7 +199,7 @@ fn watch_root_with_capabilities(
 // The watch task: notify events -> debounce -> gitignore filter -> frames
 // ---------------------------------------------------------------------------
 
-async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: Arc<AtomicBool>) {
+async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
     use notify::Watcher as _;
     let (event_tx, mut event_rx) =
         channel::<Result<notify::Event, notify::Error>>(MAX_PENDING_NOTIFY_EVENTS);
@@ -248,28 +229,22 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: A
             Ok(watcher) => watcher,
             Err(error) => {
                 let _ = outbound
-                    .critical_text_with_token(
-                        watch_error_frame(
-                            watch_id,
-                            wire::WorkspaceErrorCode::Failed,
-                            &format!("could not start the watcher: {error}"),
-                        ),
-                        Some(Arc::clone(&live)),
-                    )
+                    .critical_text(watch_error_frame(
+                        watch_id,
+                        wire::WorkspaceErrorCode::Failed,
+                        &format!("could not start the watcher: {error}"),
+                    ))
                     .await;
                 return;
             }
         };
     if let Err(error) = watcher.watch(root, notify::RecursiveMode::Recursive) {
         let _ = outbound
-            .critical_text_with_token(
-                watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    &format!("could not watch {}: {error}", root.display()),
-                ),
-                Some(Arc::clone(&live)),
-            )
+            .critical_text(watch_error_frame(
+                watch_id,
+                wire::WorkspaceErrorCode::Failed,
+                &format!("could not watch {}: {error}", root.display()),
+            ))
             .await;
         return;
     }
@@ -318,14 +293,11 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: A
         }
         if overflow {
             let _ = outbound
-                .critical_text_with_token(
-                    watch_error_frame(
-                        watch_id,
-                        wire::WorkspaceErrorCode::Failed,
-                        "watch event burst overflowed; refresh the tree",
-                    ),
-                    Some(Arc::clone(&live)),
-                )
+                .critical_text(watch_error_frame(
+                    watch_id,
+                    wire::WorkspaceErrorCode::Failed,
+                    "watch event burst overflowed; refresh the tree",
+                ))
                 .await;
         }
         let latched_error = latched_error.lock().ok().and_then(|mut error| error.take());
@@ -338,7 +310,7 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: A
                 overflow: overflow.then_some(true),
             })
             .unwrap_or_else(|_| String::new());
-            if outbound.try_watch_text_with_token(frame, Some(Arc::clone(&live))).is_err() {
+            if outbound.try_watch_text(frame).is_err() {
                 // The outbound sink is saturated or closed. Retrying by
                 // latching overflow would wake this loop immediately and
                 // spin forever while producing no observable frame. The
@@ -351,27 +323,21 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, live: A
         }
         if let Some(error) = fatal {
             let _ = outbound
-                .critical_text_with_token(
-                    watch_error_frame(
-                        watch_id,
-                        wire::WorkspaceErrorCode::Failed,
-                        &format!("the watcher died: {error}"),
-                    ),
-                    Some(Arc::clone(&live)),
-                )
+                .critical_text(watch_error_frame(
+                    watch_id,
+                    wire::WorkspaceErrorCode::Failed,
+                    &format!("the watcher died: {error}"),
+                ))
                 .await;
             break;
         }
         if let Some(error) = latched_error {
             let _ = outbound
-                .critical_text_with_token(
-                    watch_error_frame(
-                        watch_id,
-                        wire::WorkspaceErrorCode::Failed,
-                        &format!("the watcher reported an error: {error}"),
-                    ),
-                    Some(Arc::clone(&live)),
-                )
+                .critical_text(watch_error_frame(
+                    watch_id,
+                    wire::WorkspaceErrorCode::Failed,
+                    &format!("the watcher reported an error: {error}"),
+                ))
                 .await;
             break;
         }
@@ -588,52 +554,6 @@ mod tests {
             .unwrap_or_else(|_| panic!("no {what} frame within 10s"))
             .expect("channel open");
         serde_json::from_str(&frame.text).expect("valid frame json")
-    }
-
-    async fn next_raw_frame(
-        critical: &mut Receiver<OutboundFrame>,
-        watch: &mut Receiver<OutboundFrame>,
-        what: &str,
-    ) -> OutboundFrame {
-        tokio::time::timeout(Duration::from_secs(10), async {
-            tokio::select! { biased; frame = critical.recv() => frame, frame = watch.recv() => frame }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("no {what} frame within 10s"))
-        .expect("channel open")
-    }
-
-    #[tokio::test]
-    async fn queued_watch_frame_becomes_stale_when_its_token_is_retired() {
-        let (sink, _critical, mut watch) = OutboundSink::channels();
-        let live = Arc::new(AtomicBool::new(true));
-        sink.try_watch_text_with_token("event".to_owned(), Some(Arc::clone(&live)))
-            .expect("queue event");
-
-        live.store(false, Ordering::Release);
-
-        let frame = watch.recv().await.expect("queued event");
-        assert!(!frame.is_live(), "the writer must drop a retired queued frame");
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn reopening_a_watch_retires_queued_frames_before_new_opened_frame() {
-        let root = scratch("reopen-token");
-        let (sink, mut critical, mut watch) = OutboundSink::channels();
-        let registry = WatchRegistry::new(sink);
-
-        registry.open(open_frame("same", &root), None);
-        let old_opened = next_raw_frame(&mut critical, &mut watch, "first opened").await;
-        assert!(old_opened.is_live());
-
-        registry.open(open_frame("same", &root), None);
-        let new_opened = next_raw_frame(&mut critical, &mut watch, "replacement opened").await;
-
-        assert!(!old_opened.is_live(), "replacement must retire the old generation first");
-        assert!(new_opened.is_live(), "replacement opened frame must remain live");
-        registry.close("same");
-        assert!(!new_opened.is_live(), "close must retire queued frames");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/wire.rs
+++ b/cmux-tui/crates/chatmux-relay/src/wire.rs
@@ -18,18 +18,10 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::config::ManagedIdentity;
-use crate::relay_wire::RelayPtyErrorCode;
 
 /// Relay wire dialect this build advertises. Workspace/watch/preview frames
-/// use v6. Version 7 adds the typed PTY operational-error feature gate.
-pub const ADVERTISED_PROTOCOL_VERSION: u64 = 7;
-/// PTY frame shapes remain v4. This outer negotiation version gates the
-/// additive `overflow`, `trust_revoked`, and `busy` error codes.
-pub const PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION: u64 = 7;
-/// Canonical feature name used by the machine relay. Keep the descriptive
-/// alias above for older cmux call sites while the wire contract is v7.
-pub const RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION: u64 =
-    PTY_OPERATIONAL_ERRORS_PROTOCOL_VERSION;
+/// use v6; lower dialect features remain capability-gated.
+pub const ADVERTISED_PROTOCOL_VERSION: u64 = 6;
 /// Frame dialect marker (`RelayFrameVersion`, >= 2) on every sent frame.
 pub const FRAME_VERSION: u64 = 2;
 /// Verbs exist from this dialect on.
@@ -49,20 +41,6 @@ pub fn advertised_protocol() -> u64 {
         .filter(|value| !value.is_empty())
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(ADVERTISED_PROTOCOL_VERSION)
-}
-
-/// Select a PTY operational-error code that the negotiated Worker understands.
-/// Older Workers receive the v4 `failed` code and can still render the safe
-/// fallback message supplied by the caller.
-pub fn pty_operational_error_code(
-    negotiated_version: u64,
-    code: RelayPtyErrorCode,
-) -> RelayPtyErrorCode {
-    if negotiated_version >= RELAY_PROTOCOL_PTY_OPERATIONAL_ERRORS_VERSION {
-        code
-    } else {
-        RelayPtyErrorCode::Failed
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -16,13 +16,10 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
-use tokio::io::AsyncReadExt as _;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tokio_util::sync::CancellationToken;
 
 use crate::actions::{
     RootLists, ensure_scoped_file_roots_available, process_env_snapshot, scrubbed_env,
@@ -60,15 +57,6 @@ const MAX_TIMEOUT_MS: i64 = 300_000;
 /// Bound per-connection workspace task fan-out. This matches the control
 /// plane's pending-request cap and makes refusal explicit under load.
 pub const MAX_IN_FLIGHT_WORKSPACE_REQUESTS: usize = 256;
-
-// Include one byte for the line delimiter. The assembled patch still uses
-// DIFF_MAX_BYTES as its payload ceiling, so this only bounds one input line.
-const GIT_DIFF_LINE_MAX_BYTES: usize = DIFF_MAX_BYTES + 1;
-const GIT_STDERR_MAX_BYTES: usize = 64 * 1024;
-const GIT_STDERR_DRAIN_TIMEOUT_MS: u64 = 250;
-const GIT_STDOUT_DRAIN_TIMEOUT_MS: u64 = 5_000;
-const GIT_STOP_TIMEOUT_MS: u64 = 1_000;
-const CONNECTION_REQUEST_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn validate_allowed_roots_value(frame: &Value) -> Result<(), &'static str> {
     let Some(value) = frame.get("allowedRoots") else { return Ok(()) };
@@ -1439,28 +1427,6 @@ fn git_command(root: &Path, args: &[&str]) -> tokio::process::Command {
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
-    #[cfg(unix)]
-    {
-        // Git can start helpers which outlive the direct process. Keep the
-        // whole tree in a private group so cancellation closes inherited
-        // pipes before we finish cleanup.
-        unsafe {
-            command.pre_exec(|| {
-                if libc::setpgid(0, 0) == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
-    }
-    #[cfg(windows)]
-    {
-        // Tokio's Child::kill is the safe fallback on Windows. The standard
-        // Command API has no portable process-group kill; descendants which
-        // explicitly detach can therefore outlive git on this platform.
-        use std::os::windows::process::CommandExt as _;
-        command.creation_flags(windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP);
-    }
     command
 }
 
@@ -1475,315 +1441,6 @@ fn git_refusal(context: &str, stderr: &[u8]) -> Refusal {
     }
 }
 
-/// Read one git-diff line without allowing a missing newline to grow the
-/// buffer without bound. `fill_buf` is cancel-safe and `consume` is called
-/// only after the bytes have been accepted into the bounded line buffer.
-async fn read_bounded_git_diff_line<R>(
-    reader: &mut R,
-    line: &mut Vec<u8>,
-    maximum: usize,
-) -> std::io::Result<Option<String>>
-where
-    R: tokio::io::AsyncBufRead + Unpin,
-{
-    use tokio::io::AsyncBufReadExt as _;
-
-    line.clear();
-    loop {
-        let buffer = reader.fill_buf().await?;
-        if buffer.is_empty() {
-            return if line.is_empty() { Ok(None) } else { decode_git_diff_line(line).map(Some) };
-        }
-        let newline = buffer.iter().position(|byte| *byte == b'\n');
-        let take = newline.map_or(buffer.len(), |index| index + 1);
-        if line.len().saturating_add(take) > maximum {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "git diff line exceeds the configured bound",
-            ));
-        }
-        line.extend_from_slice(&buffer[..take]);
-        reader.consume(take);
-        if newline.is_some() {
-            return decode_git_diff_line(line).map(Some);
-        }
-    }
-}
-
-fn decode_git_diff_line(line: &mut Vec<u8>) -> std::io::Result<String> {
-    if line.last() == Some(&b'\n') {
-        line.pop();
-        if line.last() == Some(&b'\r') {
-            line.pop();
-        }
-    }
-    std::str::from_utf8(line)
-        .map(str::to_owned)
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
-}
-
-/// Own the stderr reader for one git operation. Dropping a JoinHandle only
-/// detaches its task, so abort it explicitly when the operation is cancelled.
-/// Once git exits, `finish` bounds the wait for descendants that inherited the
-/// pipe and never close it.
-struct GitStderrDrain {
-    task: tokio::task::JoinHandle<std::io::Result<()>>,
-    retained: Arc<std::sync::Mutex<Vec<u8>>>,
-}
-
-struct GitStderrResult {
-    bytes: Vec<u8>,
-    complete: bool,
-}
-
-struct GitProcessGuard(Option<u32>);
-
-impl GitProcessGuard {
-    fn new(child: &tokio::process::Child) -> GitProcessGuard {
-        GitProcessGuard(child.id())
-    }
-
-    fn kill_group(&self) {
-        #[cfg(unix)]
-        if let Some(pid) = self.0 {
-            unsafe {
-                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-            }
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.0 = None;
-    }
-}
-
-impl Drop for GitProcessGuard {
-    fn drop(&mut self) {
-        let Some(pid) = self.0.take() else { return };
-        #[cfg(unix)]
-        unsafe {
-            // The direct child is also configured with Tokio's kill_on_drop,
-            // but Drop cannot await Tokio's reaper. Kill the private process
-            // group and synchronously reap the direct child here. This is the
-            // cancellation fallback for a request task that is aborted before
-            // it reaches `abort_git_operation`; without the wait, the child
-            // can remain a zombie after the connection JoinSet is torn down.
-            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-            loop {
-                let result = libc::waitpid(pid as libc::pid_t, std::ptr::null_mut(), 0);
-                if result == pid as libc::pid_t {
-                    break;
-                }
-                let error = std::io::Error::last_os_error();
-                if error.raw_os_error() == Some(libc::EINTR) {
-                    continue;
-                }
-                // Tokio may have won the race to reap the child. In that
-                // case there is no process left for this guard to collect.
-                break;
-            }
-        }
-        #[cfg(windows)]
-        {
-            let _ = pid;
-            // Child::kill_on_drop remains the safe direct-child fallback.
-        }
-    }
-}
-
-fn disarm_if_reaped(child: &tokio::process::Child, process_guard: &mut GitProcessGuard) {
-    if child.id().is_none() {
-        process_guard.disarm();
-    }
-}
-
-/// Kill the process tree, then explicitly wait for the direct child. The
-/// wait is required on Unix to reap the child instead of leaving a zombie.
-async fn stop_git(child: &mut tokio::process::Child) {
-    #[cfg(unix)]
-    if let Some(pid) = child.id() {
-        unsafe {
-            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-        }
-    }
-    // `kill` is start_kill + wait in Tokio. It is intentionally awaited on
-    // every owned error path, rather than relying on Child's best-effort Drop.
-    let _ =
-        tokio::time::timeout(std::time::Duration::from_millis(GIT_STOP_TIMEOUT_MS), child.kill())
-            .await;
-}
-
-fn remaining_git_time(
-    deadline: std::time::Instant,
-    cap: std::time::Duration,
-) -> Option<std::time::Duration> {
-    let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
-    Some(remaining.min(cap))
-}
-
-/// Await the direct child with a deadline. A process can close both pipes and
-/// still keep running, so pipe EOF is not proof that the Git operation ended.
-/// On timeout, kill and await the child before returning so Unix does not keep
-/// a zombie and the request does not hold an admission permit forever.
-async fn wait_git_with_timeout(
-    child: &mut tokio::process::Child,
-    timeout: std::time::Duration,
-) -> Result<std::process::ExitStatus, Refusal> {
-    match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => Ok(status),
-        Ok(Err(error)) => Err(Refusal::failed(format!("could not wait for git: {error}"))),
-        Err(_) => {
-            stop_git(child).await;
-            Err(Refusal::failed("git process wait timed out"))
-        }
-    }
-}
-
-async fn wait_git_until(
-    child: &mut tokio::process::Child,
-    deadline: std::time::Instant,
-) -> Result<std::process::ExitStatus, Refusal> {
-    let Some(remaining) = remaining_git_time(deadline, std::time::Duration::from_secs(300)) else {
-        stop_git(child).await;
-        return Err(Refusal::failed("git operation deadline exceeded"));
-    };
-    match tokio::time::timeout(remaining, child.wait()).await {
-        Ok(Ok(status)) => Ok(status),
-        Ok(Err(error)) => Err(Refusal::failed(format!("could not wait for git: {error}"))),
-        Err(_) => {
-            stop_git(child).await;
-            Err(Refusal::failed("git operation deadline exceeded"))
-        }
-    }
-}
-
-impl Drop for GitStderrDrain {
-    fn drop(&mut self) {
-        self.task.abort();
-    }
-}
-
-impl GitStderrDrain {
-    fn start<R>(mut stderr: R) -> GitStderrDrain
-    where
-        R: tokio::io::AsyncRead + Unpin + Send + 'static,
-    {
-        let retained = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let task_retained = Arc::clone(&retained);
-        let task = tokio::spawn(async move {
-            let mut buffer = [0_u8; 8 * 1024];
-            loop {
-                let read = stderr.read(&mut buffer).await?;
-                if read == 0 {
-                    break;
-                }
-                if let Ok(mut retained) = task_retained.lock() {
-                    if retained.len() < GIT_STDERR_MAX_BYTES {
-                        let keep = (GIT_STDERR_MAX_BYTES - retained.len()).min(read);
-                        retained.extend_from_slice(&buffer[..keep]);
-                    }
-                }
-            }
-            Ok(())
-        });
-        GitStderrDrain { task, retained }
-    }
-
-    async fn finish(mut self) -> Result<GitStderrResult, Refusal> {
-        match tokio::time::timeout(
-            std::time::Duration::from_millis(GIT_STDERR_DRAIN_TIMEOUT_MS),
-            &mut self.task,
-        )
-        .await
-        {
-            Ok(result) => result
-                .map_err(|error| Refusal::failed(format!("git diff stderr drain failed: {error}")))?
-                .map_err(|error| {
-                    Refusal::failed(format!("git diff stderr read failed: {error}"))
-                })?,
-            Err(_) => {
-                self.task.abort();
-                let _ = (&mut self.task).await;
-                return Ok(GitStderrResult {
-                    bytes: self
-                        .retained
-                        .lock()
-                        .map(|retained| retained.clone())
-                        .unwrap_or_default(),
-                    complete: false,
-                });
-            }
-        }
-        Ok(GitStderrResult {
-            bytes: self.retained.lock().map(|retained| retained.clone()).unwrap_or_default(),
-            complete: true,
-        })
-    }
-}
-
-/// Finish stderr before reaping the leader. If a helper still owns the pipe,
-/// the child handle still owns the group identity, so termination cannot hit a
-/// reused PID.
-async fn finish_git_stderr(
-    stderr_task: Option<GitStderrDrain>,
-    child: &mut tokio::process::Child,
-    process_guard: &mut GitProcessGuard,
-    deadline: std::time::Instant,
-    operation: &str,
-) -> Result<Vec<u8>, Refusal> {
-    let Some(task) = stderr_task else { return Ok(Vec::new()) };
-    let Some(remaining) = remaining_git_time(deadline, std::time::Duration::from_secs(300)) else {
-        process_guard.kill_group();
-        stop_git(child).await;
-        disarm_if_reaped(child, process_guard);
-        return Err(Refusal::failed(format!("{operation} operation deadline exceeded")));
-    };
-    let result = match tokio::time::timeout(remaining, task.finish()).await {
-        Ok(result) => result,
-        Err(_) => {
-            process_guard.kill_group();
-            stop_git(child).await;
-            disarm_if_reaped(child, process_guard);
-            return Err(Refusal::failed(format!("{operation} operation deadline exceeded")));
-        }
-    };
-    match result {
-        Ok(result) if result.complete => Ok(result.bytes),
-        Ok(_) => {
-            process_guard.kill_group();
-            stop_git(child).await;
-            disarm_if_reaped(child, process_guard);
-            Err(Refusal::failed(format!("{operation} stderr drain timed out")))
-        }
-        Err(error) => {
-            process_guard.kill_group();
-            stop_git(child).await;
-            disarm_if_reaped(child, process_guard);
-            Err(error)
-        }
-    }
-}
-
-async fn abort_git_operation(
-    stderr_task: Option<GitStderrDrain>,
-    child: &mut tokio::process::Child,
-    process_guard: &mut GitProcessGuard,
-    deadline: std::time::Instant,
-    operation: &str,
-) {
-    // Start termination without reaping. The stderr owner must finish while
-    // the Child still owns the process-group identity.
-    process_guard.kill_group();
-    let _ = child.start_kill();
-    // Preserve the first stderr/deadline error, but always perform the
-    // bounded child wait. A failed stderr drain must not skip reap and leave a
-    // zombie behind while the guard's Drop can only signal the process group.
-    let _stderr_result =
-        finish_git_stderr(stderr_task, child, process_guard, deadline, operation).await;
-    let _ = wait_git_until(child, deadline).await;
-    disarm_if_reaped(child, process_guard);
-}
-
 /// Two-column XY code in the porcelain v1 spelling ("M " not "M.") — the
 /// wire schema pins v1's verbatim codes.
 fn porcelain_v1_xy(xy: &str) -> String {
@@ -1791,17 +1448,6 @@ fn porcelain_v1_xy(xy: &str) -> String {
 }
 
 async fn run_git_status(scope: &Scope) -> Result<wire::WorkspaceResultBody, Refusal> {
-    run_git_status_until(
-        scope,
-        std::time::Instant::now() + std::time::Duration::from_millis(MAX_TIMEOUT_MS as u64),
-    )
-    .await
-}
-
-async fn run_git_status_until(
-    scope: &Scope,
-    deadline: std::time::Instant,
-) -> Result<wire::WorkspaceResultBody, Refusal> {
     let root = scope.existing_workdir()?;
     let mut child = git_command(
         &root,
@@ -1809,69 +1455,38 @@ async fn run_git_status_until(
     )
     .spawn()
     .map_err(|error| Refusal::failed(format!("could not run git: {error}")))?;
-    let mut process_guard = GitProcessGuard::new(&child);
     let Some(stdout) = child.stdout.take() else {
-        stop_git(&mut child).await;
-        disarm_if_reaped(&child, &mut process_guard);
         return Err(Refusal::failed("git status produced no stdout pipe"));
     };
-    let mut stderr_task = child.stderr.take().map(GitStderrDrain::start);
+    use tokio::io::AsyncReadExt as _;
+    let stderr_task = child.stderr.take().map(|stderr| {
+        tokio::spawn(async move {
+            let mut bytes = Vec::new();
+            let _ = stderr.take(64 * 1024).read_to_end(&mut bytes).await;
+            bytes
+        })
+    });
     const STATUS_MAX_BYTES: usize = 16 * 1024 * 1024;
     let mut stdout_bytes = Vec::new();
     let read_limit = STATUS_MAX_BYTES.saturating_add(1);
-    let read_result = match remaining_git_time(
-        deadline,
-        std::time::Duration::from_millis(GIT_STDOUT_DRAIN_TIMEOUT_MS),
-    ) {
-        Some(timeout) => tokio::time::timeout(
-            timeout,
-            stdout.take(read_limit as u64).read_to_end(&mut stdout_bytes),
-        )
+    stdout
+        .take(read_limit as u64)
+        .read_to_end(&mut stdout_bytes)
         .await
-        .map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::TimedOut, "git status stdout drain timed out")
-        })
-        .and_then(|result| result),
-        None => Err(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "git operation deadline exceeded",
-        )),
-    };
-    if let Err(error) = read_result {
-        abort_git_operation(
-            stderr_task.take(),
-            &mut child,
-            &mut process_guard,
-            deadline,
-            "git status",
-        )
-        .await;
-        return Err(Refusal::failed(format!("could not read git status: {error}")));
-    }
+        .map_err(|error| Refusal::failed(format!("could not read git status: {error}")))?;
     let stdout_capped = stdout_bytes.len() > STATUS_MAX_BYTES;
     if stdout_capped {
         stdout_bytes.truncate(STATUS_MAX_BYTES);
-        process_guard.kill_group();
-        let _ = child.start_kill();
+        let _ = child.kill().await;
     }
-    let stderr = finish_git_stderr(
-        stderr_task.take(),
-        &mut child,
-        &mut process_guard,
-        deadline,
-        "git status",
-    )
-    .await?;
-    // All descendant pipes are closed before the leader is reaped. No
-    // post-reap process-group signal is needed.
-    let status = match wait_git_until(&mut child, deadline).await {
-        Ok(status) => status,
-        Err(error) => {
-            disarm_if_reaped(&child, &mut process_guard);
-            return Err(error);
-        }
+    let status = child
+        .wait()
+        .await
+        .map_err(|error| Refusal::failed(format!("could not run git: {error}")))?;
+    let stderr = match stderr_task {
+        Some(task) => task.await.unwrap_or_default(),
+        None => Vec::new(),
     };
-    process_guard.disarm();
     if !status.success() {
         return Err(git_refusal("git status failed", &stderr));
     }
@@ -1964,19 +1579,6 @@ async fn run_git_diff(
     scope: &Scope,
     op: &wire::GitDiffOp,
 ) -> Result<wire::WorkspaceResultBody, Refusal> {
-    run_git_diff_until(
-        scope,
-        op,
-        std::time::Instant::now() + std::time::Duration::from_millis(MAX_TIMEOUT_MS as u64),
-    )
-    .await
-}
-
-async fn run_git_diff_until(
-    scope: &Scope,
-    op: &wire::GitDiffOp,
-    deadline: std::time::Instant,
-) -> Result<wire::WorkspaceResultBody, Refusal> {
     let root = scope.existing_workdir()?;
     let base = op.base.as_deref().unwrap_or("HEAD");
     if base.is_empty() || base.starts_with('-') {
@@ -1999,21 +1601,22 @@ async fn run_git_diff_until(
     let mut child = git_command(&root, &args)
         .spawn()
         .map_err(|error| Refusal::failed(format!("could not run git: {error}")))?;
-    let mut process_guard = GitProcessGuard::new(&child);
     // Stream stdout: the stat counts the FULL diff, but the patch buffer
     // drops whole files past DIFF_MAX_BYTES so memory and the wire stay
     // bounded even for a pathological working tree.
+    use tokio::io::AsyncBufReadExt as _;
+    use tokio::io::AsyncReadExt as _;
     let Some(stdout) = child.stdout.take() else {
-        stop_git(&mut child).await;
-        disarm_if_reaped(&child, &mut process_guard);
         return Err(Refusal::failed("git diff produced no stdout pipe"));
     };
-    // Drain stderr while stdout is consumed. A diagnostic stream can fill its
-    // OS pipe and block git before it exits. Retain only a bounded prefix for
-    // the error message, but continue reading until EOF.
-    let mut stderr_task = child.stderr.take().map(GitStderrDrain::start);
-    let mut reader = tokio::io::BufReader::new(stdout);
-    let mut line_bytes = Vec::with_capacity(GIT_DIFF_LINE_MAX_BYTES.min(8 * 1024));
+    let stderr_task = child.stderr.take().map(|stderr| {
+        tokio::spawn(async move {
+            let mut bytes = Vec::new();
+            let _ = tokio::io::AsyncReadExt::take(stderr, 64 * 1024).read_to_end(&mut bytes).await;
+            bytes
+        })
+    });
+    let mut lines = tokio::io::BufReader::new(stdout).lines();
     let mut patch = String::new();
     let mut current_file_start = 0_usize;
     let mut capped = false;
@@ -2022,53 +1625,13 @@ async fn run_git_diff_until(
     let mut additions: i64 = 0;
     let mut deletions: i64 = 0;
     loop {
-        let line = match remaining_git_time(
-            deadline,
-            std::time::Duration::from_millis(GIT_STDOUT_DRAIN_TIMEOUT_MS),
-        ) {
-            Some(timeout) => match tokio::time::timeout(
-                timeout,
-                read_bounded_git_diff_line(&mut reader, &mut line_bytes, GIT_DIFF_LINE_MAX_BYTES),
-            )
-            .await
-            {
-                Ok(result) => match result {
-                    Ok(Some(line)) => line,
-                    Ok(None) => break,
-                    Err(error) => {
-                        abort_git_operation(
-                            stderr_task.take(),
-                            &mut child,
-                            &mut process_guard,
-                            deadline,
-                            "git diff",
-                        )
-                        .await;
-                        return Err(Refusal::failed(format!("could not read git diff: {error}")));
-                    }
-                },
-                Err(_) => {
-                    abort_git_operation(
-                        stderr_task.take(),
-                        &mut child,
-                        &mut process_guard,
-                        deadline,
-                        "git diff",
-                    )
-                    .await;
-                    return Err(Refusal::failed("git diff stdout drain timed out"));
-                }
-            },
-            None => {
-                abort_git_operation(
-                    stderr_task.take(),
-                    &mut child,
-                    &mut process_guard,
-                    deadline,
-                    "git diff",
-                )
-                .await;
-                return Err(Refusal::failed("git operation deadline exceeded"));
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(error) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(Refusal::failed(format!("could not read git diff: {error}")));
             }
         };
         if line.starts_with("diff --git ") {
@@ -2094,19 +1657,14 @@ async fn run_git_diff_until(
             }
         }
     }
-    let stderr =
-        finish_git_stderr(stderr_task.take(), &mut child, &mut process_guard, deadline, "git diff")
-            .await?;
-    // All descendant pipes are closed before the leader is reaped. No
-    // post-reap process-group signal is needed.
-    let status = match wait_git_until(&mut child, deadline).await {
-        Ok(status) => status,
-        Err(error) => {
-            disarm_if_reaped(&child, &mut process_guard);
-            return Err(error);
-        }
+    let status = child
+        .wait()
+        .await
+        .map_err(|error| Refusal::failed(format!("git diff did not finish: {error}")))?;
+    let stderr = match stderr_task {
+        Some(task) => task.await.unwrap_or_default(),
+        None => Vec::new(),
     };
-    process_guard.disarm();
     if !status.success() {
         return Err(git_refusal("git diff failed", &stderr));
     }
@@ -2199,7 +1757,6 @@ pub struct Connection {
     /// outbound queue and the relay session that created it.
     requests: std::sync::Mutex<tokio::task::JoinSet<()>>,
     admission: Arc<Semaphore>,
-    request_cancel: CancellationToken,
 }
 
 impl Connection {
@@ -2212,45 +1769,11 @@ impl Connection {
             watches,
             requests: std::sync::Mutex::new(tokio::task::JoinSet::new()),
             admission: Arc::new(Semaphore::new(MAX_IN_FLIGHT_WORKSPACE_REQUESTS)),
-            request_cancel: CancellationToken::new(),
         }
     }
 
     pub fn set_local_observe(&self, observe: bool) {
         self.local_observe.store(observe, Ordering::Relaxed);
-    }
-
-    /// Cancel and await every request admitted by this socket. Git requests
-    /// own a direct child process, so dropping the JoinSet after `abort_all`
-    /// is not enough: the task must reach its async cleanup and reap the
-    /// child before the connection releases its runtime resources.
-    pub async fn shutdown(&self) -> bool {
-        self.request_cancel.cancel();
-        let mut requests = {
-            let Ok(mut guard) = self.requests.lock() else { return true };
-            std::mem::take(&mut *guard)
-        };
-        // Cancellation is cooperative: request tasks observe the token and
-        // drop their operation future, allowing GitProcessGuard to perform
-        // its kill-and-reap fallback before the JoinSet entry completes.
-        let completed = tokio::time::timeout(CONNECTION_REQUEST_SHUTDOWN_TIMEOUT, async {
-            while requests.join_next().await.is_some() {}
-        })
-        .await
-        .is_ok();
-        if completed {
-            return true;
-        }
-
-        // A non-cooperative provider task may ignore cancellation. Abort it
-        // once more and give JoinSet a short bounded reap window so ordinary
-        // Git tasks still finish their kill-and-wait path.
-        requests.abort_all();
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while requests.join_next().await.is_some() {}
-        })
-        .await
-        .is_ok()
     }
 
     /// Entry point for the three v6 server frame types. Never blocks; never
@@ -2320,7 +1843,6 @@ impl Connection {
         let runtime = Arc::clone(&self.runtime);
         let outbound = self.outbound.clone();
         let local_observe = Arc::clone(&self.local_observe);
-        let cancelled = self.request_cancel.clone();
         let permit = match self.admission.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
@@ -2331,10 +1853,7 @@ impl Connection {
         };
         let task = async move {
             let request_id = request.request_id.clone();
-            let outcome = tokio::select! {
-                _ = cancelled.cancelled() => return,
-                outcome = execute(&runtime, &local_observe, request, permit) => outcome,
-            };
+            let outcome = execute(&runtime, &local_observe, request, permit).await;
             let text = match outcome {
                 Ok(body) => ok_frame(&request_id, body),
                 Err(refusal) => error_frame(&request_id, &refusal),
@@ -2365,11 +1884,6 @@ impl Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        // Normal session teardown calls `shutdown` and awaits every request.
-        // Drop is the last-resort path for an embedding or poisoned caller:
-        // cancel first so a task that is still being polled cannot start a
-        // new Git child after this connection has lost its owner.
-        self.request_cancel.cancel();
         if let Ok(mut requests) = self.requests.lock() {
             requests.abort_all();
         }
@@ -2423,8 +1937,7 @@ async fn execute(
     // the timeout an honest response-time diagnostic and preserves operation
     // ordering and permit ownership.
     let started = std::time::Instant::now();
-    let deadline = started + std::time::Duration::from_millis(timeout_ms as u64);
-    let outcome = run_op(runtime, request, permit, deadline).await;
+    let outcome = run_op(runtime, request, permit).await;
     if started.elapsed() > std::time::Duration::from_millis(timeout_ms.unsigned_abs()) {
         Err(Refusal::new(
             wire::WorkspaceErrorCode::Timeout,
@@ -2439,7 +1952,6 @@ async fn run_op(
     runtime: &Arc<SharedRuntime>,
     request: wire::RelayWorkspaceRequest,
     permit: OwnedSemaphorePermit,
-    deadline: std::time::Instant,
 ) -> Result<wire::WorkspaceResultBody, Refusal> {
     let scope = Scope::build(request.allowed_roots.as_deref(), runtime.local_roots.as_deref())?;
     match request.op {
@@ -2449,8 +1961,8 @@ async fn run_op(
         wire::WorkspaceOp::FsRename(op) => blocking(move || run_rename(&scope, &op), permit).await,
         wire::WorkspaceOp::FsDelete(op) => blocking(move || run_delete(&scope, &op), permit).await,
         wire::WorkspaceOp::FsSearch(op) => blocking(move || run_search(&scope, &op), permit).await,
-        wire::WorkspaceOp::GitStatus(_) => run_git_status_until(&scope, deadline).await,
-        wire::WorkspaceOp::GitDiff(op) => run_git_diff_until(&scope, &op, deadline).await,
+        wire::WorkspaceOp::GitStatus(_) => run_git_status(&scope).await,
+        wire::WorkspaceOp::GitDiff(op) => run_git_diff(&scope, &op).await,
         wire::WorkspaceOp::PreviewOpen(op) => runtime.preview.open(op.target_port).await,
         wire::WorkspaceOp::PreviewConsoleTail(op) => runtime.preview.tail(op.max_events),
     }
@@ -2977,177 +2489,6 @@ mod tests {
         assert!(!env.contains_key("OPENAI_API_KEY"));
         assert!(!env.contains_key("GIT_CONFIG"));
         assert!(!env.contains_key("GIT_EXTERNAL_DIFF"));
-    }
-
-    #[tokio::test]
-    async fn bounded_git_diff_line_rejects_oversized_input_before_appending_it() {
-        let mut reader =
-            tokio::io::BufReader::with_capacity(2, std::io::Cursor::new(b"123456789\n"));
-        let mut line = Vec::new();
-        let error = read_bounded_git_diff_line(&mut reader, &mut line, 8)
-            .await
-            .expect_err("oversized diff line");
-
-        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
-        assert!(line.len() <= 8, "reader appended bytes past its limit");
-    }
-
-    #[tokio::test]
-    async fn git_diff_stderr_drain_bounds_inherited_descriptor_wait() {
-        use tokio::io::AsyncWriteExt as _;
-
-        let (mut writer, reader) = tokio::io::duplex(64);
-        writer.write_all(b"diagnostic").await.expect("stderr write");
-        let drain = GitStderrDrain::start(reader);
-        let retained = tokio::time::timeout(
-            std::time::Duration::from_millis(GIT_STDERR_DRAIN_TIMEOUT_MS + 100),
-            drain.finish(),
-        )
-        .await
-        .expect("inherited stderr descriptor must not block git diff")
-        .expect("stderr drain");
-
-        // The duplex writer remains open to model a descriptor inherited by a
-        // helper process. The drain must return at its bound, with complete
-        // false, instead of waiting forever for EOF.
-        assert!(!retained.complete);
-        assert_eq!(retained.bytes, b"diagnostic");
-    }
-
-    #[tokio::test]
-    async fn git_stderr_drain_continues_after_retention_cap() {
-        use tokio::io::AsyncWriteExt as _;
-
-        let (mut writer, reader) = tokio::io::duplex(1024);
-        let payload = vec![b'x'; GIT_STDERR_MAX_BYTES * 2];
-        let writer_task = tokio::spawn(async move {
-            writer.write_all(&payload).await.expect("stderr payload");
-        });
-        let retained = GitStderrDrain::start(reader).finish().await.expect("stderr drain");
-        writer_task.await.expect("stderr writer");
-
-        assert!(retained.complete);
-        assert_eq!(retained.bytes.len(), GIT_STDERR_MAX_BYTES);
-        assert!(retained.bytes.iter().all(|byte| *byte == b'x'));
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn git_process_is_reaped_after_group_termination() {
-        let root = scratch("git-process-reap");
-        let mut child = git_command(&root, &["status"]).spawn().expect("git spawn");
-        let pid = child.id().expect("running git child");
-        // `setpgid(0, 0)` in git_command makes the group id equal to the
-        // direct child id, so helpers can be terminated with one signal.
-        let group = unsafe { libc::getpgid(pid as libc::pid_t) };
-        assert_eq!(group, pid as libc::pid_t);
-
-        stop_git(&mut child).await;
-        assert!(child.id().is_none(), "stop_git must await Child::wait");
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn git_wait_timeout_reaps_child_after_pipes_close() {
-        let mut child = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg("exec 1>&- 2>&-; sleep 30")
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("shell child");
-        let result = wait_git_with_timeout(&mut child, std::time::Duration::from_millis(50)).await;
-        assert!(result.is_err(), "a child that closes pipes must still hit the wait deadline");
-        assert!(child.id().is_none(), "the timeout path must reap the direct child");
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn git_abort_reaps_child_when_stderr_reader_fails() {
-        use std::task::{Context, Poll};
-        use tokio::io::{AsyncRead, ReadBuf};
-
-        struct FailingReader;
-        impl AsyncRead for FailingReader {
-            fn poll_read(
-                self: std::pin::Pin<&mut Self>,
-                _cx: &mut Context<'_>,
-                _buffer: &mut ReadBuf<'_>,
-            ) -> Poll<std::io::Result<()>> {
-                Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "synthetic stderr failure",
-                )))
-            }
-        }
-
-        let root = scratch("git-abort-stderr-error");
-        let mut child = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30")
-            .kill_on_drop(true)
-            .spawn()
-            .expect("shell child");
-        let mut guard = GitProcessGuard::new(&child);
-        let drain = GitStderrDrain::start(FailingReader);
-        abort_git_operation(
-            Some(drain),
-            &mut child,
-            &mut guard,
-            std::time::Instant::now() + std::time::Duration::from_secs(1),
-            "git",
-        )
-        .await;
-        assert!(child.id().is_none(), "stderr failure must still reap the child");
-        let _ = root;
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn git_abort_reaps_child_when_stderr_deadline_expires() {
-        let root = scratch("git-abort-stderr-timeout");
-        let mut child = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30")
-            .kill_on_drop(true)
-            .spawn()
-            .expect("shell child");
-        let (_writer, reader) = tokio::io::duplex(64);
-        let mut guard = GitProcessGuard::new(&child);
-        let drain = GitStderrDrain::start(reader);
-        // Keep the writer alive so the drain cannot observe EOF before the
-        // operation deadline. The abort path must kill and reap regardless.
-        abort_git_operation(
-            Some(drain),
-            &mut child,
-            &mut guard,
-            std::time::Instant::now() + std::time::Duration::from_millis(1),
-            "git",
-        )
-        .await;
-        assert!(child.id().is_none(), "stderr timeout must still reap the child");
-        let _ = root;
-    }
-
-    #[tokio::test]
-    async fn git_diff_refuses_an_expired_operation_deadline() {
-        let (root, scope) = seeded_repo("git-diff-expired-deadline");
-        let result = run_git_diff_until(
-            &scope,
-            &wire::GitDiffOp {
-                op: wire::TagGitDiff::GitDiff,
-                base: None,
-                paths: None,
-                context_lines: None,
-            },
-            std::time::Instant::now() - std::time::Duration::from_millis(1),
-        )
-        .await;
-        let refusal = result.expect_err("expired deadline");
-        assert_eq!(refusal.code, wire::WorkspaceErrorCode::Failed);
-        assert!(refusal.message.contains("deadline"));
-        let _ = root;
     }
 
     fn seeded_repo(name: &str) -> (PathBuf, Scope) {


### PR DESCRIPTION
cmux main's `chatmux-relay` crate stopped compiling after the #10708 aggregate merged (16 errors): its integration merge `cf791f4ee9` resolved `pty.rs` to a mangled state, and its lineage calls methods that were never committed anywhere (`try_critical_value_with_pending`). This broke every `cmux-relay-v*` release build and blocked rc.2 of the Rust relay cutover.

## What happened in this PR
1. First two commits: precise compile repairs (merge-tree-verified pty.rs restoration + the missing callee + receiver/borrow/Send fixes). They took the crate from 16 errors to compiling — and then **14 of the rework's own tests failed**. Since the rework never compiled anywhere, those tests have never run green: this is unfinished logic mid-flight, not a regression to fix forward.
2. Final commit: **revert the crate** to `a66ad80bd042` — byte-identical to the crate at `d7b59bab2b8f`, which is (a) the commit the rc.1 attested platform binaries were built from, and (b) the last state that passed the hosted focused `chatmux_relay` gate (run 32836512996).

Everything outside the crate from #10708 and the release-lane rework stays. The reverted series remains intact in #10708's history and the author's tree for a complete, gated re-landing.

## Verification
Hosted focused `chatmux_relay` dispatch at the pushed HEAD; merge on pass. The relay release lane's rc.3 tags after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Relay protocol version is now advertised as v6.
  - Removed support for legacy PTY operational-error codes and related negotiation.

- **Bug Fixes**
  - Improved PTY claim, resize, queue ordering, and failed-close handling.
  - Improved cleanup for process, pipe, workspace, and watch operations.
  - Corrected busy responses for saturated terminal and surface-list requests.

- **User Experience**
  - Simplified command-line error messages.
  - Updated autostart behavior and executable naming across platforms.

- **Documentation**
  - Updated relay protocol documentation and supported feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->