### PR TITLE
iOS: avoid stale-environ crash while loading Ghostty config

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -439,20 +439,23 @@ private extension GhosttyRuntime {
     ) {
         guard let config else { return }
         #if os(iOS)
-        setupGhosttyiOSConfigEnvironment()
         ensureDefaultGhosttyiOSConfig(theme: theme)
-        ghostty_config_load_default_files(config)
+        // Default-file discovery is a macOS integration path in Ghostty's
+        // Apple wrapper. iOS owns one sandboxed file, so load it directly.
+        let configFile = ghosttyiOSConfigFileURL
+        configFile.path.withCString { path in
+            ghostty_config_load_file(config, path)
+        }
         applyGhosttyiOSDefaults(config, theme: theme)
         #else
         ghostty_config_load_default_files(config)
         #endif
     }
 
-    func setupGhosttyiOSConfigEnvironment() {
-        setenv("XDG_CONFIG_HOME", iOSConfigRootURL.path, 0)
-        if let env = getenv("XDG_CONFIG_HOME") {
-            log.debug("XDG_CONFIG_HOME=\(String(cString: env), privacy: .public)")
-        }
+    var ghosttyiOSConfigFileURL: URL {
+        iOSConfigRootURL
+            .appendingPathComponent("ghostty", isDirectory: true)
+            .appendingPathComponent("config", isDirectory: false)
     }
 
     func applyGhosttyiOSDefaults(_ config: ghostty_config_t, theme: TerminalTheme) {
@@ -512,8 +515,8 @@ private extension GhosttyRuntime {
     }
 
     func ensureDefaultGhosttyiOSConfig(theme: TerminalTheme) {
-        let configDirectory = iOSConfigRootURL.appendingPathComponent("ghostty", isDirectory: true)
-        let configFile = configDirectory.appendingPathComponent("config", isDirectory: false)
+        let configFile = ghosttyiOSConfigFileURL
+        let configDirectory = configFile.deletingLastPathComponent()
         guard !fileManager.fileExists(atPath: configFile.path) else { return }
 
         let defaultConfig = """

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttyRuntimeConfigLoadingTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttyRuntimeConfigLoadingTests.swift
@@ -1,0 +1,41 @@
+#if canImport(UIKit)
+import Foundation
+import GhosttyKit
+import Testing
+@testable import CmuxMobileTerminal
+
+@MainActor
+@Test("runtime loads the app-owned iOS config file")
+func runtimeLoadsAppOwnedIOSConfigFile() throws {
+    let fileManager = FileManager()
+    let configRootURL = fileManager.temporaryDirectory
+        .appendingPathComponent("cmux-ghostty-config-\(UUID().uuidString)", isDirectory: true)
+    let configFileURL = configRootURL
+        .appendingPathComponent("ghostty", isDirectory: true)
+        .appendingPathComponent("config", isDirectory: false)
+    try fileManager.createDirectory(
+        at: configFileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try "focus-follows-mouse = true".write(to: configFileURL, atomically: true, encoding: .utf8)
+    defer { try? fileManager.removeItem(at: configRootURL) }
+
+    let runtime = try GhosttyRuntime(
+        fileManager: fileManager,
+        iOSConfigRootURL: configRootURL
+    )
+    let config = try #require(runtime.config)
+    var focusFollowsMouse = false
+    let key = "focus-follows-mouse"
+
+    #expect(
+        ghostty_config_get(
+            config,
+            &focusFollowsMouse,
+            key,
+            UInt(key.lengthOfBytes(using: .utf8))
+        )
+    )
+    #expect(focusFollowsMouse)
+}
+#endif


### PR DESCRIPTION
Closes #10778

Fixes https://github.com/manaflow-ai/cmux/issues/10778.

## Root cause

`ghostty_init` snapshots Darwin's process `environ` array in Ghostty global state. The iOS runtime then called `setenv("XDG_CONFIG_HOME", ...)` immediately before `ghostty_config_load_default_files`. When that insertion reallocates the environment array, Ghostty's borrowed snapshot becomes dangling; `Config.loadDefaultFiles` -> `file_load.defaultXdgPath` walks freed pointers and can branch through garbage on the main thread. This is distinct from the earlier `setlocale`/`ghostty_init` race fixed by #9437/#10279.

## Fix

On iOS, load the one sandbox-owned `ghostty/config` file with `ghostty_config_load_file` and an absolute path. This removes the post-init process-environment mutation and keeps config-file relative path expansion owned by Ghostty. The existing generated in-memory iOS defaults remain unchanged.

## Coverage and reproduction

- Commit 1 (`23c7782c`): behavior test that creates an isolated app-owned config and asserts Ghostty applies it.
- Commit 2 (`6c0d3bfe`): production fix.
- A native ARM64 harness reproduced the same stale-environ failure; captured `.ips` showed `ghostty_config_load_default_files + 36` -> `Config.loadDefaultFiles + 0x58` -> `file_load.defaultXdgPath + 0x68`.
- The local iOS build was attempted on a dedicated iOS 26.5 simulator but initially hit a full disk during SPM extraction; CI/cloud validation is being used for the app target.

No Ghostty submodule change is required; the defect is in the Swift embedder mutating an environment that Ghostty has borrowed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790324494&installation_model_id=21920&pr_number=10824&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10824&signature=fab974adaccaf7c8147f536afa449cfbafbb2d1b6da904db08625076e41a8589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->