### PR TITLE
iOS: preserve reading position for gestures landing mid-replay, report truthful anchor give-ups

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
@@ -85,9 +85,14 @@ extension GhosttySurfaceView {
 
         // Viewport anchoring is best-effort; a timeout must not replace an
         // otherwise healthy surface or turn replay into another recovery loop.
+        // Both give-ups reveal the replay's bottom reset, so they must be
+        // visible in the log next to the restore-skip lines.
         if let pending = pendingVerifiedReplayViewportAnchorCapture,
            now - pending.startedAt >= Self.visibleSnapshotTimeout {
             pendingVerifiedReplayViewportAnchorCapture = nil
+            MobileDebugLog.anchormux(
+                "verified_replay.viewport_anchor_capture.TIMEOUT elapsedMs=\(Int((now - pending.startedAt) * 1000))"
+            )
             pending.continuation.resume(returning: nil)
         }
 
@@ -95,6 +100,9 @@ extension GhosttySurfaceView {
            now - pending.startedAt >= Self.visibleSnapshotTimeout {
             pendingVerifiedReplayViewportAnchorRestore = nil
             viewportRestoreGate.withLock { $0.activeRestoreTicket = nil }
+            MobileDebugLog.anchormux(
+                "verified_replay.viewport_restore.TIMEOUT elapsedMs=\(Int((now - pending.startedAt) * 1000))"
+            )
             pending.continuation.resume(returning: false)
         }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -35,6 +35,14 @@ extension GhosttySurfaceView {
         )
         let workQueue = outputQueue
         let gate = viewportRestoreGate
+        // Seeding inputs read on the main actor: whether the pixel pump owns
+        // primary-screen scrolling (alt screens replay every frame and must
+        // never inherit a held primary anchor), and the pixel-state epoch so
+        // a typing snap racing this capture voids the seed.
+        let seedsPixelScrollAuthority =
+            delegate?.ghosttySurfaceViewOwnsLocalPrimaryScreenScroll(self) == true
+        let pixelState = localPixelScrollState
+        let pixelStateEpoch = pixelState.withLock { $0.epoch }
         return await withCheckedContinuation { continuation in
             let operationID = registerPendingVerifiedReplayViewportAnchorCapture(
                 continuation: continuation
@@ -65,6 +73,36 @@ extension GhosttySurfaceView {
                     }
                 } else {
                     captured = nil
+                }
+                // A gesture that begins while the replay presentation is
+                // frozen must compose against the position the frozen pixels
+                // still show. Without a held authority its first pixel batch
+                // rebases from the live viewport, which mid-replay is the
+                // bottom reset, teleporting the reader. Seed the pump's held
+                // position from the captured anchor; a live gesture's own
+                // held position always wins over the seed.
+                if captured != nil, seedsPixelScrollAuthority {
+                    let size = ghostty_surface_size(operation.surface)
+                    let cellHeightPx = Double(size.cell_height_px)
+                    let seedRow = scrollbar.offset
+                    let seedRevision = scrollbar.row_space_revision
+                    let seedTotal = scrollbar.total
+                    if cellHeightPx >= 1 {
+                        let seeded = pixelState.withLock {
+                            $0.seedHeldPositionIfIdle(
+                                row: seedRow,
+                                positionPx: Double(seedRow) * cellHeightPx,
+                                revision: seedRevision,
+                                total: seedTotal,
+                                epoch: pixelStateEpoch
+                            )
+                        }
+                        if seeded {
+                            MobileDebugLog.anchormux(
+                                "verified_replay.viewport_anchor.seeded row=\(seedRow) revision=\(seedRevision)"
+                            )
+                        }
+                    }
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
@@ -127,18 +165,22 @@ extension GhosttySurfaceView {
                     )
                     : nil
                 let postReplayRevision = postReplay.row_space_revision
-                let claimed = gate.withLock { state -> Bool in
-                    guard state.activeRestoreTicket == operationID,
-                          state.interactionGeneration == captured.interactionGeneration else {
-                        return false
+                let claim = gate.withLock { state -> VerifiedReplayViewportRestoreClaim in
+                    let claim = VerifiedReplayViewportRestoreClaim.decide(
+                        activeTicket: state.activeRestoreTicket,
+                        operationID: operationID,
+                        interactionGeneration: state.interactionGeneration,
+                        capturedInteractionGeneration: captured.interactionGeneration
+                    )
+                    if claim == .claimed {
+                        state.activeRestoreTicket = nil
                     }
-                    state.activeRestoreTicket = nil
-                    return true
+                    return claim
                 }
                 var restoredScrollbar = ghostty_surface_scrollbar_s()
                 // A gesture between the claim and C call composes with the
                 // restored frozen viewport, so this unlocked window is benign.
-                let restored = claimed
+                let restored = claim == .claimed
                     ? (targetTopRow.map {
                         ghostty_surface_scroll_to_row_if_revision(
                             operation.surface,
@@ -148,9 +190,12 @@ extension GhosttySurfaceView {
                         )
                     } ?? false)
                     : false
-                if !claimed, targetTopRow != nil {
+                if claim != .claimed, targetTopRow != nil {
+                    let reason = claim == .staleInteraction
+                        ? "user_interaction_late"
+                        : "restore_ticket_revoked"
                     MobileDebugLog.anchormux(
-                        "verified_replay.viewport_restore.skipped reason=user_interaction_late"
+                        "verified_replay.viewport_restore.skipped reason=\(reason)"
                     )
                 }
                 if readPostReplay {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -332,6 +332,33 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// Rate-limits slow-batch perf log lines (scroll-hitch investigation).
         var lastPerfLogTime: CFTimeInterval = 0
         #endif
+
+        /// Seeds the held position from a verified-replay viewport anchor so a
+        /// gesture that begins while the replay presentation is frozen rebases
+        /// from the pre-replay reading position (what the frozen pixels show)
+        /// instead of the mid-replay or bottom-reset live viewport. Only an
+        /// idle authority may be seeded: a live gesture's held position always
+        /// wins, and an epoch bump (typing snap, surface replacement, alt
+        /// routing) between the caller's epoch read and this write voids the
+        /// seed.
+        mutating func seedHeldPositionIfIdle(
+            row: UInt64,
+            positionPx: Double,
+            revision: UInt64,
+            total: UInt64,
+            epoch: UInt64
+        ) -> Bool {
+            guard self.epoch == epoch, lastApplied == nil else { return false }
+            remainderPx = 0
+            lastApplied = (
+                row: row,
+                remainderPx: 0,
+                positionPx: positionPx,
+                revision: revision,
+                total: total
+            )
+            return true
+        }
     }
     nonisolated let localPixelScrollState =
         OSAllocatedUnfairLock<LocalPixelScrollState>(initialState: .init())

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -324,6 +324,33 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// Rate-limits slow-batch perf log lines (scroll-hitch investigation).
         var lastPerfLogTime: CFTimeInterval = 0
         #endif
+
+        /// Seeds the held position from a verified-replay viewport anchor so a
+        /// gesture that begins while the replay presentation is frozen rebases
+        /// from the pre-replay reading position (what the frozen pixels show)
+        /// instead of the mid-replay or bottom-reset live viewport. Only an
+        /// idle authority may be seeded: a live gesture's held position always
+        /// wins, and an epoch bump (typing snap, surface replacement, alt
+        /// routing) between the caller's epoch read and this write voids the
+        /// seed.
+        mutating func seedHeldPositionIfIdle(
+            row: UInt64,
+            positionPx: Double,
+            revision: UInt64,
+            total: UInt64,
+            epoch: UInt64
+        ) -> Bool {
+            guard self.epoch == epoch, lastApplied == nil else { return false }
+            remainderPx = 0
+            lastApplied = (
+                row: row,
+                remainderPx: 0,
+                positionPx: positionPx,
+                revision: revision,
+                total: total
+            )
+            return true
+        }
     }
     nonisolated let localPixelScrollState =
         OSAllocatedUnfairLock<LocalPixelScrollState>(initialState: .init())

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportRestoreClaim.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportRestoreClaim.swift
@@ -1,0 +1,31 @@
+/// Why a queued anchor restore did or did not claim its restore ticket.
+///
+/// The distinction matters for diagnosis: `staleInteraction` means the user
+/// really scrolled or typed after the anchor was captured, so standing down
+/// preserves their intent, while `ticketRevoked` means the deadline pump or a
+/// superseding restore revoked the ticket with no user involvement, so
+/// standing down is a give-up under load. Logging the two identically hid
+/// every deadline give-up behind a user-interaction label.
+enum VerifiedReplayViewportRestoreClaim: Equatable, Sendable {
+    case claimed
+    case staleInteraction
+    case ticketRevoked
+
+    /// Decides the claim outcome for one queued restore block. A stale
+    /// interaction outranks a revoked ticket in the reported cause: when both
+    /// hold, the user-visible truth is that their newer gesture won.
+    static func decide(
+        activeTicket: UInt64?,
+        operationID: UInt64,
+        interactionGeneration: UInt64,
+        capturedInteractionGeneration: UInt64
+    ) -> Self {
+        if interactionGeneration != capturedInteractionGeneration {
+            return .staleInteraction
+        }
+        if activeTicket != operationID {
+            return .ticketRevoked
+        }
+        return .claimed
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollSeedTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollSeedTests.swift
@@ -1,0 +1,71 @@
+#if canImport(UIKit)
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Local pixel scroll anchor seeding")
+struct LocalPixelScrollSeedTests {
+    @Test("an idle authority accepts the replay anchor seed")
+    func seedsWhenIdle() {
+        var state = GhosttySurfaceView.LocalPixelScrollState()
+        state.remainderPx = 4
+
+        let seeded = state.seedHeldPositionIfIdle(
+            row: 120,
+            positionPx: 3_840,
+            revision: 5,
+            total: 400,
+            epoch: 0
+        )
+
+        #expect(seeded)
+        #expect(state.lastApplied?.row == 120)
+        #expect(state.lastApplied?.positionPx == 3_840)
+        #expect(state.lastApplied?.revision == 5)
+        #expect(state.lastApplied?.total == 400)
+        #expect(state.lastApplied?.remainderPx == 0)
+        #expect(state.remainderPx == 0)
+    }
+
+    @Test("a live gesture's held position is never overwritten by a seed")
+    func keepsLiveGestureAuthority() {
+        var state = GhosttySurfaceView.LocalPixelScrollState()
+        state.lastApplied = (
+            row: 10,
+            remainderPx: 2,
+            positionPx: 322,
+            revision: 5,
+            total: 400
+        )
+
+        let seeded = state.seedHeldPositionIfIdle(
+            row: 120,
+            positionPx: 3_840,
+            revision: 5,
+            total: 400,
+            epoch: 0
+        )
+
+        #expect(!seeded)
+        #expect(state.lastApplied?.row == 10)
+        #expect(state.lastApplied?.positionPx == 322)
+    }
+
+    @Test("an epoch bump between capture and seed voids the seed")
+    func epochBumpVoidsSeed() {
+        var state = GhosttySurfaceView.LocalPixelScrollState()
+        state.epoch = 3
+
+        let seeded = state.seedHeldPositionIfIdle(
+            row: 120,
+            positionPx: 3_840,
+            revision: 5,
+            total: 400,
+            epoch: 2
+        )
+
+        #expect(!seeded)
+        #expect(state.lastApplied == nil)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportRestoreClaimTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportRestoreClaimTests.swift
@@ -1,0 +1,62 @@
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Verified replay viewport restore claim")
+struct VerifiedReplayViewportRestoreClaimTests {
+    @Test("a matching ticket with unchanged intent claims the restore")
+    func claims() {
+        #expect(
+            VerifiedReplayViewportRestoreClaim.decide(
+                activeTicket: 7,
+                operationID: 7,
+                interactionGeneration: 3,
+                capturedInteractionGeneration: 3
+            ) == .claimed
+        )
+    }
+
+    @Test("intent advanced after capture reports a late user interaction")
+    func staleInteraction() {
+        #expect(
+            VerifiedReplayViewportRestoreClaim.decide(
+                activeTicket: 7,
+                operationID: 7,
+                interactionGeneration: 4,
+                capturedInteractionGeneration: 3
+            ) == .staleInteraction
+        )
+    }
+
+    @Test("a deadline-revoked or superseded ticket is not blamed on the user")
+    func ticketRevoked() {
+        #expect(
+            VerifiedReplayViewportRestoreClaim.decide(
+                activeTicket: nil,
+                operationID: 7,
+                interactionGeneration: 3,
+                capturedInteractionGeneration: 3
+            ) == .ticketRevoked
+        )
+        #expect(
+            VerifiedReplayViewportRestoreClaim.decide(
+                activeTicket: 9,
+                operationID: 7,
+                interactionGeneration: 3,
+                capturedInteractionGeneration: 3
+            ) == .ticketRevoked
+        )
+    }
+
+    @Test("a real user interaction outranks ticket revocation as the cause")
+    func staleInteractionOutranksRevokedTicket() {
+        #expect(
+            VerifiedReplayViewportRestoreClaim.decide(
+                activeTicket: nil,
+                operationID: 7,
+                interactionGeneration: 4,
+                capturedInteractionGeneration: 3
+            ) == .staleInteraction
+        )
+    }
+}


### PR DESCRIPTION
Two fixes plus one verification for the residual viewport-anchor gaps tracked in https://github.com/manaflow-ai/cmux/issues/9143.

**Mid-replay gesture teleport (9143's overridden-review residual).** A gesture that began while a verified replay's presentation was frozen had no held pixel position to rebase from, so its first batch derived from the live viewport, which mid-replay is the bottom reset. One stray flick while a resync landed teleported a scrolled-up reader to the bottom: the anchor restore rightly stands down for newer user intent, and the reveal drain then composed the gesture against the wrong base. Fix: `captureVerifiedReplayViewportAnchor` now seeds the pixel pump's held authority (`LocalPixelScrollState.lastApplied`) from the captured anchor, so mid-freeze gestures compose against the position the frozen pixels still show. A live gesture's own held position always wins over the seed, the seed is gated on the delegate owning confirmed-primary scrolling (alt screens replay every frame and must never inherit a primary anchor), and the existing epoch discipline voids it on typing snaps, alt routing, and surface replacement. This is the same trust envelope PR #10592's mid-gesture hold already relies on (replays repaint in place and keep the row-space revision).

**Untruthful restore-skip logging.** A restore whose ticket was revoked by the 0.6s deadline pump logged `reason=user_interaction_late`, blaming the user for a give-up under load, and both anchor deadline expiries were completely silent. The claim decision is now a pure `VerifiedReplayViewportRestoreClaim` (stale interaction outranks ticket revocation as the reported cause), and both anchor TIMEOUTs log `elapsedMs`, so real-world give-up frequency is measurable before anyone tunes the deadline.

**One-frame bottom flash (9143 item b): verified already fixed on main, no change.** The bottom-reset frame is presented behind the frozen presentation layer, `presentRestoredVerifiedReplayViewport` re-arms the ready fence to the restored frame under render suppression, and `revealVerifiedReplayPresentation` only removes the frozen pixels once that exact frame is in Core Animation's presentation tree, so no intermediate frame can flash.

Tests: `VerifiedReplayViewportRestoreClaimTests` (claim outcomes and cause precedence) and `LocalPixelScrollSeedTests` (seed accepted when idle, never overwrites a live gesture's authority, voided by epoch bumps). The red-then-green two-commit convention doesn't apply: both fixes introduce new decision APIs, so a failing-first test cannot compile against the pre-fix tree.

HIG note: this changes scroll-gesture behavior (Packages/iOS). The HIG gestures page (https://developer.apple.com/design/human-interface-guidelines/gestures) could not be fetched from this sandbox (network-restricted); the change follows its core principle that content tracks the finger and direct manipulation stays predictable, by making a gesture during a resync compose from the position the user actually sees.

Dictionary: **verified replay** = a resync where the Mac's authoritative frame rebuilds the phone's local terminal grid behind a frozen copy of the last-good pixels; **anchor** = the content-relative viewport position captured before a replay and restored after it; **pixel pump** = the serial batcher that applies gesture deltas to the local Ghostty mirror at pixel precision; **held authority** = the pump's last-applied position, trusted over the live viewport while a gesture owns the screen; **epoch** = a counter bumped by typing snaps and surface replacement that voids in-flight pixel-scroll state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790314068&installation_model_id=21920&pr_number=10796&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10796&signature=514248559f83e23b0925a91118eaba697be8aadc38257b0a610c929c73eb2e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved viewport restoration after verified replay for more reliable scroll-position recovery.
  - Preserved active user scrolling when background restoration attempts occur.
  - Prevented outdated replay data or superseded restoration requests from overriding the current viewport.
  - Improved fractional pixel scrolling for smoother, more accurate positioning.

- **Tests**
  - Added coverage for scroll-position recovery, active gesture preservation, stale replay data, and competing restoration requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->