### PR TITLE
build-package: attest release binaries even when the optional Windows build skips

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -779,7 +779,17 @@ jobs:
     needs:
       - plan-build
       - package
-    if: ${{ inputs.package_npm || inputs.package_pypi }}
+    # always() + explicit needs results: without it, the implicit success()
+    # is poisoned transitively by a skipped build-windows (include_windows
+    # false), this job skips, and attest-npm-packages skips with it — leaving
+    # a release tag with no fresh attestations for its own commit.
+    if: >-
+      ${{
+        always() &&
+        (inputs.package_npm || inputs.package_pypi) &&
+        needs.plan-build.result == 'success' &&
+        needs.package.result == 'success'
+      }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -846,8 +856,12 @@ jobs:
     needs:
       - package
       - verify-linux-packages
+    # always() for the same reason as verify-linux-packages: the explicit
+    # needs.result checks below are the real gate, and the implicit success()
+    # must not skip attestations because an optional Windows build skipped.
     if: >-
       ${{
+        always() &&
         inputs.attest_packages &&
         inputs.package_npm &&
         needs.package.result == 'success' &&

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1577,6 +1577,22 @@ def test_relay_launcher_rc_fallback_never_relaxes_stable() -> None:
     assert text.count("cmux-relay --version") == 1
 
 
+def test_relay_attestations_survive_a_skipped_windows_build() -> None:
+    text = workflow("cmux-tui-build-package.yml")
+
+    # A skipped optional build-windows poisons the implicit success() on
+    # transitive dependents. verify-linux-packages and attest-npm-packages
+    # must carry always() plus explicit needs.result gates so a Unix-only
+    # release tag still attests binaries for its own commit; without this,
+    # the publish job's --source-digest verification can only ever match a
+    # stale attestation from an older byte-identical build (rc.3 regression,
+    # run 32935658524).
+    for job_anchor in ("  verify-linux-packages:", "  attest-npm-packages:"):
+        section = text.split(job_anchor, 1)[1].split("runs-on:", 1)[0]
+        assert "always() &&" in section
+        assert "needs.package.result == 'success'" in section
+
+
 def test_npm_builder_accepts_relay_release_candidate_versions() -> None:
     builder = ROOT / "cmux-tui" / "dist" / "scripts" / "package_npm.py"
     namespace = runpy.run_path(str(builder), run_name="cmux_tui_package_npm_test")


### PR DESCRIPTION
rc.3 of the cmux-relay lane (run 32935658524) failed at the publish job's attestation verification: `expected SourceRepositoryDigest dafccec…, got b95d5b85…`.

Root cause chain:
1. The relay lane passes `include_windows: false`, so `build-windows` skips.
2. `verify-linux-packages` has a plain `if:` — the implicit `success()` is poisoned transitively by the skipped job, so it skips despite its needs succeeding (the `package` job survives only because it already uses `always() && needs.X.result`).
3. `attest-npm-packages` requires `verify-linux-packages.result == 'success'` → skips too.
4. The tag's commit gets no fresh attestations. The relay binaries were byte-identical to an older build (reproducible build after the crate revert), so `gh attestation verify --source-digest $GITHUB_SHA` found only the stale attestation and correctly failed.

Fix: extend the `package` job's own `always() && explicit needs.result` idiom to `verify-linux-packages` and `attest-npm-packages`. The publish job's fail-closed `--source-digest` verification stays exactly as designed — with fresh attestations it passes.

Gates: workflow security suite 55/55 locally (new pin `test_relay_attestations_survive_a_skipped_windows_build`), YAML parse-checked. Real-world proof is the next `cmux-relay-v*` tag (rc.4).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790318808&installation_model_id=21920&pr_number=10803&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10803&signature=c66b86d7b27d7070bed5587dec4dbd12d951ae08c7730a63a5e4a41f17d1faa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability when optional Windows builds are skipped.
  * Ensured Linux package verification and npm attestation proceed only after required planning and packaging steps succeed.

* **Tests**
  * Added regression coverage to verify the updated workflow scheduling and success requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->