### PR TITLE
Attribute /api/client-config request volume by client, channel, and build

### DIFF
--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigAttribution.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigAttribution.swift
@@ -1,0 +1,70 @@
+/// Low-cardinality request labels for `/api/client-config`.
+///
+/// The web route logs one structured line per request from these `X-Cmux-*`
+/// headers, which is the only per-client request-volume counter we have:
+/// PostHog billing reports a single project-wide daily total with no client,
+/// version, or channel breakdown. Labels ride in headers, not the request
+/// body, so the route can attribute rate-limited requests it never parses and
+/// the body keeps its telemetry-consent contract. Every value is a fleet-wide
+/// label; none identifies a user or install.
+public struct ClientConfigAttribution: Sendable, Equatable {
+    /// Why a control-plane refresh fired, separating launch bursts from
+    /// steady-state polling in server logs.
+    public enum RefreshReason: String, Sendable {
+        case launch
+        case timer
+        case foreground
+        case manual
+    }
+
+    /// The requesting app, e.g. `ios`.
+    public var client: String
+    /// The release channel, e.g. `stable`, `nightly`, or `dev`.
+    public var channel: String
+    /// The marketing version (`CFBundleShortVersionString`), if stamped.
+    public var appVersion: String?
+    /// The build number (`CFBundleVersion`), if stamped.
+    public var appBuild: String?
+    /// The trigger for this specific request.
+    public var refreshReason: RefreshReason?
+    /// The steady-state poll cadence the client is configured with.
+    public var pollIntervalSeconds: Int?
+
+    public init(
+        client: String,
+        channel: String,
+        appVersion: String? = nil,
+        appBuild: String? = nil,
+        refreshReason: RefreshReason? = nil,
+        pollIntervalSeconds: Int? = nil
+    ) {
+        self.client = client
+        self.channel = channel
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.refreshReason = refreshReason
+        self.pollIntervalSeconds = pollIntervalSeconds
+    }
+
+    /// The header fields the loader attaches to the HTTP request. Names match
+    /// `web/services/client-config/requestAttribution.ts`.
+    public var headerFields: [String: String] {
+        var fields = [
+            "X-Cmux-Client": client,
+            "X-Cmux-Channel": channel,
+        ]
+        if let appVersion, !appVersion.isEmpty {
+            fields["X-Cmux-App-Version"] = appVersion
+        }
+        if let appBuild, !appBuild.isEmpty {
+            fields["X-Cmux-App-Build"] = appBuild
+        }
+        if let refreshReason {
+            fields["X-Cmux-Refresh-Reason"] = refreshReason.rawValue
+        }
+        if let pollIntervalSeconds {
+            fields["X-Cmux-Poll-Interval"] = String(pollIntervalSeconds)
+        }
+        return fields
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigRequest.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigRequest.swift
@@ -4,10 +4,39 @@ public struct ClientConfigRequest: Encodable, Sendable, Equatable {
     public let distinctId: String
     /// Optional context forwarded to PostHog by the web route.
     public let context: ClientConfigEvaluationContext
+    /// Optional request labels sent as `X-Cmux-*` headers, never in the body,
+    /// so the encoded payload the server parses stays unchanged.
+    public var attribution: ClientConfigAttribution?
+
+    private enum CodingKeys: String, CodingKey {
+        case distinctId
+        case context
+    }
 
     /// Creates a request for feature-flag evaluation.
-    public init(distinctId: String, context: ClientConfigEvaluationContext = .init()) {
+    public init(
+        distinctId: String,
+        context: ClientConfigEvaluationContext = .init(),
+        attribution: ClientConfigAttribution? = nil
+    ) {
         self.distinctId = distinctId
         self.context = context
+        self.attribution = attribution
+    }
+
+    /// A copy of this request labeled with the trigger and poll cadence for
+    /// one specific refresh. Requests without attribution stay unlabeled.
+    public func labeled(
+        refreshReason: ClientConfigAttribution.RefreshReason,
+        pollIntervalSeconds: Int? = nil
+    ) -> ClientConfigRequest {
+        guard var attribution else { return self }
+        attribution.refreshReason = refreshReason
+        if let pollIntervalSeconds {
+            attribution.pollIntervalSeconds = pollIntervalSeconds
+        }
+        var copy = self
+        copy.attribution = attribution
+        return copy
     }
 }

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
@@ -36,6 +36,11 @@ public struct HTTPClientConfigLoader: ClientConfigLoading {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let attribution = request.attribution {
+            for (field, value) in attribution.headerFields {
+                urlRequest.setValue(value, forHTTPHeaderField: field)
+            }
+        }
         urlRequest.httpBody = try encoder.encode(request)
 
         let (data, response) = try await session.data(for: urlRequest)

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
@@ -120,5 +120,47 @@ import Testing
         #expect(request?.httpMethod == "POST")
         #expect(request?.value(forHTTPHeaderField: "Content-Type") == "application/json")
         #expect(request?.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request?.value(forHTTPHeaderField: "X-Cmux-Client") == nil)
+    }
+
+    @Test func httpLoaderSendsAttributionHeadersOutsideTheBody() async throws {
+        RecordingClientConfigURLProtocol.recorder.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RecordingClientConfigURLProtocol.self]
+        let loader = HTTPClientConfigLoader(
+            apiBaseURL: "https://cmux.test/",
+            session: URLSession(configuration: configuration)
+        )
+        let request = ClientConfigRequest(
+            distinctId: "user-1",
+            attribution: ClientConfigAttribution(
+                client: "ios",
+                channel: "stable",
+                appVersion: "0.64.22",
+                appBuild: "6422"
+            )
+        ).labeled(refreshReason: .timer, pollIntervalSeconds: 1800)
+
+        _ = try await loader.load(request)
+
+        let sent = RecordingClientConfigURLProtocol.recorder.requests.first
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-Client") == "ios")
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-Channel") == "stable")
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-App-Version") == "0.64.22")
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-App-Build") == "6422")
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-Refresh-Reason") == "timer")
+        #expect(sent?.value(forHTTPHeaderField: "X-Cmux-Poll-Interval") == "1800")
+
+        let object = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(request)
+        ) as? [String: Any]
+        #expect(object?["attribution"] == nil)
+        #expect(object?["distinctId"] as? String == "user-1")
+    }
+
+    @Test func labelingWithoutAttributionStaysUnlabeled() {
+        let request = ClientConfigRequest(distinctId: "user-1")
+            .labeled(refreshReason: .launch, pollIntervalSeconds: 1800)
+        #expect(request.attribution == nil)
     }
 }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -70,6 +70,17 @@ final class CmuxFeatureFlags {
     private static let releaseControlDistinctIDPrefix =
         releaseControlProductWideDistinctID + "-"
     private nonisolated static let maximumPostHogControlPlaneResponseBytes = 1_048_576
+    /// Steady-state control-plane poll cadence. Also sent with every request as
+    /// `X-Cmux-Poll-Interval` so server logs can attribute request volume to a
+    /// client population without any per-user identifier.
+    nonisolated static let releaseControlRefreshIntervalSeconds: TimeInterval = 30 * 60
+
+    /// Why a control-plane refresh fired. Sent as `X-Cmux-Refresh-Reason` so
+    /// server logs can separate launch bursts from steady-state polling.
+    enum RefreshReason: String, Sendable {
+        case launch
+        case timer
+    }
 
     // FLAG(key: sidebar-appkit-list-experiment, owner: lawrencecchen,
     //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
@@ -377,7 +388,7 @@ final class CmuxFeatureFlags {
     @ObservationIgnored
     private let remoteFlagValueProvider: (String) -> Any?
     @ObservationIgnored
-    private let remoteFlagLoader: @Sendable () async -> [String: Bool]?
+    private let remoteFlagLoader: @Sendable (RefreshReason) async -> [String: Bool]?
     @ObservationIgnored
     private var refreshTask: Task<Void, Never>?
     @ObservationIgnored
@@ -391,7 +402,7 @@ final class CmuxFeatureFlags {
         defaults: UserDefaults = .standard,
         telemetryEnabled: Bool = TelemetrySettings.enabledForCurrentLaunch,
         remoteFlagValueProvider: @escaping (String) -> Any? = { PostHogSDK.shared.getFeatureFlag($0) },
-        remoteFlagLoader: (@Sendable () async -> [String: Bool]?)? = nil,
+        remoteFlagLoader: (@Sendable (RefreshReason) async -> [String: Bool]?)? = nil,
         publishesOffMainSnapshot: Bool = false
     ) {
         self.defaults = defaults
@@ -404,10 +415,11 @@ final class CmuxFeatureFlags {
                 telemetryEnabled: telemetryEnabled,
                 defaults: defaults
             )
-            self.remoteFlagLoader = {
+            self.remoteFlagLoader = { reason in
                 await CmuxFeatureFlags.loadPostHogControlPlaneFlags(
                     distinctID: target.distinctID,
-                    personProperties: target.personProperties
+                    personProperties: target.personProperties,
+                    reason: reason
                 )
             }
         }
@@ -433,17 +445,20 @@ final class CmuxFeatureFlags {
     /// properties, preserving a non-identifying emergency kill switch.
     func start() {
         guard refreshTimer == nil else { return }
-        refreshRemoteFlags()
-        refreshTimer = Timer.scheduledTimer(withTimeInterval: 30 * 60, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshRemoteFlags() }
+        refreshRemoteFlags(reason: .launch)
+        refreshTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.releaseControlRefreshIntervalSeconds,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor in self?.refreshRemoteFlags(reason: .timer) }
         }
     }
 
-    private func refreshRemoteFlags() {
+    private func refreshRemoteFlags(reason: RefreshReason) {
         guard refreshTask == nil else { return }
         let loader = remoteFlagLoader
         refreshTask = Task { @MainActor [weak self] in
-            let values = await loader()
+            let values = await loader(reason)
             guard let self else { return }
             self.refreshTask = nil
             guard let values, !Task.isCancelled else { return }
@@ -469,7 +484,8 @@ final class CmuxFeatureFlags {
     static func postHogControlPlaneRequest(
         telemetryEnabled: Bool = TelemetrySettings.enabledForCurrentLaunch,
         defaults: UserDefaults = .standard,
-        bundle: Bundle = .main
+        bundle: Bundle = .main,
+        reason: RefreshReason = .launch
     ) -> URLRequest? {
         let target = releaseControlTarget(
             telemetryEnabled: telemetryEnabled,
@@ -478,7 +494,9 @@ final class CmuxFeatureFlags {
         )
         return postHogControlPlaneRequest(
             distinctID: target.distinctID,
-            personProperties: target.personProperties
+            personProperties: target.personProperties,
+            reason: reason,
+            bundle: bundle
         )
     }
 
@@ -513,18 +531,48 @@ final class CmuxFeatureFlags {
         var properties = [
             "$os": "macOS",
             "cmux_architecture": releaseControlArchitecture,
+            "cmux_release_channel": releaseControlChannel(bundle: bundle),
         ]
-        if let version = bundle.object(
-            forInfoDictionaryKey: "CFBundleShortVersionString"
-        ) as? String, !version.isEmpty {
+        if let version = releaseControlAppVersion(bundle: bundle) {
             properties["$app_version"] = version
         }
-        if let build = bundle.object(
-            forInfoDictionaryKey: "CFBundleVersion"
-        ) as? String, !build.isEmpty {
+        if let build = releaseControlAppBuild(bundle: bundle) {
             properties["$app_build"] = build
         }
         return properties
+    }
+
+    /// The release channel this binary belongs to, derived from the marketing
+    /// version the release pipelines stamp (`-nightly.<build>` for nightlies,
+    /// `-rc` for release candidates). Debug builds report `dev`.
+    nonisolated static func releaseControlChannel(bundle: Bundle = .main) -> String {
+        releaseControlChannel(version: releaseControlAppVersion(bundle: bundle))
+    }
+
+    nonisolated static func releaseControlChannel(version: String?) -> String {
+        if let version {
+            if version.contains("-nightly") { return "nightly" }
+            if version.contains("-rc") { return "rc" }
+        }
+        #if DEBUG
+        return "dev"
+        #else
+        return "stable"
+        #endif
+    }
+
+    nonisolated private static func releaseControlAppVersion(bundle: Bundle) -> String? {
+        guard let version = bundle.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String, !version.isEmpty else { return nil }
+        return version
+    }
+
+    nonisolated private static func releaseControlAppBuild(bundle: Bundle) -> String? {
+        guard let build = bundle.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String, !build.isEmpty else { return nil }
+        return build
     }
 
     private static var releaseControlArchitecture: String {
@@ -539,13 +587,32 @@ final class CmuxFeatureFlags {
 
     nonisolated private static func postHogControlPlaneRequest(
         distinctID: String,
-        personProperties: [String: String]
+        personProperties: [String: String],
+        reason: RefreshReason,
+        bundle: Bundle
     ) -> URLRequest? {
         guard let url = URL(string: "https://cmux.com/api/client-config") else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 10
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Low-cardinality attribution labels, logged in aggregate by the web
+        // route. They carry no per-user identifier, so they are sent for
+        // opted-out launches too; the request body keeps the telemetry-consent
+        // contract (no persistent identity without consent).
+        request.setValue("macos", forHTTPHeaderField: "X-Cmux-Client")
+        request.setValue(releaseControlChannel(bundle: bundle), forHTTPHeaderField: "X-Cmux-Channel")
+        request.setValue(reason.rawValue, forHTTPHeaderField: "X-Cmux-Refresh-Reason")
+        request.setValue(
+            String(Int(releaseControlRefreshIntervalSeconds)),
+            forHTTPHeaderField: "X-Cmux-Poll-Interval"
+        )
+        if let version = releaseControlAppVersion(bundle: bundle) {
+            request.setValue(version, forHTTPHeaderField: "X-Cmux-App-Version")
+        }
+        if let build = releaseControlAppBuild(bundle: bundle) {
+            request.setValue(build, forHTTPHeaderField: "X-Cmux-App-Build")
+        }
         let context: [String: Any] = personProperties.isEmpty
             ? [:]
             : ["personProperties": personProperties]
@@ -558,11 +625,15 @@ final class CmuxFeatureFlags {
 
     nonisolated private static func loadPostHogControlPlaneFlags(
         distinctID: String,
-        personProperties: [String: String]
+        personProperties: [String: String],
+        reason: RefreshReason,
+        bundle: Bundle = .main
     ) async -> [String: Bool]? {
         guard let request = postHogControlPlaneRequest(
             distinctID: distinctID,
-            personProperties: personProperties
+            personProperties: personProperties,
+            reason: reason,
+            bundle: bundle
         ) else { return nil }
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 10

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -120,6 +120,11 @@ final class PostHogAnalytics: @unchecked Sendable {
         let config = PostHogConfig(apiKey: apiKey, host: host)
         config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false
+        // CmuxFeatureFlags is the flag control plane (via /api/client-config).
+        // Nothing reads SDK-loaded flags at runtime, so the SDK's own startup
+        // /flags request is a duplicate billable PostHog feature-flag request
+        // per launch across the whole fleet.
+        config.preloadFeatureFlags = false
 #if DEBUG
         config.debug = ProcessInfo.processInfo.environment["CMUX_POSTHOG_DEBUG"] == "1"
 #endif

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -16,7 +16,7 @@ struct PostHogAnalyticsPropertiesTests {
         let flags = CmuxFeatureFlags(
             defaults: defaults,
             remoteFlagValueProvider: { _ in nil },
-            remoteFlagLoader: { await probe.load() }
+            remoteFlagLoader: { _ in await probe.load() }
         )
 
         flags.start()
@@ -60,8 +60,16 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(secondPayload["distinctId"] as? String == distinctID)
         #expect(personProperties["$os"] as? String == "macOS")
         #expect((personProperties["cmux_architecture"] as? String)?.isEmpty == false)
+        #expect((personProperties["cmux_release_channel"] as? String)?.isEmpty == false)
         #expect(firstPayload["$anon_distinct_id"] == nil)
         #expect(firstPayload["person_properties"] == nil)
+        #expect(firstRequest.value(forHTTPHeaderField: "X-Cmux-Client") == "macos")
+        #expect(firstRequest.value(forHTTPHeaderField: "X-Cmux-Refresh-Reason") == "launch")
+        #expect(firstRequest.value(forHTTPHeaderField: "X-Cmux-Poll-Interval") == "1800")
+        #expect(
+            firstRequest.value(forHTTPHeaderField: "X-Cmux-Channel")
+                == CmuxFeatureFlags.releaseControlChannel()
+        )
     }
 
     @MainActor
@@ -83,6 +91,25 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(payload["distinctId"] as? String == "cmux-desktop-release-control")
         #expect((payload["context"] as? [String: Any])?.isEmpty == true)
         #expect(defaults.object(forKey: "cmux.flags.releaseControlDistinctID") == nil)
+        // Attribution headers carry only fleet-wide labels, so they stay on
+        // opted-out requests without weakening the no-identity body contract.
+        #expect(request.value(forHTTPHeaderField: "X-Cmux-Client") == "macos")
+        #expect(request.value(forHTTPHeaderField: "X-Cmux-Refresh-Reason") == "launch")
+    }
+
+    @Test("feature flag release channel derives from the stamped marketing version")
+    func featureFlagReleaseChannelDerivesFromMarketingVersion() {
+        #expect(
+            CmuxFeatureFlags.releaseControlChannel(version: "0.64.22-nightly.202608250")
+                == "nightly"
+        )
+        #expect(CmuxFeatureFlags.releaseControlChannel(version: "0.65.0-rc.1") == "rc")
+        let plain = CmuxFeatureFlags.releaseControlChannel(version: "0.64.22")
+        #if DEBUG
+        #expect(plain == "dev")
+        #else
+        #expect(plain == "stable")
+        #endif
     }
 
     @Test("feature flag bool coercion accepts PostHog bool-like values")
@@ -286,7 +313,7 @@ struct PostHogAnalyticsPropertiesTests {
         let flags = CmuxFeatureFlags(
             defaults: defaults,
             remoteFlagValueProvider: { _ in nil },
-            remoteFlagLoader: { await probe.load() }
+            remoteFlagLoader: { _ in await probe.load() }
         )
         #expect(flags.remoteValue(for: flag) == false)
         #expect(!flags.effectiveValue(for: flag))

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
@@ -34,9 +34,15 @@ public struct MobileAnalyticsComposition {
     public let anonymousID: String
     /// The default mobile evaluation context sent to `/api/client-config`.
     public let clientConfigContext: ClientConfigEvaluationContext
+    /// The low-cardinality `X-Cmux-*` request labels for control-plane calls.
+    public let clientConfigAttribution: ClientConfigAttribution
     /// A request for anonymous mobile flag evaluation.
     public var anonymousClientConfigRequest: ClientConfigRequest {
-        ClientConfigRequest(distinctId: anonymousID, context: clientConfigContext)
+        ClientConfigRequest(
+            distinctId: anonymousID,
+            context: clientConfigContext,
+            attribution: clientConfigAttribution
+        )
     }
     /// The session store + sessionizer the app shell drives on foreground/background.
     public let sessionStore: AnalyticsSessionStore
@@ -101,6 +107,7 @@ public struct MobileAnalyticsComposition {
             anonDistinctId: anonymousID,
             evaluationContexts: ["mobile"]
         )
+        self.clientConfigAttribution = Self.clientConfigRequestAttribution()
         self.sessionStore = AnalyticsSessionStore(defaults: defaults)
     }
 
@@ -138,6 +145,29 @@ public struct MobileAnalyticsComposition {
         return props
     }
 
+    /// The `X-Cmux-*` labels sent with every control-plane request so the web
+    /// route's per-request log can attribute request volume by client, channel,
+    /// and build. Fleet-wide values only; no per-user identifier.
+    @MainActor private static func clientConfigRequestAttribution() -> ClientConfigAttribution {
+        let info = Bundle.main.infoDictionary
+        return ClientConfigAttribution(
+            client: "ios",
+            channel: releaseChannel(),
+            appVersion: info?["CFBundleShortVersionString"] as? String,
+            appBuild: info?["CFBundleVersion"] as? String
+        )
+    }
+
+    /// The coarse release channel. TestFlight installs report `stable`; the
+    /// route only needs to separate dev fleets from released clients.
+    private static func releaseChannel() -> String {
+        #if DEBUG
+        "dev"
+        #else
+        "stable"
+        #endif
+    }
+
     @MainActor private static func clientConfigDeviceProperties(
         anonymousID: String
     ) -> [String: ClientConfigJSONValue] {
@@ -145,6 +175,7 @@ public struct MobileAnalyticsComposition {
         var props: [String: ClientConfigJSONValue] = [
             "client_id": .string(anonymousID),
             "platform": .string("ios"),
+            "cmux_release_channel": .string(releaseChannel()),
         ]
         if let bundleIdentifier = Bundle.main.bundleIdentifier {
             props["bundle_identifier"] = .string(bundleIdentifier)

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileFeatureFlags.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileFeatureFlags.swift
@@ -30,7 +30,8 @@ public final class MobileFeatureFlags {
     /// Delay between foreground refresh opportunities when the app remains active.
     /// Thirty minutes bounds steady-state control-plane traffic across the fleet;
     /// launch and scene-active refreshes keep flag propagation fast where it matters.
-    private static let refreshInterval: Duration = .seconds(30 * 60)
+    private static let refreshIntervalSeconds = 30 * 60
+    private static let refreshInterval: Duration = .seconds(refreshIntervalSeconds)
 
     /// Whether the chip and its count-only artifact scan are enabled.
     public private(set) var terminalFilesChipEnabled: Bool
@@ -59,6 +60,9 @@ public final class MobileFeatureFlags {
     @ObservationIgnored private var lifecycleGeneration: UInt64 = 0
     /// Whether the app root currently owns the periodic scheduler.
     @ObservationIgnored private var isStarted = false
+    /// The trigger for the most recently requested refresh, used to label the
+    /// next control-plane request (coalesced triggers keep the latest reason).
+    @ObservationIgnored private var pendingRefreshReason: ClientConfigAttribution.RefreshReason = .launch
 
     /// Creates the runtime flag store with an injected control-plane loader.
     public init(
@@ -86,7 +90,7 @@ public final class MobileFeatureFlags {
     public func start() {
         guard !isStarted else { return }
         isStarted = true
-        requestRefresh()
+        requestRefresh(reason: .launch)
         scheduleNextPeriodicRefresh(for: lifecycleGeneration)
     }
 
@@ -108,14 +112,14 @@ public final class MobileFeatureFlags {
 
     /// Queues one foreground refresh without creating an unowned task at the call site.
     public func refreshOnForeground() {
-        requestRefresh()
+        requestRefresh(reason: .foreground)
     }
 
     /// Refreshes flags without allowing a failed request to erase the cache.
     public func refresh() async {
         await withCheckedContinuation { continuation in
             refreshWaiters.append(continuation)
-            requestRefresh()
+            requestRefresh(reason: .manual)
         }
     }
 
@@ -133,13 +137,14 @@ public final class MobileFeatureFlags {
                   self.isStarted,
                   self.lifecycleGeneration == generation else { return }
             self.periodicRefreshTask = nil
-            self.requestRefresh()
+            self.requestRefresh(reason: .timer)
             self.scheduleNextPeriodicRefresh(for: generation)
         }
     }
 
     /// Coalesces foreground and periodic triggers into one owned operation.
-    private func requestRefresh() {
+    private func requestRefresh(reason: ClientConfigAttribution.RefreshReason) {
+        pendingRefreshReason = reason
         guard refreshOperationTask == nil else {
             refreshRequested = true
             return
@@ -147,15 +152,18 @@ public final class MobileFeatureFlags {
         let generation = lifecycleGeneration
         refreshOperationTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performRefresh()
+            await self.performRefresh(reason: reason)
             self.completeRefresh(for: generation)
         }
     }
 
     /// Performs one remote load and applies only a complete, valid response.
-    private func performRefresh() async {
+    private func performRefresh(reason: ClientConfigAttribution.RefreshReason) async {
         let loader = self.loader
-        let request = self.request
+        let request = self.request.labeled(
+            refreshReason: reason,
+            pollIntervalSeconds: Self.refreshIntervalSeconds
+        )
         let config = await Self.loadConfig(loader: loader, request: request)
 
         guard !Task.isCancelled,
@@ -189,7 +197,7 @@ public final class MobileFeatureFlags {
         refreshOperationTask = nil
         if refreshRequested {
             refreshRequested = false
-            requestRefresh()
+            requestRefresh(reason: pendingRefreshReason)
             return
         }
         let waiters = refreshWaiters

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileFeatureFlagsTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileFeatureFlagsTests.swift
@@ -75,6 +75,36 @@ struct MobileFeatureFlagsTests {
         #expect(flags.terminalFilesChipEnabled)
     }
 
+    @Test("control-plane requests are labeled with their trigger and poll cadence")
+    func refreshRequestsCarryAttributionLabels() async throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let loader = QueueClientConfigLoader([
+            .success(config(terminalFilesChipEnabled: true)),
+            .success(config(terminalFilesChipEnabled: true)),
+        ])
+        let flags = MobileFeatureFlags(
+            loader: loader,
+            request: ClientConfigRequest(
+                distinctId: "test",
+                attribution: ClientConfigAttribution(client: "ios", channel: "dev")
+            ),
+            defaults: defaults
+        )
+        defer { flags.stop() }
+
+        await flags.refresh()
+        flags.refreshOnForeground()
+        await flags.refresh()
+
+        let requests = await loader.requests
+        let reasons = requests.compactMap { $0.attribution?.refreshReason }
+        #expect(reasons.first == .manual)
+        #expect(reasons.contains(.foreground))
+        #expect(requests.allSatisfy { $0.attribution?.client == "ios" })
+        #expect(requests.allSatisfy { $0.attribution?.pollIntervalSeconds == 30 * 60 })
+    }
+
     @Test("keyboard rebuild revert ships off so legacy pinning is the default")
     func keyboardDockRebuildRevertDefaultsOff() throws {
         let (defaults, suiteName) = try makeDefaults()
@@ -148,12 +178,14 @@ private enum StubClientConfigError: Error, Sendable {
 
 private actor QueueClientConfigLoader: ClientConfigLoading {
     private var results: [Result<ClientConfig, StubClientConfigError>]
+    private(set) var requests: [ClientConfigRequest] = []
 
     init(_ results: [Result<ClientConfig, StubClientConfigError>]) {
         self.results = results
     }
 
     func load(_ request: ClientConfigRequest) async throws -> ClientConfig {
+        requests.append(request)
         guard !results.isEmpty else { throw StubClientConfigError.unavailable }
         return try results.removeFirst().get()
     }

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -13,9 +13,27 @@ import {
   postHogFlagsBody,
   postHogFlagsUrl,
 } from "../../../services/client-config/posthogFlags";
+import { readClientConfigRequestAttribution } from "../../../services/client-config/requestAttribution";
 
 
 export async function POST(request: Request): Promise<Response> {
+  const startedAtMs = Date.now();
+  const attribution = readClientConfigRequestAttribution(request.headers);
+  const response = await handleClientConfigRequest(request);
+  // One structured line per request. This log is the per-client request
+  // counter: PostHog billing exposes only a daily project-wide flag-request
+  // total, so client/channel/version/reason attribution has to be recorded
+  // here, before the request loses its origin. Fields are allowlist-normalized
+  // in readClientConfigRequestAttribution; nothing user-identifying is logged.
+  console.log("client-config.route.request", {
+    ...attribution,
+    status: response.status,
+    durationMs: Date.now() - startedAtMs,
+  });
+  return response;
+}
+
+async function handleClientConfigRequest(request: Request): Promise<Response> {
   // An unset rule id means no rate limiting; a deleted rule (not-found) fails
   // open rather than making client config unavailable for every app boot.
   const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();

--- a/web/services/client-config/requestAttribution.ts
+++ b/web/services/client-config/requestAttribution.ts
@@ -1,0 +1,72 @@
+/// Low-cardinality request attribution for `/api/client-config`.
+///
+/// The native apps label every control-plane request with `X-Cmux-*` headers
+/// so the route can log one structured line per request. Those logs are the
+/// request-volume counter PostHog billing does not provide: PostHog reports
+/// only a daily project-wide total, with no client, version, or channel
+/// breakdown. Every value is normalized against a fixed allowlist before it
+/// reaches a log line, so a hostile caller cannot inject log content or grow
+/// cardinality.
+
+export const CLIENT_CONFIG_CLIENT_HEADER = "x-cmux-client";
+export const CLIENT_CONFIG_CHANNEL_HEADER = "x-cmux-channel";
+export const CLIENT_CONFIG_APP_VERSION_HEADER = "x-cmux-app-version";
+export const CLIENT_CONFIG_APP_BUILD_HEADER = "x-cmux-app-build";
+export const CLIENT_CONFIG_REFRESH_REASON_HEADER = "x-cmux-refresh-reason";
+export const CLIENT_CONFIG_POLL_INTERVAL_HEADER = "x-cmux-poll-interval";
+
+const KNOWN_CLIENTS = new Set(["macos", "ios", "web"]);
+const KNOWN_CHANNELS = new Set(["stable", "rc", "nightly", "dev"]);
+const KNOWN_REASONS = new Set(["launch", "timer", "foreground", "manual"]);
+
+/// Version and build strings are logged verbatim only when they look like
+/// version identifiers; anything else collapses to "invalid".
+const VERSION_PATTERN = /^[0-9A-Za-z.+_-]{1,64}$/;
+
+const MAX_POLL_INTERVAL_SECONDS = 7 * 24 * 60 * 60;
+
+export type ClientConfigRequestAttribution = {
+  readonly client: string;
+  readonly channel: string;
+  readonly reason: string;
+  readonly appVersion: string;
+  readonly appBuild: string;
+  readonly pollIntervalSeconds: number | null;
+};
+
+export function readClientConfigRequestAttribution(
+  headers: Headers,
+): ClientConfigRequestAttribution {
+  return {
+    client: normalizeEnum(headers.get(CLIENT_CONFIG_CLIENT_HEADER), KNOWN_CLIENTS),
+    channel: normalizeEnum(headers.get(CLIENT_CONFIG_CHANNEL_HEADER), KNOWN_CHANNELS),
+    reason: normalizeEnum(headers.get(CLIENT_CONFIG_REFRESH_REASON_HEADER), KNOWN_REASONS),
+    appVersion: normalizeVersion(headers.get(CLIENT_CONFIG_APP_VERSION_HEADER)),
+    appBuild: normalizeVersion(headers.get(CLIENT_CONFIG_APP_BUILD_HEADER)),
+    pollIntervalSeconds: normalizePollInterval(
+      headers.get(CLIENT_CONFIG_POLL_INTERVAL_HEADER),
+    ),
+  };
+}
+
+function normalizeEnum(value: string | null, known: ReadonlySet<string>): string {
+  if (value === null) return "unknown";
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return "unknown";
+  return known.has(trimmed) ? trimmed : "other";
+}
+
+function normalizeVersion(value: string | null): string {
+  if (value === null) return "unknown";
+  const trimmed = value.trim();
+  if (!trimmed) return "unknown";
+  return VERSION_PATTERN.test(trimmed) ? trimmed : "invalid";
+}
+
+function normalizePollInterval(value: string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number.parseInt(value.trim(), 10);
+  if (!Number.isSafeInteger(parsed)) return null;
+  if (parsed < 0 || parsed > MAX_POLL_INTERVAL_SECONDS) return null;
+  return parsed;
+}

--- a/web/tests/client-config-attribution.test.ts
+++ b/web/tests/client-config-attribution.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CLIENT_CONFIG_APP_BUILD_HEADER,
+  CLIENT_CONFIG_APP_VERSION_HEADER,
+  CLIENT_CONFIG_CHANNEL_HEADER,
+  CLIENT_CONFIG_CLIENT_HEADER,
+  CLIENT_CONFIG_POLL_INTERVAL_HEADER,
+  CLIENT_CONFIG_REFRESH_REASON_HEADER,
+  readClientConfigRequestAttribution,
+} from "../services/client-config/requestAttribution";
+
+describe("client config request attribution", () => {
+  test("reads labeled requests from the native apps", () => {
+    const attribution = readClientConfigRequestAttribution(new Headers({
+      [CLIENT_CONFIG_CLIENT_HEADER]: "macos",
+      [CLIENT_CONFIG_CHANNEL_HEADER]: "Nightly",
+      [CLIENT_CONFIG_REFRESH_REASON_HEADER]: "timer",
+      [CLIENT_CONFIG_APP_VERSION_HEADER]: "0.64.22-nightly.202608250",
+      [CLIENT_CONFIG_APP_BUILD_HEADER]: "202608250",
+      [CLIENT_CONFIG_POLL_INTERVAL_HEADER]: "1800",
+    }));
+
+    expect(attribution).toEqual({
+      client: "macos",
+      channel: "nightly",
+      reason: "timer",
+      appVersion: "0.64.22-nightly.202608250",
+      appBuild: "202608250",
+      pollIntervalSeconds: 1800,
+    });
+  });
+
+  test("labels unlabeled requests as unknown", () => {
+    expect(readClientConfigRequestAttribution(new Headers())).toEqual({
+      client: "unknown",
+      channel: "unknown",
+      reason: "unknown",
+      appVersion: "unknown",
+      appBuild: "unknown",
+      pollIntervalSeconds: null,
+    });
+  });
+
+  test("collapses unrecognized enum values to other instead of logging them", () => {
+    const attribution = readClientConfigRequestAttribution(new Headers({
+      [CLIENT_CONFIG_CLIENT_HEADER]: "curl/8.5 (something-unrecognized)",
+      [CLIENT_CONFIG_CHANNEL_HEADER]: "canary",
+      [CLIENT_CONFIG_REFRESH_REASON_HEADER]: "because",
+    }));
+
+    expect(attribution.client).toBe("other");
+    expect(attribution.channel).toBe("other");
+    expect(attribution.reason).toBe("other");
+  });
+
+  test("collapses malformed version, build, and interval values", () => {
+    const attribution = readClientConfigRequestAttribution(new Headers({
+      [CLIENT_CONFIG_APP_VERSION_HEADER]: "0.64 <script>",
+      [CLIENT_CONFIG_APP_BUILD_HEADER]: "x".repeat(65),
+      [CLIENT_CONFIG_POLL_INTERVAL_HEADER]: "-5",
+    }));
+
+    expect(attribution.appVersion).toBe("invalid");
+    expect(attribution.appBuild).toBe("invalid");
+    expect(attribution.pollIntervalSeconds).toBeNull();
+
+    expect(
+      readClientConfigRequestAttribution(new Headers({
+        [CLIENT_CONFIG_POLL_INTERVAL_HEADER]: "999999999",
+      })).pollIntervalSeconds,
+    ).toBeNull();
+  });
+});

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -356,6 +356,96 @@ describe("client config", () => {
     expect(checkRateLimit).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  test("logs one normalized attribution line per proxied request", async () => {
+    const logCalls: Array<[string, Record<string, unknown>]> = [];
+    const originalConsoleLog = console.log;
+    console.log = ((...args: unknown[]) => {
+      logCalls.push([args[0] as string, args[1] as Record<string, unknown>]);
+    }) as typeof console.log;
+    try {
+      const fetchMock = mock(async () => new Response(
+        JSON.stringify({
+          errorsWhileComputingFlags: false,
+          featureFlags: { "pricing-page-visible": true },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const response = await POST(new Request("https://cmux.test/api/client-config", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Cmux-Client": "macos",
+          "X-Cmux-Channel": "stable",
+          "X-Cmux-Refresh-Reason": "launch",
+          "X-Cmux-App-Version": "0.64.22",
+          "X-Cmux-App-Build": "6422",
+          "X-Cmux-Poll-Interval": "1800",
+        },
+        body: JSON.stringify({ distinctId: "browser-id" }),
+      }));
+
+      expect(response.status).toBe(200);
+      expect(logCalls).toHaveLength(1);
+      const [message, fields] = logCalls[0]!;
+      expect(message).toBe("client-config.route.request");
+      expect(fields).toMatchObject({
+        client: "macos",
+        channel: "stable",
+        reason: "launch",
+        appVersion: "0.64.22",
+        appBuild: "6422",
+        pollIntervalSeconds: 1800,
+        status: 200,
+      });
+      expect(typeof fields.durationMs).toBe("number");
+    } finally {
+      console.log = originalConsoleLog;
+    }
+  });
+
+  test("logs attribution for rate-limited requests before the body is read", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
+    const logCalls: Array<[string, Record<string, unknown>]> = [];
+    const originalConsoleLog = console.log;
+    console.log = ((...args: unknown[]) => {
+      logCalls.push([args[0] as string, args[1] as Record<string, unknown>]);
+    }) as typeof console.log;
+    try {
+      const fetchMock = mock(async () => {
+        throw new Error("PostHog flags should not be reached after a rate-limit block");
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const response = await POST(new Request("https://cmux.test/api/client-config", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Cmux-Client": "ios",
+          "X-Cmux-Channel": "weird-channel",
+          "X-Cmux-Refresh-Reason": "timer",
+        },
+        body: JSON.stringify({ distinctId: "browser-id" }),
+      }));
+
+      expect(response.status).toBe(429);
+      expect(logCalls).toHaveLength(1);
+      const [message, fields] = logCalls[0]!;
+      expect(message).toBe("client-config.route.request");
+      expect(fields).toMatchObject({
+        client: "ios",
+        channel: "other",
+        reason: "timer",
+        appVersion: "unknown",
+        status: 429,
+      });
+    } finally {
+      console.log = originalConsoleLog;
+    }
+  });
 });
 
 function restoreEnv(key: string, value: string | undefined): void {


### PR DESCRIPTION
## Why

On Aug 25 PostHog billed 7,231,055 feature-flag requests against ~816k the day before (8.9x), and nothing in PostHog or our stack could say which client sent them. PostHog billing exposes one project-wide daily total with no SDK, version, or channel breakdown, and the /api/client-config proxy forwarded nothing about its callers, so the origin of the volume was unprovable. Root-cause analysis pointed at the 5-minute control-plane poll that shipped in v0.64.22 (the 30-minute fix from https://github.com/manaflow-ai/cmux/pull/10722 is on main but unreleased).

## What

**web** (`/api/client-config`): reads allowlist-normalized `X-Cmux-*` headers and logs one structured `client-config.route.request` line per request with client, channel, refresh reason, app version/build, poll interval, status, and latency. Rate-limited requests attribute too, since labels are headers rather than body fields. Enum values collapse to `other`/`unknown` and version strings must match a bounded pattern, so cardinality is fixed and log injection is not possible. Vercel log queries over this line are the per-client request counter PostHog does not provide.

**Mac + iOS clients**: every control-plane request now carries those labels. Mac derives its channel from the stamped marketing version (`-nightly.` / `-rc`), `dev` in Debug builds, `stable` otherwise; iOS reports `dev`/`stable`. Both clients also add `cmux_release_channel` to targeting person properties so flags can roll out or kill per channel. Refresh reasons (`launch`, `timer`, `foreground`, `manual`) separate launch bursts from steady-state polling. Labels are fleet-wide values with no per-user identifier, and they ride in headers so the opted-out request body keeps its no-persistent-identity contract (test-pinned).

**Mac SDK preload**: `config.preloadFeatureFlags = false`. `CmuxFeatureFlags` is the control plane and `applyLoadedFlags()` has no callers, so the PostHog SDK's automatic startup `/flags` fetch was one extra billable request per telemetry-enabled launch, fleet-wide. (Same one-liner as the never-merged 87080c7.)

## Verification

- `bun test tests/client-config-attribution.test.ts tests/client-config-route.test.ts` — 15 pass
- `bun run typecheck` — clean
- `swift test` in `Packages/Shared/CmuxClientConfig` — 8 pass, includes new header/body-contract tests
- `cmuxTests/PostHogAnalyticsPropertiesTests` updated (headers on consented and opted-out requests, channel derivation); runs in CI
- `ios/cmuxPackage` `MobileFeatureFlagsTests` gained a reason/cadence labeling test; the package graph only builds for iOS destinations, so it runs in CI

## Privacy note for review

Attribution headers are sent on telemetry-opted-out launches too. They contain only platform, channel, version, build, reason, and interval — the same class of data URLSession's default User-Agent already leaks — and the server collapses everything through allowlists before logging. If we want opted-out clients to send fewer labels, that is a one-line change on each client.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790329132&installation_model_id=21920&pr_number=10830&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10830&signature=a005c6c068216722ccac14410189870373122d9080c844c9005d485028e48dea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added attribution for client-configuration requests, including client, release channel, app version, build, refresh reason, and polling interval.
  - Feature-flag refreshes now identify launch, foreground, timer, and manual refreshes.
  - Added release-channel detection for nightly, release-candidate, stable, and development builds.
  - Added normalized request logging for configuration requests, including status and duration.

- **Improvements**
  - Disabled automatic feature-flag preloading to prevent duplicate requests.
  - Added validation and safe defaults for attribution values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->