### PR TITLE
Guard against web-code/DB schema drift (Aug 24/25 outage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Web code auto-deploys on merge while DB migrations are dispatched
+      # separately, so destructive SQL needs an explicit deploy/migrate
+      # ordering plan (acknowledged in the .sql file). See the Aug 24/25 2026
+      # schema-drift outage.
+      - name: Lint migrations for additive SQL
+        run: bun scripts/lint-migrations-additive.ts
+
       - name: Apply migrations
         env:
           DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test

--- a/.github/workflows/cloud-vm-migrate-auto.yml
+++ b/.github/workflows/cloud-vm-migrate-auto.yml
@@ -1,0 +1,94 @@
+name: Cloud VM DB migration auto-dispatch
+
+# Web code auto-deploys to Vercel when a PR merges to main, but Cloud VM
+# database migrations only run when someone dispatches cloud-vm-migrate.yml.
+# On Aug 24/25 2026 that gap broke production: three additive migrations had
+# merged, the deployed code queried the new columns, and account deletion
+# failed with VmDatabaseError until the migration was finally dispatched.
+#
+# This workflow closes the gap: any push to main that touches migrations
+# dispatches a staging migration, waits for it, then dispatches a production
+# migration. The production run still pauses on the cloud-vm-production
+# environment approval; the point is that the run now exists and waits for a
+# reviewer instead of relying on somebody remembering to dispatch it.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - web/db/migrations/**
+
+run-name: "Auto-dispatch Cloud VM migrations for ${{ github.sha }}"
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: cloud-vm-migrate-auto
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 45
+    steps:
+      - name: Dispatch staging migration
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Buffer for clock skew between this runner and GitHub's run
+          # timestamps; the newest-first pick below tolerates the overlap.
+          dispatched_after="$(date -u -d '60 seconds ago' '+%Y-%m-%dT%H:%M:%S+00:00')"
+          echo "DISPATCHED_AFTER=$dispatched_after" >> "$GITHUB_ENV"
+          gh workflow run cloud-vm-migrate.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f target=staging
+
+      - name: Wait for the staging migration to succeed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # gh workflow run does not return a run id (see reload-build.yml);
+          # cloud-vm-migrate.yml takes no nonce input, so match the newest
+          # dispatch-event run created after our dispatch instant.
+          run_id=""
+          for _ in $(seq 1 24); do
+            sleep 5
+            run_id="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow cloud-vm-migrate.yml \
+              --event workflow_dispatch \
+              --branch main \
+              --created ">=$DISPATCHED_AFTER" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')"
+            if [ -n "$run_id" ]; then
+              break
+            fi
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::Dispatched a staging cloud-vm-migrate run but could not find it; dispatch target=staging and target=production manually."
+            exit 1
+          fi
+          echo "Watching staging migration run $run_id"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status
+
+      # The production run re-applies staging first (that is how
+      # cloud-vm-migrate.yml sequences target=production), then waits on the
+      # cloud-vm-production environment approval before touching production.
+      - name: Dispatch production migration (pauses for approval)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run cloud-vm-migrate.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f target=production
+          echo "Production migration dispatched; it waits on the cloud-vm-production environment approval." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cloud-vm-schema-parity.yml
+++ b/.github/workflows/cloud-vm-schema-parity.yml
@@ -1,0 +1,46 @@
+name: Cloud VM schema parity
+
+# Daily drift alert for the gap that broke production on Aug 24/25 2026: web
+# code auto-deploys on merge while database migrations are applied manually,
+# so deployed code can query columns whose migrations were never applied.
+# /api/health/schema-parity compares the migrations bundled in the deployed
+# code with the drizzle.__drizzle_migrations table and reports "behind" when
+# the database lags. This run fails loudly in that case.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 8 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    steps:
+      - name: Check production schema parity
+        run: |
+          set -euo pipefail
+          url="https://cmux.com/api/health/schema-parity"
+          if ! body="$(curl -sS --max-time 30 --retry 3 "$url")"; then
+            echo "::error::$url is unreachable; cannot verify schema parity."
+            exit 1
+          fi
+          echo "$body"
+          status="$(printf '%s' "$body" | jq -r '.status // "invalid"')"
+          case "$status" in
+            ok|ahead)
+              echo "Schema parity: $status (codeHead=$(printf '%s' "$body" | jq -r '.codeHead'), dbHead=$(printf '%s' "$body" | jq -r '.dbHead'))"
+              ;;
+            behind)
+              pending="$(printf '%s' "$body" | jq -r '.pending | join(", ")')"
+              echo "::error::Production database schema is BEHIND the deployed code. Pending migrations: $pending. Approve the waiting cloud-vm-migrate production run, or dispatch cloud-vm-migrate.yml with target=production."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected schema-parity response (status=$status); treat as drift until proven otherwise."
+              exit 1
+              ;;
+          esac

--- a/web/app/api/health/schema-parity/route.ts
+++ b/web/app/api/health/schema-parity/route.ts
@@ -1,0 +1,39 @@
+import {
+  listBundledMigrations,
+  schemaParityReport,
+  type SchemaParityReport,
+} from "../../../../services/health/schemaParity";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+
+/**
+ * Public, unauthenticated drift check between the migrations bundled in the
+ * deployed code and the migrations applied to the Cloud VM database. Web code
+ * auto-deploys on merge while database migrations are applied through the
+ * cloud-vm-migrate workflow, so the two can drift (Aug 24/25 2026: deployed
+ * code queried columns whose migrations were merged but not applied, and
+ * account deletion failed with VmDatabaseError until the migration ran).
+ *
+ * 200 {"status":"ok"|"ahead",...} when the database is not lagging the code;
+ * 503 {"status":"behind","pending":[...]} when applied migrations lag;
+ * 503 {"status":"unavailable"} when the database cannot be queried (codeHead
+ * is still reported when the bundled migrations are readable, so deployments
+ * without a database, e.g. previews, still prove the route and file tracing
+ * work). The body only ever contains migration names, never connection or
+ * error details.
+ */
+export async function GET(): Promise<Response> {
+  let report: SchemaParityReport;
+  try {
+    report = await schemaParityReport();
+  } catch (error) {
+    console.error("schema-parity health check failed", error);
+    let codeHead: string | null = null;
+    try {
+      codeHead = listBundledMigrations().at(-1) ?? null;
+    } catch {
+      // The migrations folder is missing from the serverless bundle.
+    }
+    return jsonResponse({ status: "unavailable", codeHead }, 503);
+  }
+  return jsonResponse(report, report.status === "behind" ? 503 : 200);
+}

--- a/web/app/api/health/schema-parity/route.ts
+++ b/web/app/api/health/schema-parity/route.ts
@@ -1,9 +1,5 @@
-import {
-  listBundledMigrations,
-  schemaParityReport,
-  type SchemaParityReport,
-} from "../../../../services/health/schemaParity";
-import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import { connection } from "next/server";
+import { schemaParityResponse } from "../../../../services/health/schemaParity";
 
 /**
  * Public, unauthenticated drift check between the migrations bundled in the
@@ -15,25 +11,13 @@ import { jsonResponse } from "../../../../services/vms/routeHelpers";
  *
  * 200 {"status":"ok"|"ahead",...} when the database is not lagging the code;
  * 503 {"status":"behind","pending":[...]} when applied migrations lag;
- * 503 {"status":"unavailable"} when the database cannot be queried (codeHead
- * is still reported when the bundled migrations are readable, so deployments
- * without a database, e.g. previews, still prove the route and file tracing
- * work). The body only ever contains migration names, never connection or
- * error details.
+ * 503 {"status":"unavailable"} when the database cannot be queried. The body
+ * only ever contains migration names, never connection or error details.
  */
 export async function GET(): Promise<Response> {
-  let report: SchemaParityReport;
-  try {
-    report = await schemaParityReport();
-  } catch (error) {
-    console.error("schema-parity health check failed", error);
-    let codeHead: string | null = null;
-    try {
-      codeHead = listBundledMigrations().at(-1) ?? null;
-    } catch {
-      // The migrations folder is missing from the serverless bundle.
-    }
-    return jsonResponse({ status: "unavailable", codeHead }, 503);
-  }
-  return jsonResponse(report, report.status === "behind" ? 503 : 200);
+  // Cache Components is enabled, so a GET handler can be prerendered at build
+  // time (`export const dynamic` no longer exists). Parity must be measured
+  // per request, never baked into the build.
+  await connection();
+  return schemaParityResponse();
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -177,6 +177,9 @@ const nextConfig: NextConfig = {
       "./public/logo.png",
     ],
     "**/browser-opengraph-image": ["./public/logo.png"],
+    // The schema-parity health route reads bundled migration names (and, for
+    // legacy rows, sql hashes) from the migrations folder at request time.
+    "**/api/health/schema-parity": ["./db/migrations/*/migration.sql"],
   },
   images: {
     // AVIF first: for the detailed hero screenshot (crisp terminal text +

--- a/web/scripts/lint-migrations-additive.ts
+++ b/web/scripts/lint-migrations-additive.ts
@@ -1,0 +1,321 @@
+/**
+ * Classifies Cloud VM migrations (web/db/migrations/<name>/migration.sql) as
+ * additive or destructive, and fails CI for destructive migrations that are
+ * not explicitly acknowledged.
+ *
+ * Web code auto-deploys to Vercel on merge, while database migrations are
+ * applied separately through the cloud-vm-migrate workflow. During that
+ * window the OLD schema serves NEW code and, after the migration, the NEW
+ * schema can serve OLD code. Additive statements (new tables, nullable or
+ * defaulted columns, new indexes, new enum values) are safe in both
+ * directions; destructive ones (DROP, type changes, NOT NULL on existing
+ * columns, renames, data backfills) are not, so they need a human to plan the
+ * deploy/migrate ordering.
+ *
+ * A destructive migration is acknowledged in the migration file itself with:
+ *
+ *   -- cmux:allow-destructive: <why this is safe to apply>
+ *
+ * which downgrades the failure to a warning. Unrecognized statements fail
+ * closed as destructive.
+ *
+ * Usage: bun scripts/lint-migrations-additive.ts [--all]
+ *   --all lints every migration, ignoring the LINT_BASELINE grandfather cut.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Migrations up to and including this name predate the linter and are
+ * grandfathered; editing an applied migration's sql would change its drizzle
+ * hash, so they must stay byte-identical. Only names sorting after this are
+ * linted.
+ */
+export const LINT_BASELINE = "20260824010000_cloud_vm_preview_leases";
+
+export const ALLOW_DESTRUCTIVE_MARKER = "cmux:allow-destructive:";
+
+export type Finding = {
+  readonly statement: string;
+  readonly reason: string;
+};
+
+/** Strips comments and splits on top-level semicolons, respecting single
+ * quotes, double quotes, and (tagged) dollar quoting, so DO $$..$$ bodies and
+ * string literals never split or hide statements. */
+export function splitSqlStatements(sqlText: string): string[] {
+  const text = sqlText.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+  const statements: string[] = [];
+  let current = "";
+  let index = 0;
+
+  while (index < text.length) {
+    const rest = text.slice(index);
+
+    // Line comment (includes drizzle's `--> statement-breakpoint`).
+    if (rest.startsWith("--")) {
+      const end = text.indexOf("\n", index);
+      index = end === -1 ? text.length : end + 1;
+      current += " ";
+      continue;
+    }
+    // Block comment; PostgreSQL block comments nest.
+    if (rest.startsWith("/*")) {
+      let depth = 1;
+      let scan = index + 2;
+      while (scan < text.length && depth > 0) {
+        if (text.startsWith("/*", scan)) {
+          depth += 1;
+          scan += 2;
+        } else if (text.startsWith("*/", scan)) {
+          depth -= 1;
+          scan += 2;
+        } else {
+          scan += 1;
+        }
+      }
+      index = scan;
+      current += " ";
+      continue;
+    }
+    // Single-quoted literal ('' escapes a quote).
+    if (text[index] === "'") {
+      let scan = index + 1;
+      while (scan < text.length) {
+        if (text[scan] === "'" && text[scan + 1] === "'") {
+          scan += 2;
+        } else if (text[scan] === "'") {
+          scan += 1;
+          break;
+        } else {
+          scan += 1;
+        }
+      }
+      current += text.slice(index, scan);
+      index = scan;
+      continue;
+    }
+    // Double-quoted identifier.
+    if (text[index] === '"') {
+      let scan = index + 1;
+      while (scan < text.length && text[scan] !== '"') scan += 1;
+      scan = Math.min(scan + 1, text.length);
+      current += text.slice(index, scan);
+      index = scan;
+      continue;
+    }
+    // Dollar quoting: $$ ... $$ or $tag$ ... $tag$.
+    if (text[index] === "$") {
+      const tagMatch = /^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/.exec(rest);
+      if (tagMatch) {
+        const tag = tagMatch[0];
+        const close = text.indexOf(tag, index + tag.length);
+        const end = close === -1 ? text.length : close + tag.length;
+        current += text.slice(index, end);
+        index = end;
+        continue;
+      }
+    }
+    if (text[index] === ";") {
+      statements.push(current);
+      current = "";
+      index += 1;
+      continue;
+    }
+    current += text[index];
+    index += 1;
+  }
+  statements.push(current);
+
+  return statements.map((statement) => statement.trim()).filter((statement) => statement.length > 0);
+}
+
+function normalize(statement: string): string {
+  return statement.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/** Splits the action list of an ALTER TABLE statement on top-level commas
+ * (commas inside parens, e.g. numeric(10,2) or default exprs, do not split). */
+function splitAlterTableActions(actions: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const char of actions) {
+    if (char === "(") depth += 1;
+    if (char === ")") depth -= 1;
+    if (char === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+function classifyAlterTableAction(rawAction: string): string | null {
+  // Blank out string literals so e.g. DEFAULT 'not null' cannot confuse the
+  // keyword checks below.
+  const action = rawAction.replace(/'(?:[^']|'')*'/g, "''");
+  if (/^add (constraint|check|unique|primary key|foreign key|exclude)\b/.test(action)) {
+    if (/\bnot valid\b/.test(action)) return null;
+    return "adds a constraint that validates existing rows and takes locks; use ADD CONSTRAINT ... NOT VALID plus a later VALIDATE CONSTRAINT";
+  }
+  // ADD [COLUMN] name type ... (the COLUMN keyword is optional in PostgreSQL).
+  if (/^add\b/.test(action)) {
+    const addsNotNull = /\bnot null\b/.test(action);
+    const hasDefault = /\bdefault\b/.test(action);
+    const isIdentity = /\bgenerated (always|by default) as identity\b/.test(action);
+    if (addsNotNull && !hasDefault && !isIdentity) {
+      return "adds a NOT NULL column without a DEFAULT; this fails on non-empty tables and breaks inserts from already-deployed code";
+    }
+    return null;
+  }
+  if (/^validate constraint\b/.test(action)) return null;
+  if (/^alter column\b/.test(action)) {
+    if (/\bset default\b/.test(action)) return null;
+    if (/\bdrop not null\b/.test(action)) return null;
+    if (/\bset not null\b/.test(action)) {
+      return "sets NOT NULL on an existing column; already-deployed code may still write NULLs and the table scan can fail";
+    }
+    if (/\b(set data )?type\b/.test(action)) {
+      return "changes a column type; this can rewrite/lock the table and break already-deployed readers";
+    }
+    return "unrecognized ALTER COLUMN action (fail closed)";
+  }
+  if (/^drop\b/.test(action)) {
+    return "drops a column/constraint that already-deployed code may still use";
+  }
+  if (/^rename\b/.test(action)) {
+    return "renames a table/column out from under already-deployed code";
+  }
+  if (/^(enable|disable|force|no force) (trigger|row level security|rule)\b/.test(action)) {
+    return "changes enforcement (trigger/RLS) semantics for already-deployed code";
+  }
+  return "unrecognized ALTER TABLE action (fail closed)";
+}
+
+/** Returns null when the statement is additive, or a reason when it is not. */
+export function classifyStatement(statement: string): string | null {
+  const s = normalize(statement);
+
+  if (/^create table\b/.test(s)) return null;
+  if (/^create( unique)? index\b/.test(s)) return null;
+  if (/^create type\b/.test(s)) return null;
+  if (/^create (sequence|extension|schema|collation)\b/.test(s)) return null;
+  if (/^create (function|procedure|trigger|view|materialized view|policy)\b/.test(s)) return null;
+  if (/^create or replace\b/.test(s)) {
+    return "CREATE OR REPLACE overwrites an existing object that already-deployed code may depend on";
+  }
+  if (/^alter type\b/.test(s)) {
+    if (/\badd value\b/.test(s)) return null;
+    return "ALTER TYPE beyond ADD VALUE (rename/drop) breaks already-deployed readers";
+  }
+  if (/^alter table\b/.test(s)) {
+    const match = /^alter table (if exists )?(only )?("[^"]+"|[a-z0-9_.]+)( \*)? (.*)$/.exec(s);
+    if (!match) return "unparseable ALTER TABLE statement (fail closed)";
+    const reasons = splitAlterTableActions(match[5]!)
+      .map((action) => classifyAlterTableAction(action))
+      .filter((reason): reason is string => reason !== null);
+    return reasons.length > 0 ? reasons.join("; ") : null;
+  }
+  if (/^comment on\b/.test(s)) return null;
+  if (/^set\b/.test(s)) return null; // session-local settings, e.g. statement_timeout
+
+  if (/^drop\b/.test(s)) return "DROP removes an object that already-deployed code may still use";
+  if (/^truncate\b/.test(s)) return "TRUNCATE deletes data";
+  if (/^(update|delete|merge)\b/.test(s)) return "data backfill (UPDATE/DELETE/MERGE) needs an explicit deploy/migrate ordering plan";
+  if (/^insert\b/.test(s)) return "data seeding/backfill (INSERT) needs an explicit deploy/migrate ordering plan";
+  if (/^with\b/.test(s)) return "CTE data backfill needs an explicit deploy/migrate ordering plan";
+  if (/^do\b/.test(s)) return "opaque procedural DO block cannot be verified as additive (fail closed)";
+  if (/^(grant|revoke|reassign)\b/.test(s)) return "permission change can revoke access already-deployed code relies on";
+  if (/^(lock|cluster|reindex|vacuum)\b/.test(s)) return "lock-heavy maintenance statement in a migration (fail closed)";
+
+  return "unrecognized statement (fail closed)";
+}
+
+export function classifyMigrationSql(sqlText: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const statement of splitSqlStatements(sqlText)) {
+    const reason = classifyStatement(statement);
+    if (reason !== null) {
+      const summary = statement.replace(/\s+/g, " ").trim();
+      findings.push({
+        statement: summary.length > 120 ? `${summary.slice(0, 117)}...` : summary,
+        reason,
+      });
+    }
+  }
+  return findings;
+}
+
+/** The justification following the allow-destructive marker, if present. */
+export function destructiveApproval(sqlText: string): string | null {
+  // [^\S\n] = horizontal whitespace only, so the justification must sit on
+  // the marker's own line.
+  const match = new RegExp(`^\\s*--[^\\S\\n]*${ALLOW_DESTRUCTIVE_MARKER}[^\\S\\n]*(\\S.*)$`, "m").exec(sqlText);
+  return match ? match[1]!.trim() : null;
+}
+
+export type MigrationLintResult = {
+  readonly name: string;
+  readonly findings: readonly Finding[];
+  readonly approval: string | null;
+};
+
+export function lintMigrationsDirectory(
+  migrationsDir: string,
+  options: { readonly all?: boolean } = {},
+): MigrationLintResult[] {
+  const names = readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(migrationsDir, entry.name, "migration.sql")))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b))
+    .filter((name) => options.all || name.localeCompare(LINT_BASELINE) > 0);
+
+  return names.map((name) => {
+    const sqlText = readFileSync(join(migrationsDir, name, "migration.sql"), "utf8");
+    return { name, findings: classifyMigrationSql(sqlText), approval: destructiveApproval(sqlText) };
+  });
+}
+
+function main(): number {
+  const all = process.argv.includes("--all");
+  const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "db", "migrations");
+  const results = lintMigrationsDirectory(migrationsDir, { all });
+
+  let failures = 0;
+  for (const result of results) {
+    const file = `web/db/migrations/${result.name}/migration.sql`;
+    if (result.findings.length === 0) {
+      console.log(`additive     ${result.name}`);
+      continue;
+    }
+    const kind = result.approval ? "warning" : "error";
+    for (const finding of result.findings) {
+      console.log(`::${kind} file=${file}::${result.name}: ${finding.reason} [${finding.statement}]`);
+    }
+    if (result.approval) {
+      console.log(`destructive  ${result.name} (acknowledged: ${result.approval})`);
+    } else {
+      console.log(`destructive  ${result.name} (NOT acknowledged)`);
+      failures += 1;
+    }
+  }
+
+  console.log(`\n${results.length} migration(s) linted after baseline ${all ? "(--all)" : LINT_BASELINE}, ${failures} unacknowledged destructive`);
+  if (failures > 0) {
+    console.log(
+      `\nDestructive migrations need a deploy/migrate ordering plan. If this migration is safe, acknowledge it inside the .sql file:\n  -- ${ALLOW_DESTRUCTIVE_MARKER} <why this is safe>`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/web/services/health/schemaParity.ts
+++ b/web/services/health/schemaParity.ts
@@ -1,0 +1,187 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { sql } from "drizzle-orm";
+import { cloudDb } from "../../db/client";
+
+/**
+ * Schema parity: compares the migrations bundled with the deployed code
+ * (web/db/migrations/<name>/migration.sql) against the migrations recorded as
+ * applied in the database.
+ *
+ * drizzle-orm's node-postgres migrator (used by scripts/migrate-aws-rds-iam.ts
+ * and scripts/cloud-vm/migrate-vercel-aurora-iam.mjs) records applied
+ * migrations in "drizzle"."__drizzle_migrations"
+ * (id, hash, created_at bigint millis, name, applied_at). Pending migrations
+ * are folder names absent from that table's "name" column; legacy rows written
+ * before the "name" column existed are matched by folder-timestamp millis,
+ * then by sql hash, mirroring drizzle's own upgrade matching.
+ */
+
+export const DRIZZLE_MIGRATIONS_SCHEMA = "drizzle";
+export const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
+
+export type AppliedMigrationRow = {
+  readonly name: string | null;
+  readonly hash: string | null;
+  readonly createdAt: string | number | bigint | null;
+};
+
+export type SchemaParityStatus = "ok" | "ahead" | "behind";
+
+export type SchemaParityReport = {
+  /** ok = heads equal; ahead = db has migrations this build does not know
+   * about (normal migrate-then-deploy window); behind = db lags the code. */
+  readonly status: SchemaParityStatus;
+  readonly codeHead: string | null;
+  readonly dbHead: string | null;
+  /** Bundled migration names not yet applied to the database, oldest first. */
+  readonly pending: readonly string[];
+};
+
+export function defaultMigrationsDir(): string {
+  // Same convention as app/lib/open-graph-image.tsx: runtime files resolved
+  // from the web project root and pinned into the serverless bundle via
+  // outputFileTracingIncludes in next.config.ts.
+  return join(process.cwd(), "db", "migrations");
+}
+
+/** Migration folder names bundled with this build, sorted oldest first. */
+export function listBundledMigrations(dir: string = defaultMigrationsDir()): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(dir, entry.name, "migration.sql")))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/** sha256 of each bundled migration.sql, keyed by folder name (drizzle's hash). */
+export function bundledMigrationHashes(
+  names: readonly string[],
+  dir: string = defaultMigrationsDir(),
+): Map<string, string> {
+  const hashes = new Map<string, string>();
+  for (const name of names) {
+    const contents = readFileSync(join(dir, name, "migration.sql"), "utf8");
+    hashes.set(name, createHash("sha256").update(contents).digest("hex"));
+  }
+  return hashes;
+}
+
+/** UTC millis encoded in a migration folder's 14-digit timestamp prefix. */
+export function migrationFolderMillis(name: string): number | null {
+  const stamp = name.slice(0, 14);
+  if (!/^\d{14}$/.test(stamp)) return null;
+  return Date.UTC(
+    Number(stamp.slice(0, 4)),
+    Number(stamp.slice(4, 6)) - 1,
+    Number(stamp.slice(6, 8)),
+    Number(stamp.slice(8, 10)),
+    Number(stamp.slice(10, 12)),
+    Number(stamp.slice(12, 14)),
+  );
+}
+
+/** created_at truncated to whole seconds, as drizzle's upgrade matcher does. */
+function rowMillis(createdAt: AppliedMigrationRow["createdAt"]): number | null {
+  if (createdAt === null || createdAt === undefined) return null;
+  const stringified = String(createdAt);
+  if (!/^\d+$/.test(stringified) || stringified.length <= 3) return null;
+  return Number(stringified.substring(0, stringified.length - 3) + "000");
+}
+
+export function compareSchemaParity(
+  codeMigrations: readonly string[],
+  appliedRows: readonly AppliedMigrationRow[],
+  hashByName?: ReadonlyMap<string, string>,
+): SchemaParityReport {
+  const code = [...codeMigrations].sort((a, b) => a.localeCompare(b));
+
+  const byMillis = new Map<number, string[]>();
+  for (const name of code) {
+    const millis = migrationFolderMillis(name);
+    if (millis === null) continue;
+    const bucket = byMillis.get(millis);
+    if (bucket) bucket.push(name);
+    else byMillis.set(millis, [name]);
+  }
+  const byHash = new Map<string, string>();
+  if (hashByName) {
+    for (const [name, hash] of hashByName) byHash.set(hash, name);
+  }
+
+  const applied = new Set<string>();
+  for (const row of appliedRows) {
+    if (row.name) {
+      applied.add(row.name);
+      continue;
+    }
+    // Legacy row from before drizzle recorded names: resolve like drizzle's
+    // migrations-table upgrade does (folder millis, then hash on collision).
+    const millis = rowMillis(row.createdAt);
+    const candidates = millis === null ? undefined : byMillis.get(millis);
+    if (candidates?.length === 1) {
+      applied.add(candidates[0]!);
+    } else {
+      const matched = row.hash ? byHash.get(row.hash) : undefined;
+      if (matched) applied.add(matched);
+    }
+  }
+
+  const pending = code.filter((name) => !applied.has(name));
+  const codeSet = new Set(code);
+  const dbOnly = [...applied].filter((name) => !codeSet.has(name));
+  const dbHead = applied.size > 0 ? [...applied].sort((a, b) => a.localeCompare(b)).at(-1)! : null;
+
+  return {
+    status: pending.length > 0 ? "behind" : dbOnly.length > 0 ? "ahead" : "ok",
+    codeHead: code.at(-1) ?? null,
+    dbHead,
+    pending,
+  };
+}
+
+function isMissingMigrationsTable(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (typeof current === "object" && "code" in current && (current as { code?: unknown }).code === "42P01") {
+      return true;
+    }
+    current = typeof current === "object" && current !== null && "cause" in current
+      ? (current as { cause?: unknown }).cause
+      : undefined;
+  }
+  return false;
+}
+
+async function appliedMigrations(): Promise<AppliedMigrationRow[]> {
+  try {
+    const result = await cloudDb().execute(sql`
+      select "name", "hash", "created_at" as "createdAt"
+      from ${sql.identifier(DRIZZLE_MIGRATIONS_SCHEMA)}.${sql.identifier(DRIZZLE_MIGRATIONS_TABLE)}
+    `);
+    return databaseRows(result).map((row) => ({
+      name: typeof row.name === "string" ? row.name : null,
+      hash: typeof row.hash === "string" ? row.hash : null,
+      createdAt: (row.createdAt ?? null) as AppliedMigrationRow["createdAt"],
+    }));
+  } catch (error) {
+    // A database that was never migrated has no drizzle bookkeeping table;
+    // report every bundled migration as pending instead of erroring.
+    if (isMissingMigrationsTable(error)) return [];
+    throw error;
+  }
+}
+
+function databaseRows(result: unknown): readonly Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as readonly Record<string, unknown>[];
+  const rows = (result as { readonly rows?: unknown } | null)?.rows;
+  return Array.isArray(rows) ? (rows as readonly Record<string, unknown>[]) : [];
+}
+
+export async function schemaParityReport(): Promise<SchemaParityReport> {
+  const code = listBundledMigrations();
+  const rows = await appliedMigrations();
+  // Hashes are only needed to disambiguate legacy nameless rows.
+  const hashByName = rows.some((row) => !row.name) ? bundledMigrationHashes(code) : undefined;
+  return compareSchemaParity(code, rows, hashByName);
+}

--- a/web/services/health/schemaParity.ts
+++ b/web/services/health/schemaParity.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
+import { jsonResponse } from "../vms/routeHelpers";
 
 /**
  * Schema parity: compares the migrations bundled with the deployed code
@@ -184,4 +185,27 @@ export async function schemaParityReport(): Promise<SchemaParityReport> {
   // Hashes are only needed to disambiguate legacy nameless rows.
   const hashByName = rows.some((row) => !row.name) ? bundledMigrationHashes(code) : undefined;
   return compareSchemaParity(code, rows, hashByName);
+}
+
+/**
+ * Full response body of GET /api/health/schema-parity, free of Next
+ * request-scope APIs so tests can drive it directly. Failures respond with a
+ * generic "unavailable" (plus codeHead when the bundled migrations are
+ * readable); connection and error details never reach the public body.
+ */
+export async function schemaParityResponse(): Promise<Response> {
+  let report: SchemaParityReport;
+  try {
+    report = await schemaParityReport();
+  } catch (error) {
+    console.error("schema-parity health check failed", error);
+    let codeHead: string | null = null;
+    try {
+      codeHead = listBundledMigrations().at(-1) ?? null;
+    } catch {
+      // The migrations folder is missing from the serverless bundle.
+    }
+    return jsonResponse({ status: "unavailable", codeHead }, 503);
+  }
+  return jsonResponse(report, report.status === "behind" ? 503 : 200);
 }

--- a/web/tests/migrations-additive-lint.test.ts
+++ b/web/tests/migrations-additive-lint.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  LINT_BASELINE,
+  classifyMigrationSql,
+  classifyStatement,
+  destructiveApproval,
+  lintMigrationsDirectory,
+  splitSqlStatements,
+} from "../scripts/lint-migrations-additive";
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "db", "migrations");
+
+describe("splitSqlStatements", () => {
+  test("splits on semicolons and strips drizzle statement breakpoints", () => {
+    const statements = splitSqlStatements(
+      'CREATE TABLE "a" ("id" text);\n--> statement-breakpoint\nCREATE INDEX "i" ON "a" ("id");',
+    );
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toStartWith('CREATE TABLE "a"');
+    expect(statements[1]).toStartWith('CREATE INDEX "i"');
+  });
+
+  test("keeps dollar-quoted DO bodies with inner semicolons as one statement", () => {
+    const statements = splitSqlStatements(
+      "DO $$ BEGIN ALTER TYPE t ADD VALUE 'x'; EXCEPTION WHEN duplicate_object THEN null; END $$;\nCREATE TYPE u AS ENUM ('a');",
+    );
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toStartWith("DO $$");
+    expect(statements[0]).toContain("EXCEPTION");
+  });
+
+  test("ignores semicolons and comment markers inside string literals", () => {
+    const statements = splitSqlStatements(
+      "INSERT INTO a (v) VALUES ('semi;colon -- not a comment; it''s data');\nSELECT 1;",
+    );
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toContain("it''s data");
+  });
+
+  test("strips nested block comments", () => {
+    const statements = splitSqlStatements("/* outer /* inner; */ still comment */ CREATE TABLE t (id text);");
+    expect(statements).toEqual(["CREATE TABLE t (id text)"]);
+  });
+});
+
+describe("classifyStatement", () => {
+  const additive = [
+    'CREATE TABLE IF NOT EXISTS "cloud_vm_preview_leases" ("id" text PRIMARY KEY)',
+    'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx" ON "t" ("a")',
+    "CREATE TYPE \"vm_kind\" AS ENUM ('a', 'b')",
+    "ALTER TYPE \"vm_provider\" ADD VALUE IF NOT EXISTS 'blaxel'",
+    'ALTER TABLE "cloud_vms" ADD COLUMN IF NOT EXISTS "display_name" text',
+    'ALTER TABLE "t" ADD COLUMN "n" integer NOT NULL DEFAULT 0',
+    'ALTER TABLE "t" ADD COLUMN "id2" bigint GENERATED ALWAYS AS IDENTITY',
+    'ALTER TABLE "t" ADD CONSTRAINT "fk" FOREIGN KEY ("a") REFERENCES "b" ("id") NOT VALID',
+    'ALTER TABLE "t" VALIDATE CONSTRAINT "fk"',
+    'ALTER TABLE "t" ALTER COLUMN "a" SET DEFAULT \'x\'',
+    'ALTER TABLE "t" ALTER COLUMN "a" DROP NOT NULL',
+    "COMMENT ON COLUMN \"t\".\"a\" IS 'docs'",
+    "SET statement_timeout = '5min'",
+  ];
+  for (const statement of additive) {
+    test(`additive: ${statement.slice(0, 60)}`, () => {
+      expect(classifyStatement(statement)).toBeNull();
+    });
+  }
+
+  const destructive = [
+    'DROP TABLE "old_stuff"',
+    'DROP INDEX IF EXISTS "idx"',
+    'ALTER TABLE "t" DROP COLUMN "a"',
+    'ALTER TABLE "t" DROP CONSTRAINT "c"',
+    'ALTER TABLE "t" ALTER COLUMN "a" TYPE bigint',
+    'ALTER TABLE "t" ALTER COLUMN "a" SET DATA TYPE text',
+    'ALTER TABLE "t" ALTER COLUMN "a" SET NOT NULL',
+    'ALTER TABLE "t" ADD COLUMN "a" text NOT NULL',
+    'ALTER TABLE "t" ADD CONSTRAINT "u" UNIQUE ("a")',
+    'ALTER TABLE "t" RENAME COLUMN "a" TO "b"',
+    'ALTER TABLE "t" RENAME TO "t2"',
+    "UPDATE \"t\" SET \"a\" = 'backfilled' WHERE \"a\" IS NULL",
+    'DELETE FROM "t" WHERE "stale" = true',
+    'TRUNCATE "t"',
+    "WITH ranked AS (SELECT id FROM t) UPDATE t SET a = 1 FROM ranked WHERE t.id = ranked.id",
+    "DO $$ BEGIN DROP TABLE x; END $$",
+    "CREATE OR REPLACE FUNCTION f() RETURNS void AS $$ BEGIN END $$ LANGUAGE plpgsql",
+    'GRANT SELECT ON "t" TO PUBLIC',
+    "FLARBLE GARBLE",
+  ];
+  for (const statement of destructive) {
+    test(`destructive: ${statement.slice(0, 60)}`, () => {
+      expect(classifyStatement(statement)).not.toBeNull();
+    });
+  }
+
+  test("string literals cannot fake NOT NULL keywords", () => {
+    expect(classifyStatement("ALTER TABLE \"t\" ADD COLUMN \"a\" text DEFAULT 'not null'")).toBeNull();
+  });
+
+  test("multi-action ALTER TABLE reports only the destructive actions", () => {
+    const reason = classifyStatement(
+      'ALTER TABLE "t" ADD COLUMN "ok" numeric(10,2), DROP COLUMN "bad"',
+    );
+    expect(reason).toContain("drops a column");
+    expect(reason).not.toContain("unrecognized");
+  });
+});
+
+describe("classifyMigrationSql and approvals", () => {
+  test("a fully additive migration has no findings", () => {
+    const sql = readFileSync(
+      join(MIGRATIONS_DIR, "20260823010000_cloud_vm_display_name", "migration.sql"),
+      "utf8",
+    );
+    expect(classifyMigrationSql(sql)).toEqual([]);
+  });
+
+  test("findings carry the offending statement and a reason", () => {
+    const findings = classifyMigrationSql('DROP TABLE "old";\nCREATE TABLE "new" ("id" text);');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.statement).toContain('DROP TABLE "old"');
+    expect(findings[0]!.reason).toContain("DROP");
+  });
+
+  test("the allow-destructive marker needs a justification", () => {
+    expect(destructiveApproval("-- cmux:allow-destructive: column unused since v2, verified no readers\nDROP TABLE x;")).toBe(
+      "column unused since v2, verified no readers",
+    );
+    expect(destructiveApproval("-- cmux:allow-destructive:\nDROP TABLE x;")).toBeNull();
+    expect(destructiveApproval("DROP TABLE x;")).toBeNull();
+  });
+});
+
+describe("lintMigrationsDirectory on the real corpus", () => {
+  test("every migration after the baseline is additive or acknowledged", () => {
+    const results = lintMigrationsDirectory(MIGRATIONS_DIR);
+    const unacknowledged = results.filter(
+      (result) => result.findings.length > 0 && result.approval === null,
+    );
+    expect(unacknowledged).toEqual([]);
+  });
+
+  test("the baseline names a real migration and the outage migrations classify additive", () => {
+    const all = lintMigrationsDirectory(MIGRATIONS_DIR, { all: true });
+    const names = all.map((result) => result.name);
+    expect(names).toContain(LINT_BASELINE);
+    for (const outageMigration of [
+      "20260820050000_blaxel_vm_provider",
+      "20260823010000_cloud_vm_display_name",
+      "20260824010000_cloud_vm_preview_leases",
+    ]) {
+      const result = all.find((candidate) => candidate.name === outageMigration);
+      expect(result).toBeDefined();
+      expect(result!.findings).toEqual([]);
+    }
+  });
+});

--- a/web/tests/schema-parity.test.ts
+++ b/web/tests/schema-parity.test.ts
@@ -146,9 +146,11 @@ describe("bundled migrations", () => {
 });
 
 describe("schema-parity route against a migrated database", () => {
+  // The route's GET additionally awaits connection(), which needs a Next
+  // request scope; the deployed handler is exercised on Vercel instead.
   dbTest("reports ok with matching heads once migrations are applied", async () => {
-    const { GET } = await import("../app/api/health/schema-parity/route");
-    const response = await GET();
+    const { schemaParityResponse } = await import("../services/health/schemaParity");
+    const response = await schemaParityResponse();
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       status: string;

--- a/web/tests/schema-parity.test.ts
+++ b/web/tests/schema-parity.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { closeCloudDbForTests } from "../db/client";
+import {
+  compareSchemaParity,
+  listBundledMigrations,
+  bundledMigrationHashes,
+  migrationFolderMillis,
+  type AppliedMigrationRow,
+} from "../services/health/schemaParity";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "db", "migrations");
+
+function row(overrides: Partial<AppliedMigrationRow>): AppliedMigrationRow {
+  return { name: null, hash: null, createdAt: null, ...overrides };
+}
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+});
+
+describe("compareSchemaParity", () => {
+  const code = [
+    "20260818090000_coderouter_session_accounts",
+    "20260820050000_blaxel_vm_provider",
+    "20260823010000_cloud_vm_display_name",
+    "20260824010000_cloud_vm_preview_leases",
+  ];
+
+  test("ok when db head equals code head", () => {
+    const report = compareSchemaParity(code, code.map((name) => row({ name })));
+    expect(report).toEqual({
+      status: "ok",
+      codeHead: "20260824010000_cloud_vm_preview_leases",
+      dbHead: "20260824010000_cloud_vm_preview_leases",
+      pending: [],
+    });
+  });
+
+  test("behind when the db lags, listing pending migrations oldest first", () => {
+    const report = compareSchemaParity(code, [row({ name: code[0]! })]);
+    expect(report.status).toBe("behind");
+    expect(report.codeHead).toBe("20260824010000_cloud_vm_preview_leases");
+    expect(report.dbHead).toBe("20260818090000_coderouter_session_accounts");
+    expect(report.pending).toEqual([
+      "20260820050000_blaxel_vm_provider",
+      "20260823010000_cloud_vm_display_name",
+      "20260824010000_cloud_vm_preview_leases",
+    ]);
+  });
+
+  test("behind with everything pending against an unmigrated database", () => {
+    const report = compareSchemaParity(code, []);
+    expect(report.status).toBe("behind");
+    expect(report.dbHead).toBeNull();
+    expect(report.pending).toEqual(code);
+  });
+
+  test("ahead when the db has migrations this build does not bundle", () => {
+    const report = compareSchemaParity(code.slice(0, 3), code.map((name) => row({ name })));
+    expect(report.status).toBe("ahead");
+    expect(report.codeHead).toBe("20260823010000_cloud_vm_display_name");
+    expect(report.dbHead).toBe("20260824010000_cloud_vm_preview_leases");
+    expect(report.pending).toEqual([]);
+  });
+
+  test("resolves legacy nameless rows by folder-timestamp millis", () => {
+    // 20260820050000 -> 2026-08-20T05:00:00Z; drizzle stores millis in created_at.
+    const millis = migrationFolderMillis("20260820050000_blaxel_vm_provider")!;
+    const report = compareSchemaParity(code.slice(0, 2), [
+      row({ name: code[0]! }),
+      row({ createdAt: String(millis) }),
+    ]);
+    expect(report.status).toBe("ok");
+    expect(report.dbHead).toBe("20260820050000_blaxel_vm_provider");
+  });
+
+  test("disambiguates same-timestamp legacy rows by hash, like drizzle's upgrader", () => {
+    // The real corpus has such a pair: 20260804030000_account_deletion_legacy_progress
+    // and 20260804030000_iroh_scoped_discovery_indexes.
+    const twins = ["20260804030000_alpha", "20260804030000_beta"];
+    const millis = migrationFolderMillis(twins[0]!)!;
+    const hashes = new Map([
+      ["20260804030000_alpha", "hash-alpha"],
+      ["20260804030000_beta", "hash-beta"],
+    ]);
+    const report = compareSchemaParity(
+      twins,
+      [
+        row({ createdAt: millis, hash: "hash-alpha" }),
+        row({ createdAt: millis, hash: "hash-beta" }),
+      ],
+      hashes,
+    );
+    expect(report.status).toBe("ok");
+
+    const partial = compareSchemaParity(twins, [row({ createdAt: millis, hash: "hash-alpha" })], hashes);
+    expect(partial.status).toBe("behind");
+    expect(partial.pending).toEqual(["20260804030000_beta"]);
+  });
+
+  test("an unmatchable legacy row never hides pending code migrations", () => {
+    const report = compareSchemaParity(code, [
+      ...code.map((name) => row({ name })),
+      row({ createdAt: "1234567890000", hash: "unknown" }),
+    ]);
+    expect(report.status).toBe("ok");
+  });
+});
+
+describe("bundled migrations", () => {
+  test("lists the real migrations folder sorted with drizzle's naming shape", () => {
+    const names = listBundledMigrations(MIGRATIONS_DIR);
+    expect(names.length).toBeGreaterThanOrEqual(59);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    for (const name of names) {
+      expect(name).toMatch(/^\d{14}_/);
+      expect(migrationFolderMillis(name)).not.toBeNull();
+    }
+    // The three additive migrations that drifted from production in the
+    // Aug 24/25 2026 outage are bundled.
+    expect(names).toContain("20260820050000_blaxel_vm_provider");
+    expect(names).toContain("20260823010000_cloud_vm_display_name");
+    expect(names).toContain("20260824010000_cloud_vm_preview_leases");
+  });
+
+  test("hashes every bundled migration.sql", () => {
+    const names = listBundledMigrations(MIGRATIONS_DIR);
+    const hashes = bundledMigrationHashes(names, MIGRATIONS_DIR);
+    expect(hashes.size).toBe(names.length);
+    for (const hash of hashes.values()) {
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  test("folder millis decode as UTC", () => {
+    expect(migrationFolderMillis("20260824010000_cloud_vm_preview_leases")).toBe(
+      Date.UTC(2026, 7, 24, 1, 0, 0),
+    );
+    expect(migrationFolderMillis("not_a_timestamp")).toBeNull();
+  });
+});
+
+describe("schema-parity route against a migrated database", () => {
+  dbTest("reports ok with matching heads once migrations are applied", async () => {
+    const { GET } = await import("../app/api/health/schema-parity/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      codeHead: string | null;
+      dbHead: string | null;
+      pending: string[];
+    };
+    const codeHead = listBundledMigrations(MIGRATIONS_DIR).at(-1) ?? null;
+    expect(body.status).toBe("ok");
+    expect(body.codeHead).toBe(codeHead);
+    expect(body.dbHead).toBe(codeHead);
+    expect(body.pending).toEqual([]);
+  });
+});


### PR DESCRIPTION
On Aug 24/25 production broke because web code auto-deploys to Vercel on merge while Cloud VM DB migrations are applied manually via [cloud-vm-migrate.yml](https://github.com/manaflow-ai/cmux/blob/main/.github/workflows/cloud-vm-migrate.yml). Prod was last migrated Aug 19; three additive migrations merged after it, the deployed code queried the new columns, and account deletion failed 100% with VmDatabaseError until the migration ran on Aug 25. Four protections, none of which change the production approval gate:

1. **Schema-parity health endpoint** `GET /api/health/schema-parity` (public, no auth): compares the migration folders bundled in the deployed code against `drizzle.__drizzle_migrations` (the table drizzle-orm's node-postgres migrator writes, including legacy nameless rows matched by folder-timestamp millis then sql hash). Returns `200 {"status":"ok"|"ahead",codeHead,dbHead}` and `503 {"status":"behind",...,pending:[...]}` when the DB lags. The body only ever contains migration names. The migrations folder is traced into the serverless bundle via `outputFileTracingIncludes`.
2. **Auto-dispatch on migration merges**: [cloud-vm-migrate-auto.yml](https://github.com/manaflow-ai/cmux/blob/feat-schema-parity-guard/.github/workflows/cloud-vm-migrate-auto.yml) runs on push to `main` touching `web/db/migrations/**`, dispatches `cloud-vm-migrate.yml` with `target=staging`, watches that run to completion (avoids two concurrent staging migrations racing, and never dispatches production after a failed staging run), then dispatches `target=production`. The production run still pauses on the `cloud-vm-production` environment approval; it now exists and waits instead of relying on someone remembering to dispatch it.
3. **Additive-SQL linter**: `web/scripts/lint-migrations-additive.ts` classifies each `migration.sql` statement (fail closed) and fails the existing `web-db-migrations` CI job for destructive SQL (DROP, ALTER COLUMN TYPE, SET NOT NULL, NOT NULL columns without DEFAULT, renames, UPDATE/DELETE backfills, DO blocks) unless the file carries `-- cmux:allow-destructive: <reason>`. Migrations up to `20260824010000_cloud_vm_preview_leases` are grandfathered because editing applied files would change their drizzle hashes.
4. **Daily drift alert**: [cloud-vm-schema-parity.yml](https://github.com/manaflow-ai/cmux/blob/feat-schema-parity-guard/.github/workflows/cloud-vm-schema-parity.yml) curls `https://cmux.com/api/health/schema-parity` daily and fails the run loudly with the pending migration list when production reports `behind`.

Verified: 53 focused bun tests (parity comparison incl. legacy-row and same-timestamp-twin resolution, SQL splitter/classifier against the real 59-migration corpus); end-to-end against a local Postgres, where deleting the three Aug 20-24 rows from `drizzle.__drizzle_migrations` reproduces the outage and the endpoint returns `503 behind` naming exactly those three; `bun run typecheck` clean; linter passes on the current corpus and flags 20 grandfathered destructive migrations under `--all`.

Dictionary: additive migration = schema change old deployed code can safely run against (new table, nullable/defaulted column, new index or enum value); destructive migration = one that can break already-deployed code or fail on existing data (drops, type changes, NOT NULL on existing columns, renames, backfills); environment approval = the GitHub Actions gate where a run waits for a reviewer before jobs bound to that environment start; file tracing = Next.js copying files a serverless route reads at runtime into that route's deployment bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790313276&installation_model_id=21920&pr_number=10794&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10794&signature=1909eefdbfe953c5402b0589802847a61e683c14ba32b87032a7c182535459af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated staging and production database migration workflows.
  * Added schema health checks to verify deployed database compatibility.
  * Added scheduled and on-demand production schema monitoring.

* **Bug Fixes**
  * Migration validation now detects potentially destructive SQL and requires explicit approval.

* **Tests**
  * Added coverage for migration validation, schema comparison, legacy migration records, and health reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Preview (branch auto-deploys are disabled in `web/vercel.json`, so this was deployed manually with `vercel deploy`): https://cmux-dffftai3t-manaflow.vercel.app — `/api/health/schema-parity` there answers `503 {"status":"unavailable","codeHead":"20260824010000_cloud_vm_preview_leases"}` since previews have no database; codeHead being present proves the route and the migration-folder file tracing work on Vercel. The build log shows the route as a dynamic function that is no longer executed during prerender (`connection()` gate, Cache Components removed `export const dynamic`).
