### PR TITLE
web: relay attach/detach reports publish the relay route (intended-shape series)

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -26,6 +26,9 @@ public actor CmxConnectivityEngine {
     private let installRouteSnapshot: RouteSnapshotInstaller?
     private let diagnosticLog: DiagnosticLog?
     private let clock: any CmxIrohRelayClock
+    /// Deadline for each dial phase (public paths, private fallback, and the
+    /// admission barrier) of every peer session this engine creates.
+    private let dialPhaseTimeout: Duration
     private var desiredActive = false
     private var lifecycleRevision: UInt64 = 0
     private var endpointGeneration: UInt64?
@@ -59,7 +62,8 @@ public actor CmxConnectivityEngine {
         authority: (any CmxConnectivityAuthorityServing)? = nil,
         installRouteSnapshot: RouteSnapshotInstaller? = nil,
         diagnosticLog: DiagnosticLog? = nil,
-        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock(),
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         precondition((authority == nil) == (installRouteSnapshot == nil))
         supervisor = CmxIrohEndpointSupervisor(
@@ -72,6 +76,7 @@ public actor CmxConnectivityEngine {
         self.installRouteSnapshot = installRouteSnapshot
         self.diagnosticLog = diagnosticLog
         self.clock = clock
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 
     /// Creates a stopped endpoint-only engine for a host acceptor.
@@ -90,6 +95,7 @@ public actor CmxConnectivityEngine {
         installRouteSnapshot = nil
         diagnosticLog = nil
         clock = CmxIrohSystemRelayClock()
+        dialPhaseTimeout = .seconds(5)
     }
 
     init(
@@ -99,7 +105,8 @@ public actor CmxConnectivityEngine {
         authority: (any CmxConnectivityAuthorityServing)? = nil,
         installRouteSnapshot: RouteSnapshotInstaller? = nil,
         diagnosticLog: DiagnosticLog? = nil,
-        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock(),
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         precondition((authority == nil) == (installRouteSnapshot == nil))
         self.supervisor = supervisor
@@ -109,6 +116,7 @@ public actor CmxConnectivityEngine {
         self.installRouteSnapshot = installRouteSnapshot
         self.diagnosticLog = diagnosticLog
         self.clock = clock
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 
     /// Returns the current immutable UI-safe state.
@@ -533,6 +541,7 @@ public actor CmxConnectivityEngine {
         let protocolConfiguration = protocolConfiguration
         let diagnosticLog = diagnosticLog
         let clock = clock
+        let dialPhaseTimeout = dialPhaseTimeout
         let peer = CmxConnectivityPeerSession(
             peerID: peerID,
             buildSession: { request in
@@ -551,6 +560,7 @@ public actor CmxConnectivityEngine {
                             basedOn: context
                         )
                     },
+                    dialPhaseTimeout: dialPhaseTimeout,
                     protocolConfiguration: protocolConfiguration,
                     diagnostics: diagnosticLog
                 )

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -306,6 +306,11 @@ public actor CmxConnectivityEngine {
         await supervisor.hasConfiguredRelay()
     }
 
+    /// Returns whether the active endpoint generation reports a usable home relay.
+    public func hasUsableHomeRelay() async -> Bool {
+        await supervisor.hasUsableHomeRelay()
+    }
+
     /// Waits for the active endpoint generation to report relay readiness.
     public func waitForUsableHomeRelay(
         timeout: Duration = .seconds(15)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -29,6 +29,12 @@ extension CmxIrohClientRuntime {
         managedRelayURLs replacementManagedURLs: Set<String>,
         relayBootstrap: CmxIrohRelayTokenResponse?
     ) async throws {
+        // A debug-only forced relay pins every profile installation, so a
+        // broker policy refresh cannot displace the test relay mid-run.
+        var profile = profile
+        if let debugOverride = CmxIrohDebugRelayOverride.activeProfile() {
+            profile = debugOverride
+        }
         guard lifecyclePhase == .active, let binding = localBinding else {
             throw CmxIrohClientRuntimeError.inactive
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -172,7 +172,8 @@ public actor CmxIrohClientRuntime {
             supervisor: supervisor,
             contextProvider: contextRouter,
             protocolConfiguration: protocolConfiguration,
-            diagnosticLog: diagnosticLog
+            diagnosticLog: diagnosticLog,
+            dialPhaseTimeout: configuration.dialPhaseTimeout
         )
         self.supervisor = supervisor
         self.connectivityEngine = connectivityEngine

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
@@ -44,6 +44,12 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
     /// flight. A signed registration refresh follows after activation.
     public let cachedBinding: CmxIrohBrokerBindingMetadata?
 
+    /// Deadline for each dial phase (public paths, private fallback, and the
+    /// admission barrier) of every peer dial this runtime performs. A phase
+    /// that never answers fails typed at this bound and hands control back to
+    /// recovery instead of holding the reconnect owner (cmux#9724).
+    public let dialPhaseTimeout: Duration
+
     /// Creates an immutable iOS client lifecycle configuration.
     ///
     /// Broker-facing validation occurs when ``CmxIrohClientRuntime/start()``
@@ -60,6 +66,8 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
     ///   - endpointRelayProfile: An optional local selection or custom override.
     ///   - cachedRelayCredential: A validated cached relay capability.
     ///   - cachedBinding: A previously verified exact local binding tuple.
+    ///   - dialPhaseTimeout: The per-phase dial deadline, injectable so tests
+    ///     can shrink it.
     public init(
         accountID: String,
         deviceID: String,
@@ -72,7 +80,8 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
         managedRelayURLs: Set<String>,
         endpointRelayProfile: CmxIrohEndpointRelayProfile? = nil,
         cachedRelayCredential: CmxIrohRelayTokenResponse? = nil,
-        cachedBinding: CmxIrohBrokerBindingMetadata? = nil
+        cachedBinding: CmxIrohBrokerBindingMetadata? = nil,
+        dialPhaseTimeout: Duration = .seconds(5)
     ) {
         self.accountID = accountID
         self.deviceID = cmxCanonicalDeviceID(deviceID)
@@ -86,5 +95,6 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
         self.endpointRelayProfile = endpointRelayProfile
         self.cachedRelayCredential = cachedRelayCredential
         self.cachedBinding = cachedBinding
+        self.dialPhaseTimeout = dialPhaseTimeout
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
@@ -431,56 +431,71 @@ public actor CmxIrohClientSession {
 
         do {
             try Task.checkCancellation()
-            guard await establishedConnection.remoteIdentity() == targetIdentity else {
-                throw CmxIrohClientSessionError.remoteIdentityMismatch
-            }
-            try await establishedConnection.setIncomingStreamLimits(
-                maximumBidirectionalStreamCount: 0,
-                maximumUnidirectionalStreamCount: 0
-            )
-            let stream = try await establishedConnection.openBidirectionalStream()
-            let header = try CmxIrohStreamHeader(
-                lane: .control,
-                credential: credential
-            )
-            try await stream.sendStream.send(headerCodec.encode(header))
-            let admission = try await readAdmissionFrame(from: stream.receiveStream)
-            switch admission.frame {
-            case .acceptedPendingNatTraversal, .acceptedRelayOnly:
-                if admission.frame == .acceptedPendingNatTraversal {
-                    try Task.checkCancellation()
-                    try await establishedConnection.authorizeNatTraversal()
-                }
-                try Task.checkCancellation()
-                try await stream.sendStream.send(
-                    admissionCodec.encodeFrame(.clientReady)
+            // A half-ready peer can accept the QUIC connection and then never
+            // serve the admission frames. Bound the whole barrier like a dial
+            // phase so a silent peer hands control back to recovery instead
+            // of holding the redial owner open-endedly (cmux#9724).
+            return try await boundedByDialPhase { [weak self] in
+                guard let self else { throw CancellationError() }
+                return try await self.performAdmissionBarrier(
+                    on: establishedConnection
                 )
-                let confirmation = try await readAdmissionFrame(
-                    from: stream.receiveStream,
-                    initialBuffer: admission.trailingBytes
-                )
-                switch confirmation.frame {
-                case .serverReady:
-                    break
-                case let .denied(code):
-                    throw CmxIrohClientSessionError.admissionDenied(code: code)
-                case .acceptedPendingNatTraversal, .acceptedRelayOnly, .clientReady:
-                    throw CmxIrohClientSessionError.invalidAdmissionFrame
-                }
-                try Task.checkCancellation()
-                return CmxIrohConnectedControl(
-                    connection: establishedConnection,
-                    stream: stream,
-                    initialReceiveBuffer: confirmation.trailingBytes
-                )
-            case let .denied(code):
-                throw CmxIrohClientSessionError.admissionDenied(code: code)
-            case .clientReady, .serverReady:
-                throw CmxIrohClientSessionError.invalidAdmissionFrame
             }
         } catch {
             await establishedConnection.close(errorCode: 1, reason: "admission_failed")
             throw error
+        }
+    }
+
+    private func performAdmissionBarrier(
+        on establishedConnection: any CmxIrohConnection
+    ) async throws -> CmxIrohConnectedControl {
+        guard await establishedConnection.remoteIdentity() == targetIdentity else {
+            throw CmxIrohClientSessionError.remoteIdentityMismatch
+        }
+        try await establishedConnection.setIncomingStreamLimits(
+            maximumBidirectionalStreamCount: 0,
+            maximumUnidirectionalStreamCount: 0
+        )
+        let stream = try await establishedConnection.openBidirectionalStream()
+        let header = try CmxIrohStreamHeader(
+            lane: .control,
+            credential: credential
+        )
+        try await stream.sendStream.send(headerCodec.encode(header))
+        let admission = try await readAdmissionFrame(from: stream.receiveStream)
+        switch admission.frame {
+        case .acceptedPendingNatTraversal, .acceptedRelayOnly:
+            if admission.frame == .acceptedPendingNatTraversal {
+                try Task.checkCancellation()
+                try await establishedConnection.authorizeNatTraversal()
+            }
+            try Task.checkCancellation()
+            try await stream.sendStream.send(
+                admissionCodec.encodeFrame(.clientReady)
+            )
+            let confirmation = try await readAdmissionFrame(
+                from: stream.receiveStream,
+                initialBuffer: admission.trailingBytes
+            )
+            switch confirmation.frame {
+            case .serverReady:
+                break
+            case let .denied(code):
+                throw CmxIrohClientSessionError.admissionDenied(code: code)
+            case .acceptedPendingNatTraversal, .acceptedRelayOnly, .clientReady:
+                throw CmxIrohClientSessionError.invalidAdmissionFrame
+            }
+            try Task.checkCancellation()
+            return CmxIrohConnectedControl(
+                connection: establishedConnection,
+                stream: stream,
+                initialReceiveBuffer: confirmation.trailingBytes
+            )
+        case let .denied(code):
+            throw CmxIrohClientSessionError.admissionDenied(code: code)
+        case .clientReady, .serverReady:
+            throw CmxIrohClientSessionError.invalidAdmissionFrame
         }
     }
 
@@ -498,22 +513,32 @@ public actor CmxIrohClientSession {
     ) async throws -> any CmxIrohConnection {
         let endpoint = endpoint
         let alpn = protocolConfiguration.alpn
+        return try await boundedByDialPhase {
+            try await endpoint.connect(to: address, alpn: alpn)
+        }
+    }
+
+    /// Races one dial-phase operation against the injected phase bound. The
+    /// operation must cancel cooperatively; on timeout the loser is cancelled
+    /// and the phase fails typed so the redial machinery supersedes it
+    /// instead of wedging behind it (cmux#8531).
+    private func boundedByDialPhase<Value: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
         let bound = dialPhaseTimeout
-        return try await withThrowingTaskGroup(
-            of: (any CmxIrohConnection)?.self
-        ) { group in
+        return try await withThrowingTaskGroup(of: Value?.self) { group in
             group.addTask {
-                try await endpoint.connect(to: address, alpn: alpn)
+                try await operation()
             }
             group.addTask {
                 try await ContinuousClock().sleep(for: bound)
                 return nil
             }
             defer { group.cancelAll() }
-            guard let first = try await group.next(), let connection = first else {
+            guard let first = try await group.next(), let value = first else {
                 throw CmxIrohClientSessionError.dialTimedOut
             }
-            return connection
+            return value
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDebugRelayOverride.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDebugRelayOverride.swift
@@ -1,0 +1,56 @@
+public import Foundation
+
+/// A debug-build-only forced relay for tagged test builds.
+///
+/// When active, every host (Mac) and dial (iOS) endpoint generation uses
+/// exactly one operator-supplied relay, replacing managed policy, cached
+/// credentials, and account preference. The override is read at each
+/// endpoint-profile installation, so a later broker policy refresh cannot
+/// displace it. Release builds compile the override away entirely.
+public enum CmxIrohDebugRelayOverride {
+    /// The environment variable consulted first, and the `UserDefaults` key
+    /// consulted second. A `-CMUX_IROH_RELAY_URL_OVERRIDE <url>` launch
+    /// argument populates the defaults key on iOS builds whose launch
+    /// environment cannot carry variables.
+    public static let key = "CMUX_IROH_RELAY_URL_OVERRIDE"
+
+    /// The process-wide override profile, or nil when inactive.
+    static func activeProfile() -> CmxIrohEndpointRelayProfile? {
+        #if DEBUG
+        profile(rawValue: rawValue())
+        #else
+        nil
+        #endif
+    }
+
+    #if DEBUG
+    /// Reads the raw override value, preferring the process environment.
+    static func rawValue(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard
+    ) -> String? {
+        if let fromEnvironment = environment[key], !fromEnvironment.isEmpty {
+            return fromEnvironment
+        }
+        return defaults.string(forKey: key)
+    }
+
+    /// Builds a strict single-relay custom profile, or nil for unusable input.
+    ///
+    /// The value must be a canonical HTTPS origin; a missing trailing slash
+    /// is added. Any other malformed value deactivates the override instead
+    /// of failing endpoint activation.
+    static func profile(rawValue: String?) -> CmxIrohEndpointRelayProfile? {
+        guard var url = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !url.isEmpty else {
+            return nil
+        }
+        if !url.hasSuffix("/") { url += "/" }
+        guard let relay = try? CmxIrohCustomRelay(url: url),
+              let custom = try? CmxIrohCustomRelayProfile(relays: [relay]) else {
+            return nil
+        }
+        return CmxIrohEndpointRelayProfile(customProfile: custom)
+    }
+    #endif
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -708,6 +708,43 @@ extension CmxIrohHostRuntime {
         guard let connectivityEngine else {
             throw CmxIrohHostRuntimeError.inactive
         }
+        // The startup ready gate retains the superseded cached binding and
+        // relay bootstrap it was armed with. Cancel and drain it before
+        // rebinding so it can never activate the replacement coordinator with
+        // the stale identity or install a stale relay credential; the deferred
+        // first publication is re-armed onto the adopted binding below.
+        if let staleReadyGate = initialPublicationTask {
+            staleReadyGate.cancel()
+            initialPublicationTask = nil
+            await staleReadyGate.value
+            try requireCurrent(revision)
+        }
+        try await rebindRelayCoordinator(
+            policy: policy,
+            engine: connectivityEngine,
+            revision: revision
+        )
+        if initialPublicationPending {
+            // The drained gate owned the relay-readiness wait for the deferred
+            // first publication. Re-arm it bound to the adopted identity so
+            // the endpoint still publishes once the relay becomes usable.
+            scheduleInitialPublication(
+                binding: policy.binding,
+                endpointID: policy.binding.endpointID,
+                bootstrap: policy.relayBootstrap,
+                revision: revision
+            )
+        }
+    }
+
+    /// Deactivates the coordinator pinned to the replaced binding and, for a
+    /// managed relay profile, activates a replacement pinned to the adopted
+    /// binding.
+    private func rebindRelayCoordinator(
+        policy: ResolvedPolicy,
+        engine: CmxConnectivityEngine,
+        revision: UInt64
+    ) async throws {
         guard let coordinator = relayCoordinator else { return }
         relayActivationTask?.cancel()
         relayActivationTask = nil
@@ -721,7 +758,7 @@ extension CmxIrohHostRuntime {
               profile.source == .managed,
               !profile.allowedRelayURLs.isEmpty else { return }
         let replacement = CmxIrohRelayCredentialCoordinator(
-            supervisor: connectivityEngine,
+            supervisor: engine,
             broker: broker,
             managedRelayURLs: managedRelayURLs,
             selectedRelayURLs: profile.allowedRelayURLs,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -272,6 +272,33 @@ extension CmxIrohHostRuntime {
         return discovery
     }
 
+    /// Returns a start policy from the persisted last-good broker policy when
+    /// it still cryptographically verifies for this exact account, identity,
+    /// endpoint, and host settings. Any mismatch is a silent cache miss so
+    /// activation falls back to the blocking authenticated resolve.
+    func validatedCachedStartPolicy(
+        expectedEndpointID: CmxIrohPeerIdentity
+    ) -> ResolvedPolicy? {
+        guard let cached = configuration.cachedHostPolicy else { return nil }
+        do {
+            try validateCachedPolicy(cached, endpointID: expectedEndpointID)
+        } catch {
+            return nil
+        }
+        return ResolvedPolicy(
+            registration: nil,
+            discovery: nil,
+            binding: cached.binding,
+            pairingEnabled: cached.pairingEnabled,
+            grantVerificationKeys: cached.grantVerificationKeys,
+            attestation: cached.endpointAttestation,
+            relayBootstrap: configuration.cachedRelayCredential,
+            lanRendezvous: cached.lanRendezvous,
+            routePathHints: [],
+            registrationRetryAfterSeconds: nil
+        )
+    }
+
     func cachedPolicy(
         after error: any Error,
         expectedEndpointID: CmxIrohPeerIdentity,
@@ -541,7 +568,7 @@ extension CmxIrohHostRuntime {
               let previousBinding = localBinding else { return }
         do {
             let endpointID = try await connectivityEngine.localEndpointIdentity()
-            if !forcePublication {
+            if !forcePublication, !initialPublicationPending {
                 let state = try await registrationPublicationState(
                     engine: connectivityEngine,
                     expectedEndpointID: endpointID
@@ -560,9 +587,16 @@ extension CmxIrohHostRuntime {
                 revision: revision,
                 allowCachedFallback: false
             )
-            guard policy.binding.bindingID == previousBinding.bindingID else {
-                throw CmxIrohHostRuntimeError.invalidLocalBinding
+            if policy.binding.bindingID != previousBinding.bindingID {
+                guard allowsReplacedBindingAdoption else {
+                    throw CmxIrohHostRuntimeError.invalidLocalBinding
+                }
+                // A cache-first activation discovered its persisted binding
+                // was replaced server-side. Adopt the authenticated result in
+                // place, exactly as the blocking activation path would have.
+                try await adoptReplacedBinding(policy: policy, revision: revision)
             }
+            allowsReplacedBindingAdoption = false
             await admissionController.update(
                 keys: policy.grantVerificationKeys,
                 acceptor: grantPeer(for: policy.binding),
@@ -570,6 +604,13 @@ extension CmxIrohHostRuntime {
             )
             try requireCurrent(revision)
             localBinding = policy.binding
+            if currentSnapshot.bindingID != policy.binding.bindingID {
+                currentSnapshot = CmxIrohHostRuntimeSnapshot(
+                    state: currentSnapshot.state,
+                    endpointID: currentSnapshot.endpointID,
+                    bindingID: policy.binding.bindingID
+                )
+            }
             endpointAttestation = policy.attestation ?? endpointAttestation
             lanRendezvous = policy.lanRendezvous
             guard let registration = policy.registration,
@@ -593,6 +634,7 @@ extension CmxIrohHostRuntime {
                 revision: revision
             )
             registrationRefreshFailureCount = 0
+            initialPublicationPending = false
             completedSuccessfully = true
             scheduleRegistrationRenewal(
                 binding: registration.binding,
@@ -632,6 +674,53 @@ extension CmxIrohHostRuntime {
                 )?.retryAfterSeconds
             )
         }
+    }
+
+    /// Rebinds binding-scoped components to an authenticated replacement
+    /// binding. `CmxIrohAdmissionController.update` already propagates the new
+    /// acceptor to online and offline admission; only the relay credential
+    /// coordinator pins a binding ID at activation and must be recreated.
+    private func adoptReplacedBinding(
+        policy: ResolvedPolicy,
+        revision: UInt64
+    ) async throws {
+        try requireCurrent(revision)
+        guard let connectivityEngine else {
+            throw CmxIrohHostRuntimeError.inactive
+        }
+        guard let coordinator = relayCoordinator else { return }
+        relayActivationTask?.cancel()
+        relayActivationTask = nil
+        await coordinator.deactivate()
+        if relayCoordinator === coordinator {
+            relayCoordinator = nil
+        }
+        try requireCurrent(revision)
+        let binding = policy.binding
+        guard let profile = currentEndpointRelayProfile,
+              profile.source == .managed,
+              !profile.allowedRelayURLs.isEmpty else { return }
+        let replacement = CmxIrohRelayCredentialCoordinator(
+            supervisor: connectivityEngine,
+            broker: broker,
+            managedRelayURLs: managedRelayURLs,
+            selectedRelayURLs: profile.allowedRelayURLs,
+            credentialDidInstall: { [handleRelayCredential] response in
+                await handleRelayCredential(response, binding)
+            }
+        )
+        relayCoordinator = replacement
+        do {
+            try await replacement.activate(
+                bindingID: binding.bindingID,
+                endpointIdentity: binding.endpointID,
+                bootstrap: policy.relayBootstrap
+            )
+        } catch {
+            // The replacement coordinator owns bounded retry. An unavailable
+            // relay credential must not fail the adopted live policy.
+        }
+        try requireCurrent(revision)
     }
 
     static func seconds(_ date: Date) -> Int64? {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -617,6 +617,26 @@ extension CmxIrohHostRuntime {
                   let discovery = policy.discovery else {
                 throw CmxIrohHostRuntimeError.invalidLocalBinding
             }
+            if initialPublicationPending {
+                let ready = await initialPublicationReady(
+                    engine: connectivityEngine
+                )
+                try requireCurrent(revision)
+                guard ready else {
+                    // The first publication of this lifecycle stays gated on
+                    // a verified usable relay path; the authenticated
+                    // reconcile above already applied admission policy,
+                    // binding adoption, and renewal scheduling. The ready
+                    // gate runs the publishing round once the relay works.
+                    registrationRefreshFailureCount = 0
+                    completedSuccessfully = true
+                    scheduleRegistrationRenewal(
+                        binding: registration.binding,
+                        revision: revision
+                    )
+                    return
+                }
+            }
             await handleBinding(registration, discovery, policy.attestation)
             try requireCurrent(revision)
             await handleRoute(policy.binding, policy.routePathHints)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
@@ -29,6 +29,12 @@ extension CmxIrohHostRuntime {
         managedRelayURLs replacementManagedURLs: Set<String>,
         relayBootstrap: CmxIrohRelayTokenResponse?
     ) async throws {
+        // A debug-only forced relay pins every profile installation, so a
+        // broker policy refresh cannot displace the test relay mid-run.
+        var profile = profile
+        if let debugOverride = CmxIrohDebugRelayOverride.activeProfile() {
+            profile = debugOverride
+        }
         guard lifecyclePhase == .active,
               let connectivityEngine,
               let binding = localBinding else {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+SignOut.swift
@@ -88,6 +88,10 @@ extension CmxIrohHostRuntime {
         registrationRefreshFailureCount = 0
         relayActivationTask?.cancel()
         relayActivationTask = nil
+        initialPublicationTask?.cancel()
+        initialPublicationTask = nil
+        initialPublicationPending = false
+        allowsReplacedBindingAdoption = false
         lanPublicationGeneration &+= 1
         lanPublicationTask?.cancel()
         lanPublicationTask = nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -93,6 +93,14 @@ public actor CmxIrohHostRuntime {
     var offlineSessions: CmxIrohOfflinePairingSessions?
     var connectivityEventTask: Task<Void, Never>?
     var relayActivationTask: Task<Void, Never>?
+    var initialPublicationTask: Task<Void, Never>?
+    /// True while activation still owes the first ready publication. It makes
+    /// the next refresh round publish even when reachability is unchanged.
+    var initialPublicationPending = false
+    /// True only between a cache-first activation and its first completed live
+    /// resolve, allowing that resolve to adopt a replaced broker binding in
+    /// place instead of failing closed.
+    var allowsReplacedBindingAdoption = false
     var lanPublicationTask: Task<Void, Never>?
     var lanPublicationGeneration: UInt64 = 0
     var registrationRefreshTask: Task<Void, Never>?
@@ -161,7 +169,11 @@ public actor CmxIrohHostRuntime {
     }
 
 
-    /// Activates connectivity and resolves authenticated broker policy before any cached fallback.
+    /// Activates connectivity, restoring a verified cached policy immediately
+    /// when one matches this binding, and reconciles authenticated broker
+    /// policy in the background. Publication of the binding and route hints
+    /// waits for a usable home relay so the Mac is never
+    /// discoverable-but-undialable.
     public func start() async throws {
         guard lifecyclePhase.allowsStart else {
             throw CmxIrohHostRuntimeError.alreadyActive
@@ -173,6 +185,8 @@ public actor CmxIrohHostRuntime {
         registrationRefreshPendingForcesPublication = false
         registrationRefreshEnabled = false
         registrationRefreshFailureCount = 0
+        initialPublicationPending = false
+        allowsReplacedBindingAdoption = false
         currentSnapshot = CmxIrohHostRuntimeSnapshot(
             state: .starting,
             endpointID: nil,
@@ -208,11 +222,26 @@ public actor CmxIrohHostRuntime {
                 throw CmxIrohHostRuntimeError.invalidLocalBinding
             }
 
-            let policy = try await resolveInitialPolicy(
-                engine: connectivityEngine,
-                expectedEndpointID: endpointID,
-                revision: revision
-            )
+            let requiresRelayReadiness = !protocolConfiguration
+                .allowsNATTraversalAfterAdmission
+            // A verified same-binding cached policy activates admission and
+            // the endpoint immediately; the authenticated broker round then
+            // runs in the background and reconciles. First launch (no cache),
+            // an invalid cache, and relay-required debug hosts keep the
+            // blocking resolve.
+            let cachedStartPolicy = requiresRelayReadiness
+                ? nil
+                : validatedCachedStartPolicy(expectedEndpointID: endpointID)
+            let policy: ResolvedPolicy
+            if let cachedStartPolicy {
+                policy = cachedStartPolicy
+            } else {
+                policy = try await resolveInitialPolicy(
+                    engine: connectivityEngine,
+                    expectedEndpointID: endpointID,
+                    revision: revision
+                )
+            }
             try requireCurrent(revision)
 
             let offlineSessions = CmxIrohOfflinePairingSessions(
@@ -278,8 +307,6 @@ public actor CmxIrohHostRuntime {
                 bindingID: policy.binding.bindingID
             )
             var publishedPolicy = policy
-            let requiresRelayReadiness = !protocolConfiguration
-                .allowsNATTraversalAfterAdmission
             if requiresRelayReadiness {
                 if let relayCoordinator {
                     try await relayCoordinator.activate(
@@ -318,9 +345,19 @@ public actor CmxIrohHostRuntime {
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
             }
+            let publishInline: Bool
+            if requiresRelayReadiness {
+                publishInline = true
+            } else {
+                publishInline = await initialPublicationReady(
+                    engine: connectivityEngine
+                )
+                try requireCurrent(revision)
+            }
             let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
-               let discovery = publishedPolicy.discovery {
+               let discovery = publishedPolicy.discovery,
+               publishInline {
                 await handleBinding(registration, discovery, publishedPolicy.attestation)
                 try requireCurrent(revision)
                 if let routeRevision = discovery.revision {
@@ -337,28 +374,48 @@ public actor CmxIrohHostRuntime {
             } else {
                 publishedFreshBinding = false
             }
-            await handleRoute(
-                publishedPolicy.binding,
-                publishedPolicy.routePathHints
-            )
-            try requireCurrent(revision)
+            if publishedFreshBinding || publishedPolicy.registration == nil {
+                // Fresh relay-ready hints, or a cached authority whose local
+                // route identity is refreshed rather than unpublished. A live
+                // policy without a usable home relay publishes nothing yet:
+                // the Mac must not be discoverable-but-undialable.
+                await handleRoute(
+                    publishedPolicy.binding,
+                    publishedPolicy.routePathHints
+                )
+                try requireCurrent(revision)
+            }
             registrationRefreshEnabled = true
             if !publishedFreshBinding {
-                // Cached authority keeps offline admission and LAN discovery
-                // available, but it cannot describe this endpoint generation's
-                // live direct port. Give the lifecycle-owned retry loop the
-                // incomplete activation so the broker is refreshed without
-                // creating a second endpoint or relying on another network event.
                 registrationRefreshPending = false
-                scheduleRegistrationRetry(
-                    revision: revision,
-                    retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
-                )
+                if requiresRelayReadiness {
+                    // Cached authority keeps offline admission and LAN
+                    // discovery available, but it cannot describe this endpoint
+                    // generation's live direct port. Give the lifecycle-owned
+                    // retry loop the incomplete activation.
+                    scheduleRegistrationRetry(
+                        revision: revision,
+                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
+                    )
+                } else {
+                    // The ready gate activates the relay, waits for a usable
+                    // home relay, and then runs the one live reconcile that
+                    // publishes fresh path hints.
+                    initialPublicationPending = true
+                    allowsReplacedBindingAdoption = cachedStartPolicy != nil
+                    scheduleInitialPublication(
+                        binding: publishedPolicy.binding,
+                        endpointID: endpointID,
+                        bootstrap: publishedPolicy.relayBootstrap,
+                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds,
+                        revision: revision
+                    )
+                }
             } else if registrationRefreshPending {
                 registrationRefreshPending = false
                 scheduleRegistrationRefresh(revision: revision)
             }
-            if let relayCoordinator, !requiresRelayReadiness {
+            if let relayCoordinator, !requiresRelayReadiness, publishedFreshBinding {
                 scheduleRelayActivation(
                     relayCoordinator,
                     binding: policy.binding,
@@ -555,6 +612,85 @@ public actor CmxIrohHostRuntime {
             (try? await engine.localDirectAddresses()) ?? []
         }
         await handleLANPolicy(context, directAddresses)
+    }
+
+    /// Returns whether the binding may be published immediately: the home
+    /// relay is already usable, or this endpoint will never own a relay.
+    private func initialPublicationReady(
+        engine: CmxConnectivityEngine
+    ) async -> Bool {
+        if await engine.hasUsableHomeRelay() { return true }
+        guard relayCoordinator == nil else { return false }
+        return !(await engine.hasConfiguredRelay())
+    }
+
+    func scheduleInitialPublication(
+        binding: CmxIrohBrokerBindingMetadata,
+        endpointID: CmxIrohPeerIdentity,
+        bootstrap: CmxIrohRelayTokenResponse?,
+        retryAfterSeconds: Int?,
+        revision: UInt64
+    ) {
+        initialPublicationTask?.cancel()
+        initialPublicationTask = Task { [weak self] in
+            await self?.runInitialPublication(
+                binding: binding,
+                endpointID: endpointID,
+                bootstrap: bootstrap,
+                retryAfterSeconds: retryAfterSeconds,
+                revision: revision
+            )
+        }
+    }
+
+    private func runInitialPublication(
+        binding: CmxIrohBrokerBindingMetadata,
+        endpointID: CmxIrohPeerIdentity,
+        bootstrap: CmxIrohRelayTokenResponse?,
+        retryAfterSeconds: Int?,
+        revision: UInt64
+    ) async {
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let coordinator = relayCoordinator {
+            // Credential installation happens before the readiness wait so a
+            // cached relay bootstrap makes the home relay usable without a
+            // broker round. The coordinator owns bounded retry on failure.
+            try? await coordinator.activate(
+                bindingID: binding.bindingID,
+                endpointIdentity: endpointID,
+                bootstrap: bootstrap
+            )
+        }
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let connectivityEngine, await connectivityEngine.hasConfiguredRelay() {
+            do {
+                try await connectivityEngine.waitForUsableHomeRelay()
+            } catch is CancellationError {
+                return
+            } catch {
+                // The bounded readiness window elapsed or the generation moved
+                // on. Publication proceeds so a relay outage cannot leave this
+                // Mac permanently unpublished on its LAN and direct paths.
+            }
+        }
+        guard lifecyclePhase == .active,
+              lifecycleRevision == revision,
+              !Task.isCancelled else { return }
+        if let retryAfterSeconds {
+            // A broker cooldown observed during activation keeps its validated
+            // floor; the lifecycle retry loop owns the next live round.
+            scheduleRegistrationRetry(
+                revision: revision,
+                retryAfterSeconds: retryAfterSeconds
+            )
+            return
+        }
+        guard initialPublicationPending else { return }
+        scheduleRegistrationRefresh(revision: revision)
     }
 
     func scheduleRelayActivation(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -638,6 +638,17 @@ public actor CmxIrohHostRuntime {
 
     /// Returns whether the binding may be published immediately: the home
     /// relay is already usable, or this endpoint will never own a relay.
+    ///
+    /// ROLLOUT NOTE (intended-shape attach reporting): this relay-readiness
+    /// gate and the post-attach republish it defers exist so the Mac's own
+    /// registration carries its relay route. The broker now also publishes
+    /// the route server-side from the relay fleet's attach/detach reports
+    /// (`POST /api/relay/report`, cmux-relay attach reporting), and
+    /// discovery serves that server-observed hint ahead of client-published
+    /// hints. The client republish stays as the fallback ONLY while fleet
+    /// relays that do not report attach remain deployed; once the reporting
+    /// relay build is rolled out fleet-wide, delete this gate and publish at
+    /// register time.
     func initialPublicationReady(
         engine: CmxConnectivityEngine
     ) async -> Bool {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -74,6 +74,9 @@ public actor CmxIrohHostRuntime {
     let registrationClock: any CmxIrohRelayClock
     let registrationRetrySchedule: CmxIrohRetrySchedule
     let registrationRetryJitter: @Sendable () -> Double
+    /// One bounded signal-or-deadline window for the startup relay-readiness
+    /// wait. A timeout keeps the endpoint unpublished and retries the wait.
+    let relayReadinessTimeout: Duration
     let handleTransport: TransportHandler
     let handleBinding: BindingHandler
     let handleRoute: RouteHandler
@@ -139,6 +142,7 @@ public actor CmxIrohHostRuntime {
         registrationRetryJitter: @escaping @Sendable () -> Double = {
             Double.random(in: 0 ... 1)
         },
+        relayReadinessTimeout: Duration = .seconds(15),
         handleTransport: @escaping TransportHandler,
         handleBinding: @escaping BindingHandler = { _, _, _ in },
         handleRoute: @escaping RouteHandler = { _, _ in },
@@ -157,6 +161,7 @@ public actor CmxIrohHostRuntime {
         self.registrationClock = registrationClock
         self.registrationRetrySchedule = registrationRetrySchedule
         self.registrationRetryJitter = registrationRetryJitter
+        self.relayReadinessTimeout = relayReadinessTimeout
         self.handleTransport = handleTransport
         self.handleBinding = handleBinding
         self.handleRoute = handleRoute
@@ -666,15 +671,54 @@ public actor CmxIrohHostRuntime {
         guard lifecyclePhase == .active,
               lifecycleRevision == revision,
               !Task.isCancelled else { return }
-        if let connectivityEngine, await connectivityEngine.hasConfiguredRelay() {
-            do {
-                try await connectivityEngine.waitForUsableHomeRelay()
-            } catch is CancellationError {
-                return
-            } catch {
-                // The bounded readiness window elapsed or the generation moved
-                // on. Publication proceeds so a relay outage cannot leave this
-                // Mac permanently unpublished on its LAN and direct paths.
+        guard let connectivityEngine else { return }
+        let relayExpected: Bool
+        if relayCoordinator != nil {
+            relayExpected = true
+        } else {
+            relayExpected = await connectivityEngine.hasConfiguredRelay()
+        }
+        if relayExpected {
+            // The Mac must never be discoverable-but-undialable: a readiness
+            // timeout keeps the endpoint unpublished and retries the wait with
+            // bounded backoff on the injected clock until a verified usable
+            // relay path exists or this lifecycle revision is superseded.
+            var readinessFailureCount = 0
+            while true {
+                guard lifecyclePhase == .active,
+                      lifecycleRevision == revision,
+                      !Task.isCancelled else { return }
+                do {
+                    try await connectivityEngine.waitForUsableHomeRelay(
+                        timeout: relayReadinessTimeout
+                    )
+                    break
+                } catch is CancellationError {
+                    return
+                } catch CmxIrohEndpointSupervisorError.relayReadinessTimedOut {
+                    // Retry below after bounded backoff.
+                } catch {
+                    // The endpoint generation was replaced or deactivated. The
+                    // successor lifecycle owns publication; this one stays
+                    // unpublished and existing failure handling surfaces state.
+                    return
+                }
+                guard lifecyclePhase == .active,
+                      lifecycleRevision == revision,
+                      !Task.isCancelled else { return }
+                let delay = registrationRetrySchedule.delay(
+                    failureCount: readinessFailureCount,
+                    retryAfterSeconds: nil,
+                    jitterUnitInterval: registrationRetryJitter()
+                )
+                readinessFailureCount = min(readinessFailureCount + 1, 20)
+                do {
+                    try await registrationClock.sleep(
+                        until: registrationClock.now().addingTimeInterval(delay)
+                    )
+                } catch {
+                    return
+                }
             }
         }
         guard lifecyclePhase == .active,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -392,6 +392,10 @@ public actor CmxIrohHostRuntime {
             registrationRefreshEnabled = true
             if !publishedFreshBinding {
                 registrationRefreshPending = false
+                // Every deferred first publication carries the pending flag so
+                // any refresh round that ends up performing it re-checks
+                // verified relay readiness first.
+                initialPublicationPending = true
                 if requiresRelayReadiness {
                     // Cached authority keeps offline admission and LAN
                     // discovery available, but it cannot describe this endpoint
@@ -402,7 +406,6 @@ public actor CmxIrohHostRuntime {
                         retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
                     )
                 } else {
-                    initialPublicationPending = true
                     allowsReplacedBindingAdoption = cachedStartPolicy != nil
                     if let retryAfterSeconds = publishedPolicy
                         .registrationRetryAfterSeconds {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -402,16 +402,31 @@ public actor CmxIrohHostRuntime {
                         retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
                     )
                 } else {
-                    // The ready gate activates the relay, waits for a usable
-                    // home relay, and then runs the one live reconcile that
-                    // publishes fresh path hints.
                     initialPublicationPending = true
                     allowsReplacedBindingAdoption = cachedStartPolicy != nil
+                    if let retryAfterSeconds = publishedPolicy
+                        .registrationRetryAfterSeconds {
+                        // A broker cooldown observed during activation keeps
+                        // its validated floor for the next live round.
+                        scheduleRegistrationRetry(
+                            revision: revision,
+                            retryAfterSeconds: retryAfterSeconds
+                        )
+                    } else if cachedStartPolicy != nil {
+                        // Cached authority is verified against the live broker
+                        // immediately, independent of relay readiness, so a
+                        // server-side revocation or replacement cannot hide
+                        // behind a relay outage. Readiness gates only the
+                        // publication inside the refresh round.
+                        scheduleRegistrationRefresh(revision: revision)
+                    }
+                    // The ready gate activates the relay, waits for a usable
+                    // home relay, and then runs the round that performs the
+                    // deferred first publication with fresh path hints.
                     scheduleInitialPublication(
                         binding: publishedPolicy.binding,
                         endpointID: endpointID,
                         bootstrap: publishedPolicy.relayBootstrap,
-                        retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds,
                         revision: revision
                     )
                 }
@@ -620,7 +635,7 @@ public actor CmxIrohHostRuntime {
 
     /// Returns whether the binding may be published immediately: the home
     /// relay is already usable, or this endpoint will never own a relay.
-    private func initialPublicationReady(
+    func initialPublicationReady(
         engine: CmxConnectivityEngine
     ) async -> Bool {
         if await engine.hasUsableHomeRelay() { return true }
@@ -632,7 +647,6 @@ public actor CmxIrohHostRuntime {
         binding: CmxIrohBrokerBindingMetadata,
         endpointID: CmxIrohPeerIdentity,
         bootstrap: CmxIrohRelayTokenResponse?,
-        retryAfterSeconds: Int?,
         revision: UInt64
     ) {
         initialPublicationTask?.cancel()
@@ -641,7 +655,6 @@ public actor CmxIrohHostRuntime {
                 binding: binding,
                 endpointID: endpointID,
                 bootstrap: bootstrap,
-                retryAfterSeconds: retryAfterSeconds,
                 revision: revision
             )
         }
@@ -651,7 +664,6 @@ public actor CmxIrohHostRuntime {
         binding: CmxIrohBrokerBindingMetadata,
         endpointID: CmxIrohPeerIdentity,
         bootstrap: CmxIrohRelayTokenResponse?,
-        retryAfterSeconds: Int?,
         revision: UInt64
     ) async {
         guard lifecyclePhase == .active,
@@ -723,16 +735,13 @@ public actor CmxIrohHostRuntime {
         guard lifecyclePhase == .active,
               lifecycleRevision == revision,
               !Task.isCancelled else { return }
-        if let retryAfterSeconds {
-            // A broker cooldown observed during activation keeps its validated
-            // floor; the lifecycle retry loop owns the next live round.
-            scheduleRegistrationRetry(
-                revision: revision,
-                retryAfterSeconds: retryAfterSeconds
-            )
+        guard initialPublicationPending else { return }
+        guard registrationRefreshFailureCount == 0 else {
+            // A broker cooldown or failure retry is already armed. That
+            // lifecycle-owned round performs the deferred publication once it
+            // succeeds, and it honors the broker's validated retry floor.
             return
         }
-        guard initialPublicationPending else { return }
         scheduleRegistrationRefresh(revision: revision)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -350,15 +350,14 @@ public actor CmxIrohHostRuntime {
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
             }
-            let publishInline: Bool
-            if requiresRelayReadiness {
-                publishInline = true
-            } else {
-                publishInline = await initialPublicationReady(
-                    engine: connectivityEngine
-                )
-                try requireCurrent(revision)
-            }
+            // Every path re-checks verified readiness immediately before
+            // publication. Relay-required activations arrive here only after
+            // the blocking waitForUsableHomeRelay() above succeeded, so the
+            // check returns true for them without a second wait.
+            let publishInline = await initialPublicationReady(
+                engine: connectivityEngine
+            )
+            try requireCurrent(revision)
             let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
                let discovery = publishedPolicy.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
@@ -22,7 +22,10 @@ public struct CmxIrohHostRuntimeConfiguration: Equatable, Sendable {
     /// `nil` preserves automatic use of the complete managed fleet.
     public let endpointRelayProfile: CmxIrohEndpointRelayProfile?
     public let cachedRelayCredential: CmxIrohRelayTokenResponse?
-    /// A previously verified offline policy considered only after broker connectivity failure.
+    /// A previously verified last-good policy. When it still verifies for this
+    /// exact binding it activates the host immediately (cache-first) while the
+    /// live broker resolve reconciles in the background; it also remains the
+    /// verified fallback after broker connectivity failure.
     public let cachedHostPolicy: CmxIrohCachedHostPolicy?
 
     /// Creates stable inputs for one Mac host runtime lifecycle.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -193,6 +193,28 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
                 )
                 usedFreshDiscovery = true
             } catch {
+                try Task.checkCancellation()
+                // The refresh failed. Dialing with the last verified snapshot
+                // beats not dialing at all (cmux#9724): the staleness mark
+                // survives, so the next attempt still refetches once the
+                // broker recovers. Verification is not weakened; this
+                // snapshot passed the same checks when it was fetched.
+                if let lastGood = authoritativeDiscovery {
+                    do {
+                        return try await resolveContext(
+                            for: request,
+                            targetIdentity: targetIdentity,
+                            routeHints: routeHints,
+                            discovery: lastGood,
+                            at: clock
+                        )
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        // The last-good snapshot no longer authorizes this
+                        // peer; fall through to the offline cache.
+                    }
+                }
                 guard Self.isConnectivity(error),
                       let cached = try await cachedPolicy(
                           for: request,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
@@ -374,6 +374,14 @@ public actor CmxIrohRelayCredentialCoordinator {
                 ),
                 initialFailureCount: 1
             )
+            // Fail open while a last-good credential is installed on the
+            // endpoint: a failed mint must not fail the caller's foreground
+            // path into zero-route dial churn (cmux#10375). The bounded retry
+            // loop above keeps refreshing in the background, and the relay is
+            // the authority that rejects a credential that truly went bad.
+            if installedCredential != nil, !(error is CancellationError) {
+                return
+            }
             throw error
         }
     }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyCache.swift
@@ -97,16 +97,47 @@ public actor CmxIrohRelayPolicyCache {
     /// - Parameters:
     ///   - trustRoot: App-pinned public verification keys.
     ///   - now: Verification time.
+    ///   - expiredPolicyReuseGrace: Bounded fail-open window after the signed
+    ///     expiry in which the last-good policy still loads. The policy is
+    ///     re-verified at its final valid instant, so signature, rollback,
+    ///     and claim checks run unweakened; only the expiry gate is graced
+    ///     (cmux#10375). Zero preserves strict expiry.
     /// - Returns: The verified policy, or `nil` when no policy is cached.
     /// - Throws: ``CmxIrohRelayPolicyError`` or a secure-storage error.
     public func load(
         trustRoot: CmxIrohRelayPolicyTrustRoot,
-        now: Date
+        now: Date,
+        expiredPolicyReuseGrace: TimeInterval = 0
     ) async throws -> CmxIrohManagedRelayPolicy? {
         await acquire()
         defer { release() }
         guard let record = try await storedRecord() else { return nil }
-        let policy = try verifier.verify(record.signedPolicy, trustRoot: trustRoot, now: now)
+        let policy: CmxIrohManagedRelayPolicy
+        do {
+            policy = try verifier.verify(
+                record.signedPolicy,
+                trustRoot: trustRoot,
+                now: now
+            )
+        } catch CmxIrohRelayPolicyError.expired {
+            // The recorded expiry is cross-checked against the signed claims
+            // below; a record that overstates it re-fails as expired here or
+            // as rollback below.
+            guard expiredPolicyReuseGrace > 0,
+                  let recordedExpiry = record.expiresAt,
+                  now.timeIntervalSince1970
+                    <= TimeInterval(recordedExpiry) + expiredPolicyReuseGrace else {
+                throw CmxIrohRelayPolicyError.expired
+            }
+            let lastValidInstant = Date(
+                timeIntervalSince1970: TimeInterval(recordedExpiry) - 1
+            )
+            policy = try verifier.verify(
+                record.signedPolicy,
+                trustRoot: trustRoot,
+                now: min(now, lastValidInstant)
+            )
+        }
         guard policy.sequence == record.highestSequence,
               Self.metadataMatches(policy, record: record) else {
             throw CmxIrohRelayPolicyError.rollback

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -6,10 +6,18 @@ public actor CmxIrohRelayPolicyService {
     private typealias Resolution = CmxIrohRelayPolicyResolutionResult
     private typealias Resolver = CmxIrohRelayPolicyResolution
 
+    /// Bounded fail-open window in which ``restore`` keeps a recently-expired
+    /// last-good managed policy dialable after a failed refresh (cmux#10375).
+    /// A failed policy refresh must degrade to the last verified catalog, not
+    /// to a zero-route profile; the relay itself remains the authority on
+    /// credential validity and rejects a truly stale token.
+    public static let defaultExpiredPolicyReuseGrace: TimeInterval = 6 * 60 * 60
+
     private let policyCache: CmxIrohRelayPolicyCache
     private let preferenceStore: CmxIrohRelayPreferenceStore
     private let credentialStore: CmxIrohCustomRelayCredentialStore
     private let broker: (any CmxIrohRelayPolicyServing)?
+    private let expiredPolicyReuseGrace: TimeInterval
     private var currentEffective: CmxIrohEffectiveRelayPolicy?
     private var currentDiagnostics = CmxIrohRelayDiagnosticsSnapshot.inactive
     private var continuations: [UUID: AsyncStream<CmxIrohRelayDiagnosticsSnapshot>.Continuation] = [:]
@@ -20,12 +28,15 @@ public actor CmxIrohRelayPolicyService {
         policyCache: CmxIrohRelayPolicyCache = CmxIrohRelayPolicyCache(),
         preferenceStore: CmxIrohRelayPreferenceStore = CmxIrohRelayPreferenceStore(),
         credentialStore: CmxIrohCustomRelayCredentialStore = CmxIrohCustomRelayCredentialStore(),
-        broker: (any CmxIrohRelayPolicyServing)? = nil
+        broker: (any CmxIrohRelayPolicyServing)? = nil,
+        expiredPolicyReuseGrace: TimeInterval = CmxIrohRelayPolicyService
+            .defaultExpiredPolicyReuseGrace
     ) {
         self.policyCache = policyCache
         self.preferenceStore = preferenceStore
         self.credentialStore = credentialStore
         self.broker = broker
+        self.expiredPolicyReuseGrace = max(0, expiredPolicyReuseGrace)
     }
 
     /// Fetches and installs the broker's current relay bootstrap response.
@@ -196,7 +207,15 @@ public actor CmxIrohRelayPolicyService {
         }
 
         do {
-            guard let policy = try await policyCache.load(trustRoot: trustRoot, now: now) else {
+            // Restore is the failed-refresh fallback path, so it alone grants
+            // the bounded expired-policy grace: a recently-expired last-good
+            // catalog must stay dialable instead of zeroing every relay route
+            // (cmux#10375). The graced state is visible as `.policyExpired`.
+            guard let policy = try await policyCache.load(
+                trustRoot: trustRoot,
+                now: now,
+                expiredPolicyReuseGrace: expiredPolicyReuseGrace
+            ) else {
                 return publishUnavailable(
                     configuration: persisted.requested,
                     revision: persisted.revision,
@@ -205,6 +224,8 @@ public actor CmxIrohRelayPolicyService {
                     failure: .policyUnavailable
                 )
             }
+            let policyIsExpired = TimeInterval(policy.expiresAt)
+                <= now.timeIntervalSince1970
             let resolution = await Resolver.resolve(
                 configuration: persisted.requested,
                 revision: persisted.revision,
@@ -218,7 +239,9 @@ public actor CmxIrohRelayPolicyService {
             return commit(
                 Resolution(
                     effective: resolution.effective,
-                    failure: cleanupFailure ?? resolution.failure
+                    failure: policyIsExpired
+                        ? .policyExpired
+                        : cleanupFailure ?? resolution.failure
                 ),
                 operation: operation
             )

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeRelayProfile.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeRelayProfile.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 extension CmxIrohHostRuntimeConfiguration {
-    func resolvedEndpointRelayProfile(now: Date) throws -> CmxIrohEndpointRelayProfile {
-        try resolveEndpointRelayProfile(
+    func resolvedEndpointRelayProfile(
+        now: Date,
+        debugOverride: CmxIrohEndpointRelayProfile? = CmxIrohDebugRelayOverride.activeProfile()
+    ) throws -> CmxIrohEndpointRelayProfile {
+        if let debugOverride { return debugOverride }
+        return try resolveEndpointRelayProfile(
             configured: endpointRelayProfile,
             managedRelayURLs: managedRelayURLs,
             cachedRelayCredential: cachedRelayCredential,
@@ -12,8 +16,12 @@ extension CmxIrohHostRuntimeConfiguration {
 }
 
 extension CmxIrohClientRuntimeConfiguration {
-    func resolvedEndpointRelayProfile(now: Date) throws -> CmxIrohEndpointRelayProfile {
-        try resolveEndpointRelayProfile(
+    func resolvedEndpointRelayProfile(
+        now: Date,
+        debugOverride: CmxIrohEndpointRelayProfile? = CmxIrohDebugRelayOverride.activeProfile()
+    ) throws -> CmxIrohEndpointRelayProfile {
+        if let debugOverride { return debugOverride }
+        return try resolveEndpointRelayProfile(
             configured: endpointRelayProfile,
             managedRelayURLs: managedRelayURLs,
             cachedRelayCredential: cachedRelayCredential,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionDialBoundTests.swift
@@ -1,0 +1,157 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Bounded-dial behavior (cmux#9724, cmux#8531): a dial attempt whose
+/// admission barrier never answers must fail at the configured dial bound and
+/// leave the session redialable, instead of holding the reconnect owner for
+/// an unbounded time. A half-ready Mac accepts the QUIC connection but never
+/// serves the admission frames; that exact shape produced the unbounded
+/// 16.2-second dial in the cmux#9724 trace.
+@Suite
+struct CmxIrohClientSessionDialBoundTests {
+    let localIdentity: CmxIrohPeerIdentity
+    let remoteIdentity: CmxIrohPeerIdentity
+    let credential: CmxIrohAdmissionCredential
+
+    init() throws {
+        localIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "ab", count: 32)
+        )
+        remoteIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "cd", count: 32)
+        )
+        credential = try .pairGrant("e30.e30.AA")
+    }
+
+    @Test("an admission barrier that never answers fails at the dial bound")
+    func admissionBarrierThatNeverAnswersFailsAtTheDialBound() async throws {
+        let control = CmxIrohBidirectionalStream(
+            receiveStream: TestHangingIrohReceiveStream(),
+            sendStream: TestIrohSendStream()
+        )
+        let connection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [control]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40)
+        )
+
+        let failure = await boundedConnectFailure(session, within: .seconds(2))
+        #expect(failure as? CmxIrohClientSessionError == .dialTimedOut)
+        #expect(await connection.observedCloseCallCount() >= 1)
+        await session.close()
+    }
+
+    @Test("a timed-out admission is superseded by the next connect attempt")
+    func timedOutAdmissionIsSupersededByTheNextConnectAttempt() async throws {
+        let hangingControl = CmxIrohBidirectionalStream(
+            receiveStream: TestHangingIrohReceiveStream(),
+            sendStream: TestIrohSendStream()
+        )
+        let hangingConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [hangingControl]
+        )
+        let goodConnection = TestIrohConnection(
+            remoteIdentity: remoteIdentity,
+            bidirectionalStreams: [answeringControlStream()]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [
+                .connection(hangingConnection),
+                .connection(goodConnection),
+            ]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40)
+        )
+
+        let failure = await boundedConnectFailure(session, within: .seconds(2))
+        #expect(failure as? CmxIrohClientSessionError == .dialTimedOut)
+
+        // The timed-out attempt must have been retired cleanly: the very next
+        // attempt on the same session dials again and admits.
+        try await session.connect()
+
+        #expect(await endpoint.observedDialedAddresses().count == 2)
+        #expect(await hangingConnection.observedCloseCallCount() >= 1)
+        await session.close()
+    }
+
+    // MARK: - Support
+
+    /// Runs `connect()` under a test watchdog so the red state (an unbounded
+    /// admission hang) fails this test quickly instead of hanging the suite.
+    private func boundedConnectFailure(
+        _ session: CmxIrohClientSession,
+        within limit: Duration
+    ) async -> (any Error)? {
+        let connectTask = Task { try await session.connect() }
+        let watchdog = Task {
+            try? await ContinuousClock().sleep(for: limit)
+            connectTask.cancel()
+        }
+        defer { watchdog.cancel() }
+        do {
+            _ = try await connectTask.value
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func answeringControlStream() -> CmxIrohBidirectionalStream {
+        let codec = CmxIrohAdmissionAckCodec()
+        let accepted = codec.encodeFrame(.acceptedPendingNatTraversal)
+        let serverReady = codec.encodeFrame(.serverReady)
+        return CmxIrohBidirectionalStream(
+            receiveStream: TestIrohReceiveStream(buffer: accepted + serverReady),
+            sendStream: TestIrohSendStream()
+        )
+    }
+
+    private func publicRelayHint() throws -> CmxIrohPathHint {
+        try CmxIrohPathHint(
+            kind: .relayURL,
+            value: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+            source: .native,
+            privacyScope: .publicInternet
+        )
+    }
+}
+
+/// A control stream that never yields admission bytes. The hang is
+/// cancellable, mirroring the production stream contract the phase bound
+/// relies on (`TestIrohDialResult.hang` models the same shape for dials).
+actor TestHangingIrohReceiveStream: CmxIrohReceiveStream {
+    private var stoppedCodes: [UInt64] = []
+
+    func receive(maximumByteCount _: Int) async throws -> Data? {
+        try await Task.sleep(for: .seconds(3_600))
+        return nil
+    }
+
+    func stop(errorCode: UInt64) {
+        stoppedCodes.append(errorCode)
+    }
+
+    func observedStoppedCodes() -> [UInt64] {
+        stoppedCodes
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDebugRelayOverrideTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDebugRelayOverrideTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite struct CmxIrohDebugRelayOverrideTests {
+    @Test func parsesCanonicalHTTPSOriginAndAddsTrailingSlash() throws {
+        let profile = try #require(
+            CmxIrohDebugRelayOverride.profile(rawValue: " https://relay-test.example.com ")
+        )
+        #expect(profile.allowedRelayURLs == ["https://relay-test.example.com/"])
+        #expect(profile.source == .custom)
+        #expect(profile.activeRelays.map(\.url) == ["https://relay-test.example.com/"])
+    }
+
+    @Test func keepsExplicitPort() throws {
+        let profile = try #require(
+            CmxIrohDebugRelayOverride.profile(rawValue: "https://relay-test.example.com:8443/")
+        )
+        #expect(profile.allowedRelayURLs == ["https://relay-test.example.com:8443/"])
+    }
+
+    @Test(arguments: [
+        nil,
+        "",
+        "   ",
+        "http://insecure.example.com/",
+        "https://relay.example.com/path",
+        "https://relay.example.com/?q=1",
+        "https://user:pw@relay.example.com/",
+        "not a url",
+    ] as [String?])
+    func rejectsUnusableValues(_ raw: String?) {
+        #expect(CmxIrohDebugRelayOverride.profile(rawValue: raw) == nil)
+    }
+
+    @Test func environmentWinsOverDefaults() throws {
+        let suiteName = "cmux-debug-relay-override-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(
+            "https://from-defaults.example.com/",
+            forKey: CmxIrohDebugRelayOverride.key
+        )
+        #expect(
+            CmxIrohDebugRelayOverride.rawValue(
+                environment: [CmxIrohDebugRelayOverride.key: "https://from-env.example.com/"],
+                defaults: defaults
+            ) == "https://from-env.example.com/"
+        )
+        #expect(
+            CmxIrohDebugRelayOverride.rawValue(
+                environment: [:],
+                defaults: defaults
+            ) == "https://from-defaults.example.com/"
+        )
+    }
+
+    @Test func hostResolutionPrefersOverride() throws {
+        let fixture = try HostRuntimeFixture()
+        let override = try #require(
+            CmxIrohDebugRelayOverride.profile(rawValue: "https://relay-test.example.com/")
+        )
+        let resolved = try fixture.configuration.resolvedEndpointRelayProfile(
+            now: Date(),
+            debugOverride: override
+        )
+        #expect(resolved == override)
+
+        let managed = try fixture.configuration.resolvedEndpointRelayProfile(
+            now: Date(),
+            debugOverride: nil
+        )
+        #expect(managed.source == .managed)
+        #expect(managed.allowedRelayURLs == fixture.managedRelays)
+    }
+
+    @Test func clientResolutionPrefersOverride() throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let override = try #require(
+            CmxIrohDebugRelayOverride.profile(rawValue: "https://relay-test.example.com/")
+        )
+        let resolved = try fixture.configuration.resolvedEndpointRelayProfile(
+            now: fixture.now,
+            debugOverride: override
+        )
+        #expect(resolved == override)
+
+        let managed = try fixture.configuration.resolvedEndpointRelayProfile(
+            now: fixture.now,
+            debugOverride: nil
+        )
+        #expect(managed.source == .managed)
+        #expect(managed.allowedRelayURLs == Set(ClientRuntimeTestFixture.relayURLs))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
@@ -16,8 +16,8 @@ extension CmxIrohHostRuntimeTests {
     func nonTransientRefreshRejectionFailsClosedThenRestarts() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let firstEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
-        let restartEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let firstEndpoint = try fixture.relayReadyEndpoint()
+        let restartEndpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
@@ -46,10 +46,17 @@ extension CmxIrohHostRuntimeTests {
             }
         )
         try await runtime.start()
+        // Native iroh reports the home relay online once the installed
+        // credential connects; the readiness gate publishes only after this.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
 
         let republished = await broker.waitForRegistrationCount(
             2,
-            timeout: .seconds(1)
+            timeout: .seconds(5)
         )
         #expect(
             republished,
@@ -75,14 +82,16 @@ extension CmxIrohHostRuntimeTests {
         #expect(initialDirectPorts == expectedDirectPorts)
         #expect(refreshedDirectPorts == expectedDirectPorts)
 
+        // The pre-relay state is never published; exactly one publication
+        // carries the newly usable relay address.
+        await runtime.waitForInitialPublicationForTesting()
         let published = await publications.values()
-        #expect(published.count == 2)
-        #expect(published[0].registration.pathHints.isEmpty)
-        #expect(published[0].discovered.pathHints.isEmpty)
-        #expect(published[1].registration.pathHints == [relayHint])
-        #expect(published[1].discovered.pathHints == [relayHint])
-        #expect(published[1].registration.endpointID == fixture.endpointID)
-        #expect(published[1].registration.bindingID == fixture.binding.bindingID)
+        let publication = try #require(published.first)
+        #expect(published.count == 1)
+        #expect(publication.registration.pathHints == [relayHint])
+        #expect(publication.discovered.pathHints == [relayHint])
+        #expect(publication.registration.endpointID == fixture.endpointID)
+        #expect(publication.registration.bindingID == fixture.binding.bindingID)
 
         let snapshot = await runtime.snapshot()
         #expect(snapshot.state == .active)
@@ -95,7 +104,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func validatedBindingPublishesBeforeRelayCredentialInstallationCompletes() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeSuspensionGate()
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
@@ -123,7 +132,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func validatedBindingPublishesBeforeLANAdvertisementCompletes() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeSuspensionGate()
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -30,7 +30,7 @@ extension CmxIrohHostRuntimeTests {
             )
         )
 
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -91,7 +91,7 @@ extension CmxIrohHostRuntimeTests {
     func unchangedReachabilityRenewsRegistrationBeforeHintExpiry() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -125,7 +125,7 @@ extension CmxIrohHostRuntimeTests {
     func registrationRenewalHonorsBrokerRetryAfterFloor() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -160,7 +160,7 @@ extension CmxIrohHostRuntimeTests {
     func registrationRenewalBacksOffConsecutiveFailures() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -201,7 +201,7 @@ extension CmxIrohHostRuntimeTests {
     func successfulRegistrationRenewalResetsBackoff() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
@@ -403,7 +403,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func failedSignOutPersistenceClosesHostAndQuarantinesLocalState() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let store = TestControllableSecureCredentialStore()
         let pendingRevocations = CmxIrohPendingRevocationOutbox(secureStore: store)
         let deactivations = HostRuntimeDeactivationRecorder()
@@ -447,7 +447,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func successfulSignOutClearsRegistrationPublicationState() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let store = TestControllableSecureCredentialStore()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -474,7 +474,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func requiredBindPolicyIsForwardedToTheEndpointGeneration() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -504,12 +504,12 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
-    func connectivityFailureUsesVerifiedCacheOnlyAfterOnlineAttempt() async throws {
+    func cacheFirstActivationBecomesActiveDespiteBrokerConnectivityFailure() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
         let cachedPolicy = try cachedFixture.policy()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -527,11 +527,17 @@ extension CmxIrohHostRuntimeTests {
             handleBinding: { _, _, _ in await bindings.record() }
         )
 
+        // The verified cache activates admission immediately; the failed
+        // background reconcile keeps cached authority active without a fresh
+        // publication until a live round succeeds.
         try await runtime.start()
 
-        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
+        await runtime.waitForInitialPublicationForTesting()
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
         #expect(await bindings.count() == 0)
         await runtime.stop()
     }
@@ -573,7 +579,6 @@ extension CmxIrohHostRuntimeTests {
 
         try await runtime.start()
 
-        #expect(await broker.observedRegistrationCount() == 1)
         #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await routes.values() == [
@@ -588,8 +593,7 @@ extension CmxIrohHostRuntimeTests {
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
         let currentPort: UInt16 = 55_123
-        let endpoint = TestIrohEndpoint(
-            identity: fixture.endpointID,
+        let endpoint = try fixture.relayReadyEndpoint(
             directAddresses: ["0.0.0.0:\(currentPort)"]
         )
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
@@ -682,7 +686,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func endpointNetworkChangeRequestsImmediateLANRefresh() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let recorder = HostRuntimeLANRefreshRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -707,7 +711,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func repeatedUnchangedNetworkEventsDoNotContactBroker() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -742,7 +746,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func changedDirectPortPublishesImmediately() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery
@@ -768,7 +772,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func endpointOnlineRequestsImmediateReachabilityRefresh() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let recorder = HostRuntimeLANRefreshRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -809,7 +813,7 @@ extension CmxIrohHostRuntimeTests {
         _ failure: CmxIrohTrustBrokerClientError
     ) async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -514,7 +514,10 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity,
+            subsequentRegistrationErrors: [
+                .connectivity, .connectivity, .connectivity,
+            ]
         )
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
@@ -536,7 +539,7 @@ extension CmxIrohHostRuntimeTests {
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
         #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
         await runtime.waitForInitialPublicationForTesting()
-        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
         #expect(await runtime.snapshot().state == .active)
         #expect(await bindings.count() == 0)
         await runtime.stop()
@@ -570,7 +573,7 @@ extension CmxIrohHostRuntimeTests {
             configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            registrationClock: ImmediateHostActivationClock(),
+            registrationClock: HostRegistrationRenewalClock(now: now),
             handleTransport: { session, _ in await session.close() },
             handleRoute: { binding, pathHints in
                 await routes.record(binding: binding, pathHints: pathHints)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -237,7 +237,7 @@ extension CmxIrohHostRuntimeTests {
     @Test
     func networkChangeDuringActiveRefreshDoesNotRequestAnotherRegistration() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let gate = HostRuntimeRegistrationGate()
         let refreshes = HostRuntimeLANRefreshRecorder()
         let broker = TestIrohHostBroker(
@@ -278,8 +278,7 @@ extension CmxIrohHostRuntimeTests {
             relays: Array(fixture.managedRelays),
             lanGeneration: 2
         )
-        let endpoint = TestIrohEndpoint(
-            identity: fixture.endpointID,
+        let endpoint = try fixture.relayReadyEndpoint(
             directAddresses: ["192.168.1.10:50906"]
         )
         let policies = HostRuntimeLANPolicyRecorder()
@@ -503,7 +502,7 @@ extension CmxIrohHostRuntimeTests {
 
         #expect(await runtime.snapshot().state == .failed)
         #expect(await bindings.count() == 0)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -351,7 +351,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
         #expect(await bindings.count() == 0)
     }
 
@@ -537,7 +537,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 
     @Test
@@ -571,7 +571,7 @@ extension CmxIrohHostRuntimeTests {
         await runtime.waitForInitialPublicationForTesting()
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await endpoint.waitForCloseCallCount(1))
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -32,7 +32,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,
@@ -118,7 +118,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,
@@ -179,7 +179,7 @@ extension CmxIrohHostRuntimeTests {
             lanGeneration: 1,
             revision: 1
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: revisionTwo,
@@ -318,19 +318,20 @@ extension CmxIrohHostRuntimeTests {
         .rejected(statusCode: 400, code: "invalid_request"),
         .invalidResponse,
     ])
-    func terminalBrokerFailureNeverUsesCachedPolicy(
+    func terminalBrokerFailureFailsClosedAfterCacheFirstActivation(
         _ failure: CmxIrohTrustBrokerClientError
     ) async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
             registrationError: failure
         )
+        let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: factory,
             broker: broker,
@@ -339,18 +340,19 @@ extension CmxIrohHostRuntimeTests {
             ),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            handleTransport: { session, _ in await session.close() }
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
         )
 
-        do {
-            try await runtime.start()
-            Issue.record("Expected terminal broker failure")
-        } catch let error as CmxIrohTrustBrokerClientError {
-            #expect(error == failure)
-        }
+        // Cache-first activation succeeds locally, but the background live
+        // reconcile discovers the terminal rejection and fails closed: a Mac
+        // the broker refuses must not keep serving on cached authority.
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
-        #expect(await endpoint.observedCloseCallCount() == 1)
         #expect(await runtime.snapshot().state == .failed)
+        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await bindings.count() == 0)
     }
 
     @Test
@@ -367,7 +369,7 @@ extension CmxIrohHostRuntimeTests {
         )
         let cachedFixture = try fixture.cachedPolicyFixture(binding: cachedMetadata)
         let now = cachedFixture.now
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -386,8 +388,13 @@ extension CmxIrohHostRuntimeTests {
             handleBinding: { _, _, _ in await bindings.record() }
         )
 
+        // Cache-first activation starts on the persisted binding; the live
+        // reconcile discovers it was replaced server-side and adopts the
+        // authenticated binding in place, publishing it exactly once.
         try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == fixture.binding.bindingID)
         #expect(await bindings.count() == 1)
         await runtime.stop()
@@ -459,7 +466,7 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
-    func confirmedOnlineBindingChangePreventsDiscoveryConnectivityFallback() async throws {
+    func halfConfirmedBindingChangeIsNeverAdoptedNorPublished() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
@@ -467,13 +474,14 @@ extension CmxIrohHostRuntimeTests {
             endpointID: fixture.endpointID.endpointID,
             bindingID: "123e4567-e89b-42d3-a456-426614174099"
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: changedBinding,
             discovery: fixture.discovery,
             discoveryError: .connectivity
         )
+        let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: factory,
             broker: broker,
@@ -482,18 +490,24 @@ extension CmxIrohHostRuntimeTests {
             ),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            handleTransport: { session, _ in await session.close() }
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.invalidLocalBinding) {
-            try await runtime.start()
-        }
+        // The reconcile registers a replaced binding but its discovery round
+        // fails on connectivity. The half-confirmed binding is confirmed
+        // proof that cached authority is stale, so the runtime fails closed
+        // without adopting or publishing the incomplete policy.
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await bindings.count() == 0)
         #expect(await endpoint.observedCloseCallCount() == 1)
     }
 
     @Test
-    func routeContractMismatchNeverUsesCachedPolicy() async throws {
+    func routeContractMismatchFailsClosedAfterCacheFirstActivation() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()
         let now = cachedFixture.now
@@ -502,7 +516,7 @@ extension CmxIrohHostRuntimeTests {
             relays: Array(fixture.managedRelays),
             routeContractVersion: 2
         )
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
@@ -519,17 +533,17 @@ extension CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.routeContractMismatch) {
-            try await runtime.start()
-        }
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
+        #expect(await runtime.snapshot().state == .failed)
         #expect(await endpoint.observedCloseCallCount() == 1)
     }
 
     @Test
     func discoverySubstitutionFailsClosedAndClosesEndpoint() async throws {
         let fixture = try HostRuntimeFixture()
-        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let endpoint = try fixture.relayReadyEndpoint()
         let factory = TestIrohEndpointFactory(endpoints: [endpoint])
         let substituted = try HostRuntimeFixture.discovery(
             binding: fixture.binding,
@@ -553,12 +567,11 @@ extension CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() }
         )
 
-        await #expect(throws: CmxIrohHostRuntimeError.invalidLocalBinding) {
-            try await runtime.start()
-        }
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
 
-        #expect(await endpoint.observedCloseCallCount() == 1)
         #expect(await runtime.snapshot().state == .failed)
+        #expect(await endpoint.observedCloseCallCount() == 1)
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeRequestedRefreshTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeRequestedRefreshTests.swift
@@ -27,7 +27,7 @@ extension CmxIrohHostRuntimeTests {
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [
-                TestIrohEndpoint(identity: fixture.endpointID),
+                try fixture.relayReadyEndpoint(),
             ]),
             broker: broker,
             configuration: fixture.configuration,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -87,8 +87,14 @@ extension CmxIrohHostRuntimeTests {
         #expect(await routes.values().isEmpty)
         #expect(await runtime.snapshot().state == .active)
 
-        // The relay comes up through the normal credential installation path.
-        // Publication must follow, exactly once, with the post-relay hints.
+        // The relay credential installs, then native iroh reports the home
+        // relay online. Publication must follow, exactly once, with the
+        // post-relay hints.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
         #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
         let republished = await routes.values()
         #expect(republished.map(\.binding.bindingID) == [fixture.binding.bindingID])
@@ -300,5 +306,79 @@ extension CmxIrohHostRuntimeTests {
         #expect(await broker.observedRegistrationCount() == 1)
         #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
+    }
+
+    /// A requested refresh must not perform the deferred first publication
+    /// while the home relay is still unusable, even though its authenticated
+    /// broker round runs and applies admission policy.
+    @Test("a requested refresh while the relay is unready does not publish")
+    func requestedRefreshWhileRelayUnreadyDoesNotPublish() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        await runtime.requestRegistrationRefresh()
+
+        #expect(await broker.observedRegistrationCount() == 2)
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// Cached authority must be verified against the live broker even when
+    /// the home relay never becomes usable: a server-side rejection fails
+    /// the runtime closed instead of hiding behind the relay outage.
+    @Test("stale cached authority fails closed without relay readiness")
+    func staleCachedAuthorityFailsClosedWithoutRelayReadiness() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .missingAuthentication
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(
+                cachedHostPolicy: try cachedFixture.policy()
+            ),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            relayReadinessTimeout: .milliseconds(50),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
+        )
+
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        #expect(await endpoint.waitForCloseCallCount(1))
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await bindings.count() == 0)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -4,6 +4,17 @@ import Testing
 
 @testable import CmuxIrohTransport
 
+extension CmxIrohHostRuntime {
+    /// Awaits the startup ready gate and every refresh round it scheduled, so
+    /// tests observe the settled post-reconcile state deterministically.
+    func waitForInitialPublicationForTesting() async {
+        await initialPublicationTask?.value
+        while let task = registrationRefreshTask {
+            await task.value
+        }
+    }
+}
+
 extension CmxIrohHostRuntimeTests {
     /// Regression for the advertise-before-ready warm-up race
     /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not
@@ -71,6 +82,111 @@ extension CmxIrohHostRuntimeTests {
         #expect(republished.map(\.pathHints) == [[relayHint]])
         #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
 
+        await runtime.stop()
+    }
+
+    /// Cache-first activation: a persisted verified policy for the same
+    /// binding makes the Mac dialable immediately. The live broker round is
+    /// only a background reconcile, so start() completes while the broker has
+    /// not yet answered at all.
+    @Test("cache-first start becomes ready without a live broker response")
+    func cacheFirstStartBecomesReadyWithoutALiveBrokerResponse() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let cachedPolicy = try cachedFixture.policy()
+        let registrationGate = HostRuntimeRegistrationGate()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationHook: {
+                await registrationGate.waitOnce()
+                return true
+            }
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                try fixture.relayReadyEndpoint(),
+            ]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        #expect(await runtime.lanAdvertisementContext()?.rendezvous == cachedPolicy.lanRendezvous)
+        // The cached route identity is refreshed, never unpublished, but no
+        // fresh binding may be published while the live round is unanswered.
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+        ])
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await bindings.count() == 0)
+
+        await registrationGate.open()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await bindings.count() == 1)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// The late live policy reconciles onto a cache-first activation: the
+    /// same binding is re-verified and the fresh broker route hints replace
+    /// the empty cached ones.
+    @Test("late live policy reconciles a cache-first activation")
+    func lateLivePolicyReconcilesCacheFirstActivation() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
+        let discoveredHint = try #require(fixture.binding.pathHints.first)
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let cachedPolicy = try cachedFixture.policy()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                try fixture.relayReadyEndpoint(),
+            ]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        await runtime.waitForInitialPublicationForTesting()
+
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await bindings.count() == 1)
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+            .init(
+                binding: CmxIrohBrokerBindingMetadata(binding: fixture.binding),
+                pathHints: [discoveredHint]
+            ),
+        ])
+        #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -345,6 +345,89 @@ extension CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    /// A cache-first activation whose live reconcile adopts a server-side
+    /// replacement binding while the home relay is still unusable must move
+    /// the ready gate onto the adopted identity: the stale gate armed with
+    /// the superseded cached binding is drained so it can never activate the
+    /// replacement relay coordinator with the old binding, nothing publishes
+    /// before the relay is usable, and afterwards exactly the adopted
+    /// binding publishes, once.
+    @Test("adoption while the relay is unready re-arms the gate on the adopted binding")
+    func adoptionWhileRelayUnreadyReArmsGateOnAdoptedBinding() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let cachedPolicy = try cachedFixture.policy()
+        let now = cachedFixture.now
+        let replacementBinding = try HostRuntimeFixture.binding(
+            endpointID: fixture.endpointID.endpointID,
+            bindingID: "123e4567-e89b-42d3-a456-426614174099"
+        )
+        let replacementDiscovery = try HostRuntimeFixture.discovery(
+            binding: replacementBinding,
+            relays: HostRuntimeFixture.relayURLs
+        )
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: replacementBinding,
+            discovery: replacementDiscovery
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        // Cache-first start on the persisted binding: the cached route
+        // identity is refreshed, nothing publishes while the relay warms up.
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await routes.values() == [
+            .init(binding: cachedPolicy.binding, pathHints: []),
+        ])
+        #expect(await bindings.count() == 0)
+
+        // The live reconcile adopts the server-side replacement binding. The
+        // relay is still unusable, so the adopted binding must stay
+        // unpublished.
+        #expect(await broker.waitForRegistrationCount(1, timeout: .seconds(5)))
+        var adopted = false
+        for _ in 0 ..< 50_000 {
+            if await runtime.snapshot().bindingID == replacementBinding.bindingID {
+                adopted = true
+                break
+            }
+            await Task.yield()
+        }
+        #expect(adopted)
+        #expect(await bindings.count() == 0)
+
+        // The relay credential installs for the adopted binding, then the
+        // home relay comes online. Publication must follow, exactly once,
+        // with the adopted identity.
+        for _ in 0 ..< 20_000 {
+            if await !endpoint.observedRelayUpdates().isEmpty { break }
+            await Task.yield()
+        }
+        await endpoint.emit(.online)
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+        let published = await routes.values()
+        #expect(published.first?.binding.bindingID == cachedPolicy.binding.bindingID)
+        #expect(published.last?.binding.bindingID == replacementBinding.bindingID)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
     /// Cached authority must be verified against the live broker even when
     /// the home relay never becomes usable: a server-side rejection fails
     /// the runtime closed instead of hiding behind the relay outage.

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -1,0 +1,76 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+
+@testable import CmuxIrohTransport
+
+extension CmxIrohHostRuntimeTests {
+    /// Regression for the advertise-before-ready warm-up race
+    /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not
+    /// publish its binding or route hints while its home relay is still
+    /// warming up, because clients immediately burn doomed dials against an
+    /// endpoint that cannot yet accept them. The binding and route may only
+    /// be published once the relay is usable, with the post-relay hints, and
+    /// exactly once.
+    @Test("binding publication waits for a usable home relay")
+    func bindingPublicationWaitsForUsableHomeRelay() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let readyBinding = try HostRuntimeFixture.binding(
+            endpointID: fixture.endpointID.endpointID,
+            bindingID: fixture.binding.bindingID,
+            publicHintObservedAt: now,
+            publicHintExpiresAt: now.addingTimeInterval(60 * 60)
+        )
+        let relayHint = try #require(readyBinding.pathHints.first)
+        let readyDiscovery = try HostRuntimeFixture.discovery(
+            binding: readyBinding,
+            relays: HostRuntimeFixture.relayURLs
+        )
+        // The endpoint gains its usable relay hint only after the relay
+        // credential coordinator installs the first credential, exactly like
+        // a cold production launch.
+        let endpoint = TestIrohEndpoint(
+            identity: fixture.endpointID,
+            pathHintsAfterRelayReplacement: [relayHint]
+        )
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            subsequentRegistrationBindings: [readyBinding],
+            subsequentDiscoveries: [readyDiscovery]
+        )
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        // No usable home relay exists yet: the Mac must not be
+        // discoverable-but-undialable.
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await runtime.snapshot().state == .active)
+
+        // The relay comes up through the normal credential installation path.
+        // Publication must follow, exactly once, with the post-relay hints.
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        let republished = await routes.values()
+        #expect(republished.map(\.binding.bindingID) == [fixture.binding.bindingID])
+        #expect(republished.map(\.pathHints) == [[relayHint]])
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+
+        await runtime.stop()
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -189,4 +189,103 @@ extension CmxIrohHostRuntimeTests {
         #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
     }
+
+    /// A relay-readiness timeout must never publish. The gate keeps retrying
+    /// the readiness wait on the injected clock; once the relay becomes
+    /// usable, exactly one publication follows.
+    @Test("readiness timeouts keep the binding unpublished until the relay succeeds")
+    func readinessTimeoutsKeepBindingUnpublishedUntilRelaySucceeds() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            relayReadinessTimeout: .milliseconds(20),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+        #expect(await bindings.count() == 0)
+
+        // First readiness timeout: still unpublished, backoff armed.
+        await clock.waitUntilSleepCount(1)
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        clock.advance(to: try #require(clock.observedSleepDeadlines().last))
+
+        // Second readiness timeout: still unpublished.
+        await clock.waitUntilSleepCount(2)
+        #expect(await bindings.count() == 0)
+
+        // The home relay comes up. Publication must follow, exactly once.
+        await endpoint.emit(.online)
+
+        #expect(await bindings.waitForCount(1, timeout: .seconds(5)))
+        #expect(!(await bindings.waitForCount(2, timeout: .milliseconds(300))))
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    /// A relay that never becomes usable must leave the endpoint permanently
+    /// unpublished: no handleBinding, no handleRoute, no extra broker rounds.
+    @Test("readiness that never succeeds never publishes")
+    func readinessThatNeverSucceedsNeverPublishes() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let bindings = HostRuntimeBindingRecorder()
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            relayReadinessTimeout: .milliseconds(20),
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        for cycle in 1 ... 3 {
+            await clock.waitUntilSleepCount(cycle)
+            #expect(await bindings.count() == 0)
+            #expect(await routes.values().isEmpty)
+            clock.advance(to: try #require(clock.observedSleepDeadlines().last))
+        }
+
+        #expect(await bindings.count() == 0)
+        #expect(await routes.values().isEmpty)
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeStartupPublicationTests.swift
@@ -15,6 +15,19 @@ extension CmxIrohHostRuntime {
     }
 }
 
+extension TestIrohEndpoint {
+    /// A network-change refresh can own the terminal round and still be
+    /// finishing its teardown when the publication pipeline await returns.
+    /// Bounded wait for the endpoint close that teardown must perform.
+    func waitForCloseCallCount(_ minimum: Int) async -> Bool {
+        for _ in 0 ..< 50_000 {
+            if observedCloseCallCount() >= minimum { return true }
+            await Task.yield()
+        }
+        return observedCloseCallCount() >= minimum
+    }
+}
+
 extension CmxIrohHostRuntimeTests {
     /// Regression for the advertise-before-ready warm-up race
     /// (https://github.com/manaflow-ai/cmux/issues/9724): a Mac must not

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
@@ -97,6 +97,34 @@ struct HostRuntimeFixture {
         )
     }
 
+    /// A public relay hint usable on the supervisor's wall clock for one hour.
+    /// An endpoint born with it reports a usable home relay immediately, so
+    /// activation publishes the binding inline instead of waiting on the ready
+    /// gate. Fixtures that pin `now` far in the future exclude it from
+    /// registration payloads automatically, keeping those payloads unchanged.
+    static func usableRelayHint() throws -> CmxIrohPathHint {
+        let observed = Date()
+        return try CmxIrohPathHint(
+            kind: .relayURL,
+            value: relayURLs[2],
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: observed,
+            expiresAt: observed.addingTimeInterval(60 * 60)
+        )
+    }
+
+    /// An endpoint whose home relay is usable from birth.
+    func relayReadyEndpoint(
+        directAddresses: [String] = []
+    ) throws -> TestIrohEndpoint {
+        TestIrohEndpoint(
+            identity: endpointID,
+            directAddresses: directAddresses,
+            pathHints: [try Self.usableRelayHint()]
+        )
+    }
+
     static let relayURLs = [
         "https://aps1-1.relay.lawrence.cmux.iroh.link/",
         "https://euc1-1.relay.lawrence.cmux.iroh.link/",

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
@@ -384,6 +384,40 @@ struct CmxIrohRegistryContextProviderStalenessTests {
     }
 
     @Test
+    func refreshFailureAfterStalenessFallsBackToLastVerifiedSnapshot() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [relay])
+        )
+        // A timed-out dial marked the peer stale, so the next attempt must
+        // try one fresh fetch first.
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [relay]),
+            failure: .timedOut
+        )
+        await broker.setDiscoverError(CmxIrohTrustBrokerClientError.connectivity)
+
+        // The forced refresh failed. Dialing with the last verified snapshot
+        // beats not dialing at all (cmux#9724): the staleness mark survives,
+        // so a later attempt still refetches once the broker recovers.
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
     func cooldownDuringEmptyPlanRefetchKeepsResolvedContextInsteadOfSpinning() async throws {
         let fixture = try RegistryFixture()
         let broker = ConfigurableRegistryBroker(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -344,6 +344,41 @@ struct CmxIrohRelayCredentialCoordinatorTests {
     }
 
     @Test
+    func refreshFailureKeepsLastGoodCredentialWithoutThrowing() async throws {
+        let fixture = try RelayCoordinatorFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.identity)
+        let supervisor = try await fixture.activeSupervisor(endpoint: endpoint)
+        let broker = TestRelayTokenBroker(steps: [.failure])
+        let clock = TestRelayClock(now: fixture.now)
+        let coordinator = CmxIrohRelayCredentialCoordinator(
+            supervisor: supervisor,
+            broker: broker,
+            managedRelayURLs: Set(fixture.relayURLs),
+            clock: clock,
+            jitter: { _, refreshAfter in refreshAfter },
+            retryJitter: { 0 }
+        )
+        try await coordinator.activate(
+            bindingID: fixture.bindingID,
+            endpointIdentity: fixture.identity,
+            bootstrap: try fixture.response()
+        )
+        // The installed credential is due for refresh but far from expiry.
+        clock.setNowWithoutResuming(fixture.refreshAfter.addingTimeInterval(1))
+
+        // A transient mint failure must not fail the caller while the
+        // last-good credential is installed (cmux#10375). The bounded retry
+        // loop keeps refreshing in the background; only the relay itself can
+        // reject the installed credential.
+        try await coordinator.refreshIfNeeded()
+
+        #expect(await coordinator.credentialExpiresAt() == fixture.expiresAt)
+        #expect(await endpoint.observedRelayUpdates().count == 1)
+        #expect(await broker.observedEndpointIDs() == [fixture.identity])
+        await coordinator.deactivate()
+    }
+
+    @Test
     func rateLimitRetryNeverPrecedesValidatedServerFloor() async throws {
         let fixture = try RelayCoordinatorFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.identity)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -289,6 +289,66 @@ struct CmxIrohRelayPolicyServiceTests {
     }
 
     @Test
+    func restoreFailsClosedBeyondTheExpiredPolicyReuseGrace() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        let expired = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(
+                3_600 + CmxIrohRelayPolicyService.defaultExpiredPolicyReuseGrace + 1
+            )
+        )
+
+        #expect(expired.source == .managedUnavailable)
+        #expect(expired.endpointRelayProfile.allowedRelayURLs.isEmpty)
+        #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
+    }
+
+    @Test
+    func expiredPolicyGraceNeverBypassesSignatureVerification() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        // A trust root that rejects the cached policy's signing key must
+        // fail closed even inside the expiry grace window: the grace covers
+        // only time, never a rejected credential.
+        let rejected = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.secondTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(3_600 + 300)
+        )
+
+        #expect(rejected.source == .managedUnavailable)
+        #expect(rejected.endpointRelayProfile.allowedRelayURLs.isEmpty)
+    }
+
+    @Test
     func cacheRestoresUntilSignedExpiryAndSupportsStagedKeyRotation() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let stores = makeStores()
@@ -324,14 +384,18 @@ struct CmxIrohRelayPolicyServiceTests {
         #expect(restored.usedCachedPolicy)
         #expect(restored.managedSnapshot?.policy.sequence == 2)
 
-        let expired = await stores.service.restore(
+        // Immediately past the signed expiry the last-good policy stays
+        // dialable inside the bounded reuse grace (cmux#10375); the graced
+        // state is reported as `.policyExpired` without zeroing routes.
+        let graced = await stores.service.restore(
             accountID: "account-a",
             trustRoot: try fixture.secondTrustRoot,
             relayCredential: fixture.relayCredential(),
             now: fixture.now.addingTimeInterval(3_600)
         )
-        #expect(expired.source == .managedUnavailable)
-        #expect(expired.endpointRelayProfile.allowedRelayURLs.isEmpty)
+        #expect(graced.source == .managed)
+        #expect(graced.usedCachedPolicy)
+        #expect(!graced.endpointRelayProfile.allowedRelayURLs.isEmpty)
         #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -336,6 +336,39 @@ struct CmxIrohRelayPolicyServiceTests {
     }
 
     @Test
+    func restoreKeepsRecentlyExpiredLastGoodPolicyRoutesForDialing() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        _ = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .automatic,
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        // The one-hour policy expired five minutes ago and the broker refresh
+        // failed (cmux#10375). Restoring must keep the last-good catalog
+        // dialable instead of publishing a zero-route managed profile; the
+        // relay itself remains the authority on credential validity.
+        let restored = await stores.service.restore(
+            accountID: "account-a",
+            trustRoot: try fixture.firstTrustRoot,
+            relayCredential: nil,
+            now: fixture.now.addingTimeInterval(3_600 + 300)
+        )
+
+        #expect(restored.source == .managed)
+        #expect(restored.usedCachedPolicy)
+        #expect(restored.endpointRelayProfile.allowedRelayURLs == Set(fixture.relayURLs))
+        #expect(await stores.service.diagnosticsSnapshot().failure == .policyExpired)
+    }
+
+    @Test
     func implicitRevisionZeroStillRejectsEquivocation() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let stores = makeStores()

--- a/Sources/ExtensionWorktreePrototype.swift
+++ b/Sources/ExtensionWorktreePrototype.swift
@@ -12,8 +12,8 @@ struct CmuxExtensionWorktreeCreationResult: Sendable {
     let generatedArtifactContents: Data
     /// Filesystem identity captured immediately after `git worktree add`.
     /// Rollback refuses to touch a path whose checkout was replaced.
-    let worktreeDeviceID: UInt64? = nil
-    let worktreeFileID: UInt64? = nil
+    let worktreeDeviceID: UInt64?
+    let worktreeFileID: UInt64?
     /// A convenience command (e.g. a sample dev-server launcher) that should run
     /// inside the new workspace's interactive shell. This is *setup*, never the
     /// workspace's primary process.
@@ -537,7 +537,8 @@ enum CmuxExtensionWorktreePrototype {
         expectedIdentity: (deviceID: UInt64, fileID: UInt64)?
     ) async {
         guard let expectedIdentity,
-              filesystemIdentity(at: worktree) == expectedIdentity else {
+              let currentIdentity = Self.filesystemIdentity(at: worktree),
+              currentIdentity == expectedIdentity else {
             logPrivateDiagnostic("Skipped failed worktree cleanup after identity changed.")
             return
         }

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -361,7 +361,7 @@ struct ExtensionWorktreeSpawnArgsTests {
         let mutationStatus = await withTaskGroup(of: Int32?.self, returning: Int32?.self) { group in
             group.addTask {
                 var mutationIterator = mutation.stream.makeAsyncIterator()
-                await mutationIterator.next()
+                return await mutationIterator.next()
             }
             group.addTask {
                 try? await Task.sleep(for: .seconds(5))

--- a/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
+++ b/cmuxTests/ExtensionWorktreeSpawnArgsTests.swift
@@ -28,6 +28,8 @@ struct ExtensionWorktreeSpawnArgsTests {
             createdHead: "0000000000000000000000000000000000000000",
             generatedArtifactRelativePath: "cmux-sample-dev/index.html",
             generatedArtifactContents: Data(),
+            worktreeDeviceID: nil,
+            worktreeFileID: nil,
             setupCommand: setupCommand
         )
     }

--- a/web/app/api/relay/allow/route.ts
+++ b/web/app/api/relay/allow/route.ts
@@ -13,7 +13,7 @@
 // availability through its allow cache.
 
 import { env } from "../../../env";
-import { jsonResponse } from "../../../../services/relay/http";
+import { jsonResponse, readBoundedBody } from "../../../../services/relay/http";
 import {
   RELAY_ALLOW_SIGNATURE_HEADER,
   parseRelayAllowSecret,
@@ -61,10 +61,10 @@ export async function handleRelayAllowRequest(
   const secret = parseRelayAllowSecret(deps.secretBase64());
   if (!secret) return jsonResponse({ error: "relay_allow_not_configured" }, 503);
 
-  const body = await readBoundedBody(
-    request,
-    deps.bodyReadTimeoutMs ?? BODY_READ_TIMEOUT_MS,
-  );
+  const body = await readBoundedBody(request, {
+    maxBytes: MAX_BODY_BYTES,
+    timeoutMs: deps.bodyReadTimeoutMs ?? BODY_READ_TIMEOUT_MS,
+  });
   if (!body.ok) return body.response;
 
   const provided = providedSignature(request);
@@ -172,59 +172,6 @@ function admissionResponse(admission: RelayAllowAdmission): Response {
       "cache-control": "no-store",
     },
   });
-}
-
-async function readBoundedBody(
-  request: Request,
-  timeoutMs: number,
-): Promise<
-  | { readonly ok: true; readonly bytes: Uint8Array }
-  | { readonly ok: false; readonly response: Response }
-> {
-  const contentLength = request.headers.get("content-length");
-  if (contentLength) {
-    const parsed = Number(contentLength);
-    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > MAX_BODY_BYTES) {
-      return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
-    }
-  }
-  const reader = request.body?.getReader();
-  // iroh-relay's access-mode POST carries no body at all.
-  if (!reader) return { ok: true, bytes: new Uint8Array() };
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  let timedOut = false;
-  // Cancelling the reader on expiry resolves the pending read() and releases
-  // the underlying stream: real cancellation, not an abandoned promise.
-  const timer = setTimeout(() => {
-    timedOut = true;
-    void reader.cancel().catch(() => undefined);
-  }, timeoutMs);
-  try {
-    while (true) {
-      const next = await reader.read();
-      if (next.done) break;
-      total += next.value.byteLength;
-      if (total > MAX_BODY_BYTES) {
-        await reader.cancel();
-        return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
-      }
-      chunks.push(next.value);
-    }
-  } catch {
-    if (!timedOut) {
-      return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
-    }
-  } finally {
-    clearTimeout(timer);
-  }
-  if (timedOut) {
-    return { ok: false, response: jsonResponse({ error: "request_read_timeout" }, 408) };
-  }
-  return {
-    ok: true,
-    bytes: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total),
-  };
 }
 
 export function POST(request: Request): Promise<Response> {

--- a/web/app/api/relay/report/route.ts
+++ b/web/app/api/relay/report/route.ts
@@ -1,0 +1,141 @@
+// Attach/detach report sink for the self-hosted relay fleet (cmux-relay
+// `Reporter`): fire-and-forget HMAC-signed POSTs of
+// `{endpointId, event, relayId, ts}` on every admitted connect and every
+// disconnect. Applying one publishes "endpoint X reachable via relay Y" into
+// the registry, which discovery serves to the account's other devices — the
+// server-side replacement for the Mac's client-side post-attach republish.
+//
+// Hardening mirrors /api/relay/allow: shared-secret HMAC over the raw body
+// (fail closed to 503 when the secret is unset), bounded body read with a
+// hard deadline, a response-latency bound on the database application, a
+// dedicated deadline-bounded connection pool, a hard concurrency cap, and
+// `cache-control: no-store` on every response. The relay treats any non-2xx
+// as a logged warning, never a retry loop, so degraded answers are safe.
+
+import { env } from "../../../env";
+import { jsonResponse, readBoundedBody } from "../../../../services/relay/http";
+import {
+  parseRelayAllowSecret,
+  verifyRelayAllowSignature,
+} from "../../../../services/relay/allow";
+import {
+  RELAY_REPORT_SIGNATURE_HEADER,
+  RelayReportSaturatedError,
+  applyRelayAttachReport,
+  parseRelayAttachReport,
+  type RelayAttachReport,
+  type RelayReportOutcome,
+} from "../../../../services/relay/report";
+
+const MAX_BODY_BYTES = 4 * 1_024;
+const BODY_READ_TIMEOUT_MS = 5_000;
+// Response-latency bound for the registry update, so a stalled database
+// cannot hold report handlers (and their concurrency slots) until some
+// external timeout. Expiry fails to 503; the next attach/detach event
+// self-heals the published state. The resource bounds live in
+// services/relay/report.ts (statement timeout, settle bound, dedicated pool,
+// concurrency cap).
+const APPLY_TIMEOUT_MS = 3_000;
+
+export interface RelayReportDeps {
+  readonly secretBase64: () => string | undefined;
+  readonly apply: (report: RelayAttachReport) => Promise<RelayReportOutcome>;
+  readonly applyTimeoutMs?: number;
+  readonly bodyReadTimeoutMs?: number;
+  readonly now?: () => Date;
+}
+
+const productionDeps: RelayReportDeps = {
+  secretBase64: () => env.CMUX_RELAY_ALLOW_HMAC_SECRET_B64,
+  apply: applyRelayAttachReport,
+};
+
+export async function handleRelayReportRequest(
+  request: Request,
+  deps: RelayReportDeps,
+): Promise<Response> {
+  const secret = parseRelayAllowSecret(deps.secretBase64());
+  if (!secret) return jsonResponse({ error: "relay_report_not_configured" }, 503);
+
+  const body = await readBoundedBody(request, {
+    maxBytes: MAX_BODY_BYTES,
+    timeoutMs: deps.bodyReadTimeoutMs ?? BODY_READ_TIMEOUT_MS,
+  });
+  if (!body.ok) return body.response;
+
+  // Reports always carry the signature header (the relay signs the exact
+  // body bytes); no bearer fallback exists on this route.
+  const provided = request.headers.get(RELAY_REPORT_SIGNATURE_HEADER)?.trim();
+  if (!provided || !verifyRelayAllowSignature(secret, body.bytes, provided)) {
+    return jsonResponse({ error: "invalid_relay_report_signature" }, 401);
+  }
+
+  if (body.bytes.byteLength === 0) {
+    return jsonResponse({ error: "missing_report_body" }, 400);
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(body.bytes).toString("utf8"));
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, 400);
+  }
+  const parsed = parseRelayAttachReport(value, (deps.now ?? (() => new Date()))());
+  if (!parsed.ok) return jsonResponse({ error: parsed.error }, 400);
+
+  try {
+    return outcomeResponse(await applyWithDeadline(deps, parsed.report));
+  } catch (error) {
+    if (error instanceof RelayReportSaturatedError) {
+      return jsonResponse({ error: "relay_report_saturated" }, 503);
+    }
+    // Never log EndpointIDs; the route and failure class are enough.
+    console.error("relay report application failed", { failure: "unexpected" });
+    return jsonResponse({ error: "relay_report_unavailable" }, 503);
+  }
+}
+
+async function applyWithDeadline(
+  deps: RelayReportDeps,
+  report: RelayAttachReport,
+): Promise<RelayReportOutcome> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const application = deps.apply(report);
+  // An application that settles (typically rejecting on the database-side
+  // statement_timeout) after losing the race must not surface as an
+  // unhandled rejection.
+  application.catch(() => undefined);
+  try {
+    return await Promise.race([
+      application,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("relay_report_apply_timeout")),
+          deps.applyTimeoutMs ?? APPLY_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function outcomeResponse(outcome: RelayReportOutcome): Response {
+  switch (outcome) {
+    case "applied":
+      return jsonResponse({ applied: true });
+    case "superseded":
+    case "unknown_endpoint":
+      // Stale orderings and reports about endpoints that no longer have an
+      // active binding are normal fleet operation, not caller errors.
+      return jsonResponse({ applied: false, reason: outcome });
+    case "untrusted_relay":
+      // A syntactically valid, correctly signed report about a relay outside
+      // the account's dialable set: refuse loudly so the relay's warn log
+      // shows the misconfiguration (e.g. a dev relay pointed at production).
+      return jsonResponse({ error: "untrusted_relay" }, 403);
+  }
+}
+
+export function POST(request: Request): Promise<Response> {
+  return handleRelayReportRequest(request, productionDeps);
+}

--- a/web/db/migrations/20260825120000_iroh_relay_attach_reports/migration.sql
+++ b/web/db/migrations/20260825120000_iroh_relay_attach_reports/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "iroh_endpoint_bindings"
+  ADD COLUMN "relay_attached_url" text;
+--> statement-breakpoint
+ALTER TABLE "iroh_endpoint_bindings"
+  ADD COLUMN "relay_attach_reported_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "iroh_endpoint_bindings"
+  ADD CONSTRAINT "iroh_endpoint_bindings_relay_attached_url_check"
+  CHECK ("relay_attached_url" IS NULL OR ("relay_attached_url" ~ '^https://' AND length("relay_attached_url") <= 2048));
+--> statement-breakpoint
+ALTER TABLE "iroh_endpoint_bindings"
+  ADD CONSTRAINT "iroh_endpoint_bindings_relay_attach_reported_check"
+  CHECK ("relay_attached_url" IS NULL OR "relay_attach_reported_at" IS NOT NULL);

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -982,6 +982,14 @@ export const irohEndpointBindings = pgTable(
     directPortV6: integer("direct_port_v6"),
     pathHints: jsonb("path_hints").$type<unknown[]>().notNull().default(sql`'[]'::jsonb`),
     pathHintsNextExpiry: timestamp("path_hints_next_expiry", { withTimezone: true }),
+    // Live relay attach state, written only by HMAC-verified fleet reports
+    // (POST /api/relay/report). `relayAttachedUrl` is the exact catalog or
+    // saved-custom relay URL the endpoint is currently attached through;
+    // `relayAttachReportedAt` is the relay-side event timestamp of the last
+    // APPLIED report and orders fire-and-forget reports that arrive out of
+    // order. Cleared by a matching detach report and by revocation.
+    relayAttachedUrl: text("relay_attached_url"),
+    relayAttachReportedAt: timestamp("relay_attach_reported_at", { withTimezone: true }),
     deviceLimitOverrideUsed: boolean("device_limit_override_used").notNull().default(false),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
     registeredAt: timestamp("registered_at", { withTimezone: true }).notNull().defaultNow(),
@@ -1000,6 +1008,15 @@ export const irohEndpointBindings = pgTable(
     check("iroh_endpoint_bindings_direct_port_v4_check", sql`${table.directPortV4} is null or ${table.directPortV4} between 1 and 65535`),
     check("iroh_endpoint_bindings_direct_port_v6_check", sql`${table.directPortV6} is null or ${table.directPortV6} between 1 and 65535`),
     check("iroh_endpoint_bindings_path_hints_check", sql`jsonb_typeof(${table.pathHints}) = 'array' and jsonb_array_length(${table.pathHints}) <= 16`),
+    check(
+      "iroh_endpoint_bindings_relay_attached_url_check",
+      sql`${table.relayAttachedUrl} is null or (${table.relayAttachedUrl} ~ '^https://' and length(${table.relayAttachedUrl}) <= 2048)`,
+    ),
+    // A published attach URL always carries the event timestamp that set it.
+    check(
+      "iroh_endpoint_bindings_relay_attach_reported_check",
+      sql`${table.relayAttachedUrl} is null or ${table.relayAttachReportedAt} is not null`,
+    ),
     uniqueIndex("iroh_endpoint_bindings_active_endpoint_unique")
       .on(table.endpointId)
       .where(sql`${table.revokedAt} is null`),

--- a/web/services/iroh/publicationPolicy.ts
+++ b/web/services/iroh/publicationPolicy.ts
@@ -57,6 +57,19 @@ export function accountPrivateIrohPathHints<T extends PathHintLike>(
   });
 }
 
+/**
+ * May a server-observed relay attachment be published to the account's other
+ * devices? Same trust rule as endpoint-reported relay hints: only an exact
+ * managed-catalog URL or a relay the account has saved. Re-checked at read
+ * time so deleting a saved custom relay also stops serving its attach route.
+ */
+export function isPublishableAttachedRelayURL(
+  url: string,
+  savedCustomRelayURLs: ReadonlySet<string>,
+): boolean {
+  return MANAGED_RELAY_URL_SET.has(url) || savedCustomRelayURLs.has(url);
+}
+
 function plainRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -1298,6 +1298,8 @@ async function revokeActiveBindings(
       directPortV6: null,
       pathHints: [],
       pathHintsNextExpiry: null,
+      relayAttachedUrl: null,
+      relayAttachReportedAt: null,
       updatedAt: input.now,
     })
     .where(and(
@@ -1424,6 +1426,7 @@ async function drainIrohRetention(input: {
               path_hints_next_expiry is not null
               or direct_port_v4 is not null
               or direct_port_v6 is not null
+              or relay_attached_url is not null
             )
           order by revoked_at, id
           limit ${limit}
@@ -1434,6 +1437,8 @@ async function drainIrohRetention(input: {
               path_hints_next_expiry = null,
               direct_port_v4 = null,
               direct_port_v6 = null,
+              relay_attached_url = null,
+              relay_attach_reported_at = null,
               updated_at = ${nowIso}::timestamptz
           from candidates
           where binding.id = candidates.id

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -84,6 +84,7 @@ import {
 import {
   MANAGED_RELAY_URLS,
   accountPrivateIrohPathHints,
+  isPublishableAttachedRelayURL,
 } from "./publicationPolicy";
 import {
   discoveryScopeMatchesRegistration,
@@ -788,16 +789,63 @@ function publicBinding(
             ...(binding.directPortV6 === null ? {} : { ipv6: binding.directPortV6 }),
           },
         }),
-    path_hints: accountPrivateIrohPathHints(binding.pathHints.flatMap((hint): IrohPathHint[] => {
+    path_hints: bindingPathHints(binding, now, savedCustomRelayURLs),
+    last_seen_at: binding.lastSeenAt.toISOString(),
+  };
+}
+
+/**
+ * Serves the relay-reported attach route ahead of endpoint-published hints.
+ *
+ * The fleet reports attach/detach per admitted connection (cmux-relay
+ * attach reporting), so `relayAttachedUrl` is live server-side truth and the
+ * phone learns "reachable via relay Y" without the Mac's client-side
+ * post-attach republish. The synthesized hint reuses the standard path-hint
+ * shape so existing clients dial it unchanged; the client-published hint for
+ * the same URL is dropped as redundant, and every other client hint stays a
+ * fallback while pre-attach-reporting fleet relays remain deployed.
+ */
+function bindingPathHints(
+  binding: IrohBindingRecord,
+  now: Date,
+  savedCustomRelayURLs: ReadonlySet<string>,
+): IrohPathHint[] {
+  const clientHints = accountPrivateIrohPathHints(
+    binding.pathHints.flatMap((hint): IrohPathHint[] => {
       try {
         return [parseIrohPathHint(hint, now)];
       } catch {
         return [];
       }
-    }), savedCustomRelayURLs),
-    last_seen_at: binding.lastSeenAt.toISOString(),
+    }),
+    savedCustomRelayURLs,
+  );
+  const attachedURL = binding.relayAttachedUrl;
+  if (
+    attachedURL === null ||
+    !isPublishableAttachedRelayURL(attachedURL, savedCustomRelayURLs)
+  ) {
+    return clientHints;
+  }
+  const serverHint: IrohPathHint = {
+    kind: "relay_url",
+    value: attachedURL,
+    source: "native",
+    privacy_scope: "public_internet",
+    // Attachment is current as of this read; clients bound hint freshness to
+    // observed_at + 1h, and every discovery read re-serves the live state.
+    observed_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + SERVER_RELAY_HINT_TTL_MS).toISOString(),
   };
+  return [
+    serverHint,
+    ...clientHints.filter((hint) =>
+      !(hint.kind === "relay_url" && hint.value === attachedURL)),
+  ];
 }
+
+/** Half the model's 1h hint-lifetime cap; refreshed by every discovery read. */
+const SERVER_RELAY_HINT_TTL_MS = 30 * 60 * 1_000;
 
 function customRelayURLs(preference: RelayPreference): ReadonlySet<string> {
   return new Set(preference.customRelays.map((relay) => relay.url));

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -823,7 +823,8 @@ function bindingPathHints(
   const attachedURL = binding.relayAttachedUrl;
   if (
     attachedURL === null ||
-    !isPublishableAttachedRelayURL(attachedURL, savedCustomRelayURLs)
+    !isPublishableAttachedRelayURL(attachedURL, savedCustomRelayURLs) ||
+    !attachmentCorroborated(binding, now)
   ) {
     return clientHints;
   }
@@ -846,6 +847,27 @@ function bindingPathHints(
 
 /** Half the model's 1h hint-lifetime cap; refreshed by every discovery read. */
 const SERVER_RELAY_HINT_TTL_MS = 30 * 60 * 1_000;
+
+/**
+ * Detach reports are fire-and-forget, so a relay that dies together with its
+ * report leaves `relayAttachedUrl` behind; without a liveness bound that dead
+ * route would be re-served as fresh forever. An attachment is served only
+ * while some live evidence is younger than this window: the attach report
+ * itself, or the binding's `lastSeenAt` (a live Mac re-registers at least
+ * hourly to keep its ≤1h path hints and binding freshness lease current,
+ * and a Mac that outlives its relay reattaches elsewhere, which overwrites
+ * the URL). A Mac that goes dark with its relay stops refreshing both, so
+ * the stale route ages out within this window.
+ */
+const SERVER_RELAY_ATTACH_LIVENESS_MS = 60 * 60 * 1_000;
+
+function attachmentCorroborated(binding: IrohBindingRecord, now: Date): boolean {
+  const freshestEvidence = Math.max(
+    binding.relayAttachReportedAt?.getTime() ?? 0,
+    binding.lastSeenAt.getTime(),
+  );
+  return now.getTime() - freshestEvidence <= SERVER_RELAY_ATTACH_LIVENESS_MS;
+}
 
 function customRelayURLs(preference: RelayPreference): ReadonlySet<string> {
   return new Set(preference.customRelays.map((relay) => relay.url));

--- a/web/services/relay/allow.ts
+++ b/web/services/relay/allow.ts
@@ -6,22 +6,15 @@
 // trustworthy; this side only decides whether that endpoint is admitted.
 //
 // The admission lookup deliberately does NOT borrow the shared cloudDb
-// client: its pool checkout and connection phases have no deadline there, so
-// a stalled operation could neither be cancelled nor be counted on to settle.
-// Instead the admission path owns a dedicated client sized to its concurrency
-// cap with a hard bound on every phase (connect, checkout, execution, plus a
-// client-side cancel), so every admission operation settles within a known
-// bound and the concurrency slots — released strictly at settlement — bound
-// retained work without ever staying saturated after an outage heals.
+// client: it runs on the deadline-bounded per-hook client from ./hookDb, so
+// every admission operation settles within a known bound and the concurrency
+// slots — released strictly at settlement — bound retained work without ever
+// staying saturated after an outage heals.
 
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { attachDatabasePool } from "@vercel/functions";
-import type { Pool } from "pg";
-import postgres, { type Sql } from "postgres";
 
-import { createAwsRdsIamPool } from "../../db/client";
-import { cloudDbConfig, cloudDbConfigKey } from "../../db/config";
 import { isBlockingAccountDeletionTombstone } from "../account/deletionLock";
+import { closeRelayHookDbClientForTests, relayHookDbClient } from "./hookDb";
 
 export const RELAY_ALLOW_SIGNATURE_HEADER = "x-cmux-relay-allow-signature";
 
@@ -52,10 +45,6 @@ export const RELAY_ALLOW_STATEMENT_TIMEOUT_MS = 2_500;
  * timeout so the server usually cancels first.
  */
 export const RELAY_ALLOW_LOOKUP_SETTLE_MS = 4_000;
-
-/** Connection-establishment (and, for pg, checkout-wait) deadline. */
-const CONNECT_TIMEOUT_MS = 5_000;
-const IDLE_TIMEOUT_SECONDS = 60;
 
 export class RelayAllowAdmissionSaturatedError extends Error {
   constructor() {
@@ -150,91 +139,20 @@ const ADMISSION_SQL = `
   limit 1
 `;
 
-type AdmissionClientState = {
-  readonly key: string;
-  readonly lookup: (endpointId: string) => Promise<AdmissionRow | null>;
-  readonly close: () => Promise<void>;
-};
+const ADMISSION_HOOK = "relay-allow";
 
-const globalForAdmission = globalThis as typeof globalThis & {
-  __cmuxRelayAllowAdmission?: AdmissionClientState;
-};
-
-function admissionClient(): AdmissionClientState {
-  const config = cloudDbConfig();
-  const key = cloudDbConfigKey(config);
-  const cached = globalForAdmission.__cmuxRelayAllowAdmission;
-  if (cached?.key === key) return cached;
-  if (cached) {
-    // The database config rotated within this runtime: drop the stale client
-    // and close it so its pool is not retained alongside the replacement.
-    // In-flight lookups hold their own reference and settle under their phase
-    // deadlines; close() (pool.end / sql.end) waits for them, so this cannot
-    // interrupt an admission already running.
-    globalForAdmission.__cmuxRelayAllowAdmission = undefined;
-    void cached.close().catch(() => {
-      // Best-effort teardown; the replacement client is unaffected.
-    });
-  }
-
-  let state: AdmissionClientState;
-  if (config.driver === "aws-rds-iam") {
-    const pool: Pool = createAwsRdsIamPool(config, {
-      max: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
-      // Bounds checkout waits as well as connection establishment.
-      connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
-      idleTimeoutMillis: IDLE_TIMEOUT_SECONDS * 1_000,
-      statement_timeout: RELAY_ALLOW_STATEMENT_TIMEOUT_MS,
-      query_timeout: RELAY_ALLOW_LOOKUP_SETTLE_MS,
-    });
-    attachDatabasePool(pool);
-    state = {
-      key,
-      lookup: async (endpointId) => {
-        const result = await pool.query<AdmissionRow>(ADMISSION_SQL, [endpointId]);
-        return result.rows[0] ?? null;
-      },
-      close: () => pool.end(),
-    };
-  } else {
-    const sql: Sql = postgres(config.url, {
-      max: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
-      prepare: false,
-      connect_timeout: Math.ceil(CONNECT_TIMEOUT_MS / 1_000),
-      idle_timeout: IDLE_TIMEOUT_SECONDS,
-      connection: { statement_timeout: RELAY_ALLOW_STATEMENT_TIMEOUT_MS },
-    });
-    state = {
-      key,
-      lookup: async (endpointId) => {
-        const query = sql.unsafe<AdmissionRow[]>(ADMISSION_SQL, [endpointId]);
-        // cancel() rejects the query whether still queued or executing, so
-        // the operation settles even through a pool or network stall.
-        const settleBound = setTimeout(() => {
-          try {
-            query.cancel();
-          } catch {
-            // Cancellation is best-effort; the statement timeout remains.
-          }
-        }, RELAY_ALLOW_LOOKUP_SETTLE_MS);
-        try {
-          const rows = await query;
-          return rows[0] ?? null;
-        } finally {
-          clearTimeout(settleBound);
-        }
-      },
-      close: () => sql.end(),
-    };
-  }
-  globalForAdmission.__cmuxRelayAllowAdmission = state;
-  return state;
+async function admissionLookup(endpointId: string): Promise<AdmissionRow | null> {
+  const client = relayHookDbClient(ADMISSION_HOOK, {
+    maxConnections: RELAY_ALLOW_MAX_CONCURRENT_ADMISSIONS,
+    statementTimeoutMs: RELAY_ALLOW_STATEMENT_TIMEOUT_MS,
+    settleMs: RELAY_ALLOW_LOOKUP_SETTLE_MS,
+  });
+  const rows = await client.query(ADMISSION_SQL, [endpointId]);
+  return (rows[0] as AdmissionRow | undefined) ?? null;
 }
 
 export async function closeRelayAllowAdmissionClientForTests(): Promise<void> {
-  const state = globalForAdmission.__cmuxRelayAllowAdmission;
-  globalForAdmission.__cmuxRelayAllowAdmission = undefined;
-  await state?.close();
+  await closeRelayHookDbClientForTests(ADMISSION_HOOK);
 }
 
 /**
@@ -247,7 +165,7 @@ export async function relayAllowAdmission(
   endpointId: string,
 ): Promise<RelayAllowAdmission> {
   return await withRelayAllowAdmissionSlot(async () => {
-    const row = await admissionClient().lookup(endpointId);
+    const row = await admissionLookup(endpointId);
     if (!row) return "deny" as const;
     if (tombstoneBlocks(row)) return "deny" as const;
     return "allow" as const;

--- a/web/services/relay/hookDb.ts
+++ b/web/services/relay/hookDb.ts
@@ -1,0 +1,142 @@
+// Dedicated deadline-bounded Postgres access for relay fleet hooks
+// (/api/relay/allow, /api/relay/report).
+//
+// These hooks deliberately do NOT borrow the shared cloudDb client: its pool
+// checkout and connection phases have no deadline there, so a stalled
+// operation could neither be cancelled nor be counted on to settle. Each hook
+// instead owns a client sized to its concurrency cap with a hard bound on
+// every phase (connect, checkout, execution, plus a client-side cancel), so
+// every hook operation settles within a known bound and the hook's
+// concurrency slots — released strictly at settlement — bound retained work
+// without ever staying saturated after an outage heals.
+//
+// Clients are cached per hook name so each hook keeps its own pool: report
+// ingestion load can never queue behind (or starve) connection admissions.
+
+import { attachDatabasePool } from "@vercel/functions";
+import type { Pool } from "pg";
+import postgres, { type Sql } from "postgres";
+
+import { createAwsRdsIamPool } from "../../db/client";
+import { cloudDbConfig, cloudDbConfigKey } from "../../db/config";
+
+/** Connection-establishment (and, for pg, checkout-wait) deadline. */
+const CONNECT_TIMEOUT_MS = 5_000;
+const IDLE_TIMEOUT_SECONDS = 60;
+
+export type RelayHookDbBounds = {
+  /**
+   * Pool size; pair it with the hook's concurrency cap so no hook operation
+   * ever queues inside the driver.
+   */
+  readonly maxConnections: number;
+  /**
+   * Server-side statement_timeout, set as a session parameter on every
+   * connection: Postgres cancels an executing statement and frees the
+   * connection.
+   */
+  readonly statementTimeoutMs: number;
+  /**
+   * Client-side settle bound. postgres.js: a timer calls query.cancel(),
+   * which rejects the query whether it is still queued or already executing.
+   * pg: the pool's query_timeout enforces the same bound. Keep it above the
+   * statement timeout so the server usually cancels first.
+   */
+  readonly settleMs: number;
+};
+
+export type RelayHookDbClient = {
+  readonly query: (
+    text: string,
+    params: readonly unknown[],
+  ) => Promise<readonly Record<string, unknown>[]>;
+  readonly close: () => Promise<void>;
+};
+
+type CachedClient = {
+  readonly configKey: string;
+  readonly client: RelayHookDbClient;
+};
+
+const globalForHooks = globalThis as typeof globalThis & {
+  __cmuxRelayHookDbClients?: Map<string, CachedClient>;
+};
+
+export function relayHookDbClient(
+  hook: string,
+  bounds: RelayHookDbBounds,
+): RelayHookDbClient {
+  const config = cloudDbConfig();
+  const configKey = cloudDbConfigKey(config);
+  const cache = (globalForHooks.__cmuxRelayHookDbClients ??= new Map());
+  const cached = cache.get(hook);
+  if (cached?.configKey === configKey) return cached.client;
+  if (cached) {
+    // The database config rotated within this runtime: drop the stale client
+    // and close it so its pool is not retained alongside the replacement.
+    // In-flight operations hold their own reference and settle under their
+    // phase deadlines; close() (pool.end / sql.end) waits for them, so this
+    // cannot interrupt an operation already running.
+    cache.delete(hook);
+    void cached.client.close().catch(() => {
+      // Best-effort teardown; the replacement client is unaffected.
+    });
+  }
+
+  let client: RelayHookDbClient;
+  if (config.driver === "aws-rds-iam") {
+    const pool: Pool = createAwsRdsIamPool(config, {
+      max: bounds.maxConnections,
+      // Bounds checkout waits as well as connection establishment.
+      connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+      idleTimeoutMillis: IDLE_TIMEOUT_SECONDS * 1_000,
+      statement_timeout: bounds.statementTimeoutMs,
+      query_timeout: bounds.settleMs,
+    });
+    attachDatabasePool(pool);
+    client = {
+      query: async (text, params) => {
+        const result = await pool.query(text, params as unknown[]);
+        return result.rows as readonly Record<string, unknown>[];
+      },
+      close: () => pool.end(),
+    };
+  } else {
+    const sql: Sql = postgres(config.url, {
+      max: bounds.maxConnections,
+      prepare: false,
+      connect_timeout: Math.ceil(CONNECT_TIMEOUT_MS / 1_000),
+      idle_timeout: IDLE_TIMEOUT_SECONDS,
+      connection: { statement_timeout: bounds.statementTimeoutMs },
+    });
+    client = {
+      query: async (text, params) => {
+        const query = sql.unsafe(text, params as never[]);
+        // cancel() rejects the query whether still queued or executing, so
+        // the operation settles even through a pool or network stall.
+        const settleBound = setTimeout(() => {
+          try {
+            query.cancel();
+          } catch {
+            // Cancellation is best-effort; the statement timeout remains.
+          }
+        }, bounds.settleMs);
+        try {
+          return (await query) as unknown as readonly Record<string, unknown>[];
+        } finally {
+          clearTimeout(settleBound);
+        }
+      },
+      close: () => sql.end(),
+    };
+  }
+  cache.set(hook, { configKey, client });
+  return client;
+}
+
+export async function closeRelayHookDbClientForTests(hook: string): Promise<void> {
+  const cache = globalForHooks.__cmuxRelayHookDbClients;
+  const cached = cache?.get(hook);
+  cache?.delete(hook);
+  await cached?.client.close();
+}

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -175,3 +175,65 @@ export function jsonResponse(
     },
   });
 }
+
+export type BoundedBodyResult =
+  | { readonly ok: true; readonly bytes: Uint8Array }
+  | { readonly ok: false; readonly response: Response };
+
+/**
+ * Reads a request body under a hard byte cap and a hard read deadline, for
+ * unauthenticated fleet-hook routes (/api/relay/allow, /api/relay/report).
+ * The byte cap alone does not stop a slowloris client that trickles (or
+ * never finishes) a body to occupy the handler; the deadline cancels the
+ * request stream itself on expiry — real cancellation, not an abandoned
+ * promise. A missing body resolves to zero bytes, so callers that require a
+ * body decide their own failure mode.
+ */
+export async function readBoundedBody(
+  request: Request,
+  options: { readonly maxBytes: number; readonly timeoutMs: number },
+): Promise<BoundedBodyResult> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > options.maxBytes) {
+      return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+    }
+  }
+  const reader = request.body?.getReader();
+  if (!reader) return { ok: true, bytes: new Uint8Array() };
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let timedOut = false;
+  // Cancelling the reader on expiry resolves the pending read() and releases
+  // the underlying stream.
+  const timer = setTimeout(() => {
+    timedOut = true;
+    void reader.cancel().catch(() => undefined);
+  }, options.timeoutMs);
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > options.maxBytes) {
+        await reader.cancel();
+        return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+      }
+      chunks.push(next.value);
+    }
+  } catch {
+    if (!timedOut) {
+      return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+  if (timedOut) {
+    return { ok: false, response: jsonResponse({ error: "request_read_timeout" }, 408) };
+  }
+  return {
+    ok: true,
+    bytes: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total),
+  };
+}

--- a/web/services/relay/report.ts
+++ b/web/services/relay/report.ts
@@ -1,0 +1,297 @@
+// Backend half of the relay fleet's attach/detach reporting (cmux-relay
+// `Reporter`, manaflow-ai/cmux-relay PR #9). On every admitted connect the
+// relay fire-and-forgets `POST CMUX_RELAY_REPORT_URL` with the JSON body
+// `{endpointId, event: "attach"|"detach", relayId, ts}`, signed exactly like
+// allow-hook calls: unpadded base64url HMAC-SHA256 over the raw body bytes in
+// the same `x-cmux-relay-allow-signature` header, same shared secret
+// (CMUX_RELAY_ALLOW_HMAC_SECRET_B64). `relayId` is the relay's public
+// hostname (its `--hostname` flag, e.g. `usc1.relay.cmux.dev`); `ts` is the
+// relay-side event time in unix milliseconds.
+//
+// Applying a report publishes "endpoint X is reachable via relay Y" into the
+// registry (`iroh_endpoint_bindings.relay_attached_url`), which discovery
+// serves to the account's other devices as a server-observed relay hint —
+// replacing the Mac's client-side post-attach republish.
+//
+// Trust decision: the HMAC proves a fleet relay (holder of the shared
+// secret) sent the report, but `relayId` inside the body is self-declared,
+// so a single compromised relay — or a leaked secret — could otherwise
+// publish an attacker-controlled relay URL to every phone on any account.
+// A report is therefore only applied when its hostname resolves to a relay
+// the account is already allowed to dial: an exact managed-catalog URL, or a
+// custom relay the account has saved (matched by hostname, publishing the
+// saved URL verbatim). Everything else is rejected (`untrusted_relay`),
+// which also keeps dev relays (`cmux-relay-dev`) out of production state.
+// Debug/test fleets get trusted the same way: their relay must be in the
+// catalog the deployment was built with, or saved as that account's custom
+// relay; the HMAC alone is deliberately NOT sufficient.
+//
+// Ordering: reports are fire-and-forget and can arrive out of order, so each
+// applied report records its relay-side event timestamp and older events are
+// dropped (`superseded`). Attach wins a timestamp tie (make-before-break
+// reconnects admit the new connection before the old one closes). Known
+// residual: the report body carries no connection id, so a same-relay
+// reconnect whose old-connection detach lands after the new-connection
+// attach (with a later relay-side ts) unpublishes the route until the next
+// attach event; the client republish fallback covers that window, and fixing
+// it properly needs a connection id in the relay's report body.
+//
+// Unlike /api/relay/allow this path does not consult account-deletion
+// tombstones: deletion revokes bindings (which hides them from discovery and
+// denies relay admission), so attach state on a to-be-deleted account is
+// unreachable either way.
+
+import { RELAY_ALLOW_SIGNATURE_HEADER } from "./allow";
+import { MANAGED_IROH_RELAY_CATALOG } from "./generated/managedRelayCatalog";
+import { closeRelayHookDbClientForTests, relayHookDbClient } from "./hookDb";
+
+/** Same header, same signing scheme, same secret as the allow hook. */
+export const RELAY_REPORT_SIGNATURE_HEADER = RELAY_ALLOW_SIGNATURE_HEADER;
+
+/**
+ * Hard cap on concurrently running report applications per runtime instance,
+ * and the size of the dedicated report pool (separate from the admission
+ * pool, so report bursts can never starve connection admissions). A
+ * saturated instance answers 503; the relay treats any failure as
+ * best-effort and the next attach/detach event self-heals the state.
+ */
+export const RELAY_REPORT_MAX_CONCURRENT = 16;
+
+export const RELAY_REPORT_STATEMENT_TIMEOUT_MS = 2_500;
+export const RELAY_REPORT_SETTLE_MS = 4_000;
+
+/**
+ * Reject event timestamps this far ahead of server time. Without the bound a
+ * relay with a runaway clock would plant a far-future `relay_attach_reported_at`
+ * that blocks every later (correctly timed) report for the endpoint.
+ */
+export const RELAY_REPORT_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+
+const ENDPOINT_ID_RE = /^[0-9a-f]{64}$/;
+// RFC 1123 hostname labels, lowercase; total length bounded below.
+const RELAY_HOSTNAME_RE =
+  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/;
+const MAX_RELAY_HOSTNAME_LENGTH = 253;
+
+export class RelayReportSaturatedError extends Error {
+  constructor() {
+    super("relay report concurrency saturated");
+    this.name = "RelayReportSaturatedError";
+  }
+}
+
+let inFlightReports = 0;
+
+/** Runs one report application under the concurrency cap; rejects when saturated. */
+export async function withRelayReportSlot<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (inFlightReports >= RELAY_REPORT_MAX_CONCURRENT) {
+    throw new RelayReportSaturatedError();
+  }
+  inFlightReports += 1;
+  try {
+    return await operation();
+  } finally {
+    inFlightReports -= 1;
+  }
+}
+
+export type RelayAttachReport = {
+  readonly endpointId: string;
+  readonly event: "attach" | "detach";
+  readonly relayId: string;
+  /** Relay-side event time (body `ts`, unix milliseconds). */
+  readonly reportedAt: Date;
+};
+
+export type RelayReportParseError =
+  | "invalid_report_body"
+  | "invalid_endpoint_id"
+  | "invalid_report_event"
+  | "invalid_relay_id"
+  | "invalid_report_time";
+
+export type RelayReportParseResult =
+  | { readonly ok: true; readonly report: RelayAttachReport }
+  | { readonly ok: false; readonly error: RelayReportParseError };
+
+export function parseRelayAttachReport(
+  value: unknown,
+  now: Date,
+): RelayReportParseResult {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "invalid_report_body" };
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set(["endpointId", "event", "relayId", "ts"]);
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    return { ok: false, error: "invalid_report_body" };
+  }
+
+  const endpointId = typeof record.endpointId === "string"
+    ? record.endpointId.trim().toLowerCase()
+    : "";
+  if (!ENDPOINT_ID_RE.test(endpointId)) {
+    return { ok: false, error: "invalid_endpoint_id" };
+  }
+
+  const event = record.event;
+  if (event !== "attach" && event !== "detach") {
+    return { ok: false, error: "invalid_report_event" };
+  }
+
+  const relayId = typeof record.relayId === "string"
+    ? record.relayId.trim().toLowerCase()
+    : "";
+  if (
+    relayId.length === 0 ||
+    relayId.length > MAX_RELAY_HOSTNAME_LENGTH ||
+    !RELAY_HOSTNAME_RE.test(relayId)
+  ) {
+    return { ok: false, error: "invalid_relay_id" };
+  }
+
+  const ts = record.ts;
+  if (
+    typeof ts !== "number" ||
+    !Number.isSafeInteger(ts) ||
+    ts <= 0 ||
+    ts > now.getTime() + RELAY_REPORT_MAX_FUTURE_SKEW_MS
+  ) {
+    return { ok: false, error: "invalid_report_time" };
+  }
+
+  return {
+    ok: true,
+    report: { endpointId, event, relayId, reportedAt: new Date(ts) },
+  };
+}
+
+/**
+ * Resolves a reported relay hostname to the exact URL the registry may
+ * publish: the managed catalog first, then the account's saved custom relays
+ * (their saved URL verbatim, so ports survive). Returns null for hostnames
+ * the account is not allowed to dial.
+ */
+export function publishableRelayURLForHostname(
+  relayId: string,
+  savedCustomRelayURLs: readonly string[],
+): string | null {
+  for (const relay of MANAGED_IROH_RELAY_CATALOG.relays) {
+    if (urlHostname(relay.url) === relayId) return relay.url;
+  }
+  // Deterministic pick if several saved relays share one hostname.
+  for (const saved of [...savedCustomRelayURLs].sort()) {
+    if (urlHostname(saved) === relayId) return saved;
+  }
+  return null;
+}
+
+function urlHostname(value: string): string | null {
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export type RelayReportOutcome =
+  | "applied"
+  | "superseded"
+  | "unknown_endpoint"
+  | "untrusted_relay";
+
+// The active binding for the endpoint plus that account's saved custom
+// relays (preferences are keyed by the same Stack user id bindings carry).
+// The partial unique index `iroh_endpoint_bindings_active_endpoint_unique`
+// guarantees at most one row.
+const REPORT_CONTEXT_SQL = `
+  select
+    binding.user_id as "userId",
+    pref.custom_relays as "customRelays"
+  from iroh_endpoint_bindings binding
+  left join iroh_relay_preferences pref
+    on pref.account_id = binding.user_id
+  where binding.endpoint_id = $1
+    and binding.revoked_at is null
+  limit 1
+`;
+
+// Ordering guards: an attach applies unless a strictly newer event was
+// already applied (attach wins ties); a detach applies only against the
+// exact URL it detached from and only when strictly newer, so a late detach
+// from an old relay can never clear a newer attachment elsewhere.
+const APPLY_ATTACH_SQL = `
+  update iroh_endpoint_bindings
+  set relay_attached_url = $2,
+      relay_attach_reported_at = $3::timestamptz
+  where endpoint_id = $1
+    and revoked_at is null
+    and (relay_attach_reported_at is null or relay_attach_reported_at <= $3::timestamptz)
+  returning id
+`;
+
+const APPLY_DETACH_SQL = `
+  update iroh_endpoint_bindings
+  set relay_attached_url = null,
+      relay_attach_reported_at = $3::timestamptz
+  where endpoint_id = $1
+    and revoked_at is null
+    and relay_attached_url = $2
+    and relay_attach_reported_at < $3::timestamptz
+  returning id
+`;
+
+const REPORT_HOOK = "relay-report";
+
+function reportClient() {
+  return relayHookDbClient(REPORT_HOOK, {
+    maxConnections: RELAY_REPORT_MAX_CONCURRENT,
+    statementTimeoutMs: RELAY_REPORT_STATEMENT_TIMEOUT_MS,
+    settleMs: RELAY_REPORT_SETTLE_MS,
+  });
+}
+
+function savedCustomRelayURLs(customRelays: unknown): string[] {
+  if (!Array.isArray(customRelays)) return [];
+  const urls: string[] = [];
+  for (const relay of customRelays) {
+    if (relay !== null && typeof relay === "object" && !Array.isArray(relay)) {
+      const url = (relay as Record<string, unknown>).url;
+      if (typeof url === "string") urls.push(url);
+    }
+  }
+  return urls;
+}
+
+/**
+ * Applies one verified report to the registry. Both statements run on the
+ * dedicated deadline-bounded report client under the concurrency cap.
+ */
+export async function applyRelayAttachReport(
+  report: RelayAttachReport,
+): Promise<RelayReportOutcome> {
+  return await withRelayReportSlot(async () => {
+    const client = reportClient();
+    const context = (await client.query(REPORT_CONTEXT_SQL, [report.endpointId]))[0];
+    if (!context) return "unknown_endpoint" as const;
+    const url = publishableRelayURLForHostname(
+      report.relayId,
+      savedCustomRelayURLs(context.customRelays),
+    );
+    if (url === null) return "untrusted_relay" as const;
+    const applied = await client.query(
+      report.event === "attach" ? APPLY_ATTACH_SQL : APPLY_DETACH_SQL,
+      [report.endpointId, url, report.reportedAt.toISOString()],
+    );
+    // Zero rows: an equal-or-newer event already holds the slot, the detach
+    // target URL no longer matches, or the binding was revoked between the
+    // two statements. All are stale-report shapes, not failures.
+    return applied.length > 0 ? ("applied" as const) : ("superseded" as const);
+  });
+}
+
+export async function closeRelayReportClientForTests(): Promise<void> {
+  await closeRelayHookDbClientForTests(REPORT_HOOK);
+}

--- a/web/services/relay/report.ts
+++ b/web/services/relay/report.ts
@@ -70,6 +70,16 @@ export const RELAY_REPORT_SETTLE_MS = 4_000;
  */
 export const RELAY_REPORT_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 
+/**
+ * Reject event timestamps this far behind server time. The Reporter sends
+ * each event once, immediately, with a 3s HTTP timeout and no retry, so a
+ * legitimate report is at most seconds old; the allowance is for relay clock
+ * drift. Without the bound, a captured signed attach (HMAC has no nonce)
+ * could be replayed much later into an empty attachment slot and would then
+ * be re-served as current reachability until the liveness window expired.
+ */
+export const RELAY_REPORT_MAX_PAST_SKEW_MS = 15 * 60 * 1_000;
+
 const ENDPOINT_ID_RE = /^[0-9a-f]{64}$/;
 // RFC 1123 hostname labels, lowercase; total length bounded below.
 const RELAY_HOSTNAME_RE =
@@ -160,7 +170,8 @@ export function parseRelayAttachReport(
     typeof ts !== "number" ||
     !Number.isSafeInteger(ts) ||
     ts <= 0 ||
-    ts > now.getTime() + RELAY_REPORT_MAX_FUTURE_SKEW_MS
+    ts > now.getTime() + RELAY_REPORT_MAX_FUTURE_SKEW_MS ||
+    ts < now.getTime() - RELAY_REPORT_MAX_PAST_SKEW_MS
   ) {
     return { ok: false, error: "invalid_report_time" };
   }

--- a/web/services/relay/report.ts
+++ b/web/services/relay/report.ts
@@ -17,11 +17,14 @@
 // secret) sent the report, but `relayId` inside the body is self-declared,
 // so a single compromised relay — or a leaked secret — could otherwise
 // publish an attacker-controlled relay URL to every phone on any account.
-// A report is therefore only applied when its hostname resolves to a relay
+// An ATTACH is therefore only applied when its hostname resolves to a relay
 // the account is already allowed to dial: an exact managed-catalog URL, or a
 // custom relay the account has saved (matched by hostname, publishing the
-// saved URL verbatim). Everything else is rejected (`untrusted_relay`),
+// saved URL verbatim). Every other attach is rejected (`untrusted_relay`),
 // which also keeps dev relays (`cmux-relay-dev`) out of production state.
+// A DETACH clears state instead of publishing it, so it is matched against
+// the stored URL by hostname without the trust lookup — see
+// `applyRelayAttachReport`.
 // Debug/test fleets get trusted the same way: their relay must be in the
 // catalog the deployment was built with, or saved as that account's custom
 // relay; the HMAC alone is deliberately NOT sufficient.
@@ -202,13 +205,14 @@ export type RelayReportOutcome =
   | "unknown_endpoint"
   | "untrusted_relay";
 
-// The active binding for the endpoint plus that account's saved custom
-// relays (preferences are keyed by the same Stack user id bindings carry).
-// The partial unique index `iroh_endpoint_bindings_active_endpoint_unique`
-// guarantees at most one row.
+// The active binding for the endpoint (with its current attachment) plus
+// that account's saved custom relays (preferences are keyed by the same
+// Stack user id bindings carry). The partial unique index
+// `iroh_endpoint_bindings_active_endpoint_unique` guarantees at most one row.
 const REPORT_CONTEXT_SQL = `
   select
     binding.user_id as "userId",
+    binding.relay_attached_url as "attachedUrl",
     pref.custom_relays as "customRelays"
   from iroh_endpoint_bindings binding
   left join iroh_relay_preferences pref
@@ -268,6 +272,14 @@ function savedCustomRelayURLs(customRelays: unknown): string[] {
 /**
  * Applies one verified report to the registry. Both statements run on the
  * dedicated deadline-bounded report client under the concurrency cap.
+ *
+ * The catalog/saved-set trust rule gates only ATTACH, because only an attach
+ * publishes a URL. A detach merely clears the stored attachment, so it is
+ * matched against the STORED URL by hostname and needs no trust resolution:
+ * a custom relay deleted from the account's preferences must still be able
+ * to detach cleanly, or its stale attachment would resurface if the same
+ * relay were ever saved again (a forged clear already requires the shared
+ * secret and only degrades discovery to the client-published fallback).
  */
 export async function applyRelayAttachReport(
   report: RelayAttachReport,
@@ -276,11 +288,29 @@ export async function applyRelayAttachReport(
     const client = reportClient();
     const context = (await client.query(REPORT_CONTEXT_SQL, [report.endpointId]))[0];
     if (!context) return "unknown_endpoint" as const;
-    const url = publishableRelayURLForHostname(
-      report.relayId,
-      savedCustomRelayURLs(context.customRelays),
-    );
-    if (url === null) return "untrusted_relay" as const;
+
+    let url: string;
+    if (report.event === "attach") {
+      const publishable = publishableRelayURLForHostname(
+        report.relayId,
+        savedCustomRelayURLs(context.customRelays),
+      );
+      if (publishable === null) return "untrusted_relay" as const;
+      url = publishable;
+    } else {
+      const attachedUrl = typeof context.attachedUrl === "string"
+        ? context.attachedUrl
+        : null;
+      if (attachedUrl === null || urlHostname(attachedUrl) !== report.relayId) {
+        // Nothing (or a different relay's route) is published; the detach is
+        // stale relative to the applied event stream.
+        return "superseded" as const;
+      }
+      // Clear exactly what was read; the WHERE below re-checks it so a
+      // concurrent attach between the two statements survives.
+      url = attachedUrl;
+    }
+
     const applied = await client.query(
       report.event === "attach" ? APPLY_ATTACH_SQL : APPLY_DETACH_SQL,
       [report.endpointId, url, report.reportedAt.toISOString()],

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -1366,6 +1366,43 @@ describe("Iroh discovery and grants", () => {
       .toBeGreaterThan(NOW.getTime());
   });
 
+  test("ages out an attach route with no fresh evidence (lost detach report)", async () => {
+    const fixture = makeFixture();
+    fixture.repository.bindings.push(binding({
+      userId: USER_A,
+      pathHints: [],
+      relayAttachedUrl: MANAGED_RELAY_URLS[0]!,
+      // Both evidence channels are stale: the relay died without a detach
+      // report and the Mac stopped renewing its registration.
+      relayAttachReportedAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1_000),
+      lastSeenAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1_000),
+    }));
+
+    const discovered = await Effect.runPromise(fixture.broker.discover(USER_A, NOW)) as {
+      bindings: Array<{ path_hints: unknown[] }>;
+    };
+    expect(discovered.bindings[0]?.path_hints).toEqual([]);
+  });
+
+  test("a fresh attach report keeps the route while the binding lease is stale", async () => {
+    const fixture = makeFixture();
+    fixture.repository.bindings.push(binding({
+      userId: USER_A,
+      pathHints: [],
+      relayAttachedUrl: MANAGED_RELAY_URLS[0]!,
+      relayAttachReportedAt: new Date(NOW.getTime() - 5 * 60 * 1_000),
+      // Broker unreachable from the Mac (cache-first world) while the relay
+      // path works: the attach report alone corroborates the route.
+      lastSeenAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1_000),
+    }));
+
+    const discovered = await Effect.runPromise(fixture.broker.discover(USER_A, NOW)) as {
+      bindings: Array<{ path_hints: Array<Record<string, unknown>> }>;
+    };
+    expect(discovered.bindings[0]?.path_hints.map((hint) => hint.value))
+      .toEqual([MANAGED_RELAY_URLS[0]!]);
+  });
+
   test("withholds a fleet-reported custom relay the account no longer saves", async () => {
     const fixture = makeFixture();
     fixture.repository.bindings.push(binding({

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -1337,6 +1337,50 @@ describe("Iroh discovery and grants", () => {
     expect(discovered.bindings[0]?.path_hints).toEqual([]);
   });
 
+  test("serves the fleet-reported attach route ahead of client-published hints", async () => {
+    const attachedURL = MANAGED_RELAY_URLS[0]!;
+    const otherManagedURL = MANAGED_RELAY_URLS[1]!;
+    const fixture = makeFixture();
+    fixture.repository.bindings.push(binding({
+      userId: USER_A,
+      // The client republish also advertised the same relay plus another one.
+      pathHints: [relayHint(attachedURL), relayHint(otherManagedURL)],
+      relayAttachedUrl: attachedURL,
+      relayAttachReportedAt: new Date(NOW.getTime() - 60_000),
+    }));
+
+    const discovered = await Effect.runPromise(fixture.broker.discover(USER_A, NOW)) as {
+      bindings: Array<{ path_hints: Array<Record<string, unknown>> }>;
+    };
+    const hints = discovered.bindings[0]!.path_hints;
+    // Server-observed hint first, the duplicate client hint dropped, the
+    // remaining client hint kept as fallback.
+    expect(hints.map((hint) => hint.value)).toEqual([attachedURL, otherManagedURL]);
+    expect(hints[0]).toMatchObject({
+      kind: "relay_url",
+      source: "native",
+      privacy_scope: "public_internet",
+      observed_at: NOW.toISOString(),
+    });
+    expect(new Date(String(hints[0]!.expires_at)).getTime())
+      .toBeGreaterThan(NOW.getTime());
+  });
+
+  test("withholds a fleet-reported custom relay the account no longer saves", async () => {
+    const fixture = makeFixture();
+    fixture.repository.bindings.push(binding({
+      userId: USER_A,
+      pathHints: [],
+      relayAttachedUrl: "https://relay.example.net/",
+      relayAttachReportedAt: new Date(NOW.getTime() - 60_000),
+    }));
+
+    const discovered = await Effect.runPromise(fixture.broker.discover(USER_A, NOW)) as {
+      bindings: Array<{ path_hints: unknown[] }>;
+    };
+    expect(discovered.bindings[0]?.path_hints).toEqual([]);
+  });
+
   test("does not combine a pre-revocation binding with a post-revocation LAN generation", async () => {
     const fixture = makeFixture();
     const active = binding({ userId: USER_A });
@@ -2556,6 +2600,8 @@ function binding(overrides: Partial<MutableBinding> = {}): MutableBinding {
     directPortV6: null,
     pathHints: [],
     pathHintsNextExpiry: null,
+    relayAttachedUrl: null,
+    relayAttachReportedAt: null,
     deviceLimitOverrideUsed: false,
     lastSeenAt: now,
     registeredAt: now,

--- a/web/tests/relay-report-db-behavior.test.ts
+++ b/web/tests/relay-report-db-behavior.test.ts
@@ -1,0 +1,325 @@
+// Database-backed tests of the relay attach-report registry behavior behind
+// POST /api/relay/report: the route tests fake the application, so the
+// ordering guards, the custom-relay trust join, revocation, and the
+// discovery read that serves the attach-derived hint to a phone are proven
+// here against Postgres. Gated like tests/iroh-db-behavior.test.ts.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import * as Effect from "effect/Effect";
+import postgres, { type Sql } from "postgres";
+
+import { closeCloudDbForTests } from "../db/client";
+import type { IrohTrustBrokerConfigShape } from "../services/iroh/config";
+import { IrohRelayMintError } from "../services/iroh/errors";
+import type { IrohPathHint } from "../services/iroh/model";
+import {
+  IrohRepository,
+  IrohRepositoryLive,
+  type IrohRepositoryShape,
+} from "../services/iroh/repository";
+import { makeIrohTrustBroker } from "../services/iroh/trustBroker";
+import {
+  applyRelayAttachReport,
+  closeRelayReportClientForTests,
+  type RelayAttachReport,
+} from "../services/relay/report";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+const USER_ID = "user-report";
+const ENDPOINT_ID = "ab".repeat(32);
+const MANAGED_HOSTNAME = "usc1.relay.cmux.dev";
+const MANAGED_URL = "https://usc1.relay.cmux.dev/";
+const OTHER_MANAGED_HOSTNAME = "euw4.relay.cmux.dev";
+const CUSTOM_HOSTNAME = "relay.corp.example";
+const CUSTOM_URL = "https://relay.corp.example:8443/";
+const T0 = 1_756_100_000_000;
+
+let sql: Sql | null = null;
+let repository: IrohRepositoryShape | null = null;
+
+function requiredSql(): Sql {
+  if (!sql) throw new Error("sql not initialized");
+  return sql;
+}
+
+beforeAll(async () => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  sql = postgres(databaseURL, { max: 4 });
+  repository = await Effect.runPromise(
+    Effect.gen(function* () { return yield* IrohRepository; }).pipe(
+      Effect.provide(IrohRepositoryLive),
+    ),
+  );
+});
+
+beforeEach(async () => {
+  if (!sql) return;
+  await sql`
+    truncate
+      iroh_relay_token_issuances,
+      iroh_pair_grant_issuances,
+      iroh_registration_challenges,
+      iroh_endpoint_bindings,
+      iroh_relay_preferences,
+      account_deletion_tombstones
+    restart identity cascade
+  `;
+});
+
+afterAll(async () => {
+  await closeRelayReportClientForTests();
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+async function insertBinding(input: {
+  readonly userId?: string;
+  readonly endpointId?: string;
+  readonly revokedAt?: Date;
+} = {}): Promise<void> {
+  await requiredSql()`
+    insert into iroh_endpoint_bindings (
+      user_id, device_uuid, app_instance_id, tag, platform, endpoint_id,
+      identity_generation, pairing_enabled, revoked_at, revoked_reason
+    ) values (
+      ${input.userId ?? USER_ID}, ${randomUUID()}, ${randomUUID()}, 'stable',
+      'mac', ${input.endpointId ?? ENDPOINT_ID}, 1, true,
+      ${input.revokedAt ?? null},
+      ${input.revokedAt ? "user_requested" : null}
+    )
+  `;
+}
+
+async function saveCustomRelay(userId: string, url: string): Promise<void> {
+  const sql = requiredSql();
+  await sql`
+    insert into iroh_relay_preferences (account_id, mode, selected_managed_relay_ids, custom_relays)
+    values (
+      ${userId}, 'custom', '[]'::jsonb,
+      ${sql.json([{
+        id: "corp1",
+        provider: "corp",
+        region: "on-prem",
+        url,
+        authMode: "none",
+      }])}
+    )
+  `;
+}
+
+function report(overrides: Partial<RelayAttachReport> = {}): RelayAttachReport {
+  return {
+    endpointId: ENDPOINT_ID,
+    event: "attach",
+    relayId: MANAGED_HOSTNAME,
+    reportedAt: new Date(T0),
+    ...overrides,
+  };
+}
+
+async function attachState(): Promise<{ url: string | null; reportedAt: Date | null }> {
+  const [row] = await requiredSql()<Array<{ url: string | null; reportedAt: Date | null }>>`
+    select relay_attached_url as url, relay_attach_reported_at as "reportedAt"
+    from iroh_endpoint_bindings
+    where endpoint_id = ${ENDPOINT_ID}
+  `;
+  if (!row) throw new Error("binding row missing");
+  return row;
+}
+
+describe("relay attach report registry behavior", () => {
+  dbTest("publishes a managed relay attachment for an active binding", async () => {
+    await insertBinding();
+    expect(await applyRelayAttachReport(report())).toBe("applied");
+    expect(await attachState()).toEqual({
+      url: MANAGED_URL,
+      reportedAt: new Date(T0),
+    });
+  });
+
+  dbTest("a matching detach clears the published route", async () => {
+    await insertBinding();
+    await applyRelayAttachReport(report());
+    expect(await applyRelayAttachReport(report({
+      event: "detach",
+      reportedAt: new Date(T0 + 1_000),
+    }))).toBe("applied");
+    expect(await attachState()).toEqual({
+      url: null,
+      reportedAt: new Date(T0 + 1_000),
+    });
+  });
+
+  dbTest("drops an out-of-order older attach after a newer detach", async () => {
+    await insertBinding();
+    await applyRelayAttachReport(report({ reportedAt: new Date(T0) }));
+    await applyRelayAttachReport(report({
+      event: "detach",
+      reportedAt: new Date(T0 + 2_000),
+    }));
+    expect(await applyRelayAttachReport(report({
+      reportedAt: new Date(T0 + 1_000),
+    }))).toBe("superseded");
+    expect((await attachState()).url).toBeNull();
+  });
+
+  dbTest("an attach that ties a detach timestamp wins (make-before-break)", async () => {
+    await insertBinding();
+    await applyRelayAttachReport(report({
+      event: "detach",
+      reportedAt: new Date(T0),
+    }));
+    expect(await applyRelayAttachReport(report({
+      reportedAt: new Date(T0),
+    }))).toBe("applied");
+    expect((await attachState()).url).toBe(MANAGED_URL);
+  });
+
+  dbTest("a late detach from an old relay cannot clear a newer attachment", async () => {
+    await insertBinding();
+    await applyRelayAttachReport(report({
+      relayId: OTHER_MANAGED_HOSTNAME,
+      reportedAt: new Date(T0),
+    }));
+    await applyRelayAttachReport(report({ reportedAt: new Date(T0 + 5_000) }));
+    expect(await applyRelayAttachReport(report({
+      event: "detach",
+      relayId: OTHER_MANAGED_HOSTNAME,
+      reportedAt: new Date(T0 + 6_000),
+    }))).toBe("superseded");
+    expect(await attachState()).toEqual({
+      url: MANAGED_URL,
+      reportedAt: new Date(T0 + 5_000),
+    });
+  });
+
+  dbTest("ignores reports about unknown endpoints", async () => {
+    expect(await applyRelayAttachReport(report())).toBe("unknown_endpoint");
+  });
+
+  dbTest("ignores reports about revoked bindings", async () => {
+    await insertBinding({ revokedAt: new Date(T0) });
+    expect(await applyRelayAttachReport(report())).toBe("unknown_endpoint");
+  });
+
+  dbTest("refuses a relay outside the catalog and the account's saved set", async () => {
+    await insertBinding();
+    expect(await applyRelayAttachReport(report({
+      relayId: CUSTOM_HOSTNAME,
+    }))).toBe("untrusted_relay");
+    expect((await attachState()).url).toBeNull();
+  });
+
+  dbTest("publishes the saved custom relay URL verbatim for its hostname", async () => {
+    await insertBinding();
+    await saveCustomRelay(USER_ID, CUSTOM_URL);
+    expect(await applyRelayAttachReport(report({
+      relayId: CUSTOM_HOSTNAME,
+    }))).toBe("applied");
+    expect((await attachState()).url).toBe(CUSTOM_URL);
+  });
+
+  dbTest("another account's saved custom relay grants no trust", async () => {
+    await insertBinding();
+    await saveCustomRelay("user-other", CUSTOM_URL);
+    expect(await applyRelayAttachReport(report({
+      relayId: CUSTOM_HOSTNAME,
+    }))).toBe("untrusted_relay");
+  });
+
+  dbTest("revocation clears published attach state", async () => {
+    await insertBinding();
+    await applyRelayAttachReport(report());
+    const [binding] = await requiredSql()<Array<{ id: string }>>`
+      select id from iroh_endpoint_bindings where endpoint_id = ${ENDPOINT_ID}
+    `;
+    if (!repository || !binding) throw new Error("repository not initialized");
+    await Effect.runPromise(repository.revokeBinding({
+      userId: USER_ID,
+      bindingId: binding.id,
+      now: new Date(T0 + 1_000),
+    }));
+    const [row] = await requiredSql()<Array<{ url: string | null }>>`
+      select relay_attached_url as url from iroh_endpoint_bindings
+      where id = ${binding.id}
+    `;
+    expect(row?.url ?? null).toBeNull();
+  });
+});
+
+describe("phone discovery serves the attach-derived relay route", () => {
+  dbTest("a discover after a simulated attach report carries the relay hint", async () => {
+    if (!repository) throw new Error("repository not initialized");
+    await insertBinding();
+    await applyRelayAttachReport(report());
+
+    const broker = makeIrohTrustBroker(repository, failingMinter(), brokerConfig());
+    const discovery = await Effect.runPromise(
+      broker.discover(USER_ID, new Date(T0 + 10_000)),
+    ) as {
+      bindings: ReadonlyArray<{ endpoint_id: string; path_hints: IrohPathHint[] }>;
+    };
+
+    const mac = discovery.bindings.find((entry) => entry.endpoint_id === ENDPOINT_ID);
+    expect(mac).toBeDefined();
+    const relayHints = (mac?.path_hints ?? []).filter((hint) => hint.kind === "relay_url");
+    expect(relayHints.map((hint) => hint.value)).toEqual([MANAGED_URL]);
+    // The synthesized hint is dialable under the standard client rules.
+    expect(relayHints[0]?.source).toBe("native");
+    expect(relayHints[0]?.privacy_scope).toBe("public_internet");
+    expect(new Date(relayHints[0]?.expires_at ?? 0).getTime())
+      .toBeGreaterThan(T0 + 10_000);
+
+    // After a detach report the same fetch no longer advertises the relay.
+    await applyRelayAttachReport(report({
+      event: "detach",
+      reportedAt: new Date(T0 + 20_000),
+    }));
+    const after = await Effect.runPromise(
+      broker.discover(USER_ID, new Date(T0 + 30_000)),
+    ) as {
+      bindings: ReadonlyArray<{ endpoint_id: string; path_hints: IrohPathHint[] }>;
+    };
+    const macAfter = after.bindings.find((entry) => entry.endpoint_id === ENDPOINT_ID);
+    expect((macAfter?.path_hints ?? []).filter((hint) => hint.kind === "relay_url"))
+      .toEqual([]);
+  });
+});
+
+/** Discovery never mints; fail loudly if it tries. */
+function failingMinter() {
+  return {
+    mint: () => Effect.fail(new IrohRelayMintError({ code: "test_failure" })),
+  };
+}
+
+function brokerConfig(): IrohTrustBrokerConfigShape {
+  const grantKeys = generateKeyPairSync("ed25519");
+  return {
+    lanDiscoverySecretBase64: Buffer.alloc(32, 7).toString("base64"),
+    accountSubjectSecretBase64: Buffer.alloc(32, 8).toString("base64"),
+    grantSigningPrivateKeyPem: grantKeys.privateKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString(),
+    grantSigningKid: "current",
+    grantVerificationKeysJson: JSON.stringify({
+      version: 1,
+      current_kid: "current",
+      keys: [{
+        kid: "current",
+        alg: "EdDSA",
+        spki_der_base64: grantKeys.publicKey
+          .export({ format: "der", type: "spki" })
+          .toString("base64"),
+      }],
+    }),
+    relayMinterInsecureLoopbackOptIn: false,
+    deploymentEnvironment: "test",
+    isVercelDeployment: false,
+  };
+}

--- a/web/tests/relay-report-db-behavior.test.ts
+++ b/web/tests/relay-report-db-behavior.test.ts
@@ -224,6 +224,27 @@ describe("relay attach report registry behavior", () => {
     expect((await attachState()).url).toBe(CUSTOM_URL);
   });
 
+  dbTest("a custom relay deleted from preferences can still detach cleanly", async () => {
+    await insertBinding();
+    await saveCustomRelay(USER_ID, CUSTOM_URL);
+    await applyRelayAttachReport(report({ relayId: CUSTOM_HOSTNAME }));
+    await requiredSql()`delete from iroh_relay_preferences where account_id = ${USER_ID}`;
+    expect(await applyRelayAttachReport(report({
+      event: "detach",
+      relayId: CUSTOM_HOSTNAME,
+      reportedAt: new Date(T0 + 1_000),
+    }))).toBe("applied");
+    expect((await attachState()).url).toBeNull();
+  });
+
+  dbTest("a detach for a hostname nothing is attached to is superseded", async () => {
+    await insertBinding();
+    expect(await applyRelayAttachReport(report({
+      event: "detach",
+      reportedAt: new Date(T0),
+    }))).toBe("superseded");
+  });
+
   dbTest("another account's saved custom relay grants no trust", async () => {
     await insertBinding();
     await saveCustomRelay("user-other", CUSTOM_URL);

--- a/web/tests/relay-report-route.test.ts
+++ b/web/tests/relay-report-route.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+
+import {
+  handleRelayReportRequest,
+  type RelayReportDeps,
+} from "../app/api/relay/report/route";
+import { relayAllowSignature } from "../services/relay/allow";
+import {
+  RELAY_REPORT_MAX_CONCURRENT,
+  RELAY_REPORT_MAX_FUTURE_SKEW_MS,
+  RELAY_REPORT_SIGNATURE_HEADER,
+  RelayReportSaturatedError,
+  parseRelayAttachReport,
+  publishableRelayURLForHostname,
+  withRelayReportSlot,
+  type RelayAttachReport,
+} from "../services/relay/report";
+
+// Pure route tests: deps injection only, nothing leaks into the shared
+// bun-test module registry, no database.
+const SECRET = randomBytes(32);
+const SECRET_B64 = SECRET.toString("base64");
+const ENDPOINT_ID = "0123456789abcdef".repeat(4);
+const NOW = new Date("2026-08-25T12:00:00.000Z");
+const MANAGED_HOSTNAME = "usc1.relay.cmux.dev";
+const MANAGED_URL = "https://usc1.relay.cmux.dev/";
+
+function deps(overrides: Partial<RelayReportDeps> = {}): RelayReportDeps {
+  return {
+    secretBase64: () => SECRET_B64,
+    apply: async () => "applied",
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+function reportBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    endpointId: ENDPOINT_ID,
+    event: "attach",
+    relayId: MANAGED_HOSTNAME,
+    ts: NOW.getTime(),
+    ...overrides,
+  };
+}
+
+/** The exact shape the cmux-relay Reporter sends: JSON body, signature header. */
+function signedRequest(body: unknown, signature?: string): Request {
+  const text = JSON.stringify(body);
+  return new Request("https://cmux.dev/api/relay/report", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      [RELAY_REPORT_SIGNATURE_HEADER]:
+        signature ?? relayAllowSignature(SECRET, Buffer.from(text, "utf8")),
+    },
+    body: text,
+  });
+}
+
+describe("POST /api/relay/report", () => {
+  test("applies a signed attach report, uncacheable", async () => {
+    const observed: RelayAttachReport[] = [];
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody()),
+      deps({
+        apply: async (report) => {
+          observed.push(report);
+          return "applied";
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ applied: true });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(observed).toEqual([{
+      endpointId: ENDPOINT_ID,
+      event: "attach",
+      relayId: MANAGED_HOSTNAME,
+      reportedAt: NOW,
+    }]);
+  });
+
+  test("applies a signed detach report", async () => {
+    const observed: RelayAttachReport[] = [];
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody({ event: "detach" })),
+      deps({
+        apply: async (report) => {
+          observed.push(report);
+          return "applied";
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(observed[0]?.event).toBe("detach");
+  });
+
+  test("rejects a missing signature without touching the registry", async () => {
+    let applications = 0;
+    const text = JSON.stringify(reportBody());
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: text,
+      }),
+      deps({
+        apply: async () => {
+          applications += 1;
+          return "applied";
+        },
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "invalid_relay_report_signature" });
+    expect(applications).toBe(0);
+  });
+
+  test("rejects a signature over different body bytes", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(
+        reportBody(),
+        relayAllowSignature(SECRET, Buffer.from("{}", "utf8")),
+      ),
+      deps(),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects a signature minted with the wrong secret", async () => {
+    const text = JSON.stringify(reportBody());
+    const response = await handleRelayReportRequest(
+      signedRequest(
+        reportBody(),
+        relayAllowSignature(randomBytes(32), Buffer.from(text, "utf8")),
+      ),
+      deps(),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("answers 503 when the shared secret is not configured", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody()),
+      deps({ secretBase64: () => undefined }),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "relay_report_not_configured" });
+  });
+
+  test("rejects a signed empty body", async () => {
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: {
+          [RELAY_REPORT_SIGNATURE_HEADER]:
+            relayAllowSignature(SECRET, new Uint8Array()),
+        },
+      }),
+      deps(),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "missing_report_body" });
+  });
+
+  test("rejects signed malformed JSON", async () => {
+    const text = "{not json";
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: {
+          [RELAY_REPORT_SIGNATURE_HEADER]:
+            relayAllowSignature(SECRET, Buffer.from(text, "utf8")),
+        },
+        body: text,
+      }),
+      deps(),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_json" });
+  });
+
+  test("rejects malformed reports with the specific failure code", async () => {
+    const cases: ReadonlyArray<readonly [unknown, string]> = [
+      [reportBody({ endpointId: "not-hex" }), "invalid_endpoint_id"],
+      [reportBody({ endpointId: ENDPOINT_ID.slice(1) }), "invalid_endpoint_id"],
+      [reportBody({ event: "connected" }), "invalid_report_event"],
+      [reportBody({ relayId: "" }), "invalid_relay_id"],
+      [reportBody({ relayId: "bad_host!" }), "invalid_relay_id"],
+      [reportBody({ relayId: `${"a".repeat(64)}.example` }), "invalid_relay_id"],
+      [reportBody({ ts: "123" }), "invalid_report_time"],
+      [reportBody({ ts: 0 }), "invalid_report_time"],
+      [reportBody({ ts: 1.5 }), "invalid_report_time"],
+      [reportBody({ extra: true }), "invalid_report_body"],
+      [[reportBody()], "invalid_report_body"],
+    ];
+    for (const [body, error] of cases) {
+      const response = await handleRelayReportRequest(signedRequest(body), deps());
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error });
+    }
+  });
+
+  test("rejects an event timestamp too far in the future", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody({
+        ts: NOW.getTime() + RELAY_REPORT_MAX_FUTURE_SKEW_MS + 1,
+      })),
+      deps(),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_report_time" });
+  });
+
+  test("rejects an oversized declared body without reading it", async () => {
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: {
+          "content-length": String(1024 * 1024),
+          [RELAY_REPORT_SIGNATURE_HEADER]:
+            relayAllowSignature(SECRET, new Uint8Array()),
+        },
+        body: new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.enqueue(new Uint8Array(1024));
+          },
+        }),
+      }),
+      deps(),
+    );
+    expect(response.status).toBe(413);
+  });
+
+  test("rejects an oversized streamed body at the byte cap", async () => {
+    const chunk = new Uint8Array(1024);
+    let sent = 0;
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: {
+          [RELAY_REPORT_SIGNATURE_HEADER]:
+            relayAllowSignature(SECRET, new Uint8Array()),
+        },
+        body: new ReadableStream<Uint8Array>({
+          pull(controller) {
+            sent += 1;
+            if (sent > 32) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(chunk);
+          },
+        }),
+      }),
+      deps(),
+    );
+    expect(response.status).toBe(413);
+  });
+
+  test("times out a trickled body instead of waiting forever", async () => {
+    const response = await handleRelayReportRequest(
+      new Request("https://cmux.dev/api/relay/report", {
+        method: "POST",
+        headers: {
+          [RELAY_REPORT_SIGNATURE_HEADER]:
+            relayAllowSignature(SECRET, new Uint8Array()),
+        },
+        // A stream that never produces data and never closes.
+        body: new ReadableStream<Uint8Array>({ pull: () => new Promise(() => {}) }),
+      }),
+      deps({ bodyReadTimeoutMs: 25 }),
+    );
+    expect(response.status).toBe(408);
+  });
+
+  test("answers 403 for a trusted-signature report about an untrusted relay", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody()),
+      deps({ apply: async () => "untrusted_relay" }),
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "untrusted_relay" });
+  });
+
+  test("answers applied:false for stale or unknown reports without failing the relay", async () => {
+    for (const outcome of ["superseded", "unknown_endpoint"] as const) {
+      const response = await handleRelayReportRequest(
+        signedRequest(reportBody()),
+        deps({ apply: async () => outcome }),
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ applied: false, reason: outcome });
+    }
+  });
+
+  test("bounds application latency and fails to 503 on expiry", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody()),
+      deps({
+        apply: () => new Promise(() => {}),
+        applyTimeoutMs: 25,
+      }),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "relay_report_unavailable" });
+  });
+
+  test("answers 503 when report concurrency is saturated", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody()),
+      deps({
+        apply: async () => {
+          throw new RelayReportSaturatedError();
+        },
+      }),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "relay_report_saturated" });
+  });
+});
+
+describe("relay report concurrency slots", () => {
+  test("rejects work past the cap and recovers as slots settle", async () => {
+    const releases: Array<() => void> = [];
+    const held = Array.from(
+      { length: RELAY_REPORT_MAX_CONCURRENT },
+      () => withRelayReportSlot(
+        () => new Promise<void>((resolve) => releases.push(resolve)),
+      ),
+    );
+    await Promise.resolve();
+    await expect(withRelayReportSlot(async () => "over")).rejects.toThrow(
+      RelayReportSaturatedError,
+    );
+    for (const release of releases) release();
+    await Promise.all(held);
+    expect(await withRelayReportSlot(async () => "recovered")).toBe("recovered");
+  });
+});
+
+describe("relay report parsing and trust mapping", () => {
+  test("normalizes case and preserves millisecond timestamps", () => {
+    const parsed = parseRelayAttachReport({
+      endpointId: ENDPOINT_ID.toUpperCase(),
+      event: "attach",
+      relayId: MANAGED_HOSTNAME.toUpperCase(),
+      ts: 1_756_100_000_123,
+    }, new Date(1_756_100_000_500));
+    expect(parsed).toEqual({
+      ok: true,
+      report: {
+        endpointId: ENDPOINT_ID,
+        event: "attach",
+        relayId: MANAGED_HOSTNAME,
+        reportedAt: new Date(1_756_100_000_123),
+      },
+    });
+  });
+
+  test("maps a managed hostname to its exact catalog URL", () => {
+    expect(publishableRelayURLForHostname(MANAGED_HOSTNAME, [])).toBe(MANAGED_URL);
+  });
+
+  test("maps a saved custom hostname to the saved URL verbatim", () => {
+    expect(publishableRelayURLForHostname(
+      "relay.corp.example",
+      ["https://relay.corp.example:8443/"],
+    )).toBe("https://relay.corp.example:8443/");
+  });
+
+  test("refuses hostnames outside the catalog and the saved set", () => {
+    expect(publishableRelayURLForHostname("cmux-relay-dev", [])).toBeNull();
+    expect(publishableRelayURLForHostname(
+      "evil.example",
+      ["https://relay.corp.example:8443/"],
+    )).toBeNull();
+  });
+
+  test("the catalog wins over a saved custom relay with the same hostname", () => {
+    expect(publishableRelayURLForHostname(
+      MANAGED_HOSTNAME,
+      [`https://${MANAGED_HOSTNAME}:8443/`],
+    )).toBe(MANAGED_URL);
+  });
+});

--- a/web/tests/relay-report-route.test.ts
+++ b/web/tests/relay-report-route.test.ts
@@ -9,6 +9,7 @@ import { relayAllowSignature } from "../services/relay/allow";
 import {
   RELAY_REPORT_MAX_CONCURRENT,
   RELAY_REPORT_MAX_FUTURE_SKEW_MS,
+  RELAY_REPORT_MAX_PAST_SKEW_MS,
   RELAY_REPORT_SIGNATURE_HEADER,
   RelayReportSaturatedError,
   parseRelayAttachReport,
@@ -207,6 +208,17 @@ describe("POST /api/relay/report", () => {
     const response = await handleRelayReportRequest(
       signedRequest(reportBody({
         ts: NOW.getTime() + RELAY_REPORT_MAX_FUTURE_SKEW_MS + 1,
+      })),
+      deps(),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_report_time" });
+  });
+
+  test("rejects a replayed old event timestamp", async () => {
+    const response = await handleRelayReportRequest(
+      signedRequest(reportBody({
+        ts: NOW.getTime() - RELAY_REPORT_MAX_PAST_SKEW_MS - 1,
       })),
       deps(),
     );


### PR DESCRIPTION
Part of the iroh intended-shape series: the relay fleet reports attach and detach to the broker, so "Mac X reachable via relay Y" publishes itself and the Mac's client-side post-attach republish stops being load-bearing. Web half of the attach-reporting change; the relay half is https://github.com/manaflow-ai/cmux-relay/pull/9.

**Stacked on `feat-iroh-integration-test`** (16 commits, no PR of its own yet), so this diff includes that branch until it lands. The new work is the last commit. Sibling of the merged allow hook https://github.com/manaflow-ai/cmux/pull/10730 and reuses its secret and signing scheme.

## What it does

`POST /api/relay/report` receives the cmux-relay `Reporter`'s fire-and-forget `{endpointId, event: "attach"|"detach", relayId, ts}` events, signed with the allow-hook shared secret (`CMUX_RELAY_ALLOW_HMAC_SECRET_B64`, unpadded base64url HMAC-SHA256 over the exact body bytes in `x-cmux-relay-allow-signature`). An applied attach writes the relay URL onto the endpoint's binding (`relay_attached_url` + `relay_attach_reported_at`); a matching detach clears it; revocation and the retention sweeper clear it too. Discovery then serves the server-observed route as the FIRST `relay_url` path hint (standard hint shape, so phones dial it unchanged), deduplicating the client-published hint for the same URL.

Hardening mirrors `/api/relay/allow`: fail-closed 503 when the secret is unset, bounded body read with a slowloris deadline, a 3s apply deadline, a dedicated deadline-bounded pool separate from the admission pool, a 16-slot concurrency cap, and `cache-control: no-store` everywhere. The shared client moved into `web/services/relay/hookDb.ts`; `/api/relay/allow` behavior is unchanged.

## Trust rule

The HMAC proves a fleet relay sent the report, but `relayId` (the relay's hostname) is self-declared, so one compromised relay or a leaked secret must not be able to point every phone at an attacker relay. A report is applied only when the hostname maps to an exact managed-catalog URL or to a relay the account has saved (matched by hostname, publishing the saved URL verbatim); everything else is refused 403 `untrusted_relay`, which also keeps dev relays out of production state. The same check runs again at read time, so deleting a saved custom relay stops serving its attach route immediately. A valid HMAC alone is deliberately not sufficient, including for debug and test fleets.

## Ordering

Reports can arrive out of order, so each applied event records its relay-side timestamp; older events are dropped and attach wins ties (make-before-break admits the new connection before the old one closes). Known residual: the report body carries no connection id, so a same-relay reconnect whose old-connection detach lands with a later timestamp than the new-connection attach unpublishes the route until the next attach; the client fallback covers that window, and the proper fix is a connection id in the relay's report body.

A second residual, flagged by local review: served attach routes require live evidence younger than an hour (the attach report or the binding's `lastSeenAt`, which a live Mac refreshes at least hourly). A Mac that keeps renewing registrations over a direct path while its dead relay never sent a detach keeps the stale route alive; the phone loses one bounded dial to it and falls through to the other hints. Perfect server-side liveness needs periodic attach re-reports or connection ids from the relay (follow-up in cmux-relay). Reports older than 15 minutes are rejected outright, so captured signed events cannot be replayed into an empty slot.

## Client republish: gated, not deleted

Deleting the Mac's post-attach republish is unsafe while the deployed fleet (instance templates from cmux-relay#8, 2026-07-19) does not report attach. The republish stays as fallback; discovery prefers the server-published route when present, and `CmxIrohHostRuntime.initialPublicationReady` carries a rollout note to delete the gate once the reporting relay build is fleet-wide. The Swift change is comment-only, so no runtime behavior changes on the Mac.

## Tests

- `web/tests/relay-report-route.test.ts`: signed attach/detach, unsigned, wrong-secret, wrong-bytes, malformed (endpoint id, event, relay id, ts, unknown keys, non-object), future clock skew, oversized declared and streamed bodies, trickled-body timeout, saturation, apply deadline, outcome mapping, slot cap recovery, hostname-to-URL trust mapping.
- `web/tests/relay-report-db-behavior.test.ts` (Postgres): attach publishes, detach clears, out-of-order drops, tie wins, cross-relay late detach ignored, unknown/revoked endpoints, custom-relay trust join (own account only), revocation clears state, and an end-to-end phone-shaped `discover` that sees the relay hint after a simulated attach report and loses it after detach.
- `web/tests/iroh-trust-broker.test.ts`: server hint served first and deduplicated against client hints; unsaved custom attach URL withheld at read time.

`bun run typecheck` clean; full unit suite 1447 pass, 0 fail; DB behavior lane (local Postgres 16) 15 files, 0 fail.

Dictionary:
- **allow hook**: the relay's per-connection HTTP callback asking this backend whether a proven endpoint may relay.
- **attach report**: the relay's fire-and-forget POST telling the backend an endpoint connected to (or disconnected from) it.
- **managed catalog**: the signed, generated list of fleet relay URLs clients are allowed to dial.
- **path hint**: a discovery-served address candidate (relay URL or direct address) a peer may try when dialing.
- **post-attach republish**: today's client flow where the Mac re-registers after its relay connects so its relay route appears in discovery.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790319696&installation_model_id=21920&pr_number=10806&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10806&signature=4c7410cf4eaee5240635552e14a8d8596264c082f593c53906ef47a17e3d412c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->