### PR TITLE
fix(ios): convert the stamped group id to a workspace id (unbreaks app-host unit tests)

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
@@ -282,7 +282,7 @@ public struct MobileWorkspaceAggregation: Sendable {
                     // Empty headers have no workspace row to namespace; use
                     // the already-namespaced group id only as a stable UI row
                     // identity, never as a workspace capability.
-                    stamped.anchorWorkspaceID = stamped.id
+                    stamped.anchorWorkspaceID = MobileWorkspacePreview.ID(rawValue: stamped.id.rawValue)
                 }
                 result.append(stamped)
             }


### PR DESCRIPTION
CI's app-host unit test shards fail on main's tree at `MobileWorkspaceAggregation.swift:285`: `stamped.anchorWorkspaceID = stamped.id` assigns a `MobileWorkspaceGroupPreview.ID` to a `MobileWorkspacePreview.ID`, which Xcode 26.3 rejects (`cannot assign value of type 'MobileWorkspaceGroupPreview.ID' to type 'MobileWorkspacePreview.ID'`). Main's own recent runs skipped those shards, so it went unnoticed and every branch built from main fails them (seen on #10812).

Both ids are string-backed; this converts through `rawValue`, keeping the documented intent (the namespaced group id as a stable UI row identity, never a workspace capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790326387&installation_model_id=21920&pr_number=10825&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10825&signature=23be6cb7cb2f10ff6f3d12b98535608d4122e172b5ac2a12c8299c6e001e489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace grouping behavior by correctly anchoring empty group headers to their associated workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->