### PR TITLE
fix: restore nightly CLI compilation after Cursor approvals

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -249,6 +249,18 @@ struct ClaudeHookSessionRecord: Codable {
             createdAt = try container.decodeIfPresent(TimeInterval.self, forKey: .createdAt) ?? 0
             requiresToolUseId = try container.decodeIfPresent(Bool.self, forKey: .requiresToolUseId) ?? false
         }
+
+        /// Encodes the persisted approval fields without emitting the decode-only legacy command.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(commandFingerprint, forKey: .commandFingerprint)
+            try container.encode(commandLength, forKey: .commandLength)
+            try container.encode(displayCommand, forKey: .displayCommand)
+            try container.encodeIfPresent(toolUseId, forKey: .toolUseId)
+            try container.encodeIfPresent(notificationCorrelationKey, forKey: .notificationCorrelationKey)
+            try container.encode(createdAt, forKey: .createdAt)
+            try container.encode(requiresToolUseId, forKey: .requiresToolUseId)
+        }
     }
 
     var sessionId: String
@@ -33084,14 +33096,14 @@ export default CMUXSessionRestore;
             let cwdURL = URL(fileURLWithPath: rawCwd).standardizedFileURL
             let fileManager = FileManager.default
             var cursor = cwdURL
-            var projectRoot: URL?
+            var discoveredProjectRoot: URL?
             let maximumProjectRootAncestors = 64
             var ancestorDepth = 0
             while ancestorDepth < maximumProjectRootAncestors {
                 if fileManager.fileExists(
                     atPath: cursor.appendingPathComponent(".git", isDirectory: false).path
                 ) {
-                    projectRoot = cursor
+                    discoveredProjectRoot = cursor
                     break
                 }
                 let parent = cursor.deletingLastPathComponent()
@@ -33100,7 +33112,7 @@ export default CMUXSessionRestore;
                 cursor = parent
                 ancestorDepth += 1
             }
-            let projectRoot = projectRoot ?? cwdURL
+            let projectRoot = discoveredProjectRoot ?? cwdURL
             applyConfig(
                 at: projectRoot
                     .appendingPathComponent(".cursor", isDirectory: true)

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1116,6 +1116,20 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(approval.status, 0, approval.stderr)
         XCTAssertEqual(approval.stdout, #"{"permission":"ask"}"# + "\n")
 
+        let persistedApprovalJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(contentsOf: root.appendingPathComponent("cursor-hook-sessions.json"))
+            ) as? [String: Any]
+        )
+        let persistedSession = try XCTUnwrap(
+            (persistedApprovalJSON["sessions"] as? [String: Any])?[sessionId] as? [String: Any]
+        )
+        let persistedApprovals = try XCTUnwrap(
+            persistedSession["pendingCursorShellApprovals"] as? [[String: Any]]
+        )
+        XCTAssertEqual(persistedApprovals.first?["commandLength"] as? Int, approvalCommand.utf8.count)
+        XCTAssertNil(persistedApprovals.first?["command"])
+
         let approvalCommands = Array(state.snapshot().dropFirst(approvalCommandStart))
         XCTAssertEqual(
             approvalCommands.filter {


### PR DESCRIPTION
## Summary

- Restore `cmux-cli` compilation under Xcode 26.5 / Swift 6.3 by explicitly encoding the persisted `PendingCursorShellApproval` fields while keeping the legacy `command` key decode-only.
- Rename the mutable project-root discovery variable so the final resolved `projectRoot` binding is not an invalid redeclaration.
- Preserve the existing Cursor approval persistence/config behavior and all #10787 worktree filesystem-identity safety behavior.
- This complete two-diagnostic repair supersedes the one-error-only open PR #10808.
- Workspace identity: `cmux163: #10787 nightly worktree compilation`.

## Testing

- Extended `CLINotifyProcessIntegrationRegressionTests.testCursorShellApprovalDistinguishesUnsandboxedAndSandboxedPayloads` to assert that persisted approval metadata round-trips through the real CLI hook path and does not emit the legacy decode-only key.
- Test-only commit: `ef4670da0f`.
- Fix commit: `3704118e5f`.
- Static repository guards pass (`git diff --check`, pbxproj normalization, package-resolved policy, workspace package grouping, and test wiring). The mandated file-length script/TSV is absent from this checkout; no budget file was created or changed.
- Full Xcode validation will run on the shared GitHub macOS lane; no local app build or XCUITest was run.

## Demo Video

Not applicable: compiler-only repair.

## Review Trigger (Copy/Paste as PR comment)

```text
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not applicable)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322445&installation_model_id=21920&pr_number=10820&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10820&signature=a29df16cb266cf3bb22340250173e55081d348942a61645276d9fa41c2437985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of shell-command approvals.
  * Approval records now retain the command’s UTF-8 length without storing the raw command text.
  * Project-root detection continues to fall back to the current working directory when no repository root is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->