### PR TITLE
iOS: keep the files chip visible while the keyboard is up

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
@@ -282,7 +282,9 @@ public struct MobileWorkspaceAggregation: Sendable {
                     // Empty headers have no workspace row to namespace; use
                     // the already-namespaced group id only as a stable UI row
                     // identity, never as a workspace capability.
-                    stamped.anchorWorkspaceID = stamped.id
+                    stamped.anchorWorkspaceID = MobileWorkspacePreview.ID(
+                        rawValue: stamped.id.rawValue
+                    )
                 }
                 result.append(stamped)
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -238,9 +238,14 @@ extension GhosttySurfaceRepresentable.Coordinator {
         private func requestArtifactFilesFromChip() {
             guard artifactChipGate.isEnabled else { return }
             guard let surfaceView, let chipView = artifactChipController?.view else { return }
-            let frame = chipView.convert(chipView.bounds, to: surfaceView)
-            let width = max(surfaceView.bounds.width, 1)
-            let height = max(surfaceView.bounds.height, 1)
+            // Normalize against the view backing the SwiftUI representable
+            // (the adopting host). The surface itself slides under the
+            // keyboard, so anchors normalized against it would drift by the
+            // slide.
+            let reference = surfaceView.artifactChipAnchorReferenceView
+            let frame = chipView.convert(chipView.bounds, to: reference)
+            let width = max(reference.bounds.width, 1)
+            let height = max(reference.bounds.height, 1)
             onArtifactFilesRequested(UnitPoint(
                 x: min(max(frame.midX / width, 0), 1),
                 y: min(max(frame.midY / height, 0), 1)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -911,7 +911,7 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
     /// Group actions are owned by the Mac connection, not by a particular
     /// workspace row. The group snapshot carries that Mac-scoped capability,
     /// including when the group has no live anchor row.
-    fileprivate func groupActionCapabilities(
+    func groupActionCapabilities(
         for group: MobileWorkspaceGroupPreview
     ) -> MobileWorkspaceActionCapabilities {
         if let capabilities = group.actionCapabilities {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
@@ -2,13 +2,34 @@
 import UIKit
 
 /// Owns the terminal artifact chip's UIKit container, sizing, and transition state.
+///
+/// The container is constraint-anchored to the top of whichever view hosts
+/// it. `GhosttySurfaceView` installs it into itself at init (standalone
+/// surfaces, tests); `GhosttySurfaceHostView` re-homes it — the same adoption
+/// ``GhosttySurfaceView/moveBottomDock(to:)`` performs for the dock — so the
+/// chip lives in the host's keyboard-invariant chrome coordinate space. The
+/// keyboard slides the render wrapper, never the chrome, so the chip needs no
+/// keyboard math and no per-frame following: its position falls out of the
+/// same layout solve that seats the dock.
 @MainActor
 final class GhosttySurfaceArtifactChipHost {
     private let container = UIView()
     private(set) var isRequestedVisible = false
     private var visibilityRequested = false
+    private weak var hostView: UIView?
+    private var anchorConstraints: [NSLayoutConstraint] = []
+    private var contentConstraints: [NSLayoutConstraint] = []
 
-    func install(in surfaceView: UIView, zPosition: CGFloat) {
+    /// Anchored to the top of the host's safe area: pinned above the toolbar
+    /// it covered the input row, which users type into far more often than
+    /// they read the first terminal line.
+    ///
+    /// Idempotent re-homing: installing into a new host replaces the previous
+    /// anchor constraints. Re-homing happens only at host construction,
+    /// before any chip is mounted, so the reset of the hidden/alpha state
+    /// never blinks a visible chip.
+    func install(in hostView: UIView, zPosition: CGFloat) {
+        guard hostView !== self.hostView else { return }
         container.backgroundColor = .clear
         container.clipsToBounds = false
         container.alpha = 0
@@ -16,48 +37,57 @@ final class GhosttySurfaceArtifactChipHost {
         container.isAccessibilityElement = false
         container.accessibilityElementsHidden = true
         container.layer.zPosition = zPosition
-        surfaceView.addSubview(container)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.deactivate(anchorConstraints)
+        container.removeFromSuperview()
+        hostView.addSubview(container)
+        self.hostView = hostView
+        // Tap-target floor and readable-width ceiling, matching the manual
+        // frame pass this container had before it was constraint-anchored.
+        // The weak default-size pulls sit below every content priority so a
+        // hosted view's intrinsic size drives the container between the
+        // floor and ceiling, while content without an intrinsic size (bare
+        // test views) still resolves unambiguously to the floor.
+        let defaultWidth = container.widthAnchor.constraint(equalToConstant: 88)
+        defaultWidth.priority = UILayoutPriority(100)
+        let defaultHeight = container.heightAnchor.constraint(equalToConstant: 44)
+        defaultHeight.priority = UILayoutPriority(100)
+        anchorConstraints = [
+            container.centerXAnchor.constraint(equalTo: hostView.centerXAnchor),
+            container.topAnchor.constraint(
+                equalTo: hostView.safeAreaLayoutGuide.topAnchor,
+                constant: 8
+            ),
+            container.widthAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+            container.widthAnchor.constraint(
+                lessThanOrEqualTo: hostView.widthAnchor,
+                constant: -32
+            ),
+            defaultWidth,
+            defaultHeight,
+        ]
+        NSLayoutConstraint.activate(anchorConstraints)
     }
 
     func setContent(_ view: UIView?) {
         isRequestedVisible = view != nil
         guard let view, container.subviews.first !== view else { return }
+        NSLayoutConstraint.deactivate(contentConstraints)
+        contentConstraints = []
         container.subviews.forEach { $0.removeFromSuperview() }
         view.backgroundColor = .clear
-        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(view)
-    }
-
-    /// The top inset the last layout actually applied. The surface's
-    /// display-link follow compares against this so re-pinning the chip while
-    /// the host slides the render wrapper for the keyboard is a no-op within
-    /// half a point.
-    private(set) var appliedTopInset: CGFloat = 0
-
-    // Anchored to the terminal's top edge: pinned above the toolbar it covered
-    // the input row, which users type into far more often than they read the
-    // first terminal line.
-    func layout(in bounds: CGRect, topInset: CGFloat) {
-        guard let content = container.subviews.first else {
-            container.frame = .zero
-            return
-        }
-        appliedTopInset = topInset
-        let maxWidth = max(44, bounds.width - 32)
-        let fitting = content.systemLayoutSizeFitting(
-            CGSize(width: maxWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .fittingSizeLevel,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-        let width = min(maxWidth, max(88, fitting.width))
-        let height = max(44, fitting.height)
-        container.frame = CGRect(
-            x: (bounds.width - width) / 2,
-            y: max(8, topInset + 8),
-            width: width,
-            height: height
-        ).integral
-        content.frame = container.bounds
+        // Edge-pinned so the hosted view's intrinsic size drives the
+        // container between the anchor floor/ceiling constraints.
+        contentConstraints = [
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            view.topAnchor.constraint(equalTo: container.topAnchor),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ]
+        NSLayoutConstraint.activate(contentConstraints)
     }
 
     func updateVisibility(shouldShow: Bool, animated: Bool) {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
@@ -28,6 +28,12 @@ final class GhosttySurfaceArtifactChipHost {
         container.addSubview(view)
     }
 
+    /// The top inset the last layout actually applied. The surface's
+    /// display-link follow compares against this so re-pinning the chip while
+    /// the host slides the render wrapper for the keyboard is a no-op within
+    /// half a point.
+    private(set) var appliedTopInset: CGFloat = 0
+
     // Anchored to the terminal's top edge: pinned above the toolbar it covered
     // the input row, which users type into far more often than they read the
     // first terminal line.
@@ -36,6 +42,7 @@ final class GhosttySurfaceArtifactChipHost {
             container.frame = .zero
             return
         }
+        appliedTopInset = topInset
         let maxWidth = max(44, bounds.width - 32)
         let fitting = content.systemLayoutSizeFitting(
             CGSize(width: maxWidth, height: UIView.layoutFittingCompressedSize.height),

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -131,6 +131,10 @@ public final class GhosttySurfaceHostView: UIView {
         surfaceView.translatesAutoresizingMaskIntoConstraints = false
         terminalPresentationView.addSubview(surfaceView)
         dockBottomConstraint = surfaceView.moveBottomDock(to: self)
+        // The artifact chip joins the dock in this host's keyboard-invariant
+        // chrome space: the render wrapper slides under a keyboard, the
+        // chrome must not.
+        surfaceView.moveArtifactChip(to: self)
         if usesKeyboardGuideSeat {
             keyboardLayoutGuide.followsUndockedKeyboard = true
             keyboardLayoutGuide.usesBottomSafeArea = true

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1891,7 +1891,53 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private func layoutArtifactChip(using snapshot: TerminalViewportSnapshot) {
-        artifactChipHost.layout(in: bounds, topInset: safeAreaInsets.top)
+        artifactChipHost.layout(in: bounds, topInset: artifactChipVisibleTopInset)
+    }
+
+    /// The top inset that keeps the chip inside the terminal's VISIBLE region.
+    ///
+    /// While the keyboard is up the host slides the full-height render wrapper
+    /// — and this surface with it — so the render bottom rides the composer
+    /// bar (see `GhosttySurfaceHostView`). The surface's own top edge, and a
+    /// chip anchored to it, then sit above the clipped-visible area, so
+    /// `safeAreaInsets.top` alone put the chip off screen for exactly the
+    /// keyboard-up sessions that need to tap it. Pin below the highest
+    /// clipping ancestor's visible top instead, preferring presentation
+    /// layers (same pattern as ``presentationFrameInSurface(of:)``) so the
+    /// display-link follow tracks the keyboard animation itself rather than
+    /// the already-final model frames.
+    private var artifactChipVisibleTopInset: CGFloat {
+        var topInset = safeAreaInsets.top
+        let surfaceLayer = layer.presentation() ?? layer
+        var ancestor = superview
+        while let view = ancestor {
+            if view.clipsToBounds || view is UIWindow {
+                let ancestorLayer = view.layer.presentation() ?? view.layer
+                let visibleTop = ancestorLayer.convert(
+                    ancestorLayer.bounds.origin,
+                    to: surfaceLayer
+                ).y
+                topInset = max(topInset, visibleTop)
+            }
+            ancestor = view.superview
+        }
+        return topInset
+    }
+
+    /// Keeps a mounted chip pinned to the visible top edge while the host
+    /// slides the render wrapper for the keyboard. Runs once per display-link
+    /// frame, like the dock's absorption follow; the rest guard skips the
+    /// presentation-layer walk entirely while nothing can be sliding, and the
+    /// drift guard makes the follow a no-op within half a point.
+    private func followArtifactChipPresentationIfNeeded() {
+        guard artifactChipHost.isRequestedVisible else { return }
+        if keyboardHeight <= 0,
+           abs(artifactChipHost.appliedTopInset - safeAreaInsets.top) <= 0.5 {
+            return
+        }
+        let topInset = artifactChipVisibleTopInset
+        guard abs(topInset - artifactChipHost.appliedTopInset) > 0.5 else { return }
+        artifactChipHost.layout(in: bounds, topInset: topInset)
     }
 
     private var artifactChipShouldBeVisible: Bool {
@@ -3803,6 +3849,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
         }
         sampleHostedKeyboardPresentation()
+        followArtifactChipPresentationIfNeeded()
         // Apply geometry at most once per frame. Every trigger (resize, zoom,
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1854,7 +1854,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     ///   - animated: Whether visibility changes should fade and slide.
     public func mountArtifactChipView(_ view: UIView?, animated: Bool) {
         artifactChipHost.setContent(view)
-        layoutArtifactChip(using: viewportSnapshot())
         updateArtifactChipVisibility(animated: animated)
     }
 
@@ -1890,54 +1889,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    private func layoutArtifactChip(using snapshot: TerminalViewportSnapshot) {
-        artifactChipHost.layout(in: bounds, topInset: artifactChipVisibleTopInset)
+    /// Re-homes the artifact chip container into the host's keyboard-invariant
+    /// chrome coordinate space — the same adoption ``moveBottomDock(to:)``
+    /// performs for the dock. The keyboard slides the render wrapper (and this
+    /// surface with it), never the host, so a chip anchored in host space
+    /// stays at the terminal's visible top edge through every keyboard leg
+    /// with no keyboard math of its own.
+    func moveArtifactChip(to host: UIView) {
+        artifactChipHost.install(in: host, zPosition: Self.artifactChipZPosition)
     }
 
-    /// The top inset that keeps the chip inside the terminal's VISIBLE region.
-    ///
-    /// While the keyboard is up the host slides the full-height render wrapper
-    /// — and this surface with it — so the render bottom rides the composer
-    /// bar (see `GhosttySurfaceHostView`). The surface's own top edge, and a
-    /// chip anchored to it, then sit above the clipped-visible area, so
-    /// `safeAreaInsets.top` alone put the chip off screen for exactly the
-    /// keyboard-up sessions that need to tap it. Pin below the highest
-    /// clipping ancestor's visible top instead, preferring presentation
-    /// layers (same pattern as ``presentationFrameInSurface(of:)``) so the
-    /// display-link follow tracks the keyboard animation itself rather than
-    /// the already-final model frames.
-    private var artifactChipVisibleTopInset: CGFloat {
-        var topInset = safeAreaInsets.top
-        let surfaceLayer = layer.presentation() ?? layer
-        var ancestor = superview
-        while let view = ancestor {
-            if view.clipsToBounds || view is UIWindow {
-                let ancestorLayer = view.layer.presentation() ?? view.layer
-                let visibleTop = ancestorLayer.convert(
-                    ancestorLayer.bounds.origin,
-                    to: surfaceLayer
-                ).y
-                topInset = max(topInset, visibleTop)
-            }
-            ancestor = view.superview
-        }
-        return topInset
-    }
-
-    /// Keeps a mounted chip pinned to the visible top edge while the host
-    /// slides the render wrapper for the keyboard. Runs once per display-link
-    /// frame, like the dock's absorption follow; the rest guard skips the
-    /// presentation-layer walk entirely while nothing can be sliding, and the
-    /// drift guard makes the follow a no-op within half a point.
-    private func followArtifactChipPresentationIfNeeded() {
-        guard artifactChipHost.isRequestedVisible else { return }
-        if keyboardHeight <= 0,
-           abs(artifactChipHost.appliedTopInset - safeAreaInsets.top) <= 0.5 {
-            return
-        }
-        let topInset = artifactChipVisibleTopInset
-        guard abs(topInset - artifactChipHost.appliedTopInset) > 0.5 else { return }
-        artifactChipHost.layout(in: bounds, topInset: topInset)
+    /// The view whose bounds match the SwiftUI representable that presents
+    /// the artifact-files popover: the adopting host once the chrome is
+    /// re-homed, else this surface. Popover anchors normalized against the
+    /// sliding surface would drift downward by the keyboard slide.
+    public var artifactChipAnchorReferenceView: UIView {
+        bottomDockHostView ?? self
     }
 
     private var artifactChipShouldBeVisible: Bool {
@@ -2155,7 +2122,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             reservedToolbarHeight,
             snapshot.toolbarFrame.height
         )
-        layoutArtifactChip(using: snapshot)
     }
 
     /// Lays out the hierarchy that owns the dock constraints. Once the dock moves
@@ -3849,7 +3815,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
         }
         sampleHostedKeyboardPresentation()
-        followArtifactChipPresentationIfNeeded()
         // Apply geometry at most once per frame. Every trigger (resize, zoom,
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalArtifactChipKeyboardTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalArtifactChipKeyboardTests.swift
@@ -9,12 +9,13 @@ import UIKit
 
 @testable import CmuxMobileTerminal
 
-/// The files-chip keyboard contract: the chip anchors to the top of the
-/// terminal's VISIBLE region. While the keyboard is up the host slides the
-/// full-height render wrapper — and the surface with it — so the render
-/// bottom rides the composer bar (#10594); the chip must counter that slide
-/// and stay inside the clipped-visible area instead of riding the surface's
-/// top edge off screen.
+/// The files-chip keyboard contract: the chip is chrome, not render. The host
+/// slides the full-height render wrapper so the render bottom rides the
+/// composer bar while the keyboard is up (#10594); the chip is adopted into
+/// the host's keyboard-invariant chrome space (like the dock), so its frame
+/// in host coordinates must not move at all across keyboard toggles — before
+/// this contract it rode the surface's top edge off screen whenever the
+/// keyboard was shown.
 @MainActor
 private final class ArtifactChipKeyboardDelegate: NSObject, GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
@@ -38,74 +39,43 @@ struct TerminalArtifactChipKeyboardTests {
         return (view, delegate)
     }
 
-    @Test("chip keeps its resting top anchor while nothing above clips the surface")
+    @Test("chip keeps its resting top anchor on a hostless surface")
     func chipRestsAtSurfaceTop() async throws {
         let (view, delegate) = try makeSurface()
         _ = delegate
         let bounds = CGRect(x: 0, y: 0, width: 402, height: 874)
         let window = UIWindow(frame: bounds)
-        let clipView = UIView(frame: bounds)
-        clipView.clipsToBounds = true
-        window.addSubview(clipView)
+        window.addSubview(view)
         window.isHidden = false
         defer {
             view.prepareForDismantle()
-            clipView.removeFromSuperview()
+            view.removeFromSuperview()
             window.isHidden = true
         }
         view.frame = bounds
-        clipView.addSubview(view)
         view.layoutIfNeeded()
 
         let chipContent = UIView()
         view.mountArtifactChipView(chipContent, animated: false)
+        view.layoutIfNeeded()
         let container = try #require(chipContent.superview)
-        let restingY = max(8, view.safeAreaInsets.top + 8)
+        let restingY = view.safeAreaInsets.top + 8
         #expect(
             abs(container.frame.minY - restingY) <= 1,
             "resting chip must keep its top anchor; minY=\(container.frame.minY) expected=\(restingY)"
         )
+        #expect(container.frame.height >= 44)
+        #expect(container.frame.width >= 88)
     }
 
-    @Test("chip stays inside the visible region while the surface is slid for the keyboard")
-    func chipPinsToVisibleTopWhileSlid() async throws {
-        let (view, delegate) = try makeSurface()
-        _ = delegate
-        let bounds = CGRect(x: 0, y: 0, width: 402, height: 874)
-        let window = UIWindow(frame: bounds)
-        let clipView = UIView(frame: bounds)
-        clipView.clipsToBounds = true
-        window.addSubview(clipView)
-        window.isHidden = false
-        defer {
-            view.prepareForDismantle()
-            clipView.removeFromSuperview()
-            window.isHidden = true
-        }
-        // The keyboard-up placement the host produces: the full-height surface
-        // slid up inside a clipping wrapper so its bottom rides the composer
-        // bar and its top sits above the visible area.
-        let slide: CGFloat = 300
-        view.frame = bounds.offsetBy(dx: 0, dy: -slide)
-        clipView.addSubview(view)
-        view.layoutIfNeeded()
-
-        let chipContent = UIView()
-        view.mountArtifactChipView(chipContent, animated: false)
-        let container = try #require(chipContent.superview)
-        #expect(
-            container.frame.minY >= slide,
-            "chip must stay inside the clipped-visible region; minY=\(container.frame.minY) visibleTop=\(slide)"
-        )
-    }
-
-    /// End-to-end through the real host: ride a keyboard seat and require the
-    /// chip to sit at or below the host's visible top edge in surface
-    /// coordinates, in both keyboard states. The slide magnitude depends on
-    /// how much blank render absorbs the intrusion (harness-dependent), so
-    /// the assertion is the visibility contract rather than a fixed offset.
-    @Test("host keeps the chip visible across keyboard toggles")
-    func hostKeepsChipVisibleAcrossKeyboardToggles() async throws {
+    /// End-to-end through the real host: the chip's frame in HOST coordinates
+    /// is identical before, during, and after a keyboard seat ride, because
+    /// the chip is constraint-anchored in the host's chrome space and the
+    /// keyboard moves only the render wrapper. The pre-contract failure mode
+    /// (chip riding the slid wrapper above the visible region) shows up here
+    /// as a keyboard-up frame shifted by the slide.
+    @Test("host keeps the chip frame keyboard-invariant")
+    func hostKeepsChipFrameKeyboardInvariant() async throws {
         let (view, delegate) = try makeSurface()
         _ = delegate
         let host = GhosttySurfaceHostView(
@@ -130,17 +100,19 @@ struct TerminalArtifactChipKeyboardTests {
                 try? await Task.sleep(nanoseconds: 20_000_000)
             }
         }
-        func visibleTop() -> CGFloat {
-            view.convert(CGPoint.zero, from: host).y
-        }
 
         let chipContent = UIView()
         view.mountArtifactChipView(chipContent, animated: false)
+        host.layoutIfNeeded()
         let container = try #require(chipContent.superview)
+        func chipFrameInHost() -> CGRect {
+            container.convert(container.bounds, to: host)
+        }
         await settle()
+        let restingFrame = chipFrameInHost()
         #expect(
-            container.frame.minY + 1 >= visibleTop(),
-            "chip below visible top before keyboard; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
+            abs(restingFrame.minY - (host.safeAreaInsets.top + 8)) <= 1,
+            "chip must rest 8pt below the host's safe top; frame=\(restingFrame)"
         )
 
         // Hand the dock seat to the plain bottom constraint (the system
@@ -154,29 +126,23 @@ struct TerminalArtifactChipKeyboardTests {
         host.setNeedsLayout()
         host.layoutIfNeeded()
         await settle()
-        // The live app re-pins the chip from the surface's display link as the
-        // wrapper animates; the harness forces one settled layout pass instead
-        // of depending on display-link timing inside xctest.
-        view.setNeedsLayout()
-        view.layoutIfNeeded()
+        host.layoutIfNeeded()
+        let keyboardUpFrame = chipFrameInHost()
         #expect(
-            container.frame.minY + 1 >= visibleTop(),
-            "chip slid off the visible region with the keyboard up; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
+            abs(keyboardUpFrame.minY - restingFrame.minY) <= 1
+                && abs(keyboardUpFrame.height - restingFrame.height) <= 1,
+            "chip frame must not move with the keyboard; resting=\(restingFrame) up=\(keyboardUpFrame)"
         )
 
         view.setKeyboardHeightForTesting(0)
         host.setNeedsLayout()
         host.layoutIfNeeded()
         await settle()
-        view.setNeedsLayout()
-        view.layoutIfNeeded()
+        host.layoutIfNeeded()
+        let keyboardDownFrame = chipFrameInHost()
         #expect(
-            container.frame.minY + 1 >= visibleTop(),
-            "chip stuck offset after the keyboard dropped; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
-        )
-        #expect(
-            abs(container.frame.minY - max(8, view.safeAreaInsets.top + 8)) <= 1,
-            "chip must return to its resting anchor after the keyboard drops; minY=\(container.frame.minY)"
+            abs(keyboardDownFrame.minY - restingFrame.minY) <= 1,
+            "chip frame must return unchanged after the keyboard drops; resting=\(restingFrame) down=\(keyboardDownFrame)"
         )
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalArtifactChipKeyboardTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalArtifactChipKeyboardTests.swift
@@ -1,0 +1,183 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import CmuxMobileSupport
+import CmuxMobileTerminalKit
+import CoreGraphics
+import Foundation
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+/// The files-chip keyboard contract: the chip anchors to the top of the
+/// terminal's VISIBLE region. While the keyboard is up the host slides the
+/// full-height render wrapper — and the surface with it — so the render
+/// bottom rides the composer bar (#10594); the chip must counter that slide
+/// and stay inside the clipped-visible area instead of riding the surface's
+/// top edge off screen.
+@MainActor
+private final class ArtifactChipKeyboardDelegate: NSObject, GhosttySurfaceViewDelegate {
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize, reportID: UInt64) {
+        // Steady-state daemon behavior: grant everything the phone asks for.
+        surfaceView.markViewportReportConfirmed()
+        surfaceView.applyConfirmedViewSize(cols: size.columns, rows: size.rows, reportID: reportID)
+    }
+}
+
+@MainActor
+@Suite("Terminal files chip keyboard visibility", .serialized)
+struct TerminalArtifactChipKeyboardTests {
+    private func makeSurface() throws -> (GhosttySurfaceView, ArtifactChipKeyboardDelegate) {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = ArtifactChipKeyboardDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        view.autoFocusOnWindowAttach = false
+        view.isRenderDispatchSuppressed = true
+        return (view, delegate)
+    }
+
+    @Test("chip keeps its resting top anchor while nothing above clips the surface")
+    func chipRestsAtSurfaceTop() async throws {
+        let (view, delegate) = try makeSurface()
+        _ = delegate
+        let bounds = CGRect(x: 0, y: 0, width: 402, height: 874)
+        let window = UIWindow(frame: bounds)
+        let clipView = UIView(frame: bounds)
+        clipView.clipsToBounds = true
+        window.addSubview(clipView)
+        window.isHidden = false
+        defer {
+            view.prepareForDismantle()
+            clipView.removeFromSuperview()
+            window.isHidden = true
+        }
+        view.frame = bounds
+        clipView.addSubview(view)
+        view.layoutIfNeeded()
+
+        let chipContent = UIView()
+        view.mountArtifactChipView(chipContent, animated: false)
+        let container = try #require(chipContent.superview)
+        let restingY = max(8, view.safeAreaInsets.top + 8)
+        #expect(
+            abs(container.frame.minY - restingY) <= 1,
+            "resting chip must keep its top anchor; minY=\(container.frame.minY) expected=\(restingY)"
+        )
+    }
+
+    @Test("chip stays inside the visible region while the surface is slid for the keyboard")
+    func chipPinsToVisibleTopWhileSlid() async throws {
+        let (view, delegate) = try makeSurface()
+        _ = delegate
+        let bounds = CGRect(x: 0, y: 0, width: 402, height: 874)
+        let window = UIWindow(frame: bounds)
+        let clipView = UIView(frame: bounds)
+        clipView.clipsToBounds = true
+        window.addSubview(clipView)
+        window.isHidden = false
+        defer {
+            view.prepareForDismantle()
+            clipView.removeFromSuperview()
+            window.isHidden = true
+        }
+        // The keyboard-up placement the host produces: the full-height surface
+        // slid up inside a clipping wrapper so its bottom rides the composer
+        // bar and its top sits above the visible area.
+        let slide: CGFloat = 300
+        view.frame = bounds.offsetBy(dx: 0, dy: -slide)
+        clipView.addSubview(view)
+        view.layoutIfNeeded()
+
+        let chipContent = UIView()
+        view.mountArtifactChipView(chipContent, animated: false)
+        let container = try #require(chipContent.superview)
+        #expect(
+            container.frame.minY >= slide,
+            "chip must stay inside the clipped-visible region; minY=\(container.frame.minY) visibleTop=\(slide)"
+        )
+    }
+
+    /// End-to-end through the real host: ride a keyboard seat and require the
+    /// chip to sit at or below the host's visible top edge in surface
+    /// coordinates, in both keyboard states. The slide magnitude depends on
+    /// how much blank render absorbs the intrusion (harness-dependent), so
+    /// the assertion is the visibility contract rather than a fixed offset.
+    @Test("host keeps the chip visible across keyboard toggles")
+    func hostKeepsChipVisibleAcrossKeyboardToggles() async throws {
+        let (view, delegate) = try makeSurface()
+        _ = delegate
+        let host = GhosttySurfaceHostView(
+            surfaceView: view,
+            keyboardFrameTracker: MobileKeyboardFrameTracker()
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        host.frame = window.bounds
+        window.addSubview(host)
+        window.isHidden = false
+        defer {
+            view.prepareForDismantle()
+            host.removeFromSuperview()
+            window.isHidden = true
+        }
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        func settle(_ interval: TimeInterval = 0.8) async {
+            let deadline = Date(timeIntervalSinceNow: interval)
+            while Date() < deadline {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+        }
+        func visibleTop() -> CGFloat {
+            view.convert(CGPoint.zero, from: host).y
+        }
+
+        let chipContent = UIView()
+        view.mountArtifactChipView(chipContent, animated: false)
+        let container = try #require(chipContent.superview)
+        await settle()
+        #expect(
+            container.frame.minY + 1 >= visibleTop(),
+            "chip below visible top before keyboard; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
+        )
+
+        // Hand the dock seat to the plain bottom constraint (the system
+        // keyboard guide cannot be driven on a simulator) and ride a keyboard.
+        view.setChromeHidden(true)
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+        await settle()
+
+        view.setKeyboardHeightForTesting(336)
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+        await settle()
+        // The live app re-pins the chip from the surface's display link as the
+        // wrapper animates; the harness forces one settled layout pass instead
+        // of depending on display-link timing inside xctest.
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        #expect(
+            container.frame.minY + 1 >= visibleTop(),
+            "chip slid off the visible region with the keyboard up; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
+        )
+
+        view.setKeyboardHeightForTesting(0)
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+        await settle()
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        #expect(
+            container.frame.minY + 1 >= visibleTop(),
+            "chip stuck offset after the keyboard dropped; minY=\(container.frame.minY) visibleTop=\(visibleTop())"
+        )
+        #expect(
+            abs(container.frame.minY - max(8, view.safeAreaInsets.top + 8)) <= 1,
+            "chip must return to its resting anchor after the keyboard drops; minY=\(container.frame.minY)"
+        )
+    }
+}
+#endif

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardFullHeightPinTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardFullHeightPinTests.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import CMUXMobileCore
+import CmuxMobileSupport
 import CmuxMobileTerminalKit
 import CoreGraphics
 import Foundation
@@ -88,7 +89,10 @@ struct TerminalKeyboardFullHeightPinTests {
         let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
         view.autoFocusOnWindowAttach = false
         view.isRenderDispatchSuppressed = true
-        let host = GhosttySurfaceHostView(surfaceView: view)
+        let host = GhosttySurfaceHostView(
+            surfaceView: view,
+            keyboardFrameTracker: MobileKeyboardFrameTracker()
+        )
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
         host.frame = window.bounds
         window.addSubview(host)


### PR DESCRIPTION
## Problem

Since https://github.com/manaflow-ai/cmux/pull/10594 the keyboard no longer resizes the terminal: `GhosttySurfaceHostView` slides the full-height render wrapper up so the render bottom rides the composer bar. The files chip was anchored to the surface's own top edge (`safeAreaInsets.top + 8`), so the slide carried it above the clipped-visible area and the only Files control disappeared whenever the keyboard was shown.

## Fix

The chip is chrome, not render. `GhosttySurfaceHostView` adopts the chip container into its own keyboard-invariant coordinate space (`moveArtifactChip(to:)`, mirroring `moveBottomDock(to:)`), constraint-anchored 8pt below the host's safe-area top with the same tap-target floor and width ceiling the old manual frame pass enforced. The keyboard slides only the render wrapper, so the chip is keyboard-invariant by construction: no keyboard math, no per-frame following. Hostless surfaces (tests, previews) keep a surface-anchored fallback with identical resting placement.

This also fixes the artifact-files popover anchor, which was normalized against the surface's bounds and would have drifted downward by the slide while the keyboard is up; it now normalizes against the view backing the SwiftUI representable.

(The first fix iteration used a display-link follow that re-derived the chip's visible-top inset per frame; it was replaced in `d1e0609` with the constraint adoption above after review feedback that a follower is the wrong shape for this.)

## Commits

Regression pair: commit 1 adds the failing tests, later commits the fix. The final tests assert the chip's frame in host coordinates is identical before, during, and after a keyboard seat ride, end to end through the real host and surface.

Note: no CI lane currently compiles `cmuxFeatureTests` (the `cmux-ios` scheme's only testable is `cmuxUITests`), which is how https://github.com/manaflow-ai/cmux/pull/10687 silently compile-broke `TerminalKeyboardFullHeightPinTests` by adding a required `keyboardFrameTracker:` parameter; commit 1 also repairs that call site.

This branch also carries the two main-red iOS compile fixes from https://github.com/manaflow-ai/cmux/pull/10813 (required to build any iOS archive from current main).

## HIG

Checked [Virtual keyboards](https://developer.apple.com/design/human-interface-guidelines/virtual-keyboards): "Using the [keyboard] layout guide also helps you keep important parts of your interface visible while the virtual keyboard is onscreen." This fix restores exactly that for the Files control; no deliberate deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal artifact-chip positioning while the keyboard appears, moves, or changes height.
  * Kept chips anchored to the visible host area and prevented them from extending beyond available width.
  * Improved chip placement during terminal transitions for smoother movement.
  * Corrected workspace anchoring for empty groups without an active workspace.

* **Tests**
  * Added coverage for chip anchoring, visibility, containment, and restoration across keyboard transitions.
  * Updated full-height keyboard tests to use mobile keyboard tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->