### PR TITLE
cmux Cloud: sessions run on the cmux-tui remote daemon (no cmuxd-remote on new machines)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2250,6 +2250,7 @@ jobs:
           ./scripts/install-prebuilt-ghostty-cli-helper.sh \
             ghostty-cli-helper/ghostty \
             build-universal/Build/Products/Release/cmux.app
+          ./scripts/install-cmux-tui-client.sh build-universal/Build/Products/Release/cmux.app
 
       - name: Validate Release artifact slices
         run: |
@@ -2260,6 +2261,9 @@ jobs:
           DIFF_SIDECAR="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux-diff-sidecar"
           test -x "$APP_BINARY"
           test -x "$CLI_BINARY"
+          TUI_CLIENT="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux-tui"
+          test -x "$TUI_CLIENT"
+          lipo "$TUI_CLIENT" -verify_arch arm64 x86_64
           test -x "$HELPER_BINARY"
           test -x "$DIFF_SIDECAR"
           file "$APP_BINARY" "$CLI_BINARY" "$HELPER_BINARY" "$DIFF_SIDECAR"

--- a/.github/workflows/cmux-tui-artifacts.yml
+++ b/.github/workflows/cmux-tui-artifacts.yml
@@ -11,7 +11,7 @@ name: cmux-tui artifacts
 # Layout in R2:
 #   cmux-tui/<commit-sha>/cmux-tui-<rust-target>   immutable, commit-addressed
 #   cmux-tui/<commit-sha>/manifest.json
-#   cmux-tui/latest/cmux-tui-<rust-target>         rolling, manual publishes only
+#   cmux-tui/latest/cmux-tui-<rust-target>         rolling, every main push
 #   cmux-tui/latest/manifest.json
 #   cmux-relay/<commit-sha>/cmux-relay-<rust-target> immutable, commit-addressed
 #   cmux-relay/<commit-sha>/manifest.json
@@ -26,7 +26,18 @@ name: cmux-tui artifacts
 #   chatmux-relay/latest/manifest.json
 
 on:
-  # Temporarily manual-only beginning 2026-07-13 to pause automatic CI/CD.
+  # Every main push that can change the binaries republishes the immutable
+  # commit-addressed artifacts and the rolling latest/ manifest: cmux Cloud
+  # machines install the daemon from latest/manifest.json and the macOS app
+  # bundles the matching client from it (scripts/install-cmux-tui-client.sh),
+  # so latest must track main. Manual dispatch stays for re-publishing.
+  push:
+    branches: [main]
+    paths:
+      - "cmux-tui/**"
+      - "ghostty"
+      - ".github/workflows/cmux-tui-artifacts.yml"
+      - ".github/workflows/cmux-tui-build-package.yml"
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -483,6 +483,11 @@ jobs:
           install -m 755 nightly-inputs/ghostty/ghostty "$DEST"
           echo "Injected Ghostty CLI helper architectures: $(lipo -archs "$DEST")"
 
+      - name: Bundle the cmux-tui client
+        run: |
+          set -euo pipefail
+          ./scripts/install-cmux-tui-client.sh build-universal/Build/Products/Release/cmux.app
+
       - name: Run bundled Ghostty theme picker helper regression
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,7 @@ jobs:
           ./scripts/install-prebuilt-ghostty-cli-helper.sh \
             ghostty-cli-helper/ghostty \
             build-universal/Build/Products/Release/cmux.app
+          ./scripts/install-cmux-tui-client.sh build-universal/Build/Products/Release/cmux.app
 
       - name: Verify binary architectures
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -80,13 +80,19 @@ extension CMUXCLI {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storeURL.path)
     }
 
-    /// CMUX_TUI_CLIENT → ~/.cmux/bin/cmux (install-static.sh's target) → `cmux-tui` on PATH.
-    /// Plain `cmux` on PATH is deliberately not probed: that is this CLI. Every candidate
-    /// must answer `remote-probe --json` as cmux-tui — ~/.cmux/bin/cmux can also be the
-    /// SSH-remote bootstrap's shell wrapper, which is executable but not a client.
-    static func locateCmuxTuiClient(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+    /// The client bundled beside this CLI (`Contents/Resources/bin/cmux-tui`, installed by
+    /// scripts/install-cmux-tui-client.sh) comes first, so the Machines panel needs no
+    /// install; then CMUX_TUI_CLIENT, ~/.cmux/bin/cmux (install-static.sh's target) and
+    /// `cmux-tui` on PATH. Plain `cmux` on PATH is deliberately not probed: that is this
+    /// CLI. Every candidate must answer `remote-probe --json` as cmux-tui —
+    /// ~/.cmux/bin/cmux can also be the SSH-remote bootstrap's shell wrapper, which is
+    /// executable but not a client.
+    func locateCmuxTuiClient(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let fm = FileManager.default
         var candidates: [String] = []
+        if let bundled = resolvedExecutableURL()?.deletingLastPathComponent().appendingPathComponent("cmux-tui").path {
+            candidates.append(bundled)
+        }
         if let explicit = environment["CMUX_TUI_CLIENT"]?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
             candidates.append(explicit)
         }
@@ -97,10 +103,17 @@ extension CMUXCLI {
         for dir in (environment["PATH"] ?? "").split(separator: ":") where !dir.isEmpty {
             candidates.append(URL(fileURLWithPath: String(dir), isDirectory: true).appendingPathComponent("cmux-tui").path)
         }
-        return candidates.first { fm.isExecutableFile(atPath: $0) && isCmuxTuiClient(at: $0) }
+        return candidates.first { fm.isExecutableFile(atPath: $0) && Self.cmuxTuiClientProbe(at: $0) != nil }
     }
 
-    static func isCmuxTuiClient(at path: String) -> Bool {
+    struct CmuxTuiClientProbe {
+        let buildIdentity: String?
+        let remoteProtocol: Int?
+        let version: String?
+    }
+
+    /// `remote-probe --json` of a candidate binary; nil unless it is a cmux-tui client.
+    static func cmuxTuiClientProbe(at path: String) -> CmuxTuiClientProbe? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: path)
         process.arguments = ["remote-probe", "--json"]
@@ -111,15 +124,39 @@ extension CMUXCLI {
         do {
             try process.run()
         } catch {
-            return false
+            return nil
         }
         let data = out.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         guard process.terminationStatus == 0,
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return false
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (object["app"] as? String) == "cmux-tui" else {
+            return nil
         }
-        return (object["app"] as? String) == "cmux-tui"
+        return CmuxTuiClientProbe(
+            buildIdentity: object["build_identity"] as? String,
+            remoteProtocol: (object["remote_protocol"] as? Int) ?? (object["remote_protocol"] as? Double).map(Int.init),
+            version: object["version"] as? String
+        )
+    }
+
+    /// Client and machine daemon must speak the same remote protocol; the daemon rejects a
+    /// mismatch, so say which side is behind up front instead of letting the pane hang.
+    static func checkCmuxTuiCompatibility(client: CmuxTuiClientProbe, daemon: [String: Any]?) throws {
+        guard let daemon,
+              let daemonProtocol = (daemon["remote_protocol"] as? Int) ?? (daemon["remote_protocol"] as? Double).map(Int.init),
+              let clientProtocol = client.remoteProtocol,
+              daemonProtocol != clientProtocol else { return }
+        let daemonCommit = (daemon["commit"] as? String).map { String($0.prefix(10)) } ?? "?"
+        let clientCommit = client.buildIdentity.map { String($0.prefix(10)) } ?? "?"
+        let stale = clientProtocol < daemonProtocol
+            ? CMUXDiffViewerLocalization.string("cli.vm.tui.staleClient", defaultValue: "Update cmux (its bundled cmux-tui client is older than the machine's daemon).")
+            : CMUXDiffViewerLocalization.string("cli.vm.tui.staleDaemon", defaultValue: "The machine's cmux-tui daemon is older than this client; reconnect once the machine has updated.")
+        let template = CMUXDiffViewerLocalization.string(
+            "cli.vm.tui.protocolMismatch",
+            defaultValue: "cmux-tui protocol mismatch: client %1$@ speaks protocol %2$d, the machine daemon %3$@ speaks protocol %4$d. %5$@"
+        )
+        throw CLIError(message: String(format: template, clientCommit, clientProtocol, daemonCommit, daemonProtocol, stale))
     }
 
     static func vmTuiDeviceName() -> String {
@@ -197,12 +234,13 @@ extension CMUXCLI {
         guard let route = info["route"] as? String, !route.isEmpty else {
             throw CLIError(message: "vm.cmux_remote_info returned no route")
         }
-        guard let clientPath = Self.locateCmuxTuiClient() else {
+        guard let clientPath = locateCmuxTuiClient(), let clientProbe = Self.cmuxTuiClientProbe(at: clientPath) else {
             throw CLIError(message: CMUXDiffViewerLocalization.string(
                 "cli.vm.tui.clientMissing",
                 defaultValue: "No cmux-tui client found. Install one with `curl -fsSL https://cmux.com/tui/install-static.sh | sh`, or point CMUX_TUI_CLIENT at a binary."
             ))
         }
+        try Self.checkCmuxTuiCompatibility(client: clientProbe, daemon: info["daemon_build"] as? [String: Any])
         let session = (info["session"] as? String) ?? "cloud"
         let invitation = info["invitation"] as? [String: Any]
         let invitationUri = invitation?["uri"] as? String

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -1,0 +1,345 @@
+import Foundation
+
+/// `cmux vm tui <id>` — attach to a cloud machine through its cmux-tui remote daemon
+/// (Phase 1 of the cmuxd-remote → cmux-tui migration, docs/cloud-cmux-tui-daemon.md).
+///
+/// The control plane returns a tokenized `/v1/link` route and, for a device that has
+/// not enrolled with this machine's daemon yet, a single-use invitation. A workspace
+/// pane runs the hidden `vm-tui-connect` helper, which hands the terminal to the
+/// local cmux-tui client (`remote connect`) and, while the client claims the
+/// invitation, asks the control plane to approve the pending enrollment through the
+/// app socket. After the first enrollment the device key lives in the client's state
+/// directory and later attaches need only a fresh route.
+extension CMUXCLI {
+    struct VMTuiConnectConfig: Codable {
+        let vmId: String
+        let route: String
+        let session: String
+        let invitationUri: String?
+        let invitationId: String?
+        let clientPath: String
+        let stateDir: String
+        let deviceName: String
+    }
+
+    struct VMTuiDeviceRecord: Codable {
+        let deviceFingerprint: String
+        let updatedAtUnix: Int
+    }
+
+    static let vmTuiApprovalPollSeconds: TimeInterval = 2
+    static let vmTuiApprovalTimeoutSeconds: TimeInterval = 5 * 60
+
+    static var vmTuiUsage: String {
+        """
+        Usage: cmux vm tui <id> [--window <id|ref|index>]
+
+        Open a workspace attached to the machine's cmux-tui remote daemon. The pane
+        runs the local cmux-tui client against the machine's authenticated link; the
+        first attach from this Mac enrolls the device (approved by cmux), later
+        attaches reconnect with the stored device key.
+
+        The client binary is found via CMUX_TUI_CLIENT, then ~/.cmux/bin/cmux, then
+        `cmux-tui` on PATH. Install one with:
+          curl -fsSL https://cmux.com/tui/install-static.sh | sh
+        """
+    }
+
+    // MARK: - local state
+
+    /// Per-Mac cmux-tui client state (device key, known daemons), separate from any
+    /// interactive `cmux-tui` the person uses so machines never share identity.
+    static func vmTuiClientStateDir() -> URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("cmux-tui-client", isDirectory: true)
+    }
+
+    static func vmTuiDevicesStoreURL() -> URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("vm-tui-devices.json", isDirectory: false)
+    }
+
+    static func loadVMTuiDevices(from url: URL? = nil) -> [String: VMTuiDeviceRecord] {
+        let storeURL = url ?? vmTuiDevicesStoreURL()
+        guard let data = try? Data(contentsOf: storeURL),
+              let store = try? JSONDecoder().decode([String: VMTuiDeviceRecord].self, from: data) else {
+            return [:]
+        }
+        return store
+    }
+
+    static func saveVMTuiDevice(vmId: String, deviceFingerprint: String, to url: URL? = nil) {
+        let storeURL = url ?? vmTuiDevicesStoreURL()
+        var store = loadVMTuiDevices(from: storeURL)
+        store[vmId] = VMTuiDeviceRecord(deviceFingerprint: deviceFingerprint, updatedAtUnix: Int(Date().timeIntervalSince1970))
+        guard let data = try? JSONEncoder().encode(store) else { return }
+        try? FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? data.write(to: storeURL, options: [.atomic])
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storeURL.path)
+    }
+
+    /// CMUX_TUI_CLIENT → ~/.cmux/bin/cmux (install-static.sh's target) → `cmux-tui` on PATH.
+    /// Plain `cmux` on PATH is deliberately not probed: that is this CLI. Every candidate
+    /// must answer `remote-probe --json` as cmux-tui — ~/.cmux/bin/cmux can also be the
+    /// SSH-remote bootstrap's shell wrapper, which is executable but not a client.
+    static func locateCmuxTuiClient(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        let fm = FileManager.default
+        var candidates: [String] = []
+        if let explicit = environment["CMUX_TUI_CLIENT"]?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            candidates.append(explicit)
+        }
+        candidates.append(
+            URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent(".cmux/bin/cmux", isDirectory: false).path
+        )
+        for dir in (environment["PATH"] ?? "").split(separator: ":") where !dir.isEmpty {
+            candidates.append(URL(fileURLWithPath: String(dir), isDirectory: true).appendingPathComponent("cmux-tui").path)
+        }
+        return candidates.first { fm.isExecutableFile(atPath: $0) && isCmuxTuiClient(at: $0) }
+    }
+
+    static func isCmuxTuiClient(at path: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = ["remote-probe", "--json"]
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return (object["app"] as? String) == "cmux-tui"
+    }
+
+    static func vmTuiDeviceName() -> String {
+        let raw = ProcessInfo.processInfo.hostName.split(separator: ".").first.map(String.init) ?? "mac"
+        let cleaned = raw.map { $0.isLetter || $0.isNumber || $0 == "-" ? $0 : Character("-") }
+        return "cmux-" + String(cleaned).prefix(40)
+    }
+
+    // MARK: - cmux vm tui <id>  (and the default for cmux vm shell)
+
+    struct VMTuiOpenResult {
+        let workspaceId: String
+        let session: String
+        let enrolling: Bool
+    }
+
+    /// `cmux vm shell` prefers this path: when the deployment runs the cmux-tui daemon,
+    /// every shell is a cmux-tui session. Returns nil only when the control plane says
+    /// the machine's deployment has no cmux-tui pin, so the caller can fall back to the
+    /// legacy cmuxd-remote websocket attach for machines that predate the migration.
+    func openVMShellViaCmuxTuiIfAvailable(vmId: String, windowRaw: String?, client: SocketClient) throws -> VMTuiOpenResult? {
+        do {
+            return try openVMTuiWorkspace(vmId: vmId, windowRaw: windowRaw, client: client)
+        } catch let error as CLIError where Self.isCmuxTuiUnavailable(error) {
+            return nil
+        }
+    }
+
+    static func isCmuxTuiUnavailable(_ error: CLIError) -> Bool {
+        let text = error.message.lowercased()
+        return text.contains("not enabled for this deployment")
+            || text.contains("not supported by this deployment")
+            || text.contains("does not run the cmux-tui")
+            || text.contains("unknown method")
+    }
+
+    func runVMTuiCommand(rest: [String], windowRaw: String?, client: SocketClient, jsonOutput: Bool) throws {
+        if rest.contains("--help") || rest.contains("-h") {
+            print(Self.vmTuiUsage)
+            return
+        }
+        guard let vmId = rest.first(where: { !$0.hasPrefix("-") }), !vmId.isEmpty else {
+            throw CLIError(message: Self.vmTuiUsage)
+        }
+        let opened = try openVMTuiWorkspace(vmId: vmId, windowRaw: windowRaw, client: client)
+        if jsonOutput {
+            print(jsonString([
+                "ok": true,
+                "vm_id": vmId,
+                "workspace_id": opened.workspaceId,
+                "session": opened.session,
+                "enrolling": opened.enrolling,
+            ]))
+            return
+        }
+        let template = CMUXDiffViewerLocalization.string(
+            "cli.vm.tui.opened",
+            defaultValue: "Opened cmux-tui for %1$@ (%2$@)"
+        )
+        let mode = opened.enrolling
+            ? CMUXDiffViewerLocalization.string("cli.vm.tui.mode.enrolling", defaultValue: "enrolling this Mac")
+            : CMUXDiffViewerLocalization.string("cli.vm.tui.mode.enrolled", defaultValue: "device already enrolled")
+        print(String(format: template, vmId, mode))
+    }
+
+    func openVMTuiWorkspace(vmId: String, windowRaw: String?, client: SocketClient) throws -> VMTuiOpenResult {
+        let known = Self.loadVMTuiDevices()[vmId]
+        var infoParams: [String: Any] = ["id": vmId]
+        if let known {
+            infoParams["device_fingerprint"] = known.deviceFingerprint
+        }
+        // Ask the control plane first: a missing client binary should only be reported
+        // when this machine can actually be reached through cmux-tui.
+        let info = try client.sendV2(method: "vm.cmux_remote_info", params: infoParams, responseTimeout: 16 * 60)
+        guard let route = info["route"] as? String, !route.isEmpty else {
+            throw CLIError(message: "vm.cmux_remote_info returned no route")
+        }
+        guard let clientPath = Self.locateCmuxTuiClient() else {
+            throw CLIError(message: CMUXDiffViewerLocalization.string(
+                "cli.vm.tui.clientMissing",
+                defaultValue: "No cmux-tui client found. Install one with `curl -fsSL https://cmux.com/tui/install-static.sh | sh`, or point CMUX_TUI_CLIENT at a binary."
+            ))
+        }
+        let session = (info["session"] as? String) ?? "cloud"
+        let invitation = info["invitation"] as? [String: Any]
+        let invitationUri = invitation?["uri"] as? String
+        let invitationId = invitation?["invitation_id"] as? String
+
+        let stateDir = Self.vmTuiClientStateDir()
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let config = VMTuiConnectConfig(
+            vmId: vmId,
+            route: route,
+            session: session,
+            invitationUri: invitationUri,
+            invitationId: invitationId,
+            clientPath: clientPath,
+            stateDir: stateDir.path,
+            deviceName: Self.vmTuiDeviceName()
+        )
+        let configURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vm-tui-\(UUID().uuidString.lowercased()).json")
+        try JSONEncoder().encode(config).write(to: configURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
+
+        let executablePath = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
+        var params: [String: Any] = [
+            "initial_command": "\(shellQuote(executablePath)) vm-tui-connect --config \(shellQuote(configURL.path))",
+            "title": "vm:\(vmId)",
+        ]
+        try applyWindowOrCallerContext(to: &params, client: client, windowRaw: windowRaw)
+        let created = try client.sendV2(method: "workspace.create", params: params)
+        guard let workspaceId = created["workspace_id"] as? String, !workspaceId.isEmpty else {
+            throw CLIError(message: "workspace.create did not return workspace_id")
+        }
+        _ = try? client.sendV2(method: "workspace.select", params: ["workspace_id": workspaceId])
+        return VMTuiOpenResult(workspaceId: workspaceId, session: session, enrolling: invitationUri != nil)
+    }
+
+    // MARK: - cmux vm-tui-connect --config <file>  (runs inside the pane)
+
+    func runVMTuiConnect(commandArgs: [String], client: SocketClient) throws {
+        let (configPath, _) = parseOption(commandArgs, name: "--config")
+        guard let configPath, !configPath.isEmpty else {
+            throw CLIError(message: "Usage: cmux vm-tui-connect --config <file>")
+        }
+        let configURL = URL(fileURLWithPath: configPath)
+        let config = try JSONDecoder().decode(VMTuiConnectConfig.self, from: Data(contentsOf: configURL))
+        // The config carries a single-use invitation secret; it has served its purpose.
+        try? FileManager.default.removeItem(at: configURL)
+
+        var inviteURL: URL?
+        if let uri = config.invitationUri, !uri.isEmpty {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-vm-tui-invite-\(UUID().uuidString.lowercased())")
+            try (uri + "\n").data(using: .utf8)!.write(to: url, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            inviteURL = url
+        }
+        defer { if let inviteURL { try? FileManager.default.removeItem(at: inviteURL) } }
+
+        var arguments = ["remote", "connect", config.route, "--device-name", config.deviceName, "--state-dir", config.stateDir]
+        if let inviteURL {
+            arguments += ["--invite-file", inviteURL.path]
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: config.clientPath)
+        process.arguments = arguments
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+
+        cliWriteStderr(String(format: CMUXDiffViewerLocalization.string(
+            "cli.vm.tui.connecting",
+            defaultValue: "Connecting to %1$@ through cmux-tui…"
+        ), config.vmId) + "\n")
+
+        // Foundation spawns the child in its own process group, so the interactive TUI
+        // would be a background job of the pane and SIGTTIN-stop on its first tty read.
+        // Hand the terminal foreground to the child for its lifetime, as the other
+        // interactive-child CLI paths do.
+        let originalForegroundProcessGroup = tcgetpgrp(STDIN_FILENO)
+        var didForegroundChild = false
+        try cliRunProcess(process)
+        if originalForegroundProcessGroup > 0 {
+            let childProcessGroup = getpgid(process.processIdentifier)
+            if childProcessGroup > 0 && childProcessGroup != originalForegroundProcessGroup {
+                do {
+                    try setTerminalForegroundProcessGroup(childProcessGroup)
+                } catch {
+                    _ = Darwin.kill(-childProcessGroup, SIGCONT)
+                    process.terminate()
+                    throw CLIError(message: "vm-tui-connect: couldn't hand the terminal to cmux-tui; aborting to avoid a hang (\(String(describing: error)))")
+                }
+                _ = Darwin.kill(-childProcessGroup, SIGCONT)
+                didForegroundChild = true
+            }
+        }
+        defer {
+            if didForegroundChild {
+                try? setTerminalForegroundProcessGroup(originalForegroundProcessGroup)
+            }
+        }
+
+        // While the client claims the invitation, approve the pending enrollment through
+        // the app: the control plane minted this invitation for the signed-in user, so
+        // approving the claim is the honest encoding of "already authenticated". Nothing
+        // is printed while the TUI owns the terminal; the device record is saved silently.
+        if let invitationId = config.invitationId, !invitationId.isEmpty {
+            let vmId = config.vmId
+            let approver = Thread {
+                let deadline = Date().addingTimeInterval(Self.vmTuiApprovalTimeoutSeconds)
+                while Date() < deadline, process.isRunning {
+                    Thread.sleep(forTimeInterval: Self.vmTuiApprovalPollSeconds)
+                    guard let result = try? client.sendV2(
+                        method: "vm.cmux_remote_approve",
+                        params: ["id": vmId, "invitation_id": invitationId],
+                        responseTimeout: 60
+                    ) else { continue }
+                    if (result["state"] as? String) == "approved" {
+                        if let fingerprint = result["device_fingerprint"] as? String, !fingerprint.isEmpty {
+                            Self.saveVMTuiDevice(vmId: vmId, deviceFingerprint: fingerprint)
+                        }
+                        return
+                    }
+                }
+            }
+            approver.start()
+        }
+
+        process.waitUntilExit()
+        let status = process.terminationStatus
+        if status != 0 {
+            throw CLIError(
+                message: String(format: CMUXDiffViewerLocalization.string(
+                    "cli.vm.tui.clientExited",
+                    defaultValue: "cmux-tui exited with status %1$d. Re-run `cmux vm tui %2$@` to reconnect."
+                ), status, config.vmId),
+                exitCode: status > 0 ? status : 1
+            )
+        }
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5925,16 +5925,27 @@ struct CMUXCLI {
                           cmux vm ls
                         """)
                 }
-                let shellWorkspaceId = try vmOpenShell(
-                    id: vmId,
-                    workspaceName: "vm:\(vmId)",
-                    windowRaw: windowOpt ?? windowId,
-                    forceSSH: false,
-                    shouldPinWorkspaceToTop: false,
-                    client: client,
-                    jsonOutput: jsonOutput,
-                    idFormat: idFormat
-                )
+                // Cloud shells are cmux-tui sessions wherever the deployment runs the
+                // cmux-tui daemon; the cmuxd-remote websocket attach remains only for
+                // deployments without a cmux-tui pin (docs/cloud-cmux-tui-daemon.md).
+                let shellWorkspaceId: String?
+                if let opened = try openVMShellViaCmuxTuiIfAvailable(vmId: vmId, windowRaw: windowOpt ?? windowId, client: client) {
+                    shellWorkspaceId = opened.workspaceId
+                    if jsonOutput {
+                        print(jsonString(["ok": true, "vm_id": vmId, "workspace_id": opened.workspaceId, "transport": "cmux-remote", "enrolling": opened.enrolling]))
+                    }
+                } else {
+                    shellWorkspaceId = try vmOpenShell(
+                        id: vmId,
+                        workspaceName: "vm:\(vmId)",
+                        windowRaw: windowOpt ?? windowId,
+                        forceSSH: false,
+                        shouldPinWorkspaceToTop: false,
+                        client: client,
+                        jsonOutput: jsonOutput,
+                        idFormat: idFormat
+                    )
+                }
                 if let status = try? client.sendV2(method: "vm.status", params: ["id": vmId], responseTimeout: 30),
                    let image = status["image"] as? String,
                    Self.cloudVMImageHasDesktop(image) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5955,6 +5955,10 @@ struct CMUXCLI {
                     _ = try? openVMDesktopSplit(vmId: vmId, client: client, workspaceId: desktopWorkspace)
                 }
 
+            case "tui":
+                let (windowOpt, vmArgs) = parseOption(rest, name: "--window")
+                try runVMTuiCommand(rest: vmArgs, windowRaw: windowOpt ?? windowId, client: client, jsonOutput: jsonOutput)
+
             case "rename":
                 let clear = hasFlag(rest, name: "--clear")
                 let positional = rest.filter { !Self.isFlagToken($0) }
@@ -6151,7 +6155,7 @@ struct CMUXCLI {
 
             default:
                 throw CLIError(message: """
-                    Usage: cmux \(command) <ls|new|status|snapshot|fork|restore|shell|rm|exec|ssh> [args...]
+                    Usage: cmux \(command) <ls|new|status|snapshot|fork|restore|shell|tui|rm|exec|ssh> [args...]
 
                     Common commands:
                       cmux vm ls
@@ -6559,6 +6563,8 @@ struct CMUXCLI {
             try runSSHSessionEnd(commandArgs: commandArgs, client: client)
         case "vm-pty-attach":
             try runVMPtyAttach(commandArgs: commandArgs, client: client)
+        case "vm-tui-connect":
+            try runVMTuiConnect(commandArgs: commandArgs, client: client)
         case "vm-ssh-attach":
             // Hidden compatibility alias for workspaces created before the split helper was
             // nested under `cmux vm`.
@@ -17793,7 +17799,7 @@ struct CMUXCLI {
             """
         case "vm", "cloud":
             return """
-            Usage: cmux \(command) <base|new|ls|status|stats|rename|snapshot|fork|restore|rm|exec|shell|desktop|attach|ssh|ssh-info> [args...]
+            Usage: cmux \(command) <base|new|ls|status|stats|rename|snapshot|fork|restore|rm|exec|shell|tui|desktop|attach|ssh|ssh-info> [args...]
 
             Manage cloud VMs. `cloud` is an alias for `vm`. Requires `cmux auth login`.
 
@@ -17821,6 +17827,9 @@ struct CMUXCLI {
               restore <snapshot-id> [--provider <provider>] [--window <id|ref|index>] [--detach|-d]
                                         Restore a snapshot as a tracked Cloud VM.
               stats <id>                     CPU, memory, and disk right now (sleeping machines stay asleep)
+              tui <id> [--window <id|ref|index>]
+                                        Open a workspace attached through the machine's
+                                        cmux-tui remote daemon (enrolls this Mac on first use).
               shell <id> [--window <id|ref|index>]
               desktop <id> [--workspace <id|ref|index>]   Open the machine's noVNC desktop as a pane in your workspace
                                         Drop into an interactive shell on an existing VM.
@@ -19879,7 +19888,7 @@ struct CMUXCLI {
         optionValue(args, name: "--window") ?? windowOverride
     }
 
-    private func applyWindowOrCallerContext(to params: inout [String: Any], client: SocketClient, windowRaw: String?) throws {
+    func applyWindowOrCallerContext(to params: inout [String: Any], client: SocketClient, windowRaw: String?) throws {
         if let windowHandle = try normalizeWindowHandle(windowRaw, client: client) {
             params["window_id"] = windowHandle
             return
@@ -36723,7 +36732,7 @@ export default CMUXSessionRestore;
         throw CLIError(message: "OpenTUI Feed exited with status \(process.terminationStatus)")
     }
 
-    private func setTerminalForegroundProcessGroup(_ processGroup: pid_t) throws {
+    func setTerminalForegroundProcessGroup(_ processGroup: pid_t) throws {
         let previousHandler = signal(SIGTTOU, SIG_IGN)
         defer { _ = signal(SIGTTOU, previousHandler) }
         guard tcsetpgrp(STDIN_FILENO, processGroup) == 0 else {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57726,6 +57726,108 @@
         }
       }
     },
+    "cli.vm.tui.clientExited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui exited with status %1$d. Re-run `cmux vm tui %2$@` to reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui がステータス %1$d で終了しました。再接続するには `cmux vm tui %2$@` を再実行してください。"
+          }
+        }
+      }
+    },
+    "cli.vm.tui.clientMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cmux-tui client found. Install one with `curl -fsSL https://cmux.com/tui/install-static.sh | sh`, or point CMUX_TUI_CLIENT at a binary."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui クライアントが見つかりません。`curl -fsSL https://cmux.com/tui/install-static.sh | sh` でインストールするか、CMUX_TUI_CLIENT にバイナリを指定してください。"
+          }
+        }
+      }
+    },
+    "cli.vm.tui.connecting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to %1$@ through cmux-tui…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui 経由で %1$@ に接続しています…"
+          }
+        }
+      }
+    },
+    "cli.vm.tui.mode.enrolled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "device already enrolled"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このデバイスは登録済みです"
+          }
+        }
+      }
+    },
+    "cli.vm.tui.mode.enrolling": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enrolling this Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac を登録しています"
+          }
+        }
+      }
+    },
+    "cli.vm.tui.opened": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opened cmux-tui for %1$@ (%2$@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ の cmux-tui を開きました（%2$@）"
+          }
+        }
+      }
+    },
     "cli.workspace.create.error.envFileRequiresValue": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57828,6 +57828,27 @@
         }
       }
     },
+    "cli.vm.tui.protocolMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "cmux-tui protocol mismatch: client %1$@ speaks protocol %2$d, the machine daemon %3$@ speaks protocol %4$d. %5$@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmux-tui のプロトコルが一致しません: クライアント %1$@ はプロトコル %2$d、マシンのデーモン %3$@ はプロトコル %4$d です。%5$@" } }
+      }
+    },
+    "cli.vm.tui.staleClient": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Update cmux (its bundled cmux-tui client is older than the machine's daemon)." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmux を更新してください（同梱の cmux-tui クライアントがマシンのデーモンより古いです）。" } }
+      }
+    },
+    "cli.vm.tui.staleDaemon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The machine's cmux-tui daemon is older than this client; reconnect once the machine has updated." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "マシンの cmux-tui デーモンがこのクライアントより古いです。マシンが更新されてから再接続してください。" } }
+      }
+    },
     "cli.workspace.create.error.envFileRequiresValue": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -383,6 +383,29 @@ struct VMWebSocketDaemonEndpoint {
     let expiresAtUnix: Int64
 }
 
+/// Attach through the cmux-tui remote daemon in the machine (Phase 1 of the
+/// cmuxd-remote → cmux-tui migration). The route carries the ingress token; the
+/// invitation is present only when this device is not yet enrolled with the daemon.
+struct VMCmuxRemoteEndpoint {
+    struct Invitation {
+        let uri: String
+        let invitationId: String
+        let expiresAtUnix: Int64
+    }
+
+    let route: String
+    let token: String
+    let expiresAtUnix: Int64
+    let session: String
+    let invitation: Invitation?
+}
+
+struct VMCmuxRemoteApproval {
+    let approved: Bool
+    let state: String
+    let deviceFingerprint: String?
+}
+
 enum VMAttachEndpoint {
     case ssh(VMSSHEndpoint)
     case websocket(VMWebSocketPtyEndpoint)
@@ -706,6 +729,55 @@ actor VMClient {
         try ensureOK(http, data: data)
         let obj = try decodeJSONObject(data)
         return try decodeAttachEndpoint(obj)
+    }
+
+    func openCmuxRemote(id: String, deviceFingerprint: String? = nil) async throws -> VMCmuxRemoteEndpoint {
+        let encodedID = try pathSegment(id, fieldName: "vm id")
+        var body: [String: Any] = ["transport": "cmux-remote"]
+        if let deviceFingerprint, !deviceFingerprint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            body["deviceFingerprint"] = deviceFingerprint
+        }
+        let (data, http) = try await request(
+            "POST",
+            path: "/api/vm/\(encodedID)/attach-endpoint",
+            jsonBody: body,
+            timeoutSeconds: Self.attachTimeoutSeconds
+        )
+        try ensureOK(http, data: data)
+        let obj = try decodeJSONObject(data)
+        guard (obj["transport"] as? String) == "cmux-remote",
+              let route = obj["route"] as? String, !route.isEmpty,
+              let token = obj["token"] as? String,
+              let session = obj["session"] as? String else {
+            throw VMClientError.malformedResponse("Cloud VM cmux-remote attach response was missing required fields.")
+        }
+        let expiresAtUnix = (obj["expiresAtUnix"] as? Int64) ?? Int64((obj["expiresAtUnix"] as? Double) ?? 0)
+        var invitation: VMCmuxRemoteEndpoint.Invitation?
+        if let raw = obj["invitation"] as? [String: Any],
+           let uri = raw["uri"] as? String, !uri.isEmpty,
+           let invitationId = raw["invitationId"] as? String, !invitationId.isEmpty {
+            let invitationExpires = (raw["expiresAtUnix"] as? Int64) ?? Int64((raw["expiresAtUnix"] as? Double) ?? 0)
+            invitation = .init(uri: uri, invitationId: invitationId, expiresAtUnix: invitationExpires)
+        }
+        return VMCmuxRemoteEndpoint(route: route, token: token, expiresAtUnix: expiresAtUnix, session: session, invitation: invitation)
+    }
+
+    func approveCmuxRemoteEnrollment(id: String, invitationId: String) async throws -> VMCmuxRemoteApproval {
+        let encodedID = try pathSegment(id, fieldName: "vm id")
+        let (data, http) = try await request(
+            "POST",
+            path: "/api/vm/\(encodedID)/cmux-remote/approve",
+            jsonBody: ["invitationId": invitationId],
+            timeoutSeconds: 60
+        )
+        try ensureOK(http, data: data)
+        let obj = try decodeJSONObject(data)
+        let state = (obj["state"] as? String) ?? "pending"
+        return VMCmuxRemoteApproval(
+            approved: (obj["approved"] as? Bool) ?? false,
+            state: state,
+            deviceFingerprint: obj["deviceFingerprint"] as? String
+        )
     }
 
     func listSessions(id: String) async throws -> [VMCloudSession] {

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -398,6 +398,14 @@ struct VMCmuxRemoteEndpoint {
     let expiresAtUnix: Int64
     let session: String
     let invitation: Invitation?
+    /// The machine daemon's build identity, for naming a protocol mismatch.
+    struct DaemonBuild {
+        let commit: String?
+        let remoteProtocol: Int?
+        let version: String?
+    }
+
+    let daemonBuild: DaemonBuild?
 }
 
 struct VMCmuxRemoteApproval {
@@ -759,7 +767,22 @@ actor VMClient {
             let invitationExpires = (raw["expiresAtUnix"] as? Int64) ?? Int64((raw["expiresAtUnix"] as? Double) ?? 0)
             invitation = .init(uri: uri, invitationId: invitationId, expiresAtUnix: invitationExpires)
         }
-        return VMCmuxRemoteEndpoint(route: route, token: token, expiresAtUnix: expiresAtUnix, session: session, invitation: invitation)
+        var daemonBuild: VMCmuxRemoteEndpoint.DaemonBuild?
+        if let raw = obj["daemonBuild"] as? [String: Any] {
+            daemonBuild = .init(
+                commit: raw["commit"] as? String,
+                remoteProtocol: (raw["remoteProtocol"] as? Int) ?? (raw["remoteProtocol"] as? Double).map(Int.init),
+                version: raw["version"] as? String
+            )
+        }
+        return VMCmuxRemoteEndpoint(
+            route: route,
+            token: token,
+            expiresAtUnix: expiresAtUnix,
+            session: session,
+            invitation: invitation,
+            daemonBuild: daemonBuild
+        )
     }
 
     func approveCmuxRemoteEnrollment(id: String, invitationId: String) async throws -> VMCmuxRemoteApproval {

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -197,6 +197,13 @@ extension TerminalController {
                     "expires_at_unix": endpoint.expiresAtUnix,
                     "session": endpoint.session,
                 ]
+                if let build = endpoint.daemonBuild {
+                    var raw: [String: Any] = [:]
+                    if let commit = build.commit { raw["commit"] = commit }
+                    if let remoteProtocol = build.remoteProtocol { raw["remote_protocol"] = remoteProtocol }
+                    if let version = build.version { raw["version"] = version }
+                    payload["daemon_build"] = raw
+                }
                 if let invitation = endpoint.invitation {
                     payload["invitation"] = [
                         "uri": invitation.uri,

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -182,6 +182,44 @@ extension TerminalController {
                 let endpoint = try await VMClient.shared.openAttach(id: vmId, requireDaemon: requireDaemon)
                 return Self.socketWorkerAttachInfoPayload(endpoint)
             }
+        case "vm.cmux_remote_info":
+            guard let vmId = Self.socketWorkerString(params["id"]), !vmId.isEmpty else {
+                return v2Error(id: id, code: "invalid_params", message: "vm.cmux_remote_info requires `id`. Run `cmux vm ls` to find one, then `cmux vm tui <id>`.")
+            }
+            let deviceFingerprint = Self.socketWorkerString(params["device_fingerprint"])
+                ?? Self.socketWorkerString(params["deviceFingerprint"])
+            return v2VmCall(id: id) {
+                let endpoint = try await VMClient.shared.openCmuxRemote(id: vmId, deviceFingerprint: deviceFingerprint)
+                var payload: [String: Any] = [
+                    "transport": "cmux-remote",
+                    "route": endpoint.route,
+                    "token": endpoint.token,
+                    "expires_at_unix": endpoint.expiresAtUnix,
+                    "session": endpoint.session,
+                ]
+                if let invitation = endpoint.invitation {
+                    payload["invitation"] = [
+                        "uri": invitation.uri,
+                        "invitation_id": invitation.invitationId,
+                        "expires_at_unix": invitation.expiresAtUnix,
+                    ]
+                }
+                return payload
+            }
+        case "vm.cmux_remote_approve":
+            guard let vmId = Self.socketWorkerString(params["id"]), !vmId.isEmpty,
+                  let invitationId = Self.socketWorkerString(params["invitation_id"]) ?? Self.socketWorkerString(params["invitationId"]),
+                  !invitationId.isEmpty else {
+                return v2Error(id: id, code: "invalid_params", message: "vm.cmux_remote_approve requires `id` and `invitation_id`.")
+            }
+            return v2VmCall(id: id) {
+                let approval = try await VMClient.shared.approveCmuxRemoteEnrollment(id: vmId, invitationId: invitationId)
+                var payload: [String: Any] = ["approved": approval.approved, "state": approval.state]
+                if let fingerprint = approval.deviceFingerprint {
+                    payload["device_fingerprint"] = fingerprint
+                }
+                return payload
+            }
         case "vm.sessions":
             guard let vmId = Self.socketWorkerString(params["id"]), !vmId.isEmpty else {
                 return v2Error(id: id, code: "invalid_params", message: "vm.sessions requires `id`. Run `cmux vm ls` to find one.")

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2816,6 +2816,8 @@ class TerminalController {
             "vm.destroy",
             "vm.exec",
             "vm.attach_info",
+            "vm.cmux_remote_info",
+            "vm.cmux_remote_approve",
             "vm.ssh_info",
             "aiAccounts.list",
             "aiAccounts.upload",

--- a/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
@@ -330,7 +330,10 @@ impl LinkGroup for WebSocketLinkGroup {
 mod tests {
     #[test]
     fn client_request_sets_user_agent_and_keeps_the_query() {
-        let endpoint = Url::parse("wss://machine-1337.vm.cmux.sh/v1/link?bl_preview_token=t&cmux_lane=control").unwrap();
+        let endpoint = Url::parse(
+            "wss://machine-1337.vm.cmux.sh/v1/link?bl_preview_token=t&cmux_lane=control",
+        )
+        .unwrap();
         let request = super::client_request(&endpoint).unwrap();
         assert_eq!(
             request.headers().get("user-agent").and_then(|value| value.to_str().ok()),

--- a/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
@@ -10,6 +10,9 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::client::Request as ClientRequest;
+use tokio_tungstenite::tungstenite::http::header::{HeaderValue, USER_AGENT};
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
 use url::Url;
@@ -114,6 +117,23 @@ where
     }
 }
 
+/// The `User-Agent` every direct WebSocket dial carries. Hosted ingress in front of
+/// cmux Cloud machines (CloudFront on the branded machine domain) refuses upgrades
+/// that omit the header, and tungstenite sends none by default. No `Origin` is set:
+/// the daemon rejects browser-style upgrades that carry one.
+pub const CLIENT_USER_AGENT: &str = concat!("cmux-tui/", env!("CARGO_PKG_VERSION"));
+
+/// Builds the upgrade request for a direct dial, preserving the endpoint's query
+/// (route tokens and lane parameters live there).
+pub fn client_request(endpoint: &Url) -> Result<ClientRequest, LinkError> {
+    let mut request = endpoint
+        .as_str()
+        .into_client_request()
+        .map_err(|error| LinkError::Transport(error.to_string()))?;
+    request.headers_mut().insert(USER_AGENT, HeaderValue::from_static(CLIENT_USER_AGENT));
+    Ok(request)
+}
+
 pub async fn connect_websocket(
     endpoint: &Url,
     maximum: usize,
@@ -121,7 +141,8 @@ pub async fn connect_websocket(
     let description = sanitized_route(endpoint);
     let config =
         WebSocketConfig::default().max_message_size(Some(maximum)).max_frame_size(Some(maximum));
-    let (socket, _) = connect_async_with_config(endpoint.as_str(), Some(config), true)
+    let request = client_request(endpoint)?;
+    let (socket, _) = connect_async_with_config(request, Some(config), true)
         .await
         .map_err(|error| LinkError::Transport(error.to_string()))?;
     Ok(TungsteniteWebSocketLink::new(description, maximum, socket))
@@ -307,6 +328,19 @@ impl LinkGroup for WebSocketLinkGroup {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn client_request_sets_user_agent_and_keeps_the_query() {
+        let endpoint = Url::parse("wss://machine-1337.vm.cmux.sh/v1/link?bl_preview_token=t&cmux_lane=control").unwrap();
+        let request = super::client_request(&endpoint).unwrap();
+        assert_eq!(
+            request.headers().get("user-agent").and_then(|value| value.to_str().ok()),
+            Some(super::CLIENT_USER_AGENT)
+        );
+        assert!(request.headers().get("origin").is_none());
+        assert_eq!(request.uri().query(), Some("bl_preview_token=t&cmux_lane=control"));
+        assert_eq!(request.uri().host(), Some("machine-1337.vm.cmux.sh"));
+    }
+
     use std::collections::BTreeMap;
 
     use cmux_remote_protocol::{LanePolicy, SessionId};

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -1671,6 +1671,9 @@ fn print_admin_response(action: &str, response: AdminResponse, json: bool) -> an
     Ok(())
 }
 
+/// Advertised by `remote-probe --json` so a control plane can choose routes the client can use.
+pub const PROBE_CAPABILITIES: &[&str] = &["direct-ws-user-agent"];
+
 fn run_probe(args: &[String]) -> anyhow::Result<()> {
     let value = serde_json::json!({
         "app": "cmux-tui",
@@ -1681,6 +1684,10 @@ fn run_probe(args: &[String]) -> anyhow::Result<()> {
         "remote_protocol": REMOTE_PROTOCOL_VERSION,
         "os": std::env::consts::OS,
         "arch": std::env::consts::ARCH,
+        // Client-side transport capabilities a control plane can key routing on.
+        // `direct-ws-user-agent`: direct WebSocket dials carry a User-Agent, which
+        // hosted ingress on branded machine domains requires.
+        "capabilities": PROBE_CAPABILITIES,
     });
     if args.iter().any(|argument| argument == "--json") {
         println!("{}", serde_json::to_string(&value)?);
@@ -2456,6 +2463,11 @@ fn expand_home(path: String) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn probe_capabilities_include_direct_ws_user_agent() {
+        assert!(super::PROBE_CAPABILITIES.contains(&"direct-ws-user-agent"));
+    }
+
     use super::*;
 
     fn seed_legacy_authorization_state(state_dir: &Path) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -737,6 +737,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */; };
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
 		D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */; };
+		CC0033E15A1B2C3D4E5F0020 /* CMUXCLI+VMTui.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0033E15A1B2C3D4E5F0021 /* CMUXCLI+VMTui.swift */; };
 		06CC2F6C1340C7424D1C7E0A /* CMUXCLI+WorkspaceTodo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */; };
 		C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */; };
 		906900000000000000000004 /* CMUXCLIMemoryAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */; };
@@ -3639,6 +3640,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatSupport.swift"; sourceTree = "<group>"; };
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
 		D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TypedDiffViewer.swift"; sourceTree = "<group>"; };
+		CC0033E15A1B2C3D4E5F0021 /* CMUXCLI+VMTui.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+VMTui.swift"; sourceTree = "<group>"; };
 		7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+WorkspaceTodo.swift"; sourceTree = "<group>"; };
 		C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIErrorOutputRegressionTests.swift; sourceTree = "<group>"; };
 		906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIMemoryAttributionTests.swift; sourceTree = "<group>"; };
@@ -7828,6 +7830,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B9000051A1B2C3D4E5F60719 /* CMUXCLI+Config.swift */,
 				7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */,
 				CC0033E15A1B2C3D4E5F0002 /* CMUXCLI+Comments.swift */,
+				CC0033E15A1B2C3D4E5F0021 /* CMUXCLI+VMTui.swift */,
 				B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */,
 				B9000060A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift */,
 				8A87C45F990549A8A0A6EE01 /* AgentSurfaceResumeBindingClearOutcome.swift */,
@@ -11075,6 +11078,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */,
 				B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */,
 				D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */,
+				CC0033E15A1B2C3D4E5F0020 /* CMUXCLI+VMTui.swift in Sources */,
 				06CC2F6C1340C7424D1C7E0A /* CMUXCLI+WorkspaceTodo.swift in Sources */,
 				918100000000000000000051 /* CodexHookFailureCandidate.swift in Sources */,
 				918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */,

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -223,6 +223,7 @@ VM subcommands:
 | `vm ssh-info` | Print SSH connection info. |
 | `vm ssh-attach` | Internal attach helper. |
 | `vm exec` | Run a shell command inside a VM. |
+| `vm tui <id>` | Open a workspace attached through the machine's cmux-tui remote daemon; enrolls this Mac's device on first use (hidden helper: `vm-tui-connect --config <file>`). |
 
 Remotes subcommands:
 
@@ -561,8 +562,8 @@ the expected text without connecting to a cmux socket.
 - `cmux capabilities --help` -> `Usage: cmux capabilities`
 - `cmux events --help` -> `Usage: cmux events [options]`
 - `cmux auth --help` -> `Usage: cmux auth <status|login|logout>`
-- `cmux vm --help` -> `Usage: cmux vm <base|new|ls|status|snapshot|fork|restore|rm|exec|shell|attach|ssh|ssh-info> [args...]`
-- `cmux cloud --help` -> `Usage: cmux cloud <base|new|ls|status|snapshot|fork|restore|rm|exec|shell|attach|ssh|ssh-info> [args...]`
+- `cmux vm --help` -> `Usage: cmux vm <base|new|ls|status|stats|rename|snapshot|fork|restore|rm|exec|shell|tui|desktop|attach|ssh|ssh-info> [args...]`
+- `cmux cloud --help` -> `Usage: cmux cloud <base|new|ls|status|stats|rename|snapshot|fork|restore|rm|exec|shell|tui|desktop|attach|ssh|ssh-info> [args...]`
 - `cmux remotes --help` -> `Usage: cmux remotes <list|add|remove> [options]`
 - `cmux remote --help` -> `Usage: cmux remotes <list|add|remove> [options]`
 - `cmux rpc --help` -> `Usage: cmux rpc <method> [json-params]`

--- a/scripts/install-cmux-tui-client.sh
+++ b/scripts/install-cmux-tui-client.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Installs the cmux-tui client into an app bundle as Contents/Resources/bin/cmux-tui,
+# the same way the Ghostty CLI helper is bundled: the app carries the exact client
+# that talks to cmux Cloud machines, so the Machines panel needs no separate install.
+#
+# The build comes from the artifacts manifest the cmux-tui-artifacts workflow publishes
+# (rolling `latest` by default; a commit-addressed manifest pins one build). Both
+# darwin slices are downloaded, sha256-verified against the manifest, and lipo'd into
+# one universal binary. Downloads are cached per commit under CMUX_TUI_CLIENT_CACHE.
+#
+#   scripts/install-cmux-tui-client.sh <app-path> [--manifest-url <url>] [--cache-dir <dir>]
+#
+# Env: CMUX_TUI_CLIENT_MANIFEST_URL overrides the manifest, CMUX_TUI_CLIENT_LOCAL points at
+# a prebuilt universal binary to install instead of downloading (offline/dev builds).
+set -euo pipefail
+
+usage() { sed -n '2,13p' "$0"; }
+
+APP_PATH=""
+MANIFEST_URL="${CMUX_TUI_CLIENT_MANIFEST_URL:-https://files.cmux.com/cmux-tui/latest/manifest.json}"
+CACHE_DIR="${CMUX_TUI_CLIENT_CACHE:-$HOME/Library/Caches/cmux/cmux-tui-client}"
+while (( $# )); do
+  case "$1" in
+    --manifest-url) shift; MANIFEST_URL="${1:?--manifest-url needs a value}" ;;
+    --cache-dir) shift; CACHE_DIR="${1:?--cache-dir needs a value}" ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "unknown option: $1" >&2; usage >&2; exit 64 ;;
+    *) APP_PATH="$1" ;;
+  esac
+  shift
+done
+[[ -n "$APP_PATH" && -d "$APP_PATH/Contents" ]] || { echo "error: app bundle not found at '${APP_PATH:-<missing>}'" >&2; exit 1; }
+DEST_DIR="$APP_PATH/Contents/Resources/bin"
+DEST="$DEST_DIR/cmux-tui"
+mkdir -p "$DEST_DIR"
+
+sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+if [[ -n "${CMUX_TUI_CLIENT_LOCAL:-}" ]]; then
+  [[ -f "$CMUX_TUI_CLIENT_LOCAL" ]] || { echo "error: CMUX_TUI_CLIENT_LOCAL not found: $CMUX_TUI_CLIENT_LOCAL" >&2; exit 1; }
+  install -m 755 "$CMUX_TUI_CLIENT_LOCAL" "$DEST"
+  echo "Installed local cmux-tui client at $DEST"
+  exit 0
+fi
+
+mkdir -p "$CACHE_DIR"
+MANIFEST="$CACHE_DIR/manifest.$(printf '%s' "$MANIFEST_URL" | shasum -a 256 | cut -c1-12).json"
+curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-delay 2 "$MANIFEST_URL" -o "$MANIFEST"
+COMMIT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["commit"])' "$MANIFEST")"
+[[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]] || { echo "error: manifest at $MANIFEST_URL has no commit" >&2; exit 1; }
+BASE="${MANIFEST_URL%/manifest.json}"
+BUILD_DIR="$CACHE_DIR/$COMMIT"
+mkdir -p "$BUILD_DIR"
+
+fetch_slice() { # <artifact-name> -> path
+  local name="$1" want got out
+  want="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["binaries"].get(sys.argv[2], ""))' "$MANIFEST" "$name")"
+  [[ "$want" =~ ^[0-9a-f]{64}$ ]] || { echo "error: manifest lacks $name" >&2; exit 1; }
+  out="$BUILD_DIR/$name"
+  if [[ -f "$out" ]] && [[ "$(sha256_of "$out")" == "$want" ]]; then
+    printf '%s' "$out"; return
+  fi
+  curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-delay 2 "$BASE/$name" -o "$out.tmp"
+  got="$(sha256_of "$out.tmp")"
+  [[ "$got" == "$want" ]] || { echo "error: sha256 mismatch for $name (want $want, got $got)" >&2; rm -f "$out.tmp"; exit 1; }
+  mv -f "$out.tmp" "$out"
+  printf '%s' "$out"
+}
+
+ARM="$(fetch_slice cmux-tui-aarch64-apple-darwin)"
+X64="$(fetch_slice cmux-tui-x86_64-apple-darwin)"
+UNIVERSAL="$BUILD_DIR/cmux-tui-universal"
+if [[ ! -f "$UNIVERSAL" ]]; then
+  lipo -create "$ARM" "$X64" -output "$UNIVERSAL.tmp"
+  mv -f "$UNIVERSAL.tmp" "$UNIVERSAL"
+fi
+install -m 755 "$UNIVERSAL" "$DEST"
+lipo "$DEST" -verify_arch arm64 x86_64
+PROBE="$("$DEST" remote-probe --json 2>/dev/null || true)"
+[[ "$PROBE" == *'"app":"cmux-tui"'* ]] || { echo "error: installed binary does not probe as cmux-tui: $PROBE" >&2; exit 1; }
+echo "Installed universal cmux-tui client (commit ${COMMIT:0:10}) at $DEST"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1715,6 +1715,15 @@ if [[ -x "$CMUXD_SRC" ]]; then
   cp "$CMUXD_SRC" "$BIN_DIR/cmuxd"
   chmod +x "$BIN_DIR/cmuxd"
 fi
+# The cmux-tui client the Machines panel uses for cloud sessions ships inside the
+# bundle like the Ghostty helper. Dev builds take the rolling latest manifest (or
+# CMUX_TUI_CLIENT_MANIFEST_URL / CMUX_TUI_CLIENT_LOCAL); CMUX_SKIP_CMUX_TUI_CLIENT=1
+# leaves an existing copy alone for offline reloads.
+if [[ "${CMUX_SKIP_CMUX_TUI_CLIENT:-}" == "1" && -x "$APP_PATH/Contents/Resources/bin/cmux-tui" ]]; then
+  echo "Preserving bundled cmux-tui client (CMUX_SKIP_CMUX_TUI_CLIENT=1)"
+else
+  "$PWD/scripts/install-cmux-tui-client.sh" "$APP_PATH"
+fi
 if command -v xattr >/dev/null 2>&1; then
   xattr -cr "$APP_PATH" || true
 fi

--- a/web/.env.example
+++ b/web/.env.example
@@ -180,3 +180,10 @@ CMUX_VAULT_MAX_USER_BYTES=53687091200
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_HEADERS=
 OTEL_SERVICE_NAME=
+
+# cmux-tui remote daemon on Blaxel machines (Phase 1 of the cmuxd-remote → cmux-tui
+# migration, docs/cloud-cmux-tui-daemon.md). Opt-in: leave unset to keep machines on
+# cmuxd-remote only. The URL is the static musl build published by
+# .github/workflows/cmux-tui-artifacts.yml; the sha256 is that commit's manifest.json entry.
+# CMUX_VM_BLAXEL_TUI_URL=https://files.cmux.com/cmux-tui/<commit>/cmux-tui-x86_64-unknown-linux-musl
+# CMUX_VM_BLAXEL_TUI_SHA256=<64 hex>

--- a/web/app/api/vm/[id]/attach-endpoint/route.ts
+++ b/web/app/api/vm/[id]/attach-endpoint/route.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../../../services/vms/routeHelpers";
 import { setSpanAttributes } from "../../../../../services/telemetry";
 import { isVmFreeAccessExpiredError, isVmNotFoundError } from "../../../../../services/vms/errors";
-import { openAttachEndpoint, runVmWorkflow } from "../../../../../services/vms/workflows";
+import { openAttachEndpoint, openVmCmuxRemote, runVmWorkflow } from "../../../../../services/vms/workflows";
 
 
 export async function POST(
@@ -38,6 +38,40 @@ export async function POST(
       const account = resolveVmRouteAccountScope(user, request);
       if (!account.ok) return account.response;
       setSpanAttributes(span, { "cmux.vm.id": id });
+      // Opt-in transport: the cmux-tui remote daemon (Phase 1 of the cmuxd-remote
+      // migration). Clients that do not ask keep the WebSocket PTY/RPC endpoint.
+      const transport = optionalString(body.transport);
+      if (transport === "cmux-remote") {
+        let deviceFingerprint: string | undefined;
+        try {
+          deviceFingerprint = optionalClientIdentifier(body.deviceFingerprint ?? body.device_fingerprint, "deviceFingerprint");
+        } catch (err) {
+          return jsonResponse({
+            error: "invalid_request",
+            message: err instanceof Error ? err.message : "Invalid Cloud VM attach request.",
+          }, 400);
+        }
+        setSpanAttributes(span, { "cmux.vm.attach.transport": "cmux-remote" });
+        try {
+          const endpoint = await runVmWorkflow(openVmCmuxRemote({
+            userId: user.id,
+            billingTeamId: account.entitlements.billingTeamId,
+            teamIds: user.teamIds,
+            providerVmId: id,
+            deviceFingerprint,
+          }));
+          return jsonResponse(endpoint);
+        } catch (err) {
+          if (isVmNotFoundError(err)) return notFoundVm(id);
+          throw err;
+        }
+      }
+      if (transport && transport !== "websocket") {
+        return jsonResponse({
+          error: "invalid_request",
+          message: `Unknown attach transport "${transport}". Use "websocket" or "cmux-remote".`,
+        }, 400);
+      }
       setSpanAttributes(span, { "cmux.vm.attach.require_daemon": requireDaemon });
       if (sessionId) setSpanAttributes(span, { "cmux.vm.attach.session_id": sessionId });
       try {

--- a/web/app/api/vm/[id]/attach-endpoint/route.ts
+++ b/web/app/api/vm/[id]/attach-endpoint/route.ts
@@ -59,10 +59,14 @@ export async function POST(
             teamIds: user.teamIds,
             providerVmId: id,
             deviceFingerprint,
+            callerPlanId: account.entitlements.planId,
           }));
           return jsonResponse(endpoint);
         } catch (err) {
           if (isVmNotFoundError(err)) return notFoundVm(id);
+          if (isVmFreeAccessExpiredError(err)) {
+            return vmFreeAccessExpiredResponse({ vmId: id, windowDays: err.windowDays });
+          }
           throw err;
         }
       }

--- a/web/app/api/vm/[id]/cmux-remote/approve/route.ts
+++ b/web/app/api/vm/[id]/cmux-remote/approve/route.ts
@@ -2,10 +2,11 @@ import {
   jsonResponse,
   notFoundVm,
   resolveVmRouteAccountScope,
+  vmFreeAccessExpiredResponse,
   withAuthedVmApiRoute,
 } from "../../../../../../services/vms/routeHelpers";
 import { setSpanAttributes } from "../../../../../../services/telemetry";
-import { isVmNotFoundError } from "../../../../../../services/vms/errors";
+import { isVmFreeAccessExpiredError, isVmNotFoundError } from "../../../../../../services/vms/errors";
 import { approveVmCmuxRemoteEnrollment, runVmWorkflow } from "../../../../../../services/vms/workflows";
 
 /**
@@ -45,11 +46,15 @@ export async function POST(
           teamIds: user.teamIds,
           providerVmId: id,
           invitationId,
+          callerPlanId: account.entitlements.planId,
         }));
         setSpanAttributes(span, { "cmux.vm.cmux_remote.approval_state": result.state });
         return jsonResponse(result);
       } catch (err) {
         if (isVmNotFoundError(err)) return notFoundVm(id);
+        if (isVmFreeAccessExpiredError(err)) {
+          return vmFreeAccessExpiredResponse({ vmId: id, windowDays: err.windowDays });
+        }
         throw err;
       }
     },

--- a/web/app/api/vm/[id]/cmux-remote/approve/route.ts
+++ b/web/app/api/vm/[id]/cmux-remote/approve/route.ts
@@ -1,0 +1,68 @@
+import {
+  jsonResponse,
+  notFoundVm,
+  resolveVmRouteAccountScope,
+  withAuthedVmApiRoute,
+} from "../../../../../../services/vms/routeHelpers";
+import { setSpanAttributes } from "../../../../../../services/telemetry";
+import { isVmNotFoundError } from "../../../../../../services/vms/errors";
+import { approveVmCmuxRemoteEnrollment, runVmWorkflow } from "../../../../../../services/vms/workflows";
+
+/**
+ * Approves the cmux-tui device enrollment that a prior `attach-endpoint`
+ * (`transport: "cmux-remote"`) invited. The control plane is the daemon owner: it
+ * minted the invitation for this authenticated user, so approving the pending claim
+ * is the honest encoding of "the web tier already authenticated this device". Returns
+ * `state: "pending"` until the client has connected with the invitation; callers poll.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/vm/[id]/cmux-remote/approve",
+    { "cmux.vm.operation": "approve_cmux_remote_enrollment" },
+    "/api/vm/[id]/cmux-remote/approve failed",
+    async ({ user, span }) => {
+      const { id } = await params;
+      const body = await parseBody(request);
+      const raw = body.invitationId ?? body.invitation_id;
+      const invitationId = typeof raw === "string" ? raw.trim() : "";
+      if (!/^[A-Za-z0-9._-]{1,128}$/.test(invitationId)) {
+        return jsonResponse({
+          error: "invalid_request",
+          message: "invitationId must be 1-128 characters of letters, numbers, dot, underscore, or dash",
+        }, 400);
+      }
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      setSpanAttributes(span, { "cmux.vm.id": id });
+      try {
+        const result = await runVmWorkflow(approveVmCmuxRemoteEnrollment({
+          userId: user.id,
+          billingTeamId: account.entitlements.billingTeamId,
+          teamIds: user.teamIds,
+          providerVmId: id,
+          invitationId,
+        }));
+        setSpanAttributes(span, { "cmux.vm.cmux_remote.approval_state": result.state });
+        return jsonResponse(result);
+      } catch (err) {
+        if (isVmNotFoundError(err)) return notFoundVm(id);
+        throw err;
+      }
+    },
+  );
+}
+
+async function parseBody(request: Request): Promise<Record<string, unknown>> {
+  try {
+    const body = await request.json();
+    return body && typeof body === "object" && !Array.isArray(body)
+      ? body as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -318,6 +318,26 @@ as `cmux vm attach <id>`. `cmux vm ssh-info <id>` is print-only for provider SSH
 
 Blaxel needs no baked image: the driver bootstraps the stock `blaxel/base-image:latest` at create time by injecting the cmuxd-remote linux/amd64 binary through the sandbox filesystem API (gzip+base64, sub-second) and starting `serve --ws` as a `keepAlive` process. `keepAlive` is required — Blaxel freezes a sandbox ~15 s after the last connection otherwise, which would pause user workloads on disconnect; standby time is free, so a later "smart sleep while all PTYs are idle" optimization can reclaim the cost without changing the bootstrap. Config: `BL_API_KEY`, `BL_WORKSPACE`, and either `CMUX_VM_BLAXEL_DAEMON_PATH` (local linux/amd64 build) or `CMUX_VM_BLAXEL_DAEMON_URL` (R2 artifact). A URL source additionally requires `CMUX_VM_BLAXEL_DAEMON_SHA256` (sha256 of the raw binary) and fails closed without it — the daemon runs in every sandbox, so the download is integrity-pinned; a local path may run unpinned but honors the pin when set. Preview ingress is enforced private: attach only reuses a preview whose spec is not public, replaces a public one, and refuses a preview that comes back public, so the daemon is never reachable without a minted preview token. Attach dials the sandbox's private preview URL for port 7777 with a minted `X-Blaxel-Preview-Token` header (12 h expiry); the workspace API key never leaves the backend. Live driver E2E: `bun scripts/test-blaxel-vm-poc.ts`.
 
+**cmux-tui remote daemon.** When `CMUX_VM_BLAXEL_TUI_URL` and
+`CMUX_VM_BLAXEL_TUI_SHA256` are set, cmux-tui is the machine's only session daemon:
+create/resurrect no longer install or start `cmuxd-remote` (the legacy websocket
+attach can still self-heal it on demand for machines that predate the pin), and
+`cmux vm shell` / the Machines panel open cmux-tui sessions, falling back to the
+websocket attach only when the control plane reports no pin. The driver installs the pinned static-musl
+`cmux-tui` onto the persistent home volume (`/root/.cmux/bin/cmux-tui`, downloaded and
+sha256-verified inside the VM, reused on resurrection) and runs `cmux-tui server start
+--session cloud --remote-ws 0.0.0.0:1337` under the sandbox supervisor, beside
+`cmuxd-remote`. `POST /api/vm/[id]/attach-endpoint` with `{"transport":"cmux-remote"}`
+returns `{route, token, session, invitation?}` where `route` is
+`wss://<hash>.preview.bl.run/v1/link?bl_preview_token=…` (the daemon preview is
+deliberately unbranded: a WebSocket upgrade carrying the token as a query parameter
+completes on the raw host but is refused through the `vm.cmux.sh` custom domain) and
+`invitation` is a single-use `cmux://enroll/…` URI minted only when the caller's
+device is not enrolled. The client connects with `cmux-tui remote connect <route>
+--invite-file …`, then `POST /api/vm/[id]/cmux-remote/approve {invitationId}` approves
+the pending claim (poll until `state` is `approved`). `cmux vm tui <id>` drives this
+from the Mac. See docs/cloud-cmux-tui-daemon.md (#10800) for the full migration.
+
 E2B and Daytona interactive paths require a cmuxd WebSocket PTY image. The backend writes only a hash of attach tokens to Postgres; raw tokens are returned once to the Mac client. Daytona attach dials the sandbox preview URL for port 7777 with the `x-daytona-preview-token` header; preview tokens reset on sandbox restart, so the backend mints a fresh preview link per attach. cmux does not use Daytona's SSH gateway.
 
 Operational note: Blaxel is the intended default. Before rollout or rollback, verify the deployed

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -373,10 +373,16 @@ export function cmuxTuiInstallCommand(source: CmuxTuiSource): string {
   const bin = shellQuote(CMUX_TUI_BINARY_PATH);
   const tmp = shellQuote(`${CMUX_TUI_BINARY_PATH}.tmp`);
   const pinned = (path: string) => `printf '%s  %s\n' ${shellQuote(source.sha256)} ${path} | sha256sum -c -s`;
+  // A stock blaxel/base-image has no curl until background provisioning adds it, so
+  // the fetch installs curl itself (apk, Alpine) and falls back to busybox wget.
+  const fetch =
+    `(command -v curl >/dev/null 2>&1 || apk add --no-cache curl >/dev/null 2>&1 || true); ` +
+    `if command -v curl >/dev/null 2>&1; then curl -fsSL --retry 3 --retry-delay 2 -o ${tmp} ${shellQuote(source.url)}; ` +
+    `else wget -q -O ${tmp} ${shellQuote(source.url)}; fi`;
   return [
     `mkdir -p ${shellQuote(dirname(CMUX_TUI_BINARY_PATH))}`,
     `if [ -x ${bin} ] && ${pinned(bin)}; then :; else ` +
-      `curl -fsSL --retry 3 --retry-delay 2 -o ${tmp} ${shellQuote(source.url)} && ${pinned(tmp)} && chmod 755 ${tmp} && mv -f ${tmp} ${bin}; fi`,
+      `${fetch} && ${pinned(tmp)} && chmod 755 ${tmp} && mv -f ${tmp} ${bin}; fi`,
     `ln -sfn ${bin} /usr/local/bin/cmux-tui`,
     `${bin} --version`,
   ].join(" && ");
@@ -602,7 +608,11 @@ export class BlaxelProvider implements VMProvider {
 
   /** Create-time bootstrap for cmux-tui deployments: the watcher, hostname/VNC chain and provisioning as before, cmux-tui instead of cmuxd-remote. */
   private async bootstrapCmuxTuiOnly(name: string, sandboxUrl: string): Promise<void> {
-    await blaxelFetch("PUT", `${sandboxUrl}/filesystem/${SMART_SLEEP_PATH}`, { content: SMART_SLEEP_SCRIPT, permissions: "0755" });
+    // A just-created sandbox answers 404 ("VM not found") on its API for a few
+    // seconds. The cmuxd path never noticed because encoding the Go binary took
+    // that long; here the first write is the readiness probe and retries instead.
+    await this.awaitSandboxApi(name, sandboxUrl, () =>
+      blaxelFetch("PUT", `${sandboxUrl}/filesystem/${SMART_SLEEP_PATH}`, { content: SMART_SLEEP_SCRIPT, permissions: "0755" }));
     const prep = await this.sandboxExec(sandboxUrl, `chmod 755 ${SMART_SLEEP_PATH} && mkdir -p /tmp/cmux && chmod 700 /tmp/cmux`);
     if (prep.exitCode !== 0) {
       throw new ProviderError("blaxel", `machine prep in ${name} failed: ${prep.stderr || prep.stdout}`);
@@ -620,6 +630,22 @@ export class BlaxelProvider implements VMProvider {
         waitForCompletion: false,
       }).catch(() => undefined),
     ]);
+  }
+
+  private async awaitSandboxApi<T>(name: string, sandboxUrl: string, call: () => Promise<T>): Promise<T> {
+    const deadline = Date.now() + 60_000;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        return await call();
+      } catch (err) {
+        const notReady = err instanceof ProviderError && /-> 404|VM not found|-> 503/i.test(err.message);
+        if (!notReady) throw err;
+        lastError = err;
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+    }
+    throw new ProviderError("blaxel", `sandbox API for ${name} did not become reachable`, lastError);
   }
 
   /** Installs (or re-verifies) the pinned binary and starts the daemon. No-op when the deployment has not opted in. */

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -86,12 +86,11 @@ INTERVAL=\${CMUX_SMART_SLEEP_INTERVAL:-15}
 idle=0
 while true; do
   busy=""
-  cm=$(pidof cmuxd-remote 2>/dev/null | awk '{print $1}')
-  if [ -n "$cm" ]; then
+  for cm in $(pidof cmuxd-remote cmux-tui 2>/dev/null); do
     for c in $(pgrep -P "$cm" 2>/dev/null); do
-      if pgrep -P "$c" >/dev/null 2>&1; then busy=jobs; break; fi
+      if pgrep -P "$c" >/dev/null 2>&1; then busy=jobs; break 2; fi
     done
-  fi
+  done
   if [ -z "$busy" ]; then
     if awk -v port="$PORT_HEX" -v tui="$TUI_PORT_HEX" '($2 ~ ":"port"$" || $2 ~ ":"tui"$") && $4 == "01" { found=1 } END { exit !found }' /proc/net/tcp /proc/net/tcp6 2>/dev/null; then
       busy=conn
@@ -539,6 +538,14 @@ export class BlaxelProvider implements VMProvider {
   }
 
   private async bootstrapDaemon(name: string, sandboxUrl: string): Promise<void> {
+    // With a cmux-tui pin configured, cmux-tui is the machine's only session daemon:
+    // cmuxd-remote is neither installed nor started (the legacy websocket attach can
+    // still self-heal it on demand through ensureDaemonRunning for machines that need
+    // it). Exec, ports, stats and the desktop never depended on cmuxd.
+    if (resolveCmuxTuiSource()) {
+      await this.bootstrapCmuxTuiOnly(name, sandboxUrl);
+      return;
+    }
     const b64 = await timedStep("daemon_binary_encode", () => daemonBinaryBase64Gzip());
     // Both filesystem writes are independent; the install exec below is the barrier
     // that needs them on disk.
@@ -592,6 +599,28 @@ export class BlaxelProvider implements VMProvider {
   }
 
   // MARK: cmux-tui remote daemon
+
+  /** Create-time bootstrap for cmux-tui deployments: the watcher, hostname/VNC chain and provisioning as before, cmux-tui instead of cmuxd-remote. */
+  private async bootstrapCmuxTuiOnly(name: string, sandboxUrl: string): Promise<void> {
+    await blaxelFetch("PUT", `${sandboxUrl}/filesystem/${SMART_SLEEP_PATH}`, { content: SMART_SLEEP_SCRIPT, permissions: "0755" });
+    const prep = await this.sandboxExec(sandboxUrl, `chmod 755 ${SMART_SLEEP_PATH} && mkdir -p /tmp/cmux && chmod 700 /tmp/cmux`);
+    if (prep.exitCode !== 0) {
+      throw new ProviderError("blaxel", `machine prep in ${name} failed: ${prep.stderr || prep.stdout}`);
+    }
+    await Promise.all([
+      timedStep("cmux_tui_bootstrap", () => this.bootstrapCmuxTui(name, sandboxUrl)),
+      timedStep("watcher_start", () => this.startWatcherProcess(sandboxUrl)),
+      (async () => {
+        await timedStep("hostname_setup", () => this.sandboxExec(sandboxUrl, hostnameSetupCommand(name)).catch(() => undefined));
+        await timedStep("vnc_heal_start", () => this.startDesktopVncHeal(sandboxUrl));
+      })(),
+      blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
+        name: "cmux-provision",
+        command: CMUX_PROVISION_COMMAND,
+        waitForCompletion: false,
+      }).catch(() => undefined),
+    ]);
+  }
 
   /** Installs (or re-verifies) the pinned binary and starts the daemon. No-op when the deployment has not opted in. */
   private async bootstrapCmuxTui(name: string, sandboxUrl: string): Promise<boolean> {

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -342,25 +342,89 @@ function daemonBinaryBase64Gzip(): Promise<string> {
 // cache empty here; create() surfaces the real configuration error to the caller.
 void daemonBinaryBase64Gzip().catch(() => undefined);
 
-export type CmuxTuiSource = { url: string; sha256: string };
+export type CmuxTuiSource = { url: string; sha256: string; commit: string; builtAt: string | null };
 
-// Phase 1 is opt-in per deployment: no CMUX_VM_BLAXEL_TUI_URL means no cmux-tui daemon
-// and no behavior change. Like the Go daemon, a remote fetch is integrity-pinned and
-// fails closed without its sha256 — the VM verifies the pin itself before installing.
-export function resolveCmuxTuiSource(): CmuxTuiSource | null {
-  const url = env("CMUX_VM_BLAXEL_TUI_URL");
-  if (!url) return null;
-  const sha256 = env("CMUX_VM_BLAXEL_TUI_SHA256")?.toLowerCase();
-  if (!sha256 || !/^[0-9a-f]{64}$/.test(sha256)) {
-    throw new ProviderError(
-      "blaxel",
-      "CMUX_VM_BLAXEL_TUI_SHA256 must be 64 hex characters (sha256 of the raw cmux-tui binary) when CMUX_VM_BLAXEL_TUI_URL is set",
-    );
-  }
+export const CMUX_TUI_LINUX_TARGET = "cmux-tui-x86_64-unknown-linux-musl";
+export const CMUX_TUI_DEFAULT_MANIFEST_URL = "https://files.cmux.com/cmux-tui/latest/manifest.json";
+const CMUX_TUI_MANIFEST_CACHE_MS = 5 * 60 * 1000;
+
+/**
+ * cmux-tui is the machine session daemon by default. CMUX_VM_CMUX_TUI_ENABLED=0 is the
+ * kill switch (machines fall back to cmuxd-remote); CMUX_VM_CMUX_TUI_MANIFEST_URL pins a
+ * deployment to one commit's manifest (`https://files.cmux.com/cmux-tui/<commit>/manifest.json`)
+ * instead of the rolling `latest`. Nothing else is configured by hand: the build and its
+ * sha256 come from the manifest the artifacts workflow publishes.
+ */
+export function isCmuxTuiEnabled(): boolean {
+  const raw = env("CMUX_VM_CMUX_TUI_ENABLED");
+  if (raw === undefined || raw === "") return true;
+  return !/^(0|false|no|off)$/i.test(raw);
+}
+
+export function cmuxTuiManifestUrl(): string {
+  const url = env("CMUX_VM_CMUX_TUI_MANIFEST_URL") || CMUX_TUI_DEFAULT_MANIFEST_URL;
   if (!/^https:\/\//.test(url)) {
-    throw new ProviderError("blaxel", "CMUX_VM_BLAXEL_TUI_URL must be an https:// URL");
+    throw new ProviderError("blaxel", "CMUX_VM_CMUX_TUI_MANIFEST_URL must be an https:// URL");
   }
-  return { url, sha256 };
+  return url;
+}
+
+/** Parses an artifacts manifest into the Linux source; the binary URL is a sibling of the manifest. */
+export function parseCmuxTuiManifest(manifestUrl: string, manifest: unknown): CmuxTuiSource {
+  const record = manifest && typeof manifest === "object" ? manifest as Record<string, unknown> : {};
+  const commit = typeof record.commit === "string" ? record.commit : "";
+  const binaries = record.binaries && typeof record.binaries === "object" ? record.binaries as Record<string, unknown> : {};
+  const sha256 = typeof binaries[CMUX_TUI_LINUX_TARGET] === "string" ? (binaries[CMUX_TUI_LINUX_TARGET] as string).toLowerCase() : "";
+  if (!/^[0-9a-f]{40}$/.test(commit)) {
+    throw new ProviderError("blaxel", `cmux-tui manifest at ${manifestUrl} has no commit`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(sha256)) {
+    throw new ProviderError("blaxel", `cmux-tui manifest at ${manifestUrl} has no ${CMUX_TUI_LINUX_TARGET} sha256 — publish artifacts from a main with the musl target`);
+  }
+  const base = manifestUrl.replace(/\/manifest\.json$/, "");
+  return {
+    url: `${base}/${CMUX_TUI_LINUX_TARGET}`,
+    sha256,
+    commit,
+    builtAt: typeof record.builtAt === "string" ? record.builtAt : null,
+  };
+}
+
+let cmuxTuiSourceCache: { url: string; fetchedAt: number; source: CmuxTuiSource } | null = null;
+
+/** The Linux daemon build to install, from the manifest (cached 5 min per manifest URL). Null when disabled. */
+export async function resolveCmuxTuiSource(): Promise<CmuxTuiSource | null> {
+  if (!isCmuxTuiEnabled()) return null;
+  const manifestUrl = cmuxTuiManifestUrl();
+  if (cmuxTuiSourceCache && cmuxTuiSourceCache.url === manifestUrl && Date.now() - cmuxTuiSourceCache.fetchedAt < CMUX_TUI_MANIFEST_CACHE_MS) {
+    return cmuxTuiSourceCache.source;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 20_000);
+  let manifest: unknown;
+  try {
+    const response = await fetch(manifestUrl, { signal: controller.signal, cache: "no-store" });
+    if (!response.ok) {
+      throw new ProviderError("blaxel", `cmux-tui manifest fetch ${manifestUrl} -> ${response.status}`);
+    }
+    manifest = await response.json();
+  } catch (err) {
+    if (cmuxTuiSourceCache?.url === manifestUrl) {
+      // A transient manifest outage must not break creates: reuse the last good build.
+      return cmuxTuiSourceCache.source;
+    }
+    throw err instanceof ProviderError ? err : new ProviderError("blaxel", `cmux-tui manifest fetch ${manifestUrl} failed`, err);
+  } finally {
+    clearTimeout(timer);
+  }
+  const source = parseCmuxTuiManifest(manifestUrl, manifest);
+  cmuxTuiSourceCache = { url: manifestUrl, fetchedAt: Date.now(), source };
+  return source;
+}
+
+/** Test hook. */
+export function resetCmuxTuiSourceCache(): void {
+  cmuxTuiSourceCache = null;
 }
 
 /**
@@ -419,6 +483,7 @@ export function parseEnrollmentInvitationUri(uri: string): { id: string; expires
 }
 
 const ENROLLMENT_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
 
 function parseJsonObject(text: string): Record<string, unknown> {
   try {
@@ -548,7 +613,7 @@ export class BlaxelProvider implements VMProvider {
     // cmuxd-remote is neither installed nor started (the legacy websocket attach can
     // still self-heal it on demand through ensureDaemonRunning for machines that need
     // it). Exec, ports, stats and the desktop never depended on cmuxd.
-    if (resolveCmuxTuiSource()) {
+    if (isCmuxTuiEnabled()) {
       await this.bootstrapCmuxTuiOnly(name, sandboxUrl);
       return;
     }
@@ -650,7 +715,7 @@ export class BlaxelProvider implements VMProvider {
 
   /** Installs (or re-verifies) the pinned binary and starts the daemon. No-op when the deployment has not opted in. */
   private async bootstrapCmuxTui(name: string, sandboxUrl: string): Promise<boolean> {
-    const source = resolveCmuxTuiSource();
+    const source = await resolveCmuxTuiSource();
     if (!source) return false;
     const install = await this.sandboxExec(sandboxUrl, cmuxTuiInstallCommand(source), CMUX_TUI_INSTALL_TIMEOUT_MS);
     if (install.exitCode !== 0) {
@@ -689,20 +754,39 @@ export class BlaxelProvider implements VMProvider {
     return this.sandboxExec(sandboxUrl, `env HOME=/root ${CMUX_TUI_BINARY_PATH} ${args}`, timeoutMs);
   }
 
+  /** The installed daemon's build identity and remote protocol, so clients can name a mismatch instead of hanging. */
+  private async cmuxTuiDaemonBuild(sandboxUrl: string): Promise<CmuxRemoteEndpoint["daemonBuild"] | null> {
+    const probe = await this.cmuxTuiExec(sandboxUrl, "remote-probe --json").catch(() => null);
+    if (!probe || probe.exitCode !== 0) return null;
+    const record = parseJsonObject(probe.stdout);
+    const commit = typeof record.build_identity === "string" ? record.build_identity : null;
+    const remoteProtocol = typeof record.remote_protocol === "number" ? record.remote_protocol : null;
+    const version = typeof record.version === "string" ? record.version : null;
+    if (!commit && remoteProtocol === null) return null;
+    return { commit, remoteProtocol, version };
+  }
+
   private async ensureCmuxTuiRunning(vmId: string, sandboxUrl: string): Promise<void> {
-    const source = resolveCmuxTuiSource();
-    if (!source) {
+    if (!isCmuxTuiEnabled()) {
       throw new ProviderError(
         "blaxel",
-        "the cmux-tui remote daemon is not enabled for this deployment (set CMUX_VM_BLAXEL_TUI_URL and CMUX_VM_BLAXEL_TUI_SHA256)",
+        "the cmux-tui remote daemon is not enabled for this deployment (CMUX_VM_CMUX_TUI_ENABLED=0)",
       );
+    }
+    const source = await resolveCmuxTuiSource();
+    if (!source) {
+      throw new ProviderError("blaxel", "the cmux-tui remote daemon is not enabled for this deployment");
     }
     const proc = await blaxelFetch<BlaxelProcess>("GET", `${sandboxUrl}/process/${CMUX_TUI_PROCESS_NAME}`).catch(() => null);
     if (proc?.status !== "running") {
       // The binary lives on the persistent volume, so a resurrected sandbox usually only
       // needs the process started; a pin change or a fresh volume re-runs the install.
-      const installed = await this.sandboxExec(sandboxUrl, `test -x ${shellQuote(CMUX_TUI_BINARY_PATH)}`).catch(() => null);
+      const installed = await this.sandboxExec(
+        sandboxUrl,
+        `test -x ${shellQuote(CMUX_TUI_BINARY_PATH)} && printf '%s  %s\n' ${shellQuote(source.sha256)} ${shellQuote(CMUX_TUI_BINARY_PATH)} | sha256sum -c -s`,
+      ).catch(() => null);
       if (installed?.exitCode !== 0) {
+        // Missing, or a different build than the manifest now pins: (re)install.
         await this.bootstrapCmuxTui(vmId, sandboxUrl);
       } else {
         await this.startCmuxTuiProcess(sandboxUrl);
@@ -776,12 +860,14 @@ export class BlaxelProvider implements VMProvider {
             invitation = { uri, invitationId: parsed.id, expiresAtUnix: parsed.expiresAtUnix };
           }
           span.setAttribute("cmux.vm.cmux_remote.invited", !enrolled);
+          const daemonBuild = await this.cmuxTuiDaemonBuild(sandboxUrl);
           return {
             transport: "cmux-remote",
             route,
             token,
             expiresAtUnix,
             session: CMUX_TUI_SESSION,
+            ...(daemonBuild ? { daemonBuild } : {}),
             ...(invitation ? { invitation } : {}),
           };
         } catch (err) {
@@ -1601,7 +1687,7 @@ function sandboxPorts(): Array<{ name: string; protocol: "HTTP"; target: number 
   const ports: Array<{ name: string; protocol: "HTTP"; target: number }> = [
     { name: CMUXD_PREVIEW_NAME, protocol: "HTTP", target: CMUXD_WS_PORT },
   ];
-  if (resolveCmuxTuiSource()) {
+  if (isCmuxTuiEnabled()) {
     ports.push({ name: CMUX_TUI_PREVIEW_NAME, protocol: "HTTP", target: CMUX_TUI_PORT });
   }
   return ports;

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 
 const gzipAsync = promisify(gzip);
 import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import {
   NotImplementedError,
@@ -18,6 +19,9 @@ import {
   type VMProvider,
   type VMStats,
   type VMStatus,
+  type CmuxRemoteApprovalResult,
+  type CmuxRemoteAttachOptions,
+  type CmuxRemoteEndpoint,
 } from "./types";
 import { withVmSpan } from "../telemetry";
 import {
@@ -56,6 +60,18 @@ const CMUXD_BINARY_PATH = "/usr/local/bin/cmuxd-remote";
 const CMUXD_PROCESS_NAME = "cmuxd-ws";
 const SMART_SLEEP_PATH = "/usr/local/bin/cmux-smart-sleep";
 const SMART_SLEEP_PROCESS_NAME = "cmux-keepalive";
+// cmux-tui remote daemon (Phase 1 of the cmuxd-remote → cmux-tui migration,
+// docs/cloud-cmux-tui-daemon.md): runs alongside cmuxd-remote on its own port with
+// its own private preview. The binary lives on the persistent home volume so a
+// resurrected sandbox reuses it; daemon identity and enrolled devices live under
+// /root too (the daemon's default state dir), so they survive as well.
+const CMUX_TUI_PORT = 1337;
+const CMUX_TUI_PREVIEW_NAME = "cmuxtui";
+const CMUX_TUI_SESSION = "cloud";
+const CMUX_TUI_BINARY_PATH = "/root/.cmux/bin/cmux-tui";
+const CMUX_TUI_PROCESS_NAME = "cmux-tui-daemon";
+const CMUX_TUI_INVITATION_TTL_SECONDS = 5 * 60;
+const CMUX_TUI_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
 // Blaxel keeps a sandbox awake while any keepAlive process runs and freezes it ~15 s after the
 // last connection otherwise. The watcher is that keepAlive process: it stays alive while any
 // PTY shell has a foreground/background job (cmuxd child with descendants) or any client is
@@ -63,7 +79,8 @@ const SMART_SLEEP_PROCESS_NAME = "cmux-keepalive";
 // ($0, memory snapshot, ~25 ms wake). Every attach re-arms it, so "wake" is just reconnecting.
 const SMART_SLEEP_SCRIPT = `#!/bin/sh
 # cmux smart sleep: hold the sandbox awake while work is running or a client is attached.
-PORT_HEX=1E61 # 7777
+PORT_HEX=1E61 # 7777 (cmuxd-remote)
+TUI_PORT_HEX=0539 # 1337 (cmux-tui remote daemon)
 IDLE_LIMIT=\${CMUX_SMART_SLEEP_IDLE_CHECKS:-8}
 INTERVAL=\${CMUX_SMART_SLEEP_INTERVAL:-15}
 idle=0
@@ -76,7 +93,7 @@ while true; do
     done
   fi
   if [ -z "$busy" ]; then
-    if awk -v port="$PORT_HEX" '$2 ~ ":"port"$" && $4 == "01" { found=1 } END { exit !found }' /proc/net/tcp /proc/net/tcp6 2>/dev/null; then
+    if awk -v port="$PORT_HEX" -v tui="$TUI_PORT_HEX" '($2 ~ ":"port"$" || $2 ~ ":"tui"$") && $4 == "01" { found=1 } END { exit !found }' /proc/net/tcp /proc/net/tcp6 2>/dev/null; then
       busy=conn
     fi
   fi
@@ -326,6 +343,98 @@ function daemonBinaryBase64Gzip(): Promise<string> {
 // cache empty here; create() surfaces the real configuration error to the caller.
 void daemonBinaryBase64Gzip().catch(() => undefined);
 
+export type CmuxTuiSource = { url: string; sha256: string };
+
+// Phase 1 is opt-in per deployment: no CMUX_VM_BLAXEL_TUI_URL means no cmux-tui daemon
+// and no behavior change. Like the Go daemon, a remote fetch is integrity-pinned and
+// fails closed without its sha256 — the VM verifies the pin itself before installing.
+export function resolveCmuxTuiSource(): CmuxTuiSource | null {
+  const url = env("CMUX_VM_BLAXEL_TUI_URL");
+  if (!url) return null;
+  const sha256 = env("CMUX_VM_BLAXEL_TUI_SHA256")?.toLowerCase();
+  if (!sha256 || !/^[0-9a-f]{64}$/.test(sha256)) {
+    throw new ProviderError(
+      "blaxel",
+      "CMUX_VM_BLAXEL_TUI_SHA256 must be 64 hex characters (sha256 of the raw cmux-tui binary) when CMUX_VM_BLAXEL_TUI_URL is set",
+    );
+  }
+  if (!/^https:\/\//.test(url)) {
+    throw new ProviderError("blaxel", "CMUX_VM_BLAXEL_TUI_URL must be an https:// URL");
+  }
+  return { url, sha256 };
+}
+
+/**
+ * Installs the pinned cmux-tui binary onto the persistent home volume, skipping the
+ * download when the installed copy already matches the pin. The VM fetches the ~50 MB
+ * static musl binary itself (in-region, seconds) instead of the driver pushing a
+ * ~30 MB base64 payload through the sandbox API on every cold create.
+ */
+export function cmuxTuiInstallCommand(source: CmuxTuiSource): string {
+  const bin = shellQuote(CMUX_TUI_BINARY_PATH);
+  const tmp = shellQuote(`${CMUX_TUI_BINARY_PATH}.tmp`);
+  const pinned = (path: string) => `printf '%s  %s\n' ${shellQuote(source.sha256)} ${path} | sha256sum -c -s`;
+  return [
+    `mkdir -p ${shellQuote(dirname(CMUX_TUI_BINARY_PATH))}`,
+    `if [ -x ${bin} ] && ${pinned(bin)}; then :; else ` +
+      `curl -fsSL --retry 3 --retry-delay 2 -o ${tmp} ${shellQuote(source.url)} && ${pinned(tmp)} && chmod 755 ${tmp} && mv -f ${tmp} ${bin}; fi`,
+    `ln -sfn ${bin} /usr/local/bin/cmux-tui`,
+    `${bin} --version`,
+  ].join(" && ");
+}
+
+/** The daemon command the sandbox supervisor runs. Launch cwd = /root so new terminals open in the persistent home. */
+export function cmuxTuiDaemonCommand(): string {
+  return `cd /root && env HOME=/root TERM=xterm-256color ${CMUX_TUI_BINARY_PATH} server start --session ${CMUX_TUI_SESSION} --remote-ws 0.0.0.0:${CMUX_TUI_PORT} --remote-ws-insecure-bind`;
+}
+
+/** Enrollment invitations are `cmux://enroll/<base64url JSON>`; the id and expiry inside are what the approve flow needs. */
+export function parseEnrollmentInvitationUri(uri: string): { id: string; expiresAtUnix: number; daemonFingerprint: string | null } {
+  const prefix = "cmux://enroll/";
+  if (!uri.startsWith(prefix)) {
+    throw new ProviderError("blaxel", "cmux-tui returned an invitation with an unexpected scheme");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(uri.slice(prefix.length), "base64url").toString("utf8"));
+  } catch (err) {
+    throw new ProviderError("blaxel", "cmux-tui returned an undecodable invitation", err);
+  }
+  const record = parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  const id = typeof record.id === "string" ? record.id : "";
+  const expiresAtUnix = typeof record.expires_at_unix === "number" ? record.expires_at_unix : 0;
+  if (!id || !expiresAtUnix) {
+    throw new ProviderError("blaxel", "cmux-tui returned an invitation without an id or expiry");
+  }
+  return {
+    id,
+    expiresAtUnix,
+    daemonFingerprint: typeof record.daemon_fingerprint === "string" ? record.daemon_fingerprint : null,
+  };
+}
+
+const ENROLLMENT_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
+function parseJsonObject(text: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(text.trim());
+    return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseJsonArray(text: string): Array<Record<string, unknown>> {
+  try {
+    const value = JSON.parse(text.trim());
+    return Array.isArray(value)
+      ? value.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === "object")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 export class BlaxelProvider implements VMProvider {
   readonly id = "blaxel" as const;
 
@@ -363,7 +472,7 @@ export class BlaxelProvider implements VMProvider {
                     image,
                     memory: memoryMb,
                     envs: [{ name: "LANG", value: "C.UTF-8" }],
-                    ports: [{ name: CMUXD_PREVIEW_NAME, protocol: "HTTP", target: CMUXD_WS_PORT }],
+                    ports: sandboxPorts(),
                   },
                   ...(homeVolume ? { volumes: [{ name: homeVolume, mountPath: HOME_VOLUME_MOUNT_PATH }] } : {}),
                 },
@@ -473,7 +582,205 @@ export class BlaxelProvider implements VMProvider {
         command: CMUX_PROVISION_COMMAND,
         waitForCompletion: false,
       }).catch(() => undefined),
+      // Phase 1: the cmux-tui daemon is best-effort at create so a bad pin or a slow
+      // download can never fail a machine; openCmuxRemote makes it deterministic when
+      // the transport is actually used.
+      timedStep("cmux_tui_bootstrap", () => this.bootstrapCmuxTui(name, sandboxUrl)).catch((err) => {
+        console.error(`[blaxel] cmux-tui daemon bootstrap in ${name} failed (attach will retry)`, err);
+      }),
     ]);
+  }
+
+  // MARK: cmux-tui remote daemon
+
+  /** Installs (or re-verifies) the pinned binary and starts the daemon. No-op when the deployment has not opted in. */
+  private async bootstrapCmuxTui(name: string, sandboxUrl: string): Promise<boolean> {
+    const source = resolveCmuxTuiSource();
+    if (!source) return false;
+    const install = await this.sandboxExec(sandboxUrl, cmuxTuiInstallCommand(source), CMUX_TUI_INSTALL_TIMEOUT_MS);
+    if (install.exitCode !== 0) {
+      throw new ProviderError("blaxel", `cmux-tui install in ${name} failed: ${install.stderr || install.stdout}`);
+    }
+    await this.startCmuxTuiProcess(sandboxUrl);
+    await this.waitForCmuxTuiReady(name, sandboxUrl);
+    return true;
+  }
+
+  private async startCmuxTuiProcess(sandboxUrl: string): Promise<void> {
+    await blaxelFetch<BlaxelProcess>("POST", `${sandboxUrl}/process`, {
+      name: CMUX_TUI_PROCESS_NAME,
+      command: cmuxTuiDaemonCommand(),
+      waitForCompletion: false,
+      // Not keepAlive: the smart-sleep watcher counts connections on the daemon's port,
+      // so an idle machine still drops to standby.
+      keepAlive: false,
+      restartOnFailure: true,
+      maxRestarts: 10,
+    });
+  }
+
+  private async waitForCmuxTuiReady(name: string, sandboxUrl: string): Promise<void> {
+    let last = "";
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      const status = await this.cmuxTuiExec(sandboxUrl, `server status --session ${CMUX_TUI_SESSION}`).catch(() => null);
+      if (status?.exitCode === 0) return;
+      last = status ? (status.stderr || status.stdout) : "status probe failed";
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    throw new ProviderError("blaxel", `cmux-tui daemon in ${name} did not become ready: ${last}`);
+  }
+
+  private cmuxTuiExec(sandboxUrl: string, args: string, timeoutMs = EXEC_DEFAULT_TIMEOUT_MS): Promise<ExecResult> {
+    return this.sandboxExec(sandboxUrl, `env HOME=/root ${CMUX_TUI_BINARY_PATH} ${args}`, timeoutMs);
+  }
+
+  private async ensureCmuxTuiRunning(vmId: string, sandboxUrl: string): Promise<void> {
+    const source = resolveCmuxTuiSource();
+    if (!source) {
+      throw new ProviderError(
+        "blaxel",
+        "the cmux-tui remote daemon is not enabled for this deployment (set CMUX_VM_BLAXEL_TUI_URL and CMUX_VM_BLAXEL_TUI_SHA256)",
+      );
+    }
+    const proc = await blaxelFetch<BlaxelProcess>("GET", `${sandboxUrl}/process/${CMUX_TUI_PROCESS_NAME}`).catch(() => null);
+    if (proc?.status !== "running") {
+      // The binary lives on the persistent volume, so a resurrected sandbox usually only
+      // needs the process started; a pin change or a fresh volume re-runs the install.
+      const installed = await this.sandboxExec(sandboxUrl, `test -x ${shellQuote(CMUX_TUI_BINARY_PATH)}`).catch(() => null);
+      if (installed?.exitCode !== 0) {
+        await this.bootstrapCmuxTui(vmId, sandboxUrl);
+      } else {
+        await this.startCmuxTuiProcess(sandboxUrl);
+        await this.waitForCmuxTuiReady(vmId, sandboxUrl);
+      }
+    }
+    const watcher = await blaxelFetch<BlaxelProcess>("GET", `${sandboxUrl}/process/${SMART_SLEEP_PROCESS_NAME}`).catch(() => null);
+    if (watcher?.status !== "running") {
+      await this.startWatcherProcess(sandboxUrl);
+    }
+  }
+
+  /** Same wake/resurrect dance as the PTY attach: a status read wakes standby, a dead sandbox with a home volume is recreated. */
+  private async liveSandboxForAttach(vmId: string, providerMetadata?: Record<string, unknown>): Promise<BlaxelSandbox> {
+    let sandbox: BlaxelSandbox | null = null;
+    try {
+      const fetched = await this.getSandbox(vmId);
+      sandbox = mapStatus(fetched) === "destroyed" ? null : fetched;
+    } catch (err) {
+      const gone = err instanceof ProviderError && /-> 404/.test(err.message);
+      if (!gone) throw err;
+    }
+    if (!sandbox) {
+      sandbox = providerMetadata ? await this.resurrectSandbox(vmId, providerMetadata) : null;
+      if (!sandbox) {
+        throw new ProviderError("blaxel", `sandbox ${vmId} is gone and has no persistent home to resurrect from`);
+      }
+    }
+    return sandbox;
+  }
+
+  async openCmuxRemote(vmId: string, options?: CmuxRemoteAttachOptions): Promise<CmuxRemoteEndpoint> {
+    return withVmSpan(
+      "cmux.vm.provider.open_cmux_remote",
+      { "cmux.vm.provider": "blaxel", "cmux.vm.operation": "open_cmux_remote", "cmux.vm.id": vmId },
+      async (span) => {
+        try {
+          const sandbox = await this.liveSandboxForAttach(vmId, options?.providerMetadata);
+          const sandboxUrl = sandbox.metadata?.url;
+          if (!sandboxUrl) {
+            throw new Error("sandbox is missing metadata.url");
+          }
+          await this.ensureCmuxTuiRunning(vmId, sandboxUrl);
+          const previewUrl = await this.ensurePreview(vmId, CMUX_TUI_PREVIEW_NAME, CMUX_TUI_PORT, { branded: false });
+          const token = await this.mintPreviewToken(vmId, CMUX_TUI_PREVIEW_NAME);
+          const expiresAtUnix = Math.floor(Date.now() / 1000) + PREVIEW_TOKEN_TTL_SECONDS;
+          const host = previewUrl.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+          // The gateway accepts the preview token as a query parameter and the Rust dialer
+          // passes the URL through verbatim, so the tokenized route is the whole story
+          // (proven by scripts/spike-cmux-tui-blaxel.sh). It travels only in this response,
+          // never inside an invitation.
+          const route = `wss://${host}/v1/link?bl_preview_token=${encodeURIComponent(token)}`;
+
+          let invitation: CmuxRemoteEndpoint["invitation"];
+          const enrolled = options?.deviceFingerprint
+            ? await this.isDeviceEnrolled(sandboxUrl, options.deviceFingerprint)
+            : false;
+          if (!enrolled) {
+            const created = await this.cmuxTuiExec(
+              sandboxUrl,
+              `remote enroll create --session ${CMUX_TUI_SESSION} --ttl ${CMUX_TUI_INVITATION_TTL_SECONDS} --json`,
+            );
+            if (created.exitCode !== 0) {
+              throw new ProviderError("blaxel", `cmux-tui enrollment invitation in ${vmId} failed: ${created.stderr || created.stdout}`);
+            }
+            const uri = parseJsonObject(created.stdout).uri;
+            if (typeof uri !== "string" || !uri) {
+              throw new ProviderError("blaxel", `cmux-tui enrollment invitation in ${vmId} returned no uri`);
+            }
+            const parsed = parseEnrollmentInvitationUri(uri);
+            invitation = { uri, invitationId: parsed.id, expiresAtUnix: parsed.expiresAtUnix };
+          }
+          span.setAttribute("cmux.vm.cmux_remote.invited", !enrolled);
+          return {
+            transport: "cmux-remote",
+            route,
+            token,
+            expiresAtUnix,
+            session: CMUX_TUI_SESSION,
+            ...(invitation ? { invitation } : {}),
+          };
+        } catch (err) {
+          throw err instanceof ProviderError ? err : new ProviderError("blaxel", `openCmuxRemote(${vmId}) failed`, err);
+        }
+      },
+    );
+  }
+
+  async approveCmuxRemoteEnrollment(vmId: string, invitationId: string): Promise<CmuxRemoteApprovalResult> {
+    return withVmSpan(
+      "cmux.vm.provider.approve_cmux_remote_enrollment",
+      { "cmux.vm.provider": "blaxel", "cmux.vm.operation": "approve_cmux_remote_enrollment", "cmux.vm.id": vmId },
+      async () => {
+        if (!ENROLLMENT_ID_PATTERN.test(invitationId)) {
+          throw new ProviderError("blaxel", "invitation id has an unexpected shape");
+        }
+        try {
+          const sandboxUrl = await this.sandboxApiUrl(vmId);
+          const pending = await this.cmuxTuiExec(sandboxUrl, `remote enroll pending --session ${CMUX_TUI_SESSION} --json`);
+          if (pending.exitCode !== 0) {
+            throw new ProviderError("blaxel", `cmux-tui pending enrollments in ${vmId} failed: ${pending.stderr || pending.stdout}`);
+          }
+          const entries = parseJsonArray(pending.stdout);
+          const match = entries.find((entry) => entry.invitation_id === invitationId);
+          if (!match) {
+            // The client has not claimed the invitation yet (or it expired); the caller polls.
+            return { approved: false, state: "pending" };
+          }
+          const approved = await this.cmuxTuiExec(
+            sandboxUrl,
+            `remote enroll approve ${shellQuote(invitationId)} --session ${CMUX_TUI_SESSION} --json`,
+          );
+          if (approved.exitCode !== 0) {
+            throw new ProviderError("blaxel", `cmux-tui enrollment approval in ${vmId} failed: ${approved.stderr || approved.stdout}`);
+          }
+          const device = parseJsonObject(approved.stdout);
+          const fingerprint = typeof device.fingerprint === "string"
+            ? device.fingerprint
+            : typeof match.device_fingerprint === "string" ? match.device_fingerprint : undefined;
+          return { approved: true, state: "approved", ...(fingerprint ? { deviceFingerprint: fingerprint } : {}) };
+        } catch (err) {
+          throw err instanceof ProviderError ? err : new ProviderError("blaxel", `approveCmuxRemoteEnrollment(${vmId}) failed`, err);
+        }
+      },
+    );
+  }
+
+  private async isDeviceEnrolled(sandboxUrl: string, fingerprint: string): Promise<boolean> {
+    const devices = await this.cmuxTuiExec(sandboxUrl, `remote enroll devices --session ${CMUX_TUI_SESSION} --json`).catch(() => null);
+    if (!devices || devices.exitCode !== 0) return false;
+    return parseJsonArray(devices.stdout).some((device) =>
+      device.fingerprint === fingerprint && (device.revoked_at_unix === null || device.revoked_at_unix === undefined)
+    );
   }
 
   // The daemon itself is NOT keepAlive: while every shell is idle and no client is attached,
@@ -742,6 +1049,7 @@ export class BlaxelProvider implements VMProvider {
           `pkill -TERM -x ${shellQuote(CMUXD_PROCESS_NAME)} 2>/dev/null || true`,
           `pkill -TERM -x ${shellQuote(SMART_SLEEP_PROCESS_NAME)} 2>/dev/null || true`,
           `pkill -KILL -x ${shellQuote(CMUXD_PROCESS_NAME)} 2>/dev/null || true`,
+          `pkill -TERM -f ${shellQuote(`${CMUX_TUI_BINARY_PATH} server start`)} 2>/dev/null || true`,
         ].join("; "),
         15_000,
       );
@@ -825,7 +1133,7 @@ export class BlaxelProvider implements VMProvider {
           image,
           memory: memoryMb,
           envs: [{ name: "LANG", value: "C.UTF-8" }],
-          ports: [{ name: CMUXD_PREVIEW_NAME, protocol: "HTTP", target: CMUXD_WS_PORT }],
+          ports: sandboxPorts(),
         },
         volumes: [{ name: homeVolume, mountPath: HOME_VOLUME_MOUNT_PATH }],
       },
@@ -927,26 +1235,42 @@ export class BlaxelProvider implements VMProvider {
   // the preview after a failed branded create instead of clobbering it.
   private readonly inflightPreviews = new Map<string, Promise<string>>();
 
-  private ensurePreview(vmId: string, previewName = CMUXD_PREVIEW_NAME, port = CMUXD_WS_PORT): Promise<string> {
+  private ensurePreview(
+    vmId: string,
+    previewName = CMUXD_PREVIEW_NAME,
+    port = CMUXD_WS_PORT,
+    options: { branded?: boolean } = {},
+  ): Promise<string> {
     const key = `${vmId}/${previewName}`;
     const inflight = this.inflightPreviews.get(key);
     if (inflight) return inflight;
-    const task = this.ensurePreviewUncoalesced(vmId, previewName, port).finally(() => {
+    const task = this.ensurePreviewUncoalesced(vmId, previewName, port, options.branded !== false).finally(() => {
       this.inflightPreviews.delete(key);
     });
     this.inflightPreviews.set(key, task);
     return task;
   }
 
-  private async ensurePreviewUncoalesced(vmId: string, previewName: string, port: number): Promise<string> {
+  // `branded: false` keeps the preview on Blaxel's own opaque `<hash>.preview.bl.run` host.
+  // The cmux-tui remote daemon needs this: a WebSocket upgrade carrying the preview token
+  // as a query parameter completes on the raw host (101) but is refused through the
+  // vm.cmux.sh custom domain (400, measured 2026-08-26), and the Rust dialer can only pass
+  // the token in the URL. Browser-facing previews keep the branded, cookie-friendly host.
+  private async ensurePreviewUncoalesced(vmId: string, previewName: string, port: number, branded = true): Promise<string> {
     const base = `${CONTROL_PLANE_BASE}/sandboxes/${encodeURIComponent(vmId)}/previews`;
     const readExisting = () =>
       blaxelFetch<BlaxelPreview>("GET", `${base}/${previewName}`).catch(() => null);
-    const prefixUrl = brandedPreviewPrefix(vmId, previewName, port);
+    const prefixUrl = branded ? brandedPreviewPrefix(vmId, previewName, port) : null;
     const customDomain = prefixUrl ? await verifiedCustomDomain() : null;
     const existing = await readExisting();
     const existingUrl = usablePrivatePreviewUrl(existing);
-    if (existingUrl) {
+    if (existingUrl && !branded) {
+      // An unbranded preview must not carry a prefix or custom domain; rotate one that does.
+      const spec = existing?.spec ?? {};
+      const isBranded = !!(spec.prefixUrl?.trim() || spec.customDomain?.trim());
+      if (!isBranded) return existingUrl;
+      await blaxelFetch("DELETE", `${base}/${previewName}`).catch(() => undefined);
+    } else if (existingUrl) {
       const existingCustomDomain = existing?.spec?.customDomain?.trim().toLowerCase();
       const existingHost = (() => {
         try {
@@ -1217,6 +1541,16 @@ const NAME_ANIMALS = [
   "newt", "orca", "osprey", "otter", "owl", "panda", "petrel", "puffin",
   "raven", "seal", "sparrow", "stoat", "swan", "tern", "wombat", "wren",
 ];
+
+function sandboxPorts(): Array<{ name: string; protocol: "HTTP"; target: number }> {
+  const ports: Array<{ name: string; protocol: "HTTP"; target: number }> = [
+    { name: CMUXD_PREVIEW_NAME, protocol: "HTTP", target: CMUXD_WS_PORT },
+  ];
+  if (resolveCmuxTuiSource()) {
+    ports.push({ name: CMUX_TUI_PREVIEW_NAME, protocol: "HTTP", target: CMUX_TUI_PORT });
+  }
+  return ports;
+}
 
 export function friendlyVmName(withSuffix = false): string {
   const pick = (list: readonly string[]) => list[randomBytes(1)[0] % list.length];

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -108,6 +108,15 @@ export type CmuxRemoteEndpoint = {
   expiresAtUnix: number;
   /** Daemon session name inside the VM (`server start --session`). */
   session: string;
+  /**
+   * The installed daemon's build identity, so a client can compare its own
+   * `remote-probe` and say which side is stale instead of failing opaquely.
+   */
+  daemonBuild?: {
+    commit: string | null;
+    remoteProtocol: number | null;
+    version: string | null;
+  };
   invitation?: {
     /** Single-use `cmux://enroll/...` URI; the client must pass it via `--invite-file`, never argv. */
     uri: string;

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -90,6 +90,50 @@ export type WebSocketPtyEndpoint = {
 
 export type AttachEndpoint = SSHEndpoint | WebSocketPtyEndpoint;
 
+/**
+ * Attach through the cmux-tui remote daemon running in the VM (Phase 1 of the
+ * cmuxd-remote → cmux-tui migration, docs/cloud-cmux-tui-daemon.md). The route
+ * is the provider's tokenized ingress to the daemon's `/v1/link` listener; the
+ * token only gates reachability — session auth is the daemon's Noise device
+ * enrollment. `invitation` is present when the caller's device is not yet
+ * enrolled: the client connects with `remote connect --invite-file`, then asks
+ * the control plane to approve the pending enrollment it minted.
+ */
+export type CmuxRemoteEndpoint = {
+  transport: "cmux-remote";
+  /** `wss://<host>/v1/link?<provider-token>` — carries the ingress token, so it is never embedded in an invitation. */
+  route: string;
+  /** Ingress token (hashed into the lease ledger, never persisted raw). */
+  token: string;
+  expiresAtUnix: number;
+  /** Daemon session name inside the VM (`server start --session`). */
+  session: string;
+  invitation?: {
+    /** Single-use `cmux://enroll/...` URI; the client must pass it via `--invite-file`, never argv. */
+    uri: string;
+    /** Identifier the client returns to the approve endpoint. */
+    invitationId: string;
+    expiresAtUnix: number;
+  };
+};
+
+export type CmuxRemoteAttachOptions = {
+  /**
+   * The caller's cmux-tui device fingerprint, when it already enrolled with this
+   * VM's daemon. Lets the provider skip minting an invitation.
+   */
+  deviceFingerprint?: string;
+  providerMetadata?: Record<string, unknown>;
+};
+
+export type CmuxRemoteApprovalResult = {
+  approved: boolean;
+  /** Fingerprint of the device that claimed the invitation, when approved. */
+  deviceFingerprint?: string;
+  /** `pending` when the client has not connected yet — the caller should retry. */
+  state: "approved" | "pending" | "already_enrolled";
+};
+
 export type AttachOptions = {
   /**
    * Workspace attaches need a cmuxd RPC endpoint so browser panels can proxy remote
@@ -153,6 +197,12 @@ export interface VMProvider {
   // Returns a live attach endpoint the client can dial into. Providers prefer cmuxd-remote
   // WebSocket PTY with a short-lived one-use lease, with provider-specific fallbacks.
   openAttach(vmId: string, options?: AttachOptions): Promise<AttachEndpoint>;
+
+  // Optional: attach through the cmux-tui remote daemon in the VM (see CmuxRemoteEndpoint).
+  // Providers that have not been migrated leave this undefined.
+  openCmuxRemote?(vmId: string, options?: CmuxRemoteAttachOptions): Promise<CmuxRemoteEndpoint>;
+  // Optional: approve the pending enrollment a previous openCmuxRemote invited.
+  approveCmuxRemoteEnrollment?(vmId: string, invitationId: string): Promise<CmuxRemoteApprovalResult>;
 
   // Returns a live SSH endpoint the client can dial into. Drivers are responsible for ensuring
   // sshd is running (some providers need an explicit start step).

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -13,6 +13,9 @@ import {
   type VMHandle,
   type VMStatus,
   type VMStats,
+  type CmuxRemoteApprovalResult,
+  type CmuxRemoteAttachOptions,
+  type CmuxRemoteEndpoint,
 } from "./drivers";
 import { VmProviderOperationError } from "./errors";
 
@@ -49,6 +52,16 @@ export type VmProviderGatewayShape = {
     vmId: string,
     options?: AttachOptions,
   ) => Effect.Effect<AttachEndpoint, VmProviderOperationError>;
+  readonly openCmuxRemote?: (
+    provider: ProviderId,
+    vmId: string,
+    options?: CmuxRemoteAttachOptions,
+  ) => Effect.Effect<CmuxRemoteEndpoint, VmProviderOperationError>;
+  readonly approveCmuxRemoteEnrollment?: (
+    provider: ProviderId,
+    vmId: string,
+    invitationId: string,
+  ) => Effect.Effect<CmuxRemoteApprovalResult, VmProviderOperationError>;
   readonly openSSH: (provider: ProviderId, vmId: string) => Effect.Effect<SSHEndpoint, VmProviderOperationError>;
   readonly revokeSSHIdentity: (
     provider: ProviderId,
@@ -123,6 +136,22 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
     }),
   openAttach: (provider, vmId, options) =>
     providerEffect(provider, "openAttach", () => getProvider(provider).openAttach(vmId, options)),
+  openCmuxRemote: (provider, vmId, options) =>
+    providerEffect(provider, "openCmuxRemote", () => {
+      const impl = getProvider(provider);
+      if (!impl.openCmuxRemote) {
+        throw new Error(`provider ${provider} does not run the cmux-tui remote daemon yet`);
+      }
+      return impl.openCmuxRemote(vmId, options);
+    }),
+  approveCmuxRemoteEnrollment: (provider, vmId, invitationId) =>
+    providerEffect(provider, "approveCmuxRemoteEnrollment", () => {
+      const impl = getProvider(provider);
+      if (!impl.approveCmuxRemoteEnrollment) {
+        throw new Error(`provider ${provider} does not run the cmux-tui remote daemon yet`);
+      }
+      return impl.approveCmuxRemoteEnrollment(vmId, invitationId);
+    }),
   openSSH: (provider, vmId) =>
     providerEffect(provider, "openSSH", () => getProvider(provider).openSSH(vmId)),
   revokeSSHIdentity: (provider, identityHandle) =>

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1580,6 +1580,97 @@ export function openVmPort(input: {
   });
 }
 
+/**
+ * Attach through the cmux-tui remote daemon (Phase 1: opt-in transport beside the
+ * cmuxd-remote PTY/RPC endpoints). The ingress token lands in the same lease ledger
+ * as previews so sign-out revokes it; session auth is the daemon's device
+ * enrollment, which the client completes with approveVmCmuxRemoteEnrollment.
+ */
+export function openVmCmuxRemote(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly teamIds?: readonly string[];
+  readonly providerVmId: string;
+  readonly deviceFingerprint?: string;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* VmRepository;
+    const providers = yield* VmProviderGateway;
+    const vm = yield* requireUserVm(input);
+    yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId, "attach");
+    if (!providers.openCmuxRemote) {
+      return yield* Effect.fail(
+        new VmProviderOperationError({
+          provider: vm.provider,
+          operation: "openCmuxRemote",
+          cause: new Error("the cmux-tui remote daemon is not supported by this deployment"),
+        }),
+      );
+    }
+    const endpoint = yield* withResumeOnSuspendedAfterFailure(
+      repo,
+      providers,
+      vm,
+      input.providerVmId,
+      "attach",
+      providers.openCmuxRemote(vm.provider, input.providerVmId, {
+        deviceFingerprint: input.deviceFingerprint,
+        providerMetadata: vm.providerMetadata,
+      }),
+    );
+    yield* repo.recordLease({
+      vmId: vm.id,
+      userId: input.userId,
+      kind: "preview",
+      tokenHash: hashToken(endpoint.token),
+      expiresAt: new Date(endpoint.expiresAtUnix * 1000),
+      transport: "cmux-remote",
+      metadata: { session: endpoint.session, invited: !!endpoint.invitation },
+    }).pipe(
+      Effect.catchAll((err) => {
+        const cleanup = providers.revokeEndpointLeases
+          ? providers.revokeEndpointLeases(vm.provider, input.providerVmId).pipe(Effect.catchAll(() => Effect.void))
+          : Effect.void;
+        return cleanup.pipe(Effect.andThen(Effect.fail(err)));
+      }),
+    );
+    yield* repo.recordUsageEvent({
+      userId: input.userId,
+      billingTeamId: vm.billingTeamId,
+      billingPlanId: vm.billingPlanId,
+      vmId: vm.id,
+      eventType: "vm.attach",
+      provider: vm.provider,
+      imageId: vm.imageId,
+      metadata: { transport: "cmux-remote", invited: !!endpoint.invitation },
+    }).pipe(Effect.catchAll(() => Effect.void));
+    return endpoint;
+  });
+}
+
+export function approveVmCmuxRemoteEnrollment(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly teamIds?: readonly string[];
+  readonly providerVmId: string;
+  readonly invitationId: string;
+}) {
+  return Effect.gen(function* () {
+    const providers = yield* VmProviderGateway;
+    const vm = yield* requireUserVm(input);
+    if (!providers.approveCmuxRemoteEnrollment) {
+      return yield* Effect.fail(
+        new VmProviderOperationError({
+          provider: vm.provider,
+          operation: "approveCmuxRemoteEnrollment",
+          cause: new Error("the cmux-tui remote daemon is not supported by this deployment"),
+        }),
+      );
+    }
+    return yield* providers.approveCmuxRemoteEnrollment(vm.provider, input.providerVmId, input.invitationId);
+  });
+}
+
 export type VmAccessRevocationResult = {
   readonly revoked: number;
   readonly cleanupFailures: number;

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1592,11 +1592,13 @@ export function openVmCmuxRemote(input: {
   readonly teamIds?: readonly string[];
   readonly providerVmId: string;
   readonly deviceFingerprint?: string;
+  /** Caller's CURRENT billing plan; the free access window applies to cmux-tui attaches too. */
+  readonly callerPlanId?: string | null;
 }) {
   return Effect.gen(function* () {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
-    const vm = yield* requireUserVm(input);
+    const vm = yield* requireAccessibleUserVm(input);
     yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId, "attach");
     if (!providers.openCmuxRemote) {
       return yield* Effect.fail(
@@ -1654,10 +1656,11 @@ export function approveVmCmuxRemoteEnrollment(input: {
   readonly teamIds?: readonly string[];
   readonly providerVmId: string;
   readonly invitationId: string;
+  readonly callerPlanId?: string | null;
 }) {
   return Effect.gen(function* () {
     const providers = yield* VmProviderGateway;
-    const vm = yield* requireUserVm(input);
+    const vm = yield* requireAccessibleUserVm(input);
     if (!providers.approveCmuxRemoteEnrollment) {
       return yield* Effect.fail(
         new VmProviderOperationError({

--- a/web/tests/vm-blaxel-cmux-tui.test.ts
+++ b/web/tests/vm-blaxel-cmux-tui.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, test } from "bun:test";
 import {
   cmuxTuiDaemonCommand,
   cmuxTuiInstallCommand,
+  cmuxTuiManifestUrl,
+  isCmuxTuiEnabled,
+  parseCmuxTuiManifest,
   parseEnrollmentInvitationUri,
-  resolveCmuxTuiSource,
 } from "../services/vms/drivers/blaxel";
 
 const SHA = "c7a3155341a85a2f10a873d69a041bdf1855ec059a802e58e0779a7a6bdec607";
-const URL = "https://files.cmux.com/cmux-tui/5a4780614cecd8e8ef040a24478f928ef31cc4ae/cmux-tui-x86_64-unknown-linux-musl";
+const COMMIT = "5a4780614cecd8e8ef040a24478f928ef31cc4ae";
+const MANIFEST = `https://files.cmux.com/cmux-tui/${COMMIT}/manifest.json`;
+const URL = `https://files.cmux.com/cmux-tui/${COMMIT}/cmux-tui-x86_64-unknown-linux-musl`;
 
 function withEnv(values: Record<string, string | undefined>, run: () => void) {
   const previous: Record<string, string | undefined> = {};
@@ -27,37 +31,40 @@ function withEnv(values: Record<string, string | undefined>, run: () => void) {
 }
 
 describe("cmux-tui daemon source", () => {
-  test("is disabled until a deployment opts in with a URL", () => {
-    withEnv({ CMUX_VM_BLAXEL_TUI_URL: undefined, CMUX_VM_BLAXEL_TUI_SHA256: undefined }, () => {
-      expect(resolveCmuxTuiSource()).toBeNull();
-    });
+  test("is on by default and only CMUX_VM_CMUX_TUI_ENABLED=0 turns it off", () => {
+    withEnv({ CMUX_VM_CMUX_TUI_ENABLED: undefined }, () => expect(isCmuxTuiEnabled()).toBe(true));
+    withEnv({ CMUX_VM_CMUX_TUI_ENABLED: "0" }, () => expect(isCmuxTuiEnabled()).toBe(false));
+    withEnv({ CMUX_VM_CMUX_TUI_ENABLED: "false" }, () => expect(isCmuxTuiEnabled()).toBe(false));
+    withEnv({ CMUX_VM_CMUX_TUI_ENABLED: "1" }, () => expect(isCmuxTuiEnabled()).toBe(true));
   });
 
-  test("a URL without a sha256 pin fails closed", () => {
-    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: undefined }, () => {
-      expect(() => resolveCmuxTuiSource()).toThrow(/CMUX_VM_BLAXEL_TUI_SHA256/);
-    });
-    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: "nope" }, () => {
-      expect(() => resolveCmuxTuiSource()).toThrow(/64 hex/);
-    });
+  test("follows the rolling latest manifest unless a deployment pins one", () => {
+    withEnv({ CMUX_VM_CMUX_TUI_MANIFEST_URL: undefined }, () =>
+      expect(cmuxTuiManifestUrl()).toBe("https://files.cmux.com/cmux-tui/latest/manifest.json"));
+    withEnv({ CMUX_VM_CMUX_TUI_MANIFEST_URL: MANIFEST }, () => expect(cmuxTuiManifestUrl()).toBe(MANIFEST));
+    withEnv({ CMUX_VM_CMUX_TUI_MANIFEST_URL: "http://files.cmux.com/x/manifest.json" }, () =>
+      expect(() => cmuxTuiManifestUrl()).toThrow(/https/));
   });
 
-  test("requires https so the pin is not the only defense", () => {
-    withEnv({ CMUX_VM_BLAXEL_TUI_URL: "http://files.cmux.com/x", CMUX_VM_BLAXEL_TUI_SHA256: SHA }, () => {
-      expect(() => resolveCmuxTuiSource()).toThrow(/https/);
+  test("takes the linux musl build and its sha256 from the manifest", () => {
+    const source = parseCmuxTuiManifest(MANIFEST, {
+      commit: COMMIT,
+      builtAt: "2026-08-19T07:05:35Z",
+      binaries: { "cmux-tui-aarch64-apple-darwin": "a".repeat(64), "cmux-tui-x86_64-unknown-linux-musl": SHA.toUpperCase() },
     });
+    expect(source).toEqual({ url: URL, sha256: SHA, commit: COMMIT, builtAt: "2026-08-19T07:05:35Z" });
   });
 
-  test("resolves a pinned https source, normalizing the pin's case", () => {
-    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: SHA.toUpperCase() }, () => {
-      expect(resolveCmuxTuiSource()).toEqual({ url: URL, sha256: SHA });
-    });
+  test("fails closed on a manifest without a commit or without the musl build", () => {
+    expect(() => parseCmuxTuiManifest(MANIFEST, { binaries: { "cmux-tui-x86_64-unknown-linux-musl": SHA } })).toThrow(/commit/);
+    expect(() => parseCmuxTuiManifest(MANIFEST, { commit: COMMIT, binaries: { "cmux-tui-x86_64-unknown-linux-gnu": SHA } })).toThrow(/musl/);
+    expect(() => parseCmuxTuiManifest(MANIFEST, "nonsense")).toThrow();
   });
 });
 
 describe("cmux-tui install and daemon commands", () => {
   test("installs onto the persistent volume, verifies the pin before and after download, and probes the binary", () => {
-    const command = cmuxTuiInstallCommand({ url: URL, sha256: SHA });
+    const command = cmuxTuiInstallCommand({ url: URL, sha256: SHA, commit: COMMIT, builtAt: null });
     expect(command).toContain("mkdir -p '/root/.cmux/bin'");
     // Skip the download when the installed copy already matches the pin.
     expect(command).toContain(`'${SHA}' '/root/.cmux/bin/cmux-tui' | sha256sum -c -s; then :; else`);

--- a/web/tests/vm-blaxel-cmux-tui.test.ts
+++ b/web/tests/vm-blaxel-cmux-tui.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cmuxTuiDaemonCommand,
+  cmuxTuiInstallCommand,
+  parseEnrollmentInvitationUri,
+  resolveCmuxTuiSource,
+} from "../services/vms/drivers/blaxel";
+
+const SHA = "c7a3155341a85a2f10a873d69a041bdf1855ec059a802e58e0779a7a6bdec607";
+const URL = "https://files.cmux.com/cmux-tui/5a4780614cecd8e8ef040a24478f928ef31cc4ae/cmux-tui-x86_64-unknown-linux-musl";
+
+function withEnv(values: Record<string, string | undefined>, run: () => void) {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(values)) {
+    previous[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe("cmux-tui daemon source", () => {
+  test("is disabled until a deployment opts in with a URL", () => {
+    withEnv({ CMUX_VM_BLAXEL_TUI_URL: undefined, CMUX_VM_BLAXEL_TUI_SHA256: undefined }, () => {
+      expect(resolveCmuxTuiSource()).toBeNull();
+    });
+  });
+
+  test("a URL without a sha256 pin fails closed", () => {
+    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: undefined }, () => {
+      expect(() => resolveCmuxTuiSource()).toThrow(/CMUX_VM_BLAXEL_TUI_SHA256/);
+    });
+    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: "nope" }, () => {
+      expect(() => resolveCmuxTuiSource()).toThrow(/64 hex/);
+    });
+  });
+
+  test("requires https so the pin is not the only defense", () => {
+    withEnv({ CMUX_VM_BLAXEL_TUI_URL: "http://files.cmux.com/x", CMUX_VM_BLAXEL_TUI_SHA256: SHA }, () => {
+      expect(() => resolveCmuxTuiSource()).toThrow(/https/);
+    });
+  });
+
+  test("resolves a pinned https source, normalizing the pin's case", () => {
+    withEnv({ CMUX_VM_BLAXEL_TUI_URL: URL, CMUX_VM_BLAXEL_TUI_SHA256: SHA.toUpperCase() }, () => {
+      expect(resolveCmuxTuiSource()).toEqual({ url: URL, sha256: SHA });
+    });
+  });
+});
+
+describe("cmux-tui install and daemon commands", () => {
+  test("installs onto the persistent volume, verifies the pin before and after download, and probes the binary", () => {
+    const command = cmuxTuiInstallCommand({ url: URL, sha256: SHA });
+    expect(command).toContain("mkdir -p '/root/.cmux/bin'");
+    // Skip the download when the installed copy already matches the pin.
+    expect(command).toContain(`'${SHA}' '/root/.cmux/bin/cmux-tui' | sha256sum -c -s; then :; else`);
+    // The download is verified against the same pin before it replaces anything.
+    expect(command).toContain(`curl -fsSL --retry 3 --retry-delay 2 -o '/root/.cmux/bin/cmux-tui.tmp' '${URL}'`);
+    expect(command).toContain(`'${SHA}' '/root/.cmux/bin/cmux-tui.tmp' | sha256sum -c -s && chmod 755`);
+    expect(command).toContain("ln -sfn '/root/.cmux/bin/cmux-tui' /usr/local/bin/cmux-tui");
+    expect(command.endsWith("'/root/.cmux/bin/cmux-tui' --version")).toBe(true);
+  });
+
+  test("the daemon serves /v1/link on its own port from the persistent home", () => {
+    const command = cmuxTuiDaemonCommand();
+    expect(command.startsWith("cd /root && env HOME=/root")).toBe(true);
+    expect(command).toContain("server start --session cloud --remote-ws 0.0.0.0:1337 --remote-ws-insecure-bind");
+  });
+});
+
+describe("enrollment invitation parsing", () => {
+  test("extracts the id and expiry the approve flow needs", () => {
+    const payload = {
+      version: 1,
+      id: "inv_abc-123",
+      secret: "s3cret",
+      daemon_public_key: "pk",
+      daemon_fingerprint: "fp-daemon",
+      daemon_name: "cloud",
+      expires_at_unix: 1_800_000_000,
+      route_hints: [],
+      relay_access: [],
+      approval_required: true,
+    };
+    const uri = `cmux://enroll/${Buffer.from(JSON.stringify(payload)).toString("base64url")}`;
+    expect(parseEnrollmentInvitationUri(uri)).toEqual({
+      id: "inv_abc-123",
+      expiresAtUnix: 1_800_000_000,
+      daemonFingerprint: "fp-daemon",
+    });
+  });
+
+  test("rejects foreign schemes and malformed payloads", () => {
+    expect(() => parseEnrollmentInvitationUri("https://example.com/enroll")).toThrow(/scheme/);
+    expect(() => parseEnrollmentInvitationUri("cmux://enroll/!!!")).toThrow(/undecodable|id or expiry/);
+    const missing = `cmux://enroll/${Buffer.from(JSON.stringify({ version: 1 })).toString("base64url")}`;
+    expect(() => parseEnrollmentInvitationUri(missing)).toThrow(/id or expiry/);
+  });
+});

--- a/web/tests/vm-blaxel-cmux-tui.test.ts
+++ b/web/tests/vm-blaxel-cmux-tui.test.ts
@@ -62,7 +62,10 @@ describe("cmux-tui install and daemon commands", () => {
     // Skip the download when the installed copy already matches the pin.
     expect(command).toContain(`'${SHA}' '/root/.cmux/bin/cmux-tui' | sha256sum -c -s; then :; else`);
     // The download is verified against the same pin before it replaces anything.
+    // A stock base image has no curl yet: install it, else fall back to busybox wget.
+    expect(command).toContain("command -v curl >/dev/null 2>&1 || apk add --no-cache curl");
     expect(command).toContain(`curl -fsSL --retry 3 --retry-delay 2 -o '/root/.cmux/bin/cmux-tui.tmp' '${URL}'`);
+    expect(command).toContain(`else wget -q -O '/root/.cmux/bin/cmux-tui.tmp' '${URL}'; fi`);
     expect(command).toContain(`'${SHA}' '/root/.cmux/bin/cmux-tui.tmp' | sha256sum -c -s && chmod 755`);
     expect(command).toContain("ln -sfn '/root/.cmux/bin/cmux-tui' /usr/local/bin/cmux-tui");
     expect(command.endsWith("'/root/.cmux/bin/cmux-tui' --version")).toBe(true);

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -983,6 +983,7 @@ describe("VM REST auth", () => {
       teamIds: ["team-1"],
       providerVmId: "provider-vm-team-1",
       deviceFingerprint: "fp-device-1",
+      callerPlanId: "pro",
     });
     expect(openAttachEndpoint).not.toHaveBeenCalled();
     const payload = await response.json();
@@ -1036,6 +1037,7 @@ describe("VM REST auth", () => {
       teamIds: ["team-1"],
       providerVmId: "provider-vm-team-1",
       invitationId: "inv_abc-123",
+      callerPlanId: "pro",
     });
   });
 

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -13,6 +13,8 @@ const destroyVm = mock(() => ({ workflow: "destroy" }));
 const execVm = mock(() => ({ workflow: "exec" }));
 const forkVm = mock(() => ({ workflow: "fork" }));
 const openAttachEndpoint = mock(() => ({ workflow: "attach" }));
+const openVmCmuxRemote = mock(() => ({ workflow: "cmux-remote" }));
+const approveVmCmuxRemoteEnrollment = mock(() => ({ workflow: "cmux-remote-approve" }));
 const openSshEndpoint = mock(() => ({ workflow: "ssh" }));
 const restoreVm = mock(() => ({ workflow: "restore" }));
 const snapshotVm = mock(() => ({ workflow: "snapshot" }));
@@ -54,6 +56,8 @@ const realGetVm = workflowsModule.getVm;
 const realListUserVms = workflowsModule.listUserVms;
 const realOpenBaseVm = workflowsModule.openBaseVm;
 const realOpenAttachEndpoint = workflowsModule.openAttachEndpoint;
+const realOpenVmCmuxRemote = workflowsModule.openVmCmuxRemote;
+const realApproveVmCmuxRemoteEnrollment = workflowsModule.approveVmCmuxRemoteEnrollment;
 const realOpenSshEndpoint = workflowsModule.openSshEndpoint;
 const realResetBaseVm = workflowsModule.resetBaseVm;
 const realRestoreVm = workflowsModule.restoreVm;
@@ -105,6 +109,10 @@ mock.module("../services/vms/workflows", () => ({
     useWorkflowStubs ? callMock(openBaseVm, args) : realOpenBaseVm(...args)) as typeof realOpenBaseVm,
   openAttachEndpoint: ((...args: Parameters<typeof realOpenAttachEndpoint>) =>
     useWorkflowStubs ? callMock(openAttachEndpoint, args) : realOpenAttachEndpoint(...args)) as typeof realOpenAttachEndpoint,
+  openVmCmuxRemote: ((...args: Parameters<typeof realOpenVmCmuxRemote>) =>
+    useWorkflowStubs ? callMock(openVmCmuxRemote, args) : realOpenVmCmuxRemote(...args)) as typeof realOpenVmCmuxRemote,
+  approveVmCmuxRemoteEnrollment: ((...args: Parameters<typeof realApproveVmCmuxRemoteEnrollment>) =>
+    useWorkflowStubs ? callMock(approveVmCmuxRemoteEnrollment, args) : realApproveVmCmuxRemoteEnrollment(...args)) as typeof realApproveVmCmuxRemoteEnrollment,
   openSshEndpoint: ((...args: Parameters<typeof realOpenSshEndpoint>) =>
     useWorkflowStubs ? callMock(openSshEndpoint, args) : realOpenSshEndpoint(...args)) as typeof realOpenSshEndpoint,
   resetBaseVm: ((...args: Parameters<typeof realResetBaseVm>) =>
@@ -151,6 +159,7 @@ const baseResetRoute = await import("../app/api/vm/base/reset/route");
 const vmIdRoute = await import("../app/api/vm/[id]/route");
 const { DELETE } = vmIdRoute;
 const attachRoute = await import("../app/api/vm/[id]/attach-endpoint/route");
+const cmuxRemoteApproveRoute = await import("../app/api/vm/[id]/cmux-remote/approve/route");
 const execRoute = await import("../app/api/vm/[id]/exec/route");
 const _forkRoute = await import("../app/api/vm/[id]/fork/route");
 const _snapshotRoute = await import("../app/api/vm/[id]/snapshot/route");
@@ -194,6 +203,9 @@ beforeEach(() => {
   openBaseVm.mockClear();
   resetBaseVm.mockClear();
   destroyVm.mockClear();
+  openVmCmuxRemote.mockClear();
+  approveVmCmuxRemoteEnrollment.mockClear();
+  openAttachEndpoint.mockClear();
   execVm.mockClear();
   forkVm.mockClear();
   getVm.mockClear();
@@ -942,6 +954,88 @@ describe("VM REST auth", () => {
     expect(listTeams).toHaveBeenCalledTimes(1);
     expect(await response.json()).toMatchObject({
       vms: [{ id: "provider-vm-team-2", provider: "e2b", status: "paused" }],
+    });
+  });
+
+  test("attach-endpoint routes transport=cmux-remote to the cmux-tui workflow with the caller's device", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const context = { params: Promise.resolve({ id: "provider-vm-team-1" }) };
+    runVmWorkflow.mockResolvedValue({
+      transport: "cmux-remote",
+      route: "wss://machine.vm.cmux.sh/v1/link?bl_preview_token=t",
+      token: "t",
+      expiresAtUnix: 1_777_000_300,
+      session: "cloud",
+      invitation: { uri: "cmux://enroll/abc", invitationId: "inv-1", expiresAtUnix: 1_777_000_200 },
+    });
+    const response = await attachRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-team-1/attach-endpoint", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ transport: "cmux-remote", deviceFingerprint: "fp-device-1" }),
+      }),
+      context,
+    );
+    expect(response.status).toBe(200);
+    expect(openVmCmuxRemote).toHaveBeenCalledWith({
+      userId: "user-1",
+      billingTeamId: "team-1",
+      teamIds: ["team-1"],
+      providerVmId: "provider-vm-team-1",
+      deviceFingerprint: "fp-device-1",
+    });
+    expect(openAttachEndpoint).not.toHaveBeenCalled();
+    const payload = await response.json();
+    expect(payload.transport).toBe("cmux-remote");
+    expect(payload.invitation.invitationId).toBe("inv-1");
+  });
+
+  test("attach-endpoint rejects an unknown transport before any workflow runs", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const context = { params: Promise.resolve({ id: "provider-vm-team-1" }) };
+    const response = await attachRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-team-1/attach-endpoint", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ transport: "carrier-pigeon" }),
+      }),
+      context,
+    );
+    expect(response.status).toBe(400);
+    expect(openVmCmuxRemote).not.toHaveBeenCalled();
+    expect(openAttachEndpoint).not.toHaveBeenCalled();
+  });
+
+  test("cmux-remote/approve validates the invitation id and passes the account scope through", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const context = { params: Promise.resolve({ id: "provider-vm-team-1" }) };
+    const bad = await cmuxRemoteApproveRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-team-1/cmux-remote/approve", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ invitationId: "not valid; rm -rf /" }),
+      }),
+      context,
+    );
+    expect(bad.status).toBe(400);
+    expect(approveVmCmuxRemoteEnrollment).not.toHaveBeenCalled();
+
+    runVmWorkflow.mockResolvedValue({ approved: true, state: "approved", deviceFingerprint: "fp-device-1" });
+    const ok = await cmuxRemoteApproveRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-team-1/cmux-remote/approve", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ invitationId: "inv_abc-123" }),
+      }),
+      context,
+    );
+    expect(ok.status).toBe(200);
+    expect(approveVmCmuxRemoteEnrollment).toHaveBeenCalledWith({
+      userId: "user-1",
+      billingTeamId: "team-1",
+      teamIds: ["team-1"],
+      providerVmId: "provider-vm-team-1",
+      invitationId: "inv_abc-123",
     });
   });
 


### PR DESCRIPTION
Moves cmux Cloud sessions off the Go `cmuxd-remote` daemon onto the **cmux-tui remote daemon**, implementing the next open item of the design in #10800 (`docs/cloud-cmux-tui-daemon.md`): *wire the attach endpoint to inject and start the new daemon* — and, per the owner's call, making cmux-tui **the** session daemon rather than a side-by-side option. On by default (`CMUX_VM_CMUX_TUI_ENABLED=0` is the kill switch): new machines get cmux-tui only (no `cmuxd-remote` install or process), and `cmux vm shell` / the Machines panel open cmux-tui sessions, falling back to the websocket attach only when the control plane reports cmux-tui disabled (machines from before the migration). #10742 (manual-IO pump) remains the rendering half; until it lands the pane runs the real cmux-tui client TUI.

## Backend (Blaxel driver, workflows, routes)

- **Daemon on every machine**: the driver resolves the daemon build from the artifacts manifest the `cmux-tui-artifacts` workflow publishes — rolling `https://files.cmux.com/cmux-tui/latest/manifest.json` by default, `CMUX_VM_CMUX_TUI_MANIFEST_URL` to pin one commit's manifest for a deployment — and installs the static-musl `cmux-tui` it names onto the persistent home volume (`/root/.cmux/bin/cmux-tui`; the machine `curl`s it in-region and verifies the manifest's sha256 itself). No sha in env, nothing hand-rolled. It runs `cmux-tui server start --session cloud --remote-ws 0.0.0.0:1337 --remote-ws-insecure-bind` under the sandbox supervisor; daemon identity and enrolled devices live under `/root` so they survive resurrection; an installed daemon that no longer matches the manifest is reinstalled on attach. The smart-sleep watcher counts connections on 1337 and cmux-tui's terminal children, so idle machines still sleep.
- **`POST /api/vm/[id]/attach-endpoint` with `{"transport":"cmux-remote"}`** returns `{transport, route, token, expiresAtUnix, session, invitation?}`: `route` is `wss://<hash>.preview.bl.run/v1/link?bl_preview_token=…` (12 h token, hashed into the lease ledger like previews, so sign-out revokes it); `invitation` is a single-use `cmux://enroll/…` minted with `remote enroll create --ttl 300` only when the caller's `deviceFingerprint` is not among the daemon's enrolled devices.
- **`POST /api/vm/[id]/cmux-remote/approve {invitationId}`** approves the pending claim (`remote enroll pending` → `approve`), returning `state: pending|approved` plus the device fingerprint — the control plane is the daemon owner and minted the invitation for this authenticated user, so this is the honest encoding of "already authenticated". Pre-approved invitations in `cmux-remote` (Rust; `approval_required` is hardcoded) stay the follow-up named in #10800.
- **Measured gateway behaviour**: the branded `vm.cmux.sh` CloudFront distribution refuses WebSocket upgrades without a `User-Agent` (403), which the Rust dialer never sent; the raw `*.preview.bl.run` host does not enforce it. Fixed at the source (see Rust commit); the daemon preview is unbranded only until that build is in `latest`.
- Provider/gateway types: `CmuxRemoteEndpoint`, `openCmuxRemote?`, `approveCmuxRemoteEnrollment?`; unmigrated providers simply don't implement them. Revocation also stops the cmux-tui daemon process, matching cmuxd's semantics.

## Mac app + CLI

- **The app bundles the client.** `scripts/install-cmux-tui-client.sh` puts a universal, sha256-verified `cmux-tui` into `Contents/Resources/bin` next to the bundled `cmux` CLI and Ghostty helper — from the same manifest the backend uses — and `reload.sh`, `ci.yml`, `release.yml` and `nightly.yml` run it. The CLI looks there first (then `CMUX_TUI_CLIENT`, `~/.cmux/bin/cmux`, `cmux-tui` on PATH; every candidate must answer `remote-probe --json` as cmux-tui), and compares its `remote_protocol` with the machine daemon's (`daemonBuild` on the endpoint) before opening a pane, naming the stale side instead of hanging.

- Socket methods `vm.cmux_remote_info` / `vm.cmux_remote_approve` (listed in `capabilities`), `VMClient.openCmuxRemote` / `approveCmuxRemoteEnrollment`.
- **`cmux vm tui <id>`** opens a workspace whose pane runs the hidden `vm-tui-connect` helper: it hands the terminal to the local cmux-tui client (`remote connect <route> --invite-file … --state-dir ~/.cmuxterm/cmux-tui-client`, own process group in the foreground like the other interactive-child paths) and, while the client claims the invitation, approves the enrollment through the socket; the device fingerprint is remembered per machine in `~/.cmuxterm/vm-tui-devices.json` so later attaches skip the invitation. The client binary is found via `CMUX_TUI_CLIENT` → `~/.cmux/bin/cmux` → `cmux-tui` on PATH, and every candidate must answer `remote-probe --json` as cmux-tui (the SSH-remote bootstrap leaves a shell wrapper at `~/.cmux/bin/cmux` that is executable but not a client).
- Localized en+ja strings for the new CLI messages; `vm --help`, the usage contract and `docs/cli-contract.md` list `tui`.
- **`cmux-tui-artifacts.yml` publishes on main pushes again** (paths-filtered), so `latest/` tracks main; `latest` was republished by dispatch and now carries the musl target (it had been stale since July 15 with a glibc-named binary).
- **`cmux-remote` sends a `User-Agent` on direct WebSocket dials** (Rust, unit-tested): the CloudFront distribution on the branded `vm.cmux.sh` domain refuses upgrades without one (measured: 403 without, 101 with; `Origin` also 403s). Once this is in `latest`, the daemon preview goes back to the branded host (`<machine>-tui.vm.cmux.sh`); until then the driver keeps the raw preview host.

## Verified live on Blaxel (`smooth-wren`)

Through the driver against the real machine: install + `server status` ready → route on the raw host → `remote connect --invite-file --headless` from the matching macOS client → control plane approves in 2 s → `known-daemons` lists the cloud daemon → a second attach with the device fingerprint mints no invitation. Over the enrolled link, workspace RPC spawned a `bash` PTY, wrote a marker, and `snapshot-process-terminal` returned the styled grid: `PHASE1-TERMINAL-OK smooth-wren root`. Alpine/musl compatibility of the pinned binary was checked first (the older glibc `latest/` artifact fails there; `gcompat` doesn't rescue it).

## Tests

- `web/tests/vm-blaxel-cmux-tui.test.ts`: on by default with the `=0` kill switch; manifest URL defaults to `latest` and must be https; the manifest parser takes the musl build + sha256 and fails closed without a commit or musl target; install command verifies the pin before and after download, installs `curl` or falls back to `wget`, and installs onto `/root`; daemon command shape; invitation URI parsing and rejection of foreign/malformed URIs.
- `web/tests/vm-route-auth.test.ts`: `transport: "cmux-remote"` reaches `openVmCmuxRemote` with the account scope and device fingerprint and never the websocket workflow; unknown transports are rejected before any workflow; the approve route validates the invitation id (shell-unsafe input rejected) and passes the scope through.
- Existing Blaxel provider, workflow and route suites unchanged and green; `tsc` clean; CLI contract-help probes pass.

## Rollout

Opt-in: set the two env vars on a deployment to start shipping the daemon; no client changes for existing attaches. Phase 2 (default new attaches to `cmux-remote`, keep websocket as fallback for one release) and Phase 3 (delete the Go daemon path per provider, then `daemon/remote`) follow the sequencing in #10800; e2b/freestyle/daytona take the same musl binary in `build-cloud-vm-images.ts`.

Refs #10800, #10742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
