### PR TITLE
cmux Cloud: Blaxel machines provision to chatmux devbox parity

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -171,6 +171,9 @@ const nextConfig: NextConfig = {
     root: webRoot,
   },
   outputFileTracingIncludes: {
+    // The Blaxel VM driver uploads this provision script into every sandbox at
+    // create time (services/vms/drivers/blaxel.ts reads it at runtime).
+    "**/*": ["./services/vms/images/*.sh"],
     "**/opengraph-image": [
       "./app/lib/open-graph-fonts/**/*",
       "./app/**/assets/landing-image.png",

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 
 const gzipAsync = promisify(gzip);
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import {
   NotImplementedError,
@@ -93,13 +94,48 @@ while true; do
 done
 `;
 // Background provisioning for every machine: coding agents plus the dev essentials a person
-// expects on "their computer". The .bashrc seed only writes when absent so user edits stick.
-const CMUX_PROVISION_COMMAND = [
-  "{ command -v apk >/dev/null 2>&1 && apk add --no-cache curl tmux vim ripgrep jq openssh-client;",
-  "command -v npm >/dev/null 2>&1 && npm install -g @anthropic-ai/claude-code @openai/codex;",
-  "[ -f /root/.bashrc ] || printf '%s\\n' \"export PS1='\\\\[\\\\e[1;36m\\\\]\\\\h\\\\[\\\\e[0m\\\\]:\\\\[\\\\e[1;34m\\\\]\\\\w\\\\[\\\\e[0m\\\\]# '\" \"alias ll='ls -la'\" > /root/.bashrc;",
-  "} >/tmp/cmux/provision.log 2>&1 || true",
-].join(" ");
+// expects on "their computer", at parity with the chatmux devbox base image. The recipe is
+// data, not driver code: services/vms/images/blaxel-provision.sh (shellcheck-able, one file
+// to diff when the devbox contract changes). It is uploaded at bootstrap and started as a
+// detached keepAlive process, so create/attach latency never waits on it and the sandbox
+// stays awake until provisioning finishes (the script exits, releasing the keepAlive).
+// timeout caps a wedged install so keepAlive cannot pin the sandbox awake forever.
+const PROVISION_SCRIPT_SANDBOX_PATH = "/usr/local/bin/cmux-provision";
+const PROVISION_PROCESS_NAME = "cmux-provision";
+const PROVISION_TIMEOUT_SECONDS = 1800;
+const PROVISION_COMMAND =
+  `timeout ${PROVISION_TIMEOUT_SECONDS} ${PROVISION_SCRIPT_SANDBOX_PATH} >>/tmp/cmux/provision.log 2>&1`;
+
+// Cached as an in-flight promise for the same reason as the daemon payload below. The
+// candidate paths cover `bun dev`/tests (cwd = web/) and a checkout-root cwd; on Vercel the
+// file rides along via outputFileTracingIncludes in next.config.ts.
+let cachedProvisionScript: Promise<string> | null = null;
+
+export function provisionScriptContent(): Promise<string> {
+  if (cachedProvisionScript) return cachedProvisionScript;
+  const load = (async () => {
+    const candidates = [
+      join(process.cwd(), "services/vms/images/blaxel-provision.sh"),
+      join(process.cwd(), "web/services/vms/images/blaxel-provision.sh"),
+    ];
+    for (const candidate of candidates) {
+      try {
+        return await readFile(candidate, "utf8");
+      } catch {
+        // try the next candidate
+      }
+    }
+    throw new ProviderError(
+      "blaxel",
+      `provision script not found; looked for services/vms/images/blaxel-provision.sh under ${process.cwd()}`,
+    );
+  })();
+  cachedProvisionScript = load.catch((err) => {
+    cachedProvisionScript = null;
+    throw err;
+  });
+  return cachedProvisionScript;
+}
 
 // The machine knows its own name: the prompt reads noble-wren:~#, not (none):~#. But a
 // renamed host must stay *resolvable*: TigerVNC's `vncserver` wrapper calls `hostname -f`
@@ -468,11 +504,7 @@ export class BlaxelProvider implements VMProvider {
         await timedStep("hostname_setup", () => this.sandboxExec(sandboxUrl, hostnameSetupCommand(name)).catch(() => undefined));
         await timedStep("vnc_heal_start", () => this.startDesktopVncHeal(sandboxUrl));
       })(),
-      blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
-        name: "cmux-provision",
-        command: CMUX_PROVISION_COMMAND,
-        waitForCompletion: false,
-      }).catch(() => undefined),
+      timedStep("provision_start", () => this.startProvisionProcess(sandboxUrl)),
     ]);
   }
 
@@ -491,6 +523,32 @@ export class BlaxelProvider implements VMProvider {
       restartOnFailure: true,
       maxRestarts: 10,
     });
+  }
+
+  // Best-effort devbox provisioning (agents, devtools, shell dressing). A missing or
+  // unreadable script must never fail a create — the machine still works, it is just bare —
+  // so every step here swallows its own error after logging it once.
+  private async startProvisionProcess(sandboxUrl: string): Promise<void> {
+    const script = await provisionScriptContent().catch((err) => {
+      console.error("[blaxel] provision script unavailable; machine stays stock", err);
+      return null;
+    });
+    if (!script) return;
+    try {
+      await blaxelFetch(
+        "PUT",
+        `${sandboxUrl}/filesystem/${PROVISION_SCRIPT_SANDBOX_PATH}`,
+        { content: script, permissions: "0755" },
+      );
+      await blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
+        name: PROVISION_PROCESS_NAME,
+        command: PROVISION_COMMAND,
+        waitForCompletion: false,
+        keepAlive: true,
+      });
+    } catch (err) {
+      console.error("[blaxel] provision start failed; machine stays stock", err);
+    }
   }
 
   private async startWatcherProcess(sandboxUrl: string): Promise<void> {

--- a/web/services/vms/images/blaxel-provision.sh
+++ b/web/services/vms/images/blaxel-provision.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# cmux machine devbox provision: bring a stock Blaxel sandbox up to parity with
+# the chatmux devbox base image (infra/sandbox-images/Dockerfile in the chatmux
+# repo): the four coding agents (claude, codex, opencode, pi), everyday
+# devtools, and the half-life bash prompt with ble.sh ghost text seeded from
+# history, so the shell a user lands in feels like their computer instead of a
+# bare stock image.
+#
+# Contract with services/vms/drivers/blaxel.ts:
+# - uploaded to /usr/local/bin/cmux-provision at daemon bootstrap and started
+#   as a detached keepAlive process, so create/attach latency never waits on it
+#   and the sandbox stays awake until provisioning finishes
+# - idempotent: the stamp file short-circuits re-runs inside one sandbox
+#   lifetime; a resurrected sandbox has a fresh rootfs and re-provisions
+# - /root is the persistent home volume: anything under /root is written only
+#   when absent, so a user's edits always win across re-provisions
+# - handles both stock image families: blaxel/base-image (Alpine, node baked)
+#   and blaxel/xfce-vnc (Ubuntu 22.04, no node)
+#
+# Deliberately absent, with reasons:
+# - Docker Engine: dockerd cannot run in Blaxel microVMs today (no cgroup
+#   mounts; docker.io 29.1.3 dockerd panics even with --storage-driver=vfs
+#   --iptables=false --bridge=none; verified live 2026-08-26 on us-pdx-1).
+# - Chrome + media capture (ffmpeg/Xvfb/cua-driver) and build-essential: the
+#   sandbox rootfs is 3.1 GB total; these don't fit alongside the agents.
+# - mise/bun: node comes from the image (Alpine) or NodeSource (Ubuntu);
+#   python3 and uv cover the python side.
+set -u
+
+STAMP=/var/lib/cmux/.provisioned
+STAMP_VERSION=v2-devbox-20260826
+if [ -f "$STAMP" ] && grep -qF "$STAMP_VERSION" "$STAMP" 2>/dev/null; then
+  exit 0
+fi
+
+step() { echo "cmux-provision: $*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+step "start $(date -u +%FT%TZ)"
+
+# --- package layer -----------------------------------------------------------
+if have apt-get; then
+  export DEBIAN_FRONTEND=noninteractive
+  step "apt devtools"
+  apt-get update -qq || true
+  apt-get install -y -qq --no-install-recommends \
+    curl ca-certificates git jq ripgrep fd-find fzf sqlite3 tmux vim nano \
+    less rsync file tree zip unzip xz-utils zstd gawk openssh-client procps \
+    || step "WARN apt devtools install failed"
+  if have fdfind && ! have fd; then
+    ln -s "$(command -v fdfind)" /usr/local/bin/fd || true
+  fi
+  # gh from the official apt repo (not in jammy main)
+  if ! have gh; then
+    step "gh cli"
+    if curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg; then
+      chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list
+      apt-get update -qq || true
+      apt-get install -y -qq --no-install-recommends gh || step "WARN gh install failed"
+    else
+      step "WARN gh keyring download failed"
+    fi
+  fi
+  # node LTS via NodeSource; jammy's archive nodejs is far too old for the
+  # coding agents.
+  if ! have node; then
+    step "node 22 (nodesource)"
+    { curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1 \
+        && apt-get install -y -qq --no-install-recommends nodejs; } \
+      || step "WARN node install failed"
+  fi
+elif have apk; then
+  step "apk devtools"
+  apk add --no-cache \
+    curl ca-certificates git jq ripgrep fd fzf sqlite tmux vim nano \
+    less rsync file tree zip unzip xz zstd gawk openssh-client procps \
+    || step "WARN apk devtools install failed"
+  have gh || apk add --no-cache github-cli || step "WARN gh install failed"
+else
+  step "WARN no known package manager; skipping devtools"
+fi
+
+# --- coding agents -----------------------------------------------------------
+# Same npm globals as the chatmux devbox image; installed one by one so a
+# platform-specific postinstall failure (e.g. a missing musl binary) cannot
+# take the other agents down with it.
+if have npm; then
+  for pkg in @anthropic-ai/claude-code @openai/codex opencode-ai @earendil-works/pi-coding-agent; do
+    step "npm -g $pkg"
+    npm install -g --no-fund --no-audit "$pkg" || step "WARN $pkg install failed"
+  done
+else
+  step "WARN npm unavailable; skipping coding agents"
+fi
+
+# --- uv (python package runner; xfce-vnc ships it, base-image does not) ------
+if ! have uv; then
+  step "uv"
+  curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh \
+    || step "WARN uv install failed"
+fi
+
+# --- ble.sh (ghost-text autosuggestions, same build the chatmux devbox uses) -
+if [ ! -f /usr/local/share/blesh/ble.sh ]; then
+  step "ble.sh"
+  if curl -fsSL https://github.com/akinomyoga/ble.sh/releases/download/nightly/ble-nightly.tar.xz \
+      -o /tmp/ble.tar.xz && tar xJf /tmp/ble.tar.xz -C /tmp; then
+    mv /tmp/ble-nightly /usr/local/share/blesh
+  else
+    step "WARN ble.sh install failed; prompt works without ghost text"
+  fi
+  rm -f /tmp/ble.tar.xz
+fi
+
+# --- shell appearance --------------------------------------------------------
+# The interactive bashrc matches the chatmux devbox (oh-my-zsh half-life
+# palette + ble.sh ghost text + seeded history) with one deliberate change:
+# the machine's own name stays in the prompt (root@noble-wren), because cmux
+# machines are addressed by name everywhere.
+mkdir -p /etc/cmux
+printf '%s\n' \
+  'claude --dangerously-skip-permissions' \
+  'codex --yolo' \
+  > /etc/cmux/seed-history
+
+cat > /etc/cmux/devshell.bashrc <<'CMUX_BASHRC'
+# cmux machine interactive bash setup (source: web/services/vms/images/
+# blaxel-provision.sh in manaflow-ai/cmux; appearance parity with the chatmux
+# devbox). Interactive shells only; exec paths (bash -lc, sh -c) return on the
+# first guard.
+case $- in *i*) ;; *) return ;; esac
+[ -n "${_CMUX_BASHRC-}" ] && return
+_CMUX_BASHRC=1
+
+# PTY sessions may not inherit the image ENV; ble.sh warns on empty LANG, and
+# prints "insane environment: $USER is empty" when exec paths leave USER unset.
+export LANG="${LANG:-C.UTF-8}"
+export USER="${USER:-$(id -un)}"
+
+[ -f "$HOME/.bash_history" ] || cp /etc/cmux/seed-history "$HOME/.bash_history" 2>/dev/null
+
+# ble.sh needs a real terminal; sourced with --noattach, attached at the end
+# of this file (the documented pattern).
+if [ -t 0 ] && [ -f /usr/local/share/blesh/ble.sh ]; then
+  source /usr/local/share/blesh/ble.sh --noattach
+  # Quiet ble.sh's status marks ([ble: EOF], [ble: exit N]): they read as
+  # errors in every terminal pane.
+  bleopt prompt_eol_mark= exec_errexit_mark= exec_elapsed_mark= exec_exit_mark=
+fi
+
+# half-life palette: purple 135, lime 118, orange 166, hotpink 161.
+__cmux_git() {
+  local b d=""
+  b=$(git symbolic-ref --short HEAD 2>/dev/null) || b=$(git rev-parse --short HEAD 2>/dev/null) || return 0
+  git diff --quiet --ignore-submodules HEAD 2>/dev/null || d="*"
+  printf ' on \001\033[38;5;166m\002%s\001\033[38;5;161m\002%s\001\033[0m\002' "$b" "$d"
+}
+PS1='\[\e[38;5;135m\]\u@\h\[\e[0m\] in \[\e[38;5;118m\]\w\[\e[0m\]$(__cmux_git) λ '
+
+HISTSIZE=50000
+HISTFILESIZE=50000
+shopt -s histappend
+
+alias ls='ls --color=auto'
+alias grep='grep --color=auto'
+alias ll='ls -la'
+alias g=git
+
+if [ -n "${BLE_VERSION-}" ]; then ble-attach; fi
+CMUX_BASHRC
+
+SOURCE_LINE='[ -f /etc/cmux/devshell.bashrc ] && . /etc/cmux/devshell.bashrc'
+# /etc/bash.bashrc only exists (and is only read) on Debian-family bash; Alpine
+# bash reads ~/.bashrc alone. Blaxel's sandbox-api runs processes with
+# HOME=/blaxel on some images (base-image) and /root on others (xfce-vnc), and
+# the PTY shells cmuxd spawns inherit that HOME — wire whichever one this
+# sandbox actually uses, plus /root (the persistent home volume) and /etc/skel.
+RC_FILES="/root/.bashrc /etc/skel/.bashrc /etc/bash.bashrc"
+if [ -n "${HOME-}" ] && [ "$HOME" != "/root" ]; then
+  RC_FILES="$RC_FILES $HOME/.bashrc"
+fi
+for rc in $RC_FILES; do
+  mkdir -p "$(dirname "$rc")"
+  [ -f "$rc" ] || : > "$rc"
+  grep -qF '/etc/cmux/devshell.bashrc' "$rc" || printf '%s\n' "$SOURCE_LINE" >> "$rc"
+done
+
+if ! grep -qs 'default-shell' /etc/tmux.conf; then
+  echo 'set -g default-shell /bin/bash' >> /etc/tmux.conf
+fi
+
+# --- cache cleanup (the rootfs is only 3.1 GB total) --------------------------
+if have apt-get; then
+  apt-get clean >/dev/null 2>&1 || true
+  rm -rf /var/lib/apt/lists/* || true
+fi
+have npm && npm cache clean --force >/dev/null 2>&1
+
+# --- stamp -------------------------------------------------------------------
+mkdir -p /var/lib/cmux
+printf '%s %s\n' "$STAMP_VERSION" "$(date -u +%FT%TZ)" > "$STAMP"
+step "done $(date -u +%FT%TZ)"
+df -h / | tail -1

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -153,12 +153,24 @@
       "version": "blaxel-bootstrap-20260820a",
       "imageId": "blaxel/xfce-vnc:latest",
       "envVar": "BLAXEL_SANDBOX_IMAGE",
-      "defaultForLocalDev": true,
+      "defaultForLocalDev": false,
       "cmuxdRemoteCommit": "bootstrap-on-create",
       "builtAt": "2026-08-20T04:30:00.000Z",
       "builderScriptVersion": "bootstrap-on-create",
       "validationStatus": "passed",
       "notes": "Stock Blaxel xfce + noVNC image (a machine comes with its screen; `cmux vm new --base` picks blaxel/base-image:latest explicitly); the driver injects cmuxd-remote at create time via the sandbox filesystem API (gzip+base64) and starts serve --ws as a keepAlive process, so no baked template is required. Validated WS PTY lease auth, shell round trip, healthz through a private preview URL + minted preview token, and standby/wake process preservation in us-pdx-1."
+    },
+    {
+      "provider": "blaxel",
+      "version": "blaxel-devbox-20260826a",
+      "imageId": "blaxel/xfce-vnc:latest",
+      "envVar": "BLAXEL_SANDBOX_IMAGE",
+      "defaultForLocalDev": true,
+      "cmuxdRemoteCommit": "bootstrap-on-create",
+      "builtAt": "2026-08-26T00:00:00.000Z",
+      "builderScriptVersion": "provision-on-create",
+      "validationStatus": "passed",
+      "notes": "Same stock Blaxel images and cmuxd bootstrap as blaxel-bootstrap-20260820a, plus detached devbox provisioning at create (services/vms/images/blaxel-provision.sh): claude/codex/opencode/pi latest at boot, gh, jq, ripgrep, fd, fzf, tmux, sqlite3, node 22 where the image lacks node, uv, and the chatmux half-life prompt with ble.sh ghost text and seeded history. Agents resolve latest at provision time, so no pinned agentToolResolvedVersions. Docker Engine excluded: dockerd cannot run in Blaxel microVMs (no cgroup mounts; verified 2026-08-26). Validated live on blaxel/xfce-vnc:latest and blaxel/base-image:latest in us-pdx-1."
     }
   ]
 }

--- a/web/tests/vm-blaxel-provider.test.ts
+++ b/web/tests/vm-blaxel-provider.test.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { describe, expect, test } from "bun:test";
 import {
   BlaxelProvider,
   DESKTOP_VNC_HEAL_COMMAND,
   hostnameSetupCommand,
   parseMachineStats,
+  provisionScriptContent,
   resolveBlaxelMemoryMb,
   resolveDaemonSource,
   usablePrivatePreviewUrl,
@@ -491,5 +493,54 @@ describe("BlaxelProvider desktop VNC bootstrap", () => {
     expect(DESKTOP_VNC_HEAL_COMMAND).toContain(":5901 ");
     expect(DESKTOP_VNC_HEAL_COMMAND).toContain("runuser -u cua");
     expect(DESKTOP_VNC_HEAL_COMMAND).toContain("start-vnc.sh");
+  });
+});
+
+describe("BlaxelProvider devbox provisioning", () => {
+  // The provision recipe is data (one shell script), not driver string concatenation. These
+  // tests pin the contract: the script exists, parses, and carries the chatmux-devbox parity
+  // pieces (four coding agents, seeded history, half-life prompt) without Docker Engine,
+  // which cannot run in Blaxel microVMs (no cgroup mounts; dockerd panics, verified
+  // 2026-08-26).
+  test("provision script loads from services/vms/images and is a bash script", async () => {
+    const script = await provisionScriptContent();
+    expect(script.startsWith("#!/bin/bash")).toBe(true);
+  });
+
+  test("provision script passes bash -n", async () => {
+    const script = await provisionScriptContent();
+    const result = spawnSync("bash", ["-n"], { input: script, encoding: "utf8" });
+    expect(result.status).toBe(0);
+  });
+
+  test("provision script installs the four coding agents and the devbox shell", async () => {
+    const script = await provisionScriptContent();
+    for (const pkg of [
+      "@anthropic-ai/claude-code",
+      "@openai/codex",
+      "opencode-ai",
+      "@earendil-works/pi-coding-agent",
+    ]) {
+      expect(script).toContain(pkg);
+    }
+    // Seeded ghost-text history and the half-life prompt.
+    expect(script).toContain("claude --dangerously-skip-permissions");
+    expect(script).toContain("codex --yolo");
+    expect(script).toContain("38;5;135m"); // half-life purple user
+    expect(script).toContain("ble.sh");
+    // Idempotence + persistent-home safety: stamp guard, write-when-absent history.
+    expect(script).toContain("/var/lib/cmux/.provisioned");
+    expect(script).toContain('[ -f "$HOME/.bash_history" ] ||');
+    // Docker Engine must stay out until Blaxel sandboxes can run dockerd.
+    expect(script).not.toMatch(/apt-get install[^\n]*docker/);
+    expect(script).not.toMatch(/apk add[^\n]*docker/);
+  });
+
+  test("provision script handles both stock image families", async () => {
+    const script = await provisionScriptContent();
+    expect(script).toContain("apt-get");
+    expect(script).toContain("apk add");
+    // Ubuntu xfce-vnc has no node; the agents need one.
+    expect(script).toContain("deb.nodesource.com");
   });
 });


### PR DESCRIPTION
Stock Blaxel images boot as bare shells: no coding agents, no devtools, default prompt. The chatmux devbox base image (`infra/sandbox-images/Dockerfile` in the chatmux repo) is the parity target. This PR turns the driver's one-line background provision into a real recipe kept as data: [`web/services/vms/images/blaxel-provision.sh`](https://github.com/manaflow-ai/cmux/blob/feat-blaxel-image-parity/web/services/vms/images/blaxel-provision.sh).

## Mechanism

`bootstrapDaemon` uploads the script through the sandbox filesystem API (parallel with the existing fanout, +137 ms measured inside an already-parallel branch) and starts it as a detached `keepAlive` process under `timeout 1800`. Create latency is unchanged (~5 s detached; provisioning finished in 60–80 s live on both image families). `keepAlive` holds the sandbox awake until the script exits, so the machine is ready even if the user never attaches; the timeout caps a wedged install so it cannot pin the sandbox forever. Idempotent via a version stamp; a resurrected sandbox has a fresh rootfs and re-provisions. `/root` is the persistent home volume and is only written when absent, so user edits always win.

## Parity table (source of truth: chatmux `infra/sandbox-images/Dockerfile`)

| chatmux devbox | this PR | note |
| --- | --- | --- |
| claude, codex, opencode, pi (npm -g) | ✅ latest at boot | verified running on Alpine (musl) and Ubuntu |
| devtools: git jq ripgrep fd fzf sqlite3 tmux vim nano less rsync file tree zip unzip xz zstd gawk openssh curl | ✅ | apt and apk variants |
| gh CLI | ✅ | GitHub apt repo / apk github-cli |
| node LTS | ✅ | image-baked on Alpine; NodeSource 22 on Ubuntu |
| uv | ✅ | xfce-vnc ships it; installed on base-image |
| half-life prompt (purple user, lime cwd, orange branch, hotpink dirty star, λ) | ✅ | one deliberate change: machine name stays in the prompt (`root@noble-wren`) since machines are addressed by name |
| ble.sh ghost text + seeded history (`claude --dangerously-skip-permissions`, `codex --yolo`) | ✅ | |
| tmux default-shell bash | ✅ | |
| Docker Engine | ❌ provider-blocked | dockerd cannot run in Blaxel microVMs: no cgroup mounts; docker.io 29.1.3 panics even with `--storage-driver=vfs --iptables=false --bridge=none` (verified live 2026-08-26, us-pdx-1). Also not in the chatmux Dockerfile itself. |
| Chrome + media capture (ffmpeg/Xvfb/cua-driver), build-essential, mise, bun | ❌ scoped out | sandbox rootfs is 3.1 GB total; these do not fit beside the agents (65% used after provision as is) |
| chatmux model-proxy agent configs | ❌ n/a | chatmux-specific model plane |

A baked custom image (`bl deploy` sandbox template) is the long-term path Blaxel supports and would also bake the daemon (follow-up flagged in https://github.com/manaflow-ai/cmux/pull/10698); it needs a registry/rollout story (`BLAXEL_SANDBOX_IMAGE=sandbox/<name>` in prod), so this PR ships the provision path and keeps the script usable as the future Dockerfile RUN body.

## Live evidence (fresh creates through the driver, then destroyed)

`blaxel/xfce-vnc:latest` (default, machine `lucid-puffin`) and `blaxel/base-image:latest` (machine `coral-wren`), created via `bun scripts/test-blaxel-vm-poc.ts` — PTY round trip, single-use lease replay rejection, smart-sleep watcher all PASS, then:

```
claude=/usr/bin/claude 2.1.246 · codex-cli 0.149.1 · opencode 1.18.23 · pi 0.84.3
gh 2.98.0 · jq rg fd fzf tmux sqlite3 node v22.23.2 uv — all present
PS1=[\[\e[38;5;135m\]\u@\h\[\e[0m\] in \[\e[38;5;118m\]\w\[\e[0m\]$(__cmux_git) λ ]
~/.bash_history: claude --dangerously-skip-permissions / codex --yolo
/usr/local/share/blesh/ble.sh present · stamp v2-devbox-20260826
```

Provision wall time: 54 s (Ubuntu), ~50 s (Alpine). Disk after provision: 65% (Ubuntu), 52% (Alpine). Also probed HOME quirks live: the sandbox-api runs shells with `HOME=/home/cua` (xfce-vnc) or `/blaxel` (base-image), so the script wires `$HOME/.bashrc` in addition to `/root`, `/etc/skel`, `/etc/bash.bashrc`.

## Tests

`bun test tests/vm-blaxel-provider.test.ts tests/vm-image-resolver.test.ts tests/vm-workflows.test.ts tests/build-cloud-vm-images.test.ts tests/vm-persistent-home.test.ts` → 99 pass, 0 fail. `bun run typecheck` clean. New tests pin the script contract: loads from `services/vms/images/`, passes `bash -n`, carries the four agents + seeded history + prompt, handles both package managers, and contains no docker install.

Dictionary: **provision** = the post-create install step that runs inside the sandbox; **keepAlive process** = a Blaxel process that keeps the microVM from freezing while it runs; **resurrection** = recreating a dead sandbox around its persistent home volume; **musl** = Alpine's libc, which prebuilt agent binaries must support.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316502&installation_model_id=21920&pr_number=10801&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10801&signature=d0ca3c82551648a6be77baa5781df907173d82ce7afb9fd3d73b8551f79a7c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Blaxel devbox image option for local development.
  - Automatically provisions common development tools, coding-agent CLIs, Node.js, GitHub CLI, `uv`, and enhanced shell features.
  - Supports both Ubuntu/Debian and Alpine-based environments.
  - Provisioning runs safely in the background and does not prevent sandbox creation if individual setup steps fail.
  - Repeated provisioning is skipped when the environment is already configured.

- **Bug Fixes**
  - Ensured provisioning resources are included in deployed builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->