### PR TITLE
iOS: fix two main-red compile errors from #10662

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
@@ -282,7 +282,9 @@ public struct MobileWorkspaceAggregation: Sendable {
                     // Empty headers have no workspace row to namespace; use
                     // the already-namespaced group id only as a stable UI row
                     // identity, never as a workspace capability.
-                    stamped.anchorWorkspaceID = stamped.id
+                    stamped.anchorWorkspaceID = MobileWorkspacePreview.ID(
+                        rawValue: stamped.id.rawValue
+                    )
                 }
                 result.append(stamped)
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -911,7 +911,7 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
     /// Group actions are owned by the Mac connection, not by a particular
     /// workspace row. The group snapshot carries that Mac-scoped capability,
     /// including when the group has no live anchor row.
-    fileprivate func groupActionCapabilities(
+    func groupActionCapabilities(
         for group: MobileWorkspaceGroupPreview
     ) -> MobileWorkspaceActionCapabilities {
         if let capabilities = group.actionCapabilities {


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/10662 broke the iOS app compile in two places (hit by any tagged iOS archive from current main; no CI lane compiles the iOS app on PRs to catch it):

1. `MobileWorkspaceAggregation.swift:285`: assigns the namespaced group id (`MobileWorkspaceGroupPreview.ID`) directly to `anchorWorkspaceID` (`MobileWorkspacePreview.ID`). Fixed by converting through `rawValue`, the same idiom `MobileWorkspaceGroupPreview.init` already uses for its empty-group anchor fallback.
2. `WorkspaceListTableCoordinator.swift:914`: `groupActionCapabilities(for:)` is `fileprivate` but called from `WorkspaceListTableCoordinator+Actions.swift`. Widened to internal.

Found while building https://github.com/manaflow-ai/cmux/pull/10802; that branch carries the same patches until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty group headers in multi-Mac workspace views so they remain correctly anchored and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->