### PR TITLE
Exempt the app's own web origin from Cloud VM loopback-alias rewriting

### DIFF
--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/RemoteLoopbackProxyAlias.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/RemoteLoopbackProxyAlias.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 /// Host-alias mapping between the localhost family and the public
 /// `cmux-loopback.localtest.me` alias domain used by remote-workspace
@@ -77,6 +77,60 @@ public struct RemoteLoopbackProxyAlias {
         let prefix = String(normalizedHost.dropLast(suffix.count))
         guard !prefix.isEmpty else { return nil }
         return "\(prefix).\(aliasHost)"
+    }
+
+    /// The alias URL a remote-workspace browser should load instead of `url`,
+    /// or `nil` when `url` must not be rewritten: non-`http` schemes,
+    /// non-loopback hosts, and URLs on the app's own web origin
+    /// (`exemptWebOrigin`).
+    ///
+    /// The exemption exists because pages served by the app's configured web
+    /// endpoint (for example the Cloud VM desktop wrapper minted by
+    /// `vm.open_port`) live on the HOST, not inside the remote workspace;
+    /// aliasing them makes the remote daemon dial a port nothing serves
+    /// there. It is keyed on the full origin (scheme, loopback-family host,
+    /// effective port), so loopback previews of apps running inside the
+    /// workspace keep proxying.
+    public static func browserLoopbackAliasURL(for url: URL, exemptWebOrigin: URL?) -> URL? {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" else { return nil }
+        guard let host = normalizeHost(url.host ?? "") else { return nil }
+        guard isLoopbackHost(host) else { return nil }
+        if matchesWebOrigin(url, webOrigin: exemptWebOrigin) { return nil }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.host = browserAliasHost(forLoopbackHost: host, aliasHost: aliasHost)
+        return components?.url
+    }
+
+    /// Whether `url` and `webOrigin` share a web origin (scheme, host,
+    /// effective port) after collapsing the exact-loopback host family to
+    /// ``canonicalLoopbackHost``. `*.localhost` subdomains stay distinct.
+    private static func matchesWebOrigin(_ url: URL, webOrigin: URL?) -> Bool {
+        guard let webOrigin,
+              let urlScheme = url.scheme?.lowercased(),
+              let originScheme = webOrigin.scheme?.lowercased(),
+              urlScheme == originScheme,
+              let urlHost = originComparableHost(url.host),
+              let originHost = originComparableHost(webOrigin.host),
+              urlHost == originHost else {
+            return false
+        }
+        return effectivePort(of: url, scheme: urlScheme)
+            == effectivePort(of: webOrigin, scheme: originScheme)
+    }
+
+    private static func originComparableHost(_ rawHost: String?) -> String? {
+        guard let rawHost, let normalized = normalizeHost(rawHost) else { return nil }
+        return exactLoopbackHosts.contains(normalized) ? canonicalLoopbackHost : normalized
+    }
+
+    private static func effectivePort(of url: URL, scheme: String) -> Int? {
+        if let port = url.port { return port }
+        switch scheme {
+        case "http", "ws": return 80
+        case "https", "wss": return 443
+        default: return nil
+        }
     }
 
     /// Normalizes a raw host string (possibly a URL, `host:port`, or

--- a/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/RemoteLoopbackProxyAliasTests.swift
+++ b/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/RemoteLoopbackProxyAliasTests.swift
@@ -60,4 +60,107 @@ struct RemoteLoopbackProxyAliasTests {
         #expect(RemoteLoopbackProxyAlias.normalizeHost("") == nil)
         #expect(RemoteLoopbackProxyAlias.normalizeHost("   ") == nil)
     }
+
+    @Test("browser rewrite aliases loopback http URLs and preserves the rest of the URL")
+    func browserRewriteAliasesLoopback() {
+        let rewritten = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost:3000/app?x=1")!,
+            exemptWebOrigin: nil
+        )
+        #expect(rewritten?.absoluteString == "http://\(alias):3000/app?x=1")
+
+        let ipRewritten = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://127.0.0.1:8080/")!,
+            exemptWebOrigin: nil
+        )
+        #expect(ipRewritten?.host == alias)
+        #expect(ipRewritten?.port == 8080)
+
+        let subdomainRewritten = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://api.localhost:3000/v1")!,
+            exemptWebOrigin: nil
+        )
+        #expect(subdomainRewritten?.host == "api.\(alias)")
+    }
+
+    @Test("browser rewrite skips non-http and non-loopback URLs")
+    func browserRewriteSkipsNonLoopback() {
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "https://localhost:3000/")!,
+            exemptWebOrigin: nil
+        ) == nil)
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://example.com/")!,
+            exemptWebOrigin: nil
+        ) == nil)
+    }
+
+    // The Cloud VM desktop wrapper (and any other page the app's configured
+    // web endpoint serves) is HOST-served: aliasing it would make the remote
+    // workspace proxy dial the dev web port from the remote daemon, where
+    // nothing listens, and the pane shows "No internet connection" (#10817).
+    @Test("the app's own web origin is exempt from the rewrite")
+    func exemptsAppWebOrigin() {
+        let origin = URL(string: "http://localhost:3800")!
+        let wrapper = URL(string: "http://localhost:3800/vm/desktop/sharp-newt?cmux_token=abc")!
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: wrapper,
+            exemptWebOrigin: origin
+        ) == nil)
+
+        // Loopback-family spellings of the same origin still match.
+        let ipWrapper = URL(string: "http://127.0.0.1:3800/vm/desktop/sharp-newt?cmux_token=abc")!
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: ipWrapper,
+            exemptWebOrigin: origin
+        ) == nil)
+        let ipOrigin = URL(string: "http://127.0.0.1:3800")!
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: wrapper,
+            exemptWebOrigin: ipOrigin
+        ) == nil)
+    }
+
+    @Test("the exemption is origin-specific, never loopback-wide")
+    func exemptionIsOriginSpecific() {
+        let origin = URL(string: "http://localhost:3800")!
+
+        // An open-port preview of an app running inside the VM keeps proxying.
+        let preview = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost:3000/")!,
+            exemptWebOrigin: origin
+        )
+        #expect(preview?.host == alias)
+        #expect(preview?.port == 3000)
+
+        // A *.localhost subdomain on the same port is a different origin.
+        let subdomain = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://api.localhost:3800/v1")!,
+            exemptWebOrigin: origin
+        )
+        #expect(subdomain?.host == "api.\(alias)")
+
+        // A production https origin never exempts loopback URLs.
+        let underProductionOrigin = RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost:3800/vm/desktop/sharp-newt")!,
+            exemptWebOrigin: URL(string: "https://cmux.com")!
+        )
+        #expect(underProductionOrigin?.host == alias)
+    }
+
+    @Test("origin matching resolves default scheme ports")
+    func exemptionResolvesDefaultPorts() {
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost:80/health")!,
+            exemptWebOrigin: URL(string: "http://localhost")!
+        ) == nil)
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost/health")!,
+            exemptWebOrigin: URL(string: "http://localhost:80")!
+        ) == nil)
+        #expect(RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: URL(string: "http://localhost:3000/health")!,
+            exemptWebOrigin: URL(string: "http://localhost")!
+        )?.host == alias)
+    }
 }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5576,16 +5576,16 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private static func remoteProxyLoopbackAliasURL(for url: URL) -> URL? {
-        guard let scheme = url.scheme?.lowercased(), scheme == "http" else { return nil }
-        guard let host = BrowserInsecureHTTPSettings.normalizeHost(url.host ?? "") else { return nil }
-        guard RemoteLoopbackProxyAlias.isLoopbackHost(host) else { return nil }
-
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        components?.host = RemoteLoopbackProxyAlias.browserAliasHost(
-            forLoopbackHost: host,
-            aliasHost: RemoteLoopbackProxyAlias.aliasHost
+        // Pages served by the app's own web endpoint (e.g. the Cloud VM
+        // desktop wrapper minted by vm.open_port against
+        // AuthEnvironment.vmAPIBaseURL) are HOST-served: aliasing them would
+        // make the workspace proxy dial the dev web port from the remote
+        // daemon, where nothing listens (issue #10817). Every other loopback
+        // origin keeps proxying into the workspace.
+        RemoteLoopbackProxyAlias.browserLoopbackAliasURL(
+            for: url,
+            exemptWebOrigin: AuthEnvironment.vmAPIBaseURL
         )
-        return components?.url
     }
 
     /// Navigate with smart URL/search detection


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/10817.

On dev builds, `cmux vm desktop <id>` opens the noVNC wrapper at `http://localhost:<port>/vm/desktop/<id>?cmux_token=...` on the local dev web server. In a Cloud VM workspace, BrowserPanel rewrote that loopback URL to `cmux-loopback.localtest.me`, so the workspace proxy dialed the dev web port from the remote daemon, where nothing listens, and the pane showed "No internet connection" (reproduced live on VMs sharp-newt and amber-newt; the identical URL renders in a non-VM workspace).

Mechanism: the rewrite decision moves into CmuxCore as `RemoteLoopbackProxyAlias.browserLoopbackAliasURL(for:exemptWebOrigin:)`. It aliases every cleartext-http loopback URL except ones sharing the exempt origin, compared as scheme + loopback-family host (`localhost`/`127.0.0.1`/`::1`/`0.0.0.0` collapse, `*.localhost` subdomains stay distinct) + effective port. `BrowserPanel.remoteProxyLoopbackAliasURL` forwards to it with `AuthEnvironment.vmAPIBaseURL`, the same config the app used to reach the web endpoint that minted the wrapper URL (`web/app/api/vm/[id]/open-port` mints it from the request origin). The exemption is origin-specific, never workspace-wide: open-port previews of apps running inside the VM (any other port) keep proxying.

Coverage: both pane-creation navigation and favicon fetches flow through the one changed helper (`remoteProxyPreparedRequest`). The in-page runtime bridge (`RemoteLoopbackRuntimeBridge`) installs only on alias-host pages, so it never runs on the now-unaliased wrapper; inside aliased VM pages, `localhost` still means the VM, unchanged.

Two commits so CI goes red then green: commit 1 adds the failing CmuxCore tests, commit 2 adds the fix.

Verified: `swift test` in `Packages/macOS/CmuxCore` (11/11 in the alias suite, 63 total), tagged compile-only `xcodebuild -scheme cmux build` with `-derivedDataPath /tmp/cmux-fixloop` succeeded. Not verified: live dogfood of a Cloud VM desktop pane on a dev web server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790327220&installation_model_id=21920&pr_number=10827&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10827&signature=33d1440c2385b3776b928b9e8081e831a94aaa163a2b7b4b510008ce579c47b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved remote workspace browsing by automatically rewriting HTTP links that target local services.
  * Supports localhost, loopback IP addresses, and loopback subdomains while preserving URL details.
  * Recognizes equivalent loopback origins and default ports when applying configured exclusions.
* **Bug Fixes**
  * Prevents rewriting non-HTTP links, external addresses, and designated application web origins.
  * Ensures other loopback services continue to work through the remote connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->