### PR TITLE
fix(cli): restore Encodable synthesis for PendingCursorShellApproval

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -249,6 +249,19 @@ struct ClaudeHookSessionRecord: Codable {
             createdAt = try container.decodeIfPresent(TimeInterval.self, forKey: .createdAt) ?? 0
             requiresToolUseId = try container.decodeIfPresent(Bool.self, forKey: .requiresToolUseId) ?? false
         }
+
+        /// `legacyCommand` exists only for decoding pre-fingerprint records,
+        /// so Encodable cannot be synthesized; encode the stored fields only.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(commandFingerprint, forKey: .commandFingerprint)
+            try container.encode(commandLength, forKey: .commandLength)
+            try container.encode(displayCommand, forKey: .displayCommand)
+            try container.encodeIfPresent(toolUseId, forKey: .toolUseId)
+            try container.encodeIfPresent(notificationCorrelationKey, forKey: .notificationCorrelationKey)
+            try container.encode(createdAt, forKey: .createdAt)
+            try container.encode(requiresToolUseId, forKey: .requiresToolUseId)
+        }
     }
 
     var sessionId: String

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33113,15 +33113,15 @@ export default CMUXSessionRestore;
                 cursor = parent
                 ancestorDepth += 1
             }
-            let projectRoot = projectRoot ?? cwdURL
+            let resolvedProjectRoot = projectRoot ?? cwdURL
             applyConfig(
-                at: projectRoot
+                at: resolvedProjectRoot
                     .appendingPathComponent(".cursor", isDirectory: true)
                     .appendingPathComponent("cli.json", isDirectory: false),
                 readsApprovalMode: false
             )
-            if cwdURL.path != projectRoot.path,
-               cwdURL.path.hasPrefix(projectRoot.path + "/") {
+            if cwdURL.path != resolvedProjectRoot.path,
+               cwdURL.path.hasPrefix(resolvedProjectRoot.path + "/") {
                 // Keep the hook's synchronous policy lookup bounded: the
                 // global file, repository root, and current project directory
                 // cover the supported effective layers without walking every

--- a/Sources/TerminalNotificationPolicyInFlightStore.swift
+++ b/Sources/TerminalNotificationPolicyInFlightStore.swift
@@ -146,7 +146,7 @@ final class TerminalNotificationPolicyInFlightStore {
         correlationKey: String,
         through generation: UInt64? = nil
     ) {
-        let idsToDiscard = requests.compactMap { id, entry in
+        let idsToDiscard = requests.compactMap { id, entry -> UUID? in
             guard generation.map({ entry.generation <= $0 }) ?? true,
                   entry.request.correlationKey == correlationKey,
                   Self.matchesSurfaceAlias(entry.request, surfaceId: surfaceId) else {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1973,7 +1973,7 @@ final class TerminalNotificationStore: ObservableObject {
         )
         let liveTabId = AppDelegate.shared?
             .agentNotificationDeliveryTarget(claimedTabId: tabId, surfaceId: surfaceId)?.tabId ?? tabId
-        let ids = notifications.compactMap { notification in
+        let ids = notifications.compactMap { notification -> UUID? in
             guard notification.correlationKey == correlationKey,
                   notification.matchesClear(
                       tabId: tabId,


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9349 added a decode-only `legacyCommand = "command"` CodingKey plus a custom `init(from:)` to `ClaudeHookSessionRecord.PendingCursorShellApproval`, but no `encode(to:)`. Swift refuses to synthesize `Encodable` when a CodingKeys case matches no stored property, so the `cmux-cli` target fails to compile on current main:

```
CLI/cmux.swift:155:12: error: type 'ClaudeHookSessionRecord.PendingCursorShellApproval' does not conform to protocol 'Encodable'
CLI/cmux.swift:227:18: note: CodingKey case 'legacyCommand' does not match any stored properties
```

Hit by two independent fleet builds of main (35e888dae0) tonight. Fix: explicit `encode(to:)` that writes the seven stored fields and never emits the legacy key, preserving the decode-side migration exactly. No behavior change for records written by the new code.

Open question for reviewers: how did #9349 pass its checks? Worth confirming the merge gate actually compiles `cmux-cli`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790320115&installation_model_id=21920&pr_number=10808&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10808&signature=9473e62299600c1e48976f759efed0bc6278f0ebd8a1a97c452839d53132dcd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record serialization to consistently preserve fingerprints, timestamps, identifiers, display commands, lengths, and tool-use requirements.
  * Excluded a legacy command field from serialized output to prevent outdated data from being written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->