### PR TITLE
Fix app target compilation: drop initial values from worktree identity lets

### DIFF
--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -12,8 +12,8 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     let generatedArtifactContents: Data
     /// Filesystem identity captured immediately after `git worktree add`.
     /// Rollback refuses to touch a path whose checkout was replaced.
-    let worktreeDeviceID: UInt64? = nil
-    let worktreeFileID: UInt64? = nil
+    let worktreeDeviceID: UInt64?
+    let worktreeFileID: UInt64?
     /// A convenience command (e.g. a sample dev-server launcher) that should run
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.


### PR DESCRIPTION
Every Debug macOS build of current main fails with:

```
Sources/ExtensionWorktreePrototype.swift:44:31: error: immutable value 'self.worktreeDeviceID' may only be initialized once
Sources/ExtensionWorktreePrototype.swift:45:29: error: immutable value 'self.worktreeFileID' may only be initialized once
```

Sequence: https://github.com/manaflow-ai/cmux/pull/8567 added the identity fields as `let ... = nil`, https://github.com/manaflow-ai/cmux/pull/10777 restored compilation by adjusting only the test call site, and https://github.com/manaflow-ai/cmux/pull/10781 added an initializer that assigns those already-initialized `let`s, which Swift rejects. Reproduced identically on two independent fleet builders (cmux13s, cmux11s) at head 8ff9d3dd98.

Fix: drop the `= nil` initial values from the two stored properties. The initializer from #10781 keeps its `= nil` parameter defaults, so every call site and the `worktreeCreationResultPreservesFilesystemIdentity` regression test are unchanged.

Dictionary: **app target** = the main `cmux` scheme that compiles `Sources/` into the macOS app; **stored property initial value** = the `= nil` on the `let` declaration, which Swift counts as the property's one-time initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315084&installation_model_id=21920&pr_number=10797&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10797&signature=c1988868d746ca3959dae4f706a9b3b8ec62656970a270596354966fac141bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal property initialization while preserving existing optional defaults and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->