### PR TITLE
fix: restore Codex sessions without stale child bindings

### DIFF
--- a/CLI/AgentSurfaceResumeBindingClearOutcome.swift
+++ b/CLI/AgentSurfaceResumeBindingClearOutcome.swift
@@ -13,6 +13,7 @@ extension CMUXCLI {
         workspaceId: String,
         surfaceId: String,
         sessionId: String?,
+        updatedAt: TimeInterval? = nil,
         sessionDidEnd: Bool = false,
         responseTimeout: TimeInterval? = nil,
         deadline: Date? = nil
@@ -24,6 +25,9 @@ extension CMUXCLI {
         ]
         if let normalizedSessionId {
             params["checkpoint_id"] = normalizedSessionId
+        }
+        if let updatedAt, updatedAt.isFinite {
+            params["expected_updated_at"] = updatedAt
         }
         if sessionDidEnd, normalizedSessionId != nil {
             params["agent_session_ended"] = true

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -38,22 +38,12 @@ extension CMUXCLI {
         launchVerificationHome: String? = nil,
         ambientEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
-        if let launchHome = normalizedHookValue(launchEnvironment?["CODEX_HOME"]) {
-            return (launchHome as NSString).expandingTildeInPath
-        }
-        if let launchHome = normalizedHookValue(launchVerificationHome)
-            ?? normalizedHookValue(launchEnvironment?["HOME"]) {
-            return URL(fileURLWithPath: (launchHome as NSString).expandingTildeInPath, isDirectory: true)
-                .appendingPathComponent(".codex", isDirectory: true)
-                .path
-        }
-        if let ambientHome = normalizedHookValue(ambientEnvironment["CODEX_HOME"]) {
-            return (ambientHome as NSString).expandingTildeInPath
-        }
-        let home = normalizedHookValue(ambientEnvironment["HOME"]) ?? NSHomeDirectory()
-        return URL(fileURLWithPath: home, isDirectory: true)
-            .appendingPathComponent(".codex", isDirectory: true)
-            .path
+        CodexHomeResolver().resolve(
+            launchEnvironment: launchEnvironment,
+            launchVerificationHome: launchVerificationHome,
+            ambientEnvironment: ambientEnvironment,
+            fallbackHomeDirectory: NSHomeDirectory()
+        )
     }
 
     /// Revalidates a structured Codex resume record at the last safe boundary
@@ -172,19 +162,27 @@ extension CMUXCLI {
         }
 
         let message: String
+        let stage: String
         switch result {
         case .bindingChanged:
+            stage = "codex.restore.binding-changed"
             message = String(
                 localized: "cli.restore.error.checkpointMismatch",
                 defaultValue: "restore: this command no longer matches the session. Run 'cmux restore --surface' to use the current record."
             )
-        case .allowed, .missing, .unavailable, .rejectedChild:
+        case .allowed:
+            return
+        case .missing, .unavailable, .rejectedChild:
+            stage = "codex.restore.checkpoint-unavailable"
             message = String(
                 localized: "cli.restore.codexCheckpointUnavailable",
-                defaultValue: "restore: the saved Codex checkpoint is unavailable. The terminal remains in its saved directory; retry later or start a new Codex session."
+                defaultValue: "restore: the saved agent session is unavailable. The terminal remains in its saved directory; retry later or start a new agent session."
             )
         }
-        cliWriteStderr(message + "\n")
+        // A rejected restore is a command failure, not a successful fallback.
+        // Throw through the normal CLI boundary so callers receive a non-zero
+        // status without exposing raw provider output.
+        throw loggedRestoreError(stage: stage, message: message)
     }
 
     private func codexRestoreBindingCheckpoint(

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -106,6 +106,43 @@ extension CMUXCLI {
         }
     }
 
+    /// Atomically claims the binding generation that produced a validated
+    /// restore record. The app keeps this claim until the same session's hook
+    /// refresh arrives, preventing a newer child/parent publication from
+    /// winning between validation and process execution.
+    func claimCodexRestoreBinding(
+        record: RestoreRecord,
+        bindingPayload: [String: Any]?,
+        surfaceID: String?,
+        client: SocketClient
+    ) -> Bool {
+        guard record.mode == AgentRestoreRequestMode.resumeAgent.rawValue,
+              record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
+              let checkpointID = normalizedHookValue(record.checkpointID),
+              codexRestoreBindingCheckpoint(bindingPayload) == checkpointID,
+              let surfaceID,
+              let source = normalizedHookValue(bindingPayload?["source"] as? String),
+              let updatedAt = (bindingPayload?["updated_at"] as? NSNumber)?.doubleValue,
+              updatedAt.isFinite else {
+            return false
+        }
+        let result: [String: Any]
+        do {
+            result = try client.sendV2(
+                method: "surface.resume.get",
+                params: [
+                    "surface_id": surfaceID,
+                    "claim_checkpoint_id": checkpointID,
+                    "claim_source": source,
+                    "claim_updated_at": updatedAt,
+                ]
+            )
+        } catch {
+            return false
+        }
+        return result["resume_claimed"] as? Bool == true
+    }
+
     /// Leaves the shell in the recorded directory, then retires only the
     /// stale checkpoint that was actually rejected. The checkpoint guard in
     /// surface.resume.clear means a concurrently published parent binding is
@@ -116,7 +153,8 @@ extension CMUXCLI {
         bindingPayload: [String: Any]?,
         surfaceID: String?,
         workspaceID: String?,
-        client: SocketClient
+        client: SocketClient,
+        workingDirectoryBeforeRestore: String? = nil
     ) throws {
         let shouldHandle: Bool
         switch result {
@@ -133,7 +171,10 @@ extension CMUXCLI {
         // A binding-change response is different: the returned record is stale,
         // so do not move the shell away from the newer parent's cwd.
         if case .bindingChanged = result {
-            // Preserve the current shell directory and the authoritative binding.
+            // Restore the shell directory from before this command changed it.
+            // The app-owned binding remains authoritative; only the stale
+            // restore attempt's local chdir is undone.
+            _ = try? applyRestoreWorkingDirectory(workingDirectoryBeforeRestore)
         } else {
             let workingDirectory = requestedRestoreWorkingDirectory(for: record)
                 ?? normalizedHookValue(bindingPayload?["cwd"] as? String)
@@ -189,7 +230,7 @@ extension CMUXCLI {
         throw loggedRestoreError(stage: stage, message: message)
     }
 
-    private func codexRestoreBindingCheckpoint(
+    func codexRestoreBindingCheckpoint(
         _ bindingPayload: [String: Any]?
     ) -> String? {
         guard let bindingPayload,

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -23,6 +23,7 @@ extension CMUXCLI {
         let environment = ProcessInfo.processInfo.environment
         let codexHome = codexResumeBindingEffectiveHome(
             launchEnvironment: launchCommand?.environment,
+            launchWorkingDirectory: launchCommand?.workingDirectory,
             launchVerificationHome: launchCommand?.verificationHome,
             ambientEnvironment: environment
         )
@@ -35,11 +36,13 @@ extension CMUXCLI {
 
     func codexResumeBindingEffectiveHome(
         launchEnvironment: [String: String]?,
+        launchWorkingDirectory: String? = nil,
         launchVerificationHome: String? = nil,
         ambientEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
         CodexHomeResolver().resolve(
             launchEnvironment: launchEnvironment,
+            launchWorkingDirectory: launchWorkingDirectory,
             launchVerificationHome: launchVerificationHome,
             ambientEnvironment: ambientEnvironment,
             fallbackHomeDirectory: NSHomeDirectory()
@@ -74,6 +77,8 @@ extension CMUXCLI {
         launchEnvironment.merge(record.environment) { _, restored in restored }
         let codexHome = codexResumeBindingEffectiveHome(
             launchEnvironment: launchEnvironment,
+            launchWorkingDirectory: record.launchCommand?.workingDirectory
+                ?? record.workingDirectory,
             launchVerificationHome: record.launchCommand?.verificationHome,
             ambientEnvironment: processEnvironment
         )

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -77,7 +77,6 @@ extension CMUXCLI {
     ) -> CodexRestoreValidationResult? {
         guard record.mode == AgentRestoreRequestMode.resumeAgent.rawValue,
               record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
-              record.launchCommand != nil || bindingPayload != nil,
               let sessionId = normalizedHookValue(record.checkpointID) else {
             return nil
         }

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -85,7 +85,8 @@ extension CMUXCLI {
         let verification = CodexSessionResumeVerifier().verify(
             sessionId: sessionId,
             transcriptPath: nil,
-            codexHome: codexHome
+            codexHome: codexHome,
+            allowLegacyFallbackForIndexedMissing: true
         )
         switch verification {
         case .exists(let evidence):
@@ -96,12 +97,10 @@ extension CMUXCLI {
                 ? .rejectedChild(evidence)
                 : .allowed(evidence)
         case .missing:
-            // #10100 may have accepted a hook transcript before Codex indexed
-            // its row. A classified TUI binding is therefore retained on this
-            // read gap; legacy/unprovenanced bindings still fail closed.
-            return codexRestoreBindingHasTUIProvenance(bindingPayload)
-                ? .unavailable
-                : .missing
+            // The restore-mode verifier has already attempted the bounded
+            // rollout bridge for a readable index. A remaining miss is
+            // definitive and may retire the guarded stale binding.
+            return .missing
         case .unavailable:
             return .unavailable
         }
@@ -203,18 +202,6 @@ extension CMUXCLI {
             (bindingPayload["checkpoint_id"] as? String)
                 ?? (bindingPayload["checkpointId"] as? String)
         )
-    }
-
-    private func codexRestoreBindingHasTUIProvenance(
-        _ bindingPayload: [String: Any]?
-    ) -> Bool {
-        guard codexRestoreBindingCheckpoint(bindingPayload) != nil,
-              let provenance = normalizedHookValue(
-                  bindingPayload?["resume_evidence_provenance"] as? String
-              ) else {
-            return false
-        }
-        return provenance.lowercased() == "tui"
     }
 
     private func isCodexRestoreBindingOwner(

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -56,14 +56,6 @@ extension CMUXCLI {
             .path
     }
 
-    enum CodexRestoreValidationResult {
-        case allowed(CodexSessionResumeEvidence)
-        case missing
-        case unavailable
-        case rejectedChild(CodexSessionResumeEvidence)
-        case bindingChanged
-    }
-
     /// Revalidates a structured Codex resume record at the last safe boundary
     /// before execve. Publication verification protects new hook events, but
     /// snapshots written by older builds can outlive that gate. A binding

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -143,6 +143,14 @@ extension CMUXCLI {
         return result["resume_claimed"] as? Bool == true
     }
 
+    /// Whether a restore record represents a Codex hook-owned surface whose
+    /// binding generation must be claimed before execution.
+    func codexRestoreBindingRequiresClaim(_ record: RestoreRecord) -> Bool {
+        record.mode == AgentRestoreRequestMode.resumeAgent.rawValue
+            && record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex"
+            && record.source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "agent-hook"
+    }
+
     /// Leaves the shell in the recorded directory, then retires only the
     /// stale checkpoint that was actually rejected. The checkpoint guard in
     /// surface.resume.clear means a concurrently published parent binding is
@@ -197,6 +205,7 @@ extension CMUXCLI {
                 workspaceId: workspaceID ?? "",
                 surfaceId: surfaceID,
                 sessionId: checkpointID,
+                updatedAt: (bindingPayload?["updated_at"] as? NSNumber)?.doubleValue,
                 sessionDidEnd: true
             )
             if outcome == .failed {

--- a/CLI/CMUXCLI+CodexResumeBindingVerification.swift
+++ b/CLI/CMUXCLI+CodexResumeBindingVerification.swift
@@ -56,6 +56,184 @@ extension CMUXCLI {
             .path
     }
 
+    enum CodexRestoreValidationResult {
+        case allowed(CodexSessionResumeEvidence)
+        case missing
+        case unavailable
+        case rejectedChild(CodexSessionResumeEvidence)
+        case bindingChanged
+    }
+
+    /// Revalidates a structured Codex resume record at the last safe boundary
+    /// before execve. Publication verification protects new hook events, but
+    /// snapshots written by older builds can outlive that gate. A binding
+    /// provenance check is applied only when the current surface still claims
+    /// the checkpoint through an agent hook; explicit persisted exec records
+    /// remain usable when they are not surface owners.
+    func codexRestoreValidation(
+        record: RestoreRecord,
+        bindingPayload: [String: Any]?,
+        processEnvironment: [String: String]
+    ) -> CodexRestoreValidationResult? {
+        guard record.mode == AgentRestoreRequestMode.resumeAgent.rawValue,
+              record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
+              record.launchCommand != nil || bindingPayload != nil,
+              let sessionId = normalizedHookValue(record.checkpointID) else {
+            return nil
+        }
+        if let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
+           bindingCheckpoint != sessionId {
+            // The app returned a newer parent (or another session) after the
+            // restore selector was persisted. Never execute the stale record,
+            // and never clear the newer binding.
+            return .bindingChanged
+        }
+
+        var launchEnvironment = record.launchCommand?.environment ?? [:]
+        launchEnvironment.merge(record.environment) { _, restored in restored }
+        let codexHome = codexResumeBindingEffectiveHome(
+            launchEnvironment: launchEnvironment,
+            launchVerificationHome: record.launchCommand?.verificationHome,
+            ambientEnvironment: processEnvironment
+        )
+        let verification = CodexSessionResumeVerifier().verify(
+            sessionId: sessionId,
+            transcriptPath: nil,
+            codexHome: codexHome
+        )
+        switch verification {
+        case .exists(let evidence):
+            return isCodexRestoreBindingOwner(
+                bindingPayload,
+                checkpointID: sessionId
+            ) && !evidence.provenance.mayOwnBinding
+                ? .rejectedChild(evidence)
+                : .allowed(evidence)
+        case .missing:
+            // #10100 may have accepted a hook transcript before Codex indexed
+            // its row. A classified TUI binding is therefore retained on this
+            // read gap; legacy/unprovenanced bindings still fail closed.
+            return codexRestoreBindingHasTUIProvenance(bindingPayload)
+                ? .unavailable
+                : .missing
+        case .unavailable:
+            return .unavailable
+        }
+    }
+
+    /// Leaves the shell in the recorded directory, then retires only the
+    /// stale checkpoint that was actually rejected. The checkpoint guard in
+    /// surface.resume.clear means a concurrently published parent binding is
+    /// never cleared by this recovery path.
+    func handleRejectedCodexRestore(
+        _ result: CodexRestoreValidationResult,
+        record: RestoreRecord,
+        bindingPayload: [String: Any]?,
+        surfaceID: String?,
+        workspaceID: String?,
+        client: SocketClient
+    ) throws {
+        let shouldHandle: Bool
+        switch result {
+        case .allowed:
+            shouldHandle = false
+        case .missing, .unavailable, .rejectedChild, .bindingChanged:
+            shouldHandle = true
+        }
+        guard shouldHandle else { return }
+
+        // applyRestoreWorkingDirectory deliberately runs before the guarded
+        // clear. If the saved path is inaccessible, keep the binding intact so
+        // the user can repair the path and retry rather than losing the parent.
+        // A binding-change response is different: the returned record is stale,
+        // so do not move the shell away from the newer parent's cwd.
+        if case .bindingChanged = result {
+            // Preserve the current shell directory and the authoritative binding.
+        } else {
+            let workingDirectory = requestedRestoreWorkingDirectory(for: record)
+                ?? normalizedHookValue(bindingPayload?["cwd"] as? String)
+            _ = try applyRestoreWorkingDirectory(workingDirectory)
+        }
+
+        let shouldClear: Bool
+        switch result {
+        case .missing, .rejectedChild:
+            shouldClear = true
+        case .allowed, .unavailable, .bindingChanged:
+            shouldClear = false
+        }
+        if shouldClear,
+           isCodexRestoreBindingOwner(bindingPayload, checkpointID: record.checkpointID),
+           let surfaceID,
+           let checkpointID = normalizedHookValue(record.checkpointID) {
+            let outcome = clearAgentSurfaceResumeBindingOutcome(
+                client: client,
+                workspaceId: workspaceID ?? "",
+                surfaceId: surfaceID,
+                sessionId: checkpointID,
+                sessionDidEnd: true
+            )
+            if outcome == .failed {
+                codexResumeBindingLogger.notice(
+                    "Codex stale restore clear failed; retaining checkpoint guard"
+                )
+            }
+        }
+
+        let message: String
+        switch result {
+        case .bindingChanged:
+            message = String(
+                localized: "cli.restore.error.checkpointMismatch",
+                defaultValue: "restore: this command no longer matches the session. Run 'cmux restore --surface' to use the current record."
+            )
+        case .allowed, .missing, .unavailable, .rejectedChild:
+            message = String(
+                localized: "cli.restore.codexCheckpointUnavailable",
+                defaultValue: "restore: the saved Codex checkpoint is unavailable. The terminal remains in its saved directory; retry later or start a new Codex session."
+            )
+        }
+        cliWriteStderr(message + "\n")
+    }
+
+    private func codexRestoreBindingCheckpoint(
+        _ bindingPayload: [String: Any]?
+    ) -> String? {
+        guard let bindingPayload,
+              let source = normalizedHookValue(bindingPayload["source"] as? String),
+              source.lowercased() == "agent-hook",
+              (normalizedHookValue(bindingPayload["kind"] as? String)?.lowercased() ?? "codex") == "codex" else {
+            return nil
+        }
+        return normalizedHookValue(
+            (bindingPayload["checkpoint_id"] as? String)
+                ?? (bindingPayload["checkpointId"] as? String)
+        )
+    }
+
+    private func codexRestoreBindingHasTUIProvenance(
+        _ bindingPayload: [String: Any]?
+    ) -> Bool {
+        guard codexRestoreBindingCheckpoint(bindingPayload) != nil,
+              let provenance = normalizedHookValue(
+                  bindingPayload?["resume_evidence_provenance"] as? String
+              ) else {
+            return false
+        }
+        return provenance.lowercased() == "tui"
+    }
+
+    private func isCodexRestoreBindingOwner(
+        _ bindingPayload: [String: Any]?,
+        checkpointID: String?
+    ) -> Bool {
+        guard let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
+              let checkpointID = normalizedHookValue(checkpointID) else {
+            return false
+        }
+        return bindingCheckpoint == checkpointID
+    }
+
     func logCodexResumeBindingRejection(
         reason: String,
         sessionId: String,

--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -143,6 +143,33 @@ extension CMUXCLI {
             }
         }
 
+        // Legacy command-only records predate structured launch captures, but
+        // an agent-hook Codex record still names a mutable surface owner. Claim
+        // that generation before handing the shell command to exec so an
+        // intervening child publication cannot steal the restore.
+        if codexRestoreBindingRequiresClaim(record),
+           record.launchCommand == nil,
+           record.preparedArguments == nil,
+           record.legacyCommand != nil,
+           !claimCodexRestoreBinding(
+               record: record,
+               bindingPayload: bindingPayload,
+               surfaceID: params["surface_id"] as? String,
+               client: client
+           ) {
+            try handleRejectedCodexRestore(
+                .bindingChanged,
+                record: record,
+                bindingPayload: bindingPayload,
+                surfaceID: params["surface_id"] as? String,
+                workspaceID: payload["workspace_id"] as? String
+                    ?? processEnvironment["CMUX_WORKSPACE_ID"],
+                client: client,
+                workingDirectoryBeforeRestore: workingDirectoryBeforeRestore
+            )
+            return
+        }
+
         let environment = processEnvironment.merging(record.environment) { _, restored in
             restored
         }
@@ -198,6 +225,25 @@ extension CMUXCLI {
             ambientEnvironment: processEnvironment
         ) else {
             if let legacyCommand = record.legacyCommand {
+                if codexRestoreBindingRequiresClaim(record),
+                   !claimCodexRestoreBinding(
+                       record: record,
+                       bindingPayload: bindingPayload,
+                       surfaceID: params["surface_id"] as? String,
+                       client: client
+                   ) {
+                    try handleRejectedCodexRestore(
+                        .bindingChanged,
+                        record: record,
+                        bindingPayload: bindingPayload,
+                        surfaceID: params["surface_id"] as? String,
+                        workspaceID: payload["workspace_id"] as? String
+                            ?? processEnvironment["CMUX_WORKSPACE_ID"],
+                        client: client,
+                        workingDirectoryBeforeRestore: workingDirectoryBeforeRestore
+                    )
+                    return
+                }
                 try execLegacyRestoreRecord(
                     legacyCommand,
                     record: record,
@@ -221,9 +267,7 @@ extension CMUXCLI {
                 appliedWorkingDirectory: effectiveWorkingDirectory
             )
         }
-        if record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
-           let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
-           bindingCheckpoint == normalizedHookValue(record.checkpointID),
+        if codexRestoreBindingRequiresClaim(record),
            !claimCodexRestoreBinding(
                record: record,
                bindingPayload: bindingPayload,

--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -44,6 +44,7 @@ extension CMUXCLI {
         processEnvironment: [String: String]
     ) throws {
         let selector = try restoreSelector(commandArgs)
+        let workingDirectoryBeforeRestore = FileManager.default.currentDirectoryPath
         var params: [String: Any] = [:]
         if let surface = selector.surface {
             let surfaceID = try normalizeSurfaceHandle(
@@ -114,9 +115,10 @@ extension CMUXCLI {
             )
         }
 
+        let bindingPayload = payload["resume_binding"] as? [String: Any]
         if let codexValidation = codexRestoreValidation(
             record: record,
-            bindingPayload: payload["resume_binding"] as? [String: Any],
+            bindingPayload: bindingPayload,
             processEnvironment: processEnvironment
         ) {
             let shouldContinue: Bool
@@ -130,11 +132,12 @@ extension CMUXCLI {
                 try handleRejectedCodexRestore(
                     codexValidation,
                     record: record,
-                    bindingPayload: payload["resume_binding"] as? [String: Any],
+                    bindingPayload: bindingPayload,
                     surfaceID: params["surface_id"] as? String,
                     workspaceID: payload["workspace_id"] as? String
                         ?? processEnvironment["CMUX_WORKSPACE_ID"],
-                    client: client
+                    client: client,
+                    workingDirectoryBeforeRestore: workingDirectoryBeforeRestore
                 )
                 return
             }
@@ -217,6 +220,26 @@ extension CMUXCLI {
                 preflight,
                 appliedWorkingDirectory: effectiveWorkingDirectory
             )
+        }
+        if let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
+           bindingCheckpoint == normalizedHookValue(record.checkpointID),
+           !claimCodexRestoreBinding(
+               record: record,
+               bindingPayload: bindingPayload,
+               surfaceID: params["surface_id"] as? String,
+               client: client
+           ) {
+            try handleRejectedCodexRestore(
+                .bindingChanged,
+                record: record,
+                bindingPayload: bindingPayload,
+                surfaceID: params["surface_id"] as? String,
+                workspaceID: payload["workspace_id"] as? String
+                    ?? processEnvironment["CMUX_WORKSPACE_ID"],
+                client: client,
+                workingDirectoryBeforeRestore: workingDirectoryBeforeRestore
+            )
+            return
         }
         client.close()
         try execRestoreInvocation(

--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -114,6 +114,32 @@ extension CMUXCLI {
             )
         }
 
+        if let codexValidation = codexRestoreValidation(
+            record: record,
+            bindingPayload: payload["resume_binding"] as? [String: Any],
+            processEnvironment: processEnvironment
+        ) {
+            let shouldContinue: Bool
+            switch codexValidation {
+            case .allowed:
+                shouldContinue = true
+            case .missing, .unavailable, .rejectedChild, .bindingChanged:
+                shouldContinue = false
+            }
+            if !shouldContinue {
+                try handleRejectedCodexRestore(
+                    codexValidation,
+                    record: record,
+                    bindingPayload: payload["resume_binding"] as? [String: Any],
+                    surfaceID: params["surface_id"] as? String,
+                    workspaceID: payload["workspace_id"] as? String
+                        ?? processEnvironment["CMUX_WORKSPACE_ID"],
+                    client: client
+                )
+                return
+            }
+        }
+
         let environment = processEnvironment.merging(record.environment) { _, restored in
             restored
         }

--- a/CLI/CMUXCLI+Restore.swift
+++ b/CLI/CMUXCLI+Restore.swift
@@ -221,7 +221,8 @@ extension CMUXCLI {
                 appliedWorkingDirectory: effectiveWorkingDirectory
             )
         }
-        if let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
+        if record.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
+           let bindingCheckpoint = codexRestoreBindingCheckpoint(bindingPayload),
            bindingCheckpoint == normalizedHookValue(record.checkpointID),
            !claimCodexRestoreBinding(
                record: record,

--- a/CLI/CodexRestoreValidationResult.swift
+++ b/CLI/CodexRestoreValidationResult.swift
@@ -1,0 +1,10 @@
+import CMUXAgentLaunch
+
+/// The durable admission result for one Codex restore request.
+enum CodexRestoreValidationResult {
+    case allowed(CodexSessionResumeEvidence)
+    case missing
+    case unavailable
+    case rejectedChild(CodexSessionResumeEvidence)
+    case bindingChanged
+}

--- a/Packages/macOS/CMUXAgentLaunch/README.md
+++ b/Packages/macOS/CMUXAgentLaunch/README.md
@@ -45,6 +45,7 @@ injected file manager, so tests never need the developer's real `~/.codex`:
 ```swift
 let home = CodexHomeResolver().resolve(
     launchEnvironment: ["HOME": "/tmp/captured-user"],
+    launchWorkingDirectory: "/tmp/project",
     ambientEnvironment: ["CODEX_HOME": "/tmp/current-codex"],
     fallbackHomeDirectory: "/tmp/fallback-user"
 )

--- a/Packages/macOS/CMUXAgentLaunch/README.md
+++ b/Packages/macOS/CMUXAgentLaunch/README.md
@@ -36,3 +36,21 @@ let resolver = AgentExecutableSearchPathResolver(
 let directories = resolver.normalizedDirectories(from: ["missing/..", "bin"])
 // ["/tmp/project/bin"]
 ```
+
+## Testing Codex durable-state resolution
+
+Codex home selection and durable verification take captured values and an
+injected file manager, so tests never need the developer's real `~/.codex`:
+
+```swift
+let home = CodexHomeResolver().resolve(
+    launchEnvironment: ["HOME": "/tmp/captured-user"],
+    ambientEnvironment: ["CODEX_HOME": "/tmp/current-codex"],
+    fallbackHomeDirectory: "/tmp/fallback-user"
+)
+let results = CodexSessionResumeVerifier().verifyBatch(
+    [CodexSessionResumeVerificationRequest(sessionId: checkpointID)],
+    codexHome: home,
+    fileManager: fixtureFileManager
+)
+```

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -168,6 +168,19 @@ public struct AgentRestorePlanner: Sendable {
     ) -> [String: String] {
         var captured = request.launchCommand?.environment ?? [:]
         captured.merge(request.environment) { _, binding in binding }
+        if kind == "codex",
+           let rawCodexHome = normalized(captured["CODEX_HOME"]),
+           let launchWorkingDirectory = normalized(request.launchCommand?.workingDirectory)
+               ?? normalized(request.workingDirectory) {
+            // CODEX_HOME is interpreted relative to the process cwd. Preserve
+            // the launch-time meaning when a restored surface uses a different
+            // cwd (for example, after a worktree rotation).
+            captured["CODEX_HOME"] = CodexHomeResolver().resolve(
+                launchEnvironment: ["CODEX_HOME": rawCodexHome],
+                launchWorkingDirectory: launchWorkingDirectory,
+                fallbackHomeDirectory: launchWorkingDirectory
+            )
+        }
         if request.mode == .direct {
             return captured
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -178,6 +178,7 @@ public struct AgentRestorePlanner: Sendable {
             captured["CODEX_HOME"] = CodexHomeResolver().resolve(
                 launchEnvironment: ["CODEX_HOME": rawCodexHome],
                 launchWorkingDirectory: launchWorkingDirectory,
+                launchVerificationHome: request.launchCommand?.verificationHome,
                 fallbackHomeDirectory: launchWorkingDirectory
             )
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
@@ -14,6 +14,8 @@ public struct CodexHomeResolver: Sendable {
     ///
     /// - Parameters:
     ///   - launchEnvironment: Environment captured with the agent launch.
+    ///   - launchWorkingDirectory: Directory captured with the agent launch,
+    ///     used to resolve a relative `CODEX_HOME`.
     ///   - launchVerificationHome: Captured user home used for provider-state
     ///     verification when `CODEX_HOME` was not set.
     ///   - ambientEnvironment: Environment of the process doing the lookup.
@@ -22,18 +24,19 @@ public struct CodexHomeResolver: Sendable {
     /// - Returns: A tilde-expanded, standardized Codex state directory path.
     public func resolve(
         launchEnvironment: [String: String]? = nil,
+        launchWorkingDirectory: String? = nil,
         launchVerificationHome: String? = nil,
         ambientEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         fallbackHomeDirectory: String? = nil
     ) -> String {
         if let launchCodexHome = normalized(launchEnvironment?["CODEX_HOME"]) {
-            return standardized(launchCodexHome)
+            return standardized(launchCodexHome, relativeTo: launchWorkingDirectory)
         }
         if let launchHome = normalized(launchVerificationHome) {
-            return codexDirectory(forHome: launchHome)
+            return codexDirectory(forHome: launchHome, relativeTo: launchWorkingDirectory)
         }
         if let launchHome = normalized(launchEnvironment?["HOME"]) {
-            return codexDirectory(forHome: launchHome)
+            return codexDirectory(forHome: launchHome, relativeTo: launchWorkingDirectory)
         }
         if let ambientCodexHome = normalized(ambientEnvironment["CODEX_HOME"]) {
             return standardized(ambientCodexHome)
@@ -44,9 +47,9 @@ public struct CodexHomeResolver: Sendable {
         return codexDirectory(forHome: fallbackHomeDirectory ?? NSHomeDirectory())
     }
 
-    private func codexDirectory(forHome home: String) -> String {
+    private func codexDirectory(forHome home: String, relativeTo base: String? = nil) -> String {
         URL(
-            fileURLWithPath: expanded(home),
+            fileURLWithPath: expanded(home, relativeTo: base),
             isDirectory: true
         )
         .appendingPathComponent(".codex", isDirectory: true)
@@ -54,12 +57,24 @@ public struct CodexHomeResolver: Sendable {
         .path
     }
 
-    private func standardized(_ path: String) -> String {
-        (expanded(path) as NSString).standardizingPath
+    private func standardized(_ path: String, relativeTo base: String? = nil) -> String {
+        (expanded(path, relativeTo: base) as NSString).standardizingPath
     }
 
-    private func expanded(_ path: String) -> String {
-        NSString(string: path).expandingTildeInPath
+    private func expanded(_ path: String, relativeTo base: String? = nil) -> String {
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        guard !expandedPath.hasPrefix("/"),
+              let base,
+              let normalizedBase = normalized(base) else {
+            return expandedPath
+        }
+        return URL(
+            fileURLWithPath: expandedPath,
+            relativeTo: URL(
+                fileURLWithPath: NSString(string: normalizedBase).expandingTildeInPath,
+                isDirectory: true
+            )
+        ).standardizedFileURL.path
     }
 
     private func normalized(_ value: String?) -> String? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
@@ -30,26 +30,49 @@ public struct CodexHomeResolver: Sendable {
         fallbackHomeDirectory: String? = nil
     ) -> String {
         if let launchCodexHome = normalized(launchEnvironment?["CODEX_HOME"]) {
-            return standardized(launchCodexHome, relativeTo: launchWorkingDirectory)
+            return standardized(
+                launchCodexHome,
+                relativeTo: launchWorkingDirectory,
+                tildeHome: launchHomeForTildeExpansion(
+                    launchEnvironment: launchEnvironment,
+                    launchVerificationHome: launchVerificationHome
+                )
+            )
         }
         if let launchHome = normalized(launchVerificationHome) {
-            return codexDirectory(forHome: launchHome, relativeTo: launchWorkingDirectory)
+            return codexDirectory(
+                forHome: launchHome,
+                relativeTo: launchWorkingDirectory,
+                tildeHome: launchHome
+            )
         }
         if let launchHome = normalized(launchEnvironment?["HOME"]) {
-            return codexDirectory(forHome: launchHome, relativeTo: launchWorkingDirectory)
+            return codexDirectory(
+                forHome: launchHome,
+                relativeTo: launchWorkingDirectory,
+                tildeHome: launchHome
+            )
         }
         if let ambientCodexHome = normalized(ambientEnvironment["CODEX_HOME"]) {
-            return standardized(ambientCodexHome)
+            return standardized(
+                ambientCodexHome,
+                tildeHome: normalized(ambientEnvironment["HOME"])
+            )
         }
         if let ambientHome = normalized(ambientEnvironment["HOME"]) {
-            return codexDirectory(forHome: ambientHome)
+            return codexDirectory(forHome: ambientHome, tildeHome: ambientHome)
         }
-        return codexDirectory(forHome: fallbackHomeDirectory ?? NSHomeDirectory())
+        let fallbackHome = fallbackHomeDirectory ?? NSHomeDirectory()
+        return codexDirectory(forHome: fallbackHome, tildeHome: fallbackHome)
     }
 
-    private func codexDirectory(forHome home: String, relativeTo base: String? = nil) -> String {
+    private func codexDirectory(
+        forHome home: String,
+        relativeTo base: String? = nil,
+        tildeHome: String? = nil
+    ) -> String {
         URL(
-            fileURLWithPath: expanded(home, relativeTo: base),
+            fileURLWithPath: expanded(home, relativeTo: base, tildeHome: tildeHome),
             isDirectory: true
         )
         .appendingPathComponent(".codex", isDirectory: true)
@@ -57,12 +80,20 @@ public struct CodexHomeResolver: Sendable {
         .path
     }
 
-    private func standardized(_ path: String, relativeTo base: String? = nil) -> String {
-        (expanded(path, relativeTo: base) as NSString).standardizingPath
+    private func standardized(
+        _ path: String,
+        relativeTo base: String? = nil,
+        tildeHome: String? = nil
+    ) -> String {
+        (expanded(path, relativeTo: base, tildeHome: tildeHome) as NSString).standardizingPath
     }
 
-    private func expanded(_ path: String, relativeTo base: String? = nil) -> String {
-        let expandedPath = NSString(string: path).expandingTildeInPath
+    private func expanded(
+        _ path: String,
+        relativeTo base: String? = nil,
+        tildeHome: String? = nil
+    ) -> String {
+        let expandedPath = expandTilde(path, using: tildeHome)
         guard !expandedPath.hasPrefix("/"),
               let base,
               let normalizedBase = normalized(base) else {
@@ -71,10 +102,29 @@ public struct CodexHomeResolver: Sendable {
         return URL(
             fileURLWithPath: expandedPath,
             relativeTo: URL(
-                fileURLWithPath: NSString(string: normalizedBase).expandingTildeInPath,
+                fileURLWithPath: expandTilde(normalizedBase, using: tildeHome),
                 isDirectory: true
             )
         ).standardizedFileURL.path
+    }
+
+    private func launchHomeForTildeExpansion(
+        launchEnvironment: [String: String]?,
+        launchVerificationHome: String?
+    ) -> String? {
+        normalized(launchVerificationHome)
+            ?? normalized(launchEnvironment?["HOME"])
+    }
+
+    private func expandTilde(_ path: String, using home: String?) -> String {
+        guard path == "~" || path.hasPrefix("~/"),
+              let home = normalized(home) else {
+            return NSString(string: path).expandingTildeInPath
+        }
+        let expandedHome = NSString(string: home).expandingTildeInPath
+        return path == "~"
+            ? expandedHome
+            : expandedHome + String(path.dropFirst())
     }
 
     private func normalized(_ value: String?) -> String? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
@@ -21,13 +21,18 @@ public struct CodexHomeResolver: Sendable {
     ///   - ambientEnvironment: Environment of the process doing the lookup.
     ///   - fallbackHomeDirectory: Home used when no launch or ambient home is
     ///     available; this is primarily a deterministic test seam.
+    ///   - preferFallbackHomeDirectory: Whether the explicit fallback root is
+    ///     authoritative over ambient process homes after launch metadata has
+    ///     been considered. Index loads use this to keep injected home roots
+    ///     isolated from the process running the test or app.
     /// - Returns: A tilde-expanded, standardized Codex state directory path.
     public func resolve(
         launchEnvironment: [String: String]? = nil,
         launchWorkingDirectory: String? = nil,
         launchVerificationHome: String? = nil,
         ambientEnvironment: [String: String] = ProcessInfo.processInfo.environment,
-        fallbackHomeDirectory: String? = nil
+        fallbackHomeDirectory: String? = nil,
+        preferFallbackHomeDirectory: Bool = false
     ) -> String {
         if let launchCodexHome = normalized(launchEnvironment?["CODEX_HOME"]) {
             return standardized(
@@ -52,6 +57,10 @@ public struct CodexHomeResolver: Sendable {
                 relativeTo: launchWorkingDirectory,
                 tildeHome: launchHome
             )
+        }
+        if preferFallbackHomeDirectory,
+           let fallbackHome = normalized(fallbackHomeDirectory) {
+            return codexDirectory(forHome: fallbackHome, tildeHome: fallbackHome)
         }
         if let ambientCodexHome = normalized(ambientEnvironment["CODEX_HOME"]) {
             return standardized(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHomeResolver.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Resolves the Codex state directory from launch-scoped and ambient homes.
+///
+/// Launch metadata wins over the current process environment so a restored
+/// surface cannot silently switch accounts when `CODEX_HOME` changed after the
+/// snapshot was written. Callers that use a synthetic home in tests can pass
+/// it as ``fallbackHomeDirectory``.
+public struct CodexHomeResolver: Sendable {
+    /// Creates a stateless Codex home resolver.
+    public init() {}
+
+    /// Resolves the effective `.codex` directory for one launch.
+    ///
+    /// - Parameters:
+    ///   - launchEnvironment: Environment captured with the agent launch.
+    ///   - launchVerificationHome: Captured user home used for provider-state
+    ///     verification when `CODEX_HOME` was not set.
+    ///   - ambientEnvironment: Environment of the process doing the lookup.
+    ///   - fallbackHomeDirectory: Home used when no launch or ambient home is
+    ///     available; this is primarily a deterministic test seam.
+    /// - Returns: A tilde-expanded, standardized Codex state directory path.
+    public func resolve(
+        launchEnvironment: [String: String]? = nil,
+        launchVerificationHome: String? = nil,
+        ambientEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        fallbackHomeDirectory: String? = nil
+    ) -> String {
+        if let launchCodexHome = normalized(launchEnvironment?["CODEX_HOME"]) {
+            return standardized(launchCodexHome)
+        }
+        if let launchHome = normalized(launchVerificationHome) {
+            return codexDirectory(forHome: launchHome)
+        }
+        if let launchHome = normalized(launchEnvironment?["HOME"]) {
+            return codexDirectory(forHome: launchHome)
+        }
+        if let ambientCodexHome = normalized(ambientEnvironment["CODEX_HOME"]) {
+            return standardized(ambientCodexHome)
+        }
+        if let ambientHome = normalized(ambientEnvironment["HOME"]) {
+            return codexDirectory(forHome: ambientHome)
+        }
+        return codexDirectory(forHome: fallbackHomeDirectory ?? NSHomeDirectory())
+    }
+
+    private func codexDirectory(forHome home: String) -> String {
+        URL(
+            fileURLWithPath: expanded(home),
+            isDirectory: true
+        )
+        .appendingPathComponent(".codex", isDirectory: true)
+        .standardizedFileURL
+        .path
+    }
+
+    private func standardized(_ path: String) -> String {
+        (expanded(path) as NSString).standardizingPath
+    }
+
+    private func expanded(_ path: String) -> String {
+        NSString(string: path).expandingTildeInPath
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -1,0 +1,260 @@
+import Foundation
+
+/// Performs the bounded legacy rollout inspection shared by Codex verification
+/// requests. The scanner has no retained state; one instance can be reused for
+/// every request in a verification batch.
+struct CodexLegacyRolloutScanner: Sendable {
+    private static let maximumRolloutBytes = 8 * 1024 * 1024
+    private static let maximumRolloutLines = 32
+    private static let maximumFallbackCandidates = 512
+    private static let maximumMatchingCandidates = 32
+    private static let maximumScannedEntries = 8_192
+
+    enum RolloutRead {
+        case metadata(SessionMetadata)
+        case readableWithoutMetadata
+        case unavailable
+    }
+
+    struct SessionMetadata {
+        let sessionId: String
+        let provenance: AgentResumeEvidenceProvenance
+        let originator: String?
+        let sourceDescription: String?
+        let parentSessionId: String?
+    }
+
+    func scan(
+        sessionIDs: Set<String>,
+        sessionsRoot: URL,
+        fileManager: FileManager
+    ) -> (found: [String: (path: String, metadata: SessionMetadata)], sawUnavailable: Bool) {
+        guard !sessionIDs.isEmpty else {
+            return (found: [:], sawUnavailable: false)
+        }
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: sessionsRoot.path, isDirectory: &isDirectory) else {
+            return (found: [:], sawUnavailable: false)
+        }
+        guard isDirectory.boolValue,
+              let enumerator = fileManager.enumerator(
+                  at: sessionsRoot,
+                  includingPropertiesForKeys: [.isRegularFileKey],
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return (found: [:], sawUnavailable: true)
+        }
+
+        var fallbackCandidates: [URL] = []
+        var sawUnavailable = false
+        var scannedEntries = 0
+        var matchingCandidatesBySessionID: [String: Int] = [:]
+        var found: [String: (path: String, metadata: SessionMetadata)] = [:]
+        while let item = enumerator.nextObject() as? URL {
+            scannedEntries += 1
+            if scannedEntries > Self.maximumScannedEntries {
+                sawUnavailable = true
+                break
+            }
+            guard item.pathExtension.lowercased() == "jsonl" else { continue }
+            let matchingSessionIDs = matchingSessionIDs(
+                in: item.lastPathComponent,
+                requested: sessionIDs
+            )
+            if !matchingSessionIDs.isEmpty {
+                let eligibleSessionIDs = matchingSessionIDs.filter { sessionID in
+                    let count = matchingCandidatesBySessionID[sessionID, default: 0] + 1
+                    matchingCandidatesBySessionID[sessionID] = count
+                    if count > Self.maximumMatchingCandidates {
+                        sawUnavailable = true
+                        return false
+                    }
+                    return true
+                }
+                guard !eligibleSessionIDs.isEmpty else { continue }
+                switch readRollout(atPath: item.path, fileManager: fileManager) {
+                case .metadata(let metadata) where eligibleSessionIDs.contains(metadata.sessionId):
+                    if found[metadata.sessionId] == nil {
+                        found[metadata.sessionId] = (item.path, metadata)
+                    }
+                case .unavailable:
+                    sawUnavailable = true
+                default:
+                    continue
+                }
+                if found.count == sessionIDs.count {
+                    break
+                }
+            } else if fallbackCandidates.count < Self.maximumFallbackCandidates {
+                fallbackCandidates.append(item)
+            }
+        }
+        guard found.count < sessionIDs.count else {
+            return (found: found, sawUnavailable: sawUnavailable)
+        }
+        for candidate in fallbackCandidates {
+            switch readRollout(atPath: candidate.path, fileManager: fileManager) {
+            case .metadata(let metadata) where sessionIDs.contains(metadata.sessionId):
+                if found[metadata.sessionId] == nil {
+                    found[metadata.sessionId] = (candidate.path, metadata)
+                }
+            case .unavailable:
+                sawUnavailable = true
+            default:
+                continue
+            }
+            if found.count == sessionIDs.count {
+                break
+            }
+        }
+        return (found: found, sawUnavailable: sawUnavailable)
+    }
+
+    private func matchingSessionIDs(
+        in filename: String,
+        requested: Set<String>
+    ) -> [String] {
+        let bytes = Array(filename.utf8)
+        guard bytes.count >= 36 else { return [] }
+        var matches: [String] = []
+        for start in 0...(bytes.count - 36) {
+            let candidate = String(decoding: bytes[start..<(start + 36)], as: UTF8.self)
+            guard requested.contains(candidate), !matches.contains(candidate) else { continue }
+            matches.append(candidate)
+        }
+        return matches
+    }
+
+    func readRollout(atPath path: String, fileManager: FileManager) -> RolloutRead {
+        guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager),
+              let handle = FileHandle(forReadingAtPath: path) else {
+            return .unavailable
+        }
+        defer { try? handle.close() }
+
+        var pending = Data()
+        var totalBytes = 0
+        var lineCount = 0
+        var sawJSON = false
+        while totalBytes < Self.maximumRolloutBytes, lineCount < Self.maximumRolloutLines {
+            guard let chunk = try? handle.read(upToCount: min(64 * 1024, Self.maximumRolloutBytes - totalBytes)),
+                  !chunk.isEmpty else {
+                break
+            }
+            totalBytes += chunk.count
+            pending.append(chunk)
+            while let newline = pending.firstIndex(of: 0x0A), lineCount < Self.maximumRolloutLines {
+                let line = Data(pending[..<newline])
+                pending.removeSubrange(...newline)
+                lineCount += 1
+                if let object = jsonObject(line) {
+                    sawJSON = true
+                    if let metadata = sessionMetadata(from: object) {
+                        return .metadata(metadata)
+                    }
+                }
+            }
+        }
+        if totalBytes >= Self.maximumRolloutBytes && !pending.contains(0x0A) {
+            return .unavailable
+        }
+        if !pending.isEmpty, let object = jsonObject(pending) {
+            sawJSON = true
+            if let metadata = sessionMetadata(from: object) {
+                return .metadata(metadata)
+            }
+        }
+        return sawJSON ? .readableWithoutMetadata : .unavailable
+    }
+
+    func sourceContainsMarker(_ marker: String, in value: Any?) -> Bool {
+        let normalizedMarker = marker.lowercased()
+        if let string = value as? String {
+            return string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedMarker
+        }
+        if let dictionary = value as? [String: Any] {
+            for (key, child) in dictionary {
+                if key.lowercased() == normalizedMarker || sourceContainsMarker(marker, in: child) {
+                    return true
+                }
+            }
+        } else if let array = value as? [Any] {
+            return array.contains { sourceContainsMarker(marker, in: $0) }
+        }
+        return false
+    }
+
+    private func sessionMetadata(from object: [String: Any]) -> SessionMetadata? {
+        guard object["type"] as? String == "session_meta",
+              let payload = object["payload"] as? [String: Any],
+              let sessionId = normalized(payload["id"] as? String) else {
+            return nil
+        }
+        let source = payload["source"]
+        let sourceDescription = normalized(source as? String)
+        let originator = normalized(payload["originator"] as? String)
+        let parentSessionId = normalized(payload["parent_thread_id"] as? String)
+            ?? normalized(payload["forked_from_id"] as? String)
+            ?? nestedString(forKey: "parent_thread_id", in: source)
+        let isExec = sourceContainsMarker("exec", in: source)
+            || sourceContainsMarker("review", in: source)
+            || originator?.lowercased().contains("codex_exec") == true
+            || originator?.lowercased().contains("review") == true
+        let isSubagent = sourceContainsMarker("subagent", in: source)
+            || normalized(payload["thread_source"] as? String)?.lowercased() == "subagent"
+        let provenance: AgentResumeEvidenceProvenance
+        if isExec {
+            provenance = .exec
+        } else if isSubagent {
+            provenance = .subagent
+        } else if sourceContainsMarker("cli", in: source)
+                    || sourceContainsMarker("tui", in: source)
+                    || sourceContainsMarker("vscode", in: source) {
+            provenance = .tui
+        } else {
+            provenance = .unknown
+        }
+        return SessionMetadata(
+            sessionId: sessionId,
+            provenance: provenance,
+            originator: originator,
+            sourceDescription: sourceDescription,
+            parentSessionId: parentSessionId
+        )
+    }
+
+    private func nestedString(forKey key: String, in value: Any?) -> String? {
+        if let dictionary = value as? [String: Any] {
+            for (childKey, child) in dictionary {
+                if childKey == key, let result = normalized(child as? String) { return result }
+                if let result = nestedString(forKey: key, in: child) { return result }
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                if let result = nestedString(forKey: key, in: child) {
+                    return result
+                }
+            }
+        }
+        return nil
+    }
+
+    private func jsonObject(_ data: Data) -> [String: Any]? {
+        guard !data.isEmpty else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private func regularNonEmptyFileExists(atPath path: String, fileManager: FileManager) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+              attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? NSNumber else { return false }
+        return size.int64Value > 0
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -173,17 +173,22 @@ struct CodexLegacyRolloutScanner: Sendable {
         guard let maximumBytes = readBudget.allowance(for: path, fileManager: fileManager) else {
             return .unavailable
         }
+        let fileWasTruncated = (try? fileManager.attributesOfItem(atPath: path))
+            .flatMap { $0[.size] as? NSNumber }
+            .map { $0.int64Value >= Int64(maximumBytes) } == true
         return readRollout(
             atPath: path,
             fileManager: fileManager,
-            maximumBytes: maximumBytes
+            maximumBytes: maximumBytes,
+            fileWasTruncated: fileWasTruncated
         )
     }
 
     private func readRollout(
         atPath path: String,
         fileManager: FileManager,
-        maximumBytes: Int
+        maximumBytes: Int,
+        fileWasTruncated: Bool
     ) -> RolloutRead {
         guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager),
               let handle = FileHandle(forReadingAtPath: path) else {
@@ -214,14 +219,16 @@ struct CodexLegacyRolloutScanner: Sendable {
                 }
             }
         }
-        if totalBytes >= maximumBytes && !pending.contains(0x0A) {
-            return .unavailable
-        }
         if !pending.isEmpty, let object = jsonObject(pending) {
             sawJSON = true
             if let metadata = sessionMetadata(from: object) {
                 return .metadata(metadata)
             }
+        }
+        if fileWasTruncated && totalBytes >= maximumBytes && !pending.contains(0x0A) {
+            // Parse the pending final object before treating a byte-ceiling
+            // truncation as an inconclusive read.
+            return .unavailable
         }
         return sawJSON ? .readableWithoutMetadata : .unavailable
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -173,9 +173,14 @@ struct CodexLegacyRolloutScanner: Sendable {
         guard let maximumBytes = readBudget.allowance(for: path, fileManager: fileManager) else {
             return .unavailable
         }
-        let fileWasTruncated = (try? fileManager.attributesOfItem(atPath: path))
+        let fileSize = (try? fileManager.attributesOfItem(atPath: path))
             .flatMap { $0[.size] as? NSNumber }
-            .map { $0.int64Value >= Int64(maximumBytes) } == true
+            .map(\.int64Value)
+        let fileWasTruncated = fileSize.map {
+            $0 > Int64(maximumBytes)
+                || (maximumBytes == CodexSessionResumeVerificationLimits.maximumRolloutBytes
+                    && $0 >= Int64(maximumBytes))
+        } == true
         return readRollout(
             atPath: path,
             fileManager: fileManager,

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -194,7 +194,8 @@ struct CodexLegacyRolloutScanner: Sendable {
             atPath: path,
             fileManager: fileManager,
             maximumBytes: maximumBytes,
-            fileWasTruncated: fileWasTruncated
+            fileWasTruncated: fileWasTruncated,
+            readBudget: &readBudget
         )
     }
 
@@ -202,7 +203,8 @@ struct CodexLegacyRolloutScanner: Sendable {
         atPath path: String,
         fileManager: FileManager,
         maximumBytes: Int,
-        fileWasTruncated: Bool
+        fileWasTruncated: Bool,
+        readBudget: inout CodexSessionResumeVerificationLimits
     ) -> RolloutRead {
         guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager),
               let handle = FileHandle(forReadingAtPath: path) else {
@@ -220,6 +222,7 @@ struct CodexLegacyRolloutScanner: Sendable {
                 break
             }
             totalBytes += chunk.count
+            readBudget.consume(chunk.count)
             pending.append(chunk)
             while let newline = pending.firstIndex(of: 0x0A), lineCount < CodexSessionResumeVerificationLimits.maximumRolloutLines {
                 let line = Data(pending[..<newline])

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -48,6 +48,7 @@ struct CodexLegacyRolloutScanner: Sendable {
         }
 
         var fallbackCandidates: [URL] = []
+        var fallbackCandidatesTruncated = false
         var sawUnavailable = false
         var scannedEntries = 0
         var matchingCandidatesBySessionID: [String: Int] = [:]
@@ -115,6 +116,11 @@ struct CodexLegacyRolloutScanner: Sendable {
                 }
             } else if fallbackCandidates.count < Self.maximumFallbackCandidates {
                 fallbackCandidates.append(item)
+            } else {
+                // A later legacy rollout may contain the requested identity.
+                // Once the bounded fallback list drops entries, absence is no
+                // longer authoritative for any unresolved request.
+                fallbackCandidatesTruncated = true
             }
         }
         guard found.count < sessionIDs.count else {
@@ -147,7 +153,10 @@ struct CodexLegacyRolloutScanner: Sendable {
                 break
             }
         }
-        return (found: found, sawUnavailable: sawUnavailable)
+        return (
+            found: found,
+            sawUnavailable: sawUnavailable || fallbackCandidatesTruncated
+        )
     }
 
     private func matchingSessionIDs(
@@ -266,7 +275,6 @@ struct CodexLegacyRolloutScanner: Sendable {
         let originator = normalized(payload["originator"] as? String)
         let parentSessionId = normalized(payload["parent_thread_id"] as? String)
             ?? normalized(payload["forked_from_id"] as? String)
-            ?? nestedString(forKey: "parent_thread_id", in: source)
         let isExec = sourceContainsMarker("exec", in: source)
             || sourceContainsMarker("review", in: source)
             || originator?.lowercased().contains("codex_exec") == true
@@ -292,22 +300,6 @@ struct CodexLegacyRolloutScanner: Sendable {
             sourceDescription: sourceDescription,
             parentSessionId: parentSessionId
         )
-    }
-
-    private func nestedString(forKey key: String, in value: Any?) -> String? {
-        if let dictionary = value as? [String: Any] {
-            for (childKey, child) in dictionary {
-                if childKey == key, let result = normalized(child as? String) { return result }
-                if let result = nestedString(forKey: key, in: child) { return result }
-            }
-        } else if let array = value as? [Any] {
-            for child in array {
-                if let result = nestedString(forKey: key, in: child) {
-                    return result
-                }
-            }
-        }
-        return nil
     }
 
     private func jsonObject(_ data: Data) -> [String: Any]? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexLegacyRolloutScanner.swift
@@ -4,8 +4,6 @@ import Foundation
 /// requests. The scanner has no retained state; one instance can be reused for
 /// every request in a verification batch.
 struct CodexLegacyRolloutScanner: Sendable {
-    private static let maximumRolloutBytes = 8 * 1024 * 1024
-    private static let maximumRolloutLines = 32
     private static let maximumFallbackCandidates = 512
     private static let maximumMatchingCandidates = 32
     private static let maximumScannedEntries = 8_192
@@ -27,10 +25,14 @@ struct CodexLegacyRolloutScanner: Sendable {
     func scan(
         sessionIDs: Set<String>,
         sessionsRoot: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        readBudget: inout CodexSessionResumeVerificationLimits
     ) -> (found: [String: (path: String, metadata: SessionMetadata)], sawUnavailable: Bool) {
         guard !sessionIDs.isEmpty else {
             return (found: [:], sawUnavailable: false)
+        }
+        guard readBudget.hasRemainingBytes else {
+            return (found: [:], sawUnavailable: true)
         }
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: sessionsRoot.path, isDirectory: &isDirectory) else {
@@ -51,6 +53,10 @@ struct CodexLegacyRolloutScanner: Sendable {
         var matchingCandidatesBySessionID: [String: Int] = [:]
         var found: [String: (path: String, metadata: SessionMetadata)] = [:]
         while let item = enumerator.nextObject() as? URL {
+            if !readBudget.hasRemainingBytes {
+                sawUnavailable = true
+                break
+            }
             scannedEntries += 1
             if scannedEntries > Self.maximumScannedEntries {
                 sawUnavailable = true
@@ -72,15 +78,37 @@ struct CodexLegacyRolloutScanner: Sendable {
                     return true
                 }
                 guard !eligibleSessionIDs.isEmpty else { continue }
-                switch readRollout(atPath: item.path, fileManager: fileManager) {
-                case .metadata(let metadata) where eligibleSessionIDs.contains(metadata.sessionId):
-                    if found[metadata.sessionId] == nil {
+                switch readRollout(
+                    atPath: item.path,
+                    fileManager: fileManager,
+                    readBudget: &readBudget
+                ) {
+                case .metadata(let metadata):
+                    guard sessionIDs.contains(metadata.sessionId) else { break }
+                    // A rollout may have been renamed or copied while its
+                    // `session_meta.id` stayed authoritative. Keep metadata
+                    // matches even when the filename's UUID points at a
+                    // different requested record.
+                    let count: Int
+                    if eligibleSessionIDs.contains(metadata.sessionId) {
+                        count = matchingCandidatesBySessionID[metadata.sessionId, default: 0]
+                    } else {
+                        count = matchingCandidatesBySessionID[metadata.sessionId, default: 0] + 1
+                        matchingCandidatesBySessionID[metadata.sessionId] = count
+                    }
+                    if count <= Self.maximumMatchingCandidates,
+                       found[metadata.sessionId] == nil {
                         found[metadata.sessionId] = (item.path, metadata)
+                    } else if count > Self.maximumMatchingCandidates {
+                        sawUnavailable = true
                     }
                 case .unavailable:
                     sawUnavailable = true
-                default:
-                    continue
+                case .readableWithoutMetadata:
+                    break
+                }
+                if !readBudget.hasRemainingBytes {
+                    sawUnavailable = true
                 }
                 if found.count == sessionIDs.count {
                     break
@@ -93,15 +121,27 @@ struct CodexLegacyRolloutScanner: Sendable {
             return (found: found, sawUnavailable: sawUnavailable)
         }
         for candidate in fallbackCandidates {
-            switch readRollout(atPath: candidate.path, fileManager: fileManager) {
-            case .metadata(let metadata) where sessionIDs.contains(metadata.sessionId):
+            guard readBudget.hasRemainingBytes else {
+                sawUnavailable = true
+                break
+            }
+            switch readRollout(
+                atPath: candidate.path,
+                fileManager: fileManager,
+                readBudget: &readBudget
+            ) {
+            case .metadata(let metadata):
+                guard sessionIDs.contains(metadata.sessionId) else { break }
                 if found[metadata.sessionId] == nil {
                     found[metadata.sessionId] = (candidate.path, metadata)
                 }
             case .unavailable:
                 sawUnavailable = true
-            default:
-                continue
+            case .readableWithoutMetadata:
+                break
+            }
+            if !readBudget.hasRemainingBytes {
+                sawUnavailable = true
             }
             if found.count == sessionIDs.count {
                 break
@@ -114,18 +154,37 @@ struct CodexLegacyRolloutScanner: Sendable {
         in filename: String,
         requested: Set<String>
     ) -> [String] {
-        let bytes = Array(filename.utf8)
-        guard bytes.count >= 36 else { return [] }
-        var matches: [String] = []
-        for start in 0...(bytes.count - 36) {
-            let candidate = String(decoding: bytes[start..<(start + 36)], as: UTF8.self)
-            guard requested.contains(candidate), !matches.contains(candidate) else { continue }
-            matches.append(candidate)
-        }
-        return matches
+        // Codex normally uses UUIDs, but older/fixture stores may use another
+        // stable identifier. Preserve the original focused `contains` probe;
+        // metadata validation below remains the authority for exact identity.
+        requested
+            .filter { !$0.isEmpty && filename.contains($0) }
+            .sorted {
+                if $0.count != $1.count { return $0.count > $1.count }
+                return $0 < $1
+            }
     }
 
-    func readRollout(atPath path: String, fileManager: FileManager) -> RolloutRead {
+    func readRollout(
+        atPath path: String,
+        fileManager: FileManager,
+        readBudget: inout CodexSessionResumeVerificationLimits
+    ) -> RolloutRead {
+        guard let maximumBytes = readBudget.allowance(for: path, fileManager: fileManager) else {
+            return .unavailable
+        }
+        return readRollout(
+            atPath: path,
+            fileManager: fileManager,
+            maximumBytes: maximumBytes
+        )
+    }
+
+    private func readRollout(
+        atPath path: String,
+        fileManager: FileManager,
+        maximumBytes: Int
+    ) -> RolloutRead {
         guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager),
               let handle = FileHandle(forReadingAtPath: path) else {
             return .unavailable
@@ -136,14 +195,14 @@ struct CodexLegacyRolloutScanner: Sendable {
         var totalBytes = 0
         var lineCount = 0
         var sawJSON = false
-        while totalBytes < Self.maximumRolloutBytes, lineCount < Self.maximumRolloutLines {
-            guard let chunk = try? handle.read(upToCount: min(64 * 1024, Self.maximumRolloutBytes - totalBytes)),
+        while totalBytes < maximumBytes, lineCount < CodexSessionResumeVerificationLimits.maximumRolloutLines {
+            guard let chunk = try? handle.read(upToCount: min(64 * 1024, maximumBytes - totalBytes)),
                   !chunk.isEmpty else {
                 break
             }
             totalBytes += chunk.count
             pending.append(chunk)
-            while let newline = pending.firstIndex(of: 0x0A), lineCount < Self.maximumRolloutLines {
+            while let newline = pending.firstIndex(of: 0x0A), lineCount < CodexSessionResumeVerificationLimits.maximumRolloutLines {
                 let line = Data(pending[..<newline])
                 pending.removeSubrange(...newline)
                 lineCount += 1
@@ -155,7 +214,7 @@ struct CodexLegacyRolloutScanner: Sendable {
                 }
             }
         }
-        if totalBytes >= Self.maximumRolloutBytes && !pending.contains(0x0A) {
+        if totalBytes >= maximumBytes && !pending.contains(0x0A) {
             return .unavailable
         }
         if !pending.isEmpty, let object = jsonObject(pending) {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationLimits.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationLimits.swift
@@ -31,7 +31,12 @@ public struct CodexSessionResumeVerificationLimits: Sendable {
         remainingBytes > 0
     }
 
-    /// Reserves a conservative per-file allowance from the aggregate budget.
+    /// Returns the maximum number of bytes this file may read from the budget.
+    ///
+    /// The budget is charged as bytes actually arrive from the file handle, not
+    /// by the file's advertised size. A large rollout normally exposes its
+    /// `session_meta` record near the beginning, so charging the whole 8 MiB
+    /// ceiling would needlessly starve later identities in the same batch.
     mutating func allowance(
         for path: String,
         fileManager: FileManager,
@@ -44,10 +49,14 @@ public struct CodexSessionResumeVerificationLimits: Sendable {
               size.int64Value > 0 else {
             return nil
         }
-        let fileSize = min(Int64(maximumFileBytes), size.int64Value)
-        let allowed = min(Int64(remainingBytes), fileSize)
+        let allowed = min(Int64(remainingBytes), Int64(maximumFileBytes))
         guard allowed > 0 else { return nil }
-        remainingBytes -= Int(allowed)
         return Int(allowed)
+    }
+
+    /// Charges bytes actually consumed by a bounded rollout read.
+    mutating func consume(_ byteCount: Int) {
+        guard byteCount > 0 else { return }
+        remainingBytes = max(0, remainingBytes - byteCount)
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationLimits.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationLimits.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Bounds the amount of Codex history a verification batch may inspect.
+///
+/// A hook store can contain a long-lived history of child and review records.
+/// These limits keep restore-index reconciliation finite while allowing the
+/// caller to distinguish an omitted read (`unavailable`) from a verified miss.
+public struct CodexSessionResumeVerificationLimits: Sendable {
+    /// Maximum number of identities admitted to one verification batch.
+    public static let maximumBatchRequests = 512
+    /// Maximum aggregate rollout bytes admitted to one verification budget.
+    public static let maximumBatchBytes = 64 * 1024 * 1024
+    /// Maximum bytes read from any one rollout.
+    public static let maximumRolloutBytes = 8 * 1024 * 1024
+    /// Maximum leading JSONL lines inspected in any one rollout.
+    public static let maximumRolloutLines = 32
+
+    /// Remaining aggregate rollout bytes in this budget.
+    public private(set) var remainingBytes: Int
+
+    /// Creates a verification budget.
+    ///
+    /// - Parameter maximumBytes: Aggregate rollout bytes allowed before
+    ///   subsequent reads become unavailable.
+    public init(maximumBytes: Int = Self.maximumBatchBytes) {
+        remainingBytes = max(0, maximumBytes)
+    }
+
+    /// Whether another bounded rollout read can be attempted.
+    public var hasRemainingBytes: Bool {
+        remainingBytes > 0
+    }
+
+    /// Reserves a conservative per-file allowance from the aggregate budget.
+    mutating func allowance(
+        for path: String,
+        fileManager: FileManager,
+        maximumFileBytes: Int = Self.maximumRolloutBytes
+    ) -> Int? {
+        guard remainingBytes > 0,
+              let attributes = try? fileManager.attributesOfItem(atPath: path),
+              attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? NSNumber,
+              size.int64Value > 0 else {
+            return nil
+        }
+        let fileSize = min(Int64(maximumFileBytes), size.int64Value)
+        let allowed = min(Int64(remainingBytes), fileSize)
+        guard allowed > 0 else { return nil }
+        remainingBytes -= Int(allowed)
+        return Int(allowed)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationRequest.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerificationRequest.swift
@@ -1,0 +1,17 @@
+/// One Codex resume identity and its optional hook-provided rollout path.
+public struct CodexSessionResumeVerificationRequest: Equatable, Sendable {
+    /// The exact identifier that would be passed to `codex resume`.
+    public let sessionId: String
+    /// A rollout path captured by the hook, when one was available.
+    public let transcriptPath: String?
+
+    /// Creates a Codex durable-state verification request.
+    ///
+    /// - Parameters:
+    ///   - sessionId: The exact Codex session identifier.
+    ///   - transcriptPath: An optional hook-provided rollout candidate.
+    public init(sessionId: String, transcriptPath: String? = nil) {
+        self.sessionId = sessionId
+        self.transcriptPath = transcriptPath
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
@@ -4,13 +4,12 @@ import SQLite3
 /// Verifies exact Codex resume identifiers against `state_5.sqlite` and rollout
 /// JSONL files under the effective CODEX_HOME.
 public struct CodexSessionResumeVerifier: Sendable {
-    private static let maximumRolloutBytes = 8 * 1024 * 1024
-    private static let maximumRolloutLines = 32
-    private static let maximumFallbackCandidates = 512
-    private static let maximumMatchingCandidates = 32
-    private static let maximumScannedEntries = 8_192
+    private let legacyRolloutScanner: CodexLegacyRolloutScanner
+
     /// Creates a stateless Codex resume verifier.
-    public init() {}
+    public init() {
+        legacyRolloutScanner = CodexLegacyRolloutScanner()
+    }
 
     /// Checks for an exact durable Codex rollout and records its provenance.
     /// A readable `threads` index is authoritative; rollout-only legacy installs
@@ -29,80 +28,147 @@ public struct CodexSessionResumeVerifier: Sendable {
         codexHome: String,
         fileManager: FileManager = .default
     ) -> CodexSessionResumeVerification {
-        guard let normalizedSessionId = normalized(sessionId) else { return .missing }
+        verifyBatch(
+            [CodexSessionResumeVerificationRequest(
+                sessionId: sessionId,
+                transcriptPath: transcriptPath
+            )],
+            codexHome: codexHome,
+            fileManager: fileManager
+        ).first ?? .missing
+    }
+
+    /// Verifies several Codex identities against one state directory.
+    ///
+    /// The legacy rollout fallback is walked at most once for the whole batch.
+    /// This keeps hook-store reconciliation bounded when an older Codex install
+    /// has no `state_5.sqlite` and the store contains many historical records.
+    /// Requests and results are aligned by array index, so callers may retain
+    /// distinct transcript candidates for the same session identifier.
+    ///
+    /// - Parameters:
+    ///   - requests: The exact identities and optional hook rollout candidates.
+    ///   - codexHome: The effective Codex state directory.
+    ///   - fileManager: The filesystem implementation used for inspection.
+    /// - Returns: One durable-state result for every request.
+    public func verifyBatch(
+        _ requests: [CodexSessionResumeVerificationRequest],
+        codexHome: String,
+        fileManager: FileManager = .default
+    ) -> [CodexSessionResumeVerification] {
+        guard !requests.isEmpty else { return [] }
         let home = expandedPath(codexHome)
         let databasePath = URL(fileURLWithPath: home, isDirectory: true)
             .appendingPathComponent("state_5.sqlite", isDirectory: false)
             .path
 
-        let shouldScanLegacyRollouts: Bool
-        switch indexedThread(
-            sessionId: normalizedSessionId,
+        let normalizedRequests = requests.map { request in
+            CodexSessionResumeVerificationRequest(
+                sessionId: normalized(request.sessionId) ?? "",
+                transcriptPath: normalized(request.transcriptPath)
+            )
+        }
+        var results = Array(
+            repeating: CodexSessionResumeVerification.missing,
+            count: normalizedRequests.count
+        )
+
+        // A missing database is the only state in which the legacy rollout
+        // tree is authoritative. Resolve hook transcripts first, then perform
+        // one bounded walk for every remaining identifier.
+        guard fileManager.fileExists(atPath: databasePath) else {
+            var unresolvedSessionIDs = Set<String>()
+            for (index, request) in normalizedRequests.enumerated() {
+                guard !request.sessionId.isEmpty else { continue }
+                if let transcriptPath = request.transcriptPath,
+                   let evidence = transcriptEvidence(
+                       sessionId: request.sessionId,
+                       path: transcriptPath,
+                       codexHome: home,
+                       fileManager: fileManager
+                   ) {
+                    results[index] = .exists(evidence)
+                } else {
+                    unresolvedSessionIDs.insert(request.sessionId)
+                }
+            }
+            if !unresolvedSessionIDs.isEmpty {
+                let scan = legacyRolloutScanner.scan(
+                    sessionIDs: unresolvedSessionIDs,
+                    sessionsRoot: URL(fileURLWithPath: home, isDirectory: true)
+                        .appendingPathComponent("sessions", isDirectory: true),
+                    fileManager: fileManager
+                )
+                for (index, request) in normalizedRequests.enumerated()
+                    where !request.sessionId.isEmpty && results[index] == .missing {
+                    if let match = scan.found[request.sessionId] {
+                        results[index] = .exists(makeEvidence(
+                            sessionId: request.sessionId,
+                            path: match.path,
+                            source: .legacyRollout,
+                            metadata: match.metadata,
+                            indexedSource: nil,
+                            threadSource: nil
+                        ))
+                    } else if scan.sawUnavailable {
+                        results[index] = .unavailable
+                    }
+                }
+            }
+            return results
+        }
+
+        guard let indexedResults = indexedThreads(
+            sessionIDs: Set(normalizedRequests.map(\.sessionId).filter { !$0.isEmpty }),
             databasePath: databasePath,
             codexHome: home,
             fileManager: fileManager
-        ) {
-        case .found(let thread):
-            switch readRollout(atPath: thread.rolloutPath, fileManager: fileManager) {
-            case .metadata(let metadata) where metadata.sessionId == normalizedSessionId:
-                return .exists(makeEvidence(
-                    sessionId: normalizedSessionId,
-                    path: thread.rolloutPath,
-                    source: .threadIndex,
-                    metadata: metadata,
-                    indexedSource: thread.indexedSource,
-                    threadSource: thread.threadSource
-                ))
-            case .unavailable:
-                // An unreadable indexed rollout is unavailable, never a
-                // missing session that may fall back to weaker evidence.
-                return .unavailable
-            case .metadata, .readableWithoutMetadata:
-                // Never accept fallback evidence after an authoritative row's
-                // rollout fails identity validation.
-                return .unavailable
+        ) else {
+            for index in normalizedRequests.indices where !normalizedRequests[index].sessionId.isEmpty {
+                results[index] = .unavailable
             }
-        case .databaseMissing:
-            shouldScanLegacyRollouts = true
-        case .threadMissing:
-            shouldScanLegacyRollouts = false
-        case .unavailable:
-            // The rollout alone cannot recover provenance from an unreadable index.
-            return .unavailable
+            return results
         }
-
-        if let transcriptPath,
-           let evidence = transcriptEvidence(
-               sessionId: normalizedSessionId,
-               path: transcriptPath,
-               codexHome: home,
-               fileManager: fileManager
-           ) {
-            return .exists(evidence)
+        for (index, request) in normalizedRequests.enumerated() {
+            guard !request.sessionId.isEmpty else { continue }
+            switch indexedResults[request.sessionId] ?? .threadMissing {
+            case .found(let thread):
+                switch legacyRolloutScanner.readRollout(
+                    atPath: thread.rolloutPath,
+                    fileManager: fileManager
+                ) {
+                case .metadata(let metadata) where metadata.sessionId == request.sessionId:
+                    results[index] = .exists(makeEvidence(
+                        sessionId: request.sessionId,
+                        path: thread.rolloutPath,
+                        source: .threadIndex,
+                        metadata: metadata,
+                        indexedSource: thread.indexedSource,
+                        threadSource: thread.threadSource
+                    ))
+                case .unavailable, .metadata, .readableWithoutMetadata:
+                    // An indexed row is authoritative. Never accept weaker
+                    // transcript or legacy evidence after it fails identity
+                    // validation.
+                    results[index] = .unavailable
+                }
+            case .threadMissing:
+                if let transcriptPath = request.transcriptPath,
+                   let evidence = transcriptEvidence(
+                       sessionId: request.sessionId,
+                       path: transcriptPath,
+                       codexHome: home,
+                       fileManager: fileManager
+                   ) {
+                    results[index] = .exists(evidence)
+                }
+            case .databaseMissing, .unavailable:
+                // The database existed when the batch started, so a race
+                // that removes it or makes it unreadable is unavailable.
+                results[index] = .unavailable
+            }
         }
-
-        guard shouldScanLegacyRollouts else { return .missing }
-
-        switch scanRollouts(
-            sessionId: normalizedSessionId,
-            sessionsRoot: URL(fileURLWithPath: home, isDirectory: true)
-                .appendingPathComponent("sessions", isDirectory: true),
-            fileManager: fileManager
-        ) {
-        case .found(let path, let metadata):
-            return .exists(makeEvidence(
-                sessionId: normalizedSessionId,
-                path: path,
-                source: .legacyRollout,
-                metadata: metadata,
-                indexedSource: nil,
-                threadSource: nil
-            ))
-        case .notFound:
-            return .missing
-        case .unavailable:
-            return .unavailable
-        }
+        return results
     }
 
     private struct IndexedThread {
@@ -118,33 +184,14 @@ public struct CodexSessionResumeVerifier: Sendable {
         case unavailable
     }
 
-    private enum RolloutRead {
-        case metadata(SessionMetadata)
-        case readableWithoutMetadata
-        case unavailable
-    }
-
-    private enum RolloutScan {
-        case found(path: String, metadata: SessionMetadata)
-        case notFound
-        case unavailable
-    }
-
-    private struct SessionMetadata {
-        let sessionId: String
-        let provenance: AgentResumeEvidenceProvenance
-        let originator: String?
-        let sourceDescription: String?
-        let parentSessionId: String?
-    }
-
-    private func indexedThread(
-        sessionId: String,
+    private func indexedThreads(
+        sessionIDs: Set<String>,
         databasePath: String,
         codexHome: String,
         fileManager: FileManager
-    ) -> IndexLookup {
-        guard fileManager.fileExists(atPath: databasePath) else { return .databaseMissing }
+    ) -> [String: IndexLookup]? {
+        guard !sessionIDs.isEmpty else { return [:] }
+        guard fileManager.fileExists(atPath: databasePath) else { return nil }
 
         var database: OpaquePointer?
         guard sqlite3_open_v2(
@@ -154,7 +201,7 @@ public struct CodexSessionResumeVerifier: Sendable {
             nil
         ) == SQLITE_OK, let database else {
             sqlite3_close(database)
-            return .unavailable
+            return nil
         }
         defer { sqlite3_close(database) }
 
@@ -194,38 +241,53 @@ public struct CodexSessionResumeVerifier: Sendable {
         }
         guard prepareResult == SQLITE_OK, let statement else {
             sqlite3_finalize(statement)
-            return .unavailable
+            return nil
         }
         defer { sqlite3_finalize(statement) }
 
         let transient = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
-        guard sqlite3_bind_text(statement, 1, sessionId, -1, transient) == SQLITE_OK else {
-            return .unavailable
+        var results: [String: IndexLookup] = [:]
+        for sessionID in sessionIDs {
+            guard sqlite3_reset(statement) == SQLITE_OK,
+                  sqlite3_clear_bindings(statement) == SQLITE_OK,
+                  sqlite3_bind_text(statement, 1, sessionID, -1, transient) == SQLITE_OK else {
+                return nil
+            }
+            let step = sqlite3_step(statement)
+            guard step == SQLITE_ROW || step == SQLITE_DONE else { return nil }
+            guard step == SQLITE_ROW else {
+                results[sessionID] = .threadMissing
+                continue
+            }
+            guard let pathBytes = sqlite3_column_text(statement, 0) else {
+                results[sessionID] = .unavailable
+                continue
+            }
+            let rawPath = String(cString: pathBytes).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !rawPath.isEmpty else {
+                results[sessionID] = .unavailable
+                continue
+            }
+            let indexedSource: String?
+            if includesSource, let sourceBytes = sqlite3_column_text(statement, 1) {
+                indexedSource = normalized(String(cString: sourceBytes))
+            } else {
+                indexedSource = nil
+            }
+            let threadSource: String?
+            if includesThreadSource, let sourceBytes = sqlite3_column_text(statement, 2) {
+                let value = String(cString: sourceBytes).trimmingCharacters(in: .whitespacesAndNewlines)
+                threadSource = value.isEmpty ? nil : value
+            } else {
+                threadSource = nil
+            }
+            results[sessionID] = .found(IndexedThread(
+                rolloutPath: resolvePath(rawPath, relativeTo: codexHome),
+                indexedSource: indexedSource,
+                threadSource: threadSource
+            ))
         }
-        let step = sqlite3_step(statement)
-        guard step == SQLITE_ROW || step == SQLITE_DONE else { return .unavailable }
-        guard step == SQLITE_ROW else { return .threadMissing }
-        guard let pathBytes = sqlite3_column_text(statement, 0) else { return .unavailable }
-        let rawPath = String(cString: pathBytes).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !rawPath.isEmpty else { return .unavailable }
-        let indexedSource: String?
-        if includesSource, let sourceBytes = sqlite3_column_text(statement, 1) {
-            indexedSource = normalized(String(cString: sourceBytes))
-        } else {
-            indexedSource = nil
-        }
-        let threadSource: String?
-        if includesThreadSource, let sourceBytes = sqlite3_column_text(statement, 2) {
-            let value = String(cString: sourceBytes).trimmingCharacters(in: .whitespacesAndNewlines)
-            threadSource = value.isEmpty ? nil : value
-        } else {
-            threadSource = nil
-        }
-        return .found(IndexedThread(
-            rolloutPath: resolvePath(rawPath, relativeTo: codexHome),
-            indexedSource: indexedSource,
-            threadSource: threadSource
-        ))
+        return results
     }
 
     private func transcriptEvidence(
@@ -235,7 +297,7 @@ public struct CodexSessionResumeVerifier: Sendable {
         fileManager: FileManager
     ) -> CodexSessionResumeEvidence? {
         let resolvedPath = resolvePath(path, relativeTo: codexHome)
-        switch readRollout(atPath: resolvedPath, fileManager: fileManager) {
+        switch legacyRolloutScanner.readRollout(atPath: resolvedPath, fileManager: fileManager) {
         case .metadata(let metadata) where metadata.sessionId == sessionId:
             return makeEvidence(
                 sessionId: sessionId,
@@ -254,7 +316,7 @@ public struct CodexSessionResumeVerifier: Sendable {
         sessionId: String,
         path: String,
         source: CodexSessionResumeEvidence.Source,
-        metadata: SessionMetadata,
+        metadata: CodexLegacyRolloutScanner.SessionMetadata,
         indexedSource: String?,
         threadSource: String?
     ) -> CodexSessionResumeEvidence {
@@ -266,16 +328,16 @@ public struct CodexSessionResumeVerifier: Sendable {
             }
             return value
         }
-        if sourceContainsMarker("exec", in: indexedValue)
-            || sourceContainsMarker("automation", in: indexedValue)
-            || sourceContainsMarker("review", in: indexedValue) {
+        if legacyRolloutScanner.sourceContainsMarker("exec", in: indexedValue)
+            || legacyRolloutScanner.sourceContainsMarker("automation", in: indexedValue)
+            || legacyRolloutScanner.sourceContainsMarker("review", in: indexedValue) {
             provenance = .exec
-        } else if sourceContainsMarker("subagent", in: indexedValue), provenance != .exec {
+        } else if legacyRolloutScanner.sourceContainsMarker("subagent", in: indexedValue), provenance != .exec {
             provenance = .subagent
         } else if provenance == .unknown,
-                  sourceContainsMarker("cli", in: indexedValue)
-                    || sourceContainsMarker("tui", in: indexedValue)
-                    || sourceContainsMarker("vscode", in: indexedValue) {
+                  legacyRolloutScanner.sourceContainsMarker("cli", in: indexedValue)
+                    || legacyRolloutScanner.sourceContainsMarker("tui", in: indexedValue)
+                    || legacyRolloutScanner.sourceContainsMarker("vscode", in: indexedValue) {
             provenance = .tui
         }
         if let threadSource {
@@ -295,192 +357,6 @@ public struct CodexSessionResumeVerifier: Sendable {
             sessionMetaSource: metadata.sourceDescription,
             parentSessionId: metadata.parentSessionId
         )
-    }
-
-    private func scanRollouts(
-        sessionId: String,
-        sessionsRoot: URL,
-        fileManager: FileManager
-    ) -> RolloutScan {
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: sessionsRoot.path, isDirectory: &isDirectory) else {
-            return .notFound
-        }
-        guard isDirectory.boolValue,
-              let enumerator = fileManager.enumerator(
-                  at: sessionsRoot,
-                  includingPropertiesForKeys: [.isRegularFileKey],
-                  options: [.skipsHiddenFiles]
-              ) else {
-            return .unavailable
-        }
-
-        var fallbackCandidates: [URL] = []
-        var sawUnavailable = false
-        var scannedEntries = 0
-        var matchingCandidates = 0
-        while let item = enumerator.nextObject() as? URL {
-            scannedEntries += 1
-            if scannedEntries > Self.maximumScannedEntries {
-                return .unavailable
-            }
-            guard item.pathExtension.lowercased() == "jsonl" else { continue }
-            if item.lastPathComponent.contains(sessionId) {
-                matchingCandidates += 1
-                guard matchingCandidates <= Self.maximumMatchingCandidates else {
-                    return .unavailable
-                }
-                // Parse focused filenames while walking so a hit avoids
-                // traversing and reopening every file in the sessions tree.
-                switch readRollout(atPath: item.path, fileManager: fileManager) {
-                case .metadata(let metadata) where metadata.sessionId == sessionId:
-                    return .found(path: item.path, metadata: metadata)
-                case .unavailable:
-                    sawUnavailable = true
-                default:
-                    continue
-                }
-            } else if fallbackCandidates.count < Self.maximumFallbackCandidates {
-                fallbackCandidates.append(item)
-            }
-        }
-        for candidate in fallbackCandidates {
-            switch readRollout(atPath: candidate.path, fileManager: fileManager) {
-            case .metadata(let metadata) where metadata.sessionId == sessionId:
-                return .found(path: candidate.path, metadata: metadata)
-            case .unavailable:
-                sawUnavailable = true
-            default:
-                continue
-            }
-        }
-        return sawUnavailable ? .unavailable : .notFound
-    }
-
-    private func readRollout(atPath path: String, fileManager: FileManager) -> RolloutRead {
-        guard regularNonEmptyFileExists(atPath: path, fileManager: fileManager),
-              let handle = FileHandle(forReadingAtPath: path) else {
-            return .unavailable
-        }
-        defer { try? handle.close() }
-
-        var pending = Data()
-        var totalBytes = 0
-        var lineCount = 0
-        var sawJSON = false
-        while totalBytes < Self.maximumRolloutBytes, lineCount < Self.maximumRolloutLines {
-            guard let chunk = try? handle.read(upToCount: min(64 * 1024, Self.maximumRolloutBytes - totalBytes)),
-                  !chunk.isEmpty else {
-                break
-            }
-            totalBytes += chunk.count
-            pending.append(chunk)
-            while let newline = pending.firstIndex(of: 0x0A), lineCount < Self.maximumRolloutLines {
-                let line = Data(pending[..<newline])
-                pending.removeSubrange(...newline)
-                lineCount += 1
-                if let object = jsonObject(line) {
-                    sawJSON = true
-                    if let metadata = sessionMetadata(from: object) {
-                        return .metadata(metadata)
-                    }
-                }
-            }
-        }
-        if totalBytes >= Self.maximumRolloutBytes && !pending.contains(0x0A) {
-            return .unavailable
-        }
-        if !pending.isEmpty, let object = jsonObject(pending) {
-            sawJSON = true
-            if let metadata = sessionMetadata(from: object) {
-                return .metadata(metadata)
-            }
-        }
-        return sawJSON ? .readableWithoutMetadata : .unavailable
-    }
-
-    private func sessionMetadata(from object: [String: Any]) -> SessionMetadata? {
-        guard object["type"] as? String == "session_meta",
-              let payload = object["payload"] as? [String: Any],
-              let sessionId = normalized(payload["id"] as? String) else {
-            return nil
-        }
-        let source = payload["source"]
-        let sourceDescription = normalized(source as? String)
-        let originator = normalized(payload["originator"] as? String)
-        let parentSessionId = normalized(payload["parent_thread_id"] as? String)
-            ?? normalized(payload["forked_from_id"] as? String)
-            ?? nestedString(forKey: "parent_thread_id", in: source)
-        let isExec = sourceContainsMarker("exec", in: source)
-            || sourceContainsMarker("review", in: source)
-            || originator?.lowercased().contains("codex_exec") == true
-            || originator?.lowercased().contains("review") == true
-        let isSubagent = sourceContainsMarker("subagent", in: source)
-            || normalized(payload["thread_source"] as? String)?.lowercased() == "subagent"
-        let provenance: AgentResumeEvidenceProvenance
-        if isExec {
-            provenance = .exec
-        } else if isSubagent {
-            provenance = .subagent
-        } else if sourceContainsMarker("cli", in: source)
-                    || sourceContainsMarker("tui", in: source)
-                    || sourceContainsMarker("vscode", in: source) {
-            provenance = .tui
-        } else {
-            provenance = .unknown
-        }
-        return SessionMetadata(
-            sessionId: sessionId,
-            provenance: provenance,
-            originator: originator,
-            sourceDescription: sourceDescription,
-            parentSessionId: parentSessionId
-        )
-    }
-
-    private func sourceContainsMarker(_ marker: String, in value: Any?) -> Bool {
-        let normalizedMarker = marker.lowercased()
-        if let string = value as? String {
-            return string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedMarker
-        }
-        if let dictionary = value as? [String: Any] {
-            for (key, child) in dictionary {
-                if key.lowercased() == normalizedMarker || sourceContainsMarker(marker, in: child) {
-                    return true
-                }
-            }
-        } else if let array = value as? [Any] {
-            return array.contains { sourceContainsMarker(marker, in: $0) }
-        }
-        return false
-    }
-
-    private func nestedString(forKey key: String, in value: Any?) -> String? {
-        if let dictionary = value as? [String: Any] {
-            for (childKey, child) in dictionary {
-                if childKey == key, let result = normalized(child as? String) { return result }
-                if let result = nestedString(forKey: key, in: child) { return result }
-            }
-        } else if let array = value as? [Any] {
-            for child in array {
-                if let result = nestedString(forKey: key, in: child) {
-                    return result
-                }
-            }
-        }
-        return nil
-    }
-
-    private func jsonObject(_ data: Data) -> [String: Any]? {
-        guard !data.isEmpty else { return nil }
-        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-    }
-
-    private func regularNonEmptyFileExists(atPath path: String, fileManager: FileManager) -> Bool {
-        guard let attributes = try? fileManager.attributesOfItem(atPath: path),
-              attributes[.type] as? FileAttributeType == .typeRegular,
-              let size = attributes[.size] as? NSNumber else { return false }
-        return size.int64Value > 0
     }
 
     private func resolvePath(_ rawPath: String, relativeTo base: String) -> String {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
@@ -50,7 +50,7 @@ public struct CodexSessionResumeVerifier: Sendable {
     ///   - requests: The exact identities and optional hook rollout candidates.
     ///   - codexHome: The effective Codex state directory.
     ///   - fileManager: The filesystem implementation used for inspection.
-    /// - Returns: One durable-state result for every request.
+    /// - Returns: Results for at most the configured maximum batch size.
     public func verifyBatch(
         _ requests: [CodexSessionResumeVerificationRequest],
         codexHome: String,
@@ -76,7 +76,7 @@ public struct CodexSessionResumeVerifier: Sendable {
     ///   - codexHome: The effective Codex state directory.
     ///   - readBudget: Shared aggregate rollout-read budget.
     ///   - fileManager: The filesystem implementation used for inspection.
-    /// - Returns: One durable-state result for every request.
+    /// - Returns: Results for at most the configured maximum batch size.
     public func verifyBatch(
         _ requests: [CodexSessionResumeVerificationRequest],
         codexHome: String,
@@ -89,7 +89,9 @@ public struct CodexSessionResumeVerifier: Sendable {
             .appendingPathComponent("state_5.sqlite", isDirectory: false)
             .path
 
-        let normalizedRequests = requests.map { request in
+        let verificationRequests = requests.prefix(
+            CodexSessionResumeVerificationLimits.maximumBatchRequests
+        ).map { request in
             CodexSessionResumeVerificationRequest(
                 sessionId: normalized(request.sessionId) ?? "",
                 transcriptPath: normalized(request.transcriptPath)
@@ -97,20 +99,8 @@ public struct CodexSessionResumeVerifier: Sendable {
         }
         var results = Array(
             repeating: CodexSessionResumeVerification.missing,
-            count: normalizedRequests.count
+            count: verificationRequests.count
         )
-        let verificationRequests = Array(
-            normalizedRequests.prefix(CodexSessionResumeVerificationLimits.maximumBatchRequests)
-        )
-        if normalizedRequests.count > verificationRequests.count {
-            for index in verificationRequests.count..<normalizedRequests.count
-                where !normalizedRequests[index].sessionId.isEmpty {
-                // A truncated batch is an inconclusive read, not proof that a
-                // historical checkpoint disappeared. Callers can preserve the
-                // current binding while retrying a later complete load.
-                results[index] = .unavailable
-            }
-        }
         // A missing database is the only state in which the legacy rollout
         // tree is authoritative. Resolve hook transcripts first, then perform
         // one bounded walk for every remaining identifier.
@@ -164,7 +154,7 @@ public struct CodexSessionResumeVerifier: Sendable {
             codexHome: home,
             fileManager: fileManager
         ) else {
-            for index in normalizedRequests.indices where !normalizedRequests[index].sessionId.isEmpty {
+            for index in verificationRequests.indices where !verificationRequests[index].sessionId.isEmpty {
                 results[index] = .unavailable
             }
             return results

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
@@ -56,6 +56,33 @@ public struct CodexSessionResumeVerifier: Sendable {
         codexHome: String,
         fileManager: FileManager = .default
     ) -> [CodexSessionResumeVerification] {
+        var readBudget = CodexSessionResumeVerificationLimits()
+        return verifyBatch(
+            requests,
+            codexHome: codexHome,
+            readBudget: &readBudget,
+            fileManager: fileManager
+        )
+    }
+
+    /// Verifies several identities while consuming a caller-owned byte budget.
+    ///
+    /// Sharing the budget across homes lets an index load bound its total
+    /// filesystem work, rather than applying the limit independently to every
+    /// account directory.
+    ///
+    /// - Parameters:
+    ///   - requests: The exact identities and optional hook rollout candidates.
+    ///   - codexHome: The effective Codex state directory.
+    ///   - readBudget: Shared aggregate rollout-read budget.
+    ///   - fileManager: The filesystem implementation used for inspection.
+    /// - Returns: One durable-state result for every request.
+    public func verifyBatch(
+        _ requests: [CodexSessionResumeVerificationRequest],
+        codexHome: String,
+        readBudget: inout CodexSessionResumeVerificationLimits,
+        fileManager: FileManager = .default
+    ) -> [CodexSessionResumeVerification] {
         guard !requests.isEmpty else { return [] }
         let home = expandedPath(codexHome)
         let databasePath = URL(fileURLWithPath: home, isDirectory: true)
@@ -72,20 +99,32 @@ public struct CodexSessionResumeVerifier: Sendable {
             repeating: CodexSessionResumeVerification.missing,
             count: normalizedRequests.count
         )
-
+        let verificationRequests = Array(
+            normalizedRequests.prefix(CodexSessionResumeVerificationLimits.maximumBatchRequests)
+        )
+        if normalizedRequests.count > verificationRequests.count {
+            for index in verificationRequests.count..<normalizedRequests.count
+                where !normalizedRequests[index].sessionId.isEmpty {
+                // A truncated batch is an inconclusive read, not proof that a
+                // historical checkpoint disappeared. Callers can preserve the
+                // current binding while retrying a later complete load.
+                results[index] = .unavailable
+            }
+        }
         // A missing database is the only state in which the legacy rollout
         // tree is authoritative. Resolve hook transcripts first, then perform
         // one bounded walk for every remaining identifier.
         guard fileManager.fileExists(atPath: databasePath) else {
             var unresolvedSessionIDs = Set<String>()
-            for (index, request) in normalizedRequests.enumerated() {
+            for (index, request) in verificationRequests.enumerated() {
                 guard !request.sessionId.isEmpty else { continue }
                 if let transcriptPath = request.transcriptPath,
                    let evidence = transcriptEvidence(
                        sessionId: request.sessionId,
                        path: transcriptPath,
                        codexHome: home,
-                       fileManager: fileManager
+                       fileManager: fileManager,
+                       readBudget: &readBudget
                    ) {
                     results[index] = .exists(evidence)
                 } else {
@@ -97,9 +136,10 @@ public struct CodexSessionResumeVerifier: Sendable {
                     sessionIDs: unresolvedSessionIDs,
                     sessionsRoot: URL(fileURLWithPath: home, isDirectory: true)
                         .appendingPathComponent("sessions", isDirectory: true),
-                    fileManager: fileManager
+                    fileManager: fileManager,
+                    readBudget: &readBudget
                 )
-                for (index, request) in normalizedRequests.enumerated()
+                for (index, request) in verificationRequests.enumerated()
                     where !request.sessionId.isEmpty && results[index] == .missing {
                     if let match = scan.found[request.sessionId] {
                         results[index] = .exists(makeEvidence(
@@ -119,7 +159,7 @@ public struct CodexSessionResumeVerifier: Sendable {
         }
 
         guard let indexedResults = indexedThreads(
-            sessionIDs: Set(normalizedRequests.map(\.sessionId).filter { !$0.isEmpty }),
+            sessionIDs: Set(verificationRequests.map(\.sessionId).filter { !$0.isEmpty }),
             databasePath: databasePath,
             codexHome: home,
             fileManager: fileManager
@@ -129,13 +169,14 @@ public struct CodexSessionResumeVerifier: Sendable {
             }
             return results
         }
-        for (index, request) in normalizedRequests.enumerated() {
+        for (index, request) in verificationRequests.enumerated() {
             guard !request.sessionId.isEmpty else { continue }
             switch indexedResults[request.sessionId] ?? .threadMissing {
             case .found(let thread):
                 switch legacyRolloutScanner.readRollout(
                     atPath: thread.rolloutPath,
-                    fileManager: fileManager
+                    fileManager: fileManager,
+                    readBudget: &readBudget
                 ) {
                 case .metadata(let metadata) where metadata.sessionId == request.sessionId:
                     results[index] = .exists(makeEvidence(
@@ -158,9 +199,14 @@ public struct CodexSessionResumeVerifier: Sendable {
                        sessionId: request.sessionId,
                        path: transcriptPath,
                        codexHome: home,
-                       fileManager: fileManager
+                       fileManager: fileManager,
+                       readBudget: &readBudget
                    ) {
                     results[index] = .exists(evidence)
+                } else if !readBudget.hasRemainingBytes {
+                    // A shared budget exhaustion is an inconclusive read, not
+                    // evidence that this indexed-missing thread is absent.
+                    results[index] = .unavailable
                 }
             case .databaseMissing, .unavailable:
                 // The database existed when the batch started, so a race
@@ -294,10 +340,15 @@ public struct CodexSessionResumeVerifier: Sendable {
         sessionId: String,
         path: String,
         codexHome: String,
-        fileManager: FileManager
+        fileManager: FileManager,
+        readBudget: inout CodexSessionResumeVerificationLimits
     ) -> CodexSessionResumeEvidence? {
         let resolvedPath = resolvePath(path, relativeTo: codexHome)
-        switch legacyRolloutScanner.readRollout(atPath: resolvedPath, fileManager: fileManager) {
+        switch legacyRolloutScanner.readRollout(
+            atPath: resolvedPath,
+            fileManager: fileManager,
+            readBudget: &readBudget
+        ) {
         case .metadata(let metadata) where metadata.sessionId == sessionId:
             return makeEvidence(
                 sessionId: sessionId,

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexSessionResumeVerifier.swift
@@ -20,13 +20,16 @@ public struct CodexSessionResumeVerifier: Sendable {
     ///   - transcriptPath: A hook-provided rollout candidate, when available.
     ///   - codexHome: The effective Codex state directory for the launch.
     ///   - fileManager: The filesystem implementation used for inspection.
+    ///   - allowLegacyFallbackForIndexedMissing: Whether restore-time callers
+    ///     may bridge an exact rollout when a readable index has no row.
     /// - Returns: Exact evidence, missing, or safely unavailable. Legacy scans
     ///   are bounded by bytes, lines, candidates, and entries and fail closed.
     public func verify(
         sessionId: String,
         transcriptPath: String?,
         codexHome: String,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        allowLegacyFallbackForIndexedMissing: Bool = false
     ) -> CodexSessionResumeVerification {
         verifyBatch(
             [CodexSessionResumeVerificationRequest(
@@ -34,7 +37,8 @@ public struct CodexSessionResumeVerifier: Sendable {
                 transcriptPath: transcriptPath
             )],
             codexHome: codexHome,
-            fileManager: fileManager
+            fileManager: fileManager,
+            allowLegacyFallbackForIndexedMissing: allowLegacyFallbackForIndexedMissing
         ).first ?? .missing
     }
 
@@ -50,18 +54,22 @@ public struct CodexSessionResumeVerifier: Sendable {
     ///   - requests: The exact identities and optional hook rollout candidates.
     ///   - codexHome: The effective Codex state directory.
     ///   - fileManager: The filesystem implementation used for inspection.
+    ///   - allowLegacyFallbackForIndexedMissing: Whether restore-time callers
+    ///     may bridge an exact rollout when a readable index has no row.
     /// - Returns: Results for at most the configured maximum batch size.
     public func verifyBatch(
         _ requests: [CodexSessionResumeVerificationRequest],
         codexHome: String,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        allowLegacyFallbackForIndexedMissing: Bool = false
     ) -> [CodexSessionResumeVerification] {
         var readBudget = CodexSessionResumeVerificationLimits()
         return verifyBatch(
             requests,
             codexHome: codexHome,
             readBudget: &readBudget,
-            fileManager: fileManager
+            fileManager: fileManager,
+            allowLegacyFallbackForIndexedMissing: allowLegacyFallbackForIndexedMissing
         )
     }
 
@@ -76,12 +84,15 @@ public struct CodexSessionResumeVerifier: Sendable {
     ///   - codexHome: The effective Codex state directory.
     ///   - readBudget: Shared aggregate rollout-read budget.
     ///   - fileManager: The filesystem implementation used for inspection.
+    ///   - allowLegacyFallbackForIndexedMissing: Whether restore-time callers
+    ///     may bridge an exact rollout when a readable index has no row.
     /// - Returns: Results for at most the configured maximum batch size.
     public func verifyBatch(
         _ requests: [CodexSessionResumeVerificationRequest],
         codexHome: String,
         readBudget: inout CodexSessionResumeVerificationLimits,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        allowLegacyFallbackForIndexedMissing: Bool = false
     ) -> [CodexSessionResumeVerification] {
         guard !requests.isEmpty else { return [] }
         let home = expandedPath(codexHome)
@@ -159,6 +170,7 @@ public struct CodexSessionResumeVerifier: Sendable {
             }
             return results
         }
+        var indexedMissingSessionIDs = Set<String>()
         for (index, request) in verificationRequests.enumerated() {
             guard !request.sessionId.isEmpty else { continue }
             switch indexedResults[request.sessionId] ?? .threadMissing {
@@ -197,11 +209,38 @@ public struct CodexSessionResumeVerifier: Sendable {
                     // A shared budget exhaustion is an inconclusive read, not
                     // evidence that this indexed-missing thread is absent.
                     results[index] = .unavailable
+                } else if allowLegacyFallbackForIndexedMissing {
+                    indexedMissingSessionIDs.insert(request.sessionId)
                 }
             case .databaseMissing, .unavailable:
                 // The database existed when the batch started, so a race
                 // that removes it or makes it unreadable is unavailable.
                 results[index] = .unavailable
+            }
+        }
+        if allowLegacyFallbackForIndexedMissing, !indexedMissingSessionIDs.isEmpty {
+            let scan = legacyRolloutScanner.scan(
+                sessionIDs: indexedMissingSessionIDs,
+                sessionsRoot: URL(fileURLWithPath: home, isDirectory: true)
+                    .appendingPathComponent("sessions", isDirectory: true),
+                fileManager: fileManager,
+                readBudget: &readBudget
+            )
+            for (index, request) in verificationRequests.enumerated()
+                where indexedMissingSessionIDs.contains(request.sessionId)
+                    && results[index] == .missing {
+                if let match = scan.found[request.sessionId] {
+                    results[index] = .exists(makeEvidence(
+                        sessionId: request.sessionId,
+                        path: match.path,
+                        source: .legacyRollout,
+                        metadata: match.metadata,
+                        indexedSource: nil,
+                        threadSource: nil
+                    ))
+                } else if scan.sawUnavailable {
+                    results[index] = .unavailable
+                }
             }
         }
         return results

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -128,6 +128,39 @@ import Testing
         #expect(invocation.arguments.contains("-lc") == false)
     }
 
+    @Test func structuredCodexRestoreCanonicalizesRelativeHomeFromLaunchDirectory() throws {
+        let launchDirectory = "/tmp/codex-launch-root/repository"
+        let restoredDirectory = "/tmp/codex-launch-root/repository/worktree"
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: restoredDirectory,
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                arguments: ["codex"],
+                workingDirectory: launchDirectory,
+                environment: ["CODEX_HOME": ".codex"]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: ["PATH": "/usr/bin:/bin"]
+            )
+        )
+
+        #expect(
+            invocation.environment["CODEX_HOME"]
+                == launchDirectory + "/.codex"
+        )
+    }
+
     @Test func structuredClaudeRestoreAppliesObservedPermissionModeWithoutParsingShell() throws {
         let request = AgentRestoreRequest(
             mode: .resumeAgent,

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -161,6 +161,42 @@ import Testing
         )
     }
 
+    @Test func structuredCodexRestoreExpandsHomeUsingCapturedLaunchHome() throws {
+        let launchHome = "/tmp/codex-captured-home"
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "codex",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/codex-project",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "codex",
+                arguments: ["codex"],
+                workingDirectory: "/tmp/codex-project",
+                environment: ["CODEX_HOME": "~/.codex-work"],
+                verificationHome: launchHome
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+
+        let invocation = try #require(
+            AgentRestorePlanner(isExecutableFile: { _ in false }).invocation(
+                for: request,
+                ambientEnvironment: [
+                    "HOME": "/tmp/restoring-process-home",
+                    "PATH": "/usr/bin:/bin",
+                ]
+            )
+        )
+
+        #expect(
+            invocation.environment["CODEX_HOME"]
+                == launchHome + "/.codex-work"
+        )
+    }
+
     @Test func structuredClaudeRestoreAppliesObservedPermissionModeWithoutParsingShell() throws {
         let request = AgentRestoreRequest(
             mode: .resumeAgent,

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -123,6 +123,14 @@ struct CodexResumeBindingVerificationTests {
                 fallbackHomeDirectory: "/tmp/fallback"
             ) == "\(launchUserHome)/.codex"
         )
+        #expect(
+            resolver.resolve(
+                launchEnvironment: ["CODEX_HOME": ".codex"],
+                launchWorkingDirectory: "/tmp/captured-project",
+                ambientEnvironment: ["CODEX_HOME": ambientCodexHome],
+                fallbackHomeDirectory: "/tmp/fallback"
+            ) == "/tmp/captured-project/.codex"
+        )
     }
 
     @Test func readableIndexWithoutThreadDoesNotScanUnindexedRollouts() throws {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -206,6 +206,21 @@ struct CodexResumeBindingVerificationTests {
         )
     }
 
+    @Test func codexHomeResolverCanPreferExplicitFallbackOverAmbientState() {
+        let resolver = CodexHomeResolver()
+
+        #expect(
+            resolver.resolve(
+                ambientEnvironment: [
+                    "HOME": "/tmp/ambient-user",
+                    "CODEX_HOME": "/tmp/ambient-codex",
+                ],
+                fallbackHomeDirectory: "/tmp/fixture-user",
+                preferFallbackHomeDirectory: true
+            ) == "/tmp/fixture-user/.codex"
+        )
+    }
+
     @Test func readableIndexWithoutThreadDoesNotScanUnindexedRollouts() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -57,6 +57,48 @@ struct CodexResumeBindingVerificationTests {
         #expect(results[2] == .missing)
     }
 
+    @Test func batchLegacyVerificationTrustsMetadataWhenFilenameNamesAnotherSession() throws {
+        let fixture = try Fixture(createIndex: false)
+        defer { fixture.remove() }
+
+        let filenameSessionID = "019ff9a7-cbe1-7231-9478-0c55a8c44560"
+        let metadataSessionID = "019ff9a8-cbe1-7231-9478-0c55a8c44560"
+        _ = try fixture.writeRollout(
+            sessionId: metadataSessionID,
+            filename: "rollout-\(filenameSessionID)-renamed.jsonl",
+            source: "cli",
+            originator: "codex-tui"
+        )
+
+        let results = CodexSessionResumeVerifier().verifyBatch(
+            [CodexSessionResumeVerificationRequest(sessionId: metadataSessionID)],
+            codexHome: fixture.codexHome.path
+        )
+
+        guard case .exists(let evidence) = results.first else {
+            Issue.record("session_meta.id must remain authoritative after a rollout rename")
+            return
+        }
+        #expect(evidence.sessionId == metadataSessionID)
+        #expect(evidence.source == .legacyRollout)
+    }
+
+    @Test func batchVerificationMarksRequestsBeyondBoundUnavailable() throws {
+        let fixture = try Fixture(createIndex: false)
+        defer { fixture.remove() }
+
+        let requests = (0...CodexSessionResumeVerificationLimits.maximumBatchRequests).map {
+            CodexSessionResumeVerificationRequest(sessionId: "batch-session-\($0)")
+        }
+        let results = CodexSessionResumeVerifier().verifyBatch(
+            requests,
+            codexHome: fixture.codexHome.path
+        )
+
+        #expect(results.count == requests.count)
+        #expect(results[CodexSessionResumeVerificationLimits.maximumBatchRequests] == .unavailable)
+    }
+
     @Test func codexHomeResolverPrefersLaunchMetadataOverAmbientState() {
         let resolver = CodexHomeResolver()
         let launchCodexHome = "/tmp/launch-codex"
@@ -502,6 +544,7 @@ struct CodexResumeBindingVerificationTests {
 
         func writeRollout(
             sessionId: String,
+            filename: String? = nil,
             source: String? = nil,
             originator: String? = nil,
             nestedSource: [String: Any]? = nil
@@ -514,7 +557,7 @@ struct CodexResumeBindingVerificationTests {
             if let nestedSource { payload["source"] = nestedSource }
             let line: [String: Any] = ["type": "session_meta", "payload": payload]
             let data = try JSONSerialization.data(withJSONObject: line, options: [.sortedKeys])
-            let url = directory.appendingPathComponent("rollout-\(sessionId).jsonl")
+            let url = directory.appendingPathComponent(filename ?? "rollout-\(sessionId).jsonl")
             try data.write(to: url, options: .atomic)
             return url
         }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -184,6 +184,37 @@ struct CodexResumeBindingVerificationTests {
         )
     }
 
+    @Test func indexedMissingCanBridgeAnExactLegacyRolloutForRestore() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let sessionID = "019ff9a6-cbe1-7231-9478-0c55a8c44560"
+        let rollout = try fixture.writeRollout(
+            sessionId: sessionID,
+            source: "cli",
+            originator: "codex-tui"
+        )
+
+        #expect(
+            CodexSessionResumeVerifier().verify(
+                sessionId: sessionID,
+                transcriptPath: nil,
+                codexHome: fixture.codexHome.path
+            ) == .missing
+        )
+        guard case .exists(let evidence) = CodexSessionResumeVerifier().verify(
+            sessionId: sessionID,
+            transcriptPath: nil,
+            codexHome: fixture.codexHome.path,
+            allowLegacyFallbackForIndexedMissing: true
+        ) else {
+            Issue.record("restore-mode verification should bridge a rollout/index write race")
+            return
+        }
+        #expect(evidence.sessionId == sessionID)
+        #expect(URL(fileURLWithPath: evidence.rolloutPath).lastPathComponent == rollout.lastPathComponent)
+    }
+
     @Test func readableIndexWithoutThreadAcceptsExactTranscript() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -492,6 +492,32 @@ struct CodexResumeBindingVerificationTests {
         #expect(evidence.provenance == .exec)
     }
 
+    @Test func ambiguousNestedParentMetadataDoesNotClaimAncestry() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let sessionID = "019ff9d1-cbe1-7231-9478-0c55a8c44560"
+        let rollout = try fixture.writeRollout(
+            sessionId: sessionID,
+            nestedSource: [
+                "review": ["parent_thread_id": "first-parent"],
+                "metadata": ["parent_thread_id": "second-parent"],
+            ]
+        )
+        try fixture.insertThread(sessionId: sessionID, rolloutPath: rollout.path)
+
+        guard case .exists(let evidence) = CodexSessionResumeVerifier().verify(
+            sessionId: sessionID,
+            transcriptPath: rollout.path,
+            codexHome: fixture.codexHome.path
+        ) else {
+            Issue.record("the rollout should still be classified as durable evidence")
+            return
+        }
+        #expect(evidence.provenance == .exec)
+        #expect(evidence.parentSessionId == nil)
+    }
+
     @Test func transcriptWithoutExactSessionMetadataIsMissing() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -164,6 +164,25 @@ struct CodexResumeBindingVerificationTests {
         )
     }
 
+    @Test func codexHomeResolverExpandsTildeUsingCapturedLaunchHome() {
+        let resolver = CodexHomeResolver()
+
+        #expect(
+            resolver.resolve(
+                launchEnvironment: [
+                    "CODEX_HOME": "~/.codex-work",
+                    "HOME": "/tmp/captured-launch-home",
+                ],
+                launchWorkingDirectory: "/tmp/captured-project",
+                ambientEnvironment: [
+                    "HOME": "/tmp/restoring-process-home",
+                    "CODEX_HOME": "/tmp/ambient-codex",
+                ],
+                fallbackHomeDirectory: "/tmp/fallback"
+            ) == "/tmp/captured-launch-home/.codex-work"
+        )
+    }
+
     @Test func readableIndexWithoutThreadDoesNotScanUnindexedRollouts() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -130,6 +130,29 @@ struct CodexResumeBindingVerificationTests {
         )
     }
 
+    @Test func aggregateVerificationBudgetChargesBytesActuallyRead() throws {
+        let fixture = try Fixture(createIndex: false)
+        defer { fixture.remove() }
+
+        let sessionIDs = (0..<9).map { "aggregate-budget-session-\($0)" }
+        for sessionID in sessionIDs {
+            try fixture.writeSparseRollout(sessionId: sessionID)
+        }
+
+        let results = CodexSessionResumeVerifier().verifyBatch(
+            sessionIDs.map {
+                CodexSessionResumeVerificationRequest(sessionId: $0)
+            },
+            codexHome: fixture.codexHome.path
+        )
+
+        #expect(results.count == sessionIDs.count)
+        #expect(results.allSatisfy {
+            if case .exists = $0 { return true }
+            return false
+        })
+    }
+
     @Test func codexHomeResolverPrefersLaunchMetadataOverAmbientState() {
         let resolver = CodexHomeResolver()
         let launchCodexHome = "/tmp/launch-codex"
@@ -675,6 +698,19 @@ struct CodexResumeBindingVerificationTests {
             let url = directory.appendingPathComponent(filename ?? "rollout-\(sessionId).jsonl")
             try data.write(to: url, options: .atomic)
             return url
+        }
+
+        func writeSparseRollout(sessionId: String) throws {
+            let url = try writeRollout(sessionId: sessionId)
+            var metadata = try Data(contentsOf: url)
+            metadata.append(0x0A)
+            try metadata.write(to: url, options: .atomic)
+            guard let handle = FileHandle(forWritingAtPath: url.path) else {
+                throw FixtureError.database
+            }
+            defer { try? handle.close() }
+            try handle.seek(toOffset: UInt64(CodexSessionResumeVerificationLimits.maximumRolloutBytes) + 1)
+            try handle.write(contentsOf: Data([0]))
         }
 
         func insertThread(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -103,6 +103,34 @@ struct CodexResumeBindingVerificationTests {
         #expect(results[CodexSessionResumeVerificationLimits.maximumBatchRequests] == .unavailable)
     }
 
+    @Test func fallbackCandidateTruncationIsUnavailable() throws {
+        let fixture = try Fixture(createIndex: false)
+        defer { fixture.remove() }
+
+        let directory = fixture.codexHome
+            .appendingPathComponent("sessions/2026/08/12", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let event: [String: Any] = [
+            "type": "event_msg",
+            "payload": ["type": "task_started"],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: event, options: [.sortedKeys])
+        for index in 0...512 {
+            try data.write(
+                to: directory.appendingPathComponent("unrelated-\(index).jsonl"),
+                options: .atomic
+            )
+        }
+
+        #expect(
+            CodexSessionResumeVerifier().verify(
+                sessionId: "fallback-candidate-cap-target",
+                transcriptPath: nil,
+                codexHome: fixture.codexHome.path
+            ) == .unavailable
+        )
+    }
+
     @Test func codexHomeResolverPrefersLaunchMetadataOverAmbientState() {
         let resolver = CodexHomeResolver()
         let launchCodexHome = "/tmp/launch-codex"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -87,7 +87,7 @@ struct CodexResumeBindingVerificationTests {
         #expect(evidence.source == .legacyRollout)
     }
 
-    @Test func batchVerificationMarksRequestsBeyondBoundUnavailable() throws {
+    @Test func batchVerificationLimitsReturnedResultsToBound() throws {
         let fixture = try Fixture(createIndex: false)
         defer { fixture.remove() }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -71,11 +71,15 @@ struct CodexResumeBindingVerificationTests {
         )
 
         let results = CodexSessionResumeVerifier().verifyBatch(
-            [CodexSessionResumeVerificationRequest(sessionId: metadataSessionID)],
+            [
+                CodexSessionResumeVerificationRequest(sessionId: filenameSessionID),
+                CodexSessionResumeVerificationRequest(sessionId: metadataSessionID),
+            ],
             codexHome: fixture.codexHome.path
         )
 
-        guard case .exists(let evidence) = results.first else {
+        guard results.count == 2,
+              case .exists(let evidence) = results[1] else {
             Issue.record("session_meta.id must remain authoritative after a rollout rename")
             return
         }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -99,8 +99,7 @@ struct CodexResumeBindingVerificationTests {
             codexHome: fixture.codexHome.path
         )
 
-        #expect(results.count == requests.count)
-        #expect(results[CodexSessionResumeVerificationLimits.maximumBatchRequests] == .unavailable)
+        #expect(results.count == CodexSessionResumeVerificationLimits.maximumBatchRequests)
     }
 
     @Test func fallbackCandidateTruncationIsUnavailable() throws {

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexResumeBindingVerificationTests.swift
@@ -20,6 +20,69 @@ struct CodexResumeBindingVerificationTests {
         #expect(result == .missing)
     }
 
+    @Test func batchLegacyVerificationWalksOneHomeForMultipleIdentities() throws {
+        let fixture = try Fixture(createIndex: false)
+        defer { fixture.remove() }
+
+        let firstID = "019ff9a5-cbe1-7231-9478-0c55a8c44560"
+        let secondID = "019ff9a6-cbe1-7231-9478-0c55a8c44560"
+        let firstRollout = try fixture.writeRollout(
+            sessionId: firstID,
+            source: "cli",
+            originator: "codex-tui"
+        )
+        let secondRollout = try fixture.writeRollout(
+            sessionId: secondID,
+            source: "cli",
+            originator: "codex-tui"
+        )
+
+        let results = CodexSessionResumeVerifier().verifyBatch(
+            [
+                CodexSessionResumeVerificationRequest(sessionId: firstID),
+                CodexSessionResumeVerificationRequest(sessionId: secondID),
+                CodexSessionResumeVerificationRequest(sessionId: "missing-batch-id"),
+            ],
+            codexHome: fixture.codexHome.path
+        )
+
+        guard results.count == 3,
+              case .exists(let firstEvidence) = results[0],
+              case .exists(let secondEvidence) = results[1] else {
+            Issue.record("one legacy batch should resolve every exact rollout")
+            return
+        }
+        #expect(URL(fileURLWithPath: firstEvidence.rolloutPath).lastPathComponent == firstRollout.lastPathComponent)
+        #expect(URL(fileURLWithPath: secondEvidence.rolloutPath).lastPathComponent == secondRollout.lastPathComponent)
+        #expect(results[2] == .missing)
+    }
+
+    @Test func codexHomeResolverPrefersLaunchMetadataOverAmbientState() {
+        let resolver = CodexHomeResolver()
+        let launchCodexHome = "/tmp/launch-codex"
+        let launchUserHome = "/tmp/launch-user"
+        let ambientCodexHome = "/tmp/ambient-codex"
+
+        #expect(
+            resolver.resolve(
+                launchEnvironment: ["CODEX_HOME": launchCodexHome],
+                launchVerificationHome: launchUserHome,
+                ambientEnvironment: [
+                    "CODEX_HOME": ambientCodexHome,
+                    "HOME": "/tmp/ambient-user",
+                ],
+                fallbackHomeDirectory: "/tmp/fallback"
+            ) == launchCodexHome
+        )
+        #expect(
+            resolver.resolve(
+                launchEnvironment: ["HOME": launchUserHome],
+                ambientEnvironment: ["CODEX_HOME": ambientCodexHome],
+                fallbackHomeDirectory: "/tmp/fallback"
+            ) == "\(launchUserHome)/.codex"
+        )
+    }
+
     @Test func readableIndexWithoutThreadDoesNotScanUnindexedRollouts() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
@@ -112,11 +112,30 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: Self.surfaceWindowUnavailableMessage, data: nil)
         }
+        let claimCheckpointID = optionalTrimmedRawString(params, "claim_checkpoint_id")
+        let claimSource = optionalTrimmedRawString(params, "claim_source")
+        let claimUpdatedAt = double(params, "claim_updated_at")
+        let hasClaimParameter = params["claim_checkpoint_id"] != nil
+            || params["claim_source"] != nil
+            || params["claim_updated_at"] != nil
+        guard !hasClaimParameter
+            || (claimCheckpointID != nil
+                && claimSource != nil
+                && claimUpdatedAt?.isFinite == true) else {
+            return .err(
+                code: "invalid_params",
+                message: surfaceResumeStrings().restoreClaimMustBeValid,
+                data: nil
+            )
+        }
         return surfaceResumeResult(
             context?.controlSurfaceResumeGet(
                 routing: routing,
                 explicitTargetID: surfaceResumeExplicitTargetID(params),
-                hasResolvedWindowID: uuid(params, "window_id") != nil
+                hasResolvedWindowID: uuid(params, "window_id") != nil,
+                claimCheckpointID: claimCheckpointID,
+                claimSource: claimSource,
+                claimUpdatedAt: claimUpdatedAt
             ) ?? .surfaceNotFound
         )
     }
@@ -183,7 +202,7 @@ extension ControlCommandCoordinator {
         case .setFailed:
             return .err(code: "internal_error", message: "Failed to set resume binding", data: nil)
         case .result(let snapshot):
-            return .ok(.object([
+            var result: [String: JSONValue] = [
                 "window_id": orNull(snapshot.windowID?.uuidString),
                 "window_ref": ref(.window, snapshot.windowID),
                 "workspace_id": .string(snapshot.workspaceID.uuidString),
@@ -195,7 +214,11 @@ extension ControlCommandCoordinator {
                 "cleared": .bool(snapshot.cleared),
                 "resume_binding": surfaceResumeBindingPayload(snapshot.binding),
                 "restore_record": surfaceRestoreRecordPayload(snapshot.restoreRecord),
-            ]))
+            ]
+            if let resumeClaimed = snapshot.resumeClaimed {
+                result["resume_claimed"] = .bool(resumeClaimed)
+            }
+            return .ok(.object(result))
         }
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
@@ -169,6 +169,7 @@ extension ControlCommandCoordinator {
             expectedCheckpointID: optionalTrimmedRawString(params, "checkpoint_id")
                 ?? optionalTrimmedRawString(params, "checkpointId"),
             expectedSource: optionalTrimmedRawString(params, "source"),
+            expectedUpdatedAt: double(params, "expected_updated_at"),
             agentSessionEnded: agentSessionEnded
         ) ?? .surfaceNotFound
         return surfaceResumeResult(resolution)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -258,7 +258,8 @@ public protocol ControlSurfaceContext: AnyObject {
         inputs: ControlSurfaceResumeSetInputs
     ) -> ControlSurfaceResumeResolution
 
-    /// Reads the resume binding for `surface.resume.get`.
+    /// Reads the resume binding for the surface resume get command, optionally claiming
+    /// one binding generation for an imminent restore launch.
     ///
     /// - Parameter routing: The routing selectors (with the surface-resume
     ///   precedence).
@@ -266,7 +267,10 @@ public protocol ControlSurfaceContext: AnyObject {
     func controlSurfaceResumeGet(
         routing: ControlRoutingSelectors,
         explicitTargetID: UUID?,
-        hasResolvedWindowID: Bool
+        hasResolvedWindowID: Bool,
+        claimCheckpointID: String?,
+        claimSource: String?,
+        claimUpdatedAt: Double?
     ) -> ControlSurfaceResumeResolution
 
     /// Clears the resume binding for `surface.resume.clear`, honoring the optional

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -280,6 +280,7 @@ public protocol ControlSurfaceContext: AnyObject {
     ///   - routing: The routing selectors (with the surface-resume precedence).
     ///   - expectedCheckpointID: The optional expected checkpoint guard.
     ///   - expectedSource: The optional expected source guard.
+    ///   - expectedUpdatedAt: The optional expected binding-generation timestamp.
     ///   - agentSessionEnded: Whether a managed hook is clearing the binding as
     ///     part of authoritative session teardown.
     /// - Returns: The resume resolution.
@@ -289,6 +290,7 @@ public protocol ControlSurfaceContext: AnyObject {
         hasResolvedWindowID: Bool,
         expectedCheckpointID: String?,
         expectedSource: String?,
+        expectedUpdatedAt: Double?,
         agentSessionEnded: Bool
     ) -> ControlSurfaceResumeResolution
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceResumeSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceResumeSnapshot.swift
@@ -22,6 +22,8 @@ public struct ControlSurfaceResumeSnapshot: Sendable, Equatable {
     public let binding: ControlSurfaceResumeBinding?
     /// Structured process data used by `cmux restore`.
     public let restoreRecord: ControlSurfaceRestoreRecord?
+    /// Whether an optional compare-and-claim request succeeded.
+    public let resumeClaimed: Bool?
 
     /// Creates a resume snapshot.
     ///
@@ -39,7 +41,8 @@ public struct ControlSurfaceResumeSnapshot: Sendable, Equatable {
         surfaceID: UUID,
         cleared: Bool,
         binding: ControlSurfaceResumeBinding?,
-        restoreRecord: ControlSurfaceRestoreRecord?
+        restoreRecord: ControlSurfaceRestoreRecord?,
+        resumeClaimed: Bool? = nil
     ) {
         self.windowID = windowID
         self.workspaceID = workspaceID
@@ -48,5 +51,6 @@ public struct ControlSurfaceResumeSnapshot: Sendable, Equatable {
         self.cleared = cleared
         self.binding = binding
         self.restoreRecord = restoreRecord
+        self.resumeClaimed = resumeClaimed
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceResumeStrings.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceResumeStrings.swift
@@ -7,6 +7,8 @@ public struct ControlSurfaceResumeStrings: Sendable, Equatable {
     public let agentSessionEndedMustBeBoolean: String
     /// The message returned when `launch_command` is present but malformed.
     public let launchCommandMustBeValid: String
+    /// The message returned when a restore claim is incomplete or malformed.
+    public let restoreClaimMustBeValid: String
 
     /// Creates the localized surface-resume message bundle.
     ///
@@ -14,11 +16,14 @@ public struct ControlSurfaceResumeStrings: Sendable, Equatable {
     ///   - agentSessionEndedMustBeBoolean: The malformed
     ///     `agent_session_ended` message.
     ///   - launchCommandMustBeValid: The malformed `launch_command` message.
+    ///   - restoreClaimMustBeValid: The malformed restore-claim message.
     public init(
         agentSessionEndedMustBeBoolean: String,
-        launchCommandMustBeValid: String
+        launchCommandMustBeValid: String,
+        restoreClaimMustBeValid: String = ""
     ) {
         self.agentSessionEndedMustBeBoolean = agentSessionEndedMustBeBoolean
         self.launchCommandMustBeValid = launchCommandMustBeValid
+        self.restoreClaimMustBeValid = restoreClaimMustBeValid
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -479,7 +479,8 @@ extension ControlSurfaceContext {
     func controlSurfaceResumeStrings() -> ControlSurfaceResumeStrings {
         ControlSurfaceResumeStrings(
             agentSessionEndedMustBeBoolean: "",
-            launchCommandMustBeValid: ""
+            launchCommandMustBeValid: "",
+            restoreClaimMustBeValid: ""
         )
     }
 
@@ -507,7 +508,10 @@ extension ControlSurfaceContext {
     func controlSurfaceResumeGet(
         routing: ControlRoutingSelectors,
         explicitTargetID: UUID?,
-        hasResolvedWindowID: Bool
+        hasResolvedWindowID: Bool,
+        claimCheckpointID: String?,
+        claimSource: String?,
+        claimUpdatedAt: Double?
     ) -> ControlSurfaceResumeResolution { .surfaceNotFound }
 
     func controlSurfaceResumeClear(

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -520,6 +520,7 @@ extension ControlSurfaceContext {
         hasResolvedWindowID: Bool,
         expectedCheckpointID: String?,
         expectedSource: String?,
+        expectedUpdatedAt: Double?,
         agentSessionEnded: Bool
     ) -> ControlSurfaceResumeResolution { .surfaceNotFound }
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -486,6 +486,23 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(resumeBinding["resume_evidence_provenance"] == .string("tui"))
     }
 
+    @Test func surfaceResumeGetRejectsPartialRestoreClaim() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.resume.get",
+            params: ["claim_checkpoint_id": .string("checkpoint")]
+        ))
+
+        #expect(result == .err(
+            code: "invalid_params",
+            message: "Missing or invalid resume claim",
+            data: nil
+        ))
+    }
+
     @Test func surfaceResumeClearForwardsManagedSessionEndProvenance() {
         let context = FakeSurfaceControlCommandContext()
         let coordinator = ControlCommandCoordinator(context: context)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -546,9 +546,13 @@ struct ControlCommandCoordinatorSurfaceTests {
         _ = coordinator.handle(ControlRequest(
             id: .int(1),
             method: "surface.resume.clear",
-            params: ["agent_session_ended": .bool(true)]
+            params: [
+                "agent_session_ended": .bool(true),
+                "expected_updated_at": .double(42.5),
+            ]
         ))
         #expect(context.resumeClearAgentSessionEnded == true)
+        #expect(context.resumeClearExpectedUpdatedAt == 42.5)
 
         _ = coordinator.handle(ControlRequest(
             id: .int(2),

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -498,9 +498,45 @@ struct ControlCommandCoordinatorSurfaceTests {
 
         #expect(result == .err(
             code: "invalid_params",
-            message: "Missing or invalid resume claim",
+            message: "restore claim must be valid",
             data: nil
         ))
+    }
+
+    @Test func surfaceResumeGetForwardsAtomicClaimAndReportsOutcome() throws {
+        let context = FakeSurfaceControlCommandContext()
+        let surfaceID = UUID()
+        context.resumeResolution = .result(ControlSurfaceResumeSnapshot(
+            windowID: nil,
+            workspaceID: UUID(),
+            paneID: nil,
+            surfaceID: surfaceID,
+            cleared: false,
+            binding: nil,
+            restoreRecord: nil,
+            resumeClaimed: false
+        ))
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.resume.get",
+            params: [
+                "surface_id": .string(surfaceID.uuidString),
+                "claim_checkpoint_id": .string("checkpoint"),
+                "claim_source": .string("agent-hook"),
+                "claim_updated_at": .double(42.5),
+            ]
+        ))
+
+        #expect(context.resumeGetClaim?.checkpointID == "checkpoint")
+        #expect(context.resumeGetClaim?.source == "agent-hook")
+        #expect(context.resumeGetClaim?.updatedAt == 42.5)
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("expected surface resume claim result")
+            return
+        }
+        #expect(payload["resume_claimed"] == .bool(false))
     }
 
     @Test func surfaceResumeClearForwardsManagedSessionEndProvenance() {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -8,10 +8,16 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
     var surfaceListSnapshot: ControlSurfaceListSnapshot?
     var resumeResolution: ControlSurfaceResumeResolution = .surfaceNotFound
     var resumeSetInputs: ControlSurfaceResumeSetInputs?
+    var resumeGetClaim: (
+        checkpointID: String?,
+        source: String?,
+        updatedAt: Double?
+    )?
     var resumeClearAgentSessionEnded: Bool?
     var resumeStrings = ControlSurfaceResumeStrings(
         agentSessionEndedMustBeBoolean: "agent_session_ended must be a boolean",
-        launchCommandMustBeValid: "launch_command must be valid"
+        launchCommandMustBeValid: "launch_command must be valid",
+        restoreClaimMustBeValid: "restore claim must be valid"
     )
     var reportPWDResolution: ControlSurfaceReportPWDResolution = .recorded(surfaceID: UUID())
     var reportedPWD: (workspaceID: UUID, requestedSurfaceID: UUID?, path: String)?
@@ -74,9 +80,13 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
     func controlSurfaceResumeGet(
         routing: ControlRoutingSelectors,
         explicitTargetID: UUID?,
-        hasResolvedWindowID: Bool
+        hasResolvedWindowID: Bool,
+        claimCheckpointID: String?,
+        claimSource: String?,
+        claimUpdatedAt: Double?
     ) -> ControlSurfaceResumeResolution {
-        resumeResolution
+        resumeGetClaim = (claimCheckpointID, claimSource, claimUpdatedAt)
+        return resumeResolution
     }
 
     func controlSurfaceResumeClear(

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -13,6 +13,7 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
         source: String?,
         updatedAt: Double?
     )?
+    var resumeClearExpectedUpdatedAt: Double?
     var resumeClearAgentSessionEnded: Bool?
     var resumeStrings = ControlSurfaceResumeStrings(
         agentSessionEndedMustBeBoolean: "agent_session_ended must be a boolean",
@@ -95,9 +96,11 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
         hasResolvedWindowID: Bool,
         expectedCheckpointID: String?,
         expectedSource: String?,
+        expectedUpdatedAt: Double?,
         agentSessionEnded: Bool
     ) -> ControlSurfaceResumeResolution {
         resumeClearAgentSessionEnded = agentSessionEnded
+        resumeClearExpectedUpdatedAt = expectedUpdatedAt
         return resumeResolution
     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -239232,6 +239232,23 @@
         }
       }
     },
+    "socket.surface.resume.restoreClaimMustBeValid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing or invalid restore claim"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復元要求のクレームがないか無効です"
+          }
+        }
+      }
+    },
     "socket.surfaceSplitOff.error.appDelegateUnavailable": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -51129,13 +51129,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "restore: the saved Codex checkpoint is unavailable. The terminal remains in its saved directory; retry later or start a new Codex session."
+            "value": "restore: the saved agent session is unavailable. The terminal remains in its saved directory; retry later or start a new agent session."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "restore: 保存された Codex チェックポイントを利用できません。ターミナルは保存されたディレクトリに残っています。後でもう一度試すか、新しい Codex セッションを開始してください。"
+            "value": "restore: 保存されたエージェント セッションを利用できません。ターミナルは保存されたディレクトリに残っています。後でもう一度試すか、新しいエージェント セッションを開始してください。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -51038,6 +51038,23 @@
         }
       }
     },
+    "cli.restore.codexCheckpointUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "restore: the saved Codex checkpoint is unavailable. The terminal remains in its saved directory; retry later or start a new Codex session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "restore: 保存された Codex チェックポイントを利用できません。ターミナルは保存されたディレクトリに残っています。後でもう一度試すか、新しい Codex セッションを開始してください。"
+          }
+        }
+      }
+    },
     "cli.restore.error.checkpointMismatch": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -73,6 +73,30 @@ enum ControlSurfaceResumeTarget {
         }
     }
 
+    /// Atomically claims the current binding generation for a CLI restore.
+    func claimBinding(
+        expectedCheckpointID: String,
+        expectedSource: String,
+        expectedUpdatedAt: TimeInterval
+    ) -> Bool {
+        switch self {
+        case .workspace(_, let workspace, let surfaceID):
+            workspace.claimSurfaceResumeBinding(
+                panelId: surfaceID,
+                expectedCheckpointID: expectedCheckpointID,
+                expectedSource: expectedSource,
+                expectedUpdatedAt: expectedUpdatedAt
+            )
+        case .dock(_, let dock, let surfaceID):
+            dock.claimSurfaceResumeBinding(
+                panelId: surfaceID,
+                expectedCheckpointID: expectedCheckpointID,
+                expectedSource: expectedSource,
+                expectedUpdatedAt: expectedUpdatedAt
+            )
+        }
+    }
+
     func bindingForClear(
         expectedSource: String?,
         agentSessionEnded: Bool
@@ -299,7 +323,8 @@ extension TerminalController {
     private func surfaceResumeSnapshot(
         target: ControlSurfaceResumeTarget,
         binding: SurfaceResumeBindingSnapshot?,
-        cleared: Bool
+        cleared: Bool,
+        claimSucceeded: Bool? = nil
     ) -> ControlSurfaceResumeSnapshot {
         ControlSurfaceResumeSnapshot(
             windowID: target.windowID(using: self),
@@ -310,7 +335,8 @@ extension TerminalController {
             binding: controlResumeBinding(from: binding),
             restoreRecord: cleared
                 ? nil
-                : controlSurfaceRestoreRecord(target: target, binding: binding)
+                : controlSurfaceRestoreRecord(target: target, binding: binding),
+            resumeClaimed: claimSucceeded
         )
     }
 
@@ -659,7 +685,10 @@ extension TerminalController {
     func controlSurfaceResumeGet(
         routing: ControlRoutingSelectors,
         explicitTargetID: UUID?,
-        hasResolvedWindowID: Bool
+        hasResolvedWindowID: Bool,
+        claimCheckpointID: String?,
+        claimSource: String?,
+        claimUpdatedAt: Double?
     ) -> ControlSurfaceResumeResolution {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .windowUnavailable
@@ -676,7 +705,24 @@ extension TerminalController {
            case .pendingSigningSecret = SurfaceResumeApprovalStore.applyingStoredApprovalLookup(to: binding) {
             return .approvalPending(message: surfaceResumeApprovalPendingMessage)
         }
-        return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: false))
+        let claimSucceeded: Bool?
+        if let claimCheckpointID, let claimSource, let claimUpdatedAt {
+            claimSucceeded = target.claimBinding(
+                expectedCheckpointID: claimCheckpointID,
+                expectedSource: claimSource,
+                expectedUpdatedAt: claimUpdatedAt
+            )
+        } else {
+            claimSucceeded = nil
+        }
+        return .result(
+            surfaceResumeSnapshot(
+                target: target,
+                binding: target.binding,
+                cleared: false,
+                claimSucceeded: claimSucceeded
+            )
+        )
     }
 
     func controlSurfaceResumeClear(

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -94,7 +94,10 @@ enum ControlSurfaceResumeTarget {
     ) {
         switch self {
         case .workspace(_, let workspace, let surfaceID):
-            _ = workspace.clearSurfaceResumeBinding(panelId: surfaceID)
+            _ = workspace.clearSurfaceResumeBinding(
+                panelId: surfaceID,
+                agentSessionEnded: agentSessionEnded
+            )
         case .dock(_, let dock, let surfaceID):
             _ = dock.clearSurfaceResumeBinding(
                 panelId: surfaceID,

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -731,6 +731,7 @@ extension TerminalController {
         hasResolvedWindowID: Bool,
         expectedCheckpointID: String?,
         expectedSource: String?,
+        expectedUpdatedAt: Double?,
         agentSessionEnded: Bool
     ) -> ControlSurfaceResumeResolution {
         guard let tabManager = resolveTabManager(routing: routing) else {
@@ -752,6 +753,10 @@ extension TerminalController {
             return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: false))
         }
         if let expectedSource, bindingForClear?.source != expectedSource {
+            return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: false))
+        }
+        if let expectedUpdatedAt,
+           !expectedUpdatedAt.isFinite || bindingForClear?.updatedAt != expectedUpdatedAt {
             return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: false))
         }
         target.clearBinding(bindingForClear, agentSessionEnded: agentSessionEnded)

--- a/Sources/DockSplitStore+Reset.swift
+++ b/Sources/DockSplitStore+Reset.swift
@@ -25,6 +25,7 @@ extension DockSplitStore {
         terminalStartupRestoreCoordinator.removeAllRestores()
         clearDeferredAgentResumeRestores()
         surfaceResumeBindingsByPanelId.removeAll()
+        surfaceResumeRestoreClaimsByPanelId.removeAll()
         managedAgentResumeBindingsByPanelId.removeAll()
         invalidatedCachedTransferAgentSessionPanelIds.removeAll()
         replacedCachedTransferAgentSessionPanelIds.removeAll()

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -461,7 +461,7 @@ extension DockSplitStore {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
-            guard index.isComplete else {
+            guard index.isComplete(forPanelId: restore.stablePanelID) else {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -12,6 +12,7 @@ extension DockSplitStore {
         restoredAgentLifecycle.clearSessionRestore(panelId: panelId)
         restoredAgentLifecycle.invalidatedFingerprintsByPanelId.removeValue(forKey: panelId)
         surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+        surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         managedAgentResumeBindingsByPanelId.removeValue(forKey: panelId)
         invalidatedCachedTransferAgentSessionPanelIds.remove(panelId)
         replacedCachedTransferAgentSessionPanelIds.remove(panelId)

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -461,7 +461,11 @@ extension DockSplitStore {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
-            guard index.isComplete(forPanelId: restore.stablePanelID) else {
+            let expectedKind = restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind
+            guard index.isComplete(
+                forPanelId: restore.stablePanelID,
+                kind: expectedKind
+            ) else {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
@@ -499,7 +503,6 @@ extension DockSplitStore {
                 }
             }
             let ownershipPanelID = restore.stablePanelID
-            let expectedKind = restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind
             let expectedSessionId = restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId
             // Deferred admission has no exact-owner snapshot that can override a
             // stable-panel tie, so structural ambiguity remains fail-closed even

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -138,7 +138,9 @@ extension DockSplitStore {
         )
         managedAgentResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
         if let resumeBinding = detached.resumeBinding {
-            surfaceResumeBindingsByPanelId[detached.panelId] = resumeBinding
+            if surfaceResumeBindingMutationAllowed(resumeBinding, panelId: detached.panelId) {
+                surfaceResumeBindingsByPanelId[detached.panelId] = resumeBinding
+            }
         }
         if let transferredManagedBinding = detached.resolvedManagedAgentResumeBinding {
             managedAgentResumeBindingsByPanelId[detached.panelId] = transferredManagedBinding
@@ -214,10 +216,14 @@ extension DockSplitStore {
         }
         if let effectiveBinding = surfaceResumeBindingsByPanelId[panelId] {
             if effectiveBinding == originalBinding || effectiveBinding.isSameManagedSession(as: binding) {
-                surfaceResumeBindingsByPanelId[panelId] = binding
+                if surfaceResumeBindingMutationAllowed(binding, panelId: panelId) {
+                    surfaceResumeBindingsByPanelId[panelId] = binding
+                }
             }
         } else {
-            surfaceResumeBindingsByPanelId[panelId] = binding
+            if surfaceResumeBindingMutationAllowed(binding, panelId: panelId) {
+                surfaceResumeBindingsByPanelId[panelId] = binding
+            }
         }
     }
 

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -427,7 +427,9 @@ extension DockSplitStore {
             terminal.adoptStableSurfaceId(stableSurfaceId)
         }
         if let resumeBinding {
-            surfaceResumeBindingsByPanelId[terminal.id] = resumeBinding
+            if surfaceResumeBindingMutationAllowed(resumeBinding, panelId: terminal.id) {
+                surfaceResumeBindingsByPanelId[terminal.id] = resumeBinding
+            }
         }
         if let managedResumeBinding {
             managedAgentResumeBindingsByPanelId[terminal.id] = managedResumeBinding

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -448,8 +448,14 @@ extension DockSplitStore {
             effective = stored
         }
         if let effective {
+            guard surfaceResumeBindingMutationAllowed(effective, panelId: panelId) else {
+                return stored
+            }
             surfaceResumeBindingsByPanelId[panelId] = effective
         } else {
+            guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                return stored
+            }
             surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
         }
         return effective

--- a/Sources/DockSplitStore+SurfaceResume.swift
+++ b/Sources/DockSplitStore+SurfaceResume.swift
@@ -139,6 +139,36 @@ extension DockSplitStore {
         return true
     }
 
+    /// Checks a non-socket binding writer against an in-flight restore claim.
+    ///
+    /// Snapshot and transfer paths historically wrote the effective binding
+    /// directly. They must share the same claim gate as hook publications so a
+    /// different process observation cannot replace the generation authorized
+    /// for execution.
+    @discardableResult
+    func surfaceResumeBindingMutationAllowed(
+        _ incoming: SurfaceResumeBindingSnapshot,
+        panelId: UUID
+    ) -> Bool {
+        guard let claim = surfaceResumeRestoreClaim(for: panelId) else {
+            return true
+        }
+        guard claim.binding.acceptsRestoreBindingClaim(from: incoming) else {
+            return false
+        }
+        surfaceResumeRestoreClaimsByPanelId[panelId] = (
+            binding: incoming,
+            claimedAt: claim.claimedAt
+        )
+        return true
+    }
+
+    /// Returns false while a claimed generation is still active.
+    @discardableResult
+    func surfaceResumeBindingRemovalAllowed(panelId: UUID) -> Bool {
+        surfaceResumeRestoreClaim(for: panelId) == nil
+    }
+
     private func surfaceResumeRestoreClaim(
         for panelId: UUID
     ) -> (binding: SurfaceResumeBindingSnapshot, claimedAt: Date)? {

--- a/Sources/DockSplitStore+SurfaceResume.swift
+++ b/Sources/DockSplitStore+SurfaceResume.swift
@@ -8,6 +8,12 @@ extension DockSplitStore {
               !startupInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
+        let activeRestoreClaim = surfaceResumeRestoreClaim(for: panelId)
+        if let activeRestoreClaim {
+            guard activeRestoreClaim.binding.acceptsRestoreBindingClaim(from: binding) else {
+                return false
+            }
+        }
         // Keep the provenance comparison in the same MainActor mutation as the
         // assignment; the managed hook binding remains authoritative while a
         // process-detected binding is temporarily effective in the Dock.
@@ -25,6 +31,9 @@ extension DockSplitStore {
             of: existingBinding
         ) else {
             return false
+        }
+        if activeRestoreClaim != nil {
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         }
         let previousRestorableAgent = restoredAgentLifecycle.snapshotsByPanelId[panelId]
         let cachedManagedBinding =
@@ -101,6 +110,58 @@ extension DockSplitStore {
         return true
     }
 
+    /// Atomically claims the current binding generation for a CLI restore.
+    ///
+    /// The claim is consumed by the next same-session hook refresh and blocks a
+    /// different checkpoint from replacing the binding during the handoff.
+    @discardableResult
+    func claimSurfaceResumeBinding(
+        panelId: UUID,
+        expectedCheckpointID: String,
+        expectedSource: String,
+        expectedUpdatedAt: TimeInterval
+    ) -> Bool {
+        guard let binding = surfaceResumeBindingsByPanelId[panelId],
+              binding.isAgentHookBinding,
+              binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
+              binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines)
+                  == expectedCheckpointID.trimmingCharacters(in: .whitespacesAndNewlines),
+              binding.source?.trimmingCharacters(in: .whitespacesAndNewlines)
+                  == expectedSource.trimmingCharacters(in: .whitespacesAndNewlines),
+              expectedUpdatedAt.isFinite,
+              binding.updatedAt == expectedUpdatedAt else {
+            return false
+        }
+        surfaceResumeRestoreClaimsByPanelId[panelId] = (
+            binding: binding,
+            claimedAt: Date.now
+        )
+        return true
+    }
+
+    private func surfaceResumeRestoreClaim(
+        for panelId: UUID
+    ) -> (binding: SurfaceResumeBindingSnapshot, claimedAt: Date)? {
+        guard let claim = surfaceResumeRestoreClaimsByPanelId[panelId] else {
+            return nil
+        }
+        guard let currentBinding = surfaceResumeBindingsByPanelId[panelId],
+              currentBinding.checkpointId == claim.binding.checkpointId,
+              currentBinding.source == claim.binding.source,
+              currentBinding.updatedAt == claim.binding.updatedAt else {
+            // A direct lifecycle mutation replaced the claimed generation
+            // without going through the hook setter. Do not let that old claim
+            // block a later, legitimate binding.
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
+            return nil
+        }
+        guard Date.now.timeIntervalSince(claim.claimedAt) < SurfaceResumeBindingSnapshot.restoreClaimTTL else {
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
+            return nil
+        }
+        return claim
+    }
+
     private func clearAgentRestoreStateIncompatible(
         with binding: SurfaceResumeBindingSnapshot,
         panelId: UUID
@@ -132,6 +193,7 @@ extension DockSplitStore {
                 ? managedBinding
                 : surfaceResumeBindingsByPanelId[panelId])
         guard let binding else {
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
             return false
         }
 
@@ -156,6 +218,7 @@ extension DockSplitStore {
                 preserveCompletedTombstone: true,
                 agentSessionEnded: agentSessionEnded
             )
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
             return true
         }
 
@@ -170,6 +233,7 @@ extension DockSplitStore {
             preserveCompletedTombstone: true,
             agentSessionEnded: agentSessionEnded
         )
+        surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         return true
     }
 

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -91,6 +91,11 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         terminalStartupRestoreCoordinator.lifecycle
     }
     @ObservationIgnored var surfaceResumeBindingsByPanelId: [UUID: SurfaceResumeBindingSnapshot] = [:]
+    /// In-memory compare-and-claim state held while a CLI restore hands the
+    /// validated binding to its child process.
+    @ObservationIgnored var surfaceResumeRestoreClaimsByPanelId: [
+        UUID: (binding: SurfaceResumeBindingSnapshot, claimedAt: Date)
+    ] = [:]
     @ObservationIgnored var deferredAgentResumeRestoresByPanelId: [UUID: DeferredAgentResumeRestore] = [:]
     @ObservationIgnored var deferredAgentResumeClaimsByPanelId: [UUID: (kind: String, sessionId: String)] = [:]
     @ObservationIgnored var deferredAgentResumeIndexTask: Task<Void, Never>?

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1582,7 +1582,13 @@ struct RestorableAgentSessionIndex: Sendable {
             guard !sessionID.isEmpty else { return .missing }
             let launchEnvironment = record.launchCommand?.environment
             let rawHome = Self.normalizedNonEmptyValue(launchEnvironment?["CODEX_HOME"])
+                ?? Self.normalizedNonEmptyValue(environment["CODEX_HOME"])
                 ?? Self.normalizedNonEmptyValue(record.launchCommand?.verificationHome).map {
+                    URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
+                        .appendingPathComponent(".codex", isDirectory: true)
+                        .path
+                }
+                ?? Self.normalizedNonEmptyValue(environment["HOME"]).map {
                     URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
                         .appendingPathComponent(".codex", isDirectory: true)
                         .path
@@ -1647,14 +1653,21 @@ struct RestorableAgentSessionIndex: Sendable {
                     isComplete = false
                     continue
                 }
+                let codexVerification = kind == .codex
+                    ? codexDurableVerification(for: effectiveRecord)
+                    : nil
+                if case .unavailable = codexVerification {
+                    // A transient Codex store/read failure is not evidence that
+                    // the session is gone. Keep the index incomplete so
+                    // reconciliation preserves the existing binding.
+                    isComplete = false
+                }
                 guard hookRecordIsRestorable(
                     effectiveRecord,
                     kind: kind,
                     fileManager: fileManager,
                     claudeTranscriptLookup: claudeTranscriptLookup,
-                    codexDurableVerification: kind == .codex
-                        ? codexDurableVerification(for: effectiveRecord)
-                        : nil
+                    codexDurableVerification: codexVerification
                 ) else {
                     continue
                 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1925,14 +1925,24 @@ struct RestorableAgentSessionIndex: Sendable {
                         PanelKey(workspaceId: workspaceId, panelId: panelId)
                     )
                 }
-                guard hookRecordIsRestorable(
+                let codexOwnerIsAdmitted = hookRecordIsRestorable(
                     effectiveRecord,
                     kind: kind,
                     fileManager: fileManager,
                     claudeTranscriptLookup: claudeTranscriptLookup,
                     codexDurableVerification: codexVerification,
                     codexHasIndexedStore: codexHasIndexedStore
-                ) else {
+                )
+                if kind == .codex, !codexOwnerIsAdmitted {
+                    // A definitive missing or lower-provenance checkpoint is
+                    // still unsafe for binding-only automatic restore. Keep
+                    // this panel deferred so the restore boundary can clear
+                    // only the rejected checkpoint.
+                    incompleteCodexPanelKeys.insert(
+                        PanelKey(workspaceId: workspaceId, panelId: panelId)
+                    )
+                }
+                guard codexOwnerIsAdmitted else {
                     continue
                 }
                 let snapshot = SessionRestorableAgentSnapshot(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1559,8 +1559,7 @@ struct RestorableAgentSessionIndex: Sendable {
             fileManager: fileManager
         )
         let codexCwdLookup = CodexSessionCwdLookupCache(fileManager: fileManager)
-        let codexResumeVerifier = CodexSessionResumeVerifier()
-        var codexVerificationCache: [String: CodexSessionResumeVerification] = [:]
+        let codexHomeResolver = CodexHomeResolver()
         let cachedAgentProcessValidator = CachedAgentProcessIdentityValidator()
         let builtInKindIDs = Set(RestorableAgentKind.allCases.map(\.rawValue))
         let hookKinds: [(kind: RestorableAgentKind, registration: CmuxVaultAgentRegistration?)] =
@@ -1574,41 +1573,84 @@ struct RestorableAgentSessionIndex: Sendable {
         var hookCandidatesByPanelAndKind: [PanelKindKey: Entry] = [:]
         var hookCandidatesByPanelIdAndKind: [PanelIDKindKey: PanelIDKindCandidate] = [:]
 
+        var codexVerificationByKey: [String: CodexSessionResumeVerification] = [:]
+        var codexRequestsByHome: [String: [CodexSessionResumeVerificationRequest]] = [:]
+        var codexRequestKeys = Set<String>()
+
+        func codexVerificationKey(
+            for record: RestorableAgentHookSessionRecord
+        ) -> (key: String, home: String, sessionID: String, transcriptPath: String?)? {
+            guard record.isRestorable == true else { return nil }
+            let sessionID = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !sessionID.isEmpty else { return nil }
+            let home = codexHomeResolver.resolve(
+                launchEnvironment: record.launchCommand?.environment,
+                launchVerificationHome: record.launchCommand?.verificationHome,
+                ambientEnvironment: environment,
+                fallbackHomeDirectory: homeDirectory
+            )
+            let transcriptPath = Self.normalizedNonEmptyValue(record.transcriptPath)
+            return (
+                key: [home, sessionID, transcriptPath ?? ""].joined(separator: "\u{0}"),
+                home: home,
+                sessionID: sessionID,
+                transcriptPath: transcriptPath
+            )
+        }
+
+        // Build one durable-state request plan per Codex home before the main
+        // hook reconciliation loop. The verifier can then walk a legacy
+        // sessions tree once instead of once per historical hook record.
+        if let codexKind = hookKinds.first(where: { $0.kind == .codex }) {
+            let fileURL = codexKind.kind.hookStoreFileURL(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+            if fileManager.fileExists(atPath: fileURL.path),
+               let data = try? Data(contentsOf: fileURL),
+               let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) {
+                for rawRecord in state.sessions.values {
+                    var record = rawRecord
+                    record.launchCommand = trustedLaunchCommand(
+                        record.launchCommand,
+                        kind: .codex
+                    )
+                    if normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() == "environment",
+                       normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) == nil,
+                       normalizedNonEmptyValue(record.launchCommand?.environment?["ANTHROPIC_BASE_URL"]) != nil
+                           || normalizedNonEmptyValue(record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]) != nil {
+                        record.launchCommand = nil
+                    }
+                    guard let key = codexVerificationKey(for: record) else { continue }
+                    guard codexRequestKeys.insert(key.key).inserted else { continue }
+                    codexRequestsByHome[key.home, default: []].append(
+                        CodexSessionResumeVerificationRequest(
+                            sessionId: key.sessionID,
+                            transcriptPath: key.transcriptPath
+                        )
+                    )
+                }
+            }
+        }
+        let codexResumeVerifier = CodexSessionResumeVerifier()
+        for (home, requests) in codexRequestsByHome {
+            let results = codexResumeVerifier.verifyBatch(
+                requests,
+                codexHome: home,
+                fileManager: fileManager
+            )
+            for (request, result) in zip(requests, results) {
+                let key = [home, request.sessionId, request.transcriptPath ?? ""]
+                    .joined(separator: "\u{0}")
+                codexVerificationByKey[key] = result
+            }
+        }
+
         func codexDurableVerification(
             for record: RestorableAgentHookSessionRecord
         ) -> CodexSessionResumeVerification? {
-            guard record.isRestorable == true else { return nil }
-            let sessionID = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !sessionID.isEmpty else { return .missing }
-            let launchEnvironment = record.launchCommand?.environment
-            let rawHome = Self.normalizedNonEmptyValue(launchEnvironment?["CODEX_HOME"])
-                ?? Self.normalizedNonEmptyValue(environment["CODEX_HOME"])
-                ?? Self.normalizedNonEmptyValue(record.launchCommand?.verificationHome).map {
-                    URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
-                        .appendingPathComponent(".codex", isDirectory: true)
-                        .path
-                }
-                ?? Self.normalizedNonEmptyValue(environment["HOME"]).map {
-                    URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
-                        .appendingPathComponent(".codex", isDirectory: true)
-                        .path
-                }
-                ?? URL(fileURLWithPath: homeDirectory, isDirectory: true)
-                    .appendingPathComponent(".codex", isDirectory: true)
-                    .path
-            let codexHome = (NSString(string: rawHome).expandingTildeInPath as NSString).standardizingPath
-            let cacheKey = codexHome + "\u{0}" + sessionID
-            if let cached = codexVerificationCache[cacheKey] {
-                return cached
-            }
-            let result = codexResumeVerifier.verify(
-                sessionId: sessionID,
-                transcriptPath: record.transcriptPath,
-                codexHome: codexHome,
-                fileManager: fileManager
-            )
-            codexVerificationCache[cacheKey] = result
-            return result
+            guard let key = codexVerificationKey(for: record) else { return nil }
+            return codexVerificationByKey[key.key]
         }
 
         for (kind, registration) in hookKinds {
@@ -1656,6 +1698,14 @@ struct RestorableAgentSessionIndex: Sendable {
                 let codexVerification = kind == .codex
                     ? codexDurableVerification(for: effectiveRecord)
                     : nil
+                if kind == .codex,
+                   effectiveRecord.isRestorable == true,
+                   codexVerification == nil {
+                    // The request plan raced the hook-store read or could not
+                    // resolve this record's home. Do not claim a complete
+                    // index when durable evidence was not inspected.
+                    isComplete = false
+                }
                 if case .unavailable = codexVerification {
                     // A transient Codex store/read failure is not evidence that
                     // the session is gone. Keep the index incomplete so
@@ -2214,7 +2264,13 @@ struct RestorableAgentSessionIndex: Sendable {
             guard record.isRestorable != false else { return false }
             guard normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else { return false }
             if record.isRestorable == true {
-                guard case .exists = codexDurableVerification else { return false }
+                guard case .exists(let evidence) = codexDurableVerification,
+                      evidence.provenance.mayOwnBinding else {
+                    // A durable automation, child, or unclassified rollout is
+                    // valid evidence for an explicit exec restore, but it can
+                    // never become the interactive surface owner.
+                    return false
+                }
                 return true
             }
             let launchSource = normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased()

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1701,7 +1701,8 @@ struct RestorableAgentSessionIndex: Sendable {
                 launchWorkingDirectory: record.launchCommand?.workingDirectory ?? record.cwd,
                 launchVerificationHome: record.launchCommand?.verificationHome,
                 ambientEnvironment: environment,
-                fallbackHomeDirectory: homeDirectory
+                fallbackHomeDirectory: homeDirectory,
+                preferFallbackHomeDirectory: true
             )
             let transcriptPath = Self.normalizedNonEmptyValue(record.transcriptPath)
             return (
@@ -2530,14 +2531,23 @@ struct RestorableAgentSessionIndex: Sendable {
             guard record.isRestorable != false else { return false }
             guard normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else { return false }
             if record.isRestorable == true {
-                guard case .some(.exists(let evidence)) = codexDurableVerification,
-                      evidence.provenance.mayOwnBinding else {
+                switch codexDurableVerification {
+                case .some(.exists(let evidence)):
                     // A durable automation, child, or unclassified rollout is
                     // valid evidence for an explicit exec restore, but it can
                     // never become the interactive surface owner.
+                    return evidence.provenance.mayOwnBinding
+                case .some(.missing):
+                    // Pre-index Codex installations cannot provide provenance.
+                    // Preserve an explicitly restorable legacy record only when
+                    // it still carries positive launch evidence; current
+                    // indexed installations remain fail-closed on a missing
+                    // durable checkpoint.
+                    return !codexHasIndexedStore
+                        && codexLegacyLaunchHasPositiveEvidence(record, fileManager: fileManager)
+                case .some(.unavailable), .none:
                     return false
                 }
-                return true
             }
             switch codexDurableVerification {
             case .some(.exists(let evidence)):

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1037,6 +1037,12 @@ struct RestorableAgentSessionIndex: Sendable {
     /// verification pass or had inconclusive durable evidence.
     private let incompleteCodexPanelKeys: Set<PanelKey>
     private let incompleteCodexPanelIds: Set<UUID>
+    /// Panel owners that completed the bounded Codex verification pass.
+    private let verifiedCodexPanelKeys: Set<PanelKey>
+    private let verifiedCodexPanelIds: Set<UUID>
+    /// Whether truncation left additional Codex panels without a retained
+    /// per-panel marker. Such panels are incomplete unless explicitly verified.
+    private let hasUnboundedCodexIncompleteness: Bool
     private let candidatesByPanelId: [UUID: [(PanelKey, Entry)]]
     private let entriesByPanelId: [UUID: Entry]
     private let ambiguousPanelIds: Set<UUID>
@@ -1067,10 +1073,21 @@ struct RestorableAgentSessionIndex: Sendable {
     /// A bounded Codex history can be incomplete for one panel while unrelated
     /// verified owners remain safe to restore. A global store failure still
     /// makes every owner incomplete through the global flag.
-    func isComplete(forWorkspaceId workspaceId: UUID, panelId: UUID) -> Bool {
-        isComplete && !incompleteCodexPanelKeys.contains(
-            PanelKey(workspaceId: workspaceId, panelId: panelId)
-        )
+    func isComplete(
+        forWorkspaceId workspaceId: UUID,
+        panelId: UUID,
+        kind: String? = nil
+    ) -> Bool {
+        guard isComplete else { return false }
+        guard kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex"
+                || kind == nil else {
+            return true
+        }
+        let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
+        if incompleteCodexPanelKeys.contains(key) {
+            return false
+        }
+        return !hasUnboundedCodexIncompleteness || verifiedCodexPanelKeys.contains(key)
     }
 
     /// Whether the durable index is complete for a restart-stable panel identity.
@@ -1078,8 +1095,16 @@ struct RestorableAgentSessionIndex: Sendable {
     /// Deferred restore admission has the stable panel UUID but may not have
     /// the pre-restart workspace UUID, so this form intentionally ignores the
     /// workspace component.
-    func isComplete(forPanelId panelId: UUID) -> Bool {
-        isComplete && !incompleteCodexPanelIds.contains(panelId)
+    func isComplete(forPanelId panelId: UUID, kind: String? = nil) -> Bool {
+        guard isComplete else { return false }
+        guard kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex"
+                || kind == nil else {
+            return true
+        }
+        if incompleteCodexPanelIds.contains(panelId) {
+            return false
+        }
+        return !hasUnboundedCodexIncompleteness || verifiedCodexPanelIds.contains(panelId)
     }
 
     /// Fingerprint used by the shared index cache to publish scoped completion
@@ -1091,6 +1116,12 @@ struct RestorableAgentSessionIndex: Sendable {
         if !isComplete {
             values.append("global")
         }
+        if hasUnboundedCodexIncompleteness {
+            values.append("codex-omitted")
+        }
+        values.append(contentsOf: verifiedCodexPanelKeys.map {
+            "codex-verified|" + $0.workspaceId.uuidString + "|" + $0.panelId.uuidString
+        })
         return Set(values)
     }
 
@@ -1504,7 +1535,9 @@ struct RestorableAgentSessionIndex: Sendable {
         return RestorableAgentSessionIndex(
             entriesByPanel: revalidatedEntries,
             isComplete: self.isComplete,
-            incompleteCodexPanelKeys: self.incompleteCodexPanelKeys
+            incompleteCodexPanelKeys: self.incompleteCodexPanelKeys,
+            verifiedCodexPanelKeys: self.verifiedCodexPanelKeys,
+            hasUnboundedCodexIncompleteness: self.hasUnboundedCodexIncompleteness
         )
     }
 
@@ -1615,6 +1648,8 @@ struct RestorableAgentSessionIndex: Sendable {
         var codexRequestKeys = Set<String>()
         var codexRequestCount = 0
         var incompleteCodexPanelKeys = Set<PanelKey>()
+        var verifiedCodexPanelKeys = Set<PanelKey>()
+        var hasUnboundedCodexIncompleteness = false
         var codexIndexedStoreByHome: [String: Bool] = [:]
         var codexHookRecordsForIndex: [RestorableAgentHookSessionRecord]?
 
@@ -1686,13 +1721,6 @@ struct RestorableAgentSessionIndex: Sendable {
             if candidateRestorable != existingRestorable {
                 return candidateRestorable
             }
-            let candidateCurrent = (candidate.pid ?? 0) > 0
-                || candidate.agentLifecycle == .running
-            let existingCurrent = (existing.pid ?? 0) > 0
-                || existing.agentLifecycle == .running
-            if candidateCurrent != existingCurrent {
-                return candidateCurrent
-            }
             if candidate.updatedAt != existing.updatedAt {
                 return candidate.updatedAt > existing.updatedAt
             }
@@ -1713,8 +1741,9 @@ struct RestorableAgentSessionIndex: Sendable {
             from values: Dictionary<String, RestorableAgentHookSessionRecord>.Values
         ) -> (records: [RestorableAgentHookSessionRecord], truncated: Bool) {
             // Keep a bounded top-K instead of sorting/materializing the full
-            // history. Restorable/current records outrank legacy entries, and
-            // timestamps plus identity provide a stable tie-breaker.
+            // history. Explicitly restorable records outrank legacy entries;
+            // timestamps and identity provide stable tie-breakers. Persisted
+            // PIDs are intentionally not used here because they may be stale.
             let maximum = CodexSessionResumeVerificationLimits.maximumBatchRequests
             var selected: [RestorableAgentHookSessionRecord] = []
             selected.reserveCapacity(maximum)
@@ -1783,14 +1812,21 @@ struct RestorableAgentSessionIndex: Sendable {
                 codexHookRecordsForIndex = selection.records
                 if selection.truncated {
                     let selectedIdentities = Set(selection.records.map(codexRecordSelectionIdentity))
+                    let selectedPanelKeys = Set(selection.records.compactMap(codexPanelKey))
                     for record in state.sessions.values {
                         guard record.isRestorable != false,
                               normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected",
-                              !selectedIdentities.contains(codexRecordSelectionIdentity(record)),
-                              let panelKey = codexPanelKey(for: record) else {
+                              !selectedIdentities.contains(codexRecordSelectionIdentity(record)) else {
                             continue
                         }
-                        incompleteCodexPanelKeys.insert(panelKey)
+                        guard let panelKey = codexPanelKey(for: record) else {
+                            continue
+                        }
+                        if selectedPanelKeys.contains(panelKey) {
+                            incompleteCodexPanelKeys.insert(panelKey)
+                        } else {
+                            hasUnboundedCodexIncompleteness = true
+                        }
                     }
                 }
                 for rawRecord in selection.records {
@@ -1907,6 +1943,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     isComplete = false
                     continue
                 }
+                let panelKey = PanelKey(workspaceId: workspaceId, panelId: panelId)
                 let codexKey = kind == .codex
                     ? codexVerificationKey(for: effectiveRecord)
                     : nil
@@ -1921,9 +1958,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     // A selected record that was not durably inspected (or
                     // hit a transient read limit) leaves this panel
                     // inconclusive, but must not poison unrelated owners.
-                    incompleteCodexPanelKeys.insert(
-                        PanelKey(workspaceId: workspaceId, panelId: panelId)
-                    )
+                    incompleteCodexPanelKeys.insert(panelKey)
                 }
                 let codexOwnerIsAdmitted = hookRecordIsRestorable(
                     effectiveRecord,
@@ -1938,12 +1973,13 @@ struct RestorableAgentSessionIndex: Sendable {
                     // still unsafe for binding-only automatic restore. Keep
                     // this panel deferred so the restore boundary can clear
                     // only the rejected checkpoint.
-                    incompleteCodexPanelKeys.insert(
-                        PanelKey(workspaceId: workspaceId, panelId: panelId)
-                    )
+                    incompleteCodexPanelKeys.insert(panelKey)
                 }
                 guard codexOwnerIsAdmitted else {
                     continue
+                }
+                if kind == .codex {
+                    verifiedCodexPanelKeys.insert(panelKey)
                 }
                 let snapshot = SessionRestorableAgentSnapshot(
                     kind: kind,
@@ -1960,7 +1996,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     registration: registration,
                     permissionMode: effectiveRecord.lastPermissionMode
                 )
-                let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
+                let key = panelKey
                 let sessionKey = SessionKey(kind: kind, sessionId: normalizedSessionId)
                 let panelKindKey = PanelKindKey(panelKey: key, kind: kind)
                 let panelIDKindKey = PanelIDKindKey(panelId: panelId, kind: kind)
@@ -2178,7 +2214,9 @@ struct RestorableAgentSessionIndex: Sendable {
         return RestorableAgentSessionIndex(
             entriesByPanel: resolved,
             isComplete: isComplete,
-            incompleteCodexPanelKeys: incompleteCodexPanelKeys
+            incompleteCodexPanelKeys: incompleteCodexPanelKeys,
+            verifiedCodexPanelKeys: verifiedCodexPanelKeys,
+            hasUnboundedCodexIncompleteness: hasUnboundedCodexIncompleteness
         )
     }
 
@@ -3379,12 +3417,17 @@ struct RestorableAgentSessionIndex: Sendable {
     private init(
         entriesByPanel: [PanelKey: Entry],
         isComplete: Bool = true,
-        incompleteCodexPanelKeys: Set<PanelKey> = []
+        incompleteCodexPanelKeys: Set<PanelKey> = [],
+        verifiedCodexPanelKeys: Set<PanelKey> = [],
+        hasUnboundedCodexIncompleteness: Bool = false
     ) {
         self.entriesByPanel = entriesByPanel
         self.isComplete = isComplete
         self.incompleteCodexPanelKeys = incompleteCodexPanelKeys
         self.incompleteCodexPanelIds = Set(incompleteCodexPanelKeys.map(\.panelId))
+        self.verifiedCodexPanelKeys = verifiedCodexPanelKeys
+        self.verifiedCodexPanelIds = Set(verifiedCodexPanelKeys.map(\.panelId))
+        self.hasUnboundedCodexIncompleteness = hasUnboundedCodexIncompleteness
         // Keep only the bounded candidate prefix while indexing. Exact owner
         // lookups still use `entriesByPanel`, but stable-panel resolution must
         // never retain or sort an unbounded owner history a second time.

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1602,6 +1602,71 @@ struct RestorableAgentSessionIndex: Sendable {
             )
         }
 
+        func codexRecordIsPreferred(
+            _ candidate: RestorableAgentHookSessionRecord,
+            over existing: RestorableAgentHookSessionRecord
+        ) -> Bool {
+            let candidateRestorable = candidate.isRestorable == true
+            let existingRestorable = existing.isRestorable == true
+            if candidateRestorable != existingRestorable {
+                return candidateRestorable
+            }
+            let candidateCurrent = (candidate.pid ?? 0) > 0
+                || candidate.agentLifecycle == .running
+            let existingCurrent = (existing.pid ?? 0) > 0
+                || existing.agentLifecycle == .running
+            if candidateCurrent != existingCurrent {
+                return candidateCurrent
+            }
+            if candidate.updatedAt != existing.updatedAt {
+                return candidate.updatedAt > existing.updatedAt
+            }
+            let candidateIdentity = [
+                candidate.workspaceId,
+                candidate.surfaceId,
+                candidate.sessionId,
+            ].joined(separator: "\u{0}")
+            let existingIdentity = [
+                existing.workspaceId,
+                existing.surfaceId,
+                existing.sessionId,
+            ].joined(separator: "\u{0}")
+            return candidateIdentity > existingIdentity
+        }
+
+        func selectedCodexHookRecords(
+            from values: Dictionary<String, RestorableAgentHookSessionRecord>.Values
+        ) -> (records: [RestorableAgentHookSessionRecord], truncated: Bool) {
+            // Keep a bounded top-K instead of sorting/materializing the full
+            // history. Restorable/current records outrank legacy entries, and
+            // timestamps plus identity provide a stable tie-breaker.
+            let maximum = CodexSessionResumeVerificationLimits.maximumBatchRequests
+            var selected: [RestorableAgentHookSessionRecord] = []
+            selected.reserveCapacity(maximum)
+            var eligibleCount = 0
+            for record in values {
+                guard record.isRestorable != false,
+                      normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else {
+                    continue
+                }
+                eligibleCount += 1
+                if selected.count < maximum {
+                    selected.append(record)
+                    continue
+                }
+                guard let leastIndex = selected.indices.min(by: { lhs, rhs in
+                    codexRecordIsPreferred(selected[rhs], over: selected[lhs])
+                }) else {
+                    continue
+                }
+                if codexRecordIsPreferred(record, over: selected[leastIndex]) {
+                    selected[leastIndex] = record
+                }
+            }
+            selected.sort(by: codexRecordIsPreferred)
+            return (records: selected, truncated: eligibleCount > maximum)
+        }
+
         // Build one durable-state request plan per Codex home before the main
         // hook reconciliation loop. The verifier can then walk a legacy
         // sessions tree once instead of once per historical hook record.
@@ -1613,15 +1678,10 @@ struct RestorableAgentSessionIndex: Sendable {
             if fileManager.fileExists(atPath: fileURL.path),
                let data = try? Data(contentsOf: fileURL),
                let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) {
-                let selectedRecords = Array(
-                    state.sessions.values.prefix(
-                        CodexSessionResumeVerificationLimits.maximumBatchRequests
-                    )
-                )
-                codexHookRecordsForIndex = selectedRecords
-                codexPlanWasTruncated = state.sessions.count
-                    > CodexSessionResumeVerificationLimits.maximumBatchRequests
-                for rawRecord in selectedRecords {
+                let selection = selectedCodexHookRecords(from: state.sessions.values)
+                codexHookRecordsForIndex = selection.records
+                codexPlanWasTruncated = selection.truncated
+                for rawRecord in selection.records {
                     var record = rawRecord
                     record.launchCommand = trustedLaunchCommand(
                         record.launchCommand,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1652,15 +1652,41 @@ struct RestorableAgentSessionIndex: Sendable {
                 eligibleCount += 1
                 if selected.count < maximum {
                     selected.append(record)
+                    var childIndex = selected.count - 1
+                    while childIndex > 0 {
+                        let parentIndex = (childIndex - 1) / 2
+                        guard codexRecordIsPreferred(
+                            selected[parentIndex],
+                            over: selected[childIndex]
+                        ) else {
+                            break
+                        }
+                        selected.swapAt(parentIndex, childIndex)
+                        childIndex = parentIndex
+                    }
                     continue
                 }
-                guard let leastIndex = selected.indices.min(by: { lhs, rhs in
-                    codexRecordIsPreferred(selected[rhs], over: selected[lhs])
-                }) else {
+                guard codexRecordIsPreferred(record, over: selected[0]) else {
                     continue
                 }
-                if codexRecordIsPreferred(record, over: selected[leastIndex]) {
-                    selected[leastIndex] = record
+                selected[0] = record
+                var parentIndex = 0
+                while true {
+                    let leftIndex = parentIndex * 2 + 1
+                    guard leftIndex < selected.count else { break }
+                    let rightIndex = leftIndex + 1
+                    let leastChildIndex = rightIndex < selected.count
+                        && codexRecordIsPreferred(selected[leftIndex], over: selected[rightIndex])
+                        ? rightIndex
+                        : leftIndex
+                    guard codexRecordIsPreferred(
+                        selected[parentIndex],
+                        over: selected[leastChildIndex]
+                    ) else {
+                        break
+                    }
+                    selected.swapAt(parentIndex, leastChildIndex)
+                    parentIndex = leastChildIndex
                 }
             }
             selected.sort(by: codexRecordIsPreferred)

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1276,6 +1276,8 @@ struct RestorableAgentSessionIndex: Sendable {
             fileManager: fileManager
         )
         let codexCwdLookup = CodexSessionCwdLookupCache(fileManager: fileManager)
+        let codexResumeVerifier = CodexSessionResumeVerifier()
+        var codexVerificationCache: [String: CodexSessionResumeVerification] = [:]
         let cachedAgentProcessValidator = CachedAgentProcessIdentityValidator()
         let builtInKindIDs = Set(RestorableAgentKind.allCases.map(\.rawValue))
         let hookKinds: [(kind: RestorableAgentKind, registration: CmuxVaultAgentRegistration?)] =
@@ -1288,6 +1290,37 @@ struct RestorableAgentSessionIndex: Sendable {
         var hookCandidatesBySession: [SessionKey: Entry] = [:]
         var hookCandidatesByPanelAndKind: [PanelKindKey: Entry] = [:]
         var hookCandidatesByPanelIdAndKind: [PanelIDKindKey: PanelIDKindCandidate] = [:]
+
+        func codexDurableVerification(
+            for record: RestorableAgentHookSessionRecord
+        ) -> CodexSessionResumeVerification? {
+            guard record.isRestorable == true else { return nil }
+            let sessionID = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !sessionID.isEmpty else { return .missing }
+            let launchEnvironment = record.launchCommand?.environment
+            let rawHome = Self.normalizedNonEmptyValue(launchEnvironment?["CODEX_HOME"])
+                ?? Self.normalizedNonEmptyValue(record.launchCommand?.verificationHome).map {
+                    URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
+                        .appendingPathComponent(".codex", isDirectory: true)
+                        .path
+                }
+                ?? URL(fileURLWithPath: homeDirectory, isDirectory: true)
+                    .appendingPathComponent(".codex", isDirectory: true)
+                    .path
+            let codexHome = (NSString(string: rawHome).expandingTildeInPath as NSString).standardizingPath
+            let cacheKey = codexHome + "\u{0}" + sessionID
+            if let cached = codexVerificationCache[cacheKey] {
+                return cached
+            }
+            let result = codexResumeVerifier.verify(
+                sessionId: sessionID,
+                transcriptPath: record.transcriptPath,
+                codexHome: codexHome,
+                fileManager: fileManager
+            )
+            codexVerificationCache[cacheKey] = result
+            return result
+        }
 
         for (kind, registration) in hookKinds {
             let fileURL = kind.hookStoreFileURL(homeDirectory: homeDirectory)
@@ -1326,7 +1359,10 @@ struct RestorableAgentSessionIndex: Sendable {
                           effectiveRecord,
                           kind: kind,
                           fileManager: fileManager,
-                          claudeTranscriptLookup: claudeTranscriptLookup
+                          claudeTranscriptLookup: claudeTranscriptLookup,
+                          codexDurableVerification: kind == .codex
+                              ? codexDurableVerification(for: effectiveRecord)
+                              : nil
                       ) else {
                     continue
                 }
@@ -1745,14 +1781,18 @@ struct RestorableAgentSessionIndex: Sendable {
         _ record: RestorableAgentHookSessionRecord,
         kind: RestorableAgentKind,
         fileManager: FileManager,
-        claudeTranscriptLookup: ClaudeTranscriptLookupCache
+        claudeTranscriptLookup: ClaudeTranscriptLookupCache,
+        codexDurableVerification: CodexSessionResumeVerification?
     ) -> Bool {
         if kind == .codex {
             guard record.isRestorable != false else { return false }
             guard normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else { return false }
+            if record.isRestorable == true {
+                guard case .exists = codexDurableVerification else { return false }
+                return true
+            }
             let launchSource = normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased()
-            if record.isRestorable == true
-                || launchSource == "default"
+            if launchSource == "default"
                 || (record.launchCommand?.arguments.isEmpty == false
                     && (launchSource == nil || ["environment", "process"].contains(launchSource))
                     && !(launchSource == "environment" && normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) == nil && (normalizedNonEmptyValue(record.launchCommand?.environment?["ANTHROPIC_BASE_URL"]) != nil || normalizedNonEmptyValue(record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]) != nil)))

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1033,6 +1033,10 @@ struct RestorableAgentSessionIndex: Sendable {
     /// Missing files are complete (the agent kind may not be installed); a
     /// present but unreadable/invalid file is incomplete and unsafe for auto-resume.
     let isComplete: Bool
+    /// Panel owners whose Codex hook records were outside the bounded
+    /// verification pass or had inconclusive durable evidence.
+    private let incompleteCodexPanelKeys: Set<PanelKey>
+    private let incompleteCodexPanelIds: Set<UUID>
     private let candidatesByPanelId: [UUID: [(PanelKey, Entry)]]
     private let entriesByPanelId: [UUID: Entry]
     private let ambiguousPanelIds: Set<UUID>
@@ -1056,6 +1060,38 @@ struct RestorableAgentSessionIndex: Sendable {
 
     func hasAmbiguousPanel(_ panelId: UUID) -> Bool {
         ambiguousPanelIds.contains(panelId)
+    }
+
+    /// Whether the durable index is complete for one exact workspace/panel owner.
+    ///
+    /// A bounded Codex history can be incomplete for one panel while unrelated
+    /// verified owners remain safe to restore. A global store failure still
+    /// makes every owner incomplete through the global flag.
+    func isComplete(forWorkspaceId workspaceId: UUID, panelId: UUID) -> Bool {
+        isComplete && !incompleteCodexPanelKeys.contains(
+            PanelKey(workspaceId: workspaceId, panelId: panelId)
+        )
+    }
+
+    /// Whether the durable index is complete for a restart-stable panel identity.
+    ///
+    /// Deferred restore admission has the stable panel UUID but may not have
+    /// the pre-restart workspace UUID, so this form intentionally ignores the
+    /// workspace component.
+    func isComplete(forPanelId panelId: UUID) -> Bool {
+        isComplete && !incompleteCodexPanelIds.contains(panelId)
+    }
+
+    /// Fingerprint used by the shared index cache to publish scoped completion
+    /// changes even when process liveness is unchanged.
+    var completionFingerprint: Set<String> {
+        var values = incompleteCodexPanelKeys.map {
+            "\($0.workspaceId.uuidString)|\($0.panelId.uuidString)"
+        }
+        if !isComplete {
+            values.append("global")
+        }
+        return Set(values)
     }
 
     /// Recomputes owner ambiguity from current PID evidence.
@@ -1467,7 +1503,8 @@ struct RestorableAgentSessionIndex: Sendable {
 
         return RestorableAgentSessionIndex(
             entriesByPanel: revalidatedEntries,
-            isComplete: self.isComplete
+            isComplete: self.isComplete,
+            incompleteCodexPanelKeys: self.incompleteCodexPanelKeys
         )
     }
 
@@ -1577,13 +1614,51 @@ struct RestorableAgentSessionIndex: Sendable {
         var codexRequestsByHome: [String: [CodexSessionResumeVerificationRequest]] = [:]
         var codexRequestKeys = Set<String>()
         var codexRequestCount = 0
-        var codexPlanWasTruncated = false
+        var incompleteCodexPanelKeys = Set<PanelKey>()
+        var codexIndexedStoreByHome: [String: Bool] = [:]
         var codexHookRecordsForIndex: [RestorableAgentHookSessionRecord]?
+
+        func codexPanelKey(
+            for record: RestorableAgentHookSessionRecord
+        ) -> PanelKey? {
+            guard let workspaceId = UUID(uuidString: record.workspaceId),
+                  let panelId = UUID(uuidString: record.surfaceId) else {
+                return nil
+            }
+            return PanelKey(workspaceId: workspaceId, panelId: panelId)
+        }
+
+        func codexRecordSelectionIdentity(
+            _ record: RestorableAgentHookSessionRecord
+        ) -> String {
+            [
+                record.workspaceId,
+                record.surfaceId,
+                record.sessionId,
+                String(record.updatedAt),
+                record.transcriptPath ?? ""
+            ].joined(separator: "\u{0}")
+        }
+
+        func codexHomeHasIndexedStore(_ home: String) -> Bool {
+            if let cached = codexIndexedStoreByHome[home] {
+                return cached
+            }
+            let databasePath = URL(fileURLWithPath: home, isDirectory: true)
+                .appendingPathComponent("state_5.sqlite", isDirectory: false)
+                .path
+            let exists = fileManager.fileExists(atPath: databasePath)
+            codexIndexedStoreByHome[home] = exists
+            return exists
+        }
 
         func codexVerificationKey(
             for record: RestorableAgentHookSessionRecord
         ) -> (key: String, home: String, sessionID: String, transcriptPath: String?)? {
-            guard record.isRestorable == true else { return nil }
+            guard record.isRestorable != false,
+                  normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else {
+                return nil
+            }
             let sessionID = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !sessionID.isEmpty else { return nil }
             let home = codexHomeResolver.resolve(
@@ -1706,7 +1781,18 @@ struct RestorableAgentSessionIndex: Sendable {
                let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) {
                 let selection = selectedCodexHookRecords(from: state.sessions.values)
                 codexHookRecordsForIndex = selection.records
-                codexPlanWasTruncated = selection.truncated
+                if selection.truncated {
+                    let selectedIdentities = Set(selection.records.map(codexRecordSelectionIdentity))
+                    for record in state.sessions.values {
+                        guard record.isRestorable != false,
+                              normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected",
+                              !selectedIdentities.contains(codexRecordSelectionIdentity(record)),
+                              let panelKey = codexPanelKey(for: record) else {
+                            continue
+                        }
+                        incompleteCodexPanelKeys.insert(panelKey)
+                    }
+                }
                 for rawRecord in selection.records {
                     var record = rawRecord
                     record.launchCommand = trustedLaunchCommand(
@@ -1719,10 +1805,17 @@ struct RestorableAgentSessionIndex: Sendable {
                            || normalizedNonEmptyValue(record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]) != nil {
                         record.launchCommand = nil
                     }
-                    guard let key = codexVerificationKey(for: record) else { continue }
+                    guard let key = codexVerificationKey(for: record) else {
+                        if let panelKey = codexPanelKey(for: rawRecord) {
+                            incompleteCodexPanelKeys.insert(panelKey)
+                        }
+                        continue
+                    }
                     guard !codexRequestKeys.contains(key.key) else { continue }
                     guard codexRequestCount < CodexSessionResumeVerificationLimits.maximumBatchRequests else {
-                        codexPlanWasTruncated = true
+                        if let panelKey = codexPanelKey(for: rawRecord) {
+                            incompleteCodexPanelKeys.insert(panelKey)
+                        }
                         continue
                     }
                     codexRequestKeys.insert(key.key)
@@ -1735,11 +1828,6 @@ struct RestorableAgentSessionIndex: Sendable {
                     )
                 }
             }
-        }
-        if codexPlanWasTruncated {
-            // Some historical records were intentionally left unverified;
-            // preserve the current binding and retry on a later index load.
-            isComplete = false
         }
         let codexResumeVerifier = CodexSessionResumeVerifier()
         let codexHomeCount = max(1, codexRequestsByHome.count)
@@ -1767,13 +1855,6 @@ struct RestorableAgentSessionIndex: Sendable {
                     .joined(separator: "\u{0}")
                 codexVerificationByKey[key] = result
             }
-        }
-
-        func codexDurableVerification(
-            for record: RestorableAgentHookSessionRecord
-        ) -> CodexSessionResumeVerification? {
-            guard let key = codexVerificationKey(for: record) else { return nil }
-            return codexVerificationByKey[key.key]
         }
 
         for (kind, registration) in hookKinds {
@@ -1826,33 +1907,34 @@ struct RestorableAgentSessionIndex: Sendable {
                     isComplete = false
                     continue
                 }
-                let codexVerification = kind == .codex
-                    ? codexDurableVerification(for: effectiveRecord)
+                let codexKey = kind == .codex
+                    ? codexVerificationKey(for: effectiveRecord)
                     : nil
-                if kind == .codex,
-                   effectiveRecord.isRestorable == true,
-                   codexVerification == nil {
-                    // The request plan raced the hook-store read or could not
-                    // resolve this record's home. Do not claim a complete
-                    // index when durable evidence was not inspected.
-                    isComplete = false
+                let codexVerification = codexKey.flatMap {
+                    codexVerificationByKey[$0.key]
                 }
-                if case .some(.unavailable) = codexVerification {
-                    // A transient Codex store/read failure is not evidence that
-                    // the session is gone. Keep the index incomplete so
-                    // reconciliation preserves the existing binding.
-                    isComplete = false
+                let codexHasIndexedStore = codexKey.map {
+                    codexHomeHasIndexedStore($0.home)
+                } ?? false
+                if kind == .codex,
+                   codexVerification == nil || codexVerification == .some(.unavailable) {
+                    // A selected record that was not durably inspected (or
+                    // hit a transient read limit) leaves this panel
+                    // inconclusive, but must not poison unrelated owners.
+                    incompleteCodexPanelKeys.insert(
+                        PanelKey(workspaceId: workspaceId, panelId: panelId)
+                    )
                 }
                 guard hookRecordIsRestorable(
                     effectiveRecord,
                     kind: kind,
                     fileManager: fileManager,
                     claudeTranscriptLookup: claudeTranscriptLookup,
-                    codexDurableVerification: codexVerification
+                    codexDurableVerification: codexVerification,
+                    codexHasIndexedStore: codexHasIndexedStore
                 ) else {
                     continue
                 }
-
                 let snapshot = SessionRestorableAgentSnapshot(
                     kind: kind,
                     sessionId: normalizedSessionId,
@@ -2083,7 +2165,11 @@ struct RestorableAgentSessionIndex: Sendable {
             }
         }
 
-        return RestorableAgentSessionIndex(entriesByPanel: resolved, isComplete: isComplete)
+        return RestorableAgentSessionIndex(
+            entriesByPanel: resolved,
+            isComplete: isComplete,
+            incompleteCodexPanelKeys: incompleteCodexPanelKeys
+        )
     }
 
     private static func matchingHookEntry(
@@ -2389,7 +2475,8 @@ struct RestorableAgentSessionIndex: Sendable {
         kind: RestorableAgentKind,
         fileManager: FileManager,
         claudeTranscriptLookup: ClaudeTranscriptLookupCache,
-        codexDurableVerification: CodexSessionResumeVerification?
+        codexDurableVerification: CodexSessionResumeVerification?,
+        codexHasIndexedStore: Bool
     ) -> Bool {
         if kind == .codex {
             guard record.isRestorable != false else { return false }
@@ -2404,19 +2491,26 @@ struct RestorableAgentSessionIndex: Sendable {
                 }
                 return true
             }
-            let launchSource = normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased()
-            if launchSource == "default"
-                || (record.launchCommand?.arguments.isEmpty == false
-                    && (launchSource == nil || ["environment", "process"].contains(launchSource))
-                    && !(launchSource == "environment" && normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) == nil && (normalizedNonEmptyValue(record.launchCommand?.environment?["ANTHROPIC_BASE_URL"]) != nil || normalizedNonEmptyValue(record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]) != nil)))
-                || normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) != nil {
-                return true
+            switch codexDurableVerification {
+            case .some(.exists(let evidence)):
+                if evidence.provenance.mayOwnBinding {
+                    return true
+                }
+                // Legacy rollout-only installs may not record producer
+                // metadata. Preserve a single explicit launch capture in that
+                // case, but never let known exec/subagent evidence own a panel.
+                return !codexHasIndexedStore
+                    && evidence.provenance == .unknown
+                    && codexLegacyLaunchHasPositiveEvidence(record, fileManager: fileManager)
+            case .some(.missing):
+                // A readable Codex index is authoritative: a missing row is
+                // not a reason to resurrect a nil-valued hook record. Older
+                // rollout-only installs retain their explicit launch fallback.
+                return !codexHasIndexedStore
+                    && codexLegacyLaunchHasPositiveEvidence(record, fileManager: fileManager)
+            case .some(.unavailable), .none:
+                return false
             }
-            guard let transcriptPath = normalizedNonEmptyValue(record.transcriptPath) else { return false }
-            return regularNonEmptyFileExists(
-                atPath: (transcriptPath as NSString).expandingTildeInPath,
-                fileManager: fileManager
-            )
         }
         guard kind == .claude else {
             return record.isRestorable != false
@@ -2429,6 +2523,30 @@ struct RestorableAgentSessionIndex: Sendable {
             return true
         }
         return claudeTranscriptExists(for: record, fileManager: fileManager, lookup: claudeTranscriptLookup)
+    }
+
+    private static func codexLegacyLaunchHasPositiveEvidence(
+        _ record: RestorableAgentHookSessionRecord,
+        fileManager: FileManager
+    ) -> Bool {
+        let launchSource = normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased()
+        if launchSource == "default"
+            || (record.launchCommand?.arguments.isEmpty == false
+                && (launchSource == nil || ["environment", "process"].contains(launchSource))
+                && !(launchSource == "environment"
+                    && normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) == nil
+                    && (normalizedNonEmptyValue(record.launchCommand?.environment?["ANTHROPIC_BASE_URL"]) != nil
+                        || normalizedNonEmptyValue(record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]) != nil)))
+            || normalizedNonEmptyValue(record.launchCommand?.environment?["CODEX_HOME"]) != nil {
+            return true
+        }
+        guard let transcriptPath = normalizedNonEmptyValue(record.transcriptPath) else {
+            return false
+        }
+        return regularNonEmptyFileExists(
+            atPath: (transcriptPath as NSString).expandingTildeInPath,
+            fileManager: fileManager
+        )
     }
 
     private static func resolvedClaudeWorkflowRecord(
@@ -3248,9 +3366,15 @@ struct RestorableAgentSessionIndex: Sendable {
         return rawValue
     }
 
-    private init(entriesByPanel: [PanelKey: Entry], isComplete: Bool = true) {
+    private init(
+        entriesByPanel: [PanelKey: Entry],
+        isComplete: Bool = true,
+        incompleteCodexPanelKeys: Set<PanelKey> = []
+    ) {
         self.entriesByPanel = entriesByPanel
         self.isComplete = isComplete
+        self.incompleteCodexPanelKeys = incompleteCodexPanelKeys
+        self.incompleteCodexPanelIds = Set(incompleteCodexPanelKeys.map(\.panelId))
         // Keep only the bounded candidate prefix while indexing. Exact owner
         // lookups still use `entriesByPanel`, but stable-panel resolution must
         // never retain or sort an unbounded owner history a second time.

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1706,7 +1706,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     // index when durable evidence was not inspected.
                     isComplete = false
                 }
-                if case .unavailable = codexVerification {
+                if case .some(.unavailable) = codexVerification {
                     // A transient Codex store/read failure is not evidence that
                     // the session is gone. Keep the index incomplete so
                     // reconciliation preserves the existing binding.
@@ -2264,7 +2264,7 @@ struct RestorableAgentSessionIndex: Sendable {
             guard record.isRestorable != false else { return false }
             guard normalizedNonEmptyValue(record.launchCommand?.source)?.lowercased() != "rejected" else { return false }
             if record.isRestorable == true {
-                guard case .exists(let evidence) = codexDurableVerification,
+                guard case .some(.exists(let evidence)) = codexDurableVerification,
                       evidence.provenance.mayOwnBinding else {
                     // A durable automation, child, or unclassified rollout is
                     // valid evidence for an explicit exec restore, but it can

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1578,6 +1578,7 @@ struct RestorableAgentSessionIndex: Sendable {
         var codexRequestKeys = Set<String>()
         var codexRequestCount = 0
         var codexPlanWasTruncated = false
+        var codexHookRecordsForIndex: [RestorableAgentHookSessionRecord]?
 
         func codexVerificationKey(
             for record: RestorableAgentHookSessionRecord
@@ -1587,6 +1588,7 @@ struct RestorableAgentSessionIndex: Sendable {
             guard !sessionID.isEmpty else { return nil }
             let home = codexHomeResolver.resolve(
                 launchEnvironment: record.launchCommand?.environment,
+                launchWorkingDirectory: record.launchCommand?.workingDirectory ?? record.cwd,
                 launchVerificationHome: record.launchCommand?.verificationHome,
                 ambientEnvironment: environment,
                 fallbackHomeDirectory: homeDirectory
@@ -1611,12 +1613,15 @@ struct RestorableAgentSessionIndex: Sendable {
             if fileManager.fileExists(atPath: fileURL.path),
                let data = try? Data(contentsOf: fileURL),
                let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) {
-                for rawRecord in state.sessions.values.sorted(by: {
-                    if $0.updatedAt != $1.updatedAt {
-                        return $0.updatedAt > $1.updatedAt
-                    }
-                    return $0.sessionId > $1.sessionId
-                }) {
+                let selectedRecords = Array(
+                    state.sessions.values.prefix(
+                        CodexSessionResumeVerificationLimits.maximumBatchRequests
+                    )
+                )
+                codexHookRecordsForIndex = selectedRecords
+                codexPlanWasTruncated = state.sessions.count
+                    > CodexSessionResumeVerificationLimits.maximumBatchRequests
+                for rawRecord in selectedRecords {
                     var record = rawRecord
                     record.launchCommand = trustedLaunchCommand(
                         record.launchCommand,
@@ -1651,9 +1656,20 @@ struct RestorableAgentSessionIndex: Sendable {
             isComplete = false
         }
         let codexResumeVerifier = CodexSessionResumeVerifier()
-        var codexReadBudget = CodexSessionResumeVerificationLimits()
+        let codexHomeCount = max(1, codexRequestsByHome.count)
+        let perHomeReadBudgetBytes = max(
+            1,
+            CodexSessionResumeVerificationLimits.maximumBatchBytes / codexHomeCount
+        )
         for home in codexRequestsByHome.keys.sorted() {
             guard let requests = codexRequestsByHome[home] else { continue }
+            // Keep each account's read allowance independent: a pathological
+            // history in one CODEX_HOME must not make later homes appear
+            // unavailable. The request cap and equal per-home allocation still
+            // bound the total work for one index load.
+            var codexReadBudget = CodexSessionResumeVerificationLimits(
+                maximumBytes: perHomeReadBudgetBytes
+            )
             let results = codexResumeVerifier.verifyBatch(
                 requests,
                 codexHome: home,
@@ -1675,25 +1691,33 @@ struct RestorableAgentSessionIndex: Sendable {
         }
 
         for (kind, registration) in hookKinds {
-            let fileURL = kind.hookStoreFileURL(
-                homeDirectory: homeDirectory,
-                environment: environment
-            )
-            guard fileManager.fileExists(atPath: fileURL.path) else {
-                continue
-            }
-            guard let data = try? Data(contentsOf: fileURL),
-                  let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) else {
-                isComplete = false
-                continue
-            }
-
-            let hookRecords = kind == .hermesAgent
-                ? canonicalHermesHookRecords(
-                    state.sessions.values,
-                    homeDirectory: homeDirectory
+            let hookRecords: [RestorableAgentHookSessionRecord]
+            if kind == .codex, let codexHookRecordsForIndex {
+                // The planning pass decoded this store once; reuse its
+                // bounded snapshot so a refresh cannot race a second decode.
+                hookRecords = codexHookRecordsForIndex
+            } else {
+                let fileURL = kind.hookStoreFileURL(
+                    homeDirectory: homeDirectory,
+                    environment: environment
                 )
-                : Array(state.sessions.values)
+                guard fileManager.fileExists(atPath: fileURL.path) else {
+                    continue
+                }
+                guard let data = try? Data(contentsOf: fileURL),
+                      let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) else {
+                    isComplete = false
+                    continue
+                }
+                if kind == .hermesAgent {
+                    hookRecords = canonicalHermesHookRecords(
+                        state.sessions.values,
+                        homeDirectory: homeDirectory
+                    )
+                } else {
+                    hookRecords = Array(state.sessions.values)
+                }
+            }
             for record in hookRecords {
                 var effectiveRecord = kind == .claude
                     ? resolvedClaudeWorkflowRecord(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1576,6 +1576,8 @@ struct RestorableAgentSessionIndex: Sendable {
         var codexVerificationByKey: [String: CodexSessionResumeVerification] = [:]
         var codexRequestsByHome: [String: [CodexSessionResumeVerificationRequest]] = [:]
         var codexRequestKeys = Set<String>()
+        var codexRequestCount = 0
+        var codexPlanWasTruncated = false
 
         func codexVerificationKey(
             for record: RestorableAgentHookSessionRecord
@@ -1609,7 +1611,12 @@ struct RestorableAgentSessionIndex: Sendable {
             if fileManager.fileExists(atPath: fileURL.path),
                let data = try? Data(contentsOf: fileURL),
                let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) {
-                for rawRecord in state.sessions.values {
+                for rawRecord in state.sessions.values.sorted(by: {
+                    if $0.updatedAt != $1.updatedAt {
+                        return $0.updatedAt > $1.updatedAt
+                    }
+                    return $0.sessionId > $1.sessionId
+                }) {
                     var record = rawRecord
                     record.launchCommand = trustedLaunchCommand(
                         record.launchCommand,
@@ -1622,7 +1629,13 @@ struct RestorableAgentSessionIndex: Sendable {
                         record.launchCommand = nil
                     }
                     guard let key = codexVerificationKey(for: record) else { continue }
-                    guard codexRequestKeys.insert(key.key).inserted else { continue }
+                    guard !codexRequestKeys.contains(key.key) else { continue }
+                    guard codexRequestCount < CodexSessionResumeVerificationLimits.maximumBatchRequests else {
+                        codexPlanWasTruncated = true
+                        continue
+                    }
+                    codexRequestKeys.insert(key.key)
+                    codexRequestCount += 1
                     codexRequestsByHome[key.home, default: []].append(
                         CodexSessionResumeVerificationRequest(
                             sessionId: key.sessionID,
@@ -1632,11 +1645,19 @@ struct RestorableAgentSessionIndex: Sendable {
                 }
             }
         }
+        if codexPlanWasTruncated {
+            // Some historical records were intentionally left unverified;
+            // preserve the current binding and retry on a later index load.
+            isComplete = false
+        }
         let codexResumeVerifier = CodexSessionResumeVerifier()
-        for (home, requests) in codexRequestsByHome {
+        var codexReadBudget = CodexSessionResumeVerificationLimits()
+        for home in codexRequestsByHome.keys.sorted() {
+            guard let requests = codexRequestsByHome[home] else { continue }
             let results = codexResumeVerifier.verifyBatch(
                 requests,
                 codexHome: home,
+                readBudget: &codexReadBudget,
                 fileManager: fileManager
             )
             for (request, result) in zip(requests, results) {

--- a/Sources/SharedLiveAgentIndex.swift
+++ b/Sources/SharedLiveAgentIndex.swift
@@ -1474,7 +1474,8 @@ final class SharedLiveAgentIndex {
             || hasPendingForkValidations
             || result.liveAgentProcessFingerprint != liveAgentProcessFingerprint
             || result.processScopeFingerprint != processScopeFingerprint
-            || index?.isComplete != result.index.isComplete {
+            || index?.isComplete != result.index.isComplete
+            || index?.completionFingerprint != result.index.completionFingerprint {
             applyReloadedIndex(
                 result.index,
                 loadedAt: loadedAt,

--- a/Sources/SurfaceResumeBindingSnapshot+ManagedSessionIdentity.swift
+++ b/Sources/SurfaceResumeBindingSnapshot+ManagedSessionIdentity.swift
@@ -52,6 +52,10 @@ enum ManagedAgentSessionIdentity {
 }
 
 extension SurfaceResumeBindingSnapshot {
+    /// Maximum time a CLI restore may hold an in-memory binding claim while
+    /// handing control to the restored process.
+    static let restoreClaimTTL: TimeInterval = 60
+
     var hasCompleteManagedSessionIdentity: Bool {
         managedSessionIdentity != nil
     }
@@ -67,6 +71,18 @@ extension SurfaceResumeBindingSnapshot {
                 lhs: identity.checkpointId,
                 rhs: otherIdentity.checkpointId
             )
+    }
+
+    /// Whether an incoming hook refresh belongs to a claimed restore session.
+    ///
+    /// A same-session refresh consumes the claim; a different checkpoint or
+    /// kind remains blocked until the claim expires or is explicitly cleared.
+    func acceptsRestoreBindingClaim(
+        from incoming: SurfaceResumeBindingSnapshot
+    ) -> Bool {
+        isAgentHookBinding
+            && incoming.isAgentHookBinding
+            && isSameManagedSession(as: incoming)
     }
 
     /// Projects an authoritative agent-hook binding into the structured

--- a/Sources/TerminalController+ControlSurfaceContext3.swift
+++ b/Sources/TerminalController+ControlSurfaceContext3.swift
@@ -17,6 +17,10 @@ extension TerminalController {
             launchCommandMustBeValid: String(
                 localized: "socket.surface.resume.launchCommandMustBeValid",
                 defaultValue: "launch_command.arguments must be a non-empty array of strings"
+            ),
+            restoreClaimMustBeValid: String(
+                localized: "socket.surface.resume.restoreClaimMustBeValid",
+                defaultValue: "Missing or invalid restore claim"
             )
         )
     }

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -648,7 +648,11 @@ extension Workspace {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
-            guard index.isComplete(forPanelId: restore.stablePanelID) else {
+            let expectedKind = restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind
+            guard index.isComplete(
+                forPanelId: restore.stablePanelID,
+                kind: expectedKind
+            ) else {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
@@ -686,7 +690,6 @@ extension Workspace {
                 }
             }
             let ownershipPanelID = restore.stablePanelID
-            let expectedKind = restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind
             let expectedSessionId = restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId
             // Deferred admission has no exact-owner snapshot that can override a
             // stable-panel tie, so structural ambiguity remains fail-closed even

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -385,7 +385,9 @@ extension Workspace {
             return
         }
         binding.autoResume = false
-        surfaceResumeBindingsByPanelId[panelId] = binding
+        if surfaceResumeBindingMutationAllowed(binding, panelId: panelId) {
+            surfaceResumeBindingsByPanelId[panelId] = binding
+        }
     }
 
     /// Keep an in-flight restored launch tied to the same structured binding

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -648,7 +648,7 @@ extension Workspace {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }
-            guard index.isComplete else {
+            guard index.isComplete(forPanelId: restore.stablePanelID) else {
                 cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
                 continue
             }

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -526,6 +526,7 @@ extension Workspace {
         surfaceTTYNames.removeValue(forKey: panelId)
         discardRemotePTYSessionID(panelId: panelId)
         surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+        surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         pendingPlainSSHRestorePanelIds.remove(panelId)
         observedPlainSSHPanelIds.remove(panelId)
         plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)

--- a/Sources/Workspace+PersistentRemotePTYReattach.swift
+++ b/Sources/Workspace+PersistentRemotePTYReattach.swift
@@ -94,7 +94,9 @@ extension Workspace {
             remotePTYSessionIDsByPanelId[panelId] = sessionID
             registerRemoteRelayIDAliases(remotePTYSessionID: sessionID, restoredPanelId: panelId)
             if let resumeBinding {
-                surfaceResumeBindingsByPanelId[panelId] = resumeBinding
+                if surfaceResumeBindingMutationAllowed(resumeBinding, panelId: panelId) {
+                    surfaceResumeBindingsByPanelId[panelId] = resumeBinding
+                }
             }
             remoteDisconnectPlaceholderPanelIds.remove(panelId)
             pendingRemoteTerminalChildExitSurfaceIds.remove(panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5490,8 +5490,20 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     }
 
     @discardableResult
-    func clearSurfaceResumeBinding(panelId: UUID) -> Bool {
+    func clearSurfaceResumeBinding(
+        panelId: UUID,
+        agentSessionEnded: Bool = false
+    ) -> Bool {
         let removed = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId) != nil
+        if removed,
+           agentSessionEnded,
+           let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] {
+            // A restore-time rejection is an authoritative end of the stale
+            // checkpoint. Keep a completed tombstone so the old snapshot cannot
+            // be auto-resumed on the next save, while the terminal's tracked cwd
+            // remains available for the shell fallback.
+            markRestoredAgentCompleted(panelId: panelId, snapshot: restoredAgent)
+        }
         pendingPlainSSHRestorePanelIds.remove(panelId)
         observedPlainSSHPanelIds.remove(panelId)
         plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5714,9 +5714,16 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         agentSessionEnded: Bool = false
     ) -> Bool {
         let removedBinding = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
-        if removedBinding != nil,
+        if let removedBinding,
            agentSessionEnded,
+           removedBinding.isAgentHookBinding,
+           let checkpointID = Self.normalizedResumeBindingValue(removedBinding.checkpointId),
            let restoredAgent = restoredAgentSnapshotsByPanelId[panelId],
+           ManagedAgentSessionIdentity.sessionIDsMatch(
+               kind: restoredAgent.kind.rawValue,
+               lhs: checkpointID,
+               rhs: restoredAgent.sessionId
+           ),
            Self.restorableAgentForSessionRestore(
                restoredAgent,
                resumeBinding: removedBinding

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5713,10 +5713,14 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         panelId: UUID,
         agentSessionEnded: Bool = false
     ) -> Bool {
-        let removed = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId) != nil
-        if removed,
+        let removedBinding = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+        if removedBinding != nil,
            agentSessionEnded,
-           let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] {
+           let restoredAgent = restoredAgentSnapshotsByPanelId[panelId],
+           Self.restorableAgentForSessionRestore(
+               restoredAgent,
+               resumeBinding: removedBinding
+           ) != nil {
             // A restore-time rejection is an authoritative end of the stale
             // checkpoint. Keep a completed tombstone so the old snapshot cannot
             // be auto-resumed on the next save, while the terminal's tracked cwd
@@ -5726,7 +5730,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         pendingPlainSSHRestorePanelIds.remove(panelId)
         observedPlainSSHPanelIds.remove(panelId)
         plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
-        return removed
+        return removedBinding != nil
     }
 
     func surfaceResumeBinding(panelId: UUID) -> SurfaceResumeBindingSnapshot? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1365,6 +1365,12 @@ extension Workspace {
 
             guard let storedBinding else {
                 if let detectedBinding, detectedBinding.isProcessDetected {
+                    guard surfaceResumeBindingMutationAllowed(
+                        detectedBinding,
+                        panelId: panelId
+                    ) else {
+                        continue
+                    }
                     surfaceResumeBindingsByPanelId[panelId] = detectedBinding
                 }
                 continue
@@ -1379,6 +1385,9 @@ extension Workspace {
                         let restoreMisses = (plainSSHDetectionMissesByPanelId[panelId] ?? 0) + 1
                         plainSSHDetectionMissesByPanelId[panelId] = restoreMisses
                         if restoreMisses >= Self.plainSSHRestoreObservationMissLimit {
+                            guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                                continue
+                            }
                             surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                             pendingPlainSSHRestorePanelIds.remove(panelId)
                             plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
@@ -1388,6 +1397,9 @@ extension Workspace {
                     let misses = (plainSSHDetectionMissesByPanelId[panelId] ?? 0) + 1
                     plainSSHDetectionMissesByPanelId[panelId] = misses
                     if misses >= 2 {
+                        guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                            continue
+                        }
                         surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                         observedPlainSSHPanelIds.remove(panelId)
                         plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
@@ -1395,6 +1407,9 @@ extension Workspace {
                     continue
                 }
                 if storedBinding.isProcessDetected {
+                    guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                        continue
+                    }
                     surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                 } else if isStaleAgentHookBinding(
                     storedBinding,
@@ -1409,12 +1424,21 @@ extension Workspace {
                 continue
             }
             if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) {
+                guard surfaceResumeBindingMutationAllowed(
+                    detectedBinding,
+                    panelId: panelId
+                ) else {
+                    continue
+                }
                 invalidateRestoredAgentLifecycleIfBindingIsReplaced(
                     by: detectedBinding,
                     panelId: panelId
                 )
                 surfaceResumeBindingsByPanelId[panelId] = detectedBinding
             } else if storedBinding.isProcessDetected {
+                guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                    continue
+                }
                 surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                 observedPlainSSHPanelIds.remove(panelId)
                 pendingPlainSSHRestorePanelIds.remove(panelId)
@@ -1921,7 +1945,12 @@ extension Workspace {
                     surfaceID: terminalPanel.id,
                     persistentPTYSessionID: restoredRemotePTYSessionID
                 )
-                surfaceResumeBindingsByPanelId[terminalPanel.id] = restoredBinding
+                if surfaceResumeBindingMutationAllowed(
+                    restoredBinding,
+                    panelId: terminalPanel.id
+                ) {
+                    surfaceResumeBindingsByPanelId[terminalPanel.id] = restoredBinding
+                }
                 if restoredBinding.isPlainSSHProcessDetectedBinding,
                    restoredBindingLaunch != nil {
                     pendingPlainSSHRestorePanelIds.insert(terminalPanel.id)
@@ -1929,7 +1958,9 @@ extension Workspace {
                     plainSSHDetectionMissesByPanelId[terminalPanel.id] = 0
                 }
             } else {
-                surfaceResumeBindingsByPanelId.removeValue(forKey: terminalPanel.id)
+                if surfaceResumeBindingRemovalAllowed(panelId: terminalPanel.id) {
+                    surfaceResumeBindingsByPanelId.removeValue(forKey: terminalPanel.id)
+                }
             }
             // A terminal whose startup command cds itself (agent resume, tmux attach, agent-hook)
             // is spawned without a working directory, so its shell starts in the default directory
@@ -5523,6 +5554,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                 // The SSH child has exited and the pane is back at its local
                 // shell.  Retaining this binding would relaunch a connection
                 // the user has intentionally left.
+                guard surfaceResumeBindingRemovalAllowed(panelId: panelId) else {
+                    break
+                }
                 surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
                 observedPlainSSHPanelIds.remove(panelId)
                 plainSSHDetectionMissesByPanelId.removeValue(forKey: panelId)
@@ -5750,6 +5784,38 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             claimedAt: Date.now
         )
         return true
+    }
+
+    /// Checks a non-socket binding writer against an in-flight restore claim.
+    ///
+    /// Hook publications use ``setSurfaceResumeBinding`` directly, while
+    /// reconciliation and transfer paths historically wrote the dictionary
+    /// inline. Those paths must share the same claim gate so no writer can
+    /// replace the generation after the CLI has been authorized to exec it.
+    @discardableResult
+    func surfaceResumeBindingMutationAllowed(
+        _ incoming: SurfaceResumeBindingSnapshot,
+        panelId: UUID
+    ) -> Bool {
+        guard let claim = surfaceResumeRestoreClaim(for: panelId) else {
+            return true
+        }
+        guard claim.binding.acceptsRestoreBindingClaim(from: incoming) else {
+            return false
+        }
+        // Preserve the lease when a same-session writer refreshes metadata,
+        // otherwise the current-generation check would discard the claim.
+        surfaceResumeRestoreClaimsByPanelId[panelId] = (
+            binding: incoming,
+            claimedAt: claim.claimedAt
+        )
+        return true
+    }
+
+    /// Returns false while a claimed generation is still active.
+    @discardableResult
+    func surfaceResumeBindingRemovalAllowed(panelId: UUID) -> Bool {
+        surfaceResumeRestoreClaim(for: panelId) == nil
     }
 
     private func surfaceResumeRestoreClaim(
@@ -10517,7 +10583,10 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             panelDirectories.removeValue(forKey: detached.panelId)
             panelDirectoryDisplayLabels.removeValue(forKey: detached.panelId)
             surfaceTTYNames.removeValue(forKey: detached.panelId)
-            surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
+            if surfaceResumeBindingRemovalAllowed(panelId: detached.panelId) {
+                surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
+                surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: detached.panelId)
+            }
             pendingPlainSSHRestorePanelIds.remove(detached.panelId)
             observedPlainSSHPanelIds.remove(detached.panelId)
             plainSSHDetectionMissesByPanelId.removeValue(forKey: detached.panelId)
@@ -10598,9 +10667,17 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             return detached.resolvedManagedAgentResumeBinding
         }()
         if let transferredResumeBinding {
-            surfaceResumeBindingsByPanelId[detached.panelId] = transferredResumeBinding
+            if surfaceResumeBindingMutationAllowed(
+                transferredResumeBinding,
+                panelId: detached.panelId
+            ) {
+                surfaceResumeBindingsByPanelId[detached.panelId] = transferredResumeBinding
+            }
         } else {
-            surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
+            if surfaceResumeBindingRemovalAllowed(panelId: detached.panelId) {
+                surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
+                surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: detached.panelId)
+            }
         }
         adoptDetachedAgentRuntimeState(detached.agentRuntime)
         if let markdownPanel = detached.panel as? MarkdownPanel,
@@ -10644,13 +10721,19 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                 surfaceId: detached.panelId
             )
             if let resumeBinding = surfaceResumeBindingsByPanelId[detached.panelId] {
-                surfaceResumeBindingsByPanelId[detached.panelId] = resumeBinding.retargetingRemoteOwner(
+                let retargetedBinding = resumeBinding.retargetingRemoteOwner(
                     expectedWorkspaceID: detached.sourceWorkspaceId,
                     expectedSurfaceID: detached.panelId,
                     workspaceID: id,
                     surfaceID: detached.panelId,
                     persistentPTYSessionID: remotePTYSessionIDsByPanelId[detached.panelId]
                 )
+                if surfaceResumeBindingMutationAllowed(
+                    retargetedBinding,
+                    panelId: detached.panelId
+                ) {
+                    surfaceResumeBindingsByPanelId[detached.panelId] = retargetedBinding
+                }
             }
         }
         // Seed deferred restore work only after the destination binding and

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -228,6 +228,7 @@ extension Workspace {
         terminalStartupRestoreCoordinator.removeAllRestores()
         clearDeferredAgentResumeRestores(startRuntime: false)
         surfaceResumeBindingsByPanelId.removeAll(keepingCapacity: false)
+        surfaceResumeRestoreClaimsByPanelId.removeAll(keepingCapacity: false)
         pendingPlainSSHRestorePanelIds.removeAll(keepingCapacity: false)
         observedPlainSSHPanelIds.removeAll(keepingCapacity: false)
         plainSSHDetectionMissesByPanelId.removeAll(keepingCapacity: false)
@@ -2907,6 +2908,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         restoredAgentLifecycle.snapshotsByPanelId
     }
     var surfaceResumeBindingsByPanelId: [UUID: SurfaceResumeBindingSnapshot] = [:]
+    /// In-memory compare-and-claim state held while a CLI restore hands the
+    /// validated binding to its child process.
+    @ObservationIgnored var surfaceResumeRestoreClaimsByPanelId: [
+        UUID: (binding: SurfaceResumeBindingSnapshot, claimedAt: Date)
+    ] = [:]
     /// Plain SSH restore bindings survive the short interval in which a new
     /// local PTY exists but its `ssh` child has not become foreground yet.
     /// These indexes make that exception explicit and bounded: once a shell
@@ -5664,6 +5670,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
               !startupInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
+        let activeRestoreClaim = surfaceResumeRestoreClaim(for: panelId)
+        if let activeRestoreClaim {
+            guard activeRestoreClaim.binding.acceptsRestoreBindingClaim(from: binding) else {
+                return false
+            }
+        }
         // This check and the assignment are one MainActor mutation, so
         // concurrent hook publications cannot observe-then-downgrade a TUI
         // binding between separate get/set socket calls.
@@ -5671,6 +5683,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             of: surfaceResumeBindingsByPanelId[panelId]
         ) else {
             return false
+        }
+        if activeRestoreClaim != nil {
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         }
         let previousRestorableAgent = restoredAgentSnapshotsByPanelId[panelId]
         invalidateRestoredAgentLifecycleIfBindingIsReplaced(
@@ -5708,12 +5723,65 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return true
     }
 
+    /// Atomically claims the current binding generation for a CLI restore.
+    ///
+    /// The claim is consumed by the next same-session hook refresh and blocks a
+    /// different checkpoint from replacing the binding during the handoff.
+    @discardableResult
+    func claimSurfaceResumeBinding(
+        panelId: UUID,
+        expectedCheckpointID: String,
+        expectedSource: String,
+        expectedUpdatedAt: TimeInterval
+    ) -> Bool {
+        guard let binding = surfaceResumeBindingsByPanelId[panelId],
+              binding.isAgentHookBinding,
+              binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "codex",
+              binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines)
+                  == expectedCheckpointID.trimmingCharacters(in: .whitespacesAndNewlines),
+              binding.source?.trimmingCharacters(in: .whitespacesAndNewlines)
+                  == expectedSource.trimmingCharacters(in: .whitespacesAndNewlines),
+              expectedUpdatedAt.isFinite,
+              binding.updatedAt == expectedUpdatedAt else {
+            return false
+        }
+        surfaceResumeRestoreClaimsByPanelId[panelId] = (
+            binding: binding,
+            claimedAt: Date.now
+        )
+        return true
+    }
+
+    private func surfaceResumeRestoreClaim(
+        for panelId: UUID
+    ) -> (binding: SurfaceResumeBindingSnapshot, claimedAt: Date)? {
+        guard let claim = surfaceResumeRestoreClaimsByPanelId[panelId] else {
+            return nil
+        }
+        guard let currentBinding = surfaceResumeBindingsByPanelId[panelId],
+              currentBinding.checkpointId == claim.binding.checkpointId,
+              currentBinding.source == claim.binding.source,
+              currentBinding.updatedAt == claim.binding.updatedAt else {
+            // A direct lifecycle mutation replaced the claimed generation
+            // without going through the hook setter. Do not let that old claim
+            // block a later, legitimate binding.
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
+            return nil
+        }
+        guard Date.now.timeIntervalSince(claim.claimedAt) < SurfaceResumeBindingSnapshot.restoreClaimTTL else {
+            surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
+            return nil
+        }
+        return claim
+    }
+
     @discardableResult
     func clearSurfaceResumeBinding(
         panelId: UUID,
         agentSessionEnded: Bool = false
     ) -> Bool {
         let removedBinding = surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
+        surfaceResumeRestoreClaimsByPanelId.removeValue(forKey: panelId)
         if let removedBinding,
            agentSessionEnded,
            removedBinding.isAgentHookBinding,
@@ -5998,6 +6066,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             refreshTrackedAgentPorts()
         }
         surfaceResumeBindingsByPanelId = surfaceResumeBindingsByPanelId.filter {
+            validSurfaceIds.contains($0.key)
+        }
+        surfaceResumeRestoreClaimsByPanelId = surfaceResumeRestoreClaimsByPanelId.filter {
             validSurfaceIds.contains($0.key)
         }
         pendingPlainSSHRestorePanelIds = pendingPlainSSHRestorePanelIds.intersection(validSurfaceIds)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2253,6 +2253,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842300000000000000000002 /* SurfaceResumeExitedAgentLivenessTests.swift */; };
 		7989B0027989B0027989B002 /* SurfaceResumeLaunchFlavor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */; };
 		7989B0037989B0037989B003 /* SurfaceResumeRemoteContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */; };
+		F6572022A1B2C3D4E5F60718 /* SurfaceResumeRestoreClaimTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572023A1B2C3D4E5F60718 /* SurfaceResumeRestoreClaimTests.swift */; };
 		F27B00000000000000000001 /* SurfaceResumeRunPromptBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C51A73B40000000000000002 /* SurfaceTabBarButtonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */; };
@@ -5074,6 +5075,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		842300000000000000000002 /* SurfaceResumeExitedAgentLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeExitedAgentLivenessTests.swift; sourceTree = "<group>"; };
 		7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeLaunchFlavor.swift; sourceTree = "<group>"; };
 		7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRemoteContext.swift; sourceTree = "<group>"; };
+		F6572023A1B2C3D4E5F60718 /* SurfaceResumeRestoreClaimTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRestoreClaimTests.swift; sourceTree = "<group>"; };
 		F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRunPromptBatch.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTabBarButtonConfiguration.swift; sourceTree = "<group>"; };
@@ -7971,6 +7973,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					7989A0027989A0027989A002 /* RemoteResumeBindingTests.swift */,
 				812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */,
 					F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */,
+					F6572023A1B2C3D4E5F60718 /* SurfaceResumeRestoreClaimTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					851500000000000000000002 /* TerminalFontZoomSessionPersistenceTests.swift */,
 					806600000000000000000001 /* SessionRestorableAgentSnapshotPermissionModeTests.swift */,
@@ -11784,6 +11787,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,
 				F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */,
 				842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */,
+				F6572022A1B2C3D4E5F60718 /* SurfaceResumeRestoreClaimTests.swift in Sources */,
 				A7206B010000000000000001 /* SystemAppearanceObserverTests.swift in Sources */,
 				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				F8120F5386FBE726864D340B /* TabManagerBackgroundWorkspaceMountBoundTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000040 /* CodexHookFailureSummary.swift */; };
 		918100000000000000000061 /* CodexHookUserInputCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000060 /* CodexHookUserInputCandidate.swift */; };
 		918100000000000000000091 /* CodexMonitorOwnerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000090 /* CodexMonitorOwnerState.swift */; };
+		C6209A010000000000000001 /* CodexRestoreValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6209A020000000000000001 /* CodexRestoreValidationResult.swift */; };
 		D96290010000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96290020000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift */; };
 		C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711C000000000000000001 /* CodexRolloutIdentity.swift */; };
 		C8711D000000000000000002 /* CodexRolloutIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */; };
@@ -3763,6 +3764,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		918100000000000000000040 /* CodexHookFailureSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureSummary.swift; sourceTree = "<group>"; };
 		918100000000000000000060 /* CodexHookUserInputCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookUserInputCandidate.swift; sourceTree = "<group>"; };
 		918100000000000000000090 /* CodexMonitorOwnerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexMonitorOwnerState.swift; sourceTree = "<group>"; };
+		C6209A020000000000000001 /* CodexRestoreValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexRestoreValidationResult.swift; sourceTree = "<group>"; };
 		D96290020000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexResumeBindingVerificationRegressionTests.swift; sourceTree = "<group>"; };
 		C8711C000000000000000001 /* CodexRolloutIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexRolloutIdentity.swift; sourceTree = "<group>"; };
 		C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexRolloutIdentityResolver.swift; sourceTree = "<group>"; };
@@ -7855,6 +7857,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				4CF59318F1D5B2195AC77C28 /* CMUXCLI+ClaudePushNotificationHook.swift */,
 				C6711B050000000000000001 /* CMUXCLI+AgentHookRestoreEvidence.swift */,
 				D96290040000000000000001 /* CMUXCLI+CodexResumeBindingVerification.swift */,
+				C6209A020000000000000001 /* CodexRestoreValidationResult.swift */,
 				5257257034CA4729B1211166 /* CMUXCLI+AutoNaming.swift */,
 				5257257034CA4729B121116A /* CMUXCLI+AutoNamingDispatch.swift */,
 				5257257034CA4729B1211167 /* CMUXCLI+AutoNamingGenericHooks.swift */,
@@ -11080,6 +11083,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */,
 				918100000000000000000061 /* CodexHookUserInputCandidate.swift in Sources */,
 				918100000000000000000091 /* CodexMonitorOwnerState.swift in Sources */,
+				C6209A010000000000000001 /* CodexRestoreValidationResult.swift in Sources */,
 				C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */,
 					A10240010000000000000001 /* CodexTeamsAppServerProcess.swift in Sources */,
 					A10240060000000000000001 /* CodexTeamsAppServerSupervisor.swift in Sources */,

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -363,15 +363,6 @@ import Testing
         let checkpointID = "01a03bc1-7649-7ec3-bdf7-03acf979e086"
         let surfaceID = UUID().uuidString.lowercased()
         let workspaceID = UUID().uuidString.lowercased()
-        let launchCommand: [String: Any] = [
-            "launcher": "codex",
-            "executable_path": executable.path,
-            "arguments": [executable.path],
-            "working_directory": workingDirectory.path,
-            "environment": ["CODEX_HOME": codexHome.path],
-            "verification_home": root.path,
-            "source": "environment",
-        ]
         let response = try restoreResponse(
             result: [
                 "restore_record": [
@@ -381,7 +372,10 @@ import Testing
                     "source": "session-snapshot",
                     "working_directory": workingDirectory.path,
                     "environment": ["CODEX_HOME": codexHome.path],
-                    "launch_command": launchCommand,
+                    // Exercise the older prepared-argv-only shape: the
+                    // checkpoint still needs validation even without launch
+                    // capture metadata.
+                    "prepared_arguments": ["codex", "resume", checkpointID],
                 ],
                 // This binding models a pre-#10100 snapshot: it has no durable
                 // provenance, but it still claims the stale Codex checkpoint.
@@ -417,6 +411,7 @@ import Testing
         environment["CMUX_SOCKET_PATH"] = socketPath
         environment["HOME"] = root.path
         environment["CODEX_HOME"] = codexHome.path
+        environment["PATH"] = "\(root.path):/usr/bin:/bin"
 
         let result = runProcess(
             executablePath: cliPath,
@@ -432,7 +427,7 @@ import Testing
             "a missing Codex checkpoint must never reach codex resume"
         )
         XCTAssertTrue(
-            result.stderr.contains("Codex session is no longer available"),
+            result.stderr.contains("saved Codex checkpoint is unavailable"),
             result.diagnostics
         )
 
@@ -800,7 +795,7 @@ import Testing
         let response = try restoreResponse(result: [
             "restore_record": [
                 "mode": "resumeAgent",
-                "kind": "codex",
+                "kind": "command",
                 "checkpoint_id": checkpointID,
                 "working_directory": root.path,
                 "environment": ["LEGACY_RESTORE_VALUE": "kept"],
@@ -821,7 +816,7 @@ import Testing
 
         let result = runProcess(
             executablePath: cliPath,
-            arguments: ["restore", "codex", checkpointID],
+            arguments: ["restore", "command", checkpointID],
             environment: environment,
             timeout: 5
         )

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -324,7 +324,7 @@ import Testing
         )
 
         XCTAssertFalse(result.timedOut, result.diagnostics)
-        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertNotEqual(result.status, 0, result.diagnostics)
         XCTAssertTrue(result.stdout.contains("pwd=\(workingDirectory.path)\n"), result.diagnostics)
         XCTAssertTrue(result.stdout.contains("env=値 with spaces\n"), result.diagnostics)
         for argument in arguments.dropFirst() {
@@ -427,7 +427,7 @@ import Testing
             "a missing Codex checkpoint must never reach codex resume"
         )
         XCTAssertTrue(
-            result.stderr.contains("saved Codex checkpoint is unavailable"),
+            result.stderr.contains("saved agent session is unavailable"),
             result.diagnostics
         )
 

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -324,7 +324,7 @@ import Testing
         )
 
         XCTAssertFalse(result.timedOut, result.diagnostics)
-        XCTAssertNotEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertTrue(result.stdout.contains("pwd=\(workingDirectory.path)\n"), result.diagnostics)
         XCTAssertTrue(result.stdout.contains("env=値 with spaces\n"), result.diagnostics)
         for argument in arguments.dropFirst() {
@@ -421,7 +421,7 @@ import Testing
         )
 
         XCTAssertFalse(result.timedOut, result.diagnostics)
-        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertNotEqual(result.status, 0, result.diagnostics)
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: attemptedURL.path),
             "a missing Codex checkpoint must never reach codex resume"

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -389,6 +389,7 @@ import Testing
                     "source": "agent-hook",
                     "resume_evidence_provenance": "tui",
                     "auto_resume": true,
+                    "updated_at": 123.5,
                 ],
             ],
             workspaceID: workspaceID,
@@ -444,6 +445,10 @@ import Testing
         let clearParams = try XCTUnwrap(requests.last?["params"] as? [String: Any])
         XCTAssertEqual(clearParams["checkpoint_id"] as? String, checkpointID)
         XCTAssertEqual(clearParams["source"] as? String, "agent-hook")
+        XCTAssertEqual(
+            (clearParams["expected_updated_at"] as? NSNumber)?.doubleValue,
+            123.5
+        )
         XCTAssertEqual(clearParams["agent_session_ended"] as? Bool, true)
     }
 

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -340,6 +340,115 @@ import Testing
         XCTAssertEqual(methods, ["system.identify", "surface.resume.get"])
     }
 
+    @Test func testRestoreDoesNotExecuteMissingCodexCheckpointAndGuardsStaleBindingClear() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux restore codex missing \(UUID().uuidString)", isDirectory: true)
+        let workingDirectory = root.appendingPathComponent("saved cwd", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let attemptedURL = root.appendingPathComponent("codex-attempted", isDirectory: false)
+        let executable = root.appendingPathComponent("codex", isDirectory: false)
+        try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try createEmptyCodexStateDatabase(at: codexHome.appendingPathComponent("state_5.sqlite"))
+        try """
+        #!/bin/sh
+        touch \(shellSingleQuote(attemptedURL.path))
+        printf 'ERROR: No saved session found with ID %s\\n' "$3" >&2
+        exit 42
+        """.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let checkpointID = "01a03bc1-7649-7ec3-bdf7-03acf979e086"
+        let surfaceID = UUID().uuidString.lowercased()
+        let workspaceID = UUID().uuidString.lowercased()
+        let launchCommand: [String: Any] = [
+            "launcher": "codex",
+            "executable_path": executable.path,
+            "arguments": [executable.path],
+            "working_directory": workingDirectory.path,
+            "environment": ["CODEX_HOME": codexHome.path],
+            "verification_home": root.path,
+            "source": "environment",
+        ]
+        let response = try restoreResponse(
+            result: [
+                "restore_record": [
+                    "mode": "resumeAgent",
+                    "kind": "codex",
+                    "checkpoint_id": checkpointID,
+                    "source": "session-snapshot",
+                    "working_directory": workingDirectory.path,
+                    "environment": ["CODEX_HOME": codexHome.path],
+                    "launch_command": launchCommand,
+                ],
+                // This binding models a pre-#10100 snapshot: it has no durable
+                // provenance, but it still claims the stale Codex checkpoint.
+                "resume_binding": [
+                    "name": "Codex",
+                    "kind": "codex",
+                    "command": "codex resume \(checkpointID)",
+                    "cwd": workingDirectory.path,
+                    "checkpoint_id": checkpointID,
+                    "source": "agent-hook",
+                    "auto_resume": true,
+                ],
+            ],
+            workspaceID: workspaceID,
+            surfaceID: surfaceID
+        )
+        let clearResponse = try jsonResponse(result: [
+            "cleared": true,
+            "resume_binding": NSNull(),
+        ])
+        let socketPath = "/tmp/cmux-restore-codex-missing-\(UUID().uuidString.prefix(8)).sock"
+        let responder = try UnixSocketResponder(
+            path: socketPath,
+            responses: [response, clearResponse]
+        )
+        defer { responder.stop() }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["HOME"] = root.path
+        environment["CODEX_HOME"] = codexHome.path
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["restore", "--surface", surfaceID, "codex", checkpointID],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: attemptedURL.path),
+            "a missing Codex checkpoint must never reach codex resume"
+        )
+        XCTAssertTrue(
+            result.stderr.contains("Codex session is no longer available"),
+            result.diagnostics
+        )
+
+        let requests = try responder.receivedRequests.map { request in
+            let data = try XCTUnwrap(request.data(using: .utf8))
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+        XCTAssertEqual(
+            requests.compactMap { $0["method"] as? String },
+            ["surface.resume.get", "surface.resume.clear"]
+        )
+        let clearParams = try XCTUnwrap(requests.last?["params"] as? [String: Any])
+        XCTAssertEqual(clearParams["checkpoint_id"] as? String, checkpointID)
+        XCTAssertEqual(clearParams["source"] as? String, "agent-hook")
+    }
+
     @Test func testRestoreDoesNotResolveBareExecutableFromEmptyPATHComponent() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
@@ -3498,6 +3607,19 @@ import Testing
         let home = URL(fileURLWithPath: "/tmp/cmxh-\(shortID)", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         return home
+    }
+
+    private func createEmptyCodexStateDatabase(at url: URL) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            throw NSError(domain: "CodexRestoreFixture", code: 1)
+        }
+        defer { sqlite3_close(database) }
+        let schema = "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, source TEXT, thread_source TEXT)"
+        guard sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK else {
+            throw NSError(domain: "CodexRestoreFixture", code: 2)
+        }
     }
 
     private func jsonResponse(result: [String: Any]) throws -> String {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -377,8 +377,9 @@ import Testing
                     // capture metadata.
                     "prepared_arguments": ["codex", "resume", checkpointID],
                 ],
-                // This binding models a pre-#10100 snapshot: it has no durable
-                // provenance, but it still claims the stale Codex checkpoint.
+                // This binding models a verified TUI checkpoint that was later
+                // deleted. Restore must retire it rather than preserving a
+                // permanently stale binding.
                 "resume_binding": [
                     "name": "Codex",
                     "kind": "codex",
@@ -386,6 +387,7 @@ import Testing
                     "cwd": workingDirectory.path,
                     "checkpoint_id": checkpointID,
                     "source": "agent-hook",
+                    "resume_evidence_provenance": "tui",
                     "auto_resume": true,
                 ],
             ],

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -447,6 +447,7 @@ import Testing
         let clearParams = try XCTUnwrap(requests.last?["params"] as? [String: Any])
         XCTAssertEqual(clearParams["checkpoint_id"] as? String, checkpointID)
         XCTAssertEqual(clearParams["source"] as? String, "agent-hook")
+        XCTAssertEqual(clearParams["agent_session_ended"] as? Bool, true)
     }
 
     @Test func testRestoreDoesNotResolveBareExecutableFromEmptyPATHComponent() throws {

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @Suite
 struct RestorableAgentSessionIndexCodexWeakRecordTests {
+    @Test
     func testCodexWeakEnvironmentOnlyRecordDoesNotOverrideTranscriptBackedSession() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -102,6 +103,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         #expect(snapshot.workingDirectory == repo.path)
     }
 
+    @Test
     func testCodexLegacyArgvRecordWithoutSourceIsRestorable() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -138,6 +140,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         #expect(snapshot.workingDirectory == repo.path)
     }
 
+    @Test
     func testCodexDefaultLaunchRecordIsRestorable() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -174,6 +177,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         #expect(snapshot.workingDirectory == repo.path)
     }
 
+    @Test
     func testCodexRestorableChildWithoutDurableCheckpointDoesNotReplaceParent() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -189,8 +193,11 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
 
         let parentID = "019ff98a-d827-7831-960d-fd9bdf7d54e2"
         let childID = "01a03bc1-7649-7ec3-bdf7-03acf979e086"
+        let reviewID = "019ff9a7-d827-7831-960d-fd9bdf7d54e2"
         let parentRollout = codexHome
             .appendingPathComponent("sessions/2026/08/26/rollout-\(parentID).jsonl")
+        let reviewRollout = codexHome
+            .appendingPathComponent("sessions/2026/08/26/rollout-\(reviewID).jsonl")
         let parentMetadata: [String: Any] = [
             "type": "session_meta",
             "payload": [
@@ -209,12 +216,29 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
             + #"{"type":"event_msg","payload":{"message":"codex thread: 01a03bc1-7649-7ec3-bdf7-03acf979e086"}}"#
             + "\n"
         try parentTranscript.write(to: parentRollout, atomically: true, encoding: .utf8)
+        let reviewMetadata: [String: Any] = [
+            "type": "session_meta",
+            "payload": [
+                "id": reviewID,
+                "cwd": repo.path,
+                "source": ["review": ["parent_thread_id": parentID]],
+                "originator": "codex_exec",
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: reviewMetadata, options: [.sortedKeys])
+            .write(to: reviewRollout, options: .atomic)
         try createCodexStateDatabase(at: codexHome.appendingPathComponent("state_5.sqlite"))
         try insertCodexThread(
             at: codexHome.appendingPathComponent("state_5.sqlite"),
             sessionID: parentID,
             rolloutPath: parentRollout.path,
             source: "cli"
+        )
+        try insertCodexThread(
+            at: codexHome.appendingPathComponent("state_5.sqlite"),
+            sessionID: reviewID,
+            rolloutPath: reviewRollout.path,
+            source: "review"
         )
 
         let ws = UUID()
@@ -235,6 +259,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
                         "executablePath": "/usr/local/bin/codex",
                         "arguments": ["/usr/local/bin/codex"],
                         "workingDirectory": repo.path,
+                        "environment": ["CODEX_HOME": codexHome.path],
                         "capturedAt": 10,
                         "source": "process",
                     ]
@@ -259,6 +284,26 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
                         "source": "environment",
                     ]
                 ),
+                // A durable review rollout is still not allowed to claim the
+                // interactive surface that belongs to the TUI parent.
+                reviewID: codexHookRecord(
+                    sessionId: reviewID,
+                    workspaceId: ws,
+                    panelId: panel,
+                    cwd: repo.path,
+                    transcriptPath: reviewRollout.path,
+                    updatedAt: 30,
+                    isRestorable: true,
+                    launchCommand: [
+                        "launcher": "codex",
+                        "executablePath": "/usr/local/bin/codex",
+                        "arguments": ["/usr/local/bin/codex"],
+                        "workingDirectory": repo.path,
+                        "environment": ["CODEX_HOME": codexHome.path],
+                        "capturedAt": 30,
+                        "source": "environment",
+                    ]
+                ),
             ]
         )
 
@@ -268,7 +313,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         )
         #expect(
             snapshot.sessionId == parentID,
-            "a missing rollout from a review child must not replace the durable parent"
+            "missing and durable review children must not replace the durable interactive parent"
         )
     }
 

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -496,9 +496,10 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
 
         let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
         #expect(index.isComplete)
-        #expect(index.isComplete(forWorkspaceId: ownerWorkspace, panelId: ownerPanel))
-        #expect(!index.isComplete(forPanelId: omittedPanelA))
-        #expect(!index.isComplete(forPanelId: omittedPanelB))
+        #expect(index.isComplete(forWorkspaceId: ownerWorkspace, panelId: ownerPanel, kind: "codex"))
+        #expect(!index.isComplete(forPanelId: omittedPanelA, kind: "codex"))
+        #expect(!index.isComplete(forPanelId: omittedPanelB, kind: "codex"))
+        #expect(index.isComplete(forPanelId: UUID(), kind: "claude"))
         let snapshot = try #require(
             index.snapshot(workspaceId: ownerWorkspace, panelId: ownerPanel)
         )

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -132,9 +132,9 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
             ]
         )
 
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
         let snapshot = try #require(
-            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
-                .snapshot(workspaceId: ws, panelId: panel)
+            index.snapshot(workspaceId: ws, panelId: panel)
         )
         #expect(snapshot.sessionId == sessionId)
         #expect(snapshot.workingDirectory == repo.path)
@@ -395,14 +395,15 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
             ]
         )
 
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
         let snapshot = try #require(
-            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
-                .snapshot(workspaceId: ws, panelId: panel)
+            index.snapshot(workspaceId: ws, panelId: panel)
         )
         #expect(
             snapshot.sessionId == parentID,
             "a nil normal hook record for a review child must not replace the TUI parent"
         )
+        #expect(!index.isComplete(forPanelId: panel))
     }
 
     @Test

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -456,7 +456,7 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
                 ]
             ),
         ]
-        let retainedNoiseCount = CodexSessionResumeVerificationLimits.maximumBatchRequests - 1
+        let retainedNoiseCount = CodexSessionResumeVerificationLimits.maximumBatchRequests
         for index in 0..<retainedNoiseCount {
             let sessionID = "noise-\(index)"
             sessions[sessionID] = codexHookRecord(
@@ -466,6 +466,8 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
                 cwd: repo.path,
                 transcriptPath: nil,
                 updatedAt: TimeInterval(index + 1),
+                pid: 10_000 + index,
+                agentLifecycle: "running",
                 launchCommand: nil
             )
         }
@@ -510,6 +512,8 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         cwd: String,
         transcriptPath: String?,
         updatedAt: TimeInterval,
+        pid: Int? = nil,
+        agentLifecycle: String? = nil,
         isRestorable: Bool? = nil,
         launchCommand: [String: Any]?
     ) -> [String: Any] {
@@ -518,9 +522,16 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
             "workspaceId": workspaceId.uuidString,
             "surfaceId": panelId.uuidString,
             "cwd": cwd,
-            "pid": NSNull(),
             "updatedAt": updatedAt,
         ]
+        if let pid {
+            record["pid"] = pid
+        } else {
+            record["pid"] = NSNull()
+        }
+        if let agentLifecycle {
+            record["agentLifecycle"] = agentLifecycle
+        }
         if let transcriptPath { record["transcriptPath"] = transcriptPath }
         if let isRestorable { record["isRestorable"] = isRestorable }
         if let launchCommand { record["launchCommand"] = launchCommand }

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -199,8 +199,15 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
                 "originator": "codex-tui",
             ],
         ]
-        try JSONSerialization.data(withJSONObject: parentMetadata, options: [.sortedKeys])
-            .write(to: parentRollout, options: .atomic)
+        let parentMetadataLine = try JSONSerialization.data(
+            withJSONObject: parentMetadata,
+            options: [.sortedKeys]
+        )
+        let parentTranscript = String(decoding: parentMetadataLine, as: UTF8.self)
+            + "\n"
+            + #"{"type":"event_msg","payload":{"message":"codex thread: 01a03bc1-7649-7ec3-bdf7-03acf979e086"}}"#
+            + "\n"
+        try parentTranscript.write(to: parentRollout, atomically: true, encoding: .utf8)
         try createCodexStateDatabase(at: codexHome.appendingPathComponent("state_5.sqlite"))
         try insertCodexThread(
             at: codexHome.appendingPathComponent("state_5.sqlite"),

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -172,6 +173,98 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
         XCTAssertEqual(snapshot.workingDirectory, repo.path)
     }
 
+    func testCodexRestorableChildWithoutDurableCheckpointDoesNotReplaceParent() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-codex-child-without-rollout-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        try fm.createDirectory(at: repo, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: codexHome.appendingPathComponent("sessions/2026/08/26", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let parentID = "019ff98a-d827-7831-960d-fd9bdf7d54e2"
+        let childID = "01a03bc1-7649-7ec3-bdf7-03acf979e086"
+        let parentRollout = codexHome
+            .appendingPathComponent("sessions/2026/08/26/rollout-\(parentID).jsonl")
+        let parentMetadata: [String: Any] = [
+            "type": "session_meta",
+            "payload": [
+                "id": parentID,
+                "cwd": repo.path,
+                "source": "cli",
+                "originator": "codex-tui",
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: parentMetadata, options: [.sortedKeys])
+            .write(to: parentRollout, options: .atomic)
+        try createCodexStateDatabase(at: codexHome.appendingPathComponent("state_5.sqlite"))
+        try insertCodexThread(
+            at: codexHome.appendingPathComponent("state_5.sqlite"),
+            sessionID: parentID,
+            rolloutPath: parentRollout.path,
+            source: "cli"
+        )
+
+        let ws = UUID()
+        let panel = UUID()
+        try writeHookStore(
+            root: root,
+            sessions: [
+                parentID: codexHookRecord(
+                    sessionId: parentID,
+                    workspaceId: ws,
+                    panelId: panel,
+                    cwd: repo.path,
+                    transcriptPath: parentRollout.path,
+                    updatedAt: 10,
+                    isRestorable: true,
+                    launchCommand: [
+                        "launcher": "codex",
+                        "executablePath": "/usr/local/bin/codex",
+                        "arguments": ["/usr/local/bin/codex"],
+                        "workingDirectory": repo.path,
+                        "capturedAt": 10,
+                        "source": "process",
+                    ]
+                ),
+                // The only trace of this review child is the parent transcript;
+                // its requested id is absent from both the index and rollouts.
+                childID: codexHookRecord(
+                    sessionId: childID,
+                    workspaceId: ws,
+                    panelId: panel,
+                    cwd: repo.path,
+                    transcriptPath: parentRollout.path,
+                    updatedAt: 20,
+                    isRestorable: true,
+                    launchCommand: [
+                        "launcher": "codex",
+                        "executablePath": "/usr/local/bin/codex",
+                        "arguments": ["/usr/local/bin/codex"],
+                        "workingDirectory": repo.path,
+                        "environment": ["CODEX_HOME": codexHome.path],
+                        "capturedAt": 20,
+                        "source": "environment",
+                    ]
+                ),
+            ]
+        )
+
+        let snapshot = try XCTUnwrap(
+            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+                .snapshot(workspaceId: ws, panelId: panel)
+        )
+        XCTAssertEqual(
+            snapshot.sessionId,
+            parentID,
+            "a missing rollout from a review child must not replace the durable parent"
+        )
+    }
+
     private func codexHookRecord(
         sessionId: String,
         workspaceId: UUID,
@@ -179,6 +272,7 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
         cwd: String,
         transcriptPath: String?,
         updatedAt: TimeInterval,
+        isRestorable: Bool? = nil,
         launchCommand: [String: Any]?
     ) -> [String: Any] {
         var record: [String: Any] = [
@@ -190,8 +284,56 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
             "updatedAt": updatedAt,
         ]
         if let transcriptPath { record["transcriptPath"] = transcriptPath }
+        if let isRestorable { record["isRestorable"] = isRestorable }
         if let launchCommand { record["launchCommand"] = launchCommand }
         return record
+    }
+
+    private func createCodexStateDatabase(at url: URL) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            throw NSError(domain: "CodexIndexFixture", code: 1)
+        }
+        defer { sqlite3_close(database) }
+        let schema = "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, source TEXT, thread_source TEXT)"
+        guard sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK else {
+            throw NSError(domain: "CodexIndexFixture", code: 2)
+        }
+    }
+
+    private func insertCodexThread(
+        at url: URL,
+        sessionID: String,
+        rolloutPath: String,
+        source: String
+    ) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            throw NSError(domain: "CodexIndexFixture", code: 3)
+        }
+        defer { sqlite3_close(database) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO threads (id, rollout_path, source, thread_source) VALUES (?, ?, ?, ?)",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK, let statement else {
+            sqlite3_finalize(statement)
+            throw NSError(domain: "CodexIndexFixture", code: 4)
+        }
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        guard sqlite3_bind_text(statement, 1, sessionID, -1, transient) == SQLITE_OK,
+              sqlite3_bind_text(statement, 2, rolloutPath, -1, transient) == SQLITE_OK,
+              sqlite3_bind_text(statement, 3, source, -1, transient) == SQLITE_OK,
+              sqlite3_bind_text(statement, 4, source, -1, transient) == SQLITE_OK,
+              sqlite3_step(statement) == SQLITE_DONE else {
+            throw NSError(domain: "CodexIndexFixture", code: 5)
+        }
     }
 
     private func writeHookStore(root: URL, sessions: [String: [String: Any]]) throws {

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import SQLite3
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -8,7 +8,8 @@ import XCTest
 @testable import cmux
 #endif
 
-final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
+@Suite
+struct RestorableAgentSessionIndexCodexWeakRecordTests {
     func testCodexWeakEnvironmentOnlyRecordDoesNotOverrideTranscriptBackedSession() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
@@ -93,12 +94,12 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
             ]
         )
 
-        let snapshot = try XCTUnwrap(
+        let snapshot = try #require(
             RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
                 .snapshot(workspaceId: ws, panelId: panel)
         )
-        XCTAssertEqual(snapshot.sessionId, goodId)
-        XCTAssertEqual(snapshot.workingDirectory, repo.path)
+        #expect(snapshot.sessionId == goodId)
+        #expect(snapshot.workingDirectory == repo.path)
     }
 
     func testCodexLegacyArgvRecordWithoutSourceIsRestorable() throws {
@@ -129,12 +130,12 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
             ]
         )
 
-        let snapshot = try XCTUnwrap(
+        let snapshot = try #require(
             RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
                 .snapshot(workspaceId: ws, panelId: panel)
         )
-        XCTAssertEqual(snapshot.sessionId, sessionId)
-        XCTAssertEqual(snapshot.workingDirectory, repo.path)
+        #expect(snapshot.sessionId == sessionId)
+        #expect(snapshot.workingDirectory == repo.path)
     }
 
     func testCodexDefaultLaunchRecordIsRestorable() throws {
@@ -165,12 +166,12 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
             ]
         )
 
-        let snapshot = try XCTUnwrap(
+        let snapshot = try #require(
             RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
                 .snapshot(workspaceId: ws, panelId: panel)
         )
-        XCTAssertEqual(snapshot.sessionId, sessionId)
-        XCTAssertEqual(snapshot.workingDirectory, repo.path)
+        #expect(snapshot.sessionId == sessionId)
+        #expect(snapshot.workingDirectory == repo.path)
     }
 
     func testCodexRestorableChildWithoutDurableCheckpointDoesNotReplaceParent() throws {
@@ -261,13 +262,12 @@ final class RestorableAgentSessionIndexCodexWeakRecordTests: XCTestCase {
             ]
         )
 
-        let snapshot = try XCTUnwrap(
+        let snapshot = try #require(
             RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
                 .snapshot(workspaceId: ws, panelId: panel)
         )
-        XCTAssertEqual(
-            snapshot.sessionId,
-            parentID,
+        #expect(
+            snapshot.sessionId == parentID,
             "a missing rollout from a review child must not replace the durable parent"
         )
     }

--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -317,6 +317,191 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         )
     }
 
+    @Test
+    func testCodexNilHookRecordUsesDurableProvenanceBeforeChoosingSurfaceOwner() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-codex-nil-hook-provenance-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        try fm.createDirectory(at: repo, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: codexHome.appendingPathComponent("sessions/2026/08/26", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let parentID = "019ff98a-d827-7831-960d-fd9bdf7d54e2"
+        let childID = "019ff9a1-cbe1-7231-9478-0c55a8c44560"
+        let parentRollout = try writeCodexRollout(
+            codexHome: codexHome,
+            sessionID: parentID,
+            source: "cli",
+            originator: "codex-tui",
+            cwd: repo.path
+        )
+        let childRollout = try writeCodexRollout(
+            codexHome: codexHome,
+            sessionID: childID,
+            source: "review",
+            originator: "codex_exec",
+            cwd: repo.path
+        )
+        let databaseURL = codexHome.appendingPathComponent("state_5.sqlite")
+        try createCodexStateDatabase(at: databaseURL)
+        try insertCodexThread(
+            at: databaseURL,
+            sessionID: parentID,
+            rolloutPath: parentRollout.path,
+            source: "cli"
+        )
+        try insertCodexThread(
+            at: databaseURL,
+            sessionID: childID,
+            rolloutPath: childRollout.path,
+            source: "review"
+        )
+
+        let ws = UUID()
+        let panel = UUID()
+        let launchCommand: [String: Any] = [
+            "launcher": "codex",
+            "arguments": ["/usr/local/bin/codex"],
+            "workingDirectory": repo.path,
+            "environment": ["CODEX_HOME": codexHome.path],
+            "source": "environment",
+        ]
+        try writeHookStore(
+            root: root,
+            sessions: [
+                parentID: codexHookRecord(
+                    sessionId: parentID,
+                    workspaceId: ws,
+                    panelId: panel,
+                    cwd: repo.path,
+                    transcriptPath: parentRollout.path,
+                    updatedAt: 10,
+                    launchCommand: launchCommand
+                ),
+                childID: codexHookRecord(
+                    sessionId: childID,
+                    workspaceId: ws,
+                    panelId: panel,
+                    cwd: repo.path,
+                    transcriptPath: childRollout.path,
+                    updatedAt: 20,
+                    launchCommand: launchCommand
+                ),
+            ]
+        )
+
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+                .snapshot(workspaceId: ws, panelId: panel)
+        )
+        #expect(
+            snapshot.sessionId == parentID,
+            "a nil normal hook record for a review child must not replace the TUI parent"
+        )
+    }
+
+    @Test
+    func testCodexOversizedStoreKeepsUnrelatedOwnerComplete() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-codex-oversized-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        try fm.createDirectory(at: repo, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: codexHome.appendingPathComponent("sessions/2026/08/26", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let ownerID = "019ff9b0-cbe1-7231-9478-0c55a8c44560"
+        let ownerWorkspace = UUID()
+        let ownerPanel = UUID()
+        let ownerRollout = try writeCodexRollout(
+            codexHome: codexHome,
+            sessionID: ownerID,
+            source: "cli",
+            originator: "codex-tui",
+            cwd: repo.path
+        )
+        let databaseURL = codexHome.appendingPathComponent("state_5.sqlite")
+        try createCodexStateDatabase(at: databaseURL)
+        try insertCodexThread(
+            at: databaseURL,
+            sessionID: ownerID,
+            rolloutPath: ownerRollout.path,
+            source: "cli"
+        )
+
+        var sessions: [String: [String: Any]] = [
+            ownerID: codexHookRecord(
+                sessionId: ownerID,
+                workspaceId: ownerWorkspace,
+                panelId: ownerPanel,
+                cwd: repo.path,
+                transcriptPath: ownerRollout.path,
+                updatedAt: 10_000,
+                launchCommand: [
+                    "launcher": "codex",
+                    "arguments": ["/usr/local/bin/codex"],
+                    "workingDirectory": repo.path,
+                    "environment": ["CODEX_HOME": codexHome.path],
+                    "source": "environment",
+                ]
+            ),
+        ]
+        let retainedNoiseCount = CodexSessionResumeVerificationLimits.maximumBatchRequests - 1
+        for index in 0..<retainedNoiseCount {
+            let sessionID = "noise-\(index)"
+            sessions[sessionID] = codexHookRecord(
+                sessionId: sessionID,
+                workspaceId: ownerWorkspace,
+                panelId: UUID(),
+                cwd: repo.path,
+                transcriptPath: nil,
+                updatedAt: TimeInterval(index + 1),
+                launchCommand: nil
+            )
+        }
+        let omittedWorkspace = ownerWorkspace
+        let omittedPanelA = UUID()
+        let omittedPanelB = UUID()
+        sessions["omitted-a"] = codexHookRecord(
+            sessionId: "omitted-a",
+            workspaceId: omittedWorkspace,
+            panelId: omittedPanelA,
+            cwd: repo.path,
+            transcriptPath: nil,
+            updatedAt: -1,
+            launchCommand: nil
+        )
+        sessions["omitted-b"] = codexHookRecord(
+            sessionId: "omitted-b",
+            workspaceId: omittedWorkspace,
+            panelId: omittedPanelB,
+            cwd: repo.path,
+            transcriptPath: nil,
+            updatedAt: -2,
+            launchCommand: nil
+        )
+        try writeHookStore(root: root, sessions: sessions)
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+        #expect(index.isComplete)
+        #expect(index.isComplete(forWorkspaceId: ownerWorkspace, panelId: ownerPanel))
+        #expect(!index.isComplete(forPanelId: omittedPanelA))
+        #expect(!index.isComplete(forPanelId: omittedPanelB))
+        let snapshot = try #require(
+            index.snapshot(workspaceId: ownerWorkspace, panelId: ownerPanel)
+        )
+        #expect(snapshot.sessionId == ownerID)
+    }
+
     private func codexHookRecord(
         sessionId: String,
         workspaceId: UUID,
@@ -339,6 +524,29 @@ struct RestorableAgentSessionIndexCodexWeakRecordTests {
         if let isRestorable { record["isRestorable"] = isRestorable }
         if let launchCommand { record["launchCommand"] = launchCommand }
         return record
+    }
+
+    private func writeCodexRollout(
+        codexHome: URL,
+        sessionID: String,
+        source: String,
+        originator: String,
+        cwd: String
+    ) throws -> URL {
+        let path = codexHome
+            .appendingPathComponent("sessions/2026/08/26/rollout-\(sessionID).jsonl")
+        let metadata: [String: Any] = [
+            "type": "session_meta",
+            "payload": [
+                "id": sessionID,
+                "cwd": cwd,
+                "source": source,
+                "originator": originator,
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: metadata, options: [.sortedKeys])
+        try data.write(to: path, options: .atomic)
+        return path
     }
 
     private func createCodexStateDatabase(at url: URL) throws {

--- a/cmuxTests/SurfaceResumeRestoreClaimTests.swift
+++ b/cmuxTests/SurfaceResumeRestoreClaimTests.swift
@@ -140,4 +140,44 @@ struct SurfaceResumeRestoreClaimTests {
 
         #expect(workspace.surfaceResumeRestoreClaimsByPanelId.isEmpty)
     }
+
+    @Test
+    func workspaceReconciliationCannotReplaceClaimedCodexBinding() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelID = try #require(workspace.focusedPanelId)
+        let parent = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume parent-session",
+            checkpointId: "parent-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 50
+        )
+        let detectedChild = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume child-session",
+            checkpointId: "child-session",
+            source: "process-detected",
+            autoResume: true,
+            updatedAt: 51
+        )
+
+        #expect(workspace.setSurfaceResumeBinding(parent, panelId: panelID))
+        #expect(workspace.claimSurfaceResumeBinding(
+            panelId: panelID,
+            expectedCheckpointID: "parent-session",
+            expectedSource: "agent-hook",
+            expectedUpdatedAt: 50
+        ))
+        workspace.reconcileSurfaceResumeBindings(
+            using: SurfaceResumeBindingIndex(bindingsByPanel: [
+                .init(workspaceId: workspace.id, panelId: panelID): detectedChild,
+            ]),
+            restorableAgentIndex: .empty
+        )
+
+        #expect(workspace.surfaceResumeBinding(panelId: panelID) == parent)
+    }
 }

--- a/cmuxTests/SurfaceResumeRestoreClaimTests.swift
+++ b/cmuxTests/SurfaceResumeRestoreClaimTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Verifies the app-owned compare-and-claim boundary used by Codex restore.
+@MainActor
+@Suite(.serialized)
+struct SurfaceResumeRestoreClaimTests {
+    @Test
+    func workspaceRestoreClaimRejectsReplacementAndPreservesParentBinding() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelID = try #require(workspace.focusedPanelId)
+        let parent = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume parent-session",
+            cwd: "/tmp/parent-cwd",
+            checkpointId: "parent-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 10
+        )
+        let child = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume child-session",
+            cwd: "/tmp/child-cwd",
+            checkpointId: "child-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 11
+        )
+
+        #expect(workspace.setSurfaceResumeBinding(parent, panelId: panelID))
+        #expect(workspace.claimSurfaceResumeBinding(
+            panelId: panelID,
+            expectedCheckpointID: "parent-session",
+            expectedSource: "agent-hook",
+            expectedUpdatedAt: 10
+        ))
+        #expect(!workspace.setSurfaceResumeBinding(child, panelId: panelID))
+        #expect(workspace.surfaceResumeBinding(panelId: panelID) == parent)
+    }
+
+    @Test
+    func dockRestoreClaimConsumesOnSameSessionRefresh() throws {
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer { store.closeAllPanels() }
+        let panel = TerminalPanel(workspaceId: store.workspaceId)
+        store.panels[panel.id] = panel
+        let parent = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume parent-session",
+            checkpointId: "parent-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 20
+        )
+        let refresh = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume parent-session",
+            cwd: "/tmp/refreshed-cwd",
+            checkpointId: "parent-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 21
+        )
+
+        #expect(store.setSurfaceResumeBinding(parent, panelId: panel.id))
+        #expect(store.claimSurfaceResumeBinding(
+            panelId: panel.id,
+            expectedCheckpointID: "parent-session",
+            expectedSource: "agent-hook",
+            expectedUpdatedAt: 20
+        ))
+        #expect(store.setSurfaceResumeBinding(refresh, panelId: panel.id))
+        #expect(store.surfaceResumeBinding(panelId: panel.id) == refresh)
+        #expect(store.surfaceResumeRestoreClaimsByPanelId[panel.id] == nil)
+    }
+
+    @Test
+    func restoreClaimRequiresExactBindingGeneration() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelID = try #require(workspace.focusedPanelId)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume parent-session",
+            checkpointId: "parent-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 30
+        )
+
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelID))
+        #expect(!workspace.claimSurfaceResumeBinding(
+            panelId: panelID,
+            expectedCheckpointID: "parent-session",
+            expectedSource: "agent-hook",
+            expectedUpdatedAt: 31
+        ))
+        #expect(workspace.surfaceResumeRestoreClaimsByPanelId[panelID] == nil)
+        #expect(workspace.surfaceResumeBinding(panelId: panelID) == binding)
+    }
+}

--- a/cmuxTests/SurfaceResumeRestoreClaimTests.swift
+++ b/cmuxTests/SurfaceResumeRestoreClaimTests.swift
@@ -114,4 +114,30 @@ struct SurfaceResumeRestoreClaimTests {
         #expect(workspace.surfaceResumeRestoreClaimsByPanelId[panelID] == nil)
         #expect(workspace.surfaceResumeBinding(panelId: panelID) == binding)
     }
+
+    @Test
+    func workspacePanelTeardownReleasesRestoreClaim() throws {
+        let workspace = Workspace()
+        let panelID = try #require(workspace.focusedPanelId)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume teardown-session",
+            checkpointId: "teardown-session",
+            source: "agent-hook",
+            autoResume: true,
+            resumeEvidenceProvenance: "tui",
+            updatedAt: 40
+        )
+
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelID))
+        #expect(workspace.claimSurfaceResumeBinding(
+            panelId: panelID,
+            expectedCheckpointID: "teardown-session",
+            expectedSource: "agent-hook",
+            expectedUpdatedAt: 40
+        ))
+        workspace.teardownAllPanels()
+
+        #expect(workspace.surfaceResumeRestoreClaimsByPanelId.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- Add behavior-level regressions for stale Codex restore checkpoints and child hook records.
- Follow with a restore-time durable verification and ownership fix that preserves the saved cwd and known-good parent binding.

Fixes #6209

## Testing
The first commit intentionally adds the regression tests before the implementation so CI proves the failure on the pre-fix commit. The implementation commit will make the suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790323867&installation_model_id=21920&pr_number=10823&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10823&signature=e1514f094a7ff68e59eb03fb63352dec2afdb87d01939fa9906aa20c9c063674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex session restoration by validating checkpoints, transcripts, provenance, and session ownership before resuming.
  * Prevented unavailable, invalid, changed, or unsupported checkpoints from being executed.
  * Safely clears stale resume links while preserving newer or valid links.
  * Prevented child sessions without durable transcripts from replacing parent sessions.
  * Improved reliability when locating Codex session data across launch environments.

* **User Experience**
  * Added localized English and Japanese messages explaining unavailable checkpoints and available next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->